### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -32,6 +32,7 @@ use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _
 use rustc_trait_selection::traits::{
     self, ObligationCause, ObligationCauseCode, ObligationCtxt, WellFormedLoc,
 };
+use rustc_type_ir::TypeFlags;
 
 use std::cell::LazyCell;
 use std::ops::{ControlFlow, Deref};
@@ -1877,7 +1878,7 @@ impl<'tcx> WfCheckingCtxt<'_, 'tcx> {
                 continue;
             }
             // Match the existing behavior.
-            if pred.is_global() && !pred.has_late_bound_vars() {
+            if pred.is_global() && !pred.has_type_flags(TypeFlags::HAS_BINDER_VARS) {
                 let pred = self.normalize(span, None, pred);
                 let hir_node = tcx.hir().find_by_def_id(self.body_def_id);
 

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -439,10 +439,10 @@ where
 /// * A Producer initializes the value of one of its fields of a specific type. (or is otherwise
 /// prepared to generate a value requested). eg, `backtrace::Backtrace` or
 /// `std::backtrace::Backtrace`
-/// * A Consumer requests an object of a specific type (say `std::backtrace::Backtrace). In the case
-/// of a `dyn Error` trait object (the Producer), there are methods called `request_ref` and
-/// `request_value` are available to simplify obtaining an ``Option<T>`` for a given type. * The
-/// Producer, when requested, populates the given Request object which is given as a mutable
+/// * A Consumer requests an object of a specific type (say `std::backtrace::Backtrace`). In the
+/// case of a `dyn Error` trait object (the Producer), there are functions called `request_ref` and
+/// `request_value` to simplify obtaining an `Option<T>` for a given type.
+/// * The Producer, when requested, populates the given Request object which is given as a mutable
 /// reference.
 /// * The Consumer extracts a value or reference to the requested type from the `Request` object
 /// wrapped in an `Option<T>`; in the case of `dyn Error` the aforementioned `request_ref` and `

--- a/tests/ui/late-bound-lifetimes/predicate-is-global.rs
+++ b/tests/ui/late-bound-lifetimes/predicate-is-global.rs
@@ -29,4 +29,12 @@ impl Inherent {
     fn inherent(&self) {}
 }
 
+// This trivial bound doesn't hold, but the unused lifetime tripped up that check after #117589, and
+// showed up in its crater results (in `soa-derive 0.13.0`).
+fn do_it()
+where
+    for<'a> Inherent: Clone,
+{
+}
+
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const_closure-const_trait_impl-ice-113381.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const_closure-const_trait_impl-ice-113381.rs
@@ -1,0 +1,15 @@
+#![feature(const_closures, const_trait_impl, effects)]
+#![allow(incomplete_features)]
+
+trait Foo {
+    fn foo(&self);
+}
+
+impl Foo for () {
+    fn foo(&self) {}
+}
+
+fn main() {
+    (const || { (()).foo() })();
+    //~^ ERROR: cannot call non-const fn
+}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const_closure-const_trait_impl-ice-113381.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/const_closure-const_trait_impl-ice-113381.stderr
@@ -1,0 +1,11 @@
+error[E0015]: cannot call non-const fn `<() as Foo>::foo` in constant functions
+  --> $DIR/const_closure-const_trait_impl-ice-113381.rs:13:22
+   |
+LL |     (const || { (()).foo() })();
+   |                      ^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-113375-index-out-of-bounds-generics.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-113375-index-out-of-bounds-generics.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+// effects ice https://github.com/rust-lang/rust/issues/113375 index out of bounds
+
+#![allow(incomplete_features, unused)]
+#![feature(effects, adt_const_params)]
+
+struct Bar<T>(T);
+
+impl<T> Bar<T> {
+    const fn value() -> usize {
+        42
+    }
+}
+
+struct Foo<const N: [u8; Bar::<u32>::value()]>;
+
+pub fn main() {}


### PR DESCRIPTION
Successful merges:

 - #117190 (add test for #113381)
 - #117516 (add test for #113375)
 - #117631 (Documentation cleanup for core::error::Request.)
 - #117637 (Check binders with bound vars for global bounds that don't hold)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117190,117516,117631,117637)
<!-- homu-ignore:end -->