### PR TITLE
fallback for `construct_generic_bound_failure`

### DIFF
--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.rs
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.rs
@@ -1,0 +1,11 @@
+// edition:2021
+// https://github.com/rust-lang/rust/issues/117547
+
+trait T {}
+
+trait MyTrait {
+    async fn foo() -> &'static impl T;
+    //~^ ERROR the associated type `<Self as MyTrait>::{opaque#0}` may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
@@ -1,0 +1,14 @@
+error[E0310]: the associated type `<Self as MyTrait>::{opaque#0}` may not live long enough
+  --> $DIR/async-and-ret-ref.rs:7:5
+   |
+LL |     async fn foo() -> &'static impl T;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     the associated type `<Self as MyTrait>::{opaque#0}` must be valid for the static lifetime...
+   |     ...so that the reference type `&'static impl T` does not outlive the data it points at
+   |
+   = help: consider adding an explicit lifetime bound `<Self as MyTrait>::{opaque#0}: 'static`...
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
Fixes #117547

This case regressed at #115882. 

In this context, `﻿generic_param_scope` is produced by `﻿RPITVisitor` and not included by `﻿hir_owner`. Therefore, I've added a fallback to address this.