### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -59,7 +59,6 @@ const EXCEPTIONS_CARGO: &[(&str, &str)] = &[
     // tidy-alphabetical-start
     ("bitmaps", "MPL-2.0+"),
     ("bytesize", "Apache-2.0"),
-    ("byteyarn", "Apache-2.0"),
     ("ciborium", "Apache-2.0"),
     ("ciborium-io", "Apache-2.0"),
     ("ciborium-ll", "Apache-2.0"),


### PR DESCRIPTION
8 commits in b4d18d4bd3db6d872892f6c87c51a02999b80802..65e297d1ec0dee1a74800efe600b8dc163bcf5db
2023-10-31 18:19:10 +0000 to 2023-11-03 20:56:31 +0000
- fix(cli): Clarify --test is for targets, not test functions (rust-lang/cargo#12915)
- Updating "features" documentation to add a note about the new limit on number of features (rust-lang/cargo#12913)
- fix: merge `trim-paths` from different profiles (rust-lang/cargo#12908)
- Add regression test for issue 6915: features and transitive dev deps (rust-lang/cargo#12907)
- chore(deps): update rust crate gix to 0.55.2 (rust-lang/cargo#12906)
- chore(deps): update compatible (rust-lang/cargo#12905)
- docs(ref): Fix open-semver-range issue link (rust-lang/cargo#12904)
- docs(ref): Highlight commands to answer dep resolution questions (rust-lang/cargo#12903)

r? ghost