### PR TITLE
ci: docker: dist-various-1: Include RISC-V C compilers

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -49,6 +49,12 @@ RUN ./install-x86_64-redox.sh
 COPY host-x86_64/dist-various-1/install-aarch64-none-elf.sh /build
 RUN ./install-aarch64-none-elf.sh
 
+COPY host-x86_64/dist-various-1/install-riscv64-none-elf.sh /build
+RUN ./install-riscv64-none-elf.sh
+
+COPY host-x86_64/dist-various-1/install-riscv32-none-elf.sh /build
+RUN ./install-riscv32-none-elf.sh
+
 # Suppress some warnings in the openwrt toolchains we downloaded
 ENV STAGING_DIR=/tmp
 
@@ -105,9 +111,6 @@ ENV TARGETS=$TARGETS,armv7r-none-eabihf
 ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 ENV TARGETS=$TARGETS,armv7a-none-eabi
 
-# riscv targets currently do not need a C compiler, as compiler_builtins
-# doesn't currently have it enabled, and the riscv gcc compiler is not
-# installed.
 ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft" \
     CFLAGS_arm_unknown_linux_musleabi="-march=armv6 -marm" \
     CFLAGS_arm_unknown_linux_musleabihf="-march=armv6 -marm -mfpu=vfp" \
@@ -125,11 +128,16 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CFLAGS_aarch64_unknown_none_softfloat=-mstrict-align -march=armv8-a+nofp+nosimd \
     CC_aarch64_unknown_none=aarch64-none-elf-gcc \
     CFLAGS_aarch64_unknown_none=-mstrict-align -march=armv8-a+fp+simd \
-    CC_riscv32i_unknown_none_elf=false \
-    CC_riscv32imc_unknown_none_elf=false \
-    CC_riscv32imac_unknown_none_elf=false \
-    CC_riscv64imac_unknown_none_elf=false \
-    CC_riscv64gc_unknown_none_elf=false
+    CC_riscv32i_unknown_none_elf=riscv32-unknown-elf-gcc \
+    CFLAGS_riscv32i_unknown_none_elf=-march=rv32i -mabi=ilp32 \
+    CC_riscv32imc_unknown_none_elf=riscv32-unknown-elf-gcc \
+    CFLAGS_riscv32imc_unknown_none_elf=-march=rv32imc -mabi=ilp32 \
+    CC_riscv32imac_unknown_none_elf=riscv32-unknown-elf-gcc \
+    CFLAGS_riscv32imac_unknown_none_elf=-march=rv32imac -mabi=ilp32 \
+    CC_riscv64imac_unknown_none_elf=riscv64-unknown-elf-gcc \
+    CFLAGS_riscv64imac_unknown_none_elf=-march=rv64imac -mabi=lp64 \
+    CC_riscv64gc_unknown_none_elf=riscv64-unknown-elf-gcc \
+    CFLAGS_riscv64gc_unknown_none_elf=-march=rv64gc -mabi=lp64
 
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-armv5te=/musl-armv5te \

--- a/src/ci/docker/host-x86_64/dist-various-1/install-riscv32-none-elf.sh
+++ b/src/ci/docker/host-x86_64/dist-various-1/install-riscv32-none-elf.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Originally from https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2023.10.18/riscv32-elf-ubuntu-22.04-gcc-nightly-2023.10.18-nightly.tar.gz
+curl -L https://ci-mirrors.rust-lang.org/rustc/riscv32-elf-ubuntu-22.04-gcc-nightly-2023.10.18-nightly.tar.gz \
+| tar --extract --gz --strip 1 --directory /usr/local

--- a/src/ci/docker/host-x86_64/dist-various-1/install-riscv64-none-elf.sh
+++ b/src/ci/docker/host-x86_64/dist-various-1/install-riscv64-none-elf.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Originally from https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2023.10.18/riscv64-elf-ubuntu-22.04-gcc-nightly-2023.10.18-nightly.tar.gz
+curl -L https://ci-mirrors.rust-lang.org/rustc/riscv64-elf-ubuntu-22.04-gcc-nightly-2023.10.18-nightly.tar.gz \
+| tar --extract --gz --strip 1 --directory /usr/local


### PR DESCRIPTION
The compiler-builtins for RISC-V are missing some key functions, such as __bswapsi2 [1].

We can't just pull in the LLVM compiler-rt builtins as the rust-lang/rust distribution container doesn't have a C compiler [2].

This patch adds RISC-V C compilers to the CI Dockerfile as the first step towards enabling LLVM compiler-rt builtins for RISC-V Rust.

1: https://github.com/rust-lang/compiler-builtins/issues/350
2: https://github.com/rust-lang/compiler-builtins/commit/e4f46b91ca843297fc065e20f1591e4971ae608c