### PR TITLE
move `Option::as_`(`mut_`)`slice` to use `offset_of!`, part 1

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -178,6 +178,7 @@
 #![feature(is_ascii_octdigit)]
 #![feature(isqrt)]
 #![feature(maybe_uninit_uninit_array)]
+#![feature(offset_of)]
 #![feature(ptr_alignment_type)]
 #![feature(ptr_metadata)]
 #![feature(set_ptr_value)]


### PR DESCRIPTION
This does the bootstrap dance to use the newly-added enum extension of the `core::mem::offset_of!` macro. Once that reaches beta, we can remove the bootstrap and the intrinsic.

r? @scottmcm 