### PR TITLE
Revert "bootstrap: do not purge docs on CI environment"

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -28,7 +28,6 @@ pub use crate::Compiler;
 // - use std::lazy for `Lazy`
 // - use std::cell for `OnceCell`
 // Once they get stabilized and reach beta.
-use build_helper::ci::CiEnv;
 use clap::ValueEnum;
 use once_cell::sync::{Lazy, OnceCell};
 
@@ -1274,12 +1273,7 @@ impl<'a> Builder<'a> {
             self.clear_if_dirty(&out_dir, &backend);
         }
 
-        if cmd == "doc"
-            || cmd == "rustdoc"
-            // FIXME: We shouldn't need to check this.
-            // ref https://github.com/rust-lang/rust/issues/117430#issuecomment-1788160523
-            && !CiEnv::is_ci()
-        {
+        if cmd == "doc" || cmd == "rustdoc" {
             let my_out = match mode {
                 // This is the intended out directory for compiler documentation.
                 Mode::Rustc | Mode::ToolRustc => self.compiler_doc_out(target),


### PR DESCRIPTION
This reverts commit 6198e881d363730900b7b0d4fa8311b3844421a7.

ref https://github.com/rust-lang/rust/issues/117430#issuecomment-1791609163, https://github.com/rust-lang/rust/pull/117471#issuecomment-1791937529