### PR TITLE
Avoid silencing relevant follow-up errors

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -166,13 +166,12 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
-    // FIXME(matthewjasper) We shouldn't need to use `track_errors`.
-    tcx.sess.track_errors(|| {
-        tcx.sess.time("type_collecting", || {
-            tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
-        });
-    })?;
+    tcx.sess.time("type_collecting", || {
+        tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
+    });
 
+    // FIXME(matthewjasper) We shouldn't need to use `track_errors` anywhere in this function
+    // or the compiler in general.
     if tcx.features().rustc_attrs {
         tcx.sess.track_errors(|| {
             tcx.sess.time("outlives_testing", || outlives::test::test_inferred_outlives(tcx));

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -279,6 +279,12 @@ pub fn normalize_param_env_or_error<'tcx>(
                 }
 
                 fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
+                    // FIXME(return_type_notation): track binders in this normalizer, as
+                    // `ty::Const::normalize` can only work with properly preserved binders.
+
+                    if c.has_escaping_bound_vars() {
+                        return ty::Const::new_misc_error(self.0, c.ty());
+                    }
                     // While it is pretty sus to be evaluating things with an empty param env, it
                     // should actually be okay since without `feature(generic_const_exprs)` the only
                     // const arguments that have a non-empty param env are array repeat counts. These

--- a/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
@@ -13,7 +13,7 @@ LL | impl<T> Windows {
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/issue-109071.rs:5:8
    |
-LL | struct Windows<T> {}
+LL | struct Windows<T> { t: T }
    |        ^^^^^^^ -
 help: add missing generic argument
    |
@@ -30,7 +30,7 @@ LL |     type Item = &[T];
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
 error[E0223]: ambiguous associated type
-  --> $DIR/issue-109071.rs:15:22
+  --> $DIR/issue-109071.rs:16:22
    |
 LL |     fn T() -> Option<Self::Item> {}
    |                      ^^^^^^^^^^

--- a/tests/ui/associated-inherent-types/issue-109071.rs
+++ b/tests/ui/associated-inherent-types/issue-109071.rs
@@ -2,18 +2,20 @@
 #![cfg_attr(with_gate, feature(inherent_associated_types))]
 #![cfg_attr(with_gate, allow(incomplete_features))]
 
-struct Windows<T> {}
+struct Windows<T> { t: T }
 
 impl<T> Windows { //~ ERROR: missing generics for struct `Windows`
     type Item = &[T]; //~ ERROR: `&` without an explicit lifetime name cannot be used here
     //[no_gate]~^ ERROR: inherent associated types are unstable
 
     fn next() -> Option<Self::Item> {}
+    //[with_gate]~^ ERROR type annotations needed
 }
 
 impl<T> Windows<T> {
     fn T() -> Option<Self::Item> {}
     //[no_gate]~^ ERROR: ambiguous associated type
+    //[with_gate]~^^ ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
@@ -13,14 +13,26 @@ LL | impl<T> Windows {
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/issue-109071.rs:5:8
    |
-LL | struct Windows<T> {}
+LL | struct Windows<T> { t: T }
    |        ^^^^^^^ -
 help: add missing generic argument
    |
 LL | impl<T> Windows<T> {
    |                +++
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/issue-109071.rs:11:18
+   |
+LL |     fn next() -> Option<Self::Item> {}
+   |                  ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
-Some errors have detailed explanations: E0107, E0637.
+error[E0282]: type annotations needed
+  --> $DIR/issue-109071.rs:16:15
+   |
+LL |     fn T() -> Option<Self::Item> {}
+   |               ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0282, E0637.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/associated-inherent-types/issue-109299-1.rs
+++ b/tests/ui/associated-inherent-types/issue-109299-1.rs
@@ -8,5 +8,6 @@ impl Lexer<i32> {
 }
 
 type X = impl for<T> Fn() -> Lexer<T>::Cursor; //~ ERROR associated type `Cursor` not found for `Lexer<T>` in the current scope
+//~^ ERROR: unconstrained opaque type
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109299-1.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299-1.stderr
@@ -10,6 +10,14 @@ LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
    = note: the associated type was found for
            - `Lexer<i32>`
 
-error: aborting due to 1 previous error
+error: unconstrained opaque type
+  --> $DIR/issue-109299-1.rs:10:10
+   |
+LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `X` must be used in combination with a concrete type within the same module
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0220`.

--- a/tests/ui/associated-inherent-types/issue-109768.rs
+++ b/tests/ui/associated-inherent-types/issue-109768.rs
@@ -8,5 +8,6 @@ impl<T> Local { //~ ERROR missing generics for struct `Local`
     type AssocType3 = T; //~ ERROR inherent associated types are unstable
 
     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
+    //~^ ERROR: this struct takes 1 argument but 0 arguments were supplied
 }
 //~^ ERROR `main` function not found

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -1,5 +1,5 @@
 error[E0601]: `main` function not found in crate `issue_109768`
-  --> $DIR/issue-109768.rs:11:2
+  --> $DIR/issue-109768.rs:12:2
    |
 LL | }
    |  ^ consider adding a `main` function to `$DIR/issue-109768.rs`
@@ -29,7 +29,23 @@ LL |     type AssocType3 = T;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0061]: this struct takes 1 argument but 0 arguments were supplied
+  --> $DIR/issue-109768.rs:10:56
+   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
+   |                                                        ^^^^^^^-- an argument is missing
+   |
+note: tuple struct defined here
+  --> $DIR/issue-109768.rs:3:8
+   |
+LL | struct Wrapper<T>(T);
+   |        ^^^^^^^
+help: provide the argument
+   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper(/* value */);
+   |                                                               ~~~~~~~~~~~~~
 
-Some errors have detailed explanations: E0107, E0601, E0658.
-For more information about an error, try `rustc --explain E0107`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0061, E0107, E0601, E0658.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/associated-type-bounds/duplicate.rs
+++ b/tests/ui/associated-type-bounds/duplicate.rs
@@ -134,14 +134,17 @@ where
 fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
@@ -194,11 +197,14 @@ trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
 trait TRS1: Iterator<Item: Copy, Item: Send> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS2: Iterator<Item: Copy, Item: Copy> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS3: Iterator<Item: 'static, Item: 'static> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRW1<T>
 where
@@ -223,12 +229,14 @@ where
     Self: Iterator<Item: Copy, Item: Send>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRSW2
 where
     Self: Iterator<Item: Copy, Item: Copy>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
@@ -237,15 +245,19 @@ where
     Self: Iterator<Item: 'static, Item: 'static>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRA1 {
     type A: Iterator<Item: Copy, Item: Send>;
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+    //~| ERROR the trait bound `<<Self as TRA1>::A as Iterator>::Item: Copy` is not satisfied
 }
 trait TRA2 {
     type A: Iterator<Item: Copy, Item: Copy>;
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the trait bound `<<Self as TRA2>::A as Iterator>::Item: Copy` is not satisfied
 }
 trait TRA3 {
     type A: Iterator<Item: 'static, Item: 'static>;

--- a/tests/ui/associated-type-bounds/duplicate.stderr
+++ b/tests/ui/associated-type-bounds/duplicate.stderr
@@ -7,7 +7,7 @@ LL | struct SI1<T: Iterator<Item: Copy, Item: Send>> {
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:255:40
+  --> $DIR/duplicate.rs:267:40
    |
 LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -15,7 +15,7 @@ LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:257:44
+  --> $DIR/duplicate.rs:269:44
    |
 LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                ----------  ^^^^^^^^^^ re-bound here
@@ -23,7 +23,7 @@ LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:259:43
+  --> $DIR/duplicate.rs:271:43
    |
 LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -223,7 +223,7 @@ LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:138:42
+  --> $DIR/duplicate.rs:139:42
    |
 LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              ----------  ^^^^^^^^^^ re-bound here
@@ -231,7 +231,7 @@ LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:142:45
+  --> $DIR/duplicate.rs:144:45
    |
 LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              -------------  ^^^^^^^^^^^^^ re-bound here
@@ -239,7 +239,7 @@ LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:146:40
+  --> $DIR/duplicate.rs:149:40
    |
 LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -247,7 +247,7 @@ LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:148:40
+  --> $DIR/duplicate.rs:151:40
    |
 LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -255,7 +255,7 @@ LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:150:43
+  --> $DIR/duplicate.rs:153:43
    |
 LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -263,7 +263,7 @@ LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:153:35
+  --> $DIR/duplicate.rs:156:35
    |
 LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       ----------  ^^^^^^^^^^ re-bound here
@@ -271,7 +271,7 @@ LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:155:35
+  --> $DIR/duplicate.rs:158:35
    |
 LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       ----------  ^^^^^^^^^^ re-bound here
@@ -279,7 +279,7 @@ LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:157:38
+  --> $DIR/duplicate.rs:160:38
    |
 LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       -------------  ^^^^^^^^^^^^^ re-bound here
@@ -287,7 +287,7 @@ LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:161:29
+  --> $DIR/duplicate.rs:164:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -295,7 +295,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:166:29
+  --> $DIR/duplicate.rs:169:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -303,7 +303,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:171:32
+  --> $DIR/duplicate.rs:174:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 -------------  ^^^^^^^^^^^^^ re-bound here
@@ -311,7 +311,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:175:36
+  --> $DIR/duplicate.rs:178:36
    |
 LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -319,7 +319,7 @@ LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:177:36
+  --> $DIR/duplicate.rs:180:36
    |
 LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -327,7 +327,7 @@ LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:179:39
+  --> $DIR/duplicate.rs:182:39
    |
 LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        -------------  ^^^^^^^^^^^^^ re-bound here
@@ -335,7 +335,7 @@ LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:181:40
+  --> $DIR/duplicate.rs:184:40
    |
 LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -343,7 +343,7 @@ LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:183:40
+  --> $DIR/duplicate.rs:186:40
    |
 LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -351,7 +351,7 @@ LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:185:43
+  --> $DIR/duplicate.rs:188:43
    |
 LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -359,7 +359,7 @@ LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:188:36
+  --> $DIR/duplicate.rs:191:36
    |
 LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -367,7 +367,7 @@ LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:190:36
+  --> $DIR/duplicate.rs:193:36
    |
 LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -375,7 +375,7 @@ LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:192:39
+  --> $DIR/duplicate.rs:195:39
    |
 LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        -------------  ^^^^^^^^^^^^^ re-bound here
@@ -383,7 +383,7 @@ LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:194:34
+  --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -391,7 +391,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:194:34
+  --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -401,7 +401,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
+  --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -409,7 +409,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
+  --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -419,7 +419,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:200:37
+  --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
@@ -427,7 +427,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:200:37
+  --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
@@ -437,7 +437,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:205:29
+  --> $DIR/duplicate.rs:211:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -445,7 +445,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:211:29
+  --> $DIR/duplicate.rs:217:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -453,7 +453,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:217:32
+  --> $DIR/duplicate.rs:223:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 -------------  ^^^^^^^^^^^^^ re-bound here
@@ -461,7 +461,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:223:32
+  --> $DIR/duplicate.rs:229:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -469,7 +469,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:223:32
+  --> $DIR/duplicate.rs:229:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -479,7 +479,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:230:32
+  --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -487,7 +487,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:230:32
+  --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -497,7 +497,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:35
+  --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
@@ -505,7 +505,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:35
+  --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
@@ -515,7 +515,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:243:34
+  --> $DIR/duplicate.rs:252:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -523,7 +523,7 @@ LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:247:34
+  --> $DIR/duplicate.rs:258:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -531,13 +531,141 @@ LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:251:37
+  --> $DIR/duplicate.rs:263:37
    |
 LL |     type A: Iterator<Item: 'static, Item: 'static>;
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
 
-error: aborting due to 66 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:136:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
 
-For more information about this error, try `rustc --explain E0719`.
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:141:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:146:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:197:34
+   |
+LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:201:34
+   |
+LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:205:37
+   |
+LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
+   |                      -------------  ^^^^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:229:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Send>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:237:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Copy>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:245:35
+   |
+LL |     Self: Iterator<Item: 'static, Item: 'static>,
+   |                    -------------  ^^^^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `<<Self as TRA1>::A as Iterator>::Item: Copy` is not satisfied
+  --> $DIR/duplicate.rs:252:28
+   |
+LL |     type A: Iterator<Item: Copy, Item: Send>;
+   |                            ^^^^ the trait `Copy` is not implemented for `<<Self as TRA1>::A as Iterator>::Item`
+   |
+help: consider further restricting the associated type
+   |
+LL | trait TRA1 where <<Self as TRA1>::A as Iterator>::Item: Copy {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+  --> $DIR/duplicate.rs:252:40
+   |
+LL |     type A: Iterator<Item: Copy, Item: Send>;
+   |                                        ^^^^ `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `<<Self as TRA1>::A as Iterator>::Item`
+help: consider further restricting the associated type
+   |
+LL | trait TRA1 where <<Self as TRA1>::A as Iterator>::Item: Send {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<<Self as TRA2>::A as Iterator>::Item: Copy` is not satisfied
+  --> $DIR/duplicate.rs:258:28
+   |
+LL |     type A: Iterator<Item: Copy, Item: Copy>;
+   |                            ^^^^ the trait `Copy` is not implemented for `<<Self as TRA2>::A as Iterator>::Item`
+   |
+help: consider further restricting the associated type
+   |
+LL | trait TRA2 where <<Self as TRA2>::A as Iterator>::Item: Copy {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 78 previous errors
+
+Some errors have detailed explanations: E0277, E0282, E0719.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.rs
+++ b/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.rs
@@ -25,7 +25,7 @@ fn c<C>(_: C::Color) where C : Vehicle, C : Box {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-struct D<X>;
+struct D<X>(X);
 impl<X> D<X> where X : Vehicle {
     fn d(&self, _: X::Color) where X : Box { }
     //~^ ERROR ambiguous associated type `Color` in bounds of `X`

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
@@ -20,7 +20,7 @@ fn dent<C:BoxCar>(c: C, color: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
+fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
     //~^ ERROR ambiguous associated type
     //~| ERROR the value of the associated types
 }
@@ -29,7 +29,7 @@ fn paint<C:BoxCar>(c: C, d: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
     //~^ ERROR the value of the associated types
     //~| ERROR equality constraints are not yet supported in `where` clauses
 }

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -1,8 +1,8 @@
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:46
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:47
    |
-LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
+LL | fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
@@ -28,7 +28,7 @@ LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
    |                                ~~~~~~~~~~~~
 
 error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:38
    |
 LL |     type Color;
    |     ---------- ambiguous `Color` from `Vehicle`
@@ -36,8 +36,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- ambiguous `Color` from `Box`
 ...
-LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                                     ^^^^^^^^^^^ ambiguous associated type `Color`
+LL | fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
+   |                                      ^^^^^^^^^^^ ambiguous associated type `Color`
    |
    = help: consider introducing a new type parameter `T` and adding `where` constraints:
                where
@@ -46,7 +46,7 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
                    T: Box::Color = COLOR
 
 error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:31
    |
 LL |     type Color;
    |     ---------- `Vehicle::Color` defined here
@@ -54,8 +54,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- `Box::Color` defined here
 ...
-LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                              ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+LL | fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
+   |                               ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 
@@ -81,7 +81,7 @@ LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
    |                             ~~~~~~~~~~~~
 
 error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:33
    |
 LL |     type Color;
    |     ---------- `Vehicle::Color` defined here
@@ -89,8 +89,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- `Box::Color` defined here
 ...
-LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+LL | fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                 ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 

--- a/tests/ui/associated-types/issue-23595-1.rs
+++ b/tests/ui/associated-types/issue-23595-1.rs
@@ -7,6 +7,7 @@ trait Hierarchy {
     type ChildKey;
     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
     //~^ ERROR: the value of the associated types
+    //~| ERROR: the size for values of type
 
     fn data(&self) -> Option<(Self::Value, Self::Children)>;
 }

--- a/tests/ui/associated-types/issue-23595-1.stderr
+++ b/tests/ui/associated-types/issue-23595-1.stderr
@@ -8,6 +8,20 @@ LL |     type ChildKey;
 LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
    |     ------------- `Children` defined here                ^^^^^^^^^ help: specify the associated types: `Hierarchy<Value = Type, ChildKey = Type, Children = Type>`
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `(dyn Index<<Self as Hierarchy>::ChildKey, Output = (dyn Hierarchy + 'static)> + 'static)` cannot be known at compilation time
+  --> $DIR/issue-23595-1.rs:8:21
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Index<<Self as Hierarchy>::ChildKey, Output = (dyn Hierarchy + 'static)> + 'static)`
+note: required by a bound in `Hierarchy::Children`
+  --> $DIR/issue-23595-1.rs:8:5
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Hierarchy::Children`
 
-For more information about this error, try `rustc --explain E0191`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0191, E0277.
+For more information about an error, try `rustc --explain E0191`.

--- a/tests/ui/async-await/issues/issue-65159.rs
+++ b/tests/ui/async-await/issues/issue-65159.rs
@@ -5,7 +5,7 @@
 async fn copy() -> Result<()>
 //~^ ERROR enum takes 2 generic arguments
 {
-    Ok(())
+    Ok(()) //~ ERROR: type annotations needed
 }
 
 fn main() { }

--- a/tests/ui/async-await/issues/issue-65159.stderr
+++ b/tests/ui/async-await/issues/issue-65159.stderr
@@ -11,6 +11,18 @@ help: add missing generic argument
 LL | async fn copy() -> Result<(), E>
    |                             +++
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-65159.rs:8:5
+   |
+LL |     Ok(())
+   |     ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     Ok::<(), E>(())
+   |       +++++++++
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
@@ -9,5 +9,6 @@ trait Super1<'a> {
 
 impl Super1<'_, bar(): Send> for () {}
 //~^ ERROR associated type bindings are not allowed here
+//~| ERROR not all trait items implemented
 
 fn main() {}

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -13,6 +13,16 @@ error[E0229]: associated type bindings are not allowed here
 LL | impl Super1<'_, bar(): Send> for () {}
    |                 ^^^^^^^^^^^ associated type not allowed here
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0046]: not all trait items implemented, missing: `bar`
+  --> $DIR/rtn-in-impl-signature.rs:10:1
+   |
+LL |     fn bar<'b>() -> bool;
+   |     --------------------- `bar` from trait
+...
+LL | impl Super1<'_, bar(): Send> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bar` in implementation
 
-For more information about this error, try `rustc --explain E0229`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0046, E0229.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
@@ -26,7 +26,7 @@ LL |     let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:28:17
+  --> $DIR/async-closure-gate.rs:29:17
    |
 LL |         let _ = #[track_caller] || {
    |                 ^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |         let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:36:9
+  --> $DIR/async-closure-gate.rs:37:9
    |
 LL |         #[track_caller] || {
    |         ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:45:13
+  --> $DIR/async-closure-gate.rs:47:13
    |
 LL |             #[track_caller] || {
    |             ^^^^^^^^^^^^^^^
@@ -52,6 +52,40 @@ LL |             #[track_caller] || {
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:27:5
+   |
+LL |   fn foo3() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = #[track_caller] || {
+LL | |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:44:5
+   |
+LL |   fn foo5() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = || {
+LL | |             #[track_caller] || {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
@@ -26,7 +26,7 @@ LL |     let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:28:17
+  --> $DIR/async-closure-gate.rs:29:17
    |
 LL |         let _ = #[track_caller] || {
    |                 ^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |         let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:36:9
+  --> $DIR/async-closure-gate.rs:37:9
    |
 LL |         #[track_caller] || {
    |         ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:45:13
+  --> $DIR/async-closure-gate.rs:47:13
    |
 LL |             #[track_caller] || {
    |             ^^^^^^^^^^^^^^^
@@ -52,6 +52,40 @@ LL |             #[track_caller] || {
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:27:5
+   |
+LL |   fn foo3() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = #[track_caller] || {
+LL | |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:44:5
+   |
+LL |   fn foo5() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = || {
+LL | |             #[track_caller] || {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.rs
+++ b/tests/ui/async-await/track-caller/async-closure-gate.rs
@@ -25,6 +25,7 @@ async fn foo2() {
 
 fn foo3() {
     async {
+        //~^ ERROR mismatched types
         let _ = #[track_caller] || {
             //~^ ERROR `#[track_caller]` on closures is currently unstable [E0658]
         };
@@ -41,6 +42,7 @@ async fn foo4() {
 
 fn foo5() {
     async {
+        //~^ ERROR mismatched types
         let _ = || {
             #[track_caller] || {
                 //~^ ERROR `#[track_caller]` on closures is currently unstable [E0658]

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
@@ -17,6 +17,7 @@ async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
     //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument was supplied
     //~^^ ERROR struct takes 1 generic argument but 0 generic arguments were supplied
     LockedMarket(coroutine.lock().unwrap().buy())
+    //~^ ERROR: cannot return value referencing temporary value
 }
 
 struct LockedMarket<T>(T);

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -7,7 +7,7 @@ LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> 
    |                                                           expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
-  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:22:8
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:23:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> 
    |                                                           ^^^^^^^^^^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:22:8
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:23:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^ -
@@ -28,6 +28,16 @@ help: add missing generic argument
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_, T> {
    |                                                                          +++
 
-error: aborting due to 2 previous errors
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:19:5
+   |
+LL |     LockedMarket(coroutine.lock().unwrap().buy())
+   |     ^^^^^^^^^^^^^-------------------------^^^^^^^
+   |     |            |
+   |     |            temporary value created here
+   |     returns a value referencing data owned by the current function
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0515.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
@@ -9,9 +9,10 @@ pub trait Parse {
 }
 
 pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
-//~^ ERROR expected type, found variant
+//~^ ERROR expected constant, found type
 //~| ERROR expected constant, found type
 //~| ERROR expected constant, found type
+//~| ERROR expected type
 
 fn no_help() -> Mode::Cool {}
 //~^ ERROR expected type, found variant

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
@@ -8,7 +8,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                                   help: try using the variant's enum: `Mode`
 
 error[E0573]: expected type, found variant `Mode::Cool`
-  --> $DIR/assoc_const_eq_diagnostic.rs:16:17
+  --> $DIR/assoc_const_eq_diagnostic.rs:17:17
    |
 LL | fn no_help() -> Mode::Cool {}
    |                 ^^^^^^^^^^
@@ -53,6 +53,25 @@ help: consider adding braces here
 LL | pub trait CoolStuff: Parse<MODE = { Mode::Cool }> {}
    |                                   +            +
 
-error: aborting due to 4 previous errors
+error: expected constant, found type
+  --> $DIR/assoc_const_eq_diagnostic.rs:11:35
+   |
+LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+   |                            ----   ^^^^^^^^^^ unexpected type
+   |                            |
+   |                            expected a constant because of this associated constant
+   |
+note: the associated constant is defined here
+  --> $DIR/assoc_const_eq_diagnostic.rs:8:5
+   |
+LL |     const MODE: Mode;
+   |     ^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding braces here
+   |
+LL | pub trait CoolStuff: Parse<MODE = { Mode::Cool }> {}
+   |                                   +            +
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0573`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
@@ -9,6 +9,11 @@ const _: () = {
     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
     //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
     //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR `X` cannot be made into an object
 };
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -28,6 +28,86 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
 
-error: aborting due to 2 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                                +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^--- help: remove these generics
+   |                              |
+   |                              expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                                +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^--- help: remove these generics
+   |                              |
+   |                              expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/issue-102768.rs:9:24
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                        ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-105257.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105257.rs
@@ -3,6 +3,7 @@
 
 trait Trait<T> {
     fn fnc<const N: usize = "">(&self) {} //~ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+    //~^ ERROR: mismatched types
     fn foo<const N: usize = { std::mem::size_of::<T>() }>(&self) {} //~ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-105257.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105257.stderr
@@ -5,10 +5,17 @@ LL |     fn fnc<const N: usize = "">(&self) {}
    |            ^^^^^^^^^^^^^^^^^^^
 
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/issue-105257.rs:6:12
+  --> $DIR/issue-105257.rs:7:12
    |
 LL |     fn foo<const N: usize = { std::mem::size_of::<T>() }>(&self) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-105257.rs:5:29
+   |
+LL |     fn fnc<const N: usize = "">(&self) {}
+   |                             ^^ expected `usize`, found `&str`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
+++ b/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
@@ -4,5 +4,14 @@ error: cannot capture late-bound lifetime in constant
 LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
    |        -- lifetime defined here                     ^^
 
-error: aborting due to 1 previous error
+error: overly complex generic constant
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.rs
@@ -14,6 +14,7 @@ impl<const N: usize> Marker<N> for Example<N> {}
 fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
   //~^ ERROR: type provided when a constant was expected
   Example::<gimme_a_const!(marker)>
+  //~^ ERROR: type provided when a constant was expected
 }
 
 fn from_marker(_: impl Marker<{
@@ -33,7 +34,9 @@ fn main() {
   }>;
 
   let _fail = Example::<external_macro!()>;
+  //~^ ERROR: type provided when a constant was expected
 
   let _fail = Example::<gimme_a_const!()>;
   //~^ ERROR unexpected end of macro invocation
+  //~| ERROR: type provided when a constant was expected
 }

--- a/tests/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:28:27
+  --> $DIR/macro-fail.rs:29:27
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ----------------------
@@ -13,7 +13,7 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:28:27
+  --> $DIR/macro-fail.rs:29:27
    |
 LL |   Example::<gimme_a_const!(marker)>
    |             ----------------------
@@ -41,7 +41,7 @@ LL |   let _fail = Example::<external_macro!()>;
    = note: this error originates in the macro `external_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-  --> $DIR/macro-fail.rs:37:25
+  --> $DIR/macro-fail.rs:39:25
    |
 LL |     macro_rules! gimme_a_const {
    |     -------------------------- when calling this macro
@@ -50,7 +50,7 @@ LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$rusty:ident`
-  --> $DIR/macro-fail.rs:28:8
+  --> $DIR/macro-fail.rs:29:8
    |
 LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |        ^^^^^^^^^^^^^
@@ -61,6 +61,24 @@ error[E0747]: type provided when a constant was expected
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:16:13
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:36:25
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |                         ^^^^^^^^^^^^^^^^^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:39:25
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/consts/escaping-bound-var.rs
+++ b/tests/ui/consts/escaping-bound-var.rs
@@ -3,7 +3,7 @@
 
 fn test<'a>(
     _: &'a (),
-) -> [(); {
+) -> [(); { //~ ERROR: mismatched types
     let x: &'a ();
     //~^ ERROR cannot capture late-bound lifetime in constant
     1

--- a/tests/ui/consts/escaping-bound-var.stderr
+++ b/tests/ui/consts/escaping-bound-var.stderr
@@ -16,5 +16,23 @@ LL | fn test<'a>(
 LL |     let x: &'a ();
    |             ^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0308]: mismatched types
+  --> $DIR/escaping-bound-var.rs:6:6
+   |
+LL |   fn test<'a>(
+   |      ---- implicitly returns `()` as its body has no tail or `return` expression
+LL |       _: &'a (),
+LL |   ) -> [(); {
+   |  ______^
+LL | |     let x: &'a ();
+LL | |
+LL | |     1
+LL | | }] {
+   | |__^ expected `[(); {
+    let x: &'a ();
+    1
+}]`, found `()`
 
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-103790.rs
+++ b/tests/ui/consts/issue-103790.rs
@@ -6,5 +6,6 @@ struct S<const S: (), const S: S = { S }>;
 //~| ERROR missing generics for struct `S`
 //~| ERROR cycle detected when computing type of `S::S`
 //~| ERROR cycle detected when computing type of `S`
+//~| ERROR `()` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -61,7 +61,16 @@ LL | | fn main() {}
    | |____________^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 4 previous errors
+error: `()` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-103790.rs:4:19
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                   ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0107, E0391, E0403.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/derives/issue-97343.rs
+++ b/tests/ui/derives/issue-97343.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed on type parameter
+    //~^ ERROR `Irrelevant` must be used
     irrelevant: Irrelevant,
 }
 

--- a/tests/ui/derives/issue-97343.stderr
+++ b/tests/ui/derives/issue-97343.stderr
@@ -16,6 +16,16 @@ LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0210]: type parameter `Irrelevant` must be used as the type parameter for some local type (e.g., `MyStruct<Irrelevant>`)
+  --> $DIR/issue-97343.rs:4:23
+   |
+LL | pub struct Irrelevant<Irrelevant> {
+   |                       ^^^^^^^^^^ type parameter `Irrelevant` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
-For more information about this error, try `rustc --explain E0109`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0109, E0210.
+For more information about an error, try `rustc --explain E0109`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -71,6 +71,7 @@ enum N<F> where F: Fn() -> _ {
 union O<F> where F: Fn() -> _ {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for unions
     foo: F,
+    //~^ ERROR must implement `Copy`
 }
 
 trait P<F> where F: Fn() -> _ {

--- a/tests/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.stderr
@@ -299,7 +299,7 @@ LL | union O<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
@@ -310,7 +310,7 @@ LL | trait P<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:81:38
+  --> $DIR/bad-assoc-ty.rs:82:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
    |                                      ^ not allowed in type signatures
@@ -320,7 +320,19 @@ help: use type parameters instead
 LL |     fn foo<F, T>(_: F) where F: Fn() -> T {}
    |             +++                         ~
 
-error: aborting due to 28 previous errors; 1 warning emitted
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/bad-assoc-ty.rs:73:5
+   |
+LL |     foo: F,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     foo: std::mem::ManuallyDrop<F>,
+   |          +++++++++++++++++++++++ +
 
-Some errors have detailed explanations: E0121, E0223.
+error: aborting due to 29 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0121, E0223, E0740.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
@@ -8,6 +8,7 @@ trait Foo<T>: Sized {
 impl Foo<usize> for () {
     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~| ERROR type annotations needed
         (1, 2)
     }
 }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
@@ -8,6 +8,7 @@ trait Foo<T>: Sized {
 impl Foo<usize> for () {
     fn bar(i: _, t: _, s: _) -> _ {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~| ERROR type annotations needed
         (1, 2)
     }
 }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
@@ -13,6 +13,13 @@ help: try replacing `_` with the types in the corresponding trait method signatu
 LL |     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
    |               ~~~     ~~~~~     ~~~     ~~~~~~~~~~~~
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:12
+   |
+LL |     fn bar(i: _, t: _, s: _) -> _ {
+   |            ^ cannot infer type
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0121, E0282.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
@@ -4,6 +4,7 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
     let _x: &SomeTrait = todo!();
+    //~^ ERROR trait objects must include the `dyn` keyword
 }
 
 trait SomeTrait {}

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -20,6 +20,17 @@ help: add `dyn` keyword before this trait
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    |                                   +++
 
-error: aborting due to 2 previous errors
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/dyn-2021-edition-error.rs:6:14
+   |
+LL |     let _x: &SomeTrait = todo!();
+   |              ^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL |     let _x: &dyn SomeTrait = todo!();
+   |              +++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/error-codes/E0227.rs
+++ b/tests/ui/error-codes/E0227.rs
@@ -6,6 +6,7 @@ trait FooBar<'foo, 'bar>: Foo<'foo> + Bar<'bar> {}
 struct Baz<'foo, 'bar> {
     baz: dyn FooBar<'foo, 'bar>,
     //~^ ERROR ambiguous lifetime bound, explicit lifetime bound required
+    //~| ERROR lifetime bound not satisfied
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0227.stderr
+++ b/tests/ui/error-codes/E0227.stderr
@@ -4,6 +4,24 @@ error[E0227]: ambiguous lifetime bound, explicit lifetime bound required
 LL |     baz: dyn FooBar<'foo, 'bar>,
    |          ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/E0227.rs:7:10
+   |
+LL |     baz: dyn FooBar<'foo, 'bar>,
+   |          ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lifetime parameter instantiated with the lifetime `'bar` as defined here
+  --> $DIR/E0227.rs:6:18
+   |
+LL | struct Baz<'foo, 'bar> {
+   |                  ^^^^
+note: but lifetime parameter must outlive the lifetime `'foo` as defined here
+  --> $DIR/E0227.rs:6:12
+   |
+LL | struct Baz<'foo, 'bar> {
+   |            ^^^^
 
-For more information about this error, try `rustc --explain E0227`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0227, E0478.
+For more information about an error, try `rustc --explain E0227`.

--- a/tests/ui/error-codes/E0229.rs
+++ b/tests/ui/error-codes/E0229.rs
@@ -12,6 +12,9 @@ impl Foo for isize {
 
 fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
 //~^ ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR the trait bound `I: Foo` is not satisfied
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -4,6 +4,34 @@ error[E0229]: associated type bindings are not allowed here
 LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
    |                         ^^^^^ associated type not allowed here
 
-error: aborting due to 1 previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/E0229.rs:13:25
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                         ^^^^^ associated type not allowed here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-For more information about this error, try `rustc --explain E0229`.
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/E0229.rs:13:25
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                         ^^^^^ associated type not allowed here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `I: Foo` is not satisfied
+  --> $DIR/E0229.rs:13:15
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |               ^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `I`
+   |
+help: consider restricting type parameter `I`
+   |
+LL | fn baz<I: Foo>(x: &<I as Foo<A=Bar>>::A) {}
+   |         +++++
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/error-codes/E0719.rs
+++ b/tests/ui/error-codes/E0719.rs
@@ -1,6 +1,7 @@
 trait Foo: Iterator<Item = i32, Item = i32> {}
 //~^ ERROR is already specified
 //~| ERROR is already specified
+//~| ERROR is already specified
 
 type Unit = ();
 
@@ -11,5 +12,6 @@ fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
 
 fn main() {
     let _: &dyn Iterator<Item = i32, Item = i32>;
+    //~^ ERROR already specified
     test();
 }

--- a/tests/ui/error-codes/E0719.stderr
+++ b/tests/ui/error-codes/E0719.stderr
@@ -17,13 +17,31 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/E0719.rs:7:42
+  --> $DIR/E0719.rs:8:42
    |
 LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
    |                               ---------  ^^^^^^^^^^^ re-bound here
    |                               |
    |                               `Item` bound here first
 
-error: aborting due to 3 previous errors
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:1:33
+   |
+LL | trait Foo: Iterator<Item = i32, Item = i32> {}
+   |                     ----------  ^^^^^^^^^^ re-bound here
+   |                     |
+   |                     `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:14:38
+   |
+LL |     let _: &dyn Iterator<Item = i32, Item = i32>;
+   |                          ----------  ^^^^^^^^^^ re-bound here
+   |                          |
+   |                          `Item` bound here first
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0719`.

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for () {
     type Bar = impl std::fmt::Debug;
     //~^ ERROR: `impl Trait` in associated types is unstable
+    //~| ERROR: unconstrained opaque type
 }
 
 struct Mop;
@@ -13,6 +14,7 @@ impl Mop {
     type Bop = impl std::fmt::Debug;
     //~^ ERROR: `impl Trait` in associated types is unstable
     //~| ERROR: inherent associated types are unstable
+    //~| ERROR: unconstrained opaque type
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
@@ -8,7 +8,7 @@ LL |     type Bar = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in associated types is unstable
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:16
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
    |
 LL |     type Bop = impl std::fmt::Debug;
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     type Bop = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: inherent associated types are unstable
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:5
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:5
    |
 LL |     type Bop = impl std::fmt::Debug;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,6 +25,22 @@ LL |     type Bop = impl std::fmt::Debug;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16
+   |
+LL |     type Bar = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bar` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
+   |
+LL |     type Bop = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bop` must be used in combination with a concrete type within the same impl
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
@@ -7,29 +7,35 @@
 
 struct Foo;
 impl Fn<()> for Foo {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `Fn` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `Fn` are experimental
+    //~| ERROR expected a `FnMut()` closure, found `Foo`
     extern "rust-call" fn call(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
+    //~| ERROR `call` has an incompatible type for trait
 }
 struct Foo1;
 impl FnOnce() for Foo1 {
-//~^ ERROR associated type bindings are not allowed here
-//~| ERROR manual implementations of `FnOnce` are experimental
+    //~^ ERROR associated type bindings are not allowed here
+    //~| ERROR manual implementations of `FnOnce` are experimental
+    //~| ERROR not all trait items implemented
     extern "rust-call" fn call_once(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }
 struct Bar;
 impl FnMut<()> for Bar {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `FnMut` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `FnMut` are experimental
+    //~| ERROR expected a `FnOnce()` closure, found `Bar`
     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
+    //~| ERROR incompatible type for trait
 }
 struct Baz;
 impl FnOnce<()> for Baz {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `FnOnce` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `FnOnce` are experimental
+    //~| ERROR not all trait items implemented
     extern "rust-call" fn call_once(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -1,5 +1,5 @@
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:12:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:12
    |
 LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:19:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:22:12
    |
 LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:12
    |
 LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:33:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:39:12
    |
 LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL | impl Fn<()> for Foo {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ manual implementations of `FnOnce` are experimental
@@ -60,19 +60,19 @@ LL | impl FnOnce() for Foo1 {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ associated type not allowed here
    |
 help: parenthesized trait syntax expands to `FnOnce<(), Output=()>`
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^
@@ -81,7 +81,7 @@ LL | impl FnMut<()> for Bar {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnMut` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^ manual implementations of `FnMut` are experimental
@@ -89,7 +89,7 @@ LL | impl FnMut<()> for Bar {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
    |
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^
@@ -98,14 +98,76 @@ LL | impl FnOnce<()> for Baz {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
    |
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 12 previous errors
+error[E0277]: expected a `FnMut()` closure, found `Foo`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:17
+   |
+LL | impl Fn<()> for Foo {
+   |                 ^^^ expected an `FnMut()` closure, found `Foo`
+   |
+   = help: the trait `FnMut<()>` is not implemented for `Foo`
+   = note: wrap the `Foo` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0229, E0658.
-For more information about an error, try `rustc --explain E0183`.
+error[E0053]: method `call` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:32
+   |
+LL |     extern "rust-call" fn call(self, args: ()) -> () {}
+   |                                ^^^^
+   |                                |
+   |                                expected `&Foo`, found `Foo`
+   |                                help: change the self-receiver type to match the trait: `&self`
+   |
+   = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
+              found signature `extern "rust-call" fn(Foo, ())`
+
+error[E0046]: not all trait items implemented, missing: `Output`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:1
+   |
+LL | impl FnOnce() for Foo1 {
+   | ^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+
+error[E0277]: expected a `FnOnce()` closure, found `Bar`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:20
+   |
+LL | impl FnMut<()> for Bar {
+   |                    ^^^ expected an `FnOnce()` closure, found `Bar`
+   |
+   = help: the trait `FnOnce<()>` is not implemented for `Bar`
+   = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `FnMut`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error[E0053]: method `call_mut` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:36
+   |
+LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
+   |                                    ^^^^^
+   |                                    |
+   |                                    types differ in mutability
+   |                                    help: change the self-receiver type to match the trait: `&mut self`
+   |
+   = note: expected signature `extern "rust-call" fn(&mut Bar, ()) -> _`
+              found signature `extern "rust-call" fn(&Bar, ())`
+
+error[E0046]: not all trait items implemented, missing: `Output`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:1
+   |
+LL | impl FnOnce<()> for Baz {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+
+error: aborting due to 18 previous errors
+
+Some errors have detailed explanations: E0046, E0053, E0183, E0229, E0277, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/fn/issue-39259.rs
+++ b/tests/ui/fn/issue-39259.rs
@@ -4,8 +4,10 @@
 struct S;
 
 impl Fn(u32) -> u32 for S {
-//~^ ERROR associated type bindings are not allowed here [E0229]
+    //~^ ERROR associated type bindings are not allowed here [E0229]
+    //~| ERROR expected a `FnMut(u32)` closure, found `S`
     fn call(&self) -> u32 {
+        //~^ ERROR method `call` has 1 parameter but the declaration in trait `call` has 2
         5
     }
 }

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -10,6 +10,25 @@ help: parenthesized trait syntax expands to `Fn<(u32,), Output=u32>`
 LL | impl Fn(u32) -> u32 for S {
    |      ^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: expected a `FnMut(u32)` closure, found `S`
+  --> $DIR/issue-39259.rs:6:25
+   |
+LL | impl Fn(u32) -> u32 for S {
+   |                         ^ expected an `FnMut(u32)` closure, found `S`
+   |
+   = help: the trait `FnMut<(u32,)>` is not implemented for `S`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0229`.
+error[E0050]: method `call` has 1 parameter but the declaration in trait `call` has 2
+  --> $DIR/issue-39259.rs:9:13
+   |
+LL |     fn call(&self) -> u32 {
+   |             ^^^^^ expected 2 parameters, found 1
+   |
+   = note: `call` from trait: `extern "rust-call" fn(&Self, Args) -> <Self as FnOnce<Args>>::Output`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0050, E0229, E0277.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
@@ -6,4 +6,7 @@ fn main() {
   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
     //~^ ERROR: use of undeclared lifetime name `'x`
     //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: the trait `X` cannot be made into an object
 }

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
@@ -20,7 +20,38 @@ error[E0582]: binding for associated type `Y` references lifetime `'a`, which do
 LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
    |                                 ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0582]: binding for associated type `Y` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:33
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-Some errors have detailed explanations: E0261, E0582.
-For more information about an error, try `rustc --explain E0261`.
+error[E0582]: binding for associated type `Y` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:33
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:19
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'x>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0038, E0261, E0582.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
@@ -4,10 +4,11 @@ trait X {
   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
 }
 
-impl<T> X for T {
+impl<T> X for T { //~ ERROR: not all trait items implemented
   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
     //~^ ERROR missing generics for associated type
     //~^^ ERROR missing generics for associated type
+    //~| ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
     t
   }
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -31,6 +31,27 @@ help: add missing lifetime argument
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
    |                     ++++
 
-error: aborting due to 2 previous errors
+error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/gat-trait-path-missing-lifetime.rs:8:10
+   |
+LL |   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
+   |          -- expected 0 type parameters
+...
+LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
+   |          ^^  ^^
+   |          |
+   |          found 1 type parameter
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0046]: not all trait items implemented, missing: `Y`
+  --> $DIR/gat-trait-path-missing-lifetime.rs:7:1
+   |
+LL |   type Y<'a>;
+   |   ---------- `Y` from trait
+...
+LL | impl<T> X for T {
+   | ^^^^^^^^^^^^^^^ missing `Y` in implementation
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0049, E0107.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
@@ -7,10 +7,19 @@ fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
   //~| ERROR: parenthesized generic arguments cannot be used
   //~| ERROR associated type takes 0 generic arguments but 1 generic argument
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR at least one trait is required
+  //~| ERROR: the trait `X` cannot be made into an object
 
 
 fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
   //~^ ERROR: parenthesized generic arguments cannot be used
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR: the trait `X` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -16,7 +16,7 @@ LL | fn foo<'a>(arg: Box<dyn X<Y<'a> = &'a ()>>) {}
    |                            ~  ~
 
 error: parenthesized generic arguments cannot be used in associated type constraints
-  --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                           ^--
@@ -54,7 +54,7 @@ LL |   type Y<'a>;
    |        ^
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                           ^ expected 1 lifetime argument
@@ -69,6 +69,141 @@ help: add missing lifetime argument
 LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
    |                             ++
 
-error: aborting due to 6 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
+   |                             +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^---- help: remove these generics
+   |                           |
+   |                           expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
+   |                             +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^---- help: remove these generics
+   |                           |
+   |                           expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:29
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                             ^^
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:21
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                     ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'a>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:21
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                     ^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'a>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0038, E0107, E0224.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-71176.rs
+++ b/tests/ui/generic-associated-types/issue-71176.rs
@@ -9,6 +9,9 @@ impl Provider for () {
 struct Holder<B> {
   inner: Box<dyn Provider<A = B>>,
   //~^ ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: the trait `Provider` cannot be made into an object
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-71176.stderr
+++ b/tests/ui/generic-associated-types/issue-71176.stderr
@@ -14,6 +14,57 @@ help: add missing lifetime argument
 LL |   inner: Box<dyn Provider<A<'a> = B>>,
    |                            ++++
 
-error: aborting due to 1 previous error
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
+
+error[E0038]: the trait `Provider` cannot be made into an object
+  --> $DIR/issue-71176.rs:10:14
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |              ^^^^^^^^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL | trait Provider {
+   |       -------- this trait cannot be made into an object...
+LL |     type A<'a>;
+   |          ^ ...because it contains the generic associated type `A`
+   = help: consider moving `A` to another trait
+   = help: only type `()` implements the trait, consider using it directly instead
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-79636-1.rs
+++ b/tests/ui/generic-associated-types/issue-79636-1.rs
@@ -3,6 +3,7 @@ trait Monad {
     type Wrapped<B>;
 
     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+        //~^ ERROR: the size for values of type `Self` cannot be known
         todo!()
     }
 }
@@ -14,8 +15,10 @@ where
     //~^ ERROR: missing generics for associated type `Monad::Wrapped`
 {
     outer.bind(|inner| inner)
+    //~^ ERROR type annotations needed
 }
 
 fn main() {
     assert_eq!(join(Some(Some(true))), Some(true));
+    //~^ ERROR: `Option<Option<bool>>: Monad` is not satisfied
 }

--- a/tests/ui/generic-associated-types/issue-79636-1.stderr
+++ b/tests/ui/generic-associated-types/issue-79636-1.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for associated type `Monad::Wrapped`
-  --> $DIR/issue-79636-1.rs:13:34
+  --> $DIR/issue-79636-1.rs:14:34
    |
 LL |     MInner: Monad<Unwrapped = A, Wrapped = MOuter::Wrapped<A>>,
    |                                  ^^^^^^^ expected 1 generic argument
@@ -14,6 +14,56 @@ help: add missing generic argument
 LL |     MInner: Monad<Unwrapped = A, Wrapped<B> = MOuter::Wrapped<A>>,
    |                                         +++
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-79636-1.rs:5:19
+   |
+LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+   |                   ^^^^ doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider further restricting `Self`
+   |
+LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> where Self: Sized {
+   |                                                   +++++++++++++++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     fn bind<B, F>(&self, f: F) -> Self::Wrapped<B> {
+   |                   +
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0282]: type annotations needed
+  --> $DIR/issue-79636-1.rs:17:17
+   |
+LL |     outer.bind(|inner| inner)
+   |                 ^^^^^
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     outer.bind(|inner: /* Type */| inner)
+   |                      ++++++++++++
+
+error[E0277]: the trait bound `Option<Option<bool>>: Monad` is not satisfied
+  --> $DIR/issue-79636-1.rs:22:21
+   |
+LL |     assert_eq!(join(Some(Some(true))), Some(true));
+   |                ---- ^^^^^^^^^^^^^^^^ the trait `Monad` is not implemented for `Option<Option<bool>>`
+   |                |
+   |                required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/issue-79636-1.rs:1:1
+   |
+LL | trait Monad {
+   | ^^^^^^^^^^^
+note: required by a bound in `join`
+  --> $DIR/issue-79636-1.rs:13:13
+   |
+LL | fn join<MOuter, MInner, A>(outer: MOuter) -> MOuter::Wrapped<A>
+   |    ---- required by a bound in this function
+LL | where
+LL |     MOuter: Monad<Unwrapped = MInner>,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `join`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0277, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -4,7 +4,7 @@ struct E<T> {
 }
 
 trait TestMut {
-    type Output<'a>;
+    type Output<'a>; //~ ERROR missing required bound
     fn test_mut<'a>(&'a mut self) -> Self::Output<'a>;
 }
 

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -14,6 +14,17 @@ help: add missing lifetime argument
 LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output<'a> = &'a mut f32>)
    |                                                     ++++
 
-error: aborting due to 1 previous error
+error: missing required bound on `Output`
+  --> $DIR/issue-80433.rs:7:5
+   |
+LL |     type Output<'a>;
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/missing_lifetime_args.rs
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.rs
@@ -10,6 +10,9 @@ struct Foo<'a, 'b, 'c> {
 
 fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
 //~^ ERROR missing generics for associated type
+//~| ERROR missing generics for associated type
+//~| ERROR missing generics for associated type
+//~| ERROR the trait `X` cannot be made into an object
 
 fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
 //~^ ERROR struct takes 3 lifetime arguments but 2 lifetime

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -15,7 +15,7 @@ LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
    |                                 ++++++++
 
 error[E0107]: struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/missing_lifetime_args.rs:14:26
+  --> $DIR/missing_lifetime_args.rs:17:26
    |
 LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
    |                          ^^^ --  -- supplied 2 lifetime arguments
@@ -33,7 +33,7 @@ LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b, 'a>) {}
    |                                    ++++
 
 error[E0107]: struct takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing_lifetime_args.rs:17:16
+  --> $DIR/missing_lifetime_args.rs:20:16
    |
 LL | fn f<'a>(_arg: Foo<'a>) {}
    |                ^^^ -- supplied 1 lifetime argument
@@ -50,6 +50,56 @@ help: add missing lifetime arguments
 LL | fn f<'a>(_arg: Foo<'a, 'a, 'a>) {}
    |                      ++++++++
 
-error: aborting due to 3 previous errors
+error[E0107]: missing generics for associated type `X::Y`
+  --> $DIR/missing_lifetime_args.rs:11:32
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                                ^ expected 2 lifetime arguments
+   |
+note: associated type defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL |     type Y<'a, 'b>;
+   |          ^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime arguments
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
+   |                                 ++++++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `X::Y`
+  --> $DIR/missing_lifetime_args.rs:11:32
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                                ^ expected 2 lifetime arguments
+   |
+note: associated type defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL |     type Y<'a, 'b>;
+   |          ^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime arguments
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
+   |                                 ++++++++
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/missing_lifetime_args.rs:11:26
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a, 'b>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
@@ -6,6 +6,11 @@ const _: () = {
   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
       //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
       //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR the trait `X` cannot be made into an object
 };
 
 fn main() {}

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -28,6 +28,86 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
 
-error: aborting due to 2 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                               +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^--- help: remove these generics
+   |                             |
+   |                             expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                               +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^--- help: remove these generics
+   |                             |
+   |                             expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:23
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                       ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/type-param-defaults.rs
+++ b/tests/ui/generic-associated-types/type-param-defaults.rs
@@ -29,6 +29,8 @@ where
 fn main() {
     // errors
     foo::<()>();
+    //~^ ERROR type mismatch
+    //~| ERROR `u64: Other` is not satisfied
     // works
     foo::<u32>();
 }

--- a/tests/ui/generic-associated-types/type-param-defaults.stderr
+++ b/tests/ui/generic-associated-types/type-param-defaults.stderr
@@ -16,5 +16,43 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 LL |     type Assoc<T = u32> = T;
    |                ^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0271]: type mismatch resolving `<() as Trait>::Assoc == u32`
+  --> $DIR/type-param-defaults.rs:31:11
+   |
+LL |     foo::<()>();
+   |           ^^ type mismatch resolving `<() as Trait>::Assoc == u32`
+   |
+note: expected this to be `u32`
+  --> $DIR/type-param-defaults.rs:11:27
+   |
+LL |     type Assoc<T = u32> = u64;
+   |                           ^^^
+note: required by a bound in `foo`
+  --> $DIR/type-param-defaults.rs:25:14
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this function
+LL | where
+LL |     T: Trait<Assoc = u32>,
+   |              ^^^^^^^^^^^ required by this bound in `foo`
 
+error[E0277]: the trait bound `u64: Other` is not satisfied
+  --> $DIR/type-param-defaults.rs:31:11
+   |
+LL |     foo::<()>();
+   |           ^^ the trait `Other` is not implemented for `u64`
+   |
+   = help: the trait `Other` is implemented for `u32`
+note: required by a bound in `foo`
+  --> $DIR/type-param-defaults.rs:26:15
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this function
+...
+LL |     T::Assoc: Other {
+   |               ^^^^^ required by this bound in `foo`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/generic-const-items/parameter-defaults.rs
+++ b/tests/ui/generic-const-items/parameter-defaults.rs
@@ -11,4 +11,5 @@ const NONE<T = ()>: Option<T> = None::<T>; //~ ERROR defaults for type parameter
 
 fn main() {
     let _ = NONE;
+    //~^ ERROR type annotations needed
 }

--- a/tests/ui/generic-const-items/parameter-defaults.stderr
+++ b/tests/ui/generic-const-items/parameter-defaults.stderr
@@ -4,5 +4,17 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 LL | const NONE<T = ()>: Option<T> = None::<T>;
    |            ^^^^^^
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed for `Option<T>`
+  --> $DIR/parameter-defaults.rs:13:9
+   |
+LL |     let _ = NONE;
+   |         ^
+   |
+help: consider giving this pattern a type, where the type for type parameter `T` is specified
+   |
+LL |     let _: Option<T> = NONE;
+   |          +++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/generics/wrong-number-of-args.rs
+++ b/tests/ui/generics/wrong-number-of-args.rs
@@ -21,7 +21,7 @@ mod no_generics {
 }
 
 mod type_and_type {
-    struct Ty<A, B>;
+    struct Ty<A, B>(A, B);
 
     type A = Ty;
     //~^ ERROR missing generics for struct `type_and_type::Ty`
@@ -43,7 +43,7 @@ mod type_and_type {
 }
 
 mod lifetime_and_type {
-    struct Ty<'a, T>;
+    struct Ty<'a, T>(&'a T);
 
     type A = Ty;
     //~^ ERROR missing generics for struct
@@ -75,7 +75,7 @@ mod lifetime_and_type {
 }
 
 mod type_and_type_and_type {
-    struct Ty<A, B, C = &'static str>;
+    struct Ty<A, B, C = &'static str>(A, B, C);
 
     type A = Ty;
     //~^ ERROR missing generics for struct `type_and_type_and_type::Ty`

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -246,7 +246,7 @@ LL |     type A = Ty;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -264,7 +264,7 @@ LL |     type B = Ty<usize>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic argument
    |
@@ -282,7 +282,7 @@ LL |     type D = Ty<usize, String, char>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 
 error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
@@ -294,7 +294,7 @@ LL |     type E = Ty<>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -310,7 +310,7 @@ LL |     type A = Ty;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -326,7 +326,7 @@ LL |     type B = Ty<'static>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -342,7 +342,7 @@ LL |     type E = Ty<>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -360,7 +360,7 @@ LL |     type F = Ty<'static, usize, 'static, usize>;
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^ --
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
@@ -374,7 +374,7 @@ LL |     type F = Ty<'static, usize, 'static, usize>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
@@ -386,7 +386,7 @@ LL |     type A = Ty;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -404,7 +404,7 @@ LL |     type B = Ty<usize>;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic argument
    |
@@ -422,7 +422,7 @@ LL |     type E = Ty<usize, String, char, f64>;
 note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -  ----------------
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
@@ -434,7 +434,7 @@ LL |     type F = Ty<>;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic arguments
    |

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied
+  --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:13
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not implemented for `()`
+
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:24
    |
@@ -9,6 +15,7 @@ help: add `dyn` keyword before this trait
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0782`.
+Some errors have detailed explanations: E0277, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
@@ -6,6 +6,7 @@
 fn ice() -> impl AsRef<Fn(&())> {
     //[edition2015]~^ ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     //[edition2021]~^^ ERROR: trait objects must include the `dyn` keyword [E0782]
+    //[edition2021]~| ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     todo!()
 }
 

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -4,16 +4,19 @@ use std::fmt::Debug;
 fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn d() -> impl Fn() -> (impl Debug + '_) {

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-fn-hrtb-bounds.rs:19:38
+  --> $DIR/impl-fn-hrtb-bounds.rs:22:38
    |
 LL | fn d() -> impl Fn() -> (impl Debug + '_) {
    |                                      ^^ expected named lifetime parameter
@@ -23,29 +23,56 @@ LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
    |                   ^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:10:52
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:10:20
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:16:52
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:16:20
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                    ^^
 
-error: aborting due to 4 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:6:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:12:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:18:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
@@ -5,6 +5,7 @@ fn a() -> impl Fn(&u8) -> impl Debug + '_ {
     //~^ ERROR ambiguous `+` in a type
     //~| ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl Fn() -> impl Debug + Send {

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -5,7 +5,7 @@ LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
 
 error: ambiguous `+` in a type
-  --> $DIR/impl-fn-parsing-ambiguities.rs:10:24
+  --> $DIR/impl-fn-parsing-ambiguities.rs:11:24
    |
 LL | fn b() -> impl Fn() -> impl Debug + Send {
    |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
@@ -22,5 +22,14 @@ note: lifetime declared here
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                   ^
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-parsing-ambiguities.rs:7:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/impl-trait/impl_trait_projections.rs
+++ b/tests/ui/impl-trait/impl_trait_projections.rs
@@ -15,7 +15,7 @@ fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
     x.next().unwrap()
 }
 
-fn projection_with_named_trait_is_disallowed(x: impl Iterator)
+fn projection_with_named_trait_is_disallowed(mut x: impl Iterator)
     -> <impl Iterator as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
 {
@@ -25,7 +25,9 @@ fn projection_with_named_trait_is_disallowed(x: impl Iterator)
 fn projection_with_named_trait_inside_path_is_disallowed()
     -> <::std::ops::Range<impl Debug> as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
+//~| ERROR `impl Debug: Step` is not satisfied
 {
+    //~^ ERROR `impl Debug: Step` is not satisfied
     (1i32..100).next().unwrap()
 }
 

--- a/tests/ui/impl-trait/impl_trait_projections.stderr
+++ b/tests/ui/impl-trait/impl_trait_projections.stderr
@@ -17,7 +17,7 @@ LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
    |                           ^^^^^^^^^^
 
 error[E0667]: `impl Trait` is not allowed in path parameters
-  --> $DIR/impl_trait_projections.rs:33:29
+  --> $DIR/impl_trait_projections.rs:35:29
    |
 LL |     -> <dyn Iterator<Item = impl Debug> as Iterator>::Item
    |                             ^^^^^^^^^^
@@ -28,6 +28,46 @@ error[E0667]: `impl Trait` is not allowed in path parameters
 LL | fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
    |                                                   ^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0277]: the trait bound `impl Debug: Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:26:8
+   |
+LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Step` is not implemented for `impl Debug`
+   |
+   = help: the following other types implement trait `Step`:
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+           and 8 others
+   = note: required for `std::ops::Range<impl Debug>` to implement `Iterator`
 
-For more information about this error, try `rustc --explain E0667`.
+error[E0277]: the trait bound `impl Debug: Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:29:1
+   |
+LL | / {
+LL | |
+LL | |     (1i32..100).next().unwrap()
+LL | | }
+   | |_^ the trait `Step` is not implemented for `impl Debug`
+   |
+   = help: the following other types implement trait `Step`:
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+           and 8 others
+   = note: required for `std::ops::Range<impl Debug>` to implement `Iterator`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0667.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/implicit-capture-late.stderr
+++ b/tests/ui/impl-trait/implicit-capture-late.stderr
@@ -4,6 +4,12 @@ error[E0657]: `impl Trait` can only capture lifetimes bound at the fn or impl le
 LL | fn foo(x: Vec<i32>) -> Box<dyn for<'a> Deref<Target = impl ?Sized>> {
    |                                    ^^
 
-error: aborting due to 1 previous error
+error: [o]
+  --> $DIR/implicit-capture-late.rs:10:55
+   |
+LL | fn foo(x: Vec<i32>) -> Box<dyn for<'a> Deref<Target = impl ?Sized>> {
+   |                                                       ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/issues/issue-67830.rs
+++ b/tests/ui/impl-trait/issues/issue-67830.rs
@@ -21,6 +21,8 @@ struct A;
 fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     Wrap(|a| Some(a).into_iter())
+    //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR implementation of `FnOnce` is not general enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-67830.stderr
+++ b/tests/ui/impl-trait/issues/issue-67830.stderr
@@ -10,5 +10,24 @@ note: lifetime declared here
 LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
    |                       ^^
 
-error: aborting due to 1 previous error
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/issue-67830.rs:23:5
+   |
+LL |     Wrap(|a| Some(a).into_iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
+
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/issue-67830.rs:23:5
+   |
+LL |     Wrap(|a| Some(a).into_iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-88236-2.rs
+++ b/tests/ui/impl-trait/issues/issue-88236-2.rs
@@ -18,11 +18,16 @@ fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
 fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     &()
+    //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR implementation of `Hrtb` is not general enough
 }
 
 fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     x
+    //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236-2.stderr
@@ -23,16 +23,70 @@ LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Sen
    |                                               ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/issue-88236-2.rs:23:78
+  --> $DIR/issue-88236-2.rs:25:78
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                                                              ^^
    |
 note: lifetime declared here
-  --> $DIR/issue-88236-2.rs:23:45
+  --> $DIR/issue-88236-2.rs:25:45
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                             ^^
 
-error: aborting due to 3 previous errors
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:20:5
+   |
+LL |     &()
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:20:5
+   |
+LL |     &()
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'a>` would have to be implemented for the type `&()`
+   = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                  -- lifetime `'b` defined here
+LL |
+LL |     x
+   |     ^ returning this value requires that `'b` must outlive `'static`
+   |
+help: to declare that `impl for<'a> Hrtb<'a, Assoc = impl Send + '_>` captures data from argument `x`, you can add an explicit `'b` lifetime bound
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> + 'b {
+   |                                                                                  ++++
+help: to declare that `impl Send + 'a` captures data from argument `x`, you can add an explicit `'b` lifetime bound
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a + 'b> {
+   |                                                                                 ++++
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL |     x
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL |     x
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'a>` would have to be implemented for the type `&()`
+   = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-92305.rs
+++ b/tests/ui/impl-trait/issues/issue-92305.rs
@@ -5,6 +5,7 @@ use std::iter;
 fn f<T>(data: &[T]) -> impl Iterator<Item = Vec> {
     //~^ ERROR: missing generics for struct `Vec` [E0107]
     iter::empty()
+    //~^ ERROR: type annotations needed
 }
 
 fn g<T>(data: &[T], target: T) -> impl Iterator<Item = Vec<T>> {

--- a/tests/ui/impl-trait/issues/issue-92305.stderr
+++ b/tests/ui/impl-trait/issues/issue-92305.stderr
@@ -9,6 +9,18 @@ help: add missing generic argument
 LL | fn f<T>(data: &[T]) -> impl Iterator<Item = Vec<T>> {
    |                                                +++
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-92305.rs:7:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -31,9 +31,11 @@ fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
 
 fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
 //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+//~| ERROR implementation of `Bar` is not general enough
 
 fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
 //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+//~| ERROR: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param<'b>() -> impl for<'a> Foo<'a, Assoc = impl Qux<'b>> {}
@@ -43,9 +45,11 @@ fn one_hrtb_mention_fn_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl Sized
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
+//~^ ERROR: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+//~^ ERROR implementation of `Bar` is not general enough
 
 // This should resolve.
 fn two_htrb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Qux<'b>> {}
@@ -56,9 +60,11 @@ fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> 
 
 // This should resolve.
 fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
+//~^ ERROR: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
 
 // `'b` is not in scope for the outlives bound.
 fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
 //~^ ERROR use of undeclared lifetime name `'b` [E0261]
+//~| ERROR implementation of `Bar` is not general enough
 
 fn main() {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:54:77
+  --> $DIR/nested-rpit-hrtb.rs:58:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:61:82
+  --> $DIR/nested-rpit-hrtb.rs:66:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -66,17 +66,72 @@ LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a
    |                                         ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/nested-rpit-hrtb.rs:35:73
+  --> $DIR/nested-rpit-hrtb.rs:36:73
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                                                         ^^
    |
 note: lifetime declared here
-  --> $DIR/nested-rpit-hrtb.rs:35:44
+  --> $DIR/nested-rpit-hrtb.rs:36:44
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
 
-error: aborting due to 6 previous errors
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:32:78
+   |
+LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
+   |                                                                              ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
-For more information about this error, try `rustc --explain E0261`.
+error[E0277]: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:36:64
+   |
+LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
+   |                                                                ^^^^^^^^^^^^ the trait `for<'a> Qux<'_>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:47:79
+   |
+LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
+   |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:51:93
+   |
+LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+   |                                                                                             ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
+
+error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:62:64
+   |
+LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
+   |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:66:86
+   |
+LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
+   |                                                                                      ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0261, E0277.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/intrinsics/safe-intrinsic-mismatch.rs
+++ b/tests/ui/intrinsics/safe-intrinsic-mismatch.rs
@@ -3,9 +3,11 @@
 
 extern "rust-intrinsic" {
     fn size_of<T>() -> usize; //~ ERROR intrinsic safety mismatch
+    //~^ ERROR intrinsic safety mismatch
 
     #[rustc_safe_intrinsic]
     fn assume(b: bool); //~ ERROR intrinsic safety mismatch
+    //~^ ERROR intrinsic safety mismatch
 }
 
 fn main() {}

--- a/tests/ui/intrinsics/safe-intrinsic-mismatch.stderr
+++ b/tests/ui/intrinsics/safe-intrinsic-mismatch.stderr
@@ -5,10 +5,26 @@ LL |     fn size_of<T>() -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `assume`
-  --> $DIR/safe-intrinsic-mismatch.rs:8:5
+  --> $DIR/safe-intrinsic-mismatch.rs:9:5
    |
 LL |     fn assume(b: bool);
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `size_of`
+  --> $DIR/safe-intrinsic-mismatch.rs:5:5
+   |
+LL |     fn size_of<T>() -> usize;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `assume`
+  --> $DIR/safe-intrinsic-mismatch.rs:9:5
+   |
+LL |     fn assume(b: bool);
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-31910.rs
+++ b/tests/ui/issues/issue-31910.rs
@@ -1,4 +1,5 @@
 enum Enum<T: Trait> {
+    //~^ ERROR: `T` is never used
     X = Trait::Number,
     //~^ ERROR mismatched types
     //~| expected `isize`, found `i32`

--- a/tests/ui/issues/issue-31910.stderr
+++ b/tests/ui/issues/issue-31910.stderr
@@ -1,9 +1,18 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-31910.rs:2:9
+  --> $DIR/issue-31910.rs:3:9
    |
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected `isize`, found `i32`
 
-error: aborting due to 1 previous error
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-31910.rs:1:11
+   |
+LL | enum Enum<T: Trait> {
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0392.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/issues/issue-3214.rs
+++ b/tests/ui/issues/issue-3214.rs
@@ -5,6 +5,7 @@ fn foo<T>() {
 
     impl<T> Drop for Foo<T> {
         //~^ ERROR struct takes 0 generic arguments but 1 generic argument
+        //~| ERROR `T` is not constrained
         fn drop(&mut self) {}
     }
 }

--- a/tests/ui/issues/issue-3214.stderr
+++ b/tests/ui/issues/issue-3214.stderr
@@ -22,7 +22,13 @@ note: struct defined here, with 0 generic parameters
 LL |     struct Foo {
    |            ^^^
 
-error: aborting due to 2 previous errors
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-3214.rs:6:10
+   |
+LL |     impl<T> Drop for Foo<T> {
+   |          ^ unconstrained type parameter
 
-Some errors have detailed explanations: E0107, E0401.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0207, E0401.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/issues/issue-34373.rs
+++ b/tests/ui/issues/issue-34373.rs
@@ -5,6 +5,8 @@ trait Trait<T> {
 }
 
 pub struct Foo<T = Box<Trait<DefaultFoo>>>;  //~ ERROR cycle detected
+//~^ ERROR `T` is never used
+//~| ERROR `Trait` cannot be made into an object
 type DefaultFoo = Foo;
 
 fn main() {

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -5,7 +5,7 @@ LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
    |                              ^^^^^^^^^^
    |
 note: ...which requires expanding type alias `DefaultFoo`...
-  --> $DIR/issue-34373.rs:8:19
+  --> $DIR/issue-34373.rs:10:19
    |
 LL | type DefaultFoo = Foo;
    |                   ^^^
@@ -23,6 +23,38 @@ LL | | }
    | |_^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/issue-34373.rs:7:24
+   |
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   |                        ^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-34373.rs:4:8
+   |
+LL | trait Trait<T> {
+   |       ----- this trait cannot be made into an object...
+LL |     fn foo(_: T) {}
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self, _: T) {}
+   |            ++++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo(_: T) where Self: Sized {}
+   |                  +++++++++++++++++
 
-For more information about this error, try `rustc --explain E0391`.
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-34373.rs:7:16
+   |
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0391, E0392.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/lang-items/lang-item-generic-requirements.rs
+++ b/tests/ui/lang-items/lang-item-generic-requirements.rs
@@ -22,8 +22,8 @@ trait MyIndex<'a, T> {}
 #[lang = "phantom_data"]
 //~^ ERROR `phantom_data` language item must be applied to a struct with 1 generic argument
 struct MyPhantomData<T, U>;
-//~^ ERROR parameter `T` is never used
-//~| ERROR parameter `U` is never used
+//~^ ERROR `T` is never used
+//~| ERROR `U` is never used
 
 #[lang = "owned_box"]
 //~^ ERROR `owned_box` language item must be applied to a struct with at least 1 generic argument
@@ -41,8 +41,7 @@ fn ice() {
     // Use add
     let r = 5;
     let a = 6;
-    r + a;
-    //~^ ERROR cannot add `{integer}` to `{integer}`
+    r + a; //~ ERROR cannot add
 
     // Use drop in place
     my_ptr_drop();

--- a/tests/ui/lifetimes/issue-95023.rs
+++ b/tests/ui/lifetimes/issue-95023.rs
@@ -3,7 +3,9 @@ struct Error(ErrorKind);
 impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental [E0183]
     //~^^ ERROR associated type bindings are not allowed here [E0229]
-    fn foo<const N: usize>(&self) -> Self::B<{N}>;
+    //~| ERROR not all trait items implemented
+    //~| ERROR expected a `FnMut(&isize)` closure, found `Error`
+    fn foo<const N: usize>(&self) -> Self::B<{ N }>;
     //~^ ERROR associated function in `impl` without body
     //~^^ ERROR method `foo` is not a member of trait `Fn` [E0407]
     //~^^^ ERROR associated type `B` not found for `Self` [E0220]

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -1,16 +1,16 @@
 error: associated function in `impl` without body
-  --> $DIR/issue-95023.rs:6:5
+  --> $DIR/issue-95023.rs:8:5
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                                  |
-   |                                                  help: provide a definition for the function: `{ <body> }`
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                                    |
+   |                                                    help: provide a definition for the function: `{ <body> }`
 
 error[E0407]: method `foo` is not a member of trait `Fn`
-  --> $DIR/issue-95023.rs:6:5
+  --> $DIR/issue-95023.rs:8:5
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
 
 error[E0183]: manual implementations of `Fn` are experimental
   --> $DIR/issue-95023.rs:3:6
@@ -33,12 +33,30 @@ LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
 error[E0220]: associated type `B` not found for `Self`
-  --> $DIR/issue-95023.rs:6:44
+  --> $DIR/issue-95023.rs:8:44
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
    |                                            ^ help: `Self` has the following associated type: `Output`
 
-error: aborting due to 5 previous errors
+error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
+  --> $DIR/issue-95023.rs:3:21
+   |
+LL | impl Fn(&isize) for Error {
+   |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
+   |
+   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0220, E0229, E0407.
-For more information about an error, try `rustc --explain E0183`.
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-95023.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0046, E0183, E0220, E0229, E0277, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.rs
@@ -4,6 +4,7 @@ trait Trait<'a> {
     type Bar<'b>
     //~^ NOTE associated type defined here, with 1 lifetime parameter
     //~| NOTE
+    //~| NOTE
     where
         Self: 'b;
 }
@@ -13,6 +14,8 @@ struct Impl<'a>(&'a ());
 impl<'a> Trait<'a> for Impl<'a> {
     type Foo = &'a ();
     type Bar<'b> = &'b ();
+    //~^ ERROR: does not fulfill the required lifetime
+    //~| NOTE: type must outlive the lifetime `'b`
 }
 
 type A<'a> = Impl<'a>;

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-alias.rs:20:24
+  --> $DIR/missing-lifetime-in-alias.rs:23:24
    |
 LL | type B<'a> = <A<'a> as Trait>::Foo;
    |                        ^^^^^ expected named lifetime parameter
@@ -10,13 +10,13 @@ LL | type B<'a> = <A<'a> as Trait<'a>>::Foo;
    |                             ++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-alias.rs:24:28
+  --> $DIR/missing-lifetime-in-alias.rs:27:28
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |                            ^^^^^ expected named lifetime parameter
    |
 note: these named lifetimes are available to use
-  --> $DIR/missing-lifetime-in-alias.rs:24:8
+  --> $DIR/missing-lifetime-in-alias.rs:27:8
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |        ^^  ^^
@@ -26,7 +26,7 @@ LL | type C<'a, 'b> = <A<'a> as Trait<'lifetime>>::Bar;
    |                                 +++++++++++
 
 error[E0107]: missing generics for associated type `Trait::Bar`
-  --> $DIR/missing-lifetime-in-alias.rs:24:36
+  --> $DIR/missing-lifetime-in-alias.rs:27:36
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |                                    ^^^ expected 1 lifetime argument
@@ -41,7 +41,26 @@ help: add missing lifetime argument
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar<'a>;
    |                                       ++++
 
-error: aborting due to 3 previous errors
+error[E0477]: the type `Impl<'a>` does not fulfill the required lifetime
+  --> $DIR/missing-lifetime-in-alias.rs:16:20
+   |
+LL |     type Bar<'b>
+   |     ------------ definition of `Bar` from trait
+...
+LL |     type Bar<'b> = &'b ();
+   |                    ^^^^^^
+   |
+note: type must outlive the lifetime `'b` as defined here
+  --> $DIR/missing-lifetime-in-alias.rs:16:14
+   |
+LL |     type Bar<'b> = &'b ();
+   |              ^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Bar<'b> = &'b () where Self: 'b;
+   |                           ++++++++++++++
 
-Some errors have detailed explanations: E0106, E0107.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0107, E0477.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
@@ -15,6 +15,7 @@ fn is_static<T>(_: T) where T: 'static { }
 // code forces us into a conservative, hacky path.
 fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
 //~^ ERROR please supply an explicit bound
+//~| ERROR `(): Foo<'_>` is not satisfied
 
 fn main() {
     let s = format!("foo");

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
@@ -4,6 +4,20 @@ error[E0228]: the lifetime bound for this object type cannot be deduced from con
 LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
    |                                    ^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `(): Foo<'_>` is not satisfied
+  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:16:47
+   |
+LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
+   |                                               ^^^ the trait `Foo<'_>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:4:1
+   |
+LL | trait Foo<'a> {
+   | ^^^^^^^^^^^^^
+   = note: required for the cast from `&()` to `&dyn Foo<'_, Item = dyn Bar>`
 
-For more information about this error, try `rustc --explain E0228`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0228, E0277.
+For more information about an error, try `rustc --explain E0228`.

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.rs
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.rs
@@ -6,6 +6,7 @@ trait Bar<T> {
 }
 
 trait Baz : Bar<Self> {
+    //~^ ERROR the size for values of type `Self` cannot be known
 }
 
 fn make_bar<T:Bar<u32>>(t: &T) -> &dyn Bar<u32> {

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Baz` cannot be made into an object
-  --> $DIR/object-safety-supertrait-mentions-Self.rs:15:31
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:16:31
    |
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ `Baz` cannot be made into an object
@@ -16,6 +16,27 @@ help: consider using an opaque type instead
 LL | fn make_baz<T:Baz>(t: &T) -> &impl Baz {
    |                               ~~~~
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
+   |
+LL | trait Baz : Bar<Self> {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Bar`
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
+   |
+LL | trait Bar<T> {
+   |           ^ required by this bound in `Bar`
+help: consider further restricting `Self`
+   |
+LL | trait Baz : Bar<Self> + Sized {
+   |                       +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Bar<T: ?Sized> {
+   |            ++++++++
 
-For more information about this error, try `rustc --explain E0038`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
@@ -17,4 +17,5 @@ impl X {
     type W where Self: Eq;
     //~^ ERROR associated type in `impl` without body
     //~| ERROR inherent associated types are unstable
+    //~| ERROR duplicate definitions
 }

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -78,6 +78,16 @@ LL |     type W where Self: Eq;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 10 previous errors
+error[E0592]: duplicate definitions with name `W`
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
+   |
+LL |     type W: Ord where Self: Eq;
+   |     ------ other definition for `W`
+...
+LL |     type W where Self: Eq;
+   |     ^^^^^^ duplicate definitions for `W`
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0592, E0658.
+For more information about an error, try `rustc --explain E0592`.

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
@@ -16,4 +16,5 @@ fn y<'a>(y: &mut 'a + Send) {
     //~| ERROR at least one trait is required for an object type
     let z = y as &mut 'a + Send;
     //~^ ERROR expected value, found trait `Send`
+    //~| ERROR at least one trait is required for an object type
 }

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
@@ -33,7 +33,13 @@ error[E0224]: at least one trait is required for an object type
 LL | fn y<'a>(y: &mut 'a + Send) {
    |                  ^^
 
-error: aborting due to 5 previous errors
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/issue-73568-lifetime-after-mut.rs:17:23
+   |
+LL |     let z = y as &mut 'a + Send;
+   |                       ^^
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0178, E0224, E0423.
 For more information about an error, try `rustc --explain E0178`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
@@ -10,5 +10,15 @@ LL | impl const A for () {}
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
 
-error: aborting due to 1 previous error
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/const-impl-requires-const-trait.rs:8:6
+   |
+LL | impl const A for () {}
+   |      ^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
@@ -8,5 +8,11 @@ LL | #[derive_const(Default)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
@@ -23,6 +23,21 @@ LL | #[derive_const(Default, PartialEq)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/derive-const-use.rs:7:6
+   |
+LL | impl const Default for A {
+   |      ^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
-For more information about this error, try `rustc --explain E0635`.
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0207, E0635.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.rs
@@ -1,12 +1,14 @@
 #![feature(const_trait_impl, effects)]
 
 const fn test() -> impl ~const Fn() { //~ ERROR `~const` can only be applied to `#[const_trait]` traits
+    //~^ ERROR cycle detected
     const move || { //~ ERROR const closures are experimental
         let sl: &[u8] = b"foo";
 
         match sl {
             [first, remainder @ ..] => {
                 assert_eq!(first, &b'f');
+                //~^ ERROR can't compare `&u8` with `&u8`
             }
             [] => panic!(),
         }

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
@@ -1,5 +1,5 @@
 error[E0658]: const closures are experimental
-  --> $DIR/ice-112822-expected-type-for-param.rs:4:5
+  --> $DIR/ice-112822-expected-type-for-param.rs:5:5
    |
 LL |     const move || {
    |     ^^^^^
@@ -13,6 +13,47 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn test() -> impl ~const Fn() {
    |                                ^^^^
 
-error: aborting due to 2 previous errors
+error[E0277]: can't compare `&u8` with `&u8`
+  --> $DIR/ice-112822-expected-type-for-param.rs:10:17
+   |
+LL |                 assert_eq!(first, &b'f');
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `&u8 == &u8`
+   |
+   = help: the trait `~const PartialEq<&u8>` is not implemented for `&u8`
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+   |
+LL | const fn test() -> impl ~const Fn() {
+   |                    ^^^^^^^^^^^^^^^^
+   |
+note: ...which requires borrow-checking `test`...
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:1
+   |
+LL | const fn test() -> impl ~const Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires promoting constants in MIR for `test`...
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:1
+   |
+LL | const fn test() -> impl ~const Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const checking `test`...
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:1
+   |
+LL | const fn test() -> impl ~const Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing whether `test::{opaque#0}` is freeze...
+   = note: ...which requires evaluating trait selection obligation `test::{opaque#0}: core::marker::Freeze`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+   |
+LL | const fn test() -> impl ~const Fn() {
+   |                    ^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0391, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
@@ -24,5 +24,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 3 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-2.rs:10:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-2.rs:10:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.rs
@@ -10,7 +10,8 @@ trait Foo {
 trait Bar: ~const Foo {}
 //[ny,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
 //[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
-//[yn,nn]~^^^ ERROR: `~const` is not allowed here
+//[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
+//[yn,nn]~^^^^ ERROR: `~const` is not allowed here
 
 const fn foo<T: Bar>(x: &T) {
     x.a();

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
@@ -11,7 +11,7 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/super-traits-fail-2.rs:16:5
+  --> $DIR/super-traits-fail-2.rs:17:5
    |
 LL |     x.a();
    |     ^^^^^ expected `host`, found `true`

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/super-traits-fail-2.rs:16:5
+  --> $DIR/super-traits-fail-2.rs:17:5
    |
 LL |     x.a();
    |     ^^^^^ expected `host`, found `true`

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -25,10 +25,18 @@ LL | trait Bar: ~const Foo {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:17:24
+  --> $DIR/super-traits-fail-3.rs:18:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^
 
-error: aborting due to 4 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:12:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:12:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
@@ -12,11 +12,13 @@ trait Foo {
 trait Bar: ~const Foo {}
 //[ny,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
 //[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
-//[yn,nn]~^^^ ERROR: `~const` is not allowed here
+//[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
+//[yn,nn]~^^^^ ERROR: `~const` is not allowed here
 
 const fn foo<T: ~const Bar>(x: &T) {
     //[yn,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
     x.a();
+    //[yn]~^ ERROR: mismatched types
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
@@ -11,10 +11,20 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:17:24
+  --> $DIR/super-traits-fail-3.rs:18:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/super-traits-fail-3.rs:20:5
+   |
+LL |     x.a();
+   |     ^^^^^ expected `host`, found `true`
+   |
+   = note: expected constant `host`
+              found constant `true`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
@@ -9,10 +9,12 @@ fn non_const_function<T: ~const Trait>() {} //~ ERROR `~const` is not allowed
 struct Struct<T: ~const Trait> { field: T } //~ ERROR `~const` is not allowed here
 struct TupleStruct<T: ~const Trait>(T); //~ ERROR `~const` is not allowed here
 struct UnitStruct<T: ~const Trait>; //~ ERROR `~const` is not allowed here
+//~^ ERROR  parameter `T` is never used
 
 enum Enum<T: ~const Trait> { Variant(T) } //~ ERROR `~const` is not allowed here
 
 union Union<T: ~const Trait> { field: T } //~ ERROR `~const` is not allowed here
+//~^ ERROR field must implement `Copy`
 
 type Type<T: ~const Trait> = T; //~ ERROR `~const` is not allowed here
 
@@ -30,6 +32,7 @@ trait NonConstTrait {
 
 impl NonConstTrait for () {
     type Type<T: ~const Trait> = (); //~ ERROR `~const` is not allowed
+    //~^ ERROR overflow evaluating the requirement `(): Trait`
     fn non_const_function<T: ~const Trait>() {} //~ ERROR `~const` is not allowed
     const CONSTANT<T: ~const Trait>: () = (); //~ ERROR `~const` is not allowed
     //~^ ERROR generic const items are experimental

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -35,7 +35,7 @@ LL | struct UnitStruct<T: ~const Trait>;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:13:14
+  --> $DIR/tilde-const-invalid-places.rs:14:14
    |
 LL | enum Enum<T: ~const Trait> { Variant(T) }
    |              ^^^^^^
@@ -43,7 +43,7 @@ LL | enum Enum<T: ~const Trait> { Variant(T) }
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:15:16
+  --> $DIR/tilde-const-invalid-places.rs:16:16
    |
 LL | union Union<T: ~const Trait> { field: T }
    |                ^^^^^^
@@ -51,7 +51,7 @@ LL | union Union<T: ~const Trait> { field: T }
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:17:14
+  --> $DIR/tilde-const-invalid-places.rs:19:14
    |
 LL | type Type<T: ~const Trait> = T;
    |              ^^^^^^
@@ -59,7 +59,7 @@ LL | type Type<T: ~const Trait> = T;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:19:19
+  --> $DIR/tilde-const-invalid-places.rs:21:19
    |
 LL | const CONSTANT<T: ~const Trait>: () = ();
    |                   ^^^^^^
@@ -67,7 +67,7 @@ LL | const CONSTANT<T: ~const Trait>: () = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:23:18
+  --> $DIR/tilde-const-invalid-places.rs:25:18
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
    |                  ^^^^^^
@@ -75,7 +75,7 @@ LL |     type Type<T: ~const Trait>: ~const Trait;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:23:33
+  --> $DIR/tilde-const-invalid-places.rs:25:33
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
    |                                 ^^^^^^
@@ -83,19 +83,19 @@ LL |     type Type<T: ~const Trait>: ~const Trait;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:26:30
+  --> $DIR/tilde-const-invalid-places.rs:28:30
    |
 LL |     fn non_const_function<T: ~const Trait>();
    |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:26:8
+  --> $DIR/tilde-const-invalid-places.rs:28:8
    |
 LL |     fn non_const_function<T: ~const Trait>();
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:27:23
+  --> $DIR/tilde-const-invalid-places.rs:29:23
    |
 LL |     const CONSTANT<T: ~const Trait>: ();
    |                       ^^^^^^
@@ -103,7 +103,7 @@ LL |     const CONSTANT<T: ~const Trait>: ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:32:18
+  --> $DIR/tilde-const-invalid-places.rs:34:18
    |
 LL |     type Type<T: ~const Trait> = ();
    |                  ^^^^^^
@@ -111,19 +111,19 @@ LL |     type Type<T: ~const Trait> = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:33:30
+  --> $DIR/tilde-const-invalid-places.rs:36:30
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:33:8
+  --> $DIR/tilde-const-invalid-places.rs:36:8
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:34:23
+  --> $DIR/tilde-const-invalid-places.rs:37:23
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                       ^^^^^^
@@ -131,7 +131,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:41:18
+  --> $DIR/tilde-const-invalid-places.rs:44:18
    |
 LL |     type Type<T: ~const Trait> = ();
    |                  ^^^^^^
@@ -139,19 +139,19 @@ LL |     type Type<T: ~const Trait> = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:43:30
+  --> $DIR/tilde-const-invalid-places.rs:46:30
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:43:8
+  --> $DIR/tilde-const-invalid-places.rs:46:8
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:44:23
+  --> $DIR/tilde-const-invalid-places.rs:47:23
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                       ^^^^^^
@@ -159,55 +159,55 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:49:15
+  --> $DIR/tilde-const-invalid-places.rs:52:15
    |
 LL | trait Child0: ~const Trait {}
    |               ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:49:1
+  --> $DIR/tilde-const-invalid-places.rs:52:1
    |
 LL | trait Child0: ~const Trait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:50:26
+  --> $DIR/tilde-const-invalid-places.rs:53:26
    |
 LL | trait Child1 where Self: ~const Trait {}
    |                          ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:50:1
+  --> $DIR/tilde-const-invalid-places.rs:53:1
    |
 LL | trait Child1 where Self: ~const Trait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:53:9
+  --> $DIR/tilde-const-invalid-places.rs:56:9
    |
 LL | impl<T: ~const Trait> Trait for T {}
    |         ^^^^^^
    |
 note: this impl is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:53:1
+  --> $DIR/tilde-const-invalid-places.rs:56:1
    |
 LL | impl<T: ~const Trait> Trait for T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:56:9
+  --> $DIR/tilde-const-invalid-places.rs:59:9
    |
 LL | impl<T: ~const Trait> Struct<T> {}
    |         ^^^^^^
    |
 note: inherent impls cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:56:1
+  --> $DIR/tilde-const-invalid-places.rs:59:1
    |
 LL | impl<T: ~const Trait> Struct<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:19:15
+  --> $DIR/tilde-const-invalid-places.rs:21:15
    |
 LL | const CONSTANT<T: ~const Trait>: () = ();
    |               ^^^^^^^^^^^^^^^^^
@@ -216,7 +216,7 @@ LL | const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:27:19
+  --> $DIR/tilde-const-invalid-places.rs:29:19
    |
 LL |     const CONSTANT<T: ~const Trait>: ();
    |                   ^^^^^^^^^^^^^^^^^
@@ -225,7 +225,7 @@ LL |     const CONSTANT<T: ~const Trait>: ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:34:19
+  --> $DIR/tilde-const-invalid-places.rs:37:19
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                   ^^^^^^^^^^^^^^^^^
@@ -234,7 +234,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:44:19
+  --> $DIR/tilde-const-invalid-places.rs:47:19
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                   ^^^^^^^^^^^^^^^^^
@@ -243,7 +243,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: inherent associated types are unstable
-  --> $DIR/tilde-const-invalid-places.rs:41:5
+  --> $DIR/tilde-const-invalid-places.rs:44:5
    |
 LL |     type Type<T: ~const Trait> = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -251,6 +251,39 @@ LL |     type Type<T: ~const Trait> = ();
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 27 previous errors
+error[E0392]: parameter `T` is never used
+  --> $DIR/tilde-const-invalid-places.rs:11:19
+   |
+LL | struct UnitStruct<T: ~const Trait>;
+   |                   ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/tilde-const-invalid-places.rs:16:32
+   |
+LL | union Union<T: ~const Trait> { field: T }
+   |                                ^^^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL | union Union<T: ~const Trait> { field: std::mem::ManuallyDrop<T> }
+   |                                       +++++++++++++++++++++++ +
+
+error[E0275]: overflow evaluating the requirement `(): Trait`
+  --> $DIR/tilde-const-invalid-places.rs:34:34
+   |
+LL |     type Type<T: ~const Trait> = ();
+   |                                  ^^
+   |
+note: required by a bound in `NonConstTrait::Type`
+  --> $DIR/tilde-const-invalid-places.rs:25:33
+   |
+LL |     type Type<T: ~const Trait>: ~const Trait;
+   |                                 ^^^^^^^^^^^^ required by this bound in `NonConstTrait::Type`
+
+error: aborting due to 30 previous errors
+
+Some errors have detailed explanations: E0275, E0392, E0658, E0740.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/stability-attribute/generics-default-stability-where.rs
+++ b/tests/ui/stability-attribute/generics-default-stability-where.rs
@@ -5,6 +5,7 @@ extern crate unstable_generic_param;
 use unstable_generic_param::*;
 
 impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature 'unstable_default'
+//~^ ERROR `T` must be used as the type parameter for some local type
     fn foo() -> usize { T::foo() }
 }
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -6,6 +6,16 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to 1 previous error
+error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/generics-default-stability-where.rs:7:6
+   |
+LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
+   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0210, E0658.
+For more information about an error, try `rustc --explain E0210`.

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.rs
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for () {
     fn bar(s: _) {}
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR has 1 parameter but the declaration in trait `Foo::bar` has 0
 }
 
 fn main() {}

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -9,6 +9,16 @@ help: use type parameters instead
 LL |     fn bar<T>(s: T) {}
    |           +++    ~
 
-error: aborting due to 1 previous error
+error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 0
+  --> $DIR/bad-infer-in-trait-impl.rs:6:15
+   |
+LL |     fn bar();
+   |     --------- trait requires 0 parameters
+...
+LL |     fn bar(s: _) {}
+   |               ^ expected 0 parameters, found 1
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0050, E0121.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/suggestions/fn-trait-notation.fixed
+++ b/tests/ui/suggestions/fn-trait-notation.fixed
@@ -2,6 +2,7 @@
 fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
 where
     F: Fn(i32) -> i32, //~ ERROR E0658
+    //~^ ERROR E0059
     G: Fn(i32, i32) -> (i32, i32), //~ ERROR E0658
     H: Fn(i32) -> i32, //~ ERROR E0658
 {

--- a/tests/ui/suggestions/fn-trait-notation.rs
+++ b/tests/ui/suggestions/fn-trait-notation.rs
@@ -2,6 +2,7 @@
 fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
 where
     F: Fn<i32, Output = i32>, //~ ERROR E0658
+    //~^ ERROR E0059
     G: Fn<(i32, i32, ), Output = (i32, i32)>, //~ ERROR E0658
     H: Fn<(i32,), Output = i32>, //~ ERROR E0658
 {

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -8,7 +8,7 @@ LL |     F: Fn<i32, Output = i32>,
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/fn-trait-notation.rs:5:8
+  --> $DIR/fn-trait-notation.rs:6:8
    |
 LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32, i32) -> (i32, i32)`
@@ -17,7 +17,7 @@ LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/fn-trait-notation.rs:6:8
+  --> $DIR/fn-trait-notation.rs:7:8
    |
 LL |     H: Fn<(i32,), Output = i32>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32) -> i32`
@@ -25,6 +25,16 @@ LL |     H: Fn<(i32,), Output = i32>,
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0059]: type parameter to bare `Fn` trait must be a tuple
+  --> $DIR/fn-trait-notation.rs:4:8
+   |
+LL |     F: Fn<i32, Output = i32>,
+   |        ^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `i32`
+   |
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0059, E0658.
+For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
@@ -18,6 +18,7 @@ mod elided {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
     //~^ ERROR missing lifetime specifier
+    //~| ERROR lifetime may not live long enough
 }
 
 mod underscore {
@@ -36,6 +37,7 @@ mod underscore {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
     //~^ ERROR missing lifetime specifier
+    //~| ERROR lifetime may not live long enough
 }
 
 mod alone_in_path {
@@ -61,8 +63,8 @@ mod in_path {
 }
 
 // This must not err, as the `&` actually resolves to `'a`.
-fn resolved_anonymous<'a, T>(f: impl Fn(&'a str) -> &T) {
-    f("f")
+fn resolved_anonymous<'a, T: 'a>(f: impl Fn(&'a str) -> &T) {
+    f("f");
 }
 
 fn main() {}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -41,7 +41,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:58
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:58
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                          ^^ expected named lifetime parameter
@@ -62,7 +62,7 @@ LL +     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:64
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                                ^^ expected named lifetime parameter
@@ -83,7 +83,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next(
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:37
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                                     ^ expected named lifetime parameter
@@ -104,7 +104,7 @@ LL +     fn g(mut x: impl Foo) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:41
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:41
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                                         ^ expected named lifetime parameter
@@ -149,7 +149,7 @@ LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next()
    |         ++++                              ++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:24:35
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:25:35
    |
 LL |     fn f(_: impl Iterator<Item = &'_ ()>) {}
    |                                   ^^ expected named lifetime parameter
@@ -161,7 +161,7 @@ LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
    |         ++++                          ~~
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:39
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:39
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                       ^^ expected named lifetime parameter
@@ -173,7 +173,7 @@ LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.nex
    |         ++++                              ~~
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:44:18
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:46:18
    |
 LL |     fn f(_: impl Foo) {}
    |                  ^^^ expected named lifetime parameter
@@ -185,7 +185,7 @@ LL |     fn f<'a>(_: impl Foo<'a>) {}
    |         ++++            ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:22
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                      ^^^ expected named lifetime parameter
@@ -197,7 +197,7 @@ LL |     fn g<'a>(mut x: impl Foo<'a>) -> Option<&()> { x.next() }
    |         ++++                ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:55:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:22
    |
 LL |     fn f(_: impl Foo<()>) {}
    |                      ^ expected named lifetime parameter
@@ -209,7 +209,7 @@ LL |     fn f<'a>(_: impl Foo<'a, ()>) {}
    |         ++++             +++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:26
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:26
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                          ^ expected named lifetime parameter
@@ -220,7 +220,23 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
    |         ++++                 +++
 
-error: aborting due to 14 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |     -----------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0106, E0658.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -1,6 +1,9 @@
+// different number of duplicated diagnostics on different targets
+// compile-flags: -Zdeduplicate-diagnostics=yes
+
 #![allow(bare_trait_objects)]
-use std::collections::HashMap;
 use std::cell::RefCell;
+use std::collections::HashMap;
 
 pub union Foo<'t, 'k> {
     i: &'t i64,
@@ -38,18 +41,10 @@ thread_local! {
 thread_local! {
     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR union takes 2 lifetime arguments but 1 lifetime argument
-    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
 }
 thread_local! {
     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR missing lifetime
     //~| ERROR missing lifetime
 }

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:18:44
+  --> $DIR/missing-lifetime-specifier.rs:21:44
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ expected 2 lifetime parameters
@@ -11,7 +11,7 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
    |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:18:44
+  --> $DIR/missing-lifetime-specifier.rs:21:44
    |
 LL | / thread_local! {
 LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
@@ -24,7 +24,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:23:44
+  --> $DIR/missing-lifetime-specifier.rs:26:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    |                                            ^^^^ expected 2 lifetime parameters
@@ -38,7 +38,7 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>
    |                                             +++++++    ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:23:44
+  --> $DIR/missing-lifetime-specifier.rs:26:44
    |
 LL | / thread_local! {
 LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
@@ -53,7 +53,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:28:47
+  --> $DIR/missing-lifetime-specifier.rs:31:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    |                                               ^ expected 2 lifetime parameters
@@ -65,7 +65,7 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:28:47
+  --> $DIR/missing-lifetime-specifier.rs:31:47
    |
 LL | / thread_local! {
 LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
@@ -78,7 +78,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:33:44
+  --> $DIR/missing-lifetime-specifier.rs:36:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^   ^ expected 2 lifetime parameters
@@ -92,7 +92,7 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i
    |                                             +++++++     +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:33:44
+  --> $DIR/missing-lifetime-specifier.rs:36:44
    |
 LL | / thread_local! {
 LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
@@ -107,7 +107,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:46:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -119,14 +119,13 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:46:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    | |                                            ^ expected named lifetime parameter
 LL | |
 LL | |
-...  |
 LL | |
 LL | | }
    | |_-
@@ -134,7 +133,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:39:44
+  --> $DIR/missing-lifetime-specifier.rs:42:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ ------- supplied 1 lifetime argument
@@ -142,7 +141,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell:
    |                                            expected 2 lifetime arguments
    |
 note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
+  --> $DIR/missing-lifetime-specifier.rs:14:11
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
@@ -151,84 +150,8 @@ help: add missing lifetime argument
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       +++++++++
 
-error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:39:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       +++++++++
-
-error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:39:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       +++++++++
-
-error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:39:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       +++++++++
-
-error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:39:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       +++++++++
-
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:46:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -236,7 +159,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell
    |                                             expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
+  --> $DIR/missing-lifetime-specifier.rs:18:7
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --
@@ -245,83 +168,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
-   |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
-   |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        +++++++++
-
-error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
-   |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
-   |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        +++++++++
-
-error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
-   |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
-   |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        +++++++++
-
-error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
-   |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
-   |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: add missing lifetime argument
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        +++++++++
-
-error: aborting due to 20 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/tag-type-args.rs
+++ b/tests/ui/tag-type-args.rs
@@ -1,4 +1,5 @@
 enum Quux<T> { Bar }
+//~^ ERROR: parameter `T` is never used
 
 fn foo(c: Quux) { assert!((false)); } //~ ERROR missing generics for enum `Quux`
 

--- a/tests/ui/tag-type-args.stderr
+++ b/tests/ui/tag-type-args.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for enum `Quux`
-  --> $DIR/tag-type-args.rs:3:11
+  --> $DIR/tag-type-args.rs:4:11
    |
 LL | fn foo(c: Quux) { assert!((false)); }
    |           ^^^^ expected 1 generic argument
@@ -14,6 +14,16 @@ help: add missing generic argument
 LL | fn foo(c: Quux<T>) { assert!((false)); }
    |               +++
 
-error: aborting due to 1 previous error
+error[E0392]: parameter `T` is never used
+  --> $DIR/tag-type-args.rs:1:11
+   |
+LL | enum Quux<T> { Bar }
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0392.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -86,6 +86,8 @@ static A: () = ();
 //~^ ERROR attribute should be applied to a function
 impl Quux for u8 {}
 //~^ NOTE not a function
+//~| NOTE missing `foo` in implementation
+//~| ERROR missing: `foo`
 
 #[target_feature(enable = "sse2")]
 //~^ ERROR attribute should be applied to a function
@@ -93,7 +95,7 @@ impl Foo {}
 //~^ NOTE not a function
 
 trait Quux {
-    fn foo();
+    fn foo(); //~ NOTE `foo` from trait
 }
 
 impl Quux for Foo {

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -117,7 +117,7 @@ LL | impl Quux for u8 {}
    | ------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:90:1
+  --> $DIR/invalid-attribute.rs:92:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL | impl Foo {}
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:108:5
+  --> $DIR/invalid-attribute.rs:110:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL | |     }
    | |_____- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:116:5
+  --> $DIR/invalid-attribute.rs:118:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +183,7 @@ LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:100:5
+  --> $DIR/invalid-attribute.rs:102:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,6 +194,16 @@ LL |     fn foo() {}
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
-error: aborting due to 22 previous errors
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/invalid-attribute.rs:87:1
+   |
+LL | impl Quux for u8 {}
+   | ^^^^^^^^^^^^^^^^ missing `foo` in implementation
+...
+LL |     fn foo();
+   |     --------- `foo` from trait
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 23 previous errors
+
+Some errors have detailed explanations: E0046, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
@@ -7,12 +7,14 @@ pub trait Trait<T> {
 }
 
 impl<T, S> Trait<T> for i32 {
+    //~^ ERROR `S` is not constrained
     type Assoc = String;
 }
 
 // Should not not trigger suggestion here...
 impl<T, S> Trait<T, S> for () {}
 //~^ ERROR trait takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR `S` is not constrained
 
 //... but should do so in all of the below cases except the last one
 fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
@@ -37,6 +39,7 @@ impl<T: Trait<u32, String>> Struct<T> {}
 trait YetAnotherTrait {}
 impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
 //~^ ERROR struct takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR `U` is not constrained
 
 
 fn main() {

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -1,5 +1,5 @@
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:14:12
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:12
    |
 LL | impl<T, S> Trait<T, S> for () {}
    |            ^^^^^ expected 1 generic argument
@@ -11,7 +11,7 @@ LL | pub trait Trait<T> {
    |           ^^^^^ -
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:18:12
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:12
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
    |            ^^^^^ expected 1 generic argument
@@ -27,7 +27,7 @@ LL | fn func<T: Trait<u32, Assoc = String>>(t: T) -> impl Trait<(), i32> {
    |                       +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:18:46
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:46
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
    |                                              ^^^^^ expected 1 generic argument
@@ -43,7 +43,7 @@ LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), Assoc = i32> {
    |                                                        +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:24:18
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:18
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |                  ^^^^^ expected 1 generic argument
@@ -59,7 +59,7 @@ LL | struct Struct<T: Trait<u32, Assoc = String>> {
    |                             +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:29:23
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:31:23
    |
 LL | trait AnotherTrait<T: Trait<T, i32>> {}
    |                       ^^^^^ expected 1 generic argument
@@ -75,7 +75,7 @@ LL | trait AnotherTrait<T: Trait<T, Assoc = i32>> {}
    |                                +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:32:9
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:34:9
    |
 LL | impl<T: Trait<u32, String>> Struct<T> {}
    |         ^^^^^ expected 1 generic argument
@@ -91,7 +91,7 @@ LL | impl<T: Trait<u32, Assoc = String>> Struct<T> {}
    |                    +++++++
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:38:58
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:58
    |
 LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          ^^^^^^    - help: remove this generic argument
@@ -99,11 +99,30 @@ LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:24:8
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:8
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
 
-error: aborting due to 7 previous errors
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
+   |
+LL | impl<T, S> Trait<T> for i32 {
+   |         ^ unconstrained type parameter
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:9
+   |
+LL | impl<T, S> Trait<T, S> for () {}
+   |         ^ unconstrained type parameter
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:35
+   |
+LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
+   |                                   ^ unconstrained type parameter
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0107, E0207.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.rs
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.rs
@@ -7,10 +7,12 @@ trait Foo {
 
 fn foo(_x: Foo + Send) {
     //~^ ERROR trait objects must include the `dyn` keyword
+    //~| ERROR size for values of type
 }
 fn bar(x: Foo) -> Foo {
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
+    //~| ERROR size for values of type
     x
 }
 

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -1,3 +1,37 @@
+error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
+  --> $DIR/not-on-bare-trait-2021.rs:8:8
+   |
+LL | fn foo(_x: Foo + Send) {
+   |        ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn foo(_x: impl Foo + Send) {
+   |            ++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn foo(_x: &(dyn Foo + Send)) {
+   |            +++++           +
+
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/not-on-bare-trait-2021.rs:12:8
+   |
+LL | fn bar(x: Foo) -> Foo {
+   |        ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn bar(x: impl Foo) -> Foo {
+   |           ++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn bar(x: &dyn Foo) -> Foo {
+   |           ++++
+
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/not-on-bare-trait-2021.rs:8:12
    |
@@ -18,7 +52,7 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/not-on-bare-trait-2021.rs:11:11
+  --> $DIR/not-on-bare-trait-2021.rs:12:11
    |
 LL | fn bar(x: Foo) -> Foo {
    |           ^^^
@@ -37,7 +71,7 @@ LL | fn bar(x: &dyn Foo) -> Foo {
    |           ++++
 
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/not-on-bare-trait-2021.rs:11:19
+  --> $DIR/not-on-bare-trait-2021.rs:12:19
    |
 LL | fn bar(x: Foo) -> Foo {
    |                   ^^^
@@ -51,6 +85,7 @@ help: alternatively, you can return an owned trait object
 LL | fn bar(x: Foo) -> Box<dyn Foo> {
    |                   +++++++    +
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0782`.
+Some errors have detailed explanations: E0277, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-106072.rs
+++ b/tests/ui/traits/issue-106072.rs
@@ -1,4 +1,5 @@
 #[derive(Clone)] //~  trait objects must include the `dyn` keyword
+//~^ ERROR: the size for values of type `(dyn Foo + 'static)` cannot be known
 struct Foo;
 trait Foo {} //~ the name `Foo` is defined multiple times
 fn main() {}

--- a/tests/ui/traits/issue-106072.stderr
+++ b/tests/ui/traits/issue-106072.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/issue-106072.rs:3:1
+  --> $DIR/issue-106072.rs:4:1
    |
 LL | struct Foo;
    | ----------- previous definition of the type `Foo` here
@@ -7,6 +7,17 @@ LL | trait Foo {}
    | ^^^^^^^^^ `Foo` redefined here
    |
    = note: `Foo` must be defined only once in the type namespace of this module
+
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/issue-106072.rs:1:10
+   |
+LL | #[derive(Clone)]
+   |          ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+note: required by a bound in `Clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-106072.rs:1:10
@@ -16,7 +27,7 @@ LL | #[derive(Clone)]
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0428, E0782.
-For more information about an error, try `rustc --explain E0428`.
+Some errors have detailed explanations: E0277, E0428, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-28576.rs
+++ b/tests/ui/traits/issue-28576.rs
@@ -3,6 +3,8 @@ pub trait Foo<RHS=Self> {
 }
 
 pub trait Bar: Foo<Assoc=()> {
+    //~^ ERROR: the size for values of type `Self` cannot be known
+    //~| ERROR: the size for values of type `Self` cannot be known
     fn new(&self, b: &
            dyn Bar //~ ERROR the trait `Bar` cannot be made into an object
               <Assoc=()>

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/issue-28576.rs:7:12
+  --> $DIR/issue-28576.rs:9:12
    |
 LL | /            dyn Bar
 LL | |               <Assoc=()>
@@ -19,6 +19,47 @@ help: consider using an opaque type instead
 LL |            impl Bar
    |            ~~~~
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by this bound in `Foo`
+help: consider further restricting `Self`
+   |
+LL | pub trait Bar: Foo<Assoc=()> + Sized {
+   |                              +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS=Self: ?Sized> {
+   |                       ++++++++
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by this bound in `Foo`
+help: consider further restricting `Self`
+   |
+LL |     ) where Self: Sized;
+   |       +++++++++++++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS=Self: ?Sized> {
+   |                       ++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/issue-38404.rs
+++ b/tests/ui/traits/issue-38404.rs
@@ -1,7 +1,8 @@
 trait A<T>: std::ops::Add<Self> + Sized {}
 trait B<T>: A<T> {}
-trait C<T>: A<dyn B<T, Output=usize>> {}
+trait C<T>: A<dyn B<T, Output = usize>> {}
 //~^ ERROR the trait `B` cannot be made into an object
+//~| ERROR the trait `B` cannot be made into an object
 //~| ERROR the trait `B` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/traits/issue-38404.stderr
+++ b/tests/ui/traits/issue-38404.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
-LL | trait C<T>: A<dyn B<T, Output=usize>> {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
@@ -15,8 +15,8 @@ LL | trait B<T>: A<T> {}
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
-LL | trait C<T>: A<dyn B<T, Output=usize>> {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
@@ -27,6 +27,21 @@ LL | trait B<T>: A<T> {}
    |       - this trait cannot be made into an object...
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `B` cannot be made into an object
+  --> $DIR/issue-38404.rs:3:15
+   |
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-38404.rs:1:13
+   |
+LL | trait A<T>: std::ops::Add<Self> + Sized {}
+   |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
+LL | trait B<T>: A<T> {}
+   |       - this trait cannot be made into an object...
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/issue-87558.rs
+++ b/tests/ui/traits/issue-87558.rs
@@ -3,6 +3,8 @@ struct Error(ErrorKind);
 impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental
     //~| ERROR associated type bindings are not allowed here
+    //~| ERROR closure, found `Error`
+    //~| ERROR not all trait items implemented, missing: `call`
     fn from() {} //~ ERROR method `from` is not a member of trait `Fn`
 }
 

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -1,5 +1,5 @@
 error[E0407]: method `from` is not a member of trait `Fn`
-  --> $DIR/issue-87558.rs:6:5
+  --> $DIR/issue-87558.rs:8:5
    |
 LL |     fn from() {}
    |     ^^^^^^^^^^^^ not a member of trait `Fn`
@@ -24,7 +24,25 @@ help: parenthesized trait syntax expands to `Fn<(&isize,), Output=()>`
 LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
+  --> $DIR/issue-87558.rs:3:21
+   |
+LL | impl Fn(&isize) for Error {
+   |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
+   |
+   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0229, E0407.
-For more information about an error, try `rustc --explain E0183`.
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-87558.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0046, E0183, E0229, E0277, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/traits/non_lifetime_binders/late-bound-in-anon-ct.rs
+++ b/tests/ui/traits/non_lifetime_binders/late-bound-in-anon-ct.rs
@@ -6,6 +6,6 @@ fn foo() -> usize
 where
     for<T> [i32; { let _: T = todo!(); 0 }]:,
     //~^ ERROR cannot capture late-bound type parameter in constant
-{}
+{ 42 }
 
 fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
@@ -3,5 +3,8 @@ trait Foo {
 }
 
 fn bar(x: &dyn Foo) {} //~ ERROR the trait `Foo` cannot be made into an object
+//~^ ERROR the trait `Foo` cannot be made into an object
+//~| ERROR the trait `Foo` cannot be made into an object
+//~| ERROR the trait `Foo` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
@@ -13,6 +13,53 @@ LL |     type Bar<T>;
    |          ^^^ ...because it contains the generic associated type `Bar`
    = help: consider moving `Bar` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:12
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |            ^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -16,6 +16,7 @@ mod assert {
     >()
     where
         Dst: BikeshedIntrinsicFrom< //~ ERROR trait takes at most 3 generic arguments but 6 generic arguments were supplied
+        //~^ ERROR: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
             Src,
             Context,
             ASSUME_ALIGNMENT,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -9,6 +9,22 @@ LL | |             ASSUME_VALIDITY,
 LL | |             ASSUME_VISIBILITY,
    | |_____________________________- help: remove these generic arguments
 
-error: aborting due to 1 previous error
+error: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
+  --> $DIR/issue-101739-2.rs:18:14
+   |
+LL |           Dst: BikeshedIntrinsicFrom<
+   |  ______________^
+LL | |
+LL | |             Src,
+LL | |             Context,
+...  |
+LL | |             ASSUME_VISIBILITY,
+LL | |         >,
+   | |_________^ expected `Assume`, found `bool`
+   |
+note: required by a bound in `BikeshedIntrinsicFrom`
+  --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -1,4 +1,4 @@
-// Regression test for #77179.
+// Regression test for the ICE in #77179.
 
 #![feature(type_alias_impl_trait)]
 
@@ -6,7 +6,9 @@ type Pointer<T> = impl std::ops::Deref<Target = T>;
 
 fn test() -> Pointer<_> {
     //~^ ERROR: the placeholder `_` is not allowed within types
+    //~| ERROR: non-defining opaque type use in defining scope
     Box::new(1)
+    //~^ ERROR expected generic type parameter, found `i32`
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -7,6 +7,28 @@ LL | fn test() -> Pointer<_> {
    |              |       not allowed in type signatures
    |              help: replace with the correct return type: `Pointer<i32>`
 
-error: aborting due to 1 previous error
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/issue-77179.rs:7:14
+   |
+LL | fn test() -> Pointer<_> {
+   |              ^^^^^^^^^^ argument `i32` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/issue-77179.rs:5:19
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0792]: expected generic type parameter, found `i32`
+  --> $DIR/issue-77179.rs:10:5
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |              - this generic parameter must be used with a generic type parameter
+...
+LL |     Box::new(1)
+   |     ^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0121, E0792.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/escaping_bound_vars.rs
+++ b/tests/ui/typeck/escaping_bound_vars.rs
@@ -10,6 +10,10 @@ pub fn test()
 where
     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
     //~^ ERROR cannot capture late-bound lifetime in constant
+    //~| ERROR associated type bindings are not allowed here
+    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
+    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
+    //~| ERROR cannot add
 {
 }
 

--- a/tests/ui/typeck/escaping_bound_vars.stderr
+++ b/tests/ui/typeck/escaping_bound_vars.stderr
@@ -6,5 +6,55 @@ LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
    |                                  |
    |                                  lifetime defined here
 
-error: aborting due to 1 previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/escaping_bound_vars.rs:11:28
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                            ^^^^^^^^^^ associated type not allowed here
 
+error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
+  --> $DIR/escaping_bound_vars.rs:11:22
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                      ^^ the trait `Elide<(&(),)>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/escaping_bound_vars.rs:5:1
+   |
+LL | trait Elide<T> {
+   | ^^^^^^^^^^^^^^
+
+error[E0277]: cannot add `fn() {<() as Elide<(&(),)>>::call}` to `{integer}`
+  --> $DIR/escaping_bound_vars.rs:11:18
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                  ^ no implementation for `{integer} + fn() {<() as Elide<(&(),)>>::call}`
+   |
+   = help: the trait `Add<fn() {<() as Elide<(&(),)>>::call}>` is not implemented for `{integer}`
+   = help: the following other types implement trait `Add<Rhs>`:
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
+           and 48 others
+
+error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
+  --> $DIR/escaping_bound_vars.rs:11:18
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                  ^ the trait `Elide<(&(),)>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/escaping_bound_vars.rs:5:1
+   |
+LL | trait Elide<T> {
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/typeck/issue-110052.rs
+++ b/tests/ui/typeck/issue-110052.rs
@@ -1,7 +1,7 @@
 // Makes sure we deal with escaping lifetimes *above* INNERMOST when
 // suggesting trait for ambiguous associated type.
 
-impl<I, V> Validator<I> for ()
+impl<I> Validator<I> for ()
 where
     for<'iter> dyn Validator<<&'iter I>::Item>:,
     //~^ ERROR ambiguous associated type

--- a/tests/ui/typeck/issue-79040.rs
+++ b/tests/ui/typeck/issue-79040.rs
@@ -1,5 +1,6 @@
 fn main() {
     const FOO = "hello" + 1; //~ ERROR cannot add `{integer}` to `&str`
     //~^ missing type for `const` item
+    //~| ERROR cannot add `{integer}` to `&str`
     println!("{}", FOO);
 }

--- a/tests/ui/typeck/issue-79040.stderr
+++ b/tests/ui/typeck/issue-79040.stderr
@@ -12,6 +12,16 @@ error: missing type for `const` item
 LL |     const FOO = "hello" + 1;
    |              ^ help: provide a type for the item: `: <type>`
 
-error: aborting due to 2 previous errors
+error[E0369]: cannot add `{integer}` to `&str`
+  --> $DIR/issue-79040.rs:2:25
+   |
+LL |     const FOO = "hello" + 1;
+   |                 ------- ^ - {integer}
+   |                 |
+   |                 &str
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
@@ -4,11 +4,12 @@ fn foo1<T:Copy<U>, U>(x: T) {}
 trait Trait: Copy<dyn Send> {}
 //~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 //~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
-struct MyStruct1<T: Copy<T>>;
+struct MyStruct1<T: Copy<T>>(T);
 //~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
-struct MyStruct2<'a, T: Copy<'a>>;
+struct MyStruct2<'a, T: Copy<'a>>(&'a T);
 //~^ ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -25,23 +25,23 @@ LL | trait Trait: Copy<dyn Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:8:21
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:9:21
    |
-LL | struct MyStruct1<T: Copy<T>>;
+LL | struct MyStruct1<T: Copy<T>>(T);
    |                     ^^^^--- help: remove these generics
    |                     |
    |                     expected 0 generic arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:11:25
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:12:25
    |
-LL | struct MyStruct2<'a, T: Copy<'a>>;
+LL | struct MyStruct2<'a, T: Copy<'a>>(&'a T);
    |                         ^^^^---- help: remove these generics
    |                         |
    |                         expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:14:15
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^ -- help: remove this lifetime argument
@@ -49,13 +49,23 @@ LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:14:15
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^     - help: remove this generic argument
    |               |
    |               expected 0 generic arguments
 
-error: aborting due to 7 previous errors
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
+   |
+LL | trait Trait: Copy<dyn Send> {}
+   |              ^^^^---------- help: remove these generics
+   |              |
+   |              expected 0 generic arguments
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -198,6 +198,7 @@ trait Qux {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
+    //~^ ERROR: not all trait items implemented, missing: `F`
     type A = _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
     type B = _;

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -29,7 +29,7 @@ LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:205:5
+  --> $DIR/typeck_type_placeholder_item.rs:206:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -411,7 +411,7 @@ LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:216:31
+  --> $DIR/typeck_type_placeholder_item.rs:217:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -420,7 +420,7 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:221:10
+  --> $DIR/typeck_type_placeholder_item.rs:222:10
    |
 LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
@@ -429,7 +429,7 @@ LL | const _: Option<_> = map(value);
    |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:224:31
+  --> $DIR/typeck_type_placeholder_item.rs:225:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -438,13 +438,13 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:229:10
+  --> $DIR/typeck_type_placeholder_item.rs:230:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:229:29}>, {closure@typeck_type_placeholder_item.rs:229:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:229:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:230:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -631,25 +631,25 @@ LL |         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
    |                                         ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:201:14
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
    |
 LL |     type A = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:203:14
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:208:14
+  --> $DIR/typeck_type_placeholder_item.rs:209:14
    |
 LL |     const D: _ = 42;
    |              ^
@@ -657,7 +657,16 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error: aborting due to 71 previous errors
+error[E0046]: not all trait items implemented, missing: `F`
+  --> $DIR/typeck_type_placeholder_item.rs:200:1
+   |
+LL |     type F: std::ops::Fn(_);
+   |     ----------------------- `F` from trait
+...
+LL | impl Qux for Struct {
+   | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
-Some errors have detailed explanations: E0121, E0282, E0403.
-For more information about an error, try `rustc --explain E0121`.
+error: aborting due to 72 previous errors
+
+Some errors have detailed explanations: E0046, E0121, E0282, E0403.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -27,7 +27,7 @@ impl Test6 {
 }
 
 pub fn main() {
-    let _: Option<usize> = test1();
-    let _: f64 = test1();
+    let _: Option<usize> = test1(); //~ ERROR mismatched types
+    let _: f64 = test1(); //~ ERROR mismatched types
     let _: Option<i32> = test1();
 }

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -55,6 +55,29 @@ LL |     const TEST6: _ = 13;
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
-error: aborting due to 7 previous errors
+error[E0308]: mismatched types
+  --> $DIR/typeck_type_placeholder_item_help.rs:30:28
+   |
+LL |     let _: Option<usize> = test1();
+   |            -------------   ^^^^^^^ expected `Option<usize>`, found `Option<i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<usize>`
+              found enum `Option<i32>`
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0308]: mismatched types
+  --> $DIR/typeck_type_placeholder_item_help.rs:31:18
+   |
+LL |     let _: f64 = test1();
+   |            ---   ^^^^^^^ expected `f64`, found `Option<i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+              found enum `Option<i32>`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0121, E0308.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -21,10 +21,12 @@ fn same_type<A,B:Eq<A>>(a: A, b: B) { }
 fn test<'a,'b>() {
     // Parens are equivalent to omitting default in angle.
     eq::< dyn Foo<(isize,),Output=()>,               dyn Foo(isize)                      >();
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
 
     // Here we specify 'static explicitly in angle-bracket version.
     // Parenthesized winds up getting inferred.
     eq::< dyn Foo<'static, (isize,),Output=()>,      dyn Foo(isize)                      >();
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
 }
 
 fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -1,5 +1,5 @@
 error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/unboxed-closure-sugar-region.rs:30:51
+  --> $DIR/unboxed-closure-sugar-region.rs:32:51
    |
 LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
    |                                                   ^^^ expected 1 lifetime argument
@@ -10,6 +10,30 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL | trait Foo<'a,T> {
    |       ^^^ --
 
-error: aborting due to 1 previous error
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unboxed-closure-sugar-region.rs:23:58
+   |
+LL |     eq::< dyn Foo<(isize,),Output=()>,               dyn Foo(isize)                      >();
+   |                                                          ^^^ expected 1 lifetime argument
+   |
+note: trait defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/unboxed-closure-sugar-region.rs:10:7
+   |
+LL | trait Foo<'a,T> {
+   |       ^^^ --
+
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unboxed-closure-sugar-region.rs:28:58
+   |
+LL |     eq::< dyn Foo<'static, (isize,),Output=()>,      dyn Foo(isize)                      >();
+   |                                                          ^^^ expected 1 lifetime argument
+   |
+note: trait defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/unboxed-closure-sugar-region.rs:10:7
+   |
+LL | trait Foo<'a,T> {
+   |       ^^^ --
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -2,25 +2,25 @@
 
 trait Zero { fn dummy(&self); }
 
-fn foo1(_: dyn Zero()) {
+fn foo1(_: &dyn Zero()) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
-fn foo2(_: dyn Zero<usize>) {
+fn foo2(_: &dyn Zero<usize>) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
-fn foo3(_: dyn Zero <   usize   >) {
+fn foo3(_: &dyn Zero <   usize   >) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
-fn foo4(_: dyn Zero(usize)) {
+fn foo4(_: &dyn Zero(usize)) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
-fn foo5(_: dyn Zero (   usize   )) {
+fn foo5(_: &dyn Zero (   usize   )) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -1,58 +1,10 @@
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
-LL | fn foo1(_: dyn Zero()) {
-   |                ^^^^-- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
-   |
-LL | fn foo1(_: dyn Zero()) {
-   |                ^^^^^^ associated type `Output` not found
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:16
-   |
-LL | fn foo2(_: dyn Zero<usize>) {
-   |                ^^^^------- help: remove these generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:16
-   |
-LL | fn foo3(_: dyn Zero <   usize   >) {
-   |                ^^^^-------------- help: remove these generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
-   |
-LL | fn foo4(_: dyn Zero(usize)) {
-   |                ^^^^------- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
+LL | fn foo1(_: &dyn Zero()) {
+   |                 ^^^^-- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
@@ -61,18 +13,46 @@ LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
-LL | fn foo4(_: dyn Zero(usize)) {
-   |                ^^^^^^^^^^^ associated type `Output` not found
+LL | fn foo1(_: &dyn Zero()) {
+   |                 ^^^^^^ associated type `Output` not found
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:17
    |
-LL | fn foo5(_: dyn Zero (   usize   )) {
-   |                ^^^^-------------- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
+LL | fn foo2(_: &dyn Zero<usize>) {
+   |                 ^^^^------- help: remove these generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:17
+   |
+LL | fn foo3(_: &dyn Zero <   usize   >) {
+   |                 ^^^^-------------- help: remove these generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
+   |
+LL | fn foo4(_: &dyn Zero(usize)) {
+   |                 ^^^^------- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
@@ -81,10 +61,30 @@ LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
    |
-LL | fn foo5(_: dyn Zero (   usize   )) {
-   |                ^^^^^^^^^^^^^^^^^^ associated type `Output` not found
+LL | fn foo4(_: &dyn Zero(usize)) {
+   |                 ^^^^^^^^^^^ associated type `Output` not found
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
+   |
+LL | fn foo5(_: &dyn Zero (   usize   )) {
+   |                 ^^^^-------------- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0220]: associated type `Output` not found for `Zero`
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
+   |
+LL | fn foo5(_: &dyn Zero (   usize   )) {
+   |                 ^^^^^^^^^^^^^^^^^^ associated type `Output` not found
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
r? @matthewjasper

This PR only adds new errors to tests that are already failing and fixes one ICE.

Several tests were changed to not emit new errors. I believe all of them were faulty tests, and not explicitly testing for the code that had new errors.