### PR TITLE
Expands help for error message E0161

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0161.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0161.md
@@ -21,9 +21,9 @@ fn main() {
 
 In Rust, you can only move a value when its size is known at compile time.
 
-To work around this restriction, consider "hiding" the value behind a reference:
-either `&x` or `&mut x`. Since a reference has a fixed size, this lets you move
-it around as usual. Example:
+To work around this restriction, consider "hiding" the value behind a
+reference: either `&x` or `&mut x`. Since a reference has a fixed size, this
+lets you move it around as usual. Example:
 
 ```
 trait Bar {
@@ -36,6 +36,30 @@ impl Bar for i32 {
 
 fn main() {
     let b: Box<dyn Bar> = Box::new(0i32);
+    b.f();
+    // ok!
+}
+```
+
+If you absolutely must use a value by moving in a trait, and you know that you
+will primarily use your trait through boxed trait objects, you may want to
+consider using the `Box<Self>` pattern.  You can then move the value out of the
+`Box` by dereferencing. For example:
+
+```
+trait Bar {
+    fn f(self: Box<Self>);
+}
+
+impl Bar for String {
+    fn f(self: Box<Self>) {
+        // move the string out of the box
+        let _string: String = *self;
+    }
+}
+
+fn main() {
+    let b: Box<dyn Bar> = Box::new(String::new());
     b.f();
     // ok!
 }


### PR DESCRIPTION
This error message gets triggered when someone wants to move a value in a trait object, for example:

```rust
pub trait Bar {
    fn finalize(self);
}

impl Bar for String {
    fn finalize(self) {}
}

fn main() {
    let boxed_trait: Box<dyn Bar> = Box::new(String::from("Hello"));
    // error!
    boxed_trait.finalize();
}
```

The existing message gives the advice of using a reference to `self` in the `finalize()` method. In general, this is sound advice for people who are new to Rust, where they may really intend to take a reference but are used to Python for example.

However, this does not address the situation where someone actually **needs** to move the value. One example is something where you have some kind of a builder pattern (or hash digester, or transaction reference) which have a `finalize(self)` method that you need to consume the boxed trait object as finalization can only be performed once.

In the case where:
- You know you will use your trait via boxed trait objects
- You need a method where self is consumed

You can achieve this in another way. This commit adds a suggestion for a possible workaround of using the `Box<Self>` pattern where one intends to move a self value in the case of using a boxed trait object.

```rust
pub trait Bar {
    fn finalize(self: Box<Self>);
}

impl Bar for String {
    fn finalize(self: Box<Self>) {}
}

fn main() {
    let boxed_trait: Box<dyn Bar> = Box::new(String::from("Hello"));
    // works!
    boxed_trait.finalize();
}
```

As this suggestion was very helpful to me, I would like to add it to the error code documentation for others to be able to find it easily as well. I do not replace the existing suggestion of using references, because in most cases that should be preferred. It is only when you know that your trait will *always be used via boxed trait objects* that this suggestion is the one you are looking for. 

What do you think about this? I'm happy to hear some feedback if this is a good thing to add to the error message (or if there is an even better way that I had not thought about).

Cheers!