### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -374,15 +374,7 @@ impl<'ll> StaticMethods for CodegenCx<'ll, '_> {
 
             let g = self.get_static(def_id);
 
-            // boolean SSA values are i1, but they have to be stored in i8 slots,
-            // otherwise some LLVM optimization passes don't work as expected
-            let mut val_llty = self.val_ty(v);
-            let v = if val_llty == self.type_i1() {
-                val_llty = self.type_i8();
-                llvm::LLVMConstZExt(v, val_llty)
-            } else {
-                v
-            };
+            let val_llty = self.val_ty(v);
 
             let instance = Instance::mono(self.tcx, def_id);
             let ty = instance.ty(self.tcx, ty::ParamEnv::reveal_all());

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -969,7 +969,6 @@ extern "C" {
         ConstantIndices: *const &'a Value,
         NumIndices: c_uint,
     ) -> &'a Value;
-    pub fn LLVMConstZExt<'a>(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
     pub fn LLVMConstPtrToInt<'a>(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
     pub fn LLVMConstIntToPtr<'a>(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;
     pub fn LLVMConstBitCast<'a>(ConstantVal: &'a Value, ToType: &'a Type) -> &'a Value;

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1033,10 +1033,8 @@ fn adt_defined_here<'p, 'tcx>(
     let ty = ty.peel_refs();
     if let ty::Adt(def, _) = ty.kind() {
         let mut spans = vec![];
-        if witnesses.len() < 5 {
-            for sp in maybe_point_at_variant(cx, *def, witnesses.iter()) {
-                spans.push(sp);
-            }
+        for sp in maybe_point_at_variant(cx, *def, witnesses.iter().take(5)) {
+            spans.push(sp);
         }
         let def_span = cx
             .tcx

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -830,12 +830,7 @@ fn report_non_exhaustive_match<'p, 'tcx>(
     if let Some(AdtDefinedHere { adt_def_span, ty, variants }) =
         report_adt_defined_here(cx.tcx, scrut_ty, &witnesses, true)
     {
-        let mut multi_span = if variants.is_empty() {
-            MultiSpan::from_span(adt_def_span)
-        } else {
-            MultiSpan::from_spans(variants.iter().map(|Variant { span }| *span).collect())
-        };
-
+        let mut multi_span = MultiSpan::from_span(adt_def_span);
         multi_span.push_span_label(adt_def_span, "");
         for Variant { span } in variants {
             multi_span.push_span_label(span, "not covered");

--- a/tests/ui/closures/2229_closure_analysis/match/non-exhaustive-match.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/non-exhaustive-match.stderr
@@ -5,10 +5,10 @@ LL |     let _b = || { match l1 { L1::A => () } };
    |                         ^^ pattern `L1::B` not covered
    |
 note: `L1` defined here
-  --> $DIR/non-exhaustive-match.rs:12:14
+  --> $DIR/non-exhaustive-match.rs:12:6
    |
 LL | enum L1 { A, B }
-   |      --      ^ not covered
+   |      ^^      - not covered
    = note: the matched value is of type `L1`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/error-codes/E0004.stderr
+++ b/tests/ui/error-codes/E0004.stderr
@@ -5,12 +5,12 @@ LL |     match x {
    |           ^ pattern `Terminator::HastaLaVistaBaby` not covered
    |
 note: `Terminator` defined here
-  --> $DIR/E0004.rs:2:5
+  --> $DIR/E0004.rs:1:6
    |
 LL | enum Terminator {
-   |      ----------
+   |      ^^^^^^^^^^
 LL |     HastaLaVistaBaby,
-   |     ^^^^^^^^^^^^^^^^ not covered
+   |     ---------------- not covered
    = note: the matched value is of type `Terminator`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
@@ -134,13 +134,13 @@ LL |     match Foo::A {
    |           ^^^^^^ pattern `Foo::C` not covered
    |
 note: `Foo` defined here
-  --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:16:9
+  --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:13:10
    |
 LL |     enum Foo {
-   |          ---
+   |          ^^^
 ...
 LL |         C,
-   |         ^ not covered
+   |         - not covered
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/match/match_non_exhaustive.stderr
+++ b/tests/ui/match/match_non_exhaustive.stderr
@@ -5,10 +5,10 @@ LL |     match l { L::A => () };
    |           ^ pattern `L::B` not covered
    |
 note: `L` defined here
-  --> $DIR/match_non_exhaustive.rs:10:13
+  --> $DIR/match_non_exhaustive.rs:10:6
    |
 LL | enum L { A, B }
-   |      -      ^ not covered
+   |      ^      - not covered
    = note: the matched value is of type `L`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/issue-94866.stderr
+++ b/tests/ui/pattern/issue-94866.stderr
@@ -5,10 +5,10 @@ LL |     match Enum::A {
    |           ^^^^^^^ pattern `Enum::B` not covered
    |
 note: `Enum` defined here
-  --> $DIR/issue-94866.rs:7:16
+  --> $DIR/issue-94866.rs:7:6
    |
 LL | enum Enum { A, B }
-   |      ----      ^ not covered
+   |      ^^^^      - not covered
    = note: the matched value is of type `Enum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/conflicting_bindings.rs
+++ b/tests/ui/pattern/usefulness/conflicting_bindings.rs
@@ -9,9 +9,11 @@ fn main() {
     if let Some(ref mut y @ ref mut z) = x {}
     //~^ ERROR: mutable more than once
     if let Some(ref mut y @ ref mut z) = x && true {}
+    //~^ ERROR: mutable more than once
     while let Some(ref mut y @ ref mut z) = x {}
     //~^ ERROR: mutable more than once
     while let Some(ref mut y @ ref mut z) = x && true {}
+    //~^ ERROR: mutable more than once
     match x {
         ref mut y @ ref mut z => {} //~ ERROR: mutable more than once
     }

--- a/tests/ui/pattern/usefulness/conflicting_bindings.rs
+++ b/tests/ui/pattern/usefulness/conflicting_bindings.rs
@@ -1,0 +1,22 @@
+#![feature(if_let_guard, let_chains)]
+
+fn main() {
+    let mut x = Some(String::new());
+    let ref mut y @ ref mut z = x;
+    //~^ ERROR: mutable more than once
+    let Some(ref mut y @ ref mut z) = x else { return };
+    //~^ ERROR: mutable more than once
+    if let Some(ref mut y @ ref mut z) = x {}
+    //~^ ERROR: mutable more than once
+    if let Some(ref mut y @ ref mut z) = x && true {}
+    while let Some(ref mut y @ ref mut z) = x {}
+    //~^ ERROR: mutable more than once
+    while let Some(ref mut y @ ref mut z) = x && true {}
+    match x {
+        ref mut y @ ref mut z => {} //~ ERROR: mutable more than once
+    }
+    match () {
+        () if let Some(ref mut y @ ref mut z) = x => {} //~ ERROR: mutable more than once
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/usefulness/conflicting_bindings.stderr
+++ b/tests/ui/pattern/usefulness/conflicting_bindings.stderr
@@ -23,7 +23,15 @@ LL |     if let Some(ref mut y @ ref mut z) = x {}
    |                 value is mutably borrowed by `y` here
 
 error: cannot borrow value as mutable more than once at a time
-  --> $DIR/conflicting_bindings.rs:12:20
+  --> $DIR/conflicting_bindings.rs:11:17
+   |
+LL |     if let Some(ref mut y @ ref mut z) = x && true {}
+   |                 ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |                 |
+   |                 value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:13:20
    |
 LL |     while let Some(ref mut y @ ref mut z) = x {}
    |                    ^^^^^^^^^   --------- value is mutably borrowed by `z` here
@@ -31,7 +39,15 @@ LL |     while let Some(ref mut y @ ref mut z) = x {}
    |                    value is mutably borrowed by `y` here
 
 error: cannot borrow value as mutable more than once at a time
-  --> $DIR/conflicting_bindings.rs:16:9
+  --> $DIR/conflicting_bindings.rs:15:20
+   |
+LL |     while let Some(ref mut y @ ref mut z) = x && true {}
+   |                    ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |                    |
+   |                    value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:18:9
    |
 LL |         ref mut y @ ref mut z => {}
    |         ^^^^^^^^^   --------- value is mutably borrowed by `z` here
@@ -39,12 +55,12 @@ LL |         ref mut y @ ref mut z => {}
    |         value is mutably borrowed by `y` here
 
 error: cannot borrow value as mutable more than once at a time
-  --> $DIR/conflicting_bindings.rs:19:24
+  --> $DIR/conflicting_bindings.rs:21:24
    |
 LL |         () if let Some(ref mut y @ ref mut z) = x => {}
    |                        ^^^^^^^^^   --------- value is mutably borrowed by `z` here
    |                        |
    |                        value is mutably borrowed by `y` here
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/pattern/usefulness/conflicting_bindings.stderr
+++ b/tests/ui/pattern/usefulness/conflicting_bindings.stderr
@@ -1,0 +1,50 @@
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:5:9
+   |
+LL |     let ref mut y @ ref mut z = x;
+   |         ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |         |
+   |         value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:7:14
+   |
+LL |     let Some(ref mut y @ ref mut z) = x else { return };
+   |              ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |              |
+   |              value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:9:17
+   |
+LL |     if let Some(ref mut y @ ref mut z) = x {}
+   |                 ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |                 |
+   |                 value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:12:20
+   |
+LL |     while let Some(ref mut y @ ref mut z) = x {}
+   |                    ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |                    |
+   |                    value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:16:9
+   |
+LL |         ref mut y @ ref mut z => {}
+   |         ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |         |
+   |         value is mutably borrowed by `y` here
+
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/conflicting_bindings.rs:19:24
+   |
+LL |         () if let Some(ref mut y @ ref mut z) = x => {}
+   |                        ^^^^^^^^^   --------- value is mutably borrowed by `z` here
+   |                        |
+   |                        value is mutably borrowed by `y` here
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
+++ b/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
@@ -23,13 +23,13 @@ LL |     match HiddenEnum::A {
    |           ^^^^^^^^^^^^^ pattern `HiddenEnum::B` not covered
    |
 note: `HiddenEnum` defined here
-  --> $DIR/auxiliary/hidden.rs:3:5
+  --> $DIR/auxiliary/hidden.rs:1:1
    |
 LL | pub enum HiddenEnum {
-   | -------------------
+   | ^^^^^^^^^^^^^^^^^^^
 LL |     A,
 LL |     B,
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
@@ -44,13 +44,13 @@ LL |     match HiddenEnum::A {
    |           ^^^^^^^^^^^^^ patterns `HiddenEnum::B` and `_` not covered
    |
 note: `HiddenEnum` defined here
-  --> $DIR/auxiliary/hidden.rs:3:5
+  --> $DIR/auxiliary/hidden.rs:1:1
    |
 LL | pub enum HiddenEnum {
-   | -------------------
+   | ^^^^^^^^^^^^^^^^^^^
 LL |     A,
 LL |     B,
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
@@ -83,13 +83,13 @@ LL |     match InCrate::A {
    |           ^^^^^^^^^^ pattern `InCrate::C` not covered
    |
 note: `InCrate` defined here
-  --> $DIR/doc-hidden-non-exhaustive.rs:11:5
+  --> $DIR/doc-hidden-non-exhaustive.rs:7:6
    |
 LL | enum InCrate {
-   |      -------
+   |      ^^^^^^^
 ...
 LL |     C,
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `InCrate`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-match.rs:58:9
+  --> $DIR/empty-match.rs:68:9
    |
 LL |         _ => {},
    |         ^
@@ -11,25 +11,25 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match.rs:61:9
-   |
-LL |         _ if false => {},
-   |         ^
-
-error: unreachable pattern
-  --> $DIR/empty-match.rs:68:9
-   |
-LL |         _ => {},
-   |         ^
-
-error: unreachable pattern
   --> $DIR/empty-match.rs:71:9
    |
 LL |         _ if false => {},
    |         ^
 
+error: unreachable pattern
+  --> $DIR/empty-match.rs:78:9
+   |
+LL |         _ => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/empty-match.rs:81:9
+   |
+LL |         _ if false => {},
+   |         ^
+
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match.rs:76:9
+  --> $DIR/empty-match.rs:86:9
    |
 LL |     let None = x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -44,19 +44,19 @@ LL |     if let None = x { todo!() };
    |     ++              +++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-match.rs:88:9
+  --> $DIR/empty-match.rs:98:9
    |
 LL |         _ => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-match.rs:91:9
+  --> $DIR/empty-match.rs:101:9
    |
 LL |         _ if false => {},
    |         ^
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/empty-match.rs:109:20
+  --> $DIR/empty-match.rs:119:20
    |
 LL |     match_no_arms!(0u8);
    |                    ^^^
@@ -65,7 +65,7 @@ LL |     match_no_arms!(0u8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct1` is non-empty
-  --> $DIR/empty-match.rs:111:20
+  --> $DIR/empty-match.rs:121:20
    |
 LL |     match_no_arms!(NonEmptyStruct1);
    |                    ^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL | struct NonEmptyStruct1;
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct2` is non-empty
-  --> $DIR/empty-match.rs:113:20
+  --> $DIR/empty-match.rs:123:20
    |
 LL |     match_no_arms!(NonEmptyStruct2(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ LL | struct NonEmptyStruct2(bool);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/empty-match.rs:115:20
+  --> $DIR/empty-match.rs:125:20
    |
 LL |     match_no_arms!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -107,7 +107,7 @@ LL | union NonEmptyUnion1 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/empty-match.rs:117:20
+  --> $DIR/empty-match.rs:127:20
    |
 LL |     match_no_arms!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL | union NonEmptyUnion2 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:119:20
+  --> $DIR/empty-match.rs:129:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
@@ -137,7 +137,7 @@ LL |     Foo(bool),
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:122:20
+  --> $DIR/empty-match.rs:132:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
@@ -156,21 +156,28 @@ LL |     Bar,
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:125:20
+  --> $DIR/empty-match.rs:135:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:49:6
+  --> $DIR/empty-match.rs:50:5
    |
 LL | enum NonEmptyEnum5 {
-   |      ^^^^^^^^^^^^^
+   |      -------------
+LL |     V1, V2, V3, V4, V5,
+   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     |   |   |   |
+   |     |   |   |   not covered
+   |     |   |   not covered
+   |     |   not covered
+   |     not covered
    = note: the matched value is of type `NonEmptyEnum5`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/empty-match.rs:129:24
+  --> $DIR/empty-match.rs:139:24
    |
 LL |     match_guarded_arm!(0u8);
    |                        ^^^ pattern `_` not covered
@@ -184,7 +191,7 @@ LL +             _ => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
-  --> $DIR/empty-match.rs:134:24
+  --> $DIR/empty-match.rs:144:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct1);
    |                        ^^^^^^^^^^^^^^^ pattern `NonEmptyStruct1` not covered
@@ -203,7 +210,7 @@ LL +             NonEmptyStruct1 => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
-  --> $DIR/empty-match.rs:139:24
+  --> $DIR/empty-match.rs:149:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct2(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct2(_)` not covered
@@ -222,7 +229,7 @@ LL +             NonEmptyStruct2(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/empty-match.rs:144:24
+  --> $DIR/empty-match.rs:154:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion1 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
@@ -241,7 +248,7 @@ LL +             NonEmptyUnion1 { .. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/empty-match.rs:149:24
+  --> $DIR/empty-match.rs:159:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion2 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
@@ -260,7 +267,7 @@ LL +             NonEmptyUnion2 { .. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:154:24
+  --> $DIR/empty-match.rs:164:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
@@ -281,7 +288,7 @@ LL +             NonEmptyEnum1::Foo(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:159:24
+  --> $DIR/empty-match.rs:169:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
@@ -305,16 +312,23 @@ LL +             NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:164:24
+  --> $DIR/empty-match.rs:174:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:49:6
+  --> $DIR/empty-match.rs:50:5
    |
 LL | enum NonEmptyEnum5 {
-   |      ^^^^^^^^^^^^^
+   |      -------------
+LL |     V1, V2, V3, V4, V5,
+   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     |   |   |   |
+   |     |   |   |   not covered
+   |     |   |   not covered
+   |     |   not covered
+   |     not covered
    = note: the matched value is of type `NonEmptyEnum5`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms

--- a/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -127,12 +127,13 @@ LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:33:5
+  --> $DIR/empty-match.rs:32:6
    |
 LL | enum NonEmptyEnum1 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
@@ -143,15 +144,16 @@ LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:40:5
+  --> $DIR/empty-match.rs:39:6
    |
 LL | enum NonEmptyEnum2 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
 ...
 LL |     Bar,
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
@@ -162,12 +164,13 @@ LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:50:5
+  --> $DIR/empty-match.rs:49:6
    |
 LL | enum NonEmptyEnum5 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     V1, V2, V3, V4, V5,
-   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     --  --  --  --  -- not covered
    |     |   |   |   |
    |     |   |   |   not covered
    |     |   |   not covered
@@ -273,12 +276,13 @@ LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:33:5
+  --> $DIR/empty-match.rs:32:6
    |
 LL | enum NonEmptyEnum1 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
@@ -294,15 +298,16 @@ LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:40:5
+  --> $DIR/empty-match.rs:39:6
    |
 LL | enum NonEmptyEnum2 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
 ...
 LL |     Bar,
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
@@ -318,12 +323,13 @@ LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:50:5
+  --> $DIR/empty-match.rs:49:6
    |
 LL | enum NonEmptyEnum5 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     V1, V2, V3, V4, V5,
-   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     --  --  --  --  -- not covered
    |     |   |   |   |
    |     |   |   |   not covered
    |     |   |   not covered

--- a/tests/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.normal.stderr
@@ -126,12 +126,13 @@ LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:33:5
+  --> $DIR/empty-match.rs:32:6
    |
 LL | enum NonEmptyEnum1 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
@@ -142,15 +143,16 @@ LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:40:5
+  --> $DIR/empty-match.rs:39:6
    |
 LL | enum NonEmptyEnum2 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
 ...
 LL |     Bar,
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
@@ -161,12 +163,13 @@ LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:50:5
+  --> $DIR/empty-match.rs:49:6
    |
 LL | enum NonEmptyEnum5 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     V1, V2, V3, V4, V5,
-   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     --  --  --  --  -- not covered
    |     |   |   |   |
    |     |   |   |   not covered
    |     |   |   not covered
@@ -272,12 +275,13 @@ LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:33:5
+  --> $DIR/empty-match.rs:32:6
    |
 LL | enum NonEmptyEnum1 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
@@ -293,15 +297,16 @@ LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:40:5
+  --> $DIR/empty-match.rs:39:6
    |
 LL | enum NonEmptyEnum2 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     Foo(bool),
-   |     ^^^ not covered
+   |     --- not covered
 ...
 LL |     Bar,
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
@@ -317,12 +322,13 @@ LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:50:5
+  --> $DIR/empty-match.rs:49:6
    |
 LL | enum NonEmptyEnum5 {
-   |      -------------
+   |      ^^^^^^^^^^^^^
+...
 LL |     V1, V2, V3, V4, V5,
-   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     --  --  --  --  -- not covered
    |     |   |   |   |
    |     |   |   |   not covered
    |     |   |   not covered

--- a/tests/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.normal.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-match.rs:58:9
+  --> $DIR/empty-match.rs:68:9
    |
 LL |         _ => {},
    |         ^
@@ -11,25 +11,25 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match.rs:61:9
-   |
-LL |         _ if false => {},
-   |         ^
-
-error: unreachable pattern
-  --> $DIR/empty-match.rs:68:9
-   |
-LL |         _ => {},
-   |         ^
-
-error: unreachable pattern
   --> $DIR/empty-match.rs:71:9
    |
 LL |         _ if false => {},
    |         ^
 
+error: unreachable pattern
+  --> $DIR/empty-match.rs:78:9
+   |
+LL |         _ => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/empty-match.rs:81:9
+   |
+LL |         _ if false => {},
+   |         ^
+
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match.rs:76:9
+  --> $DIR/empty-match.rs:86:9
    |
 LL |     let None = x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -43,19 +43,19 @@ LL |     if let None = x { todo!() };
    |     ++              +++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-match.rs:88:9
+  --> $DIR/empty-match.rs:98:9
    |
 LL |         _ => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-match.rs:91:9
+  --> $DIR/empty-match.rs:101:9
    |
 LL |         _ if false => {},
    |         ^
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/empty-match.rs:109:20
+  --> $DIR/empty-match.rs:119:20
    |
 LL |     match_no_arms!(0u8);
    |                    ^^^
@@ -64,7 +64,7 @@ LL |     match_no_arms!(0u8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct1` is non-empty
-  --> $DIR/empty-match.rs:111:20
+  --> $DIR/empty-match.rs:121:20
    |
 LL |     match_no_arms!(NonEmptyStruct1);
    |                    ^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ LL | struct NonEmptyStruct1;
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct2` is non-empty
-  --> $DIR/empty-match.rs:113:20
+  --> $DIR/empty-match.rs:123:20
    |
 LL |     match_no_arms!(NonEmptyStruct2(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL | struct NonEmptyStruct2(bool);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/empty-match.rs:115:20
+  --> $DIR/empty-match.rs:125:20
    |
 LL |     match_no_arms!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -106,7 +106,7 @@ LL | union NonEmptyUnion1 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/empty-match.rs:117:20
+  --> $DIR/empty-match.rs:127:20
    |
 LL |     match_no_arms!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL | union NonEmptyUnion2 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:119:20
+  --> $DIR/empty-match.rs:129:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
@@ -136,7 +136,7 @@ LL |     Foo(bool),
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:122:20
+  --> $DIR/empty-match.rs:132:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
@@ -155,21 +155,28 @@ LL |     Bar,
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:125:20
+  --> $DIR/empty-match.rs:135:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:49:6
+  --> $DIR/empty-match.rs:50:5
    |
 LL | enum NonEmptyEnum5 {
-   |      ^^^^^^^^^^^^^
+   |      -------------
+LL |     V1, V2, V3, V4, V5,
+   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     |   |   |   |
+   |     |   |   |   not covered
+   |     |   |   not covered
+   |     |   not covered
+   |     not covered
    = note: the matched value is of type `NonEmptyEnum5`
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/empty-match.rs:129:24
+  --> $DIR/empty-match.rs:139:24
    |
 LL |     match_guarded_arm!(0u8);
    |                        ^^^ pattern `_` not covered
@@ -183,7 +190,7 @@ LL +             _ => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
-  --> $DIR/empty-match.rs:134:24
+  --> $DIR/empty-match.rs:144:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct1);
    |                        ^^^^^^^^^^^^^^^ pattern `NonEmptyStruct1` not covered
@@ -202,7 +209,7 @@ LL +             NonEmptyStruct1 => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
-  --> $DIR/empty-match.rs:139:24
+  --> $DIR/empty-match.rs:149:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct2(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct2(_)` not covered
@@ -221,7 +228,7 @@ LL +             NonEmptyStruct2(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/empty-match.rs:144:24
+  --> $DIR/empty-match.rs:154:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion1 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
@@ -240,7 +247,7 @@ LL +             NonEmptyUnion1 { .. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/empty-match.rs:149:24
+  --> $DIR/empty-match.rs:159:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion2 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
@@ -259,7 +266,7 @@ LL +             NonEmptyUnion2 { .. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:154:24
+  --> $DIR/empty-match.rs:164:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
@@ -280,7 +287,7 @@ LL +             NonEmptyEnum1::Foo(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:159:24
+  --> $DIR/empty-match.rs:169:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
@@ -304,16 +311,23 @@ LL +             NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:164:24
+  --> $DIR/empty-match.rs:174:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:49:6
+  --> $DIR/empty-match.rs:50:5
    |
 LL | enum NonEmptyEnum5 {
-   |      ^^^^^^^^^^^^^
+   |      -------------
+LL |     V1, V2, V3, V4, V5,
+   |     ^^  ^^  ^^  ^^  ^^ not covered
+   |     |   |   |   |
+   |     |   |   |   not covered
+   |     |   |   not covered
+   |     |   not covered
+   |     not covered
    = note: the matched value is of type `NonEmptyEnum5`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms

--- a/tests/ui/pattern/usefulness/empty-match.rs
+++ b/tests/ui/pattern/usefulness/empty-match.rs
@@ -30,27 +30,27 @@ union NonEmptyUnion2 {
     bar: (),
 }
 enum NonEmptyEnum1 {
-    Foo(bool),
     //~^ NOTE `NonEmptyEnum1` defined here
     //~| NOTE `NonEmptyEnum1` defined here
-    //~| NOTE not covered
+    Foo(bool),
+    //~^ NOTE not covered
     //~| NOTE not covered
 }
 enum NonEmptyEnum2 {
-    Foo(bool),
     //~^ NOTE `NonEmptyEnum2` defined here
     //~| NOTE `NonEmptyEnum2` defined here
-    //~| NOTE not covered
+    Foo(bool),
+    //~^ NOTE not covered
     //~| NOTE not covered
     Bar,
     //~^ NOTE not covered
     //~| NOTE not covered
 }
 enum NonEmptyEnum5 {
-    V1, V2, V3, V4, V5,
     //~^ NOTE `NonEmptyEnum5` defined here
     //~| NOTE `NonEmptyEnum5` defined here
-    //~| NOTE not covered
+    V1, V2, V3, V4, V5,
+    //~^ NOTE not covered
     //~| NOTE not covered
     //~| NOTE not covered
     //~| NOTE not covered

--- a/tests/ui/pattern/usefulness/empty-match.rs
+++ b/tests/ui/pattern/usefulness/empty-match.rs
@@ -47,9 +47,19 @@ enum NonEmptyEnum2 {
     //~| NOTE not covered
 }
 enum NonEmptyEnum5 {
+    V1, V2, V3, V4, V5,
     //~^ NOTE `NonEmptyEnum5` defined here
     //~| NOTE `NonEmptyEnum5` defined here
-    V1, V2, V3, V4, V5,
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
 }
 
 fn empty_enum(x: EmptyEnum) {

--- a/tests/ui/pattern/usefulness/issue-35609.stderr
+++ b/tests/ui/pattern/usefulness/issue-35609.stderr
@@ -107,6 +107,9 @@ LL |     match Some(A) {
    |
 note: `Option<Enum>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
    = note: the matched value is of type `Option<Enum>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |

--- a/tests/ui/pattern/usefulness/issue-39362.stderr
+++ b/tests/ui/pattern/usefulness/issue-39362.stderr
@@ -5,12 +5,12 @@ LL |     match f {
    |           ^ patterns `Foo::Bar { bar: Bar::C, .. }`, `Foo::Bar { bar: Bar::D, .. }`, `Foo::Bar { bar: Bar::E, .. }` and 1 more not covered
    |
 note: `Foo` defined here
-  --> $DIR/issue-39362.rs:2:5
+  --> $DIR/issue-39362.rs:1:6
    |
 LL | enum Foo {
-   |      ---
+   |      ^^^
 LL |     Bar { bar: Bar, id: usize }
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |

--- a/tests/ui/pattern/usefulness/issue-40221.stderr
+++ b/tests/ui/pattern/usefulness/issue-40221.stderr
@@ -5,12 +5,12 @@ LL |     match proto {
    |           ^^^^^ pattern `P::C(PC::QA)` not covered
    |
 note: `P` defined here
-  --> $DIR/issue-40221.rs:2:5
+  --> $DIR/issue-40221.rs:1:6
    |
 LL | enum P {
-   |      -
+   |      ^
 LL |     C(PC),
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `P`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/issue-56379.stderr
+++ b/tests/ui/pattern/usefulness/issue-56379.stderr
@@ -5,16 +5,16 @@ LL |     match Foo::A(true) {
    |           ^^^^^^^^^^^^ patterns `Foo::A(false)`, `Foo::B(false)` and `Foo::C(false)` not covered
    |
 note: `Foo` defined here
-  --> $DIR/issue-56379.rs:2:5
+  --> $DIR/issue-56379.rs:1:6
    |
 LL | enum Foo {
-   |      ---
+   |      ^^^
 LL |     A(bool),
-   |     ^ not covered
+   |     - not covered
 LL |     B(bool),
-   |     ^ not covered
+   |     - not covered
 LL |     C(bool),
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |

--- a/tests/ui/pattern/usefulness/non-exhaustive-defined-here.rs
+++ b/tests/ui/pattern/usefulness/non-exhaustive-defined-here.rs
@@ -1,10 +1,15 @@
+#![feature(custom_inner_attributes)]
+#![rustfmt::skip]
 // Test the "defined here" and "not covered" diagnostic hints.
 // We also make sure that references are peeled off from the scrutinee type
 // so that the diagnostics work better with default binding modes.
 
 #[derive(Clone)]
 enum E {
-    //~^ NOTE
+    //~^ NOTE `E` defined here
+    //~| NOTE `E` defined here
+    //~| NOTE `E` defined here
+    //~| NOTE
     //~| NOTE
     //~| NOTE
     //~| NOTE
@@ -12,10 +17,7 @@ enum E {
     //~| NOTE
     A,
     B,
-    //~^ NOTE `E` defined here
-    //~| NOTE `E` defined here
-    //~| NOTE `E` defined here
-    //~| NOTE  not covered
+    //~^ NOTE  not covered
     //~| NOTE  not covered
     //~| NOTE  not covered
     //~| NOTE  not covered
@@ -79,12 +81,12 @@ fn by_ref_thrice(e: & &mut &E) {
 }
 
 enum Opt {
-    //~^ NOTE
+    //~^ NOTE `Opt` defined here
+    //~| NOTE
     //~| NOTE
     Some(u8),
     None,
-    //~^ NOTE `Opt` defined here
-    //~| NOTE not covered
+    //~^ NOTE not covered
     //~| NOTE not covered
 }
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
@@ -1,20 +1,20 @@
 error[E0004]: non-exhaustive patterns: `E::B` and `E::C` not covered
-  --> $DIR/non-exhaustive-defined-here.rs:35:11
+  --> $DIR/non-exhaustive-defined-here.rs:37:11
    |
 LL |     match e1 {
    |           ^^ patterns `E::B` and `E::C` not covered
    |
 note: `E` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:14:5
+  --> $DIR/non-exhaustive-defined-here.rs:8:6
    |
 LL | enum E {
-   |      -
+   |      ^
 ...
 LL |     B,
-   |     ^ not covered
+   |     - not covered
 ...
 LL |     C
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
@@ -23,7 +23,7 @@ LL +         E::B | E::C => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/non-exhaustive-defined-here.rs:41:9
+  --> $DIR/non-exhaustive-defined-here.rs:43:9
    |
 LL |     let E::A = e;
    |         ^^^^ patterns `E::B` and `E::C` not covered
@@ -31,7 +31,7 @@ LL |     let E::A = e;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
 note: `E` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:6:6
+  --> $DIR/non-exhaustive-defined-here.rs:8:6
    |
 LL | enum E {
    |      ^
@@ -48,22 +48,22 @@ LL |     if let E::A = e { todo!() };
    |     ++              +++++++++++
 
 error[E0004]: non-exhaustive patterns: `&E::B` and `&E::C` not covered
-  --> $DIR/non-exhaustive-defined-here.rs:50:11
+  --> $DIR/non-exhaustive-defined-here.rs:52:11
    |
 LL |     match e {
    |           ^ patterns `&E::B` and `&E::C` not covered
    |
 note: `E` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:14:5
+  --> $DIR/non-exhaustive-defined-here.rs:8:6
    |
 LL | enum E {
-   |      -
+   |      ^
 ...
 LL |     B,
-   |     ^ not covered
+   |     - not covered
 ...
 LL |     C
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `&E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
@@ -72,7 +72,7 @@ LL +         &E::B | &E::C => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/non-exhaustive-defined-here.rs:57:9
+  --> $DIR/non-exhaustive-defined-here.rs:59:9
    |
 LL |     let E::A = e;
    |         ^^^^ patterns `&E::B` and `&E::C` not covered
@@ -80,7 +80,7 @@ LL |     let E::A = e;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
 note: `E` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:6:6
+  --> $DIR/non-exhaustive-defined-here.rs:8:6
    |
 LL | enum E {
    |      ^
@@ -97,22 +97,22 @@ LL |     if let E::A = e { todo!() };
    |     ++              +++++++++++
 
 error[E0004]: non-exhaustive patterns: `&&mut &E::B` and `&&mut &E::C` not covered
-  --> $DIR/non-exhaustive-defined-here.rs:66:11
+  --> $DIR/non-exhaustive-defined-here.rs:68:11
    |
 LL |     match e {
    |           ^ patterns `&&mut &E::B` and `&&mut &E::C` not covered
    |
 note: `E` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:14:5
+  --> $DIR/non-exhaustive-defined-here.rs:8:6
    |
 LL | enum E {
-   |      -
+   |      ^
 ...
 LL |     B,
-   |     ^ not covered
+   |     - not covered
 ...
 LL |     C
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `&&mut &E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
@@ -121,7 +121,7 @@ LL +         &&mut &E::B | &&mut &E::C => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/non-exhaustive-defined-here.rs:73:9
+  --> $DIR/non-exhaustive-defined-here.rs:75:9
    |
 LL |     let E::A = e;
    |         ^^^^ patterns `&&mut &E::B` and `&&mut &E::C` not covered
@@ -129,7 +129,7 @@ LL |     let E::A = e;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
 note: `E` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:6:6
+  --> $DIR/non-exhaustive-defined-here.rs:8:6
    |
 LL | enum E {
    |      ^
@@ -146,19 +146,19 @@ LL |     if let E::A = e { todo!() };
    |     ++              +++++++++++
 
 error[E0004]: non-exhaustive patterns: `Opt::None` not covered
-  --> $DIR/non-exhaustive-defined-here.rs:92:11
+  --> $DIR/non-exhaustive-defined-here.rs:94:11
    |
 LL |     match e {
    |           ^ pattern `Opt::None` not covered
    |
 note: `Opt` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:85:5
+  --> $DIR/non-exhaustive-defined-here.rs:83:6
    |
 LL | enum Opt {
-   |      ---
+   |      ^^^
 ...
 LL |     None,
-   |     ^^^^ not covered
+   |     ---- not covered
    = note: the matched value is of type `Opt`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
@@ -167,7 +167,7 @@ LL +         Opt::None => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/non-exhaustive-defined-here.rs:99:9
+  --> $DIR/non-exhaustive-defined-here.rs:101:9
    |
 LL |     let Opt::Some(ref _x) = e;
    |         ^^^^^^^^^^^^^^^^^ pattern `Opt::None` not covered
@@ -175,7 +175,7 @@ LL |     let Opt::Some(ref _x) = e;
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
 note: `Opt` defined here
-  --> $DIR/non-exhaustive-defined-here.rs:81:6
+  --> $DIR/non-exhaustive-defined-here.rs:83:6
    |
 LL | enum Opt {
    |      ^^^

--- a/tests/ui/pattern/usefulness/non-exhaustive-match-nested.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-match-nested.stderr
@@ -18,10 +18,10 @@ LL |     match x {
    |           ^ pattern `T::A(U::C)` not covered
    |
 note: `T` defined here
-  --> $DIR/non-exhaustive-match-nested.rs:1:10
+  --> $DIR/non-exhaustive-match-nested.rs:1:6
    |
 LL | enum T { A(U), B }
-   |      -   ^ not covered
+   |      ^   - not covered
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -5,10 +5,10 @@ LL |     match x { T::B => { } }
    |           ^ pattern `T::A` not covered
    |
 note: `T` defined here
-  --> $DIR/non-exhaustive-match.rs:3:10
+  --> $DIR/non-exhaustive-match.rs:3:6
    |
 LL | enum T { A, B }
-   |      -   ^ not covered
+   |      ^   - not covered
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
@@ -79,10 +79,10 @@ LL |     match T::A {
    |           ^^^^ pattern `T::B` not covered
    |
 note: `T` defined here
-  --> $DIR/non-exhaustive-match.rs:3:13
+  --> $DIR/non-exhaustive-match.rs:3:6
    |
 LL | enum T { A, B }
-   |      -      ^ not covered
+   |      ^      - not covered
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -68,10 +68,21 @@ LL |     match ExcessiveEnum::First {
    |           ^^^^^^^^^^^^^^^^^^^^ patterns `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
    |
 note: `ExcessiveEnum` defined here
-  --> $DIR/non-exhaustive-pattern-witness.rs:44:6
+  --> $DIR/non-exhaustive-pattern-witness.rs:46:5
    |
 LL | enum ExcessiveEnum {
-   |      ^^^^^^^^^^^^^
+   |      -------------
+LL |     First,
+LL |     Second,
+   |     ^^^^^^ not covered
+LL |     Third,
+   |     ^^^^^ not covered
+LL |     Fourth,
+   |     ^^^^^^ not covered
+LL |     Fifth,
+   |     ^^^^^ not covered
+LL |     Sixth,
+   |     ^^^^^ not covered
    = note: the matched value is of type `ExcessiveEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |

--- a/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -23,12 +23,12 @@ LL |     match Color::Red {
    |           ^^^^^^^^^^ pattern `Color::Red` not covered
    |
 note: `Color` defined here
-  --> $DIR/non-exhaustive-pattern-witness.rs:17:5
+  --> $DIR/non-exhaustive-pattern-witness.rs:16:6
    |
 LL | enum Color {
-   |      -----
+   |      ^^^^^
 LL |     Red,
-   |     ^^^ not covered
+   |     --- not covered
    = note: the matched value is of type `Color`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
@@ -43,17 +43,17 @@ LL |     match Direction::North {
    |           ^^^^^^^^^^^^^^^^ patterns `Direction::East`, `Direction::South` and `Direction::West` not covered
    |
 note: `Direction` defined here
-  --> $DIR/non-exhaustive-pattern-witness.rs:32:5
+  --> $DIR/non-exhaustive-pattern-witness.rs:30:6
    |
 LL | enum Direction {
-   |      ---------
+   |      ^^^^^^^^^
 LL |     North,
 LL |     East,
-   |     ^^^^ not covered
+   |     ---- not covered
 LL |     South,
-   |     ^^^^^ not covered
+   |     ----- not covered
 LL |     West,
-   |     ^^^^ not covered
+   |     ---- not covered
    = note: the matched value is of type `Direction`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
@@ -68,21 +68,21 @@ LL |     match ExcessiveEnum::First {
    |           ^^^^^^^^^^^^^^^^^^^^ patterns `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
    |
 note: `ExcessiveEnum` defined here
-  --> $DIR/non-exhaustive-pattern-witness.rs:46:5
+  --> $DIR/non-exhaustive-pattern-witness.rs:44:6
    |
 LL | enum ExcessiveEnum {
-   |      -------------
+   |      ^^^^^^^^^^^^^
 LL |     First,
 LL |     Second,
-   |     ^^^^^^ not covered
+   |     ------ not covered
 LL |     Third,
-   |     ^^^^^ not covered
+   |     ----- not covered
 LL |     Fourth,
-   |     ^^^^^^ not covered
+   |     ------ not covered
 LL |     Fifth,
-   |     ^^^^^ not covered
+   |     ----- not covered
 LL |     Sixth,
-   |     ^^^^^ not covered
+   |     ----- not covered
    = note: the matched value is of type `ExcessiveEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
@@ -97,13 +97,13 @@ LL |     match Color::Red {
    |           ^^^^^^^^^^ pattern `Color::CustomRGBA { a: true, .. }` not covered
    |
 note: `Color` defined here
-  --> $DIR/non-exhaustive-pattern-witness.rs:19:5
+  --> $DIR/non-exhaustive-pattern-witness.rs:16:6
    |
 LL | enum Color {
-   |      -----
+   |      ^^^^^
 ...
 LL |     CustomRGBA { a: bool, r: u8, g: u8, b: u8 },
-   |     ^^^^^^^^^^ not covered
+   |     ---------- not covered
    = note: the matched value is of type `Color`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/stable-gated-patterns.stderr
+++ b/tests/ui/pattern/usefulness/stable-gated-patterns.stderr
@@ -5,13 +5,13 @@ LL |     match UnstableEnum::Stable {
    |           ^^^^^^^^^^^^^^^^^^^^ patterns `UnstableEnum::Stable2` and `_` not covered
    |
 note: `UnstableEnum` defined here
-  --> $DIR/auxiliary/unstable.rs:9:5
+  --> $DIR/auxiliary/unstable.rs:5:1
    |
 LL | pub enum UnstableEnum {
-   | ---------------------
+   | ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     Stable2,
-   |     ^^^^^^^ not covered
+   |     ------- not covered
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |

--- a/tests/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
+++ b/tests/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
@@ -5,12 +5,12 @@ LL |     match x {
    |           ^ pattern `A::B { x: Some(_) }` not covered
    |
 note: `A` defined here
-  --> $DIR/struct-like-enum-nonexhaustive.rs:2:5
+  --> $DIR/struct-like-enum-nonexhaustive.rs:1:6
    |
 LL | enum A {
-   |      -
+   |      ^
 LL |     B { x: Option<isize> },
-   |     ^ not covered
+   |     - not covered
    = note: the matched value is of type `A`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/pattern/usefulness/unstable-gated-patterns.stderr
+++ b/tests/ui/pattern/usefulness/unstable-gated-patterns.stderr
@@ -5,13 +5,13 @@ LL |     match UnstableEnum::Stable {
    |           ^^^^^^^^^^^^^^^^^^^^ pattern `UnstableEnum::Unstable` not covered
    |
 note: `UnstableEnum` defined here
-  --> $DIR/auxiliary/unstable.rs:11:5
+  --> $DIR/auxiliary/unstable.rs:5:1
    |
 LL | pub enum UnstableEnum {
-   | ---------------------
+   | ^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |     Unstable,
-   |     ^^^^^^^^ not covered
+   |     -------- not covered
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -17,18 +17,18 @@ LL |     match NonExhaustiveEnum::Unit {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonExhaustiveEnum::Unit`, `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered
    |
 note: `NonExhaustiveEnum` defined here
-  --> $DIR/enum_same_crate_empty_match.rs:5:5
+  --> $DIR/enum_same_crate_empty_match.rs:4:10
    |
 LL | pub enum NonExhaustiveEnum {
-   |          -----------------
+   |          ^^^^^^^^^^^^^^^^^
 LL |     Unit,
-   |     ^^^^ not covered
+   |     ---- not covered
 LL |
 LL |     Tuple(u32),
-   |     ^^^^^ not covered
+   |     ----- not covered
 LL |
 LL |     Struct { field: u32 }
-   |     ^^^^^^ not covered
+   |     ------ not covered
    = note: the matched value is of type `NonExhaustiveEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
@@ -44,18 +44,18 @@ LL |     match NormalEnum::Unit {}
    |           ^^^^^^^^^^^^^^^^ patterns `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered
    |
 note: `NormalEnum` defined here
-  --> $DIR/enum_same_crate_empty_match.rs:14:5
+  --> $DIR/enum_same_crate_empty_match.rs:13:10
    |
 LL | pub enum NormalEnum {
-   |          ----------
+   |          ^^^^^^^^^^
 LL |     Unit,
-   |     ^^^^ not covered
+   |     ---- not covered
 LL |
 LL |     Tuple(u32),
-   |     ^^^^^ not covered
+   |     ----- not covered
 LL |
 LL |     Struct { field: u32 }
-   |     ^^^^^^ not covered
+   |     ------ not covered
    = note: the matched value is of type `NormalEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -62,14 +62,14 @@ LL |     match x {}
    |           ^ patterns `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
    |
 note: `UninhabitedVariants` defined here
-  --> $DIR/auxiliary/uninhabited.rs:17:23
+  --> $DIR/auxiliary/uninhabited.rs:16:1
    |
 LL | pub enum UninhabitedVariants {
-   | ----------------------------
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |     #[non_exhaustive] Tuple(!),
-   |                       ^^^^^ not covered
+   |                       ----- not covered
 LL |     #[non_exhaustive] Struct { x: ! }
-   |                       ^^^^^^ not covered
+   |                       ------ not covered
    = note: the matched value is of type `UninhabitedVariants`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_same_crate.stderr
@@ -43,14 +43,14 @@ LL |     match x {}
    |           ^ patterns `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
    |
 note: `UninhabitedVariants` defined here
-  --> $DIR/match_same_crate.rs:16:23
+  --> $DIR/match_same_crate.rs:15:10
    |
 LL | pub enum UninhabitedVariants {
-   |          -------------------
+   |          ^^^^^^^^^^^^^^^^^^^
 LL |     #[non_exhaustive] Tuple(!),
-   |                       ^^^^^ not covered
+   |                       ----- not covered
 LL |     #[non_exhaustive] Struct { x: ! }
-   |                       ^^^^^^ not covered
+   |                       ------ not covered
    = note: the matched value is of type `UninhabitedVariants`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -62,14 +62,14 @@ LL |     match x {}
    |           ^ patterns `UninhabitedVariants::Tuple(_)` and `UninhabitedVariants::Struct { .. }` not covered
    |
 note: `UninhabitedVariants` defined here
-  --> $DIR/auxiliary/uninhabited.rs:17:23
+  --> $DIR/auxiliary/uninhabited.rs:16:1
    |
 LL | pub enum UninhabitedVariants {
-   | ----------------------------
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |     #[non_exhaustive] Tuple(!),
-   |                       ^^^^^ not covered
+   |                       ----- not covered
 LL |     #[non_exhaustive] Struct { x: ! }
-   |                       ^^^^^^ not covered
+   |                       ------ not covered
    = note: the matched value is of type `UninhabitedVariants`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |


### PR DESCRIPTION
Successful merges:

 - #117343 (Cleanup `rustc_mir_build/../check_match.rs`)
 - #117550 (Use `filter_map` in `try_par_for_each_in`)
 - #117554 (consts: remove dead code around `i1` constant values)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117343,117550,117554)
<!-- homu-ignore:end -->