### PR TITLE
Hint optimizer about try-reserved capacity

### DIFF
--- a/tests/codegen/vec-reserve-extend.rs
+++ b/tests/codegen/vec-reserve-extend.rs
@@ -1,0 +1,14 @@
+// compile-flags: -O
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: @should_reserve_once
+#[no_mangle]
+pub fn should_reserve_once(v: &mut Vec<u8>) {
+    // CHECK: tail call void @llvm.assume
+    v.try_reserve(3).unwrap();
+    // CHECK-NOT: call {{.*}}reserve
+    // CHECK-NOT: call {{.*}}do_reserve_and_handle
+    // CHECK-NOT: call {{.*}}__rust_alloc(
+    v.extend([1, 2, 3]);
+}

--- a/tests/ui/hygiene/panic-location.run.stderr
+++ b/tests/ui/hygiene/panic-location.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at library/alloc/src/raw_vec.rs:535:5:
+thread 'main' panicked at library/alloc/src/raw_vec.rs:545:5:
 capacity overflow
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This is #116568, but limited only to the less-common `try_reserve` functions to reduce bloat in debug binaries from debug info, while still addressing the main use-case #117925