### PR TITLE
Only use `normalize_param_env` when normalizing predicate in `check_item_bounds`

### DIFF
--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.rs
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.rs
@@ -1,4 +1,4 @@
-// check-pass
+// known-bug: #117606
 
 #![feature(associated_type_defaults)]
 

--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.stderr
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `<Self as Foo>::Bar<()>: Eq<i32>` is not satisfied
+  --> $DIR/assume-gat-normalization-for-nested-goals.rs:6:30
+   |
+LL |     type Bar<T>: Baz<Self> = i32;
+   |                              ^^^ the trait `Eq<i32>` is not implemented for `<Self as Foo>::Bar<()>`
+   |
+note: required for `i32` to implement `Baz<Self>`
+  --> $DIR/assume-gat-normalization-for-nested-goals.rs:13:23
+   |
+LL | impl<T: Foo + ?Sized> Baz<T> for i32 where T::Bar<()>: Eq<i32> {}
+   |                       ^^^^^^     ^^^                   ------- unsatisfied trait bound introduced here
+note: required by a bound in `Foo::Bar`
+  --> $DIR/assume-gat-normalization-for-nested-goals.rs:6:18
+   |
+LL |     type Bar<T>: Baz<Self> = i32;
+   |                  ^^^^^^^^^ required by this bound in `Foo::Bar`
+help: consider further restricting the associated type
+   |
+LL | trait Foo where <Self as Foo>::Bar<()>: Eq<i32> {
+   |           +++++++++++++++++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/generic-associated-types/higher-ranked-self-impl-requirement.rs
+++ b/tests/ui/generic-associated-types/higher-ranked-self-impl-requirement.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+trait Database: for<'r> HasValueRef<'r, Database = Self> {}
+
+trait HasValueRef<'r> {
+    type Database: Database;
+}
+
+struct Any;
+
+impl Database for Any {}
+
+impl<'r> HasValueRef<'r> for Any {
+    // Make sure we don't have issues when the GAT assumption
+    // `<Any as HasValue<'r>>::Database = Any` isn't universally
+    // parameterized over `'r`.
+    type Database = Any;
+}
+
+fn main() {}

--- a/tests/ui/traits/new-solver/specialization-transmute.rs
+++ b/tests/ui/traits/new-solver/specialization-transmute.rs
@@ -10,7 +10,7 @@ trait Default {
 }
 
 impl<T> Default for T {
-    default type Id = T;
+    default type Id = T; //~ ERROR type annotations needed
     // This will be fixed by #111994
     fn intu(&self) -> &Self::Id { //~ ERROR type annotations needed
         self

--- a/tests/ui/traits/new-solver/specialization-transmute.stderr
+++ b/tests/ui/traits/new-solver/specialization-transmute.stderr
@@ -16,6 +16,13 @@ LL |     fn intu(&self) -> &Self::Id {
    |
    = note: cannot satisfy `<T as Default>::Id == _`
 
-error: aborting due to previous error; 1 warning emitted
+error[E0282]: type annotations needed
+  --> $DIR/specialization-transmute.rs:13:23
+   |
+LL |     default type Id = T;
+   |                       ^ cannot infer type for associated type `<T as Default>::Id`
 
-For more information about this error, try `rustc --explain E0284`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0282, E0284.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/traits/new-solver/specialization-unconstrained.rs
+++ b/tests/ui/traits/new-solver/specialization-unconstrained.rs
@@ -11,7 +11,7 @@ trait Default {
 }
 
 impl<T> Default for T {
-   default type Id = T;
+   default type Id = T; //~ ERROR type annotations needed
 }
 
 fn test<T: Default<Id = U>, U>() {}

--- a/tests/ui/traits/new-solver/specialization-unconstrained.stderr
+++ b/tests/ui/traits/new-solver/specialization-unconstrained.stderr
@@ -20,6 +20,13 @@ note: required by a bound in `test`
 LL | fn test<T: Default<Id = U>, U>() {}
    |                    ^^^^^^ required by this bound in `test`
 
-error: aborting due to previous error; 1 warning emitted
+error[E0282]: type annotations needed
+  --> $DIR/specialization-unconstrained.rs:14:22
+   |
+LL |    default type Id = T;
+   |                      ^ cannot infer type for associated type `<T as Default>::Id`
 
-For more information about this error, try `rustc --explain E0284`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0282, E0284.
+For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
Only use the `normalize_param_env` when normalizing the item bound predicate in `check_item_bounds`, instead of using it when processing this obligation as well. This causes #117606 to reoccur, but hopefully with better caching in the future, we can fix this without having such bad effects on perf.

This PR also fixes #117598. It turns out that the GAT predicate that we install is actually wrong -- given code like:

```
impl<'r> HasValueRef<'r> for Any {
    type Database = Any;
}
```

We currently generate a predicate that looks like `<Any as HasValueRef<'r>>::Database = Any`, where `'r` is an early-bound variable. Really this GAT assumption should be universally quantified over the impl's args, i.e. `for<'r> <Any as HasValueRef<'r>>::Database = Any`, but then we'd need the binder to also include all the WC of the impl as well, which we don't support yet, lol.