### PR TITLE
triagebot no-merges: exclude different case

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -415,7 +415,7 @@ Issue #{number} "{title}" has been added.
 """
 
 [no-merges]
-exclude_titles = ["Rollup of", "subtree update"]
+exclude_titles = ["Rollup of", "subtree update", "Subtree update"]
 labels = ["has-merge-commits", "S-waiting-on-author"]
 
 [github-releases]


### PR DESCRIPTION
"Subtree update" as well

To address [this on zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/can't.20suppress.20merge.20commit.20warning)

cc @bjorn3 

r? @mark-simulacrum