### PR TITLE
Inline and remove `create_session`.

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -3,29 +3,24 @@ use info;
 use libloading::Library;
 use rustc_ast as ast;
 use rustc_codegen_ssa::traits::CodegenBackend;
-use rustc_data_structures::fx::FxHashMap;
 #[cfg(parallel_compiler)]
 use rustc_data_structures::sync;
-use rustc_errors::registry::Registry;
 use rustc_parse::validate_attr;
 use rustc_session as session;
-use rustc_session::config::{
-    self, Cfg, CheckCfg, CrateType, OutFileName, OutputFilenames, OutputTypes,
-};
+use rustc_session::config::{self, Cfg, CrateType, OutFileName, OutputFilenames, OutputTypes};
 use rustc_session::filesearch::sysroot_candidates;
 use rustc_session::lint::{self, BuiltinLintDiagnostics, LintBuffer};
 use rustc_session::{filesearch, output, Session};
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
-use rustc_span::source_map::FileLoader;
 use rustc_span::symbol::{sym, Symbol};
-use session::{CompilerIO, EarlyErrorHandler};
+use session::EarlyErrorHandler;
 use std::env;
 use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use std::thread;
 
 /// Function pointer type that constructs a new CodegenBackend.
@@ -50,82 +45,6 @@ pub fn add_configuration(cfg: &mut Cfg, sess: &mut Session, codegen_backend: &dy
     if sess.crt_static(None) {
         cfg.insert((tf, Some(sym::crt_dash_static)));
     }
-}
-
-pub fn create_session(
-    handler: &EarlyErrorHandler,
-    sopts: config::Options,
-    cfg: Cfg,
-    mut check_cfg: CheckCfg,
-    locale_resources: &'static [&'static str],
-    file_loader: Option<Box<dyn FileLoader + Send + Sync + 'static>>,
-    io: CompilerIO,
-    lint_caps: FxHashMap<lint::LintId, lint::Level>,
-    make_codegen_backend: Option<
-        Box<dyn FnOnce(&config::Options) -> Box<dyn CodegenBackend> + Send>,
-    >,
-    descriptions: Registry,
-    ice_file: Option<PathBuf>,
-    using_internal_features: Arc<AtomicBool>,
-    expanded_args: Vec<String>,
-) -> (Session, Box<dyn CodegenBackend>) {
-    let codegen_backend = if let Some(make_codegen_backend) = make_codegen_backend {
-        make_codegen_backend(&sopts)
-    } else {
-        get_codegen_backend(
-            handler,
-            &sopts.maybe_sysroot,
-            sopts.unstable_opts.codegen_backend.as_deref(),
-        )
-    };
-
-    // target_override is documented to be called before init(), so this is okay
-    let target_override = codegen_backend.target_override(&sopts);
-
-    let bundle = match rustc_errors::fluent_bundle(
-        sopts.maybe_sysroot.clone(),
-        sysroot_candidates().to_vec(),
-        sopts.unstable_opts.translate_lang.clone(),
-        sopts.unstable_opts.translate_additional_ftl.as_deref(),
-        sopts.unstable_opts.translate_directionality_markers,
-    ) {
-        Ok(bundle) => bundle,
-        Err(e) => {
-            handler.early_error(format!("failed to load fluent bundle: {e}"));
-        }
-    };
-
-    let mut locale_resources = Vec::from(locale_resources);
-    locale_resources.push(codegen_backend.locale_resource());
-
-    let mut sess = session::build_session(
-        handler,
-        sopts,
-        io,
-        bundle,
-        descriptions,
-        locale_resources,
-        lint_caps,
-        file_loader,
-        target_override,
-        rustc_version_str().unwrap_or("unknown"),
-        ice_file,
-        using_internal_features,
-        expanded_args,
-    );
-
-    codegen_backend.init(&sess);
-
-    let mut cfg = config::build_configuration(&sess, cfg);
-    add_configuration(&mut cfg, &mut sess, &*codegen_backend);
-
-    check_cfg.fill_well_known(&sess.target);
-
-    // These configs use symbols, rather than strings.
-    sess.parse_sess.config = cfg;
-    sess.parse_sess.check_config = check_cfg;
-
-    (sess, codegen_backend)
 }
 
 const STACK_SIZE: usize = 8 * 1024 * 1024;


### PR DESCRIPTION
Currently the parts of session initialization that happen within `rustc_interface` are split between `run_compiler` and `create_session`. This split isn't necessary and obscures what's happening.

This commit merges the two functions. I think a single longer function is much clearer than splitting this code across two functions in different modules, especially when `create_session` has 13 parameters, and is misnamed (it also creates the codegen backend). The net result is 43 fewer lines of code.

r? @oli-obk 