### PR TITLE
Detect Inuktitut brackets meant to be generics square brackets

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2202,11 +2202,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
 
         if let Some(Item {
             ident: name,
-            kind:
-                ItemKind::Fn(..)
-                | ItemKind::Enum(..)
-                | ItemKind::Struct(..)
-                | ItemKind::Union(..),
+            kind: ItemKind::Fn(..) | ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Union(..),
             ..
         }) = self.diagnostic_metadata.current_item
             && single_uppercase_char

--- a/tests/ui/suggestions/unicode-ident-looks-like-generics.fixed
+++ b/tests/ui/suggestions/unicode-ident-looks-like-generics.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+#[allow(dead_code)]
+struct A<T>(T);
+//~^ ERROR cannot find type `T` in this scope
+//~| WARNING identifier contains uncommon Unicode codepoints
+fn main() {}

--- a/tests/ui/suggestions/unicode-ident-looks-like-generics.rs
+++ b/tests/ui/suggestions/unicode-ident-looks-like-generics.rs
@@ -1,0 +1,6 @@
+// run-rustfix
+#[allow(dead_code)]
+struct AᐸTᐳ(T);
+//~^ ERROR cannot find type `T` in this scope
+//~| WARNING identifier contains uncommon Unicode codepoints
+fn main() {}

--- a/tests/ui/suggestions/unicode-ident-looks-like-generics.stderr
+++ b/tests/ui/suggestions/unicode-ident-looks-like-generics.stderr
@@ -7,7 +7,7 @@ LL | struct AᐸTᐳ(T);
 help: the name of this item includes unicode characters `ᐸ` and `ᐳ` that look like `<` and `>`, but they aren't
    |
 LL | struct A<T>(T);
-   |        ~~~~
+   |         ~~~
 
 warning: identifier contains uncommon Unicode codepoints
   --> $DIR/unicode-ident-looks-like-generics.rs:3:8

--- a/tests/ui/suggestions/unicode-ident-looks-like-generics.stderr
+++ b/tests/ui/suggestions/unicode-ident-looks-like-generics.stderr
@@ -1,0 +1,22 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/unicode-ident-looks-like-generics.rs:3:13
+   |
+LL | struct AᐸTᐳ(T);
+   |             ^ not found in this scope
+   |
+help: the name of this item includes unicode characters `ᐸ` and `ᐳ` that look like `<` and `>`, but they aren't
+   |
+LL | struct A<T>(T);
+   |        ~~~~
+
+warning: identifier contains uncommon Unicode codepoints
+  --> $DIR/unicode-ident-looks-like-generics.rs:3:8
+   |
+LL | struct AᐸTᐳ(T);
+   |        ^^^^
+   |
+   = note: `#[warn(uncommon_codepoints)]` on by default
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
When we encounter a type that isn't in scope, before suggesting adding generics we look at the item's name to see if it has Inuktitut brackets, which look like generics, and suggest replacing them.

```
error[E0412]: cannot find type `T` in this scope
  --> $DIR/unicode-ident-looks-like-generics.rs:3:13
   |
LL | struct AᐸTᐳ(T);
   |             ^ not found in this scope
   |
help: the name of this item includes unicode characters `ᐸ` and `ᐳ` that look like `<` and `>`, but they aren't
LL | struct A<T>(T);
   |        ~~~~
```

Fix #93931.