### PR TITLE
llvm-wrapper: Remove include of non-existant Vectorize.h

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -25,7 +25,6 @@
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/Scalar.h"
-#include "llvm/Transforms/Vectorize.h"
 
 #define LLVM_VERSION_GE(major, minor)                                          \
   (LLVM_VERSION_MAJOR > (major) ||                                             \


### PR DESCRIPTION
LLVM recently removed the header: https://github.com/llvm/llvm-project/commit/2400c54c37d5afdfec016b9a71f161ac10a49b31

It only contained a declaration of `createLoadStoreVectorizerPass()`, which Rust doesn't reference.