### PR TITLE
crater: test enabling MCP510

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -625,6 +625,12 @@ impl LinkSelfContainedDefault {
             _ => "crt-objects-fallback",
         }
     }
+
+    /// Creates a `LinkSelfContained` enabling the self-contained linker for target specs (the
+    /// equivalent of `-Clink-self-contained=+linker` on the CLI).
+    pub fn with_linker() -> LinkSelfContainedDefault {
+        LinkSelfContainedDefault::WithComponents(LinkSelfContainedComponents::LINKER)
+    }
 }
 
 bitflags::bitflags! {

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnu.rs
@@ -16,6 +16,12 @@ pub fn target() -> Target {
         | SanitizerSet::THREAD;
     base.supports_xray = true;
 
+    #[cfg(rust_lld)]
+    {
+        base.linker_flavor = LinkerFlavor::Gnu(Cc::Yes, Lld::Yes);
+        base.link_self_contained = crate::spec::LinkSelfContainedDefault::with_linker();
+    }
+
     Target {
         llvm_target: "x86_64-unknown-linux-gnu".into(),
         pointer_width: 64,

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1034,6 +1034,10 @@ pub fn rustc_cargo_env(
         cargo.rustflag("--cfg=parallel_compiler");
         cargo.rustdocflag("--cfg=parallel_compiler");
     }
+    if builder.config.lld_enabled {
+        cargo.rustflag("--cfg=rust_lld");
+        cargo.rustdocflag("--cfg=rust_lld");
+    }
     if builder.config.rust_verify_llvm_ir {
         cargo.env("RUSTC_VERIFY_LLVM_IR", "1");
     }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -117,6 +117,10 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     // Needed to avoid the need to copy windows.lib into the sysroot.
     (Some(Mode::Rustc), "windows_raw_dylib", None),
     (Some(Mode::ToolRustc), "windows_raw_dylib", None),
+    // If rustc wants to use rust-lld as the default linker in a target spec.
+    (Some(Mode::Rustc), "rust_lld", None),
+    (Some(Mode::ToolRustc), "rust_lld", None),
+    (Some(Mode::Codegen), "rust_lld", None),
 ];
 
 /// A structure representing a Rust compiler.

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -3,7 +3,7 @@ set -ex
 
 source shared.sh
 
-GCC=8.5.0
+GCC=9.5.0
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
 cd gcc-$GCC

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -3,6 +3,7 @@ set -ex
 
 source shared.sh
 
+# Note: in the future when bumping to version 10.1.0, also take care of the sed block below.
 GCC=9.5.0
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
@@ -21,6 +22,11 @@ cd gcc-$GCC
 # bug: the host `gcc.gnu.org` and `cygwin.com` share the same IP, and the TLS certificate of the
 # latter host is presented to `wget`! Therefore, we choose to download from the insecure HTTP server
 # instead here.
+#
+# Note: in version 10.1.0, the URL used in `download_prerequisites` has changed from using FTP to
+# using HTTP. When bumping to that gcc version, we can likely remove the sed replacement below, or
+# the expression will need to be updated. That new URL is available at:
+# https://github.com/gcc-mirror/gcc/blob/6e6e3f144a33ae504149dc992453b4f6dea12fdb/contrib/download_prerequisites#L35
 #
 sed -i'' 's|ftp://gcc\.gnu\.org/|https://gcc.gnu.org/|g' ./contrib/download_prerequisites
 


### PR DESCRIPTION
Tests pass at stage1 and 2 with the `x86_64-unknown-linux-gnu` target switched. CI passes in #113382 with most `x86_64-unknown-linux-gnu` builders enabled. Bootstrap and the perf collector work. 

The crater queue is about to be empty, so it's a good time to do another run with this linker configuration and see if anything changed since the previous run. Surely, some bug-for-bug bfd compatibility differences will remain, but it will good to check with the latest lld anyways.

Note for anyone looking at this PR coming from the crater queue: this is intended to be a low-priority run. If it hasn't started and you need your run started before this one, go ahead and bump your own priority above this.

r? @ghost