### PR TITLE
Only instantiate binder during dyn's built-in trait candidate probe once

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -628,18 +628,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         self.infcx.probe(|_snapshot| {
-            // FIXME(non_lifetime_binders): Really, we care only to check that we don't
-            // have any non-region *escaping* bound vars, but that's hard to check and
-            // we shouldn't really ever encounter those anyways.
-            if obligation.self_ty().has_non_region_late_bound() {
-                return;
-            }
+            let poly_trait_predicate = self.infcx.resolve_vars_if_possible(obligation.predicate);
+            let placeholder_trait_predicate =
+                self.infcx.instantiate_binder_with_placeholders(poly_trait_predicate);
 
-            // The code below doesn't care about regions, and the
-            // self-ty here doesn't escape this probe, so just erase
-            // any LBR.
-            let self_ty = self.tcx().erase_late_bound_regions(obligation.self_ty());
-            let poly_trait_ref = match self_ty.kind() {
+            let self_ty = placeholder_trait_predicate.self_ty();
+            let principal_trait_ref = match self_ty.kind() {
                 ty::Dynamic(ref data, ..) => {
                     if data.auto_traits().any(|did| did == obligation.predicate.def_id()) {
                         debug!(
@@ -671,18 +665,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 _ => return,
             };
 
-            debug!(?poly_trait_ref, "assemble_candidates_from_object_ty");
-
-            let poly_trait_predicate = self.infcx.resolve_vars_if_possible(obligation.predicate);
-            let placeholder_trait_predicate =
-                self.infcx.instantiate_binder_with_placeholders(poly_trait_predicate);
+            debug!(?principal_trait_ref, "assemble_candidates_from_object_ty");
 
             // Count only those upcast versions that match the trait-ref
             // we are looking for. Specifically, do not only check for the
             // correct trait, but also the correct type parameters.
             // For example, we may be trying to upcast `Foo` to `Bar<i32>`,
             // but `Foo` is declared as `trait Foo: Bar<u32>`.
-            let candidate_supertraits = util::supertraits(self.tcx(), poly_trait_ref)
+            let candidate_supertraits = util::supertraits(self.tcx(), principal_trait_ref)
                 .enumerate()
                 .filter(|&(_, upcast_trait_ref)| {
                     self.infcx.probe(|_| {

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -628,7 +628,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         self.infcx.probe(|_snapshot| {
-            if obligation.has_non_region_late_bound() {
+            // FIXME(non_lifetime_binders): Really, we care only to check that we don't
+            // have any non-region *escaping* bound vars, but that's hard to check and
+            // we shouldn't really ever encounter those anyways.
+            if obligation.self_ty().has_non_region_late_bound() {
                 return;
             }
 

--- a/tests/ui/traits/non-lifetime-via-dyn-builtin.current.stderr
+++ b/tests/ui/traits/non-lifetime-via-dyn-builtin.current.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/non-lifetime-via-dyn-builtin.rs:5:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non-lifetime-via-dyn-builtin.next.stderr
+++ b/tests/ui/traits/non-lifetime-via-dyn-builtin.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/non-lifetime-via-dyn-builtin.rs:5:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non-lifetime-via-dyn-builtin.rs
+++ b/tests/ui/traits/non-lifetime-via-dyn-builtin.rs
@@ -1,0 +1,16 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete and may not be safe
+
+fn trivial<A>()
+where
+    for<B> dyn Fn(A, *const B): Fn(A, *const B),
+{
+}
+
+fn main() {
+    trivial::<u8>();
+}

--- a/tests/ui/traits/non_lifetime_binders/disqualifying-object-candidates.rs
+++ b/tests/ui/traits/non_lifetime_binders/disqualifying-object-candidates.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+trait Foo {
+    type Bar<T>
+    where
+        dyn Send + 'static: Send;
+}
+
+impl Foo for () {
+    type Bar<T> = i32;
+    // We take `<() as Foo>::Bar<T>: Sized` and normalize it under the where clause
+    // of `for<S> <() as Foo>::Bar<S> = i32`. This gives us back `i32: Send` with
+    // the nested obligation `(dyn Send + 'static): Send`. However, during candidate
+    // assembly for object types, we disqualify any obligations that has non-region
+    // late-bound vars in the param env(!), rather than just the predicate. This causes
+    // the where clause to not hold even though it trivially should.
+}
+
+fn main() {}


### PR DESCRIPTION
See UI test for demonstration of the issue.

This was "caused" by #117131, but only because we're using the `normalize_param_env` (which has been augmented with a projection clause used to normalize GATs) which features non-lifetime bound vars in it.

Fixes #117602 technically, though that's also fixed by #117542.

r? types