### PR TITLE
Add color on item name in item declaration

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1075,7 +1075,7 @@ fn render_attributes_in_pre<'a, 'tcx: 'a>(
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
     for attr in it.attributes(cx.tcx(), cx.cache(), false) {
-        write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
+        write!(w, "<div class=\"code-attribute attr\">{attr}</div>").unwrap();
     }
 }
 

--- a/tests/rustdoc-gui/item-decl-colors.goml
+++ b/tests/rustdoc-gui/item-decl-colors.goml
@@ -24,6 +24,7 @@ define-function: (
         set-local-storage: {"rustdoc-theme": |theme|, "rustdoc-use-system-theme": "false"}
         reload:
         assert-css: (".item-decl .code-attribute", {"color": |attr_color|}, ALL)
+        assert-css: (".item-decl .struct[href='#']", {"color": |struct_color|}, ALL)
         assert-css: (".item-decl .trait", {"color": |trait_color|}, ALL)
         // We need to add `code` here because otherwise it would select the parent too.
         assert-css: (".item-decl code .struct", {"color": |struct_color|}, ALL)
@@ -41,7 +42,7 @@ call-function: (
     "check-colors",
     {
         "theme": "ayu",
-        "attr_color": "#999",
+        "attr_color": "#e6e1cf",
         "trait_color": "#39afd7",
         "struct_color": "#ffa0a5",
         "enum_color": "#ffa0a5",
@@ -55,7 +56,7 @@ call-function: (
     "check-colors",
     {
         "theme": "dark",
-        "attr_color": "#999",
+        "attr_color": "#ee6868",
         "trait_color": "#b78cf2",
         "struct_color": "#2dbfb8",
         "enum_color": "#2dbfb8",
@@ -69,7 +70,7 @@ call-function: (
     "check-colors",
     {
         "theme": "light",
-        "attr_color": "#999",
+        "attr_color": "#c82829",
         "trait_color": "#6e4fc9",
         "struct_color": "#ad378a",
         "enum_color": "#ad378a",


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/117555.

I'm really not convinced this is a good idea. It does put more colors, but I'm not sure it's adding any value. We have two different color systems: one for source codes and one for documentation. Item declaration is actually using the same system as "documentation", so only highlighting links.

So in this draft, I generated an empty link on the item name to add some color, but again, really not convinced by this approach...

You can test it [here](https://rustdoc.crud.net/imperio/item-decl-more-color/std/path/struct.PathBuf.html).

Some screenshots:

![image](https://github.com/rust-lang/rust/assets/3050060/cbfb8169-7cc2-4364-ac14-9fef5328d8e1)

![image](https://github.com/rust-lang/rust/assets/3050060/78048fe9-157c-4a2e-a5fa-ce6ac0704c07)

![image](https://github.com/rust-lang/rust/assets/3050060/dc1f2536-cdce-4463-aca7-e7cbcbc5d056)
