### PR TITLE
bump clang version for dist-x86_64-linux from 17.0.2 to 17.0.4

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-17.0.2
+LLVM=llvmorg-17.0.4
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
This fixes few miscompiles, so nice to have.

Release notes:
https://discourse.llvm.org/t/llvm-17-0-3-released/74172
https://discourse.llvm.org/t/llvm-17-0-4-released/74548

>The next release will be 17.0.5, in two weeks 14th of November.

Or maybe delay until 17.0.5?