### PR TITLE
Build pre-coroutine-transform coroutine body on error

### DIFF
--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -656,17 +656,7 @@ fn construct_error(tcx: TyCtxt<'_>, def_id: LocalDefId, guar: ErrorGuaranteed) -
             let args = args.as_coroutine();
             let yield_ty = args.yield_ty();
             let return_ty = args.return_ty();
-            let self_ty = Ty::new_adt(
-                tcx,
-                tcx.adt_def(tcx.lang_items().pin_type().unwrap()),
-                tcx.mk_args(&[Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, coroutine_ty).into()]),
-            );
-            let coroutine_state = Ty::new_adt(
-                tcx,
-                tcx.adt_def(tcx.lang_items().coroutine_state().unwrap()),
-                tcx.mk_args(&[yield_ty.into(), return_ty.into()]),
-            );
-            (vec![self_ty, args.resume_ty()], coroutine_state, Some(yield_ty))
+            (vec![coroutine_ty, args.resume_ty()], return_ty, Some(yield_ty))
         }
         dk => bug!("{:?} is not a body: {:?}", def_id, dk),
     };

--- a/tests/ui/mir/build-async-error-body-correctly.rs
+++ b/tests/ui/mir/build-async-error-body-correctly.rs
@@ -1,0 +1,8 @@
+// edition: 2021
+
+async fn asyncfn() {
+    let binding = match true {};
+    //~^ ERROR non-exhaustive patterns: type `bool` is non-empty
+}
+
+fn main() {}

--- a/tests/ui/mir/build-async-error-body-correctly.stderr
+++ b/tests/ui/mir/build-async-error-body-correctly.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `bool` is non-empty
+  --> $DIR/build-async-error-body-correctly.rs:4:25
+   |
+LL |     let binding = match true {};
+   |                         ^^^^
+   |
+   = note: the matched value is of type `bool`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     let binding = match true {
+LL +         _ => todo!(),
+LL ~     };
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
I was accidentally building the post-transform coroutine body, rather than the pre-transform coroutine body. There's no pinning expected here yet, and the return type isn't yet transformed into `CoroutineState`.

Fixes #117670