### PR TITLE
Added shadowed hint for overlapping associated types

### DIFF
--- a/tests/ui/associated-types/associated-type-shadowed-from-non-local-supertrait.rs
+++ b/tests/ui/associated-types/associated-type-shadowed-from-non-local-supertrait.rs
@@ -1,0 +1,15 @@
+// Test that no help message is emitted that suggests renaming the
+// associated type from a non-local trait
+
+pub trait NewIter: Iterator {
+    type Item;
+}
+
+impl<T> Clone for Box<dyn NewIter<Item = T>> {
+    //~^ ERROR the value of the associated type `Item` in `Iterator` must be specified
+    fn clone(&self) -> Self {
+        unimplemented!();
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/associated-types/associated-type-shadowed-from-non-local-supertrait.stderr
+++ b/tests/ui/associated-types/associated-type-shadowed-from-non-local-supertrait.stderr
@@ -1,0 +1,12 @@
+error[E0191]: the value of the associated type `Item` in `Iterator` must be specified
+  --> $DIR/associated-type-shadowed-from-non-local-supertrait.rs:8:27
+   |
+LL |     type Item;
+   |     --------- `Iterator::Item` shadowed here, consider renaming it
+...
+LL | impl<T> Clone for Box<dyn NewIter<Item = T>> {
+   |                           ^^^^^^^^^^^^^^^^^ associated type `Item` must be specified
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0191`.

--- a/tests/ui/associated-types/associated-type-shadowed-from-supertrait.rs
+++ b/tests/ui/associated-types/associated-type-shadowed-from-supertrait.rs
@@ -1,0 +1,19 @@
+// Test Setting the value of an associated type
+// that is shadowed from a supertrait
+
+pub trait Super {
+    type X;
+}
+
+pub trait Sub: Super {
+    type X;
+}
+
+impl<T> Clone for Box<dyn Sub<X = T>> {
+    //~^ ERROR value of the associated type `X` in `Super` must be specified
+    fn clone(&self) -> Self {
+        unimplemented!();
+    }
+}
+
+pub fn main() {}

--- a/tests/ui/associated-types/associated-type-shadowed-from-supertrait.stderr
+++ b/tests/ui/associated-types/associated-type-shadowed-from-supertrait.stderr
@@ -1,0 +1,15 @@
+error[E0191]: the value of the associated type `X` in `Super` must be specified
+  --> $DIR/associated-type-shadowed-from-supertrait.rs:12:27
+   |
+LL |     type X;
+   |     ------ `Super::X` defined here, consider renaming it
+...
+LL |     type X;
+   |     ------ `Super::X` shadowed here, consider renaming it
+...
+LL | impl<T> Clone for Box<dyn Sub<X = T>> {
+   |                           ^^^^^^^^^^ associated type `X` must be specified
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0191`.


### PR DESCRIPTION


Previously, when you tried to set an associated type that is shadowed by an associated type in a subtrait, like this:

```rust
trait A {
    type X;
}

trait B: A {
    type X; // note: this is legal
}

impl<Y> Clone for Box<dyn B<X=Y, X=Y>> {
    fn clone(&self) -> Self {
        todo!()
    }
}

you got a confusing error message, that says nothing about the shadowing:

error[E0719]: the value of the associated type `X` (from trait `B`) is already specified
 --> test.rs:9:34
  |
9 | impl<Y> Clone for Box<dyn B<X=Y, X=Y>> {
  |                             ---  ^^^ re-bound here
  |                             |
  |                             `X` bound here first

error[E0191]: the value of the associated type `X` (from trait `A`) must be specified
 --> test.rs:9:27
  |
2 |     type X;
  |     ------ `X` defined here
...
9 | impl<Y> Clone for Box<dyn B<X=Y, X=Y>> {
  |                           ^^^^^^^^^^^ help: specify the associated type: `B<X=Y, X=Y, X = Type>`

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0191, E0719.
For more information about an error, try `rustc --explain E0191`.
```

Now instead, the error shows that the associated type is shadowed, and suggests renaming as a potential fix.

```rust
error[E0719]: the value of the associated type `X` in trait `B` is already specified
 --> test.rs:9:34
  |
9 | impl<Y> Clone for Box<dyn B<X=Y, X=Y>> {
  |                             ---  ^^^ re-bound here
  |                             |
  |                             `X` bound here first

error[E0191]: the value of the associated type `X` in `A` must be specified
 --> test.rs:9:27
  |
2 |     type X;
  |     ------ `A::X` defined here
...
6 |     type X; // note: this is legal
  |     ------ `A::X` shadowed here
...
9 | impl<Y> Clone for Box<dyn B<X=Y, X=Y>> {
  |                           ^^^^^^^^^^^ associated type `X` must be specified
  |
help: consider renaming this associated type
 --> test.rs:2:5
  |
2 |     type X;
  |     ^^^^^^
help: consider renaming this associated type
 --> test.rs:6:5
  |
6 |     type X; // note: this is legal
  |     ^^^^^^
```

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0191, E0719.
For more information about an error, try `rustc --explain E0191`.

The rename help message is only emitted when the trait is local. This is true both for the supertrait as for the subtrait.

There might be cases where you can use the fully qualified path (for instance, in a where clause), but this PR currently does not deal with that.

fixes #100109

(continues from #117642, because I didn't know renaming the branch would close the PR)