### PR TITLE
tests/rustdoc-json: Avoid needless use of `no_core` and `lang_items`

### DIFF
--- a/tests/rustdoc-json/doc_hidden_failure.rs
+++ b/tests/rustdoc-json/doc_hidden_failure.rs
@@ -1,8 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/98007>.
 
-#![feature(no_core)]
-#![no_core]
-
 mod auto {
     mod action_row {
         pub struct ActionRowBuilder;

--- a/tests/rustdoc-json/enums/field_hidden.rs
+++ b/tests/rustdoc-json/enums/field_hidden.rs
@@ -1,11 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/100529>.
 
-#![no_core]
-#![feature(no_core, lang_items)]
-
-#[lang = "sized"]
-trait Sized {}
-
 // @has "$.index[*][?(@.name=='ParseError')]"
 // @has "$.index[*][?(@.name=='UnexpectedEndTag')]"
 // @is "$.index[*][?(@.name=='UnexpectedEndTag')].inner.variant.kind.tuple" [null]

--- a/tests/rustdoc-json/enums/kind.rs
+++ b/tests/rustdoc-json/enums/kind.rs
@@ -1,11 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core, lang_items)]
-#![no_core]
-
-#[lang = "sized"]
-trait Sized {}
-
 pub enum Foo {
     // @set Unit = "$.index[*][?(@.name=='Unit')].id"
     // @is "$.index[*][?(@.name=='Unit')].inner.variant.kind" '"plain"'

--- a/tests/rustdoc-json/enums/tuple_fields_hidden.rs
+++ b/tests/rustdoc-json/enums/tuple_fields_hidden.rs
@@ -1,9 +1,3 @@
-#![feature(no_core, lang_items)]
-#![no_core]
-
-#[lang = "sized"]
-trait Sized {}
-
 // @set 1.1.0 = "$.index[*][?(@.docs=='1.1.0')].id"
 // @set 2.1.0 = "$.index[*][?(@.docs=='2.1.0')].id"
 // @set 2.1.1 = "$.index[*][?(@.docs=='2.1.1')].id"

--- a/tests/rustdoc-json/enums/use_glob.rs
+++ b/tests/rustdoc-json/enums/use_glob.rs
@@ -1,8 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104942>
 
-#![feature(no_core)]
-#![no_core]
-
 // @set Color = "$.index[*][?(@.name == 'Color')].id"
 pub enum Color {
     Red,

--- a/tests/rustdoc-json/enums/use_variant.rs
+++ b/tests/rustdoc-json/enums/use_variant.rs
@@ -1,6 +1,3 @@
-#![feature(no_core)]
-#![no_core]
-
 // @set AlwaysNone = "$.index[*][?(@.name == 'AlwaysNone')].id"
 pub enum AlwaysNone {
     // @set None = "$.index[*][?(@.name == 'None')].id"

--- a/tests/rustdoc-json/fn_pointer/generics.rs
+++ b/tests/rustdoc-json/fn_pointer/generics.rs
@@ -1,8 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 // @count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
 // @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][0]" '"val"'
 // @is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][1].borrowed_ref.lifetime" \"\'c\"

--- a/tests/rustdoc-json/fns/extern_c_variadic.rs
+++ b/tests/rustdoc-json/fns/extern_c_variadic.rs
@@ -1,6 +1,3 @@
-#![feature(no_core)]
-#![no_core]
-
 extern "C" {
     // @is "$.index[*][?(@.name == 'not_variadic')].inner.function.decl.c_variadic" false
     pub fn not_variadic(_: i32);

--- a/tests/rustdoc-json/fns/generic_args.rs
+++ b/tests/rustdoc-json/fns/generic_args.rs
@@ -1,8 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 // @set foo = "$.index[*][?(@.name=='Foo')].id"
 pub trait Foo {}
 

--- a/tests/rustdoc-json/fns/generic_returns.rs
+++ b/tests/rustdoc-json/fns/generic_returns.rs
@@ -1,8 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 // @count "$.index[*][?(@.name=='generic_returns')].inner.module.items[*]" 2
 
 // @set foo = "$.index[*][?(@.name=='Foo')].id"

--- a/tests/rustdoc-json/fns/generics.rs
+++ b/tests/rustdoc-json/fns/generics.rs
@@ -1,8 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 // @set wham_id = "$.index[*][?(@.name=='Wham')].id"
 pub trait Wham {}
 

--- a/tests/rustdoc-json/generic-associated-types/gats.rs
+++ b/tests/rustdoc-json/generic-associated-types/gats.rs
@@ -1,14 +1,5 @@
 // ignore-tidy-linelength
 
-#![no_core]
-#![feature(lang_items, no_core, arbitrary_self_types)]
-
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "receiver"]
-pub trait Receiver {}
-
 pub trait Display {}
 
 pub trait LendingIterator {

--- a/tests/rustdoc-json/glob_import.rs
+++ b/tests/rustdoc-json/glob_import.rs
@@ -1,12 +1,9 @@
 // This is a regression test for <https://github.com/rust-lang/rust/issues/98003>.
 
-#![feature(no_core)]
 #![no_std]
-#![no_core]
 
 // @has "$.index[*][?(@.name=='glob')]"
 // @has "$.index[*][?(@.inner.import)].inner.import.name" \"*\"
-
 
 mod m1 {
     pub fn f() {}

--- a/tests/rustdoc-json/impls/impl_item_visibility.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility.rs
@@ -1,6 +1,3 @@
-#![feature(no_core)]
-#![no_core]
-
 pub struct Foo;
 
 /// impl Foo priv
@@ -9,18 +6,16 @@ impl Foo {
 }
 // @!has '$.index[*][?(@.docs=="impl Foo priv")]'
 
-
 /// impl Foo pub
 impl Foo {
     pub fn qux() {}
 }
 // @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
 
-
 /// impl Foo hidden
 impl Foo {
     #[doc(hidden)]
-    pub fn __quazl(){}
+    pub fn __quazl() {}
 }
 // FIXME(#111564): Is this the right behaviour?
 // @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/impl_item_visibility_show_hidden.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility_show_hidden.rs
@@ -1,6 +1,4 @@
 // compile-flags: --document-hidden-items
-#![feature(no_core)]
-#![no_core]
 
 pub struct Foo;
 
@@ -11,18 +9,16 @@ impl Foo {
 // FIXME(#111564): Is this the right behaviour?
 // @is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
 
-
 /// impl Foo pub
 impl Foo {
     pub fn qux() {}
 }
 // @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
 
-
 /// impl Foo hidden
 impl Foo {
     #[doc(hidden)]
-    pub fn __quazl(){}
+    pub fn __quazl() {}
 }
 // FIXME(#111564): Is this the right behaviour?
 // @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/impl_item_visibility_show_private.rs
+++ b/tests/rustdoc-json/impls/impl_item_visibility_show_private.rs
@@ -1,6 +1,4 @@
 // compile-flags: --document-private-items
-#![feature(no_core)]
-#![no_core]
 
 pub struct Foo;
 
@@ -10,18 +8,16 @@ impl Foo {
 }
 // @is '$.index[*][?(@.docs=="impl Foo priv")].visibility' '"default"'
 
-
 /// impl Foo pub
 impl Foo {
     pub fn qux() {}
 }
 // @is '$.index[*][?(@.docs=="impl Foo pub")].visibility' '"default"'
 
-
 /// impl Foo hidden
 impl Foo {
     #[doc(hidden)]
-    pub fn __quazl(){}
+    pub fn __quazl() {}
 }
 // FIXME(#111564): Is this the right behaviour?
 // @is '$.index[*][?(@.docs=="impl Foo hidden")].visibility' '"default"'

--- a/tests/rustdoc-json/impls/import_from_private.rs
+++ b/tests/rustdoc-json/impls/import_from_private.rs
@@ -1,14 +1,12 @@
 // https://github.com/rust-lang/rust/issues/100252
 
-#![feature(no_core)]
-#![no_core]
-
 mod bar {
-    // @set baz = "$.index[*][?(@.inner.struct)].id"
+    // @set baz = "$.index[*][?(@.name == 'Baz')].id"
     pub struct Baz;
-    // @set impl = "$.index[*][?(@.inner.impl)].id"
+    // @set impl = "$.index[*][?(@.docs == 'impl')].id"
+    /// impl
     impl Baz {
-        // @set doit = "$.index[*][?(@.inner.function)].id"
+        // @set doit = "$.index[*][?(@.name == 'doit')].id"
         pub fn doit() {}
     }
 }
@@ -18,5 +16,5 @@ pub use bar::Baz;
 
 // @is "$.index[*].inner.module.items[*]" $import
 // @is "$.index[*].inner.import.id" $baz
-// @is "$.index[*].inner.struct.impls[*]" $impl
-// @is "$.index[*].inner.impl.items[*]" $doit
+// @has "$.index[*][?(@.name == 'Baz')].inner.struct.impls[*]" $impl
+// @is "$.index[*][?(@.docs=='impl')].inner.impl.items[*]" $doit

--- a/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-2.rs
+++ b/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-2.rs
@@ -1,7 +1,5 @@
-#![feature(no_core)]
-#![no_core]
-
-// @count "$.index[*][?(@.inner.impl)]" 1
+// @has "$.index[*][?(@.docs=='Here')]"
+// @!has "$.index[*][?(@.docs=='Not Here')]"
 // @!has "$.index[*][?(@.name == 'HiddenPubStruct')]"
 // @has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
 // @has "$.index[*][?(@.name=='PubTrait')]"
@@ -11,5 +9,7 @@ pub trait PubTrait {}
 pub struct HiddenPubStruct;
 pub struct NotHiddenPubStruct;
 
+/// Not Here
 impl PubTrait for HiddenPubStruct {}
+/// Here
 impl PubTrait for NotHiddenPubStruct {}

--- a/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-3.rs
+++ b/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id-3.rs
@@ -1,8 +1,5 @@
 // compile-flags: --document-hidden-items
 
-#![feature(no_core)]
-#![no_core]
-
 // @has "$.index[*][?(@.name == 'HiddenPubStruct')]"
 // @has "$.index[*][?(@.inner.impl)]"
 // @has "$.index[*][?(@.name=='PubTrait')]"

--- a/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id.rs
+++ b/tests/rustdoc-json/impls/issue-112852-dangling-trait-impl-id.rs
@@ -1,21 +1,21 @@
-#![feature(no_core)]
-#![no_core]
-
-// @count "$.index[*][?(@.inner.impl)]" 1
-// @!has "$.index[*][?(@.name == 'HiddenPubStruct')]"
-// @has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
 // @has "$.index[*][?(@.name=='PubTrait')]"
 pub trait PubTrait {}
 
 #[doc(hidden)]
 pub mod hidden {
+    // @!has "$.index[*][?(@.name == 'HiddenPubStruct')]"
     pub struct HiddenPubStruct;
 
+    // @!has "$.index[*][?(@.docs == 'Not Here')]"
+    /// Not Here
     impl crate::PubTrait for HiddenPubStruct {}
 }
 
 pub mod not_hidden {
+    // @has "$.index[*][?(@.name == 'NotHiddenPubStruct')]"
     pub struct NotHiddenPubStruct;
 
+    // @has "$.index[*][?(@.docs == 'Here')]"
+    /// Here
     impl crate::PubTrait for NotHiddenPubStruct {}
 }

--- a/tests/rustdoc-json/impls/local_for_local.rs
+++ b/tests/rustdoc-json/impls/local_for_local.rs
@@ -1,6 +1,3 @@
-#![feature(no_core)]
-#![no_core]
-
 // @set struct = "$.index[*][?(@.name=='Struct')].id"
 pub struct Struct;
 // @set trait = "$.index[*][?(@.name=='Trait')].id"
@@ -9,7 +6,7 @@ pub trait Trait {}
 /// impl
 impl Trait for Struct {}
 
-// @is "$.index[*][?(@.name=='Struct')].inner.struct.impls[*]" $impl
+// @has "$.index[*][?(@.name=='Struct')].inner.struct.impls[*]" $impl
 // @is "$.index[*][?(@.name=='Trait')].inner.trait.implementations[*]" $impl
 // @is "$.index[*][?(@.docs=='impl')].inner.impl.trait.id" $trait
 // @is "$.index[*][?(@.docs=='impl')].inner.impl.for.resolved_path.id" $struct

--- a/tests/rustdoc-json/impls/local_for_local_primitive.rs
+++ b/tests/rustdoc-json/impls/local_for_local_primitive.rs
@@ -1,6 +1,4 @@
-#![feature(no_core)]
 #![feature(rustc_attrs)]
-#![no_core]
 
 // @set Local = "$.index[*][?(@.name=='Local')].id"
 pub trait Local {}

--- a/tests/rustdoc-json/lifetime/longest.rs
+++ b/tests/rustdoc-json/lifetime/longest.rs
@@ -1,8 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 // @is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].name"  \"\'a\"
 // @is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
 // @is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
@@ -26,5 +23,9 @@
 // @is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.type.primitive" \"str\"
 
 pub fn longest<'a>(l: &'a str, r: &'a str) -> &'a str {
-    if l.len() > r.len() { l } else { r }
+    if l.len() > r.len() {
+        l
+    } else {
+        r
+    }
 }

--- a/tests/rustdoc-json/lifetime/outlives.rs
+++ b/tests/rustdoc-json/lifetime/outlives.rs
@@ -1,8 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 // @count "$.index[*][?(@.name=='foo')].inner.function.generics.params[*]" 3
 // @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates" []
 // @is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].name" \"\'a\"

--- a/tests/rustdoc-json/methods/abi.rs
+++ b/tests/rustdoc-json/methods/abi.rs
@@ -1,8 +1,6 @@
 // ignore-tidy-linelength
 
 #![feature(abi_vectorcall)]
-#![feature(no_core)]
-#![no_core]
 
 // @has "$.index[*][?(@.name=='Foo')]"
 pub struct Foo;

--- a/tests/rustdoc-json/non_lifetime_binders.rs
+++ b/tests/rustdoc-json/non_lifetime_binders.rs
@@ -3,18 +3,9 @@
 #![feature(non_lifetime_binders)]
 #![allow(incomplete_features)]
 
-#![no_core]
-#![feature(lang_items, no_core)]
-
-#[lang = "sized"]
-pub trait Sized {}
-
 pub trait Trait {}
 
-#[lang = "phantom_data"]
-struct PhantomData<T_>;
-
-pub struct Wrapper<T_>(PhantomData<T_>);
+pub struct Wrapper<T_>(std::marker::PhantomData<T_>);
 
 // @count "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[*]" 2
 // @is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].name" \"\'a\"

--- a/tests/rustdoc-json/primitives/primitive_overloading.rs
+++ b/tests/rustdoc-json/primitives/primitive_overloading.rs
@@ -3,14 +3,10 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/98006>.
 
 #![feature(rustc_attrs)]
-#![feature(no_core)]
-
-#![no_core]
 
 // @has "$.index[*][?(@.name=='usize')]"
 // @has "$.index[*][?(@.name=='prim')]"
 
 #[rustc_doc_primitive = "usize"]
 /// This is the built-in type `usize`.
-mod prim {
-}
+mod prim {}

--- a/tests/rustdoc-json/reexport/export_extern_crate_as_self.rs
+++ b/tests/rustdoc-json/reexport/export_extern_crate_as_self.rs
@@ -1,8 +1,5 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/100531>
 
-#![feature(no_core)]
-#![no_core]
-
 #![crate_name = "export_extern_crate_as_self"]
 
 // ignore-tidy-linelength

--- a/tests/rustdoc-json/reexport/glob_collision.rs
+++ b/tests/rustdoc-json/reexport/glob_collision.rs
@@ -1,8 +1,5 @@
 // Regression test for https://github.com/rust-lang/rust/issues/100973
 
-#![feature(no_core)]
-#![no_core]
-
 // @set m1 = "$.index[*][?(@.name == 'm1' && @.inner.module)].id"
 // @is "$.index[*][?(@.name == 'm1')].inner.module.items" []
 // @is "$.index[*][?(@.name == 'm1')].inner.module.is_stripped" true

--- a/tests/rustdoc-json/reexport/glob_extern.rs
+++ b/tests/rustdoc-json/reexport/glob_extern.rs
@@ -1,8 +1,5 @@
 // edition:2018
 
-#![no_core]
-#![feature(no_core)]
-
 // @is "$.index[*][?(@.name=='mod1')].inner.module.is_stripped" "true"
 mod mod1 {
     extern "C" {

--- a/tests/rustdoc-json/reexport/glob_private.rs
+++ b/tests/rustdoc-json/reexport/glob_private.rs
@@ -1,8 +1,5 @@
 // edition:2018
 
-#![no_core]
-#![feature(no_core)]
-
 // @is "$.index[*][?(@.name=='mod1')].inner.module.is_stripped" "true"
 mod mod1 {
     // @is "$.index[*][?(@.name=='mod2')].inner.module.is_stripped" "true"

--- a/tests/rustdoc-json/reexport/in_root_and_mod.rs
+++ b/tests/rustdoc-json/reexport/in_root_and_mod.rs
@@ -1,6 +1,3 @@
-#![feature(no_core)]
-#![no_core]
-
 // @!has "$.index[*][?(@.name=='foo')]"
 mod foo {
     // @has "$.index[*][?(@.name=='Foo')]"

--- a/tests/rustdoc-json/reexport/in_root_and_mod_pub.rs
+++ b/tests/rustdoc-json/reexport/in_root_and_mod_pub.rs
@@ -1,6 +1,3 @@
-#![feature(no_core)]
-#![no_core]
-
 pub mod foo {
     // @set bar_id = "$.index[*][?(@.name=='Bar')].id"
     // @ismany "$.index[*][?(@.name=='foo')].inner.module.items[*]" $bar_id

--- a/tests/rustdoc-json/reexport/macro.rs
+++ b/tests/rustdoc-json/reexport/macro.rs
@@ -1,8 +1,5 @@
 // edition:2018
 
-#![no_core]
-#![feature(no_core)]
-
 // @set repro_id = "$.index[*][?(@.name=='repro')].id"
 #[macro_export]
 macro_rules! repro {

--- a/tests/rustdoc-json/reexport/mod_not_included.rs
+++ b/tests/rustdoc-json/reexport/mod_not_included.rs
@@ -1,8 +1,5 @@
 // Regression test for https://github.com/rust-lang/rust/issues/101103
 
-#![feature(no_core)]
-#![no_core]
-
 mod m1 {
     pub fn x() {}
 }

--- a/tests/rustdoc-json/reexport/private_twice_one_inline.rs
+++ b/tests/rustdoc-json/reexport/private_twice_one_inline.rs
@@ -4,12 +4,8 @@
 // Test for the ICE in https://github.com/rust-lang/rust/issues/83057
 // An external type re-exported with different attributes shouldn't cause an error
 
-#![no_core]
-#![feature(no_core)]
-
 extern crate pub_struct as foo;
 #[doc(inline)]
-
 // @set crate_use_id = "$.index[*][?(@.docs=='Hack A')].id"
 // @set foo_id = "$.index[*][?(@.docs=='Hack A')].inner.import.id"
 /// Hack A

--- a/tests/rustdoc-json/reexport/private_two_names.rs
+++ b/tests/rustdoc-json/reexport/private_two_names.rs
@@ -3,9 +3,6 @@
 // Test for the ICE in https://github.com/rust-lang/rust/issues/83720
 // A pub-in-private type re-exported under two different names shouldn't cause an error
 
-#![no_core]
-#![feature(no_core)]
-
 // @!has "$.index[*][?(@.name=='style')]"
 mod style {
     // @set color_struct_id = "$.index[*][?(@.inner.struct && @.name=='Color')].id"

--- a/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
+++ b/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
@@ -1,8 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/106379>
 
-#![feature(no_core)]
-#![no_core]
-
 mod repeat_n {
     #[doc(hidden)]
     pub struct RepeatN {}

--- a/tests/rustdoc-json/reexport/rename_private.rs
+++ b/tests/rustdoc-json/reexport/rename_private.rs
@@ -1,8 +1,5 @@
 // edition:2018
 
-#![no_core]
-#![feature(no_core)]
-
 // @!has "$.index[*][?(@.name=='inner')]"
 mod inner {
     // @has "$.index[*][?(@.name=='Public')]"

--- a/tests/rustdoc-json/reexport/rename_public.rs
+++ b/tests/rustdoc-json/reexport/rename_public.rs
@@ -1,8 +1,5 @@
 // edition:2018
 
-#![no_core]
-#![feature(no_core)]
-
 // @set inner_id = "$.index[*][?(@.name=='inner')].id"
 pub mod inner {
     // @set public_id = "$.index[*][?(@.name=='Public')].id"

--- a/tests/rustdoc-json/reexport/same_name_different_types.rs
+++ b/tests/rustdoc-json/reexport/same_name_different_types.rs
@@ -1,8 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/107677>.
 
-#![feature(no_core)]
-#![no_core]
-
 pub mod nested {
     // @set foo_struct = "$.index[*][?(@.docs == 'Foo the struct')].id"
 

--- a/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
+++ b/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
@@ -2,9 +2,7 @@
 
 // Regression test for <https://github.com/rust-lang/rust/issues/97432>.
 
-#![feature(no_core)]
 #![no_std]
-#![no_core]
 
 mod inner {
     // @set trait_id = "$.index[*][?(@.name=='Trait')].id"

--- a/tests/rustdoc-json/reexport/simple_private.rs
+++ b/tests/rustdoc-json/reexport/simple_private.rs
@@ -1,6 +1,4 @@
 // edition:2018
-#![no_core]
-#![feature(no_core)]
 
 // @!has "$.index[*][?(@.name=='inner')]"
 mod inner {

--- a/tests/rustdoc-json/reexport/simple_public.rs
+++ b/tests/rustdoc-json/reexport/simple_public.rs
@@ -1,8 +1,5 @@
 // edition:2018
 
-#![no_core]
-#![feature(no_core)]
-
 // @set inner_id = "$.index[*][?(@.name=='inner')].id"
 pub mod inner {
 

--- a/tests/rustdoc-json/return_private.rs
+++ b/tests/rustdoc-json/return_private.rs
@@ -1,9 +1,6 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/96161>.
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
 mod secret {
     pub struct Secret;
 }

--- a/tests/rustdoc-json/stripped_modules.rs
+++ b/tests/rustdoc-json/stripped_modules.rs
@@ -1,6 +1,3 @@
-#![no_core]
-#![feature(no_core)]
-
 // @!has "$.index[*][?(@.name=='no_pub_inner')]"
 mod no_pub_inner {
     fn priv_inner() {}

--- a/tests/rustdoc-json/traits/implementors.rs
+++ b/tests/rustdoc-json/traits/implementors.rs
@@ -1,19 +1,18 @@
-#![feature(no_core)]
-#![no_core]
-
-// @set wham = "$.index[*][?(@.name=='Wham')].id"
-// @count "$.index[*][?(@.name=='Wham')].inner.trait.implementations[*]" 1
-// @set gmWham = "$.index[*][?(@.name=='Wham')].inner.trait.implementations[0]"
 pub trait Wham {}
-
-// @count "$.index[*][?(@.name=='GeorgeMichael')].inner.struct.impls[*]" 1
-// @is "$.index[*][?(@.name=='GeorgeMichael')].inner.struct.impls[0]" $gmWham
-// @set gm = "$.index[*][?(@.name=='Wham')].id"
-
-// jsonpath_lib isnt expressive enough (for now) to get the "impl" item, so we
-// just check it isn't pointing to the type, but when you port to jsondocck-ng
-// check what the impl item is
-// @!is "$.index[*][?(@.name=='Wham')].inner.trait.implementations[0]" $gm
 pub struct GeorgeMichael {}
 
+/// Wham for George Michael
 impl Wham for GeorgeMichael {}
+
+// Find IDs.
+// @set wham = "$.index[*][?(@.name=='Wham')].id"
+// @set gmWham = "$.index[*][?(@.docs=='Wham for George Michael')].id"
+// @set gm = "$.index[*][?(@.name=='GeorgeMichael')].id"
+
+// Both struct and trait point to impl.
+// @has "$.index[*][?(@.name=='GeorgeMichael')].inner.struct.impls[*]" $gmWham
+// @is "$.index[*][?(@.name=='Wham')].inner.trait.implementations[*]" $gmWham
+
+// Impl points to both struct and trait.
+// @is "$.index[*][?(@.docs == 'Wham for George Michael')].inner.impl.trait.id" $wham
+// @is "$.index[*][?(@.docs == 'Wham for George Michael')].inner.impl.for.resolved_path.id" $gm

--- a/tests/rustdoc-json/traits/private_supertrait.rs
+++ b/tests/rustdoc-json/traits/private_supertrait.rs
@@ -1,9 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
-#![no_core]
-
-
 // @!has "$.index[*][?(@.name == 'sealed')]"
 mod sealed {
     // @set sealed_id = "$.index[*][?(@.name=='Sealed')].id"

--- a/tests/rustdoc-json/traits/supertrait.rs
+++ b/tests/rustdoc-json/traits/supertrait.rs
@@ -1,8 +1,6 @@
 // ignore-tidy-linelength
 
-#![feature(no_core)]
 #![feature(lang_items)]
-#![no_core]
 
 // @set loud_id = "$.index[*][?(@.name=='Loud')].id"
 pub trait Loud {}

--- a/tests/rustdoc-json/traits/supertrait.rs
+++ b/tests/rustdoc-json/traits/supertrait.rs
@@ -1,7 +1,5 @@
 // ignore-tidy-linelength
 
-#![feature(lang_items)]
-
 // @set loud_id = "$.index[*][?(@.name=='Loud')].id"
 pub trait Loud {}
 

--- a/tests/rustdoc-json/type/inherent_associated_type.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type.rs
@@ -1,8 +1,6 @@
 // ignore-tidy-linelength
 #![feature(inherent_associated_types)]
-#![feature(no_core)]
 #![allow(incomplete_features)]
-#![no_core]
 
 // @set OwnerMetadata = '$.index[*][?(@.name=="OwnerMetadata")].id'
 pub struct OwnerMetadata;


### PR DESCRIPTION
See #117487 for motivation.


I've split it into three commits, depending on how much work it was to remove `#![no_core]`. The first is entirely mechanical, the second makes no logical changes but couldn't be done with find+replace, and the third required rewriting assertions no not depend on having `#![no_core]`. All of the interesting changes for review are in the third commit, so I recommend reviewing commit-by-commit.

After this, 3 tests still use `#![no_core]`:

- `./tests/rustdoc-json/primitives/primitive_impls.rs`. Uses impls on primitives, so needs to simulate core
- `./tests/rustdoc-json/primitives/local_primitive.rs`: Uses `rustc_doc_primitive`, so needs to simulate core
- `./tests/rustdoc-json/impls/auto.rs`: Uses auto traits, so needs to simulate core

But after this change, we only rely on the core-rustc boundary in tests that deliberately test those interactions.

r? @GuillaumeGomez 

Fixes #117487