### PR TITLE
Extend builtin/auto trait args with error when they have >1 argument

### DIFF
--- a/tests/ui/auto-traits/has-arguments.rs
+++ b/tests/ui/auto-traits/has-arguments.rs
@@ -1,0 +1,10 @@
+#![feature(auto_traits)]
+
+auto trait Trait1<'outer> {}
+//~^ ERROR auto traits cannot have generic parameters
+
+fn f<'a>(x: impl Trait1<'a>) {}
+
+fn main() {
+    f("");
+}

--- a/tests/ui/auto-traits/has-arguments.stderr
+++ b/tests/ui/auto-traits/has-arguments.stderr
@@ -1,0 +1,11 @@
+error[E0567]: auto traits cannot have generic parameters
+  --> $DIR/has-arguments.rs:3:18
+   |
+LL | auto trait Trait1<'outer> {}
+   |            ------^^^^^^^^ help: remove the parameters
+   |            |
+   |            auto trait cannot have generic parameters
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0567`.


### PR DESCRIPTION
Reuse `extend_with_error` to add error args to any auto trait (or built-in trait like `Copy` that is defined incorrectly) that has additional non-`Self` args.

Fixes #117628