### PR TITLE
Emit #[inline] on derive(Debug)

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -33,7 +33,7 @@ pub fn expand_deriving_debug(
             explicit_self: true,
             nonself_args: vec![(fmtr, sym::f)],
             ret_ty: Path(path_std!(fmt::Result)),
-            attributes: ast::AttrVec::new(),
+            attributes: thin_vec![cx.attr_word(sym::inline, span)],
             fieldless_variants_strategy:
                 FieldlessVariantsStrategy::SpecializeIfAllVariantsFieldless,
             combine_substructure: combine_substructure(Box::new(|a, b, c| {

--- a/tests/codegen/simd/unpadded-simd.rs
+++ b/tests/codegen/simd/unpadded-simd.rs
@@ -5,10 +5,15 @@
 #![crate_type = "lib"]
 #![feature(repr_simd)]
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 #[repr(simd)]
 pub struct int16x4_t(pub i16, pub i16, pub i16, pub i16);
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct int16x4x2_t(pub int16x4_t, pub int16x4_t);
+
 // CHECK: %int16x4x2_t = type { <4 x i16>, <4 x i16> }
+#[no_mangle]
+fn takes_int16x4x2_t(t: int16x4x2_t) -> int16x4x2_t {
+    t
+}

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -33,6 +33,7 @@ impl ::core::clone::Clone for Empty {
 impl ::core::marker::Copy for Empty { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Empty {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::write_str(f, "Empty")
     }
@@ -97,6 +98,7 @@ impl ::core::clone::Clone for Point {
 impl ::core::marker::Copy for Point { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Point {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_struct_field2_finish(f, "Point", "x",
             &self.x, "y", &&self.y)
@@ -183,6 +185,7 @@ impl ::core::clone::Clone for PackedPoint {
 impl ::core::marker::Copy for PackedPoint { }
 #[automatically_derived]
 impl ::core::fmt::Debug for PackedPoint {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_struct_field2_finish(f, "PackedPoint",
             "x", &{ self.x }, "y", &&{ self.y })
@@ -276,6 +279,7 @@ impl ::core::clone::Clone for Big {
 impl ::core::marker::Copy for Big { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Big {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         let names: &'static _ =
             &["b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8"];
@@ -475,6 +479,7 @@ impl Copy for PackedManualCopy {}
 struct Unsized([u32]);
 #[automatically_derived]
 impl ::core::fmt::Debug for Unsized {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_tuple_field1_finish(f, "Unsized",
             &&self.0)
@@ -527,6 +532,7 @@ impl ::core::cmp::Ord for Unsized {
 struct PackedUnsizedU8([u8]);
 #[automatically_derived]
 impl ::core::fmt::Debug for PackedUnsizedU8 {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_tuple_field1_finish(f,
             "PackedUnsizedU8", &&self.0)
@@ -569,6 +575,7 @@ impl<T: ::core::marker::Copy + Trait, U: ::core::marker::Copy>
 #[automatically_derived]
 impl<T: ::core::fmt::Debug + Trait, U: ::core::fmt::Debug> ::core::fmt::Debug
     for Generic<T, U> where T::A: ::core::fmt::Debug {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_struct_field3_finish(f, "Generic", "t",
             &self.t, "ta", &self.ta, "u", &&self.u)
@@ -687,6 +694,7 @@ impl<T: ::core::fmt::Debug + ::core::marker::Copy + Trait,
     U: ::core::fmt::Debug + ::core::marker::Copy> ::core::fmt::Debug for
     PackedGeneric<T, U> where T::A: ::core::fmt::Debug + ::core::marker::Copy
     {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::debug_tuple_field3_finish(f, "PackedGeneric",
             &{ self.0 }, &{ self.1 }, &&{ self.2 })
@@ -797,6 +805,7 @@ impl ::core::clone::Clone for Enum0 {
 impl ::core::marker::Copy for Enum0 { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Enum0 {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match *self {}
     }
@@ -856,6 +865,7 @@ impl ::core::clone::Clone for Enum1 {
 }
 #[automatically_derived]
 impl ::core::fmt::Debug for Enum1 {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match self {
             Enum1::Single { x: __self_0 } =>
@@ -932,6 +942,7 @@ impl ::core::clone::Clone for Fieldless1 {
 }
 #[automatically_derived]
 impl ::core::fmt::Debug for Fieldless1 {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::write_str(f, "A")
     }
@@ -995,6 +1006,7 @@ impl ::core::clone::Clone for Fieldless {
 impl ::core::marker::Copy for Fieldless { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Fieldless {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         ::core::fmt::Formatter::write_str(f,
             match self {
@@ -1083,6 +1095,7 @@ impl ::core::clone::Clone for Mixed {
 impl ::core::marker::Copy for Mixed { }
 #[automatically_derived]
 impl ::core::fmt::Debug for Mixed {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match self {
             Mixed::P => ::core::fmt::Formatter::write_str(f, "P"),
@@ -1217,6 +1230,7 @@ impl ::core::clone::Clone for Fielded {
 }
 #[automatically_derived]
 impl ::core::fmt::Debug for Fielded {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match self {
             Fielded::X(__self_0) =>
@@ -1341,6 +1355,7 @@ impl<T: ::core::marker::Copy, U: ::core::marker::Copy> ::core::marker::Copy
 #[automatically_derived]
 impl<T: ::core::fmt::Debug, U: ::core::fmt::Debug> ::core::fmt::Debug for
     EnumGeneric<T, U> {
+    #[inline]
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match self {
             EnumGeneric::One(__self_0) =>


### PR DESCRIPTION
While working on https://github.com/rust-lang/rust/pull/116583 I noticed that the `cross_crate_inlinable` query identifies a lot of derived `Debug` impls as a MIR body that's little more than a call, which suggests they may be a good candidate for `#[inline]`. So here I've implemented that change specifically.

It seems to provide a nice improvement to build times.