### PR TITLE
update and clarify addr_of docs

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1989,9 +1989,18 @@ impl<F: FnPtr> fmt::Debug for F {
 /// as all other references. This macro can create a raw pointer *without* creating
 /// a reference first.
 ///
-/// Note, however, that the `expr` in `addr_of!(expr)` is still subject to all
-/// the usual rules. In particular, `addr_of!(*ptr::null())` is Undefined
-/// Behavior because it dereferences a null pointer.
+/// The `expr` in `addr_of!(expr)` is evaluated as a place expression, but never loads
+/// from the place or requires the place to be dereferenceable. This means that
+/// `addr_of!(*ptr)` is defined behavior even if `ptr` is dangling or misaligned.
+/// Note however that `addr_of!((*ptr).field)` still requires the projection to
+/// `field` to be in-bounds, using the same rules as [`offset`].
+///
+/// Note that `Deref`/`Index` coercions (and their mutable counterparts) are applied inside
+/// `addr_of!` like everywhere else, in which case a reference is created to call `Deref::deref` or
+/// `Index::index`, respectively. The statements above only apply when no such coercions are
+/// applied.
+///
+/// [`offset`]: pointer::offset
 ///
 /// # Example
 ///
@@ -2029,9 +2038,18 @@ pub macro addr_of($place:expr) {
 /// as all other references. This macro can create a raw pointer *without* creating
 /// a reference first.
 ///
-/// Note, however, that the `expr` in `addr_of_mut!(expr)` is still subject to all
-/// the usual rules. In particular, `addr_of_mut!(*ptr::null_mut())` is Undefined
-/// Behavior because it dereferences a null pointer.
+/// The `expr` in `addr_of_mut!(expr)` is evaluated as a place expression, but never loads
+/// from the place or requires the place to be dereferenceable. This means that
+/// `addr_of_mut!(*ptr)` is defined behavior even if `ptr` is dangling or misaligned.
+/// Note however that `addr_of_mut!((*ptr).field)` still requires the projection to
+/// `field` to be in-bounds, using the same rules as [`offset`].
+///
+/// Note that `Deref`/`Index` coercions (and their mutable counterparts) are applied inside
+/// `addr_of_mut!` like everywhere else, in which case a reference is created to call `Deref::deref`
+/// or `Index::index`, respectively. The statements above only apply when no such coercions are
+/// applied.
+///
+/// [`offset`]: pointer::offset
 ///
 /// # Examples
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1991,7 +1991,7 @@ impl<F: FnPtr> fmt::Debug for F {
 ///
 /// The `expr` in `addr_of!(expr)` is evaluated as a place expression, but never loads
 /// from the place or requires the place to be dereferenceable. This means that
-/// `addr_of!(*ptr)` is defined behavior even if `ptr` is dangling or misaligned.
+/// `addr_of!(*ptr)` is defined behavior even if `ptr` is null, dangling, or misaligned.
 /// Note however that `addr_of!((*ptr).field)` still requires the projection to
 /// `field` to be in-bounds, using the same rules as [`offset`].
 ///
@@ -2040,7 +2040,7 @@ pub macro addr_of($place:expr) {
 ///
 /// The `expr` in `addr_of_mut!(expr)` is evaluated as a place expression, but never loads
 /// from the place or requires the place to be dereferenceable. This means that
-/// `addr_of_mut!(*ptr)` is defined behavior even if `ptr` is dangling or misaligned.
+/// `addr_of_mut!(*ptr)` is defined behavior even if `ptr` is null, dangling, or misaligned.
 /// Note however that `addr_of_mut!((*ptr).field)` still requires the projection to
 /// `field` to be in-bounds, using the same rules as [`offset`].
 ///


### PR DESCRIPTION
This updates the docs to match https://github.com/rust-lang/reference/pull/1387. Cc @rust-lang/opsem 

@chorman0773 not sure if you had anything else you wanted to say here, I'd be happy to get your feedback. :)

Fixes https://github.com/rust-lang/rust/issues/114902, so Cc @joshlf 