### PR TITLE
speed up `x clean`

### DIFF
--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -139,7 +139,6 @@ fn clean_specific_stage(build: &Build, stage: u32) {
 fn clean_default(build: &Build) {
     rm_rf(&build.out.join("tmp"));
     rm_rf(&build.out.join("dist"));
-    rm_rf(&build.out.join("bootstrap"));
     rm_rf(&build.out.join("rustfmt.stamp"));
 
     for host in &build.hosts {


### PR DESCRIPTION
Since `x clean` runs with bootstrap, we can speed up this process by avoiding the cleaning of bootstrap artifacts, as they are not necessarily needed to be cleaned.

ref #https://github.com/rust-lang/rust/issues/117653#issuecomment-1802482768