### PR TITLE
Add `Duration::abs_diff`

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -461,6 +461,27 @@ impl Duration {
         self.secs as u128 * NANOS_PER_SEC as u128 + self.nanos.0 as u128
     }
 
+    /// Computes the absolute difference between `self` and `other`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(duration_abs_diff)]
+    /// use std::time::Duration;
+    ///
+    /// assert_eq!(Duration::new(100, 0).abs_diff(Duration::new(80, 0)), Duration::new(20, 0));
+    /// assert_eq!(Duration::new(100, 400_000_000).abs_diff(Duration::new(110, 0)), Duration::new(9, 600_000_000));
+    /// ```
+    #[unstable(feature = "duration_abs_diff", issue = "117618")]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    #[inline]
+    pub const fn abs_diff(self, other: Duration) -> Duration {
+        if let Some(res) = self.checked_sub(other) { res } else { other.checked_sub(self).unwrap() }
+    }
+
     /// Checked `Duration` addition. Computes `self + other`, returning [`None`]
     /// if overflow occurred.
     ///

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -27,6 +27,7 @@
 #![feature(core_private_diy_float)]
 #![feature(dec2flt)]
 #![feature(div_duration)]
+#![feature(duration_abs_diff)]
 #![feature(duration_consts_float)]
 #![feature(duration_constants)]
 #![feature(exact_size_is_empty)]

--- a/library/core/tests/time.rs
+++ b/library/core/tests/time.rs
@@ -74,6 +74,19 @@ fn nanos() {
 }
 
 #[test]
+fn abs_diff() {
+    assert_eq!(Duration::new(2, 0).abs_diff(Duration::new(1, 0)), Duration::new(1, 0));
+    assert_eq!(Duration::new(1, 0).abs_diff(Duration::new(2, 0)), Duration::new(1, 0));
+    assert_eq!(Duration::new(1, 0).abs_diff(Duration::new(1, 0)), Duration::new(0, 0));
+    assert_eq!(Duration::new(1, 1).abs_diff(Duration::new(0, 2)), Duration::new(0, 999_999_999));
+    assert_eq!(Duration::new(1, 1).abs_diff(Duration::new(2, 1)), Duration::new(1, 0));
+    assert_eq!(Duration::MAX.abs_diff(Duration::MAX), Duration::ZERO);
+    assert_eq!(Duration::ZERO.abs_diff(Duration::ZERO), Duration::ZERO);
+    assert_eq!(Duration::MAX.abs_diff(Duration::ZERO), Duration::MAX);
+    assert_eq!(Duration::ZERO.abs_diff(Duration::MAX), Duration::MAX);
+}
+
+#[test]
 fn add() {
     assert_eq!(Duration::new(0, 0) + Duration::new(0, 1), Duration::new(0, 1));
     assert_eq!(Duration::new(0, 500_000_000) + Duration::new(0, 500_000_001), Duration::new(1, 1));


### PR DESCRIPTION
This adds a `Duration::abs_diff` method analogous to the existing one on the primitive integers.

ACP: https://github.com/rust-lang/libs-team/issues/291
Tracking Issue: https://github.com/rust-lang/rust/issues/117618