### PR TITLE
Feature gate enums in offset_of

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0795.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0795.md
@@ -3,7 +3,7 @@ Invalid argument for the `offset_of!` macro.
 Erroneous code example:
 
 ```compile_fail,E0795
-#![feature(offset_of)]
+#![feature(offset_of, offset_of_enum)]
 
 let x = std::mem::offset_of!(Option<u8>, Some);
 ```
@@ -16,7 +16,7 @@ The offset of the contained `u8` in the `Option<u8>` can be found by specifying
 the field name `0`:
 
 ```
-#![feature(offset_of)]
+#![feature(offset_of, offset_of_enum)]
 
 let x: usize = std::mem::offset_of!(Option<u8>, Some.0);
 ```

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -526,6 +526,8 @@ declare_features! (
     /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
     /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.
     (unstable, object_safe_for_dispatch, "1.40.0", Some(43561), None),
+    /// Allows using enums in offset_of!
+    (unstable, offset_of_enum, "CURRENT_RUSTC_VERSION", Some(106655), None),
     /// Allows using `#[optimize(X)]`.
     (unstable, optimize_attribute, "1.34.0", Some(54882), None),
     /// Allows using `#![plugin(myplugin)]`.

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3118,6 +3118,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let (ident, _def_scope) =
                         self.tcx.adjust_ident_and_get_scope(field, container_def.did(), block);
 
+                    if !self.tcx.features().offset_of_enum {
+                        rustc_session::parse::feature_err(
+                            &self.tcx.sess.parse_sess,
+                            sym::offset_of_enum,
+                            ident.span,
+                            "using enums in offset_of is experimental",
+                            ).emit();
+                    }
+
                     let Some((index, variant)) = container_def.variants()
                         .iter_enumerated()
                         .find(|(_, v)| v.ident(self.tcx).normalize_to_macros_2_0() == ident) else {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3124,7 +3124,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             sym::offset_of_enum,
                             ident.span,
                             "using enums in offset_of is experimental",
-                            ).emit();
+                        ).emit();
                     }
 
                     let Some((index, variant)) = container_def.variants()

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1114,6 +1114,7 @@ symbols! {
         off,
         offset,
         offset_of,
+        offset_of_enum,
         omit_gdb_pretty_printer_section,
         on,
         on_unimplemented,

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1355,7 +1355,8 @@ impl<T> SizedTypeProperties for T {}
 /// # Examples
 ///
 /// ```
-/// #![feature(offset_of, offset_of_enum)]
+/// #![feature(offset_of)]
+/// # #![cfg_attr(not(bootstrap), feature(offset_of_enum))]
 ///
 /// use std::mem;
 /// #[repr(C)]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1355,7 +1355,7 @@ impl<T> SizedTypeProperties for T {}
 /// # Examples
 ///
 /// ```
-/// #![feature(offset_of)]
+/// #![feature(offset_of, offset_of_enum)]
 ///
 /// use std::mem;
 /// #[repr(C)]

--- a/tests/mir-opt/const_prop/offset_of.rs
+++ b/tests/mir-opt/const_prop/offset_of.rs
@@ -2,7 +2,7 @@
 // unit-test: ConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
-#![feature(offset_of)]
+#![feature(offset_of, offset_of_enum)]
 
 use std::marker::PhantomData;
 use std::mem::offset_of;

--- a/tests/ui/feature-gates/feature-gate-offset-of-enum.rs
+++ b/tests/ui/feature-gates/feature-gate-offset-of-enum.rs
@@ -1,0 +1,15 @@
+#![feature(offset_of)]
+
+use std::mem::offset_of;
+
+enum Alpha {
+    One(u8),
+    Two(u8),
+}
+
+fn main() {
+    offset_of!(Alpha::One, 0); //~ ERROR expected type, found variant `Alpha::One`
+    offset_of!(Alpha, One); //~ ERROR `One` is an enum variant; expected field at end of `offset_of`
+                            //~| ERROR using enums in offset_of is experimental
+    offset_of!(Alpha, Two.0); //~ ERROR using enums in offset_of is experimental
+}

--- a/tests/ui/feature-gates/feature-gate-offset-of-enum.stderr
+++ b/tests/ui/feature-gates/feature-gate-offset-of-enum.stderr
@@ -1,0 +1,37 @@
+error[E0573]: expected type, found variant `Alpha::One`
+  --> $DIR/feature-gate-offset-of-enum.rs:11:16
+   |
+LL |     offset_of!(Alpha::One, 0);
+   |                ^^^^^^^^^^
+   |                |
+   |                not a type
+   |                help: try using the variant's enum: `Alpha`
+
+error[E0658]: using enums in offset_of is experimental
+  --> $DIR/feature-gate-offset-of-enum.rs:12:23
+   |
+LL |     offset_of!(Alpha, One);
+   |                       ^^^
+   |
+   = note: see issue #106655 <https://github.com/rust-lang/rust/issues/106655> for more information
+   = help: add `#![feature(offset_of_enum)]` to the crate attributes to enable
+
+error[E0795]: `One` is an enum variant; expected field at end of `offset_of`
+  --> $DIR/feature-gate-offset-of-enum.rs:12:23
+   |
+LL |     offset_of!(Alpha, One);
+   |                       ^^^ enum variant
+
+error[E0658]: using enums in offset_of is experimental
+  --> $DIR/feature-gate-offset-of-enum.rs:14:23
+   |
+LL |     offset_of!(Alpha, Two.0);
+   |                       ^^^
+   |
+   = note: see issue #106655 <https://github.com/rust-lang/rust/issues/106655> for more information
+   = help: add `#![feature(offset_of_enum)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0573, E0658, E0795.
+For more information about an error, try `rustc --explain E0573`.

--- a/tests/ui/offset-of/offset-of-enum.rs
+++ b/tests/ui/offset-of/offset-of-enum.rs
@@ -1,4 +1,4 @@
-#![feature(offset_of)]
+#![feature(offset_of, offset_of_enum)]
 
 use std::mem::offset_of;
 

--- a/tests/ui/offset-of/offset-of-private.rs
+++ b/tests/ui/offset-of/offset-of-private.rs
@@ -1,4 +1,4 @@
-#![feature(offset_of)]
+#![feature(offset_of, offset_of_enum)]
 
 use std::mem::offset_of;
 


### PR DESCRIPTION
As requested at https://github.com/rust-lang/rust/issues/106655#issuecomment-1790815262, put enums in offset_of behind their own feature gate.

@rustbot label F-offset_of