### PR TITLE
add test for #113272

### DIFF
--- a/tests/ui/transmute/missing-bound-normalization-ice-113272.rs
+++ b/tests/ui/transmute/missing-bound-normalization-ice-113272.rs
@@ -1,0 +1,19 @@
+// test for ICE #113272  Failed to normalize <() as Trait>::RefTarget ...
+
+trait Trait {
+    type RefTarget;
+}
+
+impl Trait for () where Missing: Trait {}
+//~^ ERROR: cannot find type `Missing` in this scope
+//~^^ ERROR: not all trait items implemented, missing: `RefTarget`
+
+struct Other {
+    data: <() as Trait>::RefTarget,
+}
+
+fn main() {
+    unsafe {
+        std::mem::transmute::<Option<()>, Option<&Other>>(None);
+    }
+}

--- a/tests/ui/transmute/missing-bound-normalization-ice-113272.stderr
+++ b/tests/ui/transmute/missing-bound-normalization-ice-113272.stderr
@@ -1,0 +1,19 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/missing-bound-normalization-ice-113272.rs:7:25
+   |
+LL | impl Trait for () where Missing: Trait {}
+   |                         ^^^^^^^ not found in this scope
+
+error[E0046]: not all trait items implemented, missing: `RefTarget`
+  --> $DIR/missing-bound-normalization-ice-113272.rs:7:1
+   |
+LL |     type RefTarget;
+   |     -------------- `RefTarget` from trait
+...
+LL | impl Trait for () where Missing: Trait {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `RefTarget` in implementation
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0046, E0412.
+For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
error: internal compiler error: compiler/rustc_middle/src/ty/normalize_erasing_regions.rs:195:90: Failed to normalize <() as Trait>::RefTarget, maybe try to call `try_normalize_erasing_regions` instead

Fixes #113272