### PR TITLE
Add debug_assert_nounwind to unchecked_{add,sub,neg,mul,shl,shr} methods (haunted PR)

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -7,6 +7,7 @@ use crate::hint;
 use crate::intrinsics;
 use crate::mem;
 use crate::ops::{Add, Mul, Sub};
+use crate::panic::debug_assert_nounwind;
 use crate::str::FromStr;
 
 // Used because the `?` operator is not allowed in a const context.

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -1,4 +1,3 @@
-use crate::intrinsics::{unchecked_add, unchecked_sub};
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::num::NonZero;
 
@@ -44,7 +43,7 @@ impl IndexRange {
     #[inline]
     pub const fn len(&self) -> usize {
         // SAFETY: By invariant, this cannot wrap
-        unsafe { unchecked_sub(self.end, self.start) }
+        unsafe { self.end.unchecked_sub(self.start) }
     }
 
     /// # Safety
@@ -55,7 +54,7 @@ impl IndexRange {
 
         let value = self.start;
         // SAFETY: The range isn't empty, so this cannot overflow
-        self.start = unsafe { unchecked_add(value, 1) };
+        self.start = unsafe { value.unchecked_add(1) };
         value
     }
 
@@ -66,7 +65,7 @@ impl IndexRange {
         debug_assert!(self.start < self.end);
 
         // SAFETY: The range isn't empty, so this cannot overflow
-        let value = unsafe { unchecked_sub(self.end, 1) };
+        let value = unsafe { self.end.unchecked_sub(1) };
         self.end = value;
         value
     }
@@ -81,7 +80,7 @@ impl IndexRange {
         let mid = if n <= self.len() {
             // SAFETY: We just checked that this will be between start and end,
             // and thus the addition cannot overflow.
-            unsafe { unchecked_add(self.start, n) }
+            unsafe { self.start.unchecked_add(n) }
         } else {
             self.end
         };
@@ -100,7 +99,7 @@ impl IndexRange {
         let mid = if n <= self.len() {
             // SAFETY: We just checked that this will be between start and end,
             // and thus the addition cannot overflow.
-            unsafe { unchecked_sub(self.end, n) }
+            unsafe { self.end.unchecked_sub(n) }
         } else {
             self.start
         };

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -167,7 +167,7 @@ pub macro debug_assert_nounwind {
             }
         }
     },
-    ($cond:expr, $message:expr) => {
+    ($cond:expr, $message:expr $(,)?) => {
         if $crate::intrinsics::debug_assertions() {
             if !$cond {
                 $crate::panicking::panic_nounwind($message);

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1021,8 +1021,8 @@ impl<T: ?Sized> *const T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     // We could always go back to wrapping if unchecked becomes unacceptable
-    #[rustc_allow_const_fn_unstable(const_int_unchecked_arith)]
     #[inline(always)]
+    #[rustc_allow_const_fn_unstable(unchecked_math)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn sub(self, count: usize) -> Self
     where
@@ -1035,7 +1035,10 @@ impl<T: ?Sized> *const T {
             // SAFETY: the caller must uphold the safety contract for `offset`.
             // Because the pointee is *not* a ZST, that means that `count` is
             // at most `isize::MAX`, and thus the negation cannot overflow.
-            unsafe { self.offset(intrinsics::unchecked_sub(0, count as isize)) }
+            // FIXME: replacing unchecked_sub with unchecked_neg and replacing the
+            // unchecked_math flag with unchecked_neg will anger the UnstableInStable lint
+            // and I cannot for the life of me understand why
+            unsafe { self.offset(0isize.unchecked_sub(count as isize)) }
         }
     }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1121,7 +1121,7 @@ impl<T: ?Sized> *mut T {
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
     // We could always go back to wrapping if unchecked becomes unacceptable
-    #[rustc_allow_const_fn_unstable(const_int_unchecked_arith)]
+    #[rustc_allow_const_fn_unstable(unchecked_math)]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn sub(self, count: usize) -> Self
@@ -1135,7 +1135,10 @@ impl<T: ?Sized> *mut T {
             // SAFETY: the caller must uphold the safety contract for `offset`.
             // Because the pointee is *not* a ZST, that means that `count` is
             // at most `isize::MAX`, and thus the negation cannot overflow.
-            unsafe { self.offset(intrinsics::unchecked_sub(0, count as isize)) }
+            // FIXME: replacing unchecked_sub with unchecked_neg and replacing the
+            // unchecked_math flag with unchecked_neg will anger the UnstableInStable lint
+            // and I cannot for the life of me understand why
+            unsafe { self.offset(0isize.unchecked_sub(count as isize)) }
         }
     }
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -702,7 +702,7 @@ impl<T: ?Sized> NonNull<T> {
     #[rustc_const_unstable(feature = "non_null_convenience", issue = "117691")]
     #[must_use = "returns a new pointer rather than modifying its argument"]
     // We could always go back to wrapping if unchecked becomes unacceptable
-    #[rustc_allow_const_fn_unstable(const_int_unchecked_arith)]
+    #[rustc_allow_const_fn_unstable(unchecked_math)]
     #[inline(always)]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn sub(self, count: usize) -> Self
@@ -716,7 +716,10 @@ impl<T: ?Sized> NonNull<T> {
             // SAFETY: the caller must uphold the safety contract for `offset`.
             // Because the pointee is *not* a ZST, that means that `count` is
             // at most `isize::MAX`, and thus the negation cannot overflow.
-            unsafe { self.offset(intrinsics::unchecked_sub(0, count as isize)) }
+            // FIXME: replacing unchecked_sub with unchecked_neg and replacing the
+            // unchecked_math flag with unchecked_neg will anger the UnstableInStable lint
+            // and I cannot for the life of me understand why
+            unsafe { self.offset(0isize.unchecked_sub(count as isize)) }
         }
     }
 

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -1,7 +1,6 @@
 //! Indexing implementations for `[T]`.
 
 use crate::intrinsics::const_eval_select;
-use crate::intrinsics::unchecked_sub;
 use crate::ops;
 use crate::panic::debug_assert_nounwind;
 use crate::ptr;
@@ -372,7 +371,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
         // `self` is in bounds of `slice` so `self` cannot overflow an `isize`,
         // so the call to `add` is safe and the length calculation cannot overflow.
         unsafe {
-            let new_len = unchecked_sub(self.end, self.start);
+            let new_len = self.end.unchecked_sub(self.start);
             ptr::slice_from_raw_parts(slice.as_ptr().add(self.start), new_len)
         }
     }
@@ -385,7 +384,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
         );
         // SAFETY: see comments for `get_unchecked` above.
         unsafe {
-            let new_len = unchecked_sub(self.end, self.start);
+            let new_len = self.end.unchecked_sub(self.start);
             ptr::slice_from_raw_parts_mut(slice.as_mut_ptr().add(self.start), new_len)
         }
     }

--- a/src/tools/miri/tests/pass/shims/time-with-isolation2.stdout
+++ b/src/tools/miri/tests/pass/shims/time-with-isolation2.stdout
@@ -1,1 +1,1 @@
-The loop took around 7s
+The loop took around 8s

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.Inline.panic-abort.diff
@@ -10,8 +10,17 @@
 +     scope 1 (inlined core::num::<impl u64>::unchecked_shl) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: u64;
++         let mut _5: bool;
++         let mut _6: bool;
++         let _7: !;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: u64;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -21,13 +30,34 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl u64>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind unreachable];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
-+         _5 = _4 as u64 (IntToInt);
-+         _0 = ShlUnchecked(_3, move _5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageLive(_6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
++         StorageDead(_6);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "u64::unchecked_shl cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         _8 = _4 as u64 (IntToInt);
++         _0 = ShlUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.Inline.panic-unwind.diff
@@ -10,8 +10,17 @@
 +     scope 1 (inlined core::num::<impl u64>::unchecked_shl) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: u64;
++         let mut _5: bool;
++         let mut _6: bool;
++         let _7: !;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: u64;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -21,13 +30,34 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl u64>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind continue];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
-+         _5 = _4 as u64 (IntToInt);
-+         _0 = ShlUnchecked(_3, move _5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageLive(_6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
++         StorageDead(_6);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "u64::unchecked_shl cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         _8 = _4 as u64 (IntToInt);
++         _0 = ShlUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.PreCodegen.after.panic-abort.mir
@@ -7,16 +7,47 @@ fn unchecked_shl_unsigned_bigger(_1: u64, _2: u32) -> u64 {
     scope 1 (inlined core::num::<impl u64>::unchecked_shl) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: u64;
+        let mut _3: bool;
+        let mut _4: bool;
+        let _5: !;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _6: u64;
+                scope 4 {
+                    debug rhs => _6;
+                }
+            }
         }
     }
 
     bb0: {
+        StorageLive(_6);
         StorageLive(_3);
-        _3 = _2 as u64 (IntToInt);
-        _0 = ShlUnchecked(_1, move _3);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "u64::unchecked_shl cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
+        _6 = _2 as u64 (IntToInt);
+        _0 = ShlUnchecked(_1, _6);
+        StorageDead(_6);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_bigger.PreCodegen.after.panic-unwind.mir
@@ -7,16 +7,47 @@ fn unchecked_shl_unsigned_bigger(_1: u64, _2: u32) -> u64 {
     scope 1 (inlined core::num::<impl u64>::unchecked_shl) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: u64;
+        let mut _3: bool;
+        let mut _4: bool;
+        let _5: !;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _6: u64;
+                scope 4 {
+                    debug rhs => _6;
+                }
+            }
         }
     }
 
     bb0: {
+        StorageLive(_6);
         StorageLive(_3);
-        _3 = _2 as u64 (IntToInt);
-        _0 = ShlUnchecked(_1, move _3);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "u64::unchecked_shl cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
+        _6 = _2 as u64 (IntToInt);
+        _0 = ShlUnchecked(_1, _6);
+        StorageDead(_6);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -10,9 +10,18 @@
 +     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: u16;
++         let mut _5: bool;
 +         let mut _6: bool;
++         let _7: !;
++         let mut _9: bool;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: u16;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -22,17 +31,38 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind unreachable];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
 +         StorageLive(_6);
-+         _6 = Le(_4, const 65535_u32);
-+         assume(move _6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
 +         StorageDead(_6);
-+         _5 = _4 as u16 (IntToInt);
-+         _0 = ShlUnchecked(_3, move _5);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "u16::unchecked_shl cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         StorageLive(_9);
++         _9 = Le(_4, const 65535_u32);
++         assume(move _9);
++         StorageDead(_9);
++         _8 = _4 as u16 (IntToInt);
++         _0 = ShlUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -10,9 +10,18 @@
 +     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: u16;
++         let mut _5: bool;
 +         let mut _6: bool;
++         let _7: !;
++         let mut _9: bool;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: u16;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -22,17 +31,38 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind continue];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
 +         StorageLive(_6);
-+         _6 = Le(_4, const 65535_u32);
-+         assume(move _6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
 +         StorageDead(_6);
-+         _5 = _4 as u16 (IntToInt);
-+         _0 = ShlUnchecked(_3, move _5);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "u16::unchecked_shl cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         StorageLive(_9);
++         _9 = Le(_4, const 65535_u32);
++         assume(move _9);
++         StorageDead(_9);
++         _8 = _4 as u16 (IntToInt);
++         _0 = ShlUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-abort.mir
@@ -8,20 +8,51 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
         debug self => _1;
         debug rhs => _2;
         let mut _3: bool;
-        let mut _4: u16;
+        let mut _4: bool;
+        let _5: !;
+        let mut _6: bool;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _7: u16;
+                scope 4 {
+                    debug rhs => _7;
+                }
+            }
         }
     }
 
     bb0: {
-        StorageLive(_4);
+        StorageLive(_7);
         StorageLive(_3);
-        _3 = Le(_2, const 65535_u32);
-        assume(move _3);
-        StorageDead(_3);
-        _4 = _2 as u16 (IntToInt);
-        _0 = ShlUnchecked(_1, move _4);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "u16::unchecked_shl cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
         StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = Le(_2, const 65535_u32);
+        assume(move _6);
+        StorageDead(_6);
+        _7 = _2 as u16 (IntToInt);
+        _0 = ShlUnchecked(_1, _7);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.PreCodegen.after.panic-unwind.mir
@@ -8,20 +8,51 @@ fn unchecked_shl_unsigned_smaller(_1: u16, _2: u32) -> u16 {
         debug self => _1;
         debug rhs => _2;
         let mut _3: bool;
-        let mut _4: u16;
+        let mut _4: bool;
+        let _5: !;
+        let mut _6: bool;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _7: u16;
+                scope 4 {
+                    debug rhs => _7;
+                }
+            }
         }
     }
 
     bb0: {
-        StorageLive(_4);
+        StorageLive(_7);
         StorageLive(_3);
-        _3 = Le(_2, const 65535_u32);
-        assume(move _3);
-        StorageDead(_3);
-        _4 = _2 as u16 (IntToInt);
-        _0 = ShlUnchecked(_1, move _4);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "u16::unchecked_shl cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
         StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = Le(_2, const 65535_u32);
+        assume(move _6);
+        StorageDead(_6);
+        _7 = _2 as u16 (IntToInt);
+        _0 = ShlUnchecked(_1, _7);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
@@ -10,8 +10,17 @@
 +     scope 1 (inlined core::num::<impl i64>::unchecked_shr) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: i64;
++         let mut _5: bool;
++         let mut _6: bool;
++         let _7: !;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: i64;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -21,13 +30,34 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl i64>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind unreachable];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
-+         _5 = _4 as i64 (IntToInt);
-+         _0 = ShrUnchecked(_3, move _5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageLive(_6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
++         StorageDead(_6);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "i64::unchecked_shr cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         _8 = _4 as i64 (IntToInt);
++         _0 = ShrUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
@@ -10,8 +10,17 @@
 +     scope 1 (inlined core::num::<impl i64>::unchecked_shr) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: i64;
++         let mut _5: bool;
++         let mut _6: bool;
++         let _7: !;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: i64;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -21,13 +30,34 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl i64>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind continue];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
-+         _5 = _4 as i64 (IntToInt);
-+         _0 = ShrUnchecked(_3, move _5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageLive(_6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
++         StorageDead(_6);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "i64::unchecked_shr cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         _8 = _4 as i64 (IntToInt);
++         _0 = ShrUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.PreCodegen.after.panic-abort.mir
@@ -7,16 +7,47 @@ fn unchecked_shr_signed_bigger(_1: i64, _2: u32) -> i64 {
     scope 1 (inlined core::num::<impl i64>::unchecked_shr) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: i64;
+        let mut _3: bool;
+        let mut _4: bool;
+        let _5: !;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _6: i64;
+                scope 4 {
+                    debug rhs => _6;
+                }
+            }
         }
     }
 
     bb0: {
+        StorageLive(_6);
         StorageLive(_3);
-        _3 = _2 as i64 (IntToInt);
-        _0 = ShrUnchecked(_1, move _3);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "i64::unchecked_shr cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
+        _6 = _2 as i64 (IntToInt);
+        _0 = ShrUnchecked(_1, _6);
+        StorageDead(_6);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.PreCodegen.after.panic-unwind.mir
@@ -7,16 +7,47 @@ fn unchecked_shr_signed_bigger(_1: i64, _2: u32) -> i64 {
     scope 1 (inlined core::num::<impl i64>::unchecked_shr) {
         debug self => _1;
         debug rhs => _2;
-        let mut _3: i64;
+        let mut _3: bool;
+        let mut _4: bool;
+        let _5: !;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _6: i64;
+                scope 4 {
+                    debug rhs => _6;
+                }
+            }
         }
     }
 
     bb0: {
+        StorageLive(_6);
         StorageLive(_3);
-        _3 = _2 as i64 (IntToInt);
-        _0 = ShrUnchecked(_1, move _3);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "i64::unchecked_shr cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
         StorageDead(_3);
+        _6 = _2 as i64 (IntToInt);
+        _0 = ShrUnchecked(_1, _6);
+        StorageDead(_6);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-abort.diff
@@ -10,9 +10,18 @@
 +     scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: i16;
++         let mut _5: bool;
 +         let mut _6: bool;
++         let _7: !;
++         let mut _9: bool;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: i16;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -22,17 +31,38 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind unreachable];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
 +         StorageLive(_6);
-+         _6 = Le(_4, const 32767_u32);
-+         assume(move _6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
 +         StorageDead(_6);
-+         _5 = _4 as i16 (IntToInt);
-+         _0 = ShrUnchecked(_3, move _5);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "i16::unchecked_shr cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         StorageLive(_9);
++         _9 = Le(_4, const 32767_u32);
++         assume(move _9);
++         StorageDead(_9);
++         _8 = _4 as i16 (IntToInt);
++         _0 = ShrUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.Inline.panic-unwind.diff
@@ -10,9 +10,18 @@
 +     scope 1 (inlined core::num::<impl i16>::unchecked_shr) {
 +         debug self => _3;
 +         debug rhs => _4;
-+         let mut _5: i16;
++         let mut _5: bool;
 +         let mut _6: bool;
++         let _7: !;
++         let mut _9: bool;
 +         scope 2 {
++             scope 3 {
++                 debug lhs => _3;
++                 let _8: i16;
++                 scope 4 {
++                     debug rhs => _8;
++                 }
++             }
 +         }
 +     }
   
@@ -22,17 +31,38 @@
           StorageLive(_4);
           _4 = _2;
 -         _0 = core::num::<impl i16>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind continue];
--     }
-- 
--     bb1: {
++         StorageLive(_7);
++         StorageLive(_8);
 +         StorageLive(_5);
++         _5 = cfg!(debug_assertions);
++         switchInt(move _5) -> [0: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
 +         StorageLive(_6);
-+         _6 = Le(_4, const 32767_u32);
-+         assume(move _6);
++         _6 = Lt(_4, const _);
++         switchInt(move _6) -> [0: bb3, otherwise: bb2];
++     }
++ 
++     bb2: {
 +         StorageDead(_6);
-+         _5 = _4 as i16 (IntToInt);
-+         _0 = ShrUnchecked(_3, move _5);
++         goto -> bb4;
++     }
++ 
++     bb3: {
++         _7 = core::panicking::panic_nounwind(const "i16::unchecked_shr cannot overflow") -> unwind unreachable;
++     }
++ 
++     bb4: {
 +         StorageDead(_5);
++         StorageLive(_9);
++         _9 = Le(_4, const 32767_u32);
++         assume(move _9);
++         StorageDead(_9);
++         _8 = _4 as i16 (IntToInt);
++         _0 = ShrUnchecked(_3, _8);
++         StorageDead(_8);
++         StorageDead(_7);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-abort.mir
@@ -8,20 +8,51 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
         debug self => _1;
         debug rhs => _2;
         let mut _3: bool;
-        let mut _4: i16;
+        let mut _4: bool;
+        let _5: !;
+        let mut _6: bool;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _7: i16;
+                scope 4 {
+                    debug rhs => _7;
+                }
+            }
         }
     }
 
     bb0: {
-        StorageLive(_4);
+        StorageLive(_7);
         StorageLive(_3);
-        _3 = Le(_2, const 32767_u32);
-        assume(move _3);
-        StorageDead(_3);
-        _4 = _2 as i16 (IntToInt);
-        _0 = ShrUnchecked(_1, move _4);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "i16::unchecked_shr cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
         StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = Le(_2, const 32767_u32);
+        assume(move _6);
+        StorageDead(_6);
+        _7 = _2 as i16 (IntToInt);
+        _0 = ShrUnchecked(_1, _7);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_smaller.PreCodegen.after.panic-unwind.mir
@@ -8,20 +8,51 @@ fn unchecked_shr_signed_smaller(_1: i16, _2: u32) -> i16 {
         debug self => _1;
         debug rhs => _2;
         let mut _3: bool;
-        let mut _4: i16;
+        let mut _4: bool;
+        let _5: !;
+        let mut _6: bool;
         scope 2 {
+            scope 3 {
+                debug lhs => _1;
+                let _7: i16;
+                scope 4 {
+                    debug rhs => _7;
+                }
+            }
         }
     }
 
     bb0: {
-        StorageLive(_4);
+        StorageLive(_7);
         StorageLive(_3);
-        _3 = Le(_2, const 32767_u32);
-        assume(move _3);
-        StorageDead(_3);
-        _4 = _2 as i16 (IntToInt);
-        _0 = ShrUnchecked(_1, move _4);
+        _3 = cfg!(debug_assertions);
+        switchInt(move _3) -> [0: bb4, otherwise: bb1];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = Lt(_2, const _);
+        switchInt(move _4) -> [0: bb2, otherwise: bb3];
+    }
+
+    bb2: {
+        _5 = core::panicking::panic_nounwind(const "i16::unchecked_shr cannot overflow") -> unwind unreachable;
+    }
+
+    bb3: {
         StorageDead(_4);
+        goto -> bb4;
+    }
+
+    bb4: {
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = Le(_2, const 32767_u32);
+        assume(move _6);
+        StorageDead(_6);
+        _7 = _2 as i16 (IntToInt);
+        _0 = ShrUnchecked(_1, _7);
+        StorageDead(_7);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.mir
@@ -20,13 +20,10 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
             scope 4 (inlined core::num::<impl u32>::wrapping_shl) {
                 debug self => _1;
                 debug rhs => _2;
-                let mut _3: u32;
                 scope 5 {
-                    scope 6 (inlined core::num::<impl u32>::unchecked_shl) {
-                        debug self => _1;
+                    let _3: u32;
+                    scope 6 {
                         debug rhs => _3;
-                        scope 7 {
-                        }
                     }
                 }
             }


### PR DESCRIPTION
This ensures that these preconditions are actually checked in debug mode, and hopefully should let people know if they messed up. I've also replaced the calls (I could find) in the code that use these intrinsics directly with those that use these methods, so that the asserts actually apply.

More discussions on people misusing these methods in the tracking issue: #85122.