### PR TITLE
check config file before prompts on `x setup`

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -211,7 +211,7 @@ def require(cmd, exit=True, exception=False):
         if exception:
             raise
         elif exit:
-            eprint("error: unable to run `{}`: {}".format(' '.join(cmd), exc))
+            eprint("ERROR: unable to run `{}`: {}".format(' '.join(cmd), exc))
             eprint("Please make sure it's installed and in the path.")
             sys.exit(1)
         return None
@@ -681,7 +681,7 @@ class RustBuild(object):
 
         answer = self._should_fix_bins_and_dylibs = get_answer()
         if answer:
-            eprint("info: You seem to be using Nix.")
+            eprint("INFO: You seem to be using Nix.")
         return answer
 
     def fix_bin_or_dylib(self, fname):
@@ -727,7 +727,7 @@ class RustBuild(object):
                     "nix-build", "-E", nix_expr, "-o", nix_deps_dir,
                 ])
             except subprocess.CalledProcessError as reason:
-                eprint("warning: failed to call nix-build:", reason)
+                eprint("WARNING: failed to call nix-build:", reason)
                 return
             self.nix_deps_dir = nix_deps_dir
 
@@ -747,7 +747,7 @@ class RustBuild(object):
         try:
             subprocess.check_output([patchelf] + patchelf_args + [fname])
         except subprocess.CalledProcessError as reason:
-            eprint("warning: failed to call patchelf:", reason)
+            eprint("WARNING: failed to call patchelf:", reason)
             return
 
     def rustc_stamp(self):
@@ -1005,7 +1005,7 @@ class RustBuild(object):
         if 'SUDO_USER' in os.environ and not self.use_vendored_sources:
             if os.getuid() == 0:
                 self.use_vendored_sources = True
-                eprint('info: looks like you\'re trying to run this command as root')
+                eprint('INFO: looks like you\'re trying to run this command as root')
                 eprint('      and so in order to preserve your $HOME this will now')
                 eprint('      use vendored sources by default.')
 
@@ -1017,14 +1017,14 @@ class RustBuild(object):
                             "--sync ./src/tools/rust-analyzer/Cargo.toml " \
                             "--sync ./compiler/rustc_codegen_cranelift/Cargo.toml " \
                             "--sync ./src/bootstrap/Cargo.toml "
-                eprint('error: vendoring required, but vendor directory does not exist.')
+                eprint('ERROR: vendoring required, but vendor directory does not exist.')
                 eprint('       Run `cargo vendor {}` to initialize the '
                       'vendor directory.'.format(sync_dirs))
                 eprint('Alternatively, use the pre-vendored `rustc-src` dist component.')
                 raise Exception("{} not found".format(vendor_dir))
 
             if not os.path.exists(cargo_dir):
-                eprint('error: vendoring required, but .cargo/config does not exist.')
+                eprint('ERROR: vendoring required, but .cargo/config does not exist.')
                 raise Exception("{} not found".format(cargo_dir))
         else:
             if os.path.exists(cargo_dir):
@@ -1125,7 +1125,7 @@ def main():
     # process has to happen before anything is printed out.
     if help_triggered:
         eprint(
-            "info: Downloading and building bootstrap before processing --help command.\n"
+            "INFO: Downloading and building bootstrap before processing --help command.\n"
             "      See src/bootstrap/README.md for help with common commands.")
 
     exit_code = 0

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -34,7 +34,7 @@ def serialize_and_parse(configure_args, bootstrap_args=None):
         # Verify this is actually valid TOML.
         tomllib.loads(build.config_toml)
     except ImportError:
-        print("warning: skipping TOML validation, need at least python 3.11", file=sys.stderr)
+        print("WARNING: skipping TOML validation, need at least python 3.11", file=sys.stderr)
     return build
 
 

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -253,7 +253,7 @@ def parse_args(args):
         if not found:
             unknown_args.append(arg)
 
-    # Note: here and a few other places, we use [-1] to apply the *last* value
+    # NOTE: here and a few other places, we use [-1] to apply the *last* value
     # passed.  But if option-checking is enabled, then the known_args loop will
     # also assert that options are only passed once.
     option_checking = ('option-checking' not in known_args
@@ -477,7 +477,7 @@ def configure_section(lines, config):
             # These are used by rpm, but aren't accepted by x.py.
             # Give a warning that they're ignored, but not a hard error.
             if key in ["infodir", "localstatedir"]:
-                print("warning: {} will be ignored".format(key))
+                print("WARNING: {} will be ignored".format(key))
             else:
                 raise RuntimeError("failed to find config line for {}".format(key))
 

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -63,7 +63,7 @@ fn main() {
     if suggest_setup {
         println!("WARNING: you have not made a `config.toml`");
         println!(
-            "help: consider running `./x.py setup` or copying `config.example.toml` by running \
+            "HELP: consider running `./x.py setup` or copying `config.example.toml` by running \
             `cp config.example.toml config.toml`"
         );
     } else if let Some(suggestion) = &changelog_suggestion {
@@ -76,7 +76,7 @@ fn main() {
     if suggest_setup {
         println!("WARNING: you have not made a `config.toml`");
         println!(
-            "help: consider running `./x.py setup` or copying `config.example.toml` by running \
+            "HELP: consider running `./x.py setup` or copying `config.example.toml` by running \
             `cp config.example.toml config.toml`"
         );
     } else if let Some(suggestion) = &changelog_suggestion {
@@ -97,7 +97,7 @@ fn main() {
     }
 
     if suggest_setup || changelog_suggestion.is_some() {
-        println!("note: this message was printed twice to make it more likely to be seen");
+        println!("NOTE: this message was printed twice to make it more likely to be seen");
     }
 }
 
@@ -128,14 +128,14 @@ fn check_version(config: &Config) -> Option<String> {
 
             msg.push_str("WARNING: there have been changes to x.py since you last updated.\n");
 
-            msg.push_str("note: to silence this warning, ");
+            msg.push_str("NOTE: to silence this warning, ");
             msg.push_str(&format!(
                 "update `config.toml` to use `change-id = {latest_config_id}` instead"
             ));
         }
     } else {
         msg.push_str("WARNING: The `change-id` is missing in the `config.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.\n");
-        msg.push_str("note: to silence this warning, ");
+        msg.push_str("NOTE: to silence this warning, ");
         msg.push_str(&format!("add `change-id = {latest_config_id}` at the top of `config.toml`"));
     };
 

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -242,7 +242,7 @@ fn main() {
 
     if status.success() {
         std::process::exit(0);
-        // note: everything below here is unreachable. do not put code that
+        // NOTE: everything below here is unreachable. do not put code that
         // should run on success, after this block.
     }
     if verbose > 0 {

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -178,7 +178,7 @@ fn rm_rf(path: &Path) {
                             && p.file_name().and_then(std::ffi::OsStr::to_str)
                                 == Some("bootstrap.exe")
                         {
-                            eprintln!("warning: failed to delete '{}'.", p.display());
+                            eprintln!("WARNING: failed to delete '{}'.", p.display());
                             return Ok(());
                         }
                         Err(e)

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -141,7 +141,7 @@ impl Step for Std {
         if builder.config.keep_stage.contains(&compiler.stage)
             || builder.config.keep_stage_std.contains(&compiler.stage)
         {
-            builder.info("Warning: Using a potentially old libstd. This may not behave well.");
+            builder.info("WARNING: Using a potentially old libstd. This may not behave well.");
 
             copy_third_party_objects(builder, &compiler, target);
             copy_self_contained_objects(builder, &compiler, target);
@@ -817,8 +817,8 @@ impl Step for Rustc {
         builder.ensure(Std::new(compiler, target));
 
         if builder.config.keep_stage.contains(&compiler.stage) {
-            builder.info("Warning: Using a potentially old librustc. This may not behave well.");
-            builder.info("Warning: Use `--keep-stage-std` if you want to rebuild the compiler when it changes");
+            builder.info("WARNING: Using a potentially old librustc. This may not behave well.");
+            builder.info("WARNING: Use `--keep-stage-std` if you want to rebuild the compiler when it changes");
             builder.ensure(RustcLink::from_rustc(self, compiler));
             return;
         }
@@ -1203,8 +1203,8 @@ fn is_codegen_cfg_needed(path: &TaskPath, run: &RunConfig<'_>) -> bool {
         }
         if needs_codegen_backend_config {
             run.builder.info(
-                "Warning: no codegen-backends config matched the requested path to build a codegen backend. \
-                Help: add backend to codegen-backends in config.toml.",
+                "WARNING: no codegen-backends config matched the requested path to build a codegen backend. \
+                HELP: add backend to codegen-backends in config.toml.",
             );
             return true;
         }
@@ -1250,7 +1250,7 @@ impl Step for CodegenBackend {
 
         if builder.config.keep_stage.contains(&compiler.stage) {
             builder.info(
-                "Warning: Using a potentially old codegen backend. \
+                "WARNING: Using a potentially old codegen backend. \
                 This may not behave well.",
             );
             // Codegen backends are linked separately from this step today, so we don't do
@@ -1525,14 +1525,14 @@ impl Step for Sysroot {
         let sysroot_lib_rustlib_src_rust = sysroot_lib_rustlib_src.join("rust");
         if let Err(e) = symlink_dir(&builder.config, &builder.src, &sysroot_lib_rustlib_src_rust) {
             eprintln!(
-                "warning: creating symbolic link `{}` to `{}` failed with {}",
+                "WARNING: creating symbolic link `{}` to `{}` failed with {}",
                 sysroot_lib_rustlib_src_rust.display(),
                 builder.src.display(),
                 e,
             );
             if builder.config.rust_remap_debuginfo {
                 eprintln!(
-                    "warning: some `tests/ui` tests will fail when lacking `{}`",
+                    "WARNING: some `tests/ui` tests will fail when lacking `{}`",
                     sysroot_lib_rustlib_src_rust.display(),
                 );
             }
@@ -1545,7 +1545,7 @@ impl Step for Sysroot {
             symlink_dir(&builder.config, &builder.src, &sysroot_lib_rustlib_rustcsrc_rust)
         {
             eprintln!(
-                "warning: creating symbolic link `{}` to `{}` failed with {}",
+                "WARNING: creating symbolic link `{}` to `{}` failed with {}",
                 sysroot_lib_rustlib_rustcsrc_rust.display(),
                 builder.src.display(),
                 e,
@@ -1986,7 +1986,7 @@ pub fn stream_cargo(
     builder.verbose(&format!("running: {cargo:?}"));
     let mut child = match cargo.spawn() {
         Ok(child) => child,
-        Err(e) => panic!("failed to execute command: {cargo:?}\nerror: {e}"),
+        Err(e) => panic!("failed to execute command: {cargo:?}\nERROR: {e}"),
     };
 
     // Spawn Cargo slurping up its JSON output. We'll start building up the
@@ -2050,7 +2050,7 @@ pub fn strip_debug(builder: &Builder<'_>, target: TargetSelection, path: &Path) 
     }
 
     let previous_mtime = FileTime::from_last_modification_time(&path.metadata().unwrap());
-    // Note: `output` will propagate any errors here.
+    // NOTE: `output` will propagate any errors here.
     output(Command::new("strip").arg("--strip-debug").arg(path));
 
     // After running `strip`, we have to set the file modification time to what it was before,

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -269,7 +269,7 @@ install!((self, builder, _config),
         }
     };
     RustDemangler, alias = "rust-demangler", Self::should_build(_config), only_hosts: true, {
-        // Note: Even though `should_build` may return true for `extended` default tools,
+        // NOTE: Even though `should_build` may return true for `extended` default tools,
         // dist::RustDemangler may still return None, unless the target-dependent `profiler` config
         // is also true, or the `tools` array explicitly includes "rust-demangler".
         if let Some(tarball) = builder.ensure(dist::RustDemangler {

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -156,9 +156,9 @@ pub(crate) fn detect_llvm_sha(config: &Config, is_git: bool) -> String {
 
     if llvm_sha.is_empty() {
         eprintln!("error: could not find commit hash for downloading LLVM");
-        eprintln!("help: maybe your repository history is too shallow?");
-        eprintln!("help: consider disabling `download-ci-llvm`");
-        eprintln!("help: or fetch enough history to include one upstream commit");
+        eprintln!("HELP: maybe your repository history is too shallow?");
+        eprintln!("HELP: consider disabling `download-ci-llvm`");
+        eprintln!("HELP: or fetch enough history to include one upstream commit");
         panic!();
     }
 

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -126,7 +126,7 @@ impl Step for Profile {
         if path.exists() {
             eprintln!();
             eprintln!(
-                "error: you asked for a new config file, but one already exists at `{}`",
+                "ERROR: you asked for a new config file, but one already exists at `{}`",
                 t!(path.canonicalize()).display()
             );
 
@@ -212,7 +212,7 @@ pub fn setup(config: &Config, profile: Profile) {
     if profile == Profile::Tools {
         eprintln!();
         eprintln!(
-            "note: the `tools` profile sets up the `stage2` toolchain (use \
+            "NOTE: the `tools` profile sets up the `stage2` toolchain (use \
             `rustup toolchain link 'name' build/host/stage2` to use rustc)"
         )
     }
@@ -414,8 +414,8 @@ pub fn interactive_path() -> io::Result<Profile> {
         break match parse_with_abbrev(&input) {
             Ok(profile) => profile,
             Err(err) => {
-                eprintln!("error: {err}");
-                eprintln!("note: press Ctrl+C to exit");
+                eprintln!("ERROR: {err}");
+                eprintln!("NOTE: press Ctrl+C to exit");
                 continue;
             }
         };
@@ -444,8 +444,8 @@ fn prompt_user(prompt: &str) -> io::Result<Option<PromptResult>> {
             "p" | "print" => return Ok(Some(PromptResult::Print)),
             "" => return Ok(None),
             _ => {
-                eprintln!("error: unrecognized option '{}'", input.trim());
-                eprintln!("note: press Ctrl+C to exit");
+                eprintln!("ERROR: unrecognized option '{}'", input.trim());
+                eprintln!("NOTE: press Ctrl+C to exit");
             }
         };
     }
@@ -512,7 +512,7 @@ undesirable, simply delete the `pre-push` file from .git/hooks."
     match fs::hard_link(src, &dst) {
         Err(e) => {
             eprintln!(
-                "error: could not create hook {}: do you already have the git hook installed?\n{}",
+                "ERROR: could not create hook {}: do you already have the git hook installed?\n{}",
                 dst.display(),
                 e
             );
@@ -578,10 +578,10 @@ fn create_vscode_settings_maybe(config: &Config) -> io::Result<()> {
     );
     match mismatched_settings {
         Some(true) => eprintln!(
-            "warning: existing `.vscode/settings.json` is out of date, x.py will update it"
+            "WARNING: existing `.vscode/settings.json` is out of date, x.py will update it"
         ),
         Some(false) => eprintln!(
-            "warning: existing `.vscode/settings.json` has been modified by user, x.py will back it up and replace it"
+            "WARNING: existing `.vscode/settings.json` has been modified by user, x.py will back it up and replace it"
         ),
         _ => (),
     }
@@ -608,7 +608,7 @@ fn create_vscode_settings_maybe(config: &Config) -> io::Result<()> {
                 // exists and is not current version or outdated, so back it up
                 let mut backup = vscode_settings.clone();
                 backup.set_extension("json.bak");
-                eprintln!("warning: copying `settings.json` to `settings.json.bak`");
+                eprintln!("WARNING: copying `settings.json` to `settings.json.bak`");
                 fs::copy(&vscode_settings, &backup)?;
                 "Updated"
             }

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -122,6 +122,17 @@ impl Step for Profile {
             return;
         }
 
+        let path = &run.builder.config.config.clone().unwrap_or(PathBuf::from("config.toml"));
+        if path.exists() {
+            eprintln!();
+            eprintln!(
+                "error: you asked for a new config file, but one already exists at `{}`",
+                t!(path.canonicalize()).display()
+            );
+
+            crate::exit!(1);
+        }
+
         // for Profile, `run.paths` will have 1 and only 1 element
         // this is because we only accept at most 1 path from user input.
         // If user calls `x.py setup` without arguments, the interactive TUI
@@ -203,19 +214,6 @@ pub fn setup(config: &Config, profile: Profile) {
 fn setup_config_toml(path: &PathBuf, profile: Profile, config: &Config) {
     if profile == Profile::None {
         return;
-    }
-    if path.exists() {
-        eprintln!();
-        eprintln!(
-            "error: you asked `x.py` to setup a new config file, but one already exists at `{}`",
-            path.display()
-        );
-        eprintln!("help: try adding `profile = \"{}\"` at the top of {}", profile, path.display());
-        eprintln!(
-            "note: this will use the configuration in {}",
-            profile.include_path(&config.src).display()
-        );
-        crate::exit!(1);
     }
 
     let latest_change_id = CONFIG_CHANGE_HISTORY.last().unwrap();

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -130,7 +130,17 @@ impl Step for Profile {
                 t!(path.canonicalize()).display()
             );
 
-            crate::exit!(1);
+            match prompt_user(
+                "Do you wish to override the existing configuration (which will allow the setup process to continue)?: [y/N]",
+            ) {
+                Ok(Some(PromptResult::Yes)) => {
+                    t!(fs::remove_file(path));
+                }
+                _ => {
+                    println!("Exiting.");
+                    crate::exit!(1);
+                }
+            }
         }
 
         // for Profile, `run.paths` will have 1 and only 1 element

--- a/src/bootstrap/src/core/build_steps/suggest.rs
+++ b/src/bootstrap/src/core/build_steps/suggest.rs
@@ -68,6 +68,6 @@ pub fn suggest(builder: &Builder<'_>, run: bool) {
             build.build();
         }
     } else {
-        println!("help: consider using the `--run` flag to automatically run suggested tests");
+        println!("HELP: consider using the `--run` flag to automatically run suggested tests");
     }
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1127,10 +1127,10 @@ impl Step for Tidy {
                 let inferred_rustfmt_dir = builder.initial_rustc.parent().unwrap();
                 eprintln!(
                     "\
-error: no `rustfmt` binary found in {PATH}
-info: `rust.channel` is currently set to \"{CHAN}\"
-help: if you are testing a beta branch, set `rust.channel` to \"beta\" in the `config.toml` file
-help: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to `x.py test`",
+ERROR: no `rustfmt` binary found in {PATH}
+INFO: `rust.channel` is currently set to \"{CHAN}\"
+HELP: if you are testing a beta branch, set `rust.channel` to \"beta\" in the `config.toml` file
+HELP: to skip test's attempt to check tidiness, pass `--skip src/tools/tidy` to `x.py test`",
                     PATH = inferred_rustfmt_dir.display(),
                     CHAN = builder.config.channel,
                 );
@@ -1183,7 +1183,7 @@ impl Step for ExpandYamlAnchors {
     /// appropriate configuration for all our CI providers. This step ensures the tool was called
     /// by the user before committing CI changes.
     fn run(self, builder: &Builder<'_>) {
-        // Note: `.github/` is not included in dist-src tarballs
+        // NOTE: `.github/` is not included in dist-src tarballs
         if !builder.src.join(".github/workflows/ci.yml").exists() {
             builder.info("Skipping YAML anchors check: GitHub Actions config not found");
             return;
@@ -1566,10 +1566,10 @@ impl Step for Compiletest {
     fn run(self, builder: &Builder<'_>) {
         if builder.top_stage == 0 && env::var("COMPILETEST_FORCE_STAGE0").is_err() {
             eprintln!("\
-error: `--stage 0` runs compiletest on the beta compiler, not your local changes, and will almost always cause tests to fail
-help: to test the compiler, use `--stage 1` instead
-help: to test the standard library, use `--stage 0 library/std` instead
-note: if you're sure you want to do this, please open an issue as to why. In the meantime, you can override this with `COMPILETEST_FORCE_STAGE0=1`."
+ERROR: `--stage 0` runs compiletest on the beta compiler, not your local changes, and will almost always cause tests to fail
+HELP: to test the compiler, use `--stage 1` instead
+HELP: to test the standard library, use `--stage 0 library/std` instead
+NOTE: if you're sure you want to do this, please open an issue as to why. In the meantime, you can override this with `COMPILETEST_FORCE_STAGE0=1`."
             );
             crate::exit!(1);
         }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -422,7 +422,7 @@ impl Step for Rustdoc {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustdoc {
-            // Note: this is somewhat unique in that we actually want a *target*
+            // NOTE: this is somewhat unique in that we actually want a *target*
             // compiler here, because rustdoc *is* a compiler. We won't be using
             // this as the compiler to build with, but rather this is "what
             // compiler are we producing"?
@@ -454,7 +454,7 @@ impl Step for Rustdoc {
         // compiler, since you do just as much work.
         if !builder.config.dry_run() && builder.download_rustc() && build_compiler.stage == 0 {
             println!(
-                "warning: `download-rustc` does nothing when building stage1 tools; consider using `--stage 2` instead"
+                "WARNING: `download-rustc` does nothing when building stage1 tools; consider using `--stage 2` instead"
             );
         }
 
@@ -787,9 +787,9 @@ macro_rules! tool_extended {
     }
 }
 
-// Note: tools need to be also added to `Builder::get_step_descriptions` in `builder.rs`
+// NOTE: tools need to be also added to `Builder::get_step_descriptions` in `builder.rs`
 // to make `./x.py build <tool>` work.
-// Note: Most submodule updates for tools are handled by bootstrap.py, since they're needed just to
+// NOTE: Most submodule updates for tools are handled by bootstrap.py, since they're needed just to
 // invoke Cargo to build bootstrap. See the comment there for more details.
 tool_extended!((self, builder),
     Cargofmt, "src/tools/rustfmt", "cargo-fmt", stable=true;

--- a/src/bootstrap/src/core/build_steps/toolstate.rs
+++ b/src/bootstrap/src/core/build_steps/toolstate.rs
@@ -172,7 +172,7 @@ impl Step for ToolStateCheck {
         for (tool, _) in STABLE_TOOLS.iter().chain(NIGHTLY_TOOLS.iter()) {
             if !toolstates.contains_key(*tool) {
                 did_error = true;
-                eprintln!("error: Tool `{tool}` was not recorded in tool state.");
+                eprintln!("ERROR: Tool `{tool}` was not recorded in tool state.");
             }
         }
 
@@ -190,7 +190,7 @@ impl Step for ToolStateCheck {
             if state != ToolState::TestPass {
                 if !is_nightly {
                     did_error = true;
-                    eprintln!("error: Tool `{tool}` should be test-pass but is {state}");
+                    eprintln!("ERROR: Tool `{tool}` should be test-pass but is {state}");
                 } else if in_beta_week {
                     let old_state = old_toolstate
                         .iter()
@@ -200,14 +200,14 @@ impl Step for ToolStateCheck {
                     if state < old_state {
                         did_error = true;
                         eprintln!(
-                            "error: Tool `{tool}` has regressed from {old_state} to {state} during beta week."
+                            "ERROR: Tool `{tool}` has regressed from {old_state} to {state} during beta week."
                         );
                     } else {
                         // This warning only appears in the logs, which most
                         // people won't read. It's mostly here for testing and
                         // debugging.
                         eprintln!(
-                            "warning: Tool `{tool}` is not test-pass (is `{state}`), \
+                            "WARNING: Tool `{tool}` is not test-pass (is `{state}`), \
                             this should be fixed before beta is branched."
                         );
                     }

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -386,13 +386,13 @@ impl StepDescription {
         }
 
         if !paths.is_empty() {
-            eprintln!("error: no `{}` rules matched {:?}", builder.kind.as_str(), paths,);
+            eprintln!("ERROR: no `{}` rules matched {:?}", builder.kind.as_str(), paths,);
             eprintln!(
-                "help: run `x.py {} --help --verbose` to show a list of available paths",
+                "HELP: run `x.py {} --help --verbose` to show a list of available paths",
                 builder.kind.as_str()
             );
             eprintln!(
-                "note: if you are adding a new Step to bootstrap itself, make sure you register it with `describe!`"
+                "NOTE: if you are adding a new Step to bootstrap itself, make sure you register it with `describe!`"
             );
             crate::exit!(1);
         }
@@ -1360,9 +1360,9 @@ impl<'a> Builder<'a> {
                     }
                 }).unwrap_or_else(|_| {
                     eprintln!(
-                        "error: `x.py clippy` requires a host `rustc` toolchain with the `clippy` component"
+                        "ERROR: `x.py clippy` requires a host `rustc` toolchain with the `clippy` component"
                     );
-                    eprintln!("help: try `rustup component add clippy`");
+                    eprintln!("HELP: try `rustup component add clippy`");
                     crate::exit!(1);
                 });
                 if !t!(std::str::from_utf8(&output.stdout)).contains("nightly") {

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1462,7 +1462,7 @@ impl Config {
                         if available_backends.contains(&backend) {
                             panic!("Invalid value '{s}' for 'rust.codegen-backends'. Instead, please use '{backend}'.");
                         } else {
-                            println!("help: '{s}' for 'rust.codegen-backends' might fail. \
+                            println!("HELP: '{s}' for 'rust.codegen-backends' might fail. \
                                 Codegen backends are mostly defined without the '{CODEGEN_BACKEND_PREFIX}' prefix. \
                                 In this case, it would be referred to as '{backend}'.");
                         }
@@ -1806,9 +1806,9 @@ impl Config {
                 }
                 (channel, version) => {
                     let src = self.src.display();
-                    eprintln!("error: failed to determine artifact channel and/or version");
+                    eprintln!("ERROR: failed to determine artifact channel and/or version");
                     eprintln!(
-                        "help: consider using a git checkout or ensure these files are readable"
+                        "HELP: consider using a git checkout or ensure these files are readable"
                     );
                     if let Err(channel) = channel {
                         eprintln!("reading {src}/src/ci/channel failed: {channel:?}");
@@ -2064,10 +2064,10 @@ impl Config {
         );
         let commit = merge_base.trim_end();
         if commit.is_empty() {
-            println!("error: could not find commit hash for downloading rustc");
-            println!("help: maybe your repository history is too shallow?");
-            println!("help: consider disabling `download-rustc`");
-            println!("help: or fetch enough history to include one upstream commit");
+            println!("ERROR: could not find commit hash for downloading rustc");
+            println!("HELP: maybe your repository history is too shallow?");
+            println!("HELP: consider disabling `download-rustc`");
+            println!("HELP: or fetch enough history to include one upstream commit");
             crate::exit!(1);
         }
 
@@ -2081,14 +2081,14 @@ impl Config {
             if if_unchanged {
                 if self.verbose > 0 {
                     println!(
-                        "warning: saw changes to compiler/ or library/ since {commit}; \
+                        "WARNING: saw changes to compiler/ or library/ since {commit}; \
                             ignoring `download-rustc`"
                     );
                 }
                 return None;
             }
             println!(
-                "warning: `download-rustc` is enabled, but there are changes to \
+                "WARNING: `download-rustc` is enabled, but there are changes to \
                     compiler/ or library/"
             );
         }

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -190,7 +190,7 @@ impl Flags {
         if let Ok(HelpVerboseOnly { help: true, verbose: 1.., cmd: subcommand }) =
             HelpVerboseOnly::try_parse_from(it.clone())
         {
-            println!("note: updating submodules before printing available paths");
+            println!("NOTE: updating submodules before printing available paths");
             let config = Config::parse(&[String::from("build")]);
             let build = Build::new(config);
             let paths = Builder::get_help(&build, subcommand);

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -114,7 +114,7 @@ impl Config {
             is_nixos
         });
         if val {
-            eprintln!("info: You seem to be using Nix.");
+            eprintln!("INFO: You seem to be using Nix.");
         }
         val
     }
@@ -606,10 +606,10 @@ impl Config {
 
         let mut help_on_error = "";
         if destination == "ci-rustc" {
-            help_on_error = "error: failed to download pre-built rustc from CI
+            help_on_error = "ERROR: failed to download pre-built rustc from CI
 
-note: old builds get deleted after a certain time
-help: if trying to compile an old commit of rustc, disable `download-rustc` in config.toml:
+NOTE: old builds get deleted after a certain time
+HELP: if trying to compile an old commit of rustc, disable `download-rustc` in config.toml:
 
 [rust]
 download-rustc = false
@@ -685,10 +685,10 @@ download-rustc = false
         let filename = format!("rust-dev-{}-{}.tar.xz", version, self.build.triple);
         let tarball = rustc_cache.join(&filename);
         if !tarball.exists() {
-            let help_on_error = "error: failed to download llvm from ci
+            let help_on_error = "ERROR: failed to download llvm from ci
 
-    help: old builds get deleted after a certain time
-    help: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:
+    HELP: old builds get deleted after a certain time
+    HELP: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:
 
     [llvm]
     download-ci-llvm = false

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1568,7 +1568,7 @@ impl Build {
 
         if !stamp.exists() {
             eprintln!(
-                "Error: Unable to find the stamp file {}, did you try to keep a nonexistent build stage?",
+                "ERROR: Unable to find the stamp file {}, did you try to keep a nonexistent build stage?",
                 stamp.display()
             );
             crate::exit!(1);
@@ -1697,7 +1697,7 @@ impl Build {
         self.verbose_than(1, &format!("Install {src:?} to {dst:?}"));
         t!(fs::create_dir_all(dstdir));
         if !src.exists() {
-            panic!("Error: File \"{}\" not found!", src.display());
+            panic!("ERROR: File \"{}\" not found!", src.display());
         }
         self.copy_internal(src, &dst, true);
         chmod(&dst, perms);

--- a/src/bootstrap/src/utils/bin_helpers.rs
+++ b/src/bootstrap/src/utils/bin_helpers.rs
@@ -22,8 +22,8 @@ pub(crate) fn parse_rustc_verbose() -> usize {
 pub(crate) fn parse_rustc_stage() -> String {
     std::env::var("RUSTC_STAGE").unwrap_or_else(|_| {
         // Don't panic here; it's reasonable to try and run these shims directly. Give a helpful error instead.
-        eprintln!("rustc shim: fatal: RUSTC_STAGE was not set");
-        eprintln!("rustc shim: note: use `x.py build -vvv` to see all environment variables set by bootstrap");
+        eprintln!("rustc shim: FATAL: RUSTC_STAGE was not set");
+        eprintln!("rustc shim: NOTE: use `x.py build -vvv` to see all environment variables set by bootstrap");
         std::process::exit(101);
     })
 }

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -233,7 +233,7 @@ pub fn check_run(cmd: &mut Command, print_cmd_on_fail: bool) -> bool {
     let status = match cmd.status() {
         Ok(status) => status,
         Err(e) => {
-            println!("failed to execute command: {cmd:?}\nerror: {e}");
+            println!("failed to execute command: {cmd:?}\nERROR: {e}");
             return false;
         }
     };
@@ -262,7 +262,7 @@ pub fn make(host: &str) -> PathBuf {
 pub fn output(cmd: &mut Command) -> String {
     let output = match cmd.stderr(Stdio::inherit()).output() {
         Ok(status) => status,
-        Err(e) => fail(&format!("failed to execute command: {cmd:?}\nerror: {e}")),
+        Err(e) => fail(&format!("failed to execute command: {cmd:?}\nERROR: {e}")),
     };
     if !output.status.success() {
         panic!(
@@ -327,7 +327,7 @@ pub(crate) fn absolute(path: &Path) -> PathBuf {
     }
     #[cfg(not(any(unix, windows)))]
     {
-        println!("warning: bootstrap is not supported on non-unix platforms");
+        println!("WARNING: bootstrap is not supported on non-unix platforms");
         t!(std::fs::canonicalize(t!(std::env::current_dir()))).join(path)
     }
 }

--- a/src/bootstrap/src/utils/metrics.rs
+++ b/src/bootstrap/src/utils/metrics.rs
@@ -180,7 +180,7 @@ impl BuildMetrics {
                     t!(serde_json::from_slice::<JsonRoot>(&contents)).invocations
                 } else {
                     println!(
-                        "warning: overriding existing build/metrics.json, as it's not \
+                        "WARNING: overriding existing build/metrics.json, as it's not \
                          compatible with build metrics format version {CURRENT_FORMAT_VERSION}."
                     );
                     Vec::new()

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -197,7 +197,7 @@ impl<'a> Renderer<'a> {
                         println!("{stdout}");
                     }
                     if let Some(message) = &failure.message {
-                        println!("note: {message}");
+                        println!("NOTE: {message}");
                     }
                 }
             }


### PR DESCRIPTION
First 2 commit moves the check of configuration existence to the first step of `x setup`. And then followed by a prompt that allows devs to decide whether to continue with the configuration override or exit bootstrap.

Closes #110471

I can revert the last commit if needed. Maybe it's just me, but I feel it's better to have those tags capitalized. If you think otherwise, please let me know so that I can revert.