### PR TITLE
Revert "Auto merge of #117328 - lqd:cranelift-rocket, r=Mark-Simulacrum"

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1298,18 +1298,10 @@ impl Step for CodegenBackend {
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<GeneratedTarball> {
-        if builder.config.dry_run() {
-            return None;
-        }
-
         // This prevents rustc_codegen_cranelift from being built for "dist"
         // or "install" on the stable/beta channels. It is not yet stable and
         // should not be included.
         if !builder.build.unstable_features() {
-            return None;
-        }
-
-        if !builder.config.rust_codegen_backends.contains(&self.backend) {
             return None;
         }
 
@@ -1351,15 +1343,12 @@ impl Step for CodegenBackend {
         let backends_dst = PathBuf::from("lib").join(&backends_rel);
 
         let backend_name = format!("rustc_codegen_{}", backend);
-        let mut found_backend = false;
         for backend in fs::read_dir(&backends_src).unwrap() {
             let file_name = backend.unwrap().file_name();
             if file_name.to_str().unwrap().contains(&backend_name) {
                 tarball.add_file(backends_src.join(file_name), &backends_dst, 0o644);
-                found_backend = true;
             }
         }
-        assert!(found_backend);
 
         Some(tarball.generate())
     }

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -302,7 +302,6 @@ docker \
   --env DIST_TRY_BUILD \
   --env PR_CI_JOB \
   --env OBJDIR_ON_HOST="$objdir" \
-  --env CODEGEN_BACKENDS \
   --init \
   --rm \
   rust-ci \


### PR DESCRIPTION
This reverts commit 1dfb6b162be402d8ca37e8aad4f58898b44e3a15, reversing changes made to bcb5798dd890a691644af9d371f3bd7fcc465584.

That commit broke generating nightly rustc docs. Revert it until we can figure out how to have both, cranelift and docs.

Fixes https://github.com/rust-lang/rust/issues/117430