### PR TITLE
Fix incorrect trait bound restriction suggestion

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -274,6 +274,8 @@ pub fn suggest_constraining_type_params<'a>(
                 span,
                 if span_to_replace.is_some() {
                     constraint.clone()
+                } else if constraint.starts_with("<") {
+                    constraint.to_string()
                 } else if bound_list_non_empty {
                     format!(" + {constraint}")
                 } else {

--- a/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.fixed
+++ b/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+pub trait MyTrait {
+    type T;
+
+    fn bar(self) -> Self::T;
+}
+
+pub fn foo<A: MyTrait<T = B>, B>(a: A) -> B {
+    return a.bar(); //~ ERROR mismatched types
+}
+fn main() {}

--- a/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.rs
+++ b/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+pub trait MyTrait {
+    type T;
+
+    fn bar(self) -> Self::T;
+}
+
+pub fn foo<A: MyTrait, B>(a: A) -> B {
+    return a.bar(); //~ ERROR mismatched types
+}
+fn main() {}

--- a/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
+++ b/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/restrict-assoc-type-of-generic-bound.rs:9:12
+   |
+LL | pub fn foo<A: MyTrait, B>(a: A) -> B {
+   |                        -           - expected `B` because of return type
+   |                        |
+   |                        expected this type parameter
+LL |     return a.bar();
+   |            ^^^^^^^ expected type parameter `B`, found associated type
+   |
+   = note: expected type parameter `B`
+             found associated type `<A as MyTrait>::T`
+help: consider further restricting this bound
+   |
+LL | pub fn foo<A: MyTrait<T = B>, B>(a: A) -> B {
+   |                      +++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Suggest

```
error[E0308]: mismatched types
  --> $DIR/restrict-assoc-type-of-generic-bound.rs:9:12
   |
LL | pub fn foo<A: MyTrait, B>(a: A) -> B {
   |                        -           - expected `B` because of return type
   |                        |
   |                        expected this type parameter
LL |     return a.bar();
   |            ^^^^^^^ expected type parameter `B`, found associated type
   |
   = note: expected type parameter `B`
             found associated type `<A as MyTrait>::T`
help: consider further restricting this bound
   |
LL | pub fn foo<A: MyTrait<T = B>, B>(a: A) -> B {
   |                      +++++++
```

instead of

```
error[E0308]: mismatched types
  --> $DIR/restrict-assoc-type-of-generic-bound.rs:9:12
   |
LL | pub fn foo<A: MyTrait, B>(a: A) -> B {
   |                        -           - expected `B` because of return type
   |                        |
   |                        expected this type parameter
LL |     return a.bar();
   |            ^^^^^^^ expected type parameter `B`, found associated type
   |
   = note: expected type parameter `B`
             found associated type `<A as MyTrait>::T`
help: consider further restricting this bound
   |
LL | pub fn foo<A: MyTrait + <T = B>, B>(a: A) -> B {
   |                      +++++++++
```

Fix #117501.