### PR TITLE
bootstrap/setup: create hooks directory if non-existing

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -469,7 +469,8 @@ fn install_git_hook_maybe(config: &Config) -> io::Result<()> {
         assert!(output.status.success(), "failed to run `git`");
         PathBuf::from(t!(String::from_utf8(output.stdout)).trim())
     }));
-    let dst = git.join("hooks").join("pre-push");
+    let hooks_dir = git.join("hooks");
+    let dst = hooks_dir.join("pre-push");
     if dst.exists() {
         // The git hook has already been set up, or the user already has a custom hook.
         return Ok(());
@@ -485,6 +486,10 @@ undesirable, simply delete the `pre-push` file from .git/hooks."
     if prompt_user("Would you like to install the git hook?: [y/N]")? != Some(PromptResult::Yes) {
         println!("Ok, skipping installation!");
         return Ok(());
+    }
+    if !hooks_dir.exists() {
+        // We need to (try to) create the hooks directory first.
+        let _ = fs::create_dir(hooks_dir);
     }
     let src = config.src.join("src").join("etc").join("pre-push.sh");
     match fs::hard_link(src, &dst) {


### PR DESCRIPTION
When running `./x setup` on a local repository I chose to install a `pre-push` git hook, but this happened:

```shell
Would you like to install the git hook?: [y/N] y
error: could not create hook .git/hooks/pre-push: do you already have the git hook installed?
No such file or directory (os error 2)
thread 'main' panicked at src/core/build_steps/setup.rs:462:9:
install_git_hook_maybe(&config) failed with No such file or directory (os error 2)
```

This was caused because the `.git/hooks` directory did not exist in my local repository. Creating it manually and re-running the command works fine.

This PR tests for the above directory and if it does not exist then it _tries_ to create it before hard linking the pre-push hook - we use `fs::create_dir()` and disregard the result (ie. it could fail if the directory was created in the meantime) and proceed to call `fs::hard_link()` all the same.