### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_incremental/messages.ftl
+++ b/compiler/rustc_incremental/messages.ftl
@@ -30,8 +30,6 @@ incremental_create_lock =
     incremental compilation: could not create session directory lock file: {$lock_err}
 incremental_create_new = failed to create {$name} at `{$path}`: {$err}
 
-incremental_decode_incr_cache = could not decode incremental cache: {$err}
-
 incremental_delete_full = error deleting incremental compilation session directory `{$path}`: {$err}
 
 incremental_delete_incompatible =

--- a/compiler/rustc_incremental/src/errors.rs
+++ b/compiler/rustc_incremental/src/errors.rs
@@ -271,12 +271,6 @@ pub struct LoadDepGraph {
 }
 
 #[derive(Diagnostic)]
-#[diag(incremental_decode_incr_cache)]
-pub struct DecodeIncrCache {
-    pub err: String,
-}
-
-#[derive(Diagnostic)]
 #[diag(incremental_write_dep_graph)]
 pub struct WriteDepGraph<'a> {
     pub path: &'a Path,

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1044,6 +1044,7 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
+    #[rustc_diagnostic_item = "env_macro"] // useful for external lints
     macro_rules! env {
         ($name:expr $(,)?) => {{ /* compiler built-in */ }};
         ($name:expr, $error_msg:expr $(,)?) => {{ /* compiler built-in */ }};
@@ -1074,6 +1075,7 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
+    #[rustc_diagnostic_item = "option_env_macro"] // useful for external lints
     macro_rules! option_env {
         ($name:expr $(,)?) => {{ /* compiler built-in */ }};
     }
@@ -1479,6 +1481,7 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
     #[macro_export]
+    #[rustc_diagnostic_item = "include_macro"] // useful for external lints
     macro_rules! include {
         ($file:expr $(,)?) => {{ /* compiler built-in */ }};
     }

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -469,7 +469,8 @@ fn install_git_hook_maybe(config: &Config) -> io::Result<()> {
         assert!(output.status.success(), "failed to run `git`");
         PathBuf::from(t!(String::from_utf8(output.stdout)).trim())
     }));
-    let dst = git.join("hooks").join("pre-push");
+    let hooks_dir = git.join("hooks");
+    let dst = hooks_dir.join("pre-push");
     if dst.exists() {
         // The git hook has already been set up, or the user already has a custom hook.
         return Ok(());
@@ -485,6 +486,10 @@ undesirable, simply delete the `pre-push` file from .git/hooks."
     if prompt_user("Would you like to install the git hook?: [y/N]")? != Some(PromptResult::Yes) {
         println!("Ok, skipping installation!");
         return Ok(());
+    }
+    if !hooks_dir.exists() {
+        // We need to (try to) create the hooks directory first.
+        let _ = fs::create_dir(hooks_dir);
     }
     let src = config.src.join("src").join("etc").join("pre-push.sh");
     match fs::hard_link(src, &dst) {

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1146,11 +1146,10 @@ impl Build {
             .filter(|s| !s.starts_with("-O") && !s.starts_with("/O"))
             .collect::<Vec<String>>();
 
-        // If we're compiling on macOS then we add a few unconditional flags
-        // indicating that we want libc++ (more filled out than libstdc++) and
-        // we want to compile for 10.7. This way we can ensure that
+        // If we're compiling C++ on macOS then we add a flag indicating that
+        // we want libc++ (more filled out than libstdc++), ensuring that
         // LLVM/etc are all properly compiled.
-        if target.contains("apple-darwin") {
+        if matches!(c, CLang::Cxx) && target.contains("apple-darwin") {
             base.push("-stdlib=libc++".into());
         }
 


### PR DESCRIPTION
Successful merges:

 - #116017 (Don't pass `-stdlib=libc++` when building C files on macOS)
 - #117524 (bootstrap/setup: create hooks directory if non-existing)
 - #117588 (Remove unused LoadResult::DecodeIncrCache variant)
 - #117596 (Add diagnostic items for a few of core's builtin macros)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116017,117524,117588,117596)
<!-- homu-ignore:end -->