### PR TITLE
Add test for reexported hidden item with `--document-hidden-items`

### DIFF
--- a/tests/rustdoc-json/reexport/reexport_of_hidden.rs
+++ b/tests/rustdoc-json/reexport/reexport_of_hidden.rs
@@ -1,0 +1,10 @@
+// compile-flags: --document-hidden-items
+
+// @has "$.index[*].inner[?(@.import.name=='UsedHidden')]"
+// @has "$.index[*][?(@.name=='Hidden')]"
+pub mod submodule {
+    #[doc(hidden)]
+    pub struct Hidden {}
+}
+
+pub use submodule::Hidden as UsedHidden;


### PR DESCRIPTION
Coming from [this discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/Using.20cargo-semver-checks.20in.20rustdoc.20JSON.20tests.3A.20revisited).

cc @aDotInTheVoid
r? @notriddle 