### PR TITLE
Scrub param-env when evaluating constant with no generic args

### DIFF
--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -50,6 +50,8 @@ impl<'tcx> UnevaluatedConst<'tcx> {
                     args: ty::GenericArgs::identity_for_item(tcx, self.def),
                 },
             )
+        } else if self.args.is_empty() && !tcx.features().generic_const_exprs {
+            (param_env.without_caller_bounds(), tcx.erase_regions(self))
         } else {
             (tcx.erase_regions(param_env).with_reveal_all_normalized(tcx), tcx.erase_regions(self))
         }

--- a/tests/ui/consts/const-size_of-cycle.stderr
+++ b/tests/ui/consts/const-size_of-cycle.stderr
@@ -1,28 +1,28 @@
-error[E0391]: cycle detected when evaluating type-level constant
+error[E0391]: cycle detected when const-evaluating + checking `Foo::bytes::{constant#0}`
   --> $DIR/const-size_of-cycle.rs:4:17
    |
 LL |     bytes: [u8; std::mem::size_of::<Foo>()]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/const-size_of-cycle.rs:4:17
-   |
-LL |     bytes: [u8; std::mem::size_of::<Foo>()]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/const-size_of-cycle.rs:4:17
-   |
-LL |     bytes: [u8; std::mem::size_of::<Foo>()]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Foo`...
    = note: ...which requires computing layout of `[u8; std::mem::size_of::<Foo>()]`...
    = note: ...which requires normalizing `[u8; std::mem::size_of::<Foo>()]`...
-   = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/const-size_of-cycle.rs:3:1
+note: ...which requires evaluating type-level constant...
+  --> $DIR/const-size_of-cycle.rs:4:17
    |
-LL | struct Foo {
-   | ^^^^^^^^^^
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+  --> $DIR/const-size_of-cycle.rs:4:17
+   |
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating + checking `Foo::bytes::{constant#0}`, completing the cycle
+note: cycle used when evaluating type-level constant
+  --> $DIR/const-size_of-cycle.rs:4:17
+   |
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to previous error

--- a/tests/ui/consts/issue-44415.rs
+++ b/tests/ui/consts/issue-44415.rs
@@ -4,7 +4,7 @@ use std::intrinsics;
 
 struct Foo {
     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-    //~^ ERROR cycle detected when evaluating type-level constant
+    //~^ ERROR cycle detected when const-evaluating + checking `Foo::bytes::{constant#0}`
     x: usize,
 }
 

--- a/tests/ui/consts/issue-44415.stderr
+++ b/tests/ui/consts/issue-44415.stderr
@@ -1,28 +1,28 @@
-error[E0391]: cycle detected when evaluating type-level constant
+error[E0391]: cycle detected when const-evaluating + checking `Foo::bytes::{constant#0}`
   --> $DIR/issue-44415.rs:6:17
    |
 LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Foo`...
    = note: ...which requires computing layout of `[u8; unsafe { intrinsics::size_of::<Foo>() }]`...
    = note: ...which requires normalizing `[u8; unsafe { intrinsics::size_of::<Foo>() }]`...
-   = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/issue-44415.rs:5:1
+note: ...which requires evaluating type-level constant...
+  --> $DIR/issue-44415.rs:6:17
    |
-LL | struct Foo {
-   | ^^^^^^^^^^
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+  --> $DIR/issue-44415.rs:6:17
+   |
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires const-evaluating + checking `Foo::bytes::{constant#0}`, completing the cycle
+note: cycle used when evaluating type-level constant
+  --> $DIR/issue-44415.rs:6:17
+   |
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to previous error


### PR DESCRIPTION
r? @ghost