### PR TITLE
Fix order of implementations in the "implementations on foreign types" section

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -991,7 +991,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
             }
         }
 
-        let (local, foreign) =
+        let (local, mut foreign) =
             implementors.iter().partition::<Vec<_>, _>(|i| i.is_on_local_type(cx));
 
         let (mut synthetic, mut concrete): (Vec<&&Impl>, Vec<&&Impl>) =
@@ -999,6 +999,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
 
         synthetic.sort_by_cached_key(|i| ImplString::new(i, cx));
         concrete.sort_by_cached_key(|i| ImplString::new(i, cx));
+        foreign.sort_by_cached_key(|i| ImplString::new(i, cx));
 
         if !foreign.is_empty() {
             write_small_section_header(w, "foreign-impls", "Implementations on Foreign Types", "");

--- a/tests/rustdoc-gui/impl_on_foreign_order.goml
+++ b/tests/rustdoc-gui/impl_on_foreign_order.goml
@@ -1,0 +1,6 @@
+// This test ensures that the "implementations on foreign types" of a trait are correctly sorted.
+go-to: "file://" + |DOC_PATH| + "/test_docs/foreign_impl_order/trait.Foo.html"
+assert-text: ("details:nth-of-type(1) h3", "impl Foo<1> for [u8; 1]")
+assert-text: ("details:nth-of-type(2) h3", "impl Foo<2> for [u8; 2]")
+assert-text: ("details:nth-of-type(3) h3", "impl Foo<3> for [u8; 3]")
+assert-text: ("details:nth-of-type(4) h3", "impl Foo<4> for [u8; 4]")

--- a/tests/rustdoc-gui/search-tab.goml
+++ b/tests/rustdoc-gui/search-tab.goml
@@ -79,7 +79,7 @@ call-function: ("check-colors", {
 set-window-size: (851, 600)
 
 // Check the size and count in tabs
-assert-text: ("#search-tabs > button:nth-child(1) > .count", " (24) ")
+assert-text: ("#search-tabs > button:nth-child(1) > .count", " (25) ")
 assert-text: ("#search-tabs > button:nth-child(2) > .count", " (5)  ")
 assert-text: ("#search-tabs > button:nth-child(3) > .count", " (0)  ")
 store-property: ("#search-tabs > button:nth-child(1)", {"offsetWidth": buttonWidth})

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -574,3 +574,22 @@ impl ZyxwvutTrait for ZyxwvutMethodDisambiguation {
         x
     }
 }
+
+pub mod foreign_impl_order {
+    pub trait Foo<const W: usize> {
+        fn f(&mut self, with: [u8; W]);
+    }
+
+    impl Foo<4> for [u8; 4] {
+        fn f(&mut self, fg: [u8; 4]) {}
+    }
+    impl Foo<2> for [u8; 2] {
+        fn f(&mut self, fg: [u8; 2]) {}
+    }
+    impl Foo<1> for [u8; 1] {
+        fn f(&mut self, fg: [u8; 1]) {}
+    }
+    impl Foo<3> for [u8; 3] {
+        fn f(&mut self, fg: [u8; 3]) {}
+    }
+}


### PR DESCRIPTION
Fixes #117391.

We forgot to run the `sort_by_cached_key` on this section. This fixes it.

r? @notriddle 