### PR TITLE
Check binders with bound vars for global bounds that don't hold

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -32,6 +32,7 @@ use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _
 use rustc_trait_selection::traits::{
     self, ObligationCause, ObligationCauseCode, ObligationCtxt, WellFormedLoc,
 };
+use rustc_type_ir::TypeFlags;
 
 use std::cell::LazyCell;
 use std::ops::{ControlFlow, Deref};
@@ -1877,7 +1878,7 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
                 continue;
             }
             // Match the existing behavior.
-            if pred.is_global() && !pred.has_late_bound_vars() {
+            if pred.is_global() && !pred.has_type_flags(TypeFlags::HAS_BINDER_VARS) {
                 let pred = self.normalize(span, None, pred);
                 let hir_node = tcx.hir().find_by_def_id(self.body_def_id);
 

--- a/tests/ui/late-bound-lifetimes/predicate-is-global.rs
+++ b/tests/ui/late-bound-lifetimes/predicate-is-global.rs
@@ -29,4 +29,12 @@ impl Inherent {
     fn inherent(&self) {}
 }
 
+// This trivial bound doesn't hold, but the unused lifetime tripped up that check after #117589, and
+// showed up in its crater results (in `soa-derive 0.13.0`).
+fn do_it()
+where
+    for<'a> Inherent: Clone,
+{
+}
+
 fn main() {}


### PR DESCRIPTION
This fixes `soa_derive-0.13.0` from #117589's crater run.

r? @compiler-errors 