### PR TITLE
Documentation cleanup for core::error::Request.

### DIFF
--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -439,10 +439,10 @@ where
 /// * A Producer initializes the value of one of its fields of a specific type. (or is otherwise
 /// prepared to generate a value requested). eg, `backtrace::Backtrace` or
 /// `std::backtrace::Backtrace`
-/// * A Consumer requests an object of a specific type (say `std::backtrace::Backtrace). In the case
-/// of a `dyn Error` trait object (the Producer), there are methods called `request_ref` and
-/// `request_value` are available to simplify obtaining an ``Option<T>`` for a given type. * The
-/// Producer, when requested, populates the given Request object which is given as a mutable
+/// * A Consumer requests an object of a specific type (say `std::backtrace::Backtrace`). In the
+/// case of a `dyn Error` trait object (the Producer), there are functions called `request_ref` and
+/// `request_value` to simplify obtaining an `Option<T>` for a given type.
+/// * The Producer, when requested, populates the given Request object which is given as a mutable
 /// reference.
 /// * The Consumer extracts a value or reference to the requested type from the `Request` object
 /// wrapped in an `Option<T>`; in the case of `dyn Error` the aforementioned `request_ref` and `


### PR DESCRIPTION
This part of the documentation currently render like this:

![image](https://github.com/rust-lang/rust/assets/249196/b34cb907-4ce4-4e85-beca-510d8aa1fefb)

The new version renders like this:

![image](https://github.com/rust-lang/rust/assets/249196/fe18398a-15fb-42a7-82a4-f1856d48bd79)

Fixes:
* Add missing closing back tick.
* Remove spurious double back ticks.
* Add missing newline to render bullet point correctly.
* Fix grammar "there are methods calledrequest_ref and request_value are available" -> "there are methods calledrequest_ref and request_value".
* Change "methods" to "functions", which seems more appropriate for free functions.