### PR TITLE
rename ptr::invalid -> ptr::without_provenance

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -95,7 +95,7 @@ impl<T> ArenaChunk<T> {
         unsafe {
             if mem::size_of::<T>() == 0 {
                 // A pointer as large as possible for zero-sized elements.
-                ptr::invalid_mut(!0)
+                ptr::without_provenance_mut(!0)
             } else {
                 self.start().add(self.storage.len())
             }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2804,7 +2804,9 @@ impl<T> Weak<T> {
     #[must_use]
     pub const fn new() -> Weak<T> {
         Weak {
-            ptr: unsafe { NonNull::new_unchecked(ptr::invalid_mut::<RcBox<T>>(usize::MAX)) },
+            ptr: unsafe {
+                NonNull::new_unchecked(ptr::without_provenance_mut::<RcBox<T>>(usize::MAX))
+            },
             alloc: Global,
         }
     }
@@ -2829,7 +2831,9 @@ impl<T, A: Allocator> Weak<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub fn new_in(alloc: A) -> Weak<T, A> {
         Weak {
-            ptr: unsafe { NonNull::new_unchecked(ptr::invalid_mut::<RcBox<T>>(usize::MAX)) },
+            ptr: unsafe {
+                NonNull::new_unchecked(ptr::without_provenance_mut::<RcBox<T>>(usize::MAX))
+            },
             alloc,
         }
     }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2555,7 +2555,9 @@ impl<T> Weak<T> {
     #[must_use]
     pub const fn new() -> Weak<T> {
         Weak {
-            ptr: unsafe { NonNull::new_unchecked(ptr::invalid_mut::<ArcInner<T>>(usize::MAX)) },
+            ptr: unsafe {
+                NonNull::new_unchecked(ptr::without_provenance_mut::<ArcInner<T>>(usize::MAX))
+            },
             alloc: Global,
         }
     }
@@ -2583,7 +2585,9 @@ impl<T, A: Allocator> Weak<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub fn new_in(alloc: A) -> Weak<T, A> {
         Weak {
-            ptr: unsafe { NonNull::new_unchecked(ptr::invalid_mut::<ArcInner<T>>(usize::MAX)) },
+            ptr: unsafe {
+                NonNull::new_unchecked(ptr::without_provenance_mut::<ArcInner<T>>(usize::MAX))
+            },
             alloc,
         }
     }

--- a/library/alloc/tests/fmt.rs
+++ b/library/alloc/tests/fmt.rs
@@ -77,14 +77,14 @@ fn test_format_macro_interface() {
     t!(format!("{}", "foo"), "foo");
     t!(format!("{}", "foo".to_string()), "foo");
     if cfg!(target_pointer_width = "32") {
-        t!(format!("{:#p}", ptr::invalid::<isize>(0x1234)), "0x00001234");
-        t!(format!("{:#p}", ptr::invalid_mut::<isize>(0x1234)), "0x00001234");
+        t!(format!("{:#p}", ptr::without_provenance::<isize>(0x1234)), "0x00001234");
+        t!(format!("{:#p}", ptr::without_provenance_mut::<isize>(0x1234)), "0x00001234");
     } else {
-        t!(format!("{:#p}", ptr::invalid::<isize>(0x1234)), "0x0000000000001234");
-        t!(format!("{:#p}", ptr::invalid_mut::<isize>(0x1234)), "0x0000000000001234");
+        t!(format!("{:#p}", ptr::without_provenance::<isize>(0x1234)), "0x0000000000001234");
+        t!(format!("{:#p}", ptr::without_provenance_mut::<isize>(0x1234)), "0x0000000000001234");
     }
-    t!(format!("{:p}", ptr::invalid::<isize>(0x1234)), "0x1234");
-    t!(format!("{:p}", ptr::invalid_mut::<isize>(0x1234)), "0x1234");
+    t!(format!("{:p}", ptr::without_provenance::<isize>(0x1234)), "0x1234");
+    t!(format!("{:p}", ptr::without_provenance_mut::<isize>(0x1234)), "0x1234");
     t!(format!("{A:x}"), "aloha");
     t!(format!("{B:X}"), "adios");
     t!(format!("foo {} ☃☃☃☃☃☃", "bar"), "foo bar ☃☃☃☃☃☃");
@@ -208,7 +208,7 @@ fn test_format_macro_interface() {
     {
         let val = usize::MAX;
         let exp = format!("{val:#x}");
-        t!(format!("{:p}", std::ptr::invalid::<isize>(val)), exp);
+        t!(format!("{:p}", std::ptr::without_provenance::<isize>(val)), exp);
     }
 
     // Escaping

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -2575,7 +2575,7 @@ fn test_box_zero_allocator() {
                 assert!(state.0.insert(addr));
                 state.1 += 1;
                 std::println!("allocating {addr}");
-                std::ptr::invalid_mut(addr)
+                std::ptr::without_provenance_mut(addr)
             } else {
                 unsafe { std::alloc::alloc(layout) }
             };

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -215,7 +215,7 @@ impl Layout {
     #[inline]
     pub const fn dangling(&self) -> NonNull<u8> {
         // SAFETY: align is guaranteed to be non-zero
-        unsafe { NonNull::new_unchecked(crate::ptr::invalid_mut::<u8>(self.align())) }
+        unsafe { NonNull::new_unchecked(crate::ptr::without_provenance_mut::<u8>(self.align())) }
     }
 
     /// Creates a layout describing the record that can hold a value

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1155,7 +1155,7 @@ extern "rust-intrinsic" {
     ///
     /// Transmuting pointers *to* integers in a `const` context is [undefined behavior][ub],
     /// unless the pointer was originally created *from* an integer.
-    /// (That includes this function specifically, integer-to-pointer casts, and helpers like [`invalid`][crate::ptr::invalid],
+    /// (That includes this function specifically, integer-to-pointer casts, and helpers like [`invalid`][crate::ptr::dangling],
     /// but also semantically-equivalent conversions such as punning through `repr(C)` union fields.)
     /// Any attempt to use the resulting value for integer operations will abort const-evaluation.
     /// (And even outside `const`, such transmutation is touching on many unspecified aspects of the

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -181,7 +181,7 @@ impl<T: ?Sized> *const T {
     ///
     /// This is similar to `self as usize`, which semantically discards *provenance* and
     /// *address-space* information. However, unlike `self as usize`, casting the returned address
-    /// back to a pointer yields [`invalid`][], which is undefined behavior to dereference. To
+    /// back to a pointer yields a [pointer without provenance][without_provenance], which is undefined behavior to dereference. To
     /// properly restore the lost information and obtain a dereferenceable pointer, use
     /// [`with_addr`][pointer::with_addr] or [`map_addr`][pointer::map_addr].
     ///

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -188,9 +188,10 @@ impl<T: ?Sized> *mut T {
     ///
     /// This is similar to `self as usize`, which semantically discards *provenance* and
     /// *address-space* information. However, unlike `self as usize`, casting the returned address
-    /// back to a pointer yields [`invalid`][], which is undefined behavior to dereference. To
-    /// properly restore the lost information and obtain a dereferenceable pointer, use
-    /// [`with_addr`][pointer::with_addr] or [`map_addr`][pointer::map_addr].
+    /// back to a pointer yields yields a [pointer without provenance][without_provenance_mut], which is undefined
+    /// behavior to dereference. To properly restore the lost information and obtain a
+    /// dereferenceable pointer, use [`with_addr`][pointer::with_addr] or
+    /// [`map_addr`][pointer::map_addr].
     ///
     /// If using those APIs is not possible because there is no way to preserve a pointer with the
     /// required provenance, then Strict Provenance might not be for you. Use pointer-integer casts

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -4,8 +4,7 @@ use crate::hash;
 use crate::intrinsics;
 use crate::intrinsics::assert_unsafe_precondition;
 use crate::marker::Unsize;
-use crate::mem::SizedTypeProperties;
-use crate::mem::{self, MaybeUninit};
+use crate::mem::{MaybeUninit, SizedTypeProperties};
 use crate::num::{NonZero, NonZeroUsize};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 use crate::ptr;
@@ -114,7 +113,7 @@ impl<T: Sized> NonNull<T> {
         // to a *mut T. Therefore, `ptr` is not null and the conditions for
         // calling new_unchecked() are respected.
         unsafe {
-            let ptr = crate::ptr::invalid_mut::<T>(mem::align_of::<T>());
+            let ptr = crate::ptr::dangling_mut::<T>();
             NonNull::new_unchecked(ptr)
         }
     }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -12,7 +12,7 @@ use crate::iter::{
 use crate::marker::PhantomData;
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZero;
-use crate::ptr::{self, invalid, invalid_mut, NonNull};
+use crate::ptr::{self, without_provenance, without_provenance_mut, NonNull};
 
 use super::{from_raw_parts, from_raw_parts_mut};
 
@@ -67,7 +67,7 @@ pub struct Iter<'a, T: 'a> {
     ptr: NonNull<T>,
     /// For non-ZSTs, the non-null pointer to the past-the-end element.
     ///
-    /// For ZSTs, this is `ptr::invalid(len)`.
+    /// For ZSTs, this is `ptr::dangling(len)`.
     end_or_len: *const T,
     _marker: PhantomData<&'a T>,
 }
@@ -91,7 +91,8 @@ impl<'a, T> Iter<'a, T> {
         let ptr: NonNull<T> = NonNull::from(slice).cast();
         // SAFETY: Similar to `IterMut::new`.
         unsafe {
-            let end_or_len = if T::IS_ZST { invalid(len) } else { ptr.as_ptr().add(len) };
+            let end_or_len =
+                if T::IS_ZST { without_provenance(len) } else { ptr.as_ptr().add(len) };
 
             Self { ptr, end_or_len, _marker: PhantomData }
         }
@@ -189,7 +190,7 @@ pub struct IterMut<'a, T: 'a> {
     ptr: NonNull<T>,
     /// For non-ZSTs, the non-null pointer to the past-the-end element.
     ///
-    /// For ZSTs, this is `ptr::invalid_mut(len)`.
+    /// For ZSTs, this is `ptr::without_provenance_mut(len)`.
     end_or_len: *mut T,
     _marker: PhantomData<&'a mut T>,
 }
@@ -228,7 +229,8 @@ impl<'a, T> IterMut<'a, T> {
         // See the `next_unchecked!` and `is_empty!` macros as well as the
         // `post_inc_start` method for more information.
         unsafe {
-            let end_or_len = if T::IS_ZST { invalid_mut(len) } else { ptr.as_ptr().add(len) };
+            let end_or_len =
+                if T::IS_ZST { without_provenance_mut(len) } else { ptr.as_ptr().add(len) };
 
             Self { ptr, end_or_len, _marker: PhantomData }
         }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1842,7 +1842,7 @@ impl<T> AtomicPtr<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn fetch_byte_add(&self, val: usize, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_add(self.p.get(), core::ptr::invalid_mut(val), order).cast() }
+        unsafe { atomic_add(self.p.get(), core::ptr::without_provenance_mut(val), order).cast() }
     }
 
     /// Offsets the pointer's address by subtracting `val` *bytes*, returning the
@@ -1867,7 +1867,7 @@ impl<T> AtomicPtr<T> {
     /// #![feature(strict_provenance_atomic_ptr, strict_provenance)]
     /// use core::sync::atomic::{AtomicPtr, Ordering};
     ///
-    /// let atom = AtomicPtr::<i64>::new(core::ptr::invalid_mut(1));
+    /// let atom = AtomicPtr::<i64>::new(core::ptr::without_provenance_mut(1));
     /// assert_eq!(atom.fetch_byte_sub(1, Ordering::Relaxed).addr(), 1);
     /// assert_eq!(atom.load(Ordering::Relaxed).addr(), 0);
     /// ```
@@ -1877,7 +1877,7 @@ impl<T> AtomicPtr<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn fetch_byte_sub(&self, val: usize, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_sub(self.p.get(), core::ptr::invalid_mut(val), order).cast() }
+        unsafe { atomic_sub(self.p.get(), core::ptr::without_provenance_mut(val), order).cast() }
     }
 
     /// Performs a bitwise "or" operation on the address of the current pointer,
@@ -1928,7 +1928,7 @@ impl<T> AtomicPtr<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn fetch_or(&self, val: usize, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_or(self.p.get(), core::ptr::invalid_mut(val), order).cast() }
+        unsafe { atomic_or(self.p.get(), core::ptr::without_provenance_mut(val), order).cast() }
     }
 
     /// Performs a bitwise "and" operation on the address of the current
@@ -1978,7 +1978,7 @@ impl<T> AtomicPtr<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn fetch_and(&self, val: usize, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_and(self.p.get(), core::ptr::invalid_mut(val), order).cast() }
+        unsafe { atomic_and(self.p.get(), core::ptr::without_provenance_mut(val), order).cast() }
     }
 
     /// Performs a bitwise "xor" operation on the address of the current
@@ -2026,7 +2026,7 @@ impl<T> AtomicPtr<T> {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn fetch_xor(&self, val: usize, order: Ordering) -> *mut T {
         // SAFETY: data races are prevented by atomic intrinsics.
-        unsafe { atomic_xor(self.p.get(), core::ptr::invalid_mut(val), order).cast() }
+        unsafe { atomic_xor(self.p.get(), core::ptr::without_provenance_mut(val), order).cast() }
     }
 
     /// Returns a mutable pointer to the underlying pointer.

--- a/library/core/tests/alloc.rs
+++ b/library/core/tests/alloc.rs
@@ -10,7 +10,7 @@ fn const_unchecked_layout() {
     const DANGLING: NonNull<u8> = LAYOUT.dangling();
     assert_eq!(LAYOUT.size(), SIZE);
     assert_eq!(LAYOUT.align(), ALIGN);
-    assert_eq!(Some(DANGLING), NonNull::new(ptr::invalid_mut(ALIGN)));
+    assert_eq!(Some(DANGLING), NonNull::new(ptr::without_provenance_mut(ALIGN)));
 }
 
 #[test]

--- a/library/core/tests/hash/mod.rs
+++ b/library/core/tests/hash/mod.rs
@@ -87,10 +87,10 @@ fn test_writer_hasher() {
     let cs: Rc<[u8]> = Rc::new([1, 2, 3]);
     assert_eq!(hash(&cs), 9);
 
-    let ptr = ptr::invalid::<i32>(5_usize);
+    let ptr = ptr::without_provenance::<i32>(5_usize);
     assert_eq!(hash(&ptr), 5);
 
-    let ptr = ptr::invalid_mut::<i32>(5_usize);
+    let ptr = ptr::without_provenance_mut::<i32>(5_usize);
     assert_eq!(hash(&ptr), 5);
 
     if cfg!(miri) {

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -350,9 +350,9 @@ fn align_offset_zst() {
     // all, because no amount of elements will align the pointer.
     let mut p = 1;
     while p < 1024 {
-        assert_eq!(ptr::invalid::<()>(p).align_offset(p), 0);
+        assert_eq!(ptr::without_provenance::<()>(p).align_offset(p), 0);
         if p != 1 {
-            assert_eq!(ptr::invalid::<()>(p + 1).align_offset(p), !0);
+            assert_eq!(ptr::without_provenance::<()>(p + 1).align_offset(p), !0);
         }
         p = (p + 1).next_power_of_two();
     }
@@ -365,9 +365,9 @@ fn align_offset_zst_const() {
         // all, because no amount of elements will align the pointer.
         let mut p = 1;
         while p < 1024 {
-            assert!(ptr::invalid::<()>(p).align_offset(p) == 0);
+            assert!(ptr::without_provenance::<()>(p).align_offset(p) == 0);
             if p != 1 {
-                assert!(ptr::invalid::<()>(p + 1).align_offset(p) == !0);
+                assert!(ptr::without_provenance::<()>(p + 1).align_offset(p) == !0);
             }
             p = (p + 1).next_power_of_two();
         }
@@ -384,7 +384,7 @@ fn align_offset_stride_one() {
             let expected = ptr % align;
             let offset = if expected == 0 { 0 } else { align - expected };
             assert_eq!(
-                ptr::invalid::<u8>(ptr).align_offset(align),
+                ptr::without_provenance::<u8>(ptr).align_offset(align),
                 offset,
                 "ptr = {}, align = {}, size = 1",
                 ptr,
@@ -406,7 +406,7 @@ fn align_offset_stride_one_const() {
             while ptr < 2 * align {
                 let expected = ptr % align;
                 let offset = if expected == 0 { 0 } else { align - expected };
-                assert!(ptr::invalid::<u8>(ptr).align_offset(align) == offset);
+                assert!(ptr::without_provenance::<u8>(ptr).align_offset(align) == offset);
                 ptr += 1;
             }
             align = (align + 1).next_power_of_two();
@@ -452,30 +452,30 @@ fn align_offset_various_strides() {
             unsafe {
                 #[repr(packed)]
                 struct A3(#[allow(dead_code)] u16, #[allow(dead_code)] u8);
-                x |= test_stride::<A3>(ptr::invalid::<A3>(ptr), align);
+                x |= test_stride::<A3>(ptr::without_provenance::<A3>(ptr), align);
 
                 struct A4(#[allow(dead_code)] u32);
-                x |= test_stride::<A4>(ptr::invalid::<A4>(ptr), align);
+                x |= test_stride::<A4>(ptr::without_provenance::<A4>(ptr), align);
 
                 #[repr(packed)]
                 struct A5(#[allow(dead_code)] u32, #[allow(dead_code)] u8);
-                x |= test_stride::<A5>(ptr::invalid::<A5>(ptr), align);
+                x |= test_stride::<A5>(ptr::without_provenance::<A5>(ptr), align);
 
                 #[repr(packed)]
                 struct A6(#[allow(dead_code)] u32, #[allow(dead_code)] u16);
-                x |= test_stride::<A6>(ptr::invalid::<A6>(ptr), align);
+                x |= test_stride::<A6>(ptr::without_provenance::<A6>(ptr), align);
 
                 #[repr(packed)]
                 struct A7(#[allow(dead_code)] u32, #[allow(dead_code)] u16, #[allow(dead_code)] u8);
-                x |= test_stride::<A7>(ptr::invalid::<A7>(ptr), align);
+                x |= test_stride::<A7>(ptr::without_provenance::<A7>(ptr), align);
 
                 #[repr(packed)]
                 struct A8(#[allow(dead_code)] u32, #[allow(dead_code)] u32);
-                x |= test_stride::<A8>(ptr::invalid::<A8>(ptr), align);
+                x |= test_stride::<A8>(ptr::without_provenance::<A8>(ptr), align);
 
                 #[repr(packed)]
                 struct A9(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u8);
-                x |= test_stride::<A9>(ptr::invalid::<A9>(ptr), align);
+                x |= test_stride::<A9>(ptr::without_provenance::<A9>(ptr), align);
 
                 #[repr(packed)]
                 struct A10(
@@ -483,10 +483,10 @@ fn align_offset_various_strides() {
                     #[allow(dead_code)] u32,
                     #[allow(dead_code)] u16,
                 );
-                x |= test_stride::<A10>(ptr::invalid::<A10>(ptr), align);
+                x |= test_stride::<A10>(ptr::without_provenance::<A10>(ptr), align);
 
-                x |= test_stride::<u32>(ptr::invalid::<u32>(ptr), align);
-                x |= test_stride::<u128>(ptr::invalid::<u128>(ptr), align);
+                x |= test_stride::<u32>(ptr::without_provenance::<u32>(ptr), align);
+                x |= test_stride::<u128>(ptr::without_provenance::<u128>(ptr), align);
             }
         }
         align = (align + 1).next_power_of_two();
@@ -522,18 +522,18 @@ fn align_offset_various_strides_const() {
                 unsafe {
                     #[repr(packed)]
                     struct A3(#[allow(dead_code)] u16, #[allow(dead_code)] u8);
-                    test_stride::<A3>(ptr::invalid::<A3>(ptr), ptr, align);
+                    test_stride::<A3>(ptr::without_provenance::<A3>(ptr), ptr, align);
 
                     struct A4(#[allow(dead_code)] u32);
-                    test_stride::<A4>(ptr::invalid::<A4>(ptr), ptr, align);
+                    test_stride::<A4>(ptr::without_provenance::<A4>(ptr), ptr, align);
 
                     #[repr(packed)]
                     struct A5(#[allow(dead_code)] u32, #[allow(dead_code)] u8);
-                    test_stride::<A5>(ptr::invalid::<A5>(ptr), ptr, align);
+                    test_stride::<A5>(ptr::without_provenance::<A5>(ptr), ptr, align);
 
                     #[repr(packed)]
                     struct A6(#[allow(dead_code)] u32, #[allow(dead_code)] u16);
-                    test_stride::<A6>(ptr::invalid::<A6>(ptr), ptr, align);
+                    test_stride::<A6>(ptr::without_provenance::<A6>(ptr), ptr, align);
 
                     #[repr(packed)]
                     struct A7(
@@ -541,11 +541,11 @@ fn align_offset_various_strides_const() {
                         #[allow(dead_code)] u16,
                         #[allow(dead_code)] u8,
                     );
-                    test_stride::<A7>(ptr::invalid::<A7>(ptr), ptr, align);
+                    test_stride::<A7>(ptr::without_provenance::<A7>(ptr), ptr, align);
 
                     #[repr(packed)]
                     struct A8(#[allow(dead_code)] u32, #[allow(dead_code)] u32);
-                    test_stride::<A8>(ptr::invalid::<A8>(ptr), ptr, align);
+                    test_stride::<A8>(ptr::without_provenance::<A8>(ptr), ptr, align);
 
                     #[repr(packed)]
                     struct A9(
@@ -553,7 +553,7 @@ fn align_offset_various_strides_const() {
                         #[allow(dead_code)] u32,
                         #[allow(dead_code)] u8,
                     );
-                    test_stride::<A9>(ptr::invalid::<A9>(ptr), ptr, align);
+                    test_stride::<A9>(ptr::without_provenance::<A9>(ptr), ptr, align);
 
                     #[repr(packed)]
                     struct A10(
@@ -561,10 +561,10 @@ fn align_offset_various_strides_const() {
                         #[allow(dead_code)] u32,
                         #[allow(dead_code)] u16,
                     );
-                    test_stride::<A10>(ptr::invalid::<A10>(ptr), ptr, align);
+                    test_stride::<A10>(ptr::without_provenance::<A10>(ptr), ptr, align);
 
-                    test_stride::<u32>(ptr::invalid::<u32>(ptr), ptr, align);
-                    test_stride::<u128>(ptr::invalid::<u128>(ptr), ptr, align);
+                    test_stride::<u32>(ptr::without_provenance::<u32>(ptr), ptr, align);
+                    test_stride::<u128>(ptr::without_provenance::<u128>(ptr), ptr, align);
                 }
                 ptr += 1;
             }
@@ -689,7 +689,7 @@ fn align_offset_issue_103361() {
     #[cfg(target_pointer_width = "16")]
     const SIZE: usize = 1 << 13;
     struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
-    let _ = ptr::invalid::<HugeSize>(SIZE).align_offset(SIZE);
+    let _ = ptr::without_provenance::<HugeSize>(SIZE).align_offset(SIZE);
 }
 
 #[test]
@@ -703,9 +703,9 @@ fn align_offset_issue_103361_const() {
     struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
 
     const {
-        assert!(ptr::invalid::<HugeSize>(SIZE - 1).align_offset(SIZE) == SIZE - 1);
-        assert!(ptr::invalid::<HugeSize>(SIZE).align_offset(SIZE) == 0);
-        assert!(ptr::invalid::<HugeSize>(SIZE + 1).align_offset(SIZE) == 1);
+        assert!(ptr::without_provenance::<HugeSize>(SIZE - 1).align_offset(SIZE) == SIZE - 1);
+        assert!(ptr::without_provenance::<HugeSize>(SIZE).align_offset(SIZE) == 0);
+        assert!(ptr::without_provenance::<HugeSize>(SIZE + 1).align_offset(SIZE) == 1);
     }
 }
 

--- a/library/core/tests/waker.rs
+++ b/library/core/tests/waker.rs
@@ -3,7 +3,7 @@ use std::task::{RawWaker, RawWakerVTable, Waker};
 
 #[test]
 fn test_waker_getters() {
-    let raw_waker = RawWaker::new(ptr::invalid_mut(42usize), &WAKER_VTABLE);
+    let raw_waker = RawWaker::new(ptr::without_provenance_mut(42usize), &WAKER_VTABLE);
     assert_eq!(raw_waker.data() as usize, 42);
     assert!(ptr::eq(raw_waker.vtable(), &WAKER_VTABLE));
 
@@ -15,7 +15,7 @@ fn test_waker_getters() {
 }
 
 static WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    |data| RawWaker::new(ptr::invalid_mut(data as usize + 1), &WAKER_VTABLE),
+    |data| RawWaker::new(ptr::without_provenance_mut(data as usize + 1), &WAKER_VTABLE),
     |_| {},
     |_| {},
     |_| {},

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -467,7 +467,7 @@ impl RawFrame {
         match self {
             RawFrame::Actual(frame) => frame.ip(),
             #[cfg(test)]
-            RawFrame::Fake => crate::ptr::invalid_mut(1),
+            RawFrame::Fake => crate::ptr::without_provenance_mut(1),
         }
     }
 }

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -174,7 +174,10 @@ impl Repr {
     pub(super) fn new_os(code: RawOsError) -> Self {
         let utagged = ((code as usize) << 32) | TAG_OS;
         // Safety: `TAG_OS` is not zero, so the result of the `|` is not 0.
-        let res = Self(unsafe { NonNull::new_unchecked(ptr::invalid_mut(utagged)) }, PhantomData);
+        let res = Self(
+            unsafe { NonNull::new_unchecked(ptr::without_provenance_mut(utagged)) },
+            PhantomData,
+        );
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in std's tests, unless the user uses -Zbuild-std)
         debug_assert!(
@@ -188,7 +191,10 @@ impl Repr {
     pub(super) fn new_simple(kind: ErrorKind) -> Self {
         let utagged = ((kind as usize) << 32) | TAG_SIMPLE;
         // Safety: `TAG_SIMPLE` is not zero, so the result of the `|` is not 0.
-        let res = Self(unsafe { NonNull::new_unchecked(ptr::invalid_mut(utagged)) }, PhantomData);
+        let res = Self(
+            unsafe { NonNull::new_unchecked(ptr::without_provenance_mut(utagged)) },
+            PhantomData,
+        );
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in std's tests, unless the user uses -Zbuild-std)
         debug_assert!(

--- a/library/std/src/sys/pal/common/thread_local/os_local.rs
+++ b/library/std/src/sys/pal/common/thread_local/os_local.rs
@@ -176,7 +176,7 @@ unsafe extern "C" fn destroy_value<T: 'static>(ptr: *mut u8) {
     if let Err(_) = panic::catch_unwind(|| unsafe {
         let ptr = Box::from_raw(ptr as *mut Value<T>);
         let key = ptr.key;
-        key.os.set(ptr::invalid_mut(1));
+        key.os.set(ptr::without_provenance_mut(1));
         drop(ptr);
         key.os.set(ptr::null_mut());
     }) {

--- a/library/std/src/sys/pal/unix/futex.rs
+++ b/library/std/src/sys/pal/unix/futex.rs
@@ -53,7 +53,7 @@ pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) -
                         futex as *const AtomicU32 as *mut _,
                         libc::UMTX_OP_WAIT_UINT_PRIVATE,
                         expected as libc::c_ulong,
-                        crate::ptr::invalid_mut(umtx_timeout_size),
+                        crate::ptr::without_provenance_mut(umtx_timeout_size),
                         umtx_timeout_ptr as *mut _,
                     )
                 } else if #[cfg(any(target_os = "linux", target_os = "android"))] {

--- a/library/std/src/sys/pal/unix/thread_parking/netbsd.rs
+++ b/library/std/src/sys/pal/unix/thread_parking/netbsd.rs
@@ -25,7 +25,7 @@ pub fn current() -> ThreadId {
 #[inline]
 pub fn park(hint: usize) {
     unsafe {
-        ___lwp_park60(0, 0, ptr::null_mut(), 0, ptr::invalid(hint), ptr::null());
+        ___lwp_park60(0, 0, ptr::null_mut(), 0, ptr::without_provenance(hint), ptr::null());
     }
 }
 
@@ -40,13 +40,20 @@ pub fn park_timeout(dur: Duration, hint: usize) {
     // Timeout needs to be mutable since it is modified on NetBSD 9.0 and
     // above.
     unsafe {
-        ___lwp_park60(CLOCK_MONOTONIC, 0, &mut timeout, 0, ptr::invalid(hint), ptr::null());
+        ___lwp_park60(
+            CLOCK_MONOTONIC,
+            0,
+            &mut timeout,
+            0,
+            ptr::without_provenance(hint),
+            ptr::null(),
+        );
     }
 }
 
 #[inline]
 pub fn unpark(tid: ThreadId, hint: usize) {
     unsafe {
-        _lwp_unpark(tid, ptr::invalid(hint));
+        _lwp_unpark(tid, ptr::without_provenance(hint));
     }
 }

--- a/library/std/src/sys/pal/unix/weak.rs
+++ b/library/std/src/sys/pal/unix/weak.rs
@@ -80,7 +80,11 @@ pub(crate) struct DlsymWeak<F> {
 
 impl<F> DlsymWeak<F> {
     pub(crate) const fn new(name: &'static str) -> Self {
-        DlsymWeak { name, func: AtomicPtr::new(ptr::invalid_mut(1)), _marker: PhantomData }
+        DlsymWeak {
+            name,
+            func: AtomicPtr::new(ptr::without_provenance_mut(1)),
+            _marker: PhantomData,
+        }
     }
 
     #[inline]

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -47,7 +47,7 @@ pub use FD_SET as fd_set;
 pub use LINGER as linger;
 pub use TIMEVAL as timeval;
 
-pub const INVALID_HANDLE_VALUE: HANDLE = ::core::ptr::invalid_mut(-1i32 as _);
+pub const INVALID_HANDLE_VALUE: HANDLE = ::core::ptr::without_provenance_mut(-1i32 as _);
 
 // https://learn.microsoft.com/en-us/cpp/c-runtime-library/exit-success-exit-failure?view=msvc-170
 pub const EXIT_SUCCESS: u32 = 0;

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -327,7 +327,7 @@ fn home_dir_crt() -> Option<PathBuf> {
         super::fill_utf16_buf(
             |buf, mut sz| {
                 match c::GetUserProfileDirectoryW(
-                    ptr::invalid_mut(CURRENT_PROCESS_TOKEN),
+                    ptr::without_provenance_mut(CURRENT_PROCESS_TOKEN),
                     buf,
                     &mut sz,
                 ) {

--- a/library/std/src/sys/pal/windows/thread_local_key/tests.rs
+++ b/library/std/src/sys/pal/windows/thread_local_key/tests.rs
@@ -13,8 +13,8 @@ fn smoke() {
     unsafe {
         assert!(K1.get().is_null());
         assert!(K2.get().is_null());
-        K1.set(ptr::invalid_mut(1));
-        K2.set(ptr::invalid_mut(2));
+        K1.set(ptr::without_provenance_mut(1));
+        K2.set(ptr::without_provenance_mut(2));
         assert_eq!(K1.get() as usize, 1);
         assert_eq!(K2.get() as usize, 2);
     }

--- a/library/std/src/sys/pal/windows/thread_parking.rs
+++ b/library/std/src/sys/pal/windows/thread_parking.rs
@@ -220,7 +220,7 @@ impl Parker {
 }
 
 fn keyed_event_handle() -> c::HANDLE {
-    const INVALID: c::HANDLE = ptr::invalid_mut(!0);
+    const INVALID: c::HANDLE = ptr::without_provenance_mut(!0);
     static HANDLE: AtomicPtr<crate::ffi::c_void> = AtomicPtr::new(INVALID);
     match HANDLE.load(Relaxed) {
         INVALID => {

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -218,7 +218,7 @@ pub fn output_filename(
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 pub fn set_image_base() {
     let image_base = crate::os::fortanix_sgx::mem::image_base();
-    backtrace_rs::set_image_base(crate::ptr::invalid_mut(image_base as _));
+    backtrace_rs::set_image_base(crate::ptr::without_provenance_mut(image_base as _));
 }
 
 #[cfg(not(all(target_vendor = "fortanix", target_env = "sgx")))]

--- a/library/std/src/sys_common/once/queue.rs
+++ b/library/std/src/sys_common/once/queue.rs
@@ -110,7 +110,7 @@ impl Once {
     #[inline]
     #[rustc_const_stable(feature = "const_once_new", since = "1.32.0")]
     pub const fn new() -> Once {
-        Once { state_and_queue: AtomicPtr::new(ptr::invalid_mut(INCOMPLETE)) }
+        Once { state_and_queue: AtomicPtr::new(ptr::without_provenance_mut(INCOMPLETE)) }
     }
 
     #[inline]
@@ -158,7 +158,7 @@ impl Once {
                     // Try to register this thread as the one RUNNING.
                     let exchange_result = self.state_and_queue.compare_exchange(
                         state_and_queue,
-                        ptr::invalid_mut(RUNNING),
+                        ptr::without_provenance_mut(RUNNING),
                         Ordering::Acquire,
                         Ordering::Acquire,
                     );
@@ -170,14 +170,14 @@ impl Once {
                     // wake them up on drop.
                     let mut waiter_queue = WaiterQueue {
                         state_and_queue: &self.state_and_queue,
-                        set_state_on_drop_to: ptr::invalid_mut(POISONED),
+                        set_state_on_drop_to: ptr::without_provenance_mut(POISONED),
                     };
                     // Run the initialization function, letting it know if we're
                     // poisoned or not.
                     let init_state = public::OnceState {
                         inner: OnceState {
                             poisoned: state_and_queue.addr() == POISONED,
-                            set_state_on_drop_to: Cell::new(ptr::invalid_mut(COMPLETE)),
+                            set_state_on_drop_to: Cell::new(ptr::without_provenance_mut(COMPLETE)),
                         },
                     };
                     init(&init_state);
@@ -289,6 +289,6 @@ impl OnceState {
 
     #[inline]
     pub fn poison(&self) {
-        self.set_state_on_drop_to.set(ptr::invalid_mut(POISONED));
+        self.set_state_on_drop_to.set(ptr::without_provenance_mut(POISONED));
     }
 }

--- a/library/std/src/sys_common/thread_local_key/tests.rs
+++ b/library/std/src/sys_common/thread_local_key/tests.rs
@@ -9,8 +9,8 @@ fn statik() {
     unsafe {
         assert!(K1.get().is_null());
         assert!(K2.get().is_null());
-        K1.set(ptr::invalid_mut(1));
-        K2.set(ptr::invalid_mut(2));
+        K1.set(ptr::without_provenance_mut(1));
+        K2.set(ptr::without_provenance_mut(2));
         assert_eq!(K1.get() as usize, 1);
         assert_eq!(K2.get() as usize, 2);
     }

--- a/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_box.rs
+++ b/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_box.rs
@@ -8,7 +8,7 @@ use std::ptr::{self, addr_of_mut};
 // (This test relies on the `deref_copy` pass that lowers `**ptr` to materialize the intermediate pointer.)
 
 fn main() {
-    let mut inner = ptr::invalid::<i32>(24);
+    let mut inner = ptr::without_provenance::<i32>(24);
     let outer = addr_of_mut!(inner).cast::<Box<i32>>();
     // Now `outer` is a pointer to a dangling reference.
     // Deref'ing that should be UB.

--- a/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_ref.rs
+++ b/src/tools/miri/tests/fail/dangling_pointers/deref_dangling_ref.rs
@@ -8,7 +8,7 @@ use std::ptr::{self, addr_of_mut};
 // (This test relies on the `deref_copy` pass that lowers `**ptr` to materialize the intermediate pointer.)
 
 fn main() {
-    let mut inner = ptr::invalid::<i32>(24);
+    let mut inner = ptr::without_provenance::<i32>(24);
     let outer = addr_of_mut!(inner).cast::<&'static mut i32>();
     // Now `outer` is a pointer to a dangling reference.
     // Deref'ing that should be UB.

--- a/src/tools/miri/tests/fail/provenance/ptr_invalid.rs
+++ b/src/tools/miri/tests/fail/provenance/ptr_invalid.rs
@@ -1,9 +1,9 @@
 #![feature(strict_provenance, exposed_provenance)]
 
-// Ensure that a `ptr::invalid` ptr is truly invalid.
+// Ensure that a `ptr::without_provenance` ptr is truly invalid.
 fn main() {
     let x = 42;
     let xptr = &x as *const i32;
-    let xptr_invalid = std::ptr::invalid::<i32>(xptr.expose_addr());
+    let xptr_invalid = std::ptr::without_provenance::<i32>(xptr.expose_addr());
     let _val = unsafe { *xptr_invalid }; //~ ERROR: is a dangling pointer
 }

--- a/src/tools/miri/tests/fail/provenance/ptr_invalid_offset.rs
+++ b/src/tools/miri/tests/fail/provenance/ptr_invalid_offset.rs
@@ -4,7 +4,7 @@
 fn main() {
     let x = 22;
     let ptr = &x as *const _ as *const u8;
-    let roundtrip = std::ptr::invalid::<u8>(ptr as usize);
+    let roundtrip = std::ptr::without_provenance::<u8>(ptr as usize);
     // Not even offsetting this is allowed.
     let _ = unsafe { roundtrip.offset(1) }; //~ERROR: is a dangling pointer
 }

--- a/src/tools/miri/tests/pass-dep/shims/mmap.rs
+++ b/src/tools/miri/tests/pass-dep/shims/mmap.rs
@@ -71,7 +71,7 @@ fn test_mmap<Offset: Default>(
 
     let ptr = unsafe {
         mmap(
-            ptr::invalid_mut(page_size * 64),
+            ptr::without_provenance_mut(page_size * 64),
             page_size,
             libc::PROT_READ | libc::PROT_WRITE,
             // We don't support MAP_FIXED
@@ -114,13 +114,13 @@ fn test_mmap<Offset: Default>(
     assert_eq!(ptr, libc::MAP_FAILED);
 
     // We report an error when trying to munmap an address which is not a multiple of the page size
-    let res = unsafe { libc::munmap(ptr::invalid_mut(1), page_size) };
+    let res = unsafe { libc::munmap(ptr::without_provenance_mut(1), page_size) };
     assert_eq!(res, -1);
     assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
 
     // We report an error when trying to munmap a length that cannot be rounded up to a multiple of
     // the page size.
-    let res = unsafe { libc::munmap(ptr::invalid_mut(page_size), usize::MAX - 1) };
+    let res = unsafe { libc::munmap(ptr::without_provenance_mut(page_size), usize::MAX - 1) };
     assert_eq!(res, -1);
     assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
 }
@@ -156,7 +156,7 @@ fn test_mremap() {
     // Test all of our error conditions
     // Not aligned
     let ptr =
-        unsafe { libc::mremap(ptr::invalid_mut(1), page_size, page_size, libc::MREMAP_MAYMOVE) };
+        unsafe { libc::mremap(ptr::without_provenance_mut(1), page_size, page_size, libc::MREMAP_MAYMOVE) };
     assert_eq!(ptr, libc::MAP_FAILED);
     assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
 

--- a/src/tools/miri/tests/pass-dep/shims/posix_memalign.rs
+++ b/src/tools/miri/tests/pass-dep/shims/posix_memalign.rs
@@ -58,7 +58,7 @@ fn main() {
 
     // Non-power of 2 align
     unsafe {
-        let mut ptr: *mut libc::c_void = ptr::invalid_mut(0x1234567);
+        let mut ptr: *mut libc::c_void = ptr::without_provenance_mut(0x1234567);
         let align = 15;
         let size = 8;
         assert_eq!(libc::posix_memalign(&mut ptr, align, size), libc::EINVAL);
@@ -70,7 +70,7 @@ fn main() {
 
     // Too small align (smaller than ptr)
     unsafe {
-        let mut ptr: *mut libc::c_void = ptr::invalid_mut(0x1234567);
+        let mut ptr: *mut libc::c_void = ptr::without_provenance_mut(0x1234567);
         let align = std::mem::size_of::<usize>() / 2;
         let size = 8;
         assert_eq!(libc::posix_memalign(&mut ptr, align, size), libc::EINVAL);

--- a/src/tools/miri/tests/pass/align_offset_symbolic.rs
+++ b/src/tools/miri/tests/pass/align_offset_symbolic.rs
@@ -100,7 +100,7 @@ fn huge_align() {
     #[cfg(target_pointer_width = "16")]
     const SIZE: usize = 1 << 13;
     struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
-    let _ = std::ptr::invalid::<HugeSize>(SIZE).align_offset(SIZE);
+    let _ = std::ptr::without_provenance::<HugeSize>(SIZE).align_offset(SIZE);
 }
 
 // This shows that we cannot store the promised alignment info in `AllocExtra`,

--- a/src/tools/miri/tests/pass/atomic.rs
+++ b/src/tools/miri/tests/pass/atomic.rs
@@ -137,7 +137,7 @@ fn atomic_ptr() {
 
     let ptr = AtomicPtr::<i32>::new(ptr::null_mut());
     assert!(ptr.load(Relaxed).addr() == 0);
-    ptr.store(ptr::invalid_mut(13), SeqCst);
+    ptr.store(ptr::without_provenance_mut(13), SeqCst);
     assert!(ptr.swap(x, Relaxed).addr() == 13);
     unsafe { assert!(*ptr.load(Acquire) == 0) };
 
@@ -145,7 +145,7 @@ fn atomic_ptr() {
     assert_eq!(
         ptr.compare_exchange(
             (&mut 0 as *mut i32).with_addr(x.addr()),
-            ptr::invalid_mut(0),
+            ptr::without_provenance_mut(0),
             SeqCst,
             SeqCst
         )
@@ -156,7 +156,7 @@ fn atomic_ptr() {
     assert_eq!(
         ptr.compare_exchange(
             (&mut 0 as *mut i32).with_addr(x.addr()),
-            ptr::invalid_mut(0),
+            ptr::without_provenance_mut(0),
             SeqCst,
             SeqCst
         )

--- a/src/tools/miri/tests/pass/ptr_raw.rs
+++ b/src/tools/miri/tests/pass/ptr_raw.rs
@@ -35,12 +35,12 @@ fn assign_overlapping() {
 fn deref_invalid() {
     unsafe {
         // `addr_of!(*ptr)` is never UB.
-        let _val = addr_of!(*ptr::invalid::<i32>(0));
-        let _val = addr_of!(*ptr::invalid::<i32>(1)); // not aligned
+        let _val = addr_of!(*ptr::without_provenance::<i32>(0));
+        let _val = addr_of!(*ptr::without_provenance::<i32>(1)); // not aligned
 
         // Similarly, just mentioning the place is fine.
-        let _ = *ptr::invalid::<i32>(0);
-        let _ = *ptr::invalid::<i32>(1);
+        let _ = *ptr::without_provenance::<i32>(0);
+        let _ = *ptr::without_provenance::<i32>(1);
     }
 }
 

--- a/src/tools/miri/tests/pass/slices.rs
+++ b/src/tools/miri/tests/pass/slices.rs
@@ -29,7 +29,7 @@ fn slice_of_zst() {
 
     // In a slice of zero-size elements the pointer is meaningless.
     // Ensure iteration still works even if the pointer is at the end of the address space.
-    let slice: &[()] = unsafe { slice::from_raw_parts(ptr::invalid(-5isize as usize), 10) };
+    let slice: &[()] = unsafe { slice::from_raw_parts(ptr::without_provenance(-5isize as usize), 10) };
     assert_eq!(slice.len(), 10);
     assert_eq!(slice.iter().count(), 10);
 
@@ -43,7 +43,7 @@ fn slice_of_zst() {
 
     // Test mutable iterators as well
     let slice: &mut [()] =
-        unsafe { slice::from_raw_parts_mut(ptr::invalid_mut(-5isize as usize), 10) };
+        unsafe { slice::from_raw_parts_mut(ptr::without_provenance_mut(-5isize as usize), 10) };
     assert_eq!(slice.len(), 10);
     assert_eq!(slice.iter_mut().count(), 10);
 
@@ -263,7 +263,7 @@ fn test_for_invalidated_pointers() {
 fn large_raw_slice() {
     let size = isize::MAX as usize;
     // Creating a raw slice of size isize::MAX and asking for its size is okay.
-    let s = std::ptr::slice_from_raw_parts(ptr::invalid::<u8>(1), size);
+    let s = std::ptr::slice_from_raw_parts(ptr::without_provenance::<u8>(1), size);
     assert_eq!(size, unsafe { std::mem::size_of_val_raw(s) });
 }
 

--- a/src/tools/miri/tests/pass/underscore_pattern.rs
+++ b/src/tools/miri/tests/pass/underscore_pattern.rs
@@ -38,7 +38,7 @@ fn invalid_match() {
 
 fn dangling_let() {
     unsafe {
-        let ptr = ptr::invalid::<bool>(0x40);
+        let ptr = ptr::without_provenance::<bool>(0x40);
         let _ = *ptr;
     }
 }
@@ -54,7 +54,7 @@ fn invalid_let() {
 // Adding a type annotation used to change how MIR is generated, make sure we cover both cases.
 fn dangling_let_type_annotation() {
     unsafe {
-        let ptr = ptr::invalid::<bool>(0x40);
+        let ptr = ptr::without_provenance::<bool>(0x40);
         let _: bool = *ptr;
     }
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -17,26 +17,28 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let mut _7: usize;
                   scope 6 {
                       let _6: *mut [bool; 0];
                       scope 7 {
                           debug ptr => _6;
-                          scope 11 (inlined NonNull::<[bool; 0]>::new_unchecked) {
+                          scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
                               let mut _8: bool;
                               let _9: ();
                               let mut _10: *mut ();
                               let mut _11: *const [bool; 0];
-                              scope 12 {
+                              scope 13 {
                               }
                           }
                       }
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined invalid_mut::<[bool; 0]>) {
-                          debug addr => _7;
-                          scope 10 {
+                      scope 8 (inlined dangling_mut::<[bool; 0]>) {
+                          let mut _7: usize;
+                          scope 9 (inlined align_of::<[bool; 0]>) {
+                          }
+                          scope 10 (inlined without_provenance_mut::<[bool; 0]>) {
+                              debug addr => _7;
+                              scope 11 {
+                              }
                           }
                       }
                   }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -42,7 +42,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                         scope 8 {
                             debug end_or_len => _11;
                         }
-                        scope 14 (inlined invalid::<T>) {
+                        scope 14 (inlined without_provenance::<T>) {
                             debug addr => _3;
                             scope 15 {
                             }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -42,7 +42,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                         scope 8 {
                             debug end_or_len => _11;
                         }
-                        scope 14 (inlined invalid::<T>) {
+                        scope 14 (inlined without_provenance::<T>) {
                             debug addr => _3;
                             scope 15 {
                             }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -39,7 +39,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 8 {
                             debug end_or_len => _11;
                         }
-                        scope 14 (inlined invalid::<T>) {
+                        scope 14 (inlined without_provenance::<T>) {
                             debug addr => _3;
                             scope 15 {
                             }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -39,7 +39,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 8 {
                             debug end_or_len => _11;
                         }
-                        scope 14 (inlined invalid::<T>) {
+                        scope 14 (inlined without_provenance::<T>) {
                             debug addr => _3;
                             scope 15 {
                             }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -44,7 +44,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 8 {
                             debug end_or_len => _11;
                         }
-                        scope 14 (inlined invalid::<T>) {
+                        scope 14 (inlined without_provenance::<T>) {
                             debug addr => _3;
                             scope 15 {
                             }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -44,7 +44,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                         scope 8 {
                             debug end_or_len => _11;
                         }
-                        scope 14 (inlined invalid::<T>) {
+                        scope 14 (inlined without_provenance::<T>) {
                             debug addr => _3;
                             scope 15 {
                             }


### PR DESCRIPTION
It has long bothered me that `ptr::invalid` returns a pointer that is actually valid for zero-sized memory accesses. In general, it doesn't even make sense to ask "is this pointer valid", you have to ask "is this pointer valid for a given memory access". We could say that a pointer is invalid if it is not valid for *any* memory access, but [the way this FCP is going](https://github.com/rust-lang/unsafe-code-guidelines/issues/472), it looks like *all* pointers will be valid for zero-sized memory accesses.

Two possible alternative names emerged as people's favorites:
1. Something involving `dangling`, in analogy to `NonNull::dangling`. To avoid inconsistency with the `NonNull` method, the address-taking method could be called `dangling_at(addr: usize) -> *const T`.
2. `without_provenance`, to be symmetric with the inverse operation `ptr.addr_without_provenance()` (currently still called `ptr.addr()` but probably going to be renamed)

I have no idea which one of these is better. I read [this comment](https://github.com/rust-lang/rust/pull/117658#issuecomment-1830934701) as expressing a slight preference for something like the second option, so I went for that. I'm happy to go with `dangling_at` as well.

Cc @rust-lang/opsem 