### PR TITLE
Derive `TyEncodable`/`TyDecodable` in `rustc_type_ir`

### DIFF
--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -10,6 +10,8 @@
 #![deny(rustc::diagnostic_outside_of_impl)]
 #![allow(internal_features)]
 
+extern crate self as rustc_type_ir;
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]


### PR DESCRIPTION
when `derive(TyEncodable)` or `derive(TyDecodable)` sees an `I` type parameter on a struct that has no `'tcx`, then parameterize the `TyEncoder`/`TyDecoder`'s interner over that variable rather than `TyCtxt<'tcx>`.

Also, emit where clauses for fields rather than generics.