### PR TITLE
Implement `From<&'a [T; N]>` for `Cow<'a, [T]>`

### DIFF
--- a/library/alloc/src/vec/cow.rs
+++ b/library/alloc/src/vec/cow.rs
@@ -2,6 +2,19 @@ use crate::borrow::Cow;
 
 use super::Vec;
 
+#[stable(feature = "cow_from_array", since = "CURRENT_RUSTC_VERSION")]
+impl<'a, T: Clone, const N: usize> From<&'a [T; N]> for Cow<'a, [T]> {
+    /// Creates a [`Borrowed`] slice
+    /// from a reference to an array.
+    ///
+    /// This conversion does not allocate or clone the data.
+    ///
+    /// [`Borrowed`]: crate::borrow::Cow::Borrowed
+    fn from(s: &'a [T; N]) -> Cow<'a, [T]> {
+        Cow::Borrowed(s)
+    }
+}
+
 #[stable(feature = "cow_from_vec", since = "1.8.0")]
 impl<'a, T: Clone> From<&'a [T]> for Cow<'a, [T]> {
     /// Creates a [`Borrowed`] variant of [`Cow`]


### PR DESCRIPTION
(see also: #116890)

Currently, converting an array reference to a `Cow<[T]>` requires either slicing and reborrowing (`Cow::from(&arr_ref[..])`), or explicitly constructing a `Cow::Borrowed`, sometimes with a type annotation ([playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=bf97250e85199a628fd1808e9fe863c6) of some conversions that do and do not compile).

Note that this does not conflict with a possible future `impl From<&'a U> for Cow<'_, U>`, but could cause inference errors if coexisting with such an impl (where `U = [T; N]`, `Cow::from(array_ref)` would be ambiguous if not otherwise constrained).

Needs FCP since this is an insta-stable impl.

@rustbot label +T-libs-api

r? @ghost