### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -168,12 +168,9 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
-    // FIXME(matthewjasper) We shouldn't need to use `track_errors`.
-    tcx.sess.track_errors(|| {
-        tcx.sess.time("type_collecting", || {
-            tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
-        });
-    })?;
+    tcx.sess.time("type_collecting", || {
+        tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
+    });
 
     if tcx.features().rustc_attrs {
         tcx.sess.track_errors(|| {

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -163,6 +163,7 @@ pub fn provide(providers: &mut Providers) {
     hir_wf_check::provide(providers);
 }
 
+// FIXME(matthewjasper) We shouldn't need to use `track_errors` in this function.
 pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
     let _prof_timer = tcx.sess.timer("type_check_crate");
 

--- a/compiler/rustc_hir_analysis/src/outlives/test.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/test.rs
@@ -8,14 +8,12 @@ pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
         // attribute and report an error with various results if found.
         if tcx.has_attr(id.owner_id, sym::rustc_outlives) {
             let inferred_outlives_of = tcx.inferred_outlives_of(id.owner_id);
-            struct_span_err!(
-                tcx.sess,
-                tcx.def_span(id.owner_id),
-                E0640,
-                "{:?}",
-                inferred_outlives_of
-            )
-            .emit();
+            let mut err =
+                struct_span_err!(tcx.sess, tcx.def_span(id.owner_id), E0640, "rustc_outlives");
+            for &(clause, span) in inferred_outlives_of {
+                err.span_note(span, format!("{clause}"));
+            }
+            err.emit();
         }
     }
 }

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -480,6 +480,14 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     // it prevents control flow from "falling through" into whatever code
     // happens to be laid out next in memory.
     Options.TrapUnreachable = true;
+    // But don't emit traps after other traps or no-returns unnecessarily.
+    // ...except for when targeting WebAssembly, because the NoTrapAfterNoreturn
+    // option causes bugs in the LLVM WebAssembly backend. You should be able to
+    // remove this check when Rust's minimum supported LLVM version is >= 18
+    // https://github.com/llvm/llvm-project/pull/65876
+    if (!Trip.isWasm()) {
+      Options.NoTrapAfterNoreturn = true;
+    }
   }
 
   if (Singlethread) {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -24,6 +24,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
 #![feature(cfg_match)]
+#![feature(core_io_borrowed_buf)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(min_specialization)]

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -279,6 +279,12 @@ pub fn normalize_param_env_or_error<'tcx>(
                 }
 
                 fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
+                    // FIXME(return_type_notation): track binders in this normalizer, as
+                    // `ty::Const::normalize` can only work with properly preserved binders.
+
+                    if c.has_escaping_bound_vars() {
+                        return ty::Const::new_misc_error(self.0, c.ty());
+                    }
                     // While it is pretty sus to be evaluating things with an empty param env, it
                     // should actually be okay since without `feature(generic_const_exprs)` the only
                     // const arguments that have a non-empty param env are array repeat counts. These

--- a/library/core/src/internal_macros.rs
+++ b/library/core/src/internal_macros.rs
@@ -31,6 +31,7 @@ macro_rules! forward_ref_binop {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: $u) -> <$t as $imp<$u>>::Output {
                 $imp::$method(*self, other)
             }
@@ -41,6 +42,7 @@ macro_rules! forward_ref_binop {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: &$u) -> <$t as $imp<$u>>::Output {
                 $imp::$method(self, *other)
             }
@@ -51,6 +53,7 @@ macro_rules! forward_ref_binop {
             type Output = <$t as $imp<$u>>::Output;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: &$u) -> <$t as $imp<$u>>::Output {
                 $imp::$method(*self, *other)
             }
@@ -69,6 +72,7 @@ macro_rules! forward_ref_op_assign {
         #[$attr]
         impl $imp<&$u> for $t {
             #[inline]
+            #[track_caller]
             fn $method(&mut self, other: &$u) {
                 $imp::$method(self, *other);
             }

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -1,10 +1,6 @@
-#![unstable(feature = "read_buf", issue = "78485")]
-
-#[cfg(test)]
-mod tests;
+#![unstable(feature = "core_io_borrowed_buf", issue = "117693")]
 
 use crate::fmt::{self, Debug, Formatter};
-use crate::io::{Result, Write};
 use crate::mem::{self, MaybeUninit};
 use crate::{cmp, ptr};
 
@@ -301,18 +297,5 @@ impl<'a> BorrowedCursor<'a> {
             self.set_init(buf.len());
         }
         self.buf.filled += buf.len();
-    }
-}
-
-impl<'a> Write for BorrowedCursor<'a> {
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        let amt = cmp::min(buf.len(), self.capacity());
-        self.append(&buf[..amt]);
-        Ok(amt)
-    }
-
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        Ok(())
     }
 }

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -1,0 +1,6 @@
+//! Traits, helpers, and type definitions for core I/O functionality.
+
+mod borrowed_buf;
+
+#[unstable(feature = "core_io_borrowed_buf", issue = "117693")]
+pub use self::borrowed_buf::{BorrowedBuf, BorrowedCursor};

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -369,6 +369,8 @@ pub mod async_iter;
 pub mod cell;
 pub mod char;
 pub mod ffi;
+#[unstable(feature = "core_io_borrowed_buf", issue = "117693")]
+pub mod io;
 pub mod iter;
 pub mod net;
 pub mod option;

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -98,6 +98,7 @@ macro_rules! add_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn add(self, other: $t) -> $t { self + other }
         }
@@ -206,6 +207,7 @@ macro_rules! sub_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn sub(self, other: $t) -> $t { self - other }
         }
@@ -335,6 +337,7 @@ macro_rules! mul_impl {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn mul(self, other: $t) -> $t { self * other }
         }
@@ -474,6 +477,7 @@ macro_rules! div_impl_integer {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             fn div(self, other: $t) -> $t { self / other }
         }
 
@@ -575,6 +579,7 @@ macro_rules! rem_impl_integer {
             type Output = $t;
 
             #[inline]
+            #[track_caller]
             fn rem(self, other: $t) -> $t { self % other }
         }
 
@@ -749,6 +754,7 @@ macro_rules! add_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl AddAssign for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn add_assign(&mut self, other: $t) { *self += other }
         }
@@ -815,6 +821,7 @@ macro_rules! sub_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl SubAssign for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn sub_assign(&mut self, other: $t) { *self -= other }
         }
@@ -872,6 +879,7 @@ macro_rules! mul_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl MulAssign for $t {
             #[inline]
+            #[track_caller]
             #[rustc_inherit_overflow_checks]
             fn mul_assign(&mut self, other: $t) { *self *= other }
         }
@@ -929,6 +937,7 @@ macro_rules! div_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl DivAssign for $t {
             #[inline]
+            #[track_caller]
             fn div_assign(&mut self, other: $t) { *self /= other }
         }
 
@@ -989,6 +998,7 @@ macro_rules! rem_assign_impl {
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl RemAssign for $t {
             #[inline]
+            #[track_caller]
             fn rem_assign(&mut self, other: $t) { *self %= other }
         }
 

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -4,25 +4,11 @@
 //! threads, and are the building blocks of other concurrent
 //! types.
 //!
-//! Rust atomics currently follow the same rules as [C++20 atomics][cpp], specifically `atomic_ref`.
-//! Basically, creating a *shared reference* to one of the Rust atomic types corresponds to creating
-//! an `atomic_ref` in C++; the `atomic_ref` is destroyed when the lifetime of the shared reference
-//! ends. (A Rust atomic type that is exclusively owned or behind a mutable reference does *not*
-//! correspond to an "atomic object" in C++, since it can be accessed via non-atomic operations.)
-//!
 //! This module defines atomic versions of a select number of primitive
 //! types, including [`AtomicBool`], [`AtomicIsize`], [`AtomicUsize`],
 //! [`AtomicI8`], [`AtomicU16`], etc.
 //! Atomic types present operations that, when used correctly, synchronize
 //! updates between threads.
-//!
-//! Each method takes an [`Ordering`] which represents the strength of
-//! the memory barrier for that operation. These orderings are the
-//! same as the [C++20 atomic orderings][1]. For more information see the [nomicon][2].
-//!
-//! [cpp]: https://en.cppreference.com/w/cpp/atomic
-//! [1]: https://en.cppreference.com/w/cpp/atomic/memory_order
-//! [2]: ../../../nomicon/atomics.html
 //!
 //! Atomic variables are safe to share between threads (they implement [`Sync`])
 //! but they do not themselves provide the mechanism for sharing and follow the
@@ -35,6 +21,75 @@
 //! Atomic types may be stored in static variables, initialized using
 //! the constant initializers like [`AtomicBool::new`]. Atomic statics
 //! are often used for lazy global initialization.
+//!
+//! ## Memory model for atomic accesses
+//!
+//! Rust atomics currently follow the same rules as [C++20 atomics][cpp], specifically `atomic_ref`.
+//! Basically, creating a *shared reference* to one of the Rust atomic types corresponds to creating
+//! an `atomic_ref` in C++; the `atomic_ref` is destroyed when the lifetime of the shared reference
+//! ends. (A Rust atomic type that is exclusively owned or behind a mutable reference does *not*
+//! correspond to an "atomic object" in C++, since it can be accessed via non-atomic operations.)
+//!
+//! [cpp]: https://en.cppreference.com/w/cpp/atomic
+//!
+//! Each method takes an [`Ordering`] which represents the strength of
+//! the memory barrier for that operation. These orderings are the
+//! same as the [C++20 atomic orderings][1]. For more information see the [nomicon][2].
+//!
+//! [1]: https://en.cppreference.com/w/cpp/atomic/memory_order
+//! [2]: ../../../nomicon/atomics.html
+//!
+//! Since C++ does not support mixing atomic and non-atomic accesses, or non-synchronized
+//! different-sized accesses to the same data, Rust does not support those operations either.
+//! Note that both of those restrictions only apply if the accesses are non-synchronized.
+//!
+//! ```rust,no_run undefined_behavior
+//! use std::sync::atomic::{AtomicU16, AtomicU8, Ordering};
+//! use std::mem::transmute;
+//! use std::thread;
+//!
+//! let atomic = AtomicU16::new(0);
+//!
+//! thread::scope(|s| {
+//!     // This is UB: mixing atomic and non-atomic accesses
+//!     s.spawn(|| atomic.store(1, Ordering::Relaxed));
+//!     s.spawn(|| unsafe { atomic.as_ptr().write(2) });
+//! });
+//!
+//! thread::scope(|s| {
+//!     // This is UB: even reads are not allowed to be mixed
+//!     s.spawn(|| atomic.load(Ordering::Relaxed));
+//!     s.spawn(|| unsafe { atomic.as_ptr().read() });
+//! });
+//!
+//! thread::scope(|s| {
+//!     // This is fine, `join` synchronizes the code in a way such that atomic
+//!     // and non-atomic accesses can't happen "at the same time"
+//!     let handle = s.spawn(|| atomic.store(1, Ordering::Relaxed));
+//!     handle.join().unwrap();
+//!     s.spawn(|| unsafe { atomic.as_ptr().write(2) });
+//! });
+//!
+//! thread::scope(|s| {
+//!     // This is UB: using different-sized atomic accesses to the same data
+//!     s.spawn(|| atomic.store(1, Ordering::Relaxed));
+//!     s.spawn(|| unsafe {
+//!         let differently_sized = transmute::<&AtomicU16, &AtomicU8>(&atomic);
+//!         differently_sized.store(2, Ordering::Relaxed);
+//!     });
+//! });
+//!
+//! thread::scope(|s| {
+//!     // This is fine, `join` synchronizes the code in a way such that
+//!     // differently-sized accesses can't happen "at the same time"
+//!     let handle = s.spawn(|| atomic.store(1, Ordering::Relaxed));
+//!     handle.join().unwrap();
+//!     s.spawn(|| unsafe {
+//!         let differently_sized = transmute::<&AtomicU16, &AtomicU8>(&atomic);
+//!         differently_sized.store(2, Ordering::Relaxed);
+//!     });
+//! });
+//! ```
 //!
 //! # Portability
 //!
@@ -349,16 +404,12 @@ impl AtomicBool {
     /// * `ptr` must be aligned to `align_of::<AtomicBool>()` (note that on some platforms this can
     ///   be bigger than `align_of::<bool>()`).
     /// * `ptr` must be [valid] for both reads and writes for the whole lifetime `'a`.
-    /// * Non-atomic accesses to the value behind `ptr` must have a happens-before relationship
-    ///   with atomic accesses via the returned value (or vice-versa).
-    ///   * In other words, time periods where the value is accessed atomically may not overlap
-    ///     with periods where the value is accessed non-atomically.
-    ///   * This requirement is trivially satisfied if `ptr` is never used non-atomically for the
-    ///     duration of lifetime `'a`. Most use cases should be able to follow this guideline.
-    ///   * This requirement is also trivially satisfied if all accesses (atomic or not) are done
-    ///     from the same thread.
+    /// * You must adhere to the [Memory model for atomic accesses]. In particular, it is not
+    ///   allowed to mix atomic and non-atomic accesses, or atomic accesses of different sizes,
+    ///   without synchronization.
     ///
     /// [valid]: crate::ptr#safety
+    /// [Memory model for atomic accesses]: self#memory-model-for-atomic-accesses
     #[stable(feature = "atomic_from_ptr", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_atomic_from_ptr", issue = "108652")]
     pub const unsafe fn from_ptr<'a>(ptr: *mut bool) -> &'a AtomicBool {
@@ -1151,18 +1202,12 @@ impl<T> AtomicPtr<T> {
     /// * `ptr` must be aligned to `align_of::<AtomicPtr<T>>()` (note that on some platforms this
     ///   can be bigger than `align_of::<*mut T>()`).
     /// * `ptr` must be [valid] for both reads and writes for the whole lifetime `'a`.
-    /// * Non-atomic accesses to the value behind `ptr` must have a happens-before relationship
-    ///   with atomic accesses via the returned value (or vice-versa).
-    ///   * In other words, time periods where the value is accessed atomically may not overlap
-    ///     with periods where the value is accessed non-atomically.
-    ///   * This requirement is trivially satisfied if `ptr` is never used non-atomically for the
-    ///     duration of lifetime `'a`. Most use cases should be able to follow this guideline.
-    ///   * This requirement is also trivially satisfied if all accesses (atomic or not) are done
-    ///     from the same thread.
-    /// * This method should not be used to create overlapping or mixed-size atomic accesses, as
-    ///   these are not supported by the memory model.
+    /// * You must adhere to the [Memory model for atomic accesses]. In particular, it is not
+    ///   allowed to mix atomic and non-atomic accesses, or atomic accesses of different sizes,
+    ///   without synchronization.
     ///
     /// [valid]: crate::ptr#safety
+    /// [Memory model for atomic accesses]: self#memory-model-for-atomic-accesses
     #[stable(feature = "atomic_from_ptr", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_atomic_from_ptr", issue = "108652")]
     pub const unsafe fn from_ptr<'a>(ptr: *mut *mut T) -> &'a AtomicPtr<T> {
@@ -2133,19 +2178,12 @@ macro_rules! atomic_int {
                 `align_of::<", stringify!($atomic_type), ">()` (note that on some platforms this \
                 can be bigger than `align_of::<", stringify!($int_type), ">()`).")]
             /// * `ptr` must be [valid] for both reads and writes for the whole lifetime `'a`.
-            /// * Non-atomic accesses to the value behind `ptr` must have a happens-before
-            ///   relationship with atomic accesses via the returned value (or vice-versa).
-            ///   * In other words, time periods where the value is accessed atomically may not
-            ///     overlap with periods where the value is accessed non-atomically.
-            ///   * This requirement is trivially satisfied if `ptr` is never used non-atomically
-            ///     for the duration of lifetime `'a`. Most use cases should be able to follow
-            ///     this guideline.
-            ///   * This requirement is also trivially satisfied if all accesses (atomic or not) are
-            ///     done from the same thread.
-            /// * This method should not be used to create overlapping or mixed-size atomic
-            ///   accesses, as these are not supported by the memory model.
+            /// * You must adhere to the [Memory model for atomic accesses]. In particular, it is not
+            ///   allowed to mix atomic and non-atomic accesses, or atomic accesses of different sizes,
+            ///   without synchronization.
             ///
             /// [valid]: crate::ptr#safety
+            /// [Memory model for atomic accesses]: self#memory-model-for-atomic-accesses
             #[stable(feature = "atomic_from_ptr", since = "CURRENT_RUSTC_VERSION")]
             #[rustc_const_unstable(feature = "const_atomic_from_ptr", issue = "108652")]
             pub const unsafe fn from_ptr<'a>(ptr: *mut $int_type) -> &'a $atomic_type {

--- a/library/core/tests/io/borrowed_buf.rs
+++ b/library/core/tests/io/borrowed_buf.rs
@@ -1,5 +1,5 @@
-use super::BorrowedBuf;
-use crate::mem::MaybeUninit;
+use core::io::BorrowedBuf;
+use core::mem::MaybeUninit;
 
 /// Test that BorrowedBuf has the correct numbers when created with new
 #[test]

--- a/library/core/tests/io/mod.rs
+++ b/library/core/tests/io/mod.rs
@@ -1,0 +1,1 @@
+mod borrowed_buf;

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(const_likely)]
 #![feature(const_location_fields)]
 #![feature(core_intrinsics)]
+#![feature(core_io_borrowed_buf)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
 #![feature(dec2flt)]
@@ -135,6 +136,7 @@ mod fmt;
 mod future;
 mod hash;
 mod intrinsics;
+mod io;
 mod iter;
 mod lazy;
 #[cfg(test)]

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -22,7 +22,7 @@ use crate::os::unix::fs::symlink as symlink_file;
 #[cfg(unix)]
 use crate::os::unix::fs::symlink as symlink_junction;
 #[cfg(windows)]
-use crate::os::windows::fs::{symlink_dir, symlink_file};
+use crate::os::windows::fs::{symlink_dir, symlink_file, OpenOptionsExt};
 #[cfg(windows)]
 use crate::sys::fs::symlink_junction;
 #[cfg(target_os = "macos")]
@@ -1741,4 +1741,29 @@ fn windows_unix_socket_exists() {
     assert_eq!(socket_path.exists(), true);
     assert_eq!(socket_path.try_exists().unwrap(), true);
     assert_eq!(socket_path.metadata().is_ok(), true);
+}
+
+#[cfg(windows)]
+#[test]
+fn test_hidden_file_truncation() {
+    // Make sure that File::create works on an existing hidden file. See #115745.
+    let tmpdir = tmpdir();
+    let path = tmpdir.join("hidden_file.txt");
+
+    // Create a hidden file.
+    const FILE_ATTRIBUTE_HIDDEN: u32 = 2;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .attributes(FILE_ATTRIBUTE_HIDDEN)
+        .open(&path)
+        .unwrap();
+    file.write("hidden world!".as_bytes()).unwrap();
+    file.flush().unwrap();
+    drop(file);
+
+    // Create a new file by truncating the existing one.
+    let file = File::create(&path).unwrap();
+    let metadata = file.metadata().unwrap();
+    assert_eq!(metadata.len(), 0);
 }

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -528,3 +528,17 @@ impl<A: Allocator> Write for VecDeque<u8, A> {
         Ok(())
     }
 }
+
+#[unstable(feature = "read_buf", issue = "78485")]
+impl<'a> io::Write for core::io::BorrowedCursor<'a> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let amt = cmp::min(buf.len(), self.capacity());
+        self.append(&buf[..amt]);
+        Ok(amt)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -330,7 +330,7 @@ pub use self::{
 };
 
 #[unstable(feature = "read_buf", issue = "78485")]
-pub use self::readbuf::{BorrowedBuf, BorrowedCursor};
+pub use core::io::{BorrowedBuf, BorrowedCursor};
 pub(crate) use error::const_io_error;
 
 mod buffered;
@@ -339,7 +339,6 @@ mod cursor;
 mod error;
 mod impls;
 pub mod prelude;
-mod readbuf;
 mod stdio;
 mod util;
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -310,6 +310,7 @@
 // tidy-alphabetical-start
 #![feature(char_internals)]
 #![feature(core_intrinsics)]
+#![feature(core_io_borrowed_buf)]
 #![feature(duration_constants)]
 #![feature(error_generic_member_access)]
 #![feature(error_in_core)]

--- a/library/std/src/sys/windows/c/windows_sys.lst
+++ b/library/std/src/sys/windows/c/windows_sys.lst
@@ -2224,6 +2224,7 @@ Windows.Win32.Storage.FileSystem.FILE_ACCESS_RIGHTS
 Windows.Win32.Storage.FileSystem.FILE_ADD_FILE
 Windows.Win32.Storage.FileSystem.FILE_ADD_SUBDIRECTORY
 Windows.Win32.Storage.FileSystem.FILE_ALL_ACCESS
+Windows.Win32.Storage.FileSystem.FILE_ALLOCATION_INFO
 Windows.Win32.Storage.FileSystem.FILE_APPEND_DATA
 Windows.Win32.Storage.FileSystem.FILE_ATTRIBUTE_ARCHIVE
 Windows.Win32.Storage.FileSystem.FILE_ATTRIBUTE_COMPRESSED

--- a/library/std/src/sys/windows/c/windows_sys.rs
+++ b/library/std/src/sys/windows/c/windows_sys.rs
@@ -3107,6 +3107,16 @@ impl ::core::clone::Clone for FILETIME {
 pub type FILE_ACCESS_RIGHTS = u32;
 pub const FILE_ADD_FILE: FILE_ACCESS_RIGHTS = 2u32;
 pub const FILE_ADD_SUBDIRECTORY: FILE_ACCESS_RIGHTS = 4u32;
+#[repr(C)]
+pub struct FILE_ALLOCATION_INFO {
+    pub AllocationSize: i64,
+}
+impl ::core::marker::Copy for FILE_ALLOCATION_INFO {}
+impl ::core::clone::Clone for FILE_ALLOCATION_INFO {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 pub const FILE_ALL_ACCESS: FILE_ACCESS_RIGHTS = 2032127u32;
 pub const FILE_APPEND_DATA: FILE_ACCESS_RIGHTS = 4u32;
 pub const FILE_ATTRIBUTE_ARCHIVE: FILE_FLAGS_AND_ATTRIBUTES = 32u32;

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -1,7 +1,7 @@
 use crate::os::windows::prelude::*;
 
 use crate::borrow::Cow;
-use crate::ffi::OsString;
+use crate::ffi::{c_void, OsString};
 use crate::fmt;
 use crate::io::{self, BorrowedCursor, Error, IoSlice, IoSliceMut, SeekFrom};
 use crate::mem::{self, MaybeUninit};
@@ -15,8 +15,6 @@ use crate::sys::time::SystemTime;
 use crate::sys::{c, cvt, Align8};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::thread;
-
-use core::ffi::c_void;
 
 use super::path::maybe_verbatim;
 use super::to_u16s;
@@ -273,7 +271,9 @@ impl OpenOptions {
             (false, false, false) => c::OPEN_EXISTING,
             (true, false, false) => c::OPEN_ALWAYS,
             (false, true, false) => c::TRUNCATE_EXISTING,
-            (true, true, false) => c::CREATE_ALWAYS,
+            // `CREATE_ALWAYS` has weird semantics so we emulate it using
+            // `OPEN_ALWAYS` and a manual truncation step. See #115745.
+            (true, true, false) => c::OPEN_ALWAYS,
             (_, _, true) => c::CREATE_NEW,
         })
     }
@@ -289,19 +289,40 @@ impl OpenOptions {
 impl File {
     pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
         let path = maybe_verbatim(path)?;
+        let creation = opts.get_creation_mode()?;
         let handle = unsafe {
             c::CreateFileW(
                 path.as_ptr(),
                 opts.get_access_mode()?,
                 opts.share_mode,
                 opts.security_attributes,
-                opts.get_creation_mode()?,
+                creation,
                 opts.get_flags_and_attributes(),
                 ptr::null_mut(),
             )
         };
         let handle = unsafe { HandleOrInvalid::from_raw_handle(handle) };
-        if let Ok(handle) = handle.try_into() {
+        if let Ok(handle) = OwnedHandle::try_from(handle) {
+            // Manual truncation. See #115745.
+            if opts.truncate
+                && creation == c::OPEN_ALWAYS
+                && unsafe { c::GetLastError() } == c::ERROR_ALREADY_EXISTS
+            {
+                unsafe {
+                    // Setting the allocation size to zero also sets the
+                    // EOF position to zero.
+                    let alloc = c::FILE_ALLOCATION_INFO { AllocationSize: 0 };
+                    let result = c::SetFileInformationByHandle(
+                        handle.as_raw_handle(),
+                        c::FileAllocationInfo,
+                        ptr::addr_of!(alloc).cast::<c_void>(),
+                        mem::size_of::<c::FILE_ALLOCATION_INFO>() as u32,
+                    );
+                    if result == 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
+            }
             Ok(File { handle: Handle::from_inner(handle) })
         } else {
             Err(Error::last_os_error())

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -32,6 +32,9 @@ fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
     let arg = |name| args.windows(2).find(|args| args[0] == name).and_then(|args| args[1].to_str());
 
+    // We don't use the stage in this shim, but let's parse it to make sure that we're invoked
+    // by bootstrap, or that we provide a helpful error message if not.
+    bin_helpers::parse_rustc_stage();
     let verbose = bin_helpers::parse_rustc_verbose();
 
     // Detect whether or not we're a build script depending on whether --target

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -139,7 +139,6 @@ fn clean_specific_stage(build: &Build, stage: u32) {
 fn clean_default(build: &Build) {
     rm_rf(&build.out.join("tmp"));
     rm_rf(&build.out.join("dist"));
-    rm_rf(&build.out.join("bootstrap"));
     rm_rf(&build.out.join("rustfmt.stamp"));
 
     for host in &build.hosts {

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -89,7 +89,7 @@ fn get_modified_rs_files(build: &Builder<'_>) -> Result<Option<Vec<String>>, Str
         return Ok(None);
     }
 
-    get_git_modified_files(Some(&build.config.src), &vec!["rs"])
+    get_git_modified_files(&build.config.git_config(), Some(&build.config.src), &vec!["rs"])
 }
 
 #[derive(serde_derive::Deserialize)]

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -132,8 +132,8 @@ pub(crate) fn detect_llvm_sha(config: &Config, is_git: bool) -> String {
         // walk back further to the last bors merge commit that actually changed LLVM. The first
         // step will fail on CI because only the `auto` branch exists; we just fall back to `HEAD`
         // in that case.
-        let closest_upstream =
-            get_git_merge_base(Some(&config.src)).unwrap_or_else(|_| "HEAD".into());
+        let closest_upstream = get_git_merge_base(&config.git_config(), Some(&config.src))
+            .unwrap_or_else(|_| "HEAD".into());
         let mut rev_list = config.git();
         rev_list.args(&[
             PathBuf::from("rev-list"),

--- a/src/bootstrap/src/core/build_steps/suggest.rs
+++ b/src/bootstrap/src/core/build_steps/suggest.rs
@@ -12,7 +12,7 @@ pub fn suggest(builder: &Builder<'_>, run: bool) {
     let git_config = builder.config.git_config();
     let suggestions = builder
         .tool_cmd(Tool::SuggestTests)
-        .env("SUGGEST_TESTS_GITHUB_REPOSITORY", git_config.github_repository)
+        .env("SUGGEST_TESTS_GIT_REPOSITORY", git_config.git_repository)
         .env("SUGGEST_TESTS_NIGHTLY_BRANCH", git_config.nightly_branch)
         .output()
         .expect("failed to run `suggest-tests` tool");

--- a/src/bootstrap/src/core/build_steps/suggest.rs
+++ b/src/bootstrap/src/core/build_steps/suggest.rs
@@ -9,8 +9,13 @@ use crate::core::builder::Builder;
 
 /// Suggests a list of possible `x.py` commands to run based on modified files in branch.
 pub fn suggest(builder: &Builder<'_>, run: bool) {
-    let suggestions =
-        builder.tool_cmd(Tool::SuggestTests).output().expect("failed to run `suggest-tests` tool");
+    let git_config = builder.config.git_config();
+    let suggestions = builder
+        .tool_cmd(Tool::SuggestTests)
+        .env("SUGGEST_TESTS_GITHUB_REPOSITORY", git_config.github_repository)
+        .env("SUGGEST_TESTS_NIGHTLY_BRANCH", git_config.nightly_branch)
+        .output()
+        .expect("failed to run `suggest-tests` tool");
 
     if !suggestions.status.success() {
         println!("failed to run `suggest-tests` tool ({})", suggestions.status);

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1873,6 +1873,10 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             cmd.arg("--git-hash");
         }
 
+        let git_config = builder.config.git_config();
+        cmd.arg("--github-repository").arg(git_config.github_repository);
+        cmd.arg("--nightly-branch").arg(git_config.nightly_branch);
+
         builder.ci_env.force_coloring_in_ci(&mut cmd);
 
         #[cfg(feature = "build-metrics")]

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1874,7 +1874,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         }
 
         let git_config = builder.config.git_config();
-        cmd.arg("--github-repository").arg(git_config.github_repository);
+        cmd.arg("--git-repository").arg(git_config.git_repository);
         cmd.arg("--nightly-branch").arg(git_config.nightly_branch);
 
         builder.ci_env.force_coloring_in_ci(&mut cmd);

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -319,7 +319,7 @@ pub struct Stage0Config {
     pub artifacts_server: String,
     pub artifacts_with_llvm_assertions_server: String,
     pub git_merge_commit_email: String,
-    pub github_repository: String,
+    pub git_repository: String,
     pub nightly_branch: String,
 }
 #[derive(Default, Deserialize, Clone)]
@@ -2009,7 +2009,7 @@ impl Config {
 
     pub fn git_config(&self) -> GitConfig<'_> {
         GitConfig {
-            github_repository: &self.stage0_metadata.config.github_repository,
+            git_repository: &self.stage0_metadata.config.git_repository,
             nightly_branch: &self.stage0_metadata.config.nightly_branch,
         }
     }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Deserializer};
 use serde_derive::Deserialize;
 
 pub use crate::core::config::flags::Subcommand;
+use build_helper::git::GitConfig;
 
 macro_rules! check_ci_llvm {
     ($name:expr) => {
@@ -318,6 +319,7 @@ pub struct Stage0Config {
     pub artifacts_server: String,
     pub artifacts_with_llvm_assertions_server: String,
     pub git_merge_commit_email: String,
+    pub github_repository: String,
     pub nightly_branch: String,
 }
 #[derive(Default, Deserialize, Clone)]
@@ -2003,6 +2005,13 @@ impl Config {
 
     pub fn default_codegen_backend(&self) -> Option<Interned<String>> {
         self.rust_codegen_backends.get(0).cloned()
+    }
+
+    pub fn git_config(&self) -> GitConfig<'_> {
+        GitConfig {
+            github_repository: &self.stage0_metadata.config.github_repository,
+            nightly_branch: &self.stage0_metadata.config.nightly_branch,
+        }
     }
 
     pub fn check_build_rustc_version(&self, rustc_path: &str) {

--- a/src/bootstrap/src/utils/bin_helpers.rs
+++ b/src/bootstrap/src/utils/bin_helpers.rs
@@ -18,7 +18,6 @@ pub(crate) fn parse_rustc_verbose() -> usize {
 /// Parses the value of the "RUSTC_STAGE" environment variable and returns it as a `String`.
 ///
 /// If "RUSTC_STAGE" was not set, the program will be terminated with 101.
-#[allow(unused)]
 pub(crate) fn parse_rustc_stage() -> String {
     std::env::var("RUSTC_STAGE").unwrap_or_else(|_| {
         // Don't panic here; it's reasonable to try and run these shims directly. Give a helpful error instead.

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -4,7 +4,7 @@
     "artifacts_server": "https://ci-artifacts.rust-lang.org/rustc-builds",
     "artifacts_with_llvm_assertions_server": "https://ci-artifacts.rust-lang.org/rustc-builds-alt",
     "git_merge_commit_email": "bors@rust-lang.org",
-    "github_repository": "rust-lang/rust",
+    "git_repository": "rust-lang/rust",
     "nightly_branch": "master"
   },
   "__comments": [

--- a/src/stage0.json
+++ b/src/stage0.json
@@ -4,6 +4,7 @@
     "artifacts_server": "https://ci-artifacts.rust-lang.org/rustc-builds",
     "artifacts_with_llvm_assertions_server": "https://ci-artifacts.rust-lang.org/rustc-builds-alt",
     "git_merge_commit_email": "bors@rust-lang.org",
+    "github_repository": "rust-lang/rust",
     "nightly_branch": "master"
   },
   "__comments": [

--- a/src/tools/build_helper/src/git.rs
+++ b/src/tools/build_helper/src/git.rs
@@ -2,7 +2,7 @@ use std::process::Stdio;
 use std::{path::Path, process::Command};
 
 pub struct GitConfig<'a> {
-    pub github_repository: &'a str,
+    pub git_repository: &'a str,
     pub nightly_branch: &'a str,
 }
 
@@ -45,8 +45,8 @@ pub fn get_rust_lang_rust_remote(
 
     let rust_lang_remote = stdout
         .lines()
-        .find(|remote| remote.contains(config.github_repository))
-        .ok_or_else(|| format!("{} remote not found", config.github_repository))?;
+        .find(|remote| remote.contains(config.git_repository))
+        .ok_or_else(|| format!("{} remote not found", config.git_repository))?;
 
     let remote_name =
         rust_lang_remote.split('.').nth(1).ok_or_else(|| "remote name not found".to_owned())?;

--- a/src/tools/build_helper/src/git.rs
+++ b/src/tools/build_helper/src/git.rs
@@ -1,6 +1,11 @@
 use std::process::Stdio;
 use std::{path::Path, process::Command};
 
+pub struct GitConfig<'a> {
+    pub github_repository: &'a str,
+    pub nightly_branch: &'a str,
+}
+
 /// Runs a command and returns the output
 fn output_result(cmd: &mut Command) -> Result<String, String> {
     let output = match cmd.stderr(Stdio::inherit()).output() {
@@ -27,7 +32,10 @@ fn output_result(cmd: &mut Command) -> Result<String, String> {
 /// upstream        https://github.com/rust-lang/rust (fetch)
 /// upstream        https://github.com/rust-lang/rust (push)
 /// ```
-pub fn get_rust_lang_rust_remote(git_dir: Option<&Path>) -> Result<String, String> {
+pub fn get_rust_lang_rust_remote(
+    config: &GitConfig<'_>,
+    git_dir: Option<&Path>,
+) -> Result<String, String> {
     let mut git = Command::new("git");
     if let Some(git_dir) = git_dir {
         git.current_dir(git_dir);
@@ -37,8 +45,8 @@ pub fn get_rust_lang_rust_remote(git_dir: Option<&Path>) -> Result<String, Strin
 
     let rust_lang_remote = stdout
         .lines()
-        .find(|remote| remote.contains("rust-lang"))
-        .ok_or_else(|| "rust-lang/rust remote not found".to_owned())?;
+        .find(|remote| remote.contains(config.github_repository))
+        .ok_or_else(|| format!("{} remote not found", config.github_repository))?;
 
     let remote_name =
         rust_lang_remote.split('.').nth(1).ok_or_else(|| "remote name not found".to_owned())?;
@@ -76,9 +84,13 @@ pub fn rev_exists(rev: &str, git_dir: Option<&Path>) -> Result<bool, String> {
 /// This could be because the user is updating their forked master branch using the GitHub UI
 /// and therefore doesn't need an upstream master branch checked out.
 /// We will then fall back to origin/master in the hope that at least this exists.
-pub fn updated_master_branch(git_dir: Option<&Path>) -> Result<String, String> {
-    let upstream_remote = get_rust_lang_rust_remote(git_dir)?;
-    for upstream_master in [format!("{upstream_remote}/master"), format!("origin/master")] {
+pub fn updated_master_branch(
+    config: &GitConfig<'_>,
+    git_dir: Option<&Path>,
+) -> Result<String, String> {
+    let upstream_remote = get_rust_lang_rust_remote(config, git_dir)?;
+    let branch = config.nightly_branch;
+    for upstream_master in [format!("{upstream_remote}/{branch}"), format!("origin/{branch}")] {
         if rev_exists(&upstream_master, git_dir)? {
             return Ok(upstream_master);
         }
@@ -87,8 +99,11 @@ pub fn updated_master_branch(git_dir: Option<&Path>) -> Result<String, String> {
     Err(format!("Cannot find any suitable upstream master branch"))
 }
 
-pub fn get_git_merge_base(git_dir: Option<&Path>) -> Result<String, String> {
-    let updated_master = updated_master_branch(git_dir)?;
+pub fn get_git_merge_base(
+    config: &GitConfig<'_>,
+    git_dir: Option<&Path>,
+) -> Result<String, String> {
+    let updated_master = updated_master_branch(config, git_dir)?;
     let mut git = Command::new("git");
     if let Some(git_dir) = git_dir {
         git.current_dir(git_dir);
@@ -100,10 +115,11 @@ pub fn get_git_merge_base(git_dir: Option<&Path>) -> Result<String, String> {
 /// The `extensions` parameter can be used to filter the files by their extension.
 /// If `extensions` is empty, all files will be returned.
 pub fn get_git_modified_files(
+    config: &GitConfig<'_>,
     git_dir: Option<&Path>,
     extensions: &Vec<&str>,
 ) -> Result<Option<Vec<String>>, String> {
-    let merge_base = get_git_merge_base(git_dir)?;
+    let merge_base = get_git_merge_base(config, git_dir)?;
 
     let mut git = Command::new("git");
     if let Some(git_dir) = git_dir {
@@ -122,8 +138,11 @@ pub fn get_git_modified_files(
 }
 
 /// Returns the files that haven't been added to git yet.
-pub fn get_git_untracked_files(git_dir: Option<&Path>) -> Result<Option<Vec<String>>, String> {
-    let Ok(_updated_master) = updated_master_branch(git_dir) else {
+pub fn get_git_untracked_files(
+    config: &GitConfig<'_>,
+    git_dir: Option<&Path>,
+) -> Result<Option<Vec<String>>, String> {
+    let Ok(_updated_master) = updated_master_branch(config, git_dir) else {
         return Ok(None);
     };
     let mut git = Command::new("git");

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 use std::str::FromStr;
 
 use crate::util::{add_dylib_path, PathBufExt};
+use build_helper::git::GitConfig;
 use lazycell::AtomicLazyCell;
 use serde::de::{Deserialize, Deserializer, Error as _};
 use std::collections::{HashMap, HashSet};
@@ -370,6 +371,10 @@ pub struct Config {
     pub target_cfgs: AtomicLazyCell<TargetCfgs>,
 
     pub nocapture: bool,
+
+    // Needed both to construct build_helper::git::GitConfig
+    pub github_repository: String,
+    pub nightly_branch: String,
 }
 
 impl Config {
@@ -440,6 +445,13 @@ impl Config {
             // "nvptx64", "hexagon", "mips", "mips64", "spirv", "wasm32",
         ];
         ASM_SUPPORTED_ARCHS.contains(&self.target_cfg().arch.as_str())
+    }
+
+    pub fn git_config(&self) -> GitConfig<'_> {
+        GitConfig {
+            github_repository: &self.github_repository,
+            nightly_branch: &self.nightly_branch,
+        }
     }
 }
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -373,7 +373,7 @@ pub struct Config {
     pub nocapture: bool,
 
     // Needed both to construct build_helper::git::GitConfig
-    pub github_repository: String,
+    pub git_repository: String,
     pub nightly_branch: String,
 }
 
@@ -449,7 +449,7 @@ impl Config {
 
     pub fn git_config(&self) -> GitConfig<'_> {
         GitConfig {
-            github_repository: &self.github_repository,
+            git_repository: &self.git_repository,
             nightly_branch: &self.nightly_branch,
         }
     }

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -126,6 +126,8 @@ impl ConfigBuilder {
             self.host.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
             "--target",
             self.target.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
+            "--github-repository=",
+            "--nightly-branch=",
         ];
         let mut args: Vec<String> = args.iter().map(ToString::to_string).collect();
 

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -126,7 +126,7 @@ impl ConfigBuilder {
             self.host.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
             "--target",
             self.target.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
-            "--github-repository=",
+            "--git-repository=",
             "--nightly-branch=",
         ];
         let mut args: Vec<String> = args.iter().map(ToString::to_string).collect();

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -145,7 +145,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .reqopt("", "channel", "current Rust channel", "CHANNEL")
         .optflag("", "git-hash", "run tests which rely on commit version being compiled into the binaries")
         .optopt("", "edition", "default Rust edition", "EDITION")
-        .reqopt("", "github-repository", "name of the GitHub repository", "ORG/REPO")
+        .reqopt("", "git-repository", "name of the git repository", "ORG/REPO")
         .reqopt("", "nightly-branch", "name of the git branch for nightly", "BRANCH");
 
     let (argv0, args_) = args.split_first().unwrap();
@@ -310,7 +310,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
 
         nocapture: matches.opt_present("nocapture"),
 
-        github_repository: matches.opt_str("github-repository").unwrap(),
+        git_repository: matches.opt_str("git-repository").unwrap(),
         nightly_branch: matches.opt_str("nightly-branch").unwrap(),
     }
 }

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -144,7 +144,9 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optflag("h", "help", "show this message")
         .reqopt("", "channel", "current Rust channel", "CHANNEL")
         .optflag("", "git-hash", "run tests which rely on commit version being compiled into the binaries")
-        .optopt("", "edition", "default Rust edition", "EDITION");
+        .optopt("", "edition", "default Rust edition", "EDITION")
+        .reqopt("", "github-repository", "name of the GitHub repository", "ORG/REPO")
+        .reqopt("", "nightly-branch", "name of the git branch for nightly", "BRANCH");
 
     let (argv0, args_) = args.split_first().unwrap();
     if args.len() == 1 || args[1] == "-h" || args[1] == "--help" {
@@ -307,6 +309,9 @@ pub fn parse_config(args: Vec<String>) -> Config {
         target_cfgs: AtomicLazyCell::new(),
 
         nocapture: matches.opt_present("nocapture"),
+
+        github_repository: matches.opt_str("github-repository").unwrap(),
+        nightly_branch: matches.opt_str("nightly-branch").unwrap(),
     }
 }
 
@@ -609,9 +614,10 @@ fn modified_tests(config: &Config, dir: &Path) -> Result<Vec<PathBuf>, String> {
         return Ok(vec![]);
     }
     let files =
-        get_git_modified_files(Some(dir), &vec!["rs", "stderr", "fixed"])?.unwrap_or(vec![]);
+        get_git_modified_files(&config.git_config(), Some(dir), &vec!["rs", "stderr", "fixed"])?
+            .unwrap_or(vec![]);
     // Add new test cases to the list, it will be convenient in daily development.
-    let untracked_files = get_git_untracked_files(None)?.unwrap_or(vec![]);
+    let untracked_files = get_git_untracked_files(&config.git_config(), None)?.unwrap_or(vec![]);
 
     let all_paths = [&files[..], &untracked_files[..]].concat();
     let full_paths = {

--- a/src/tools/suggest-tests/src/main.rs
+++ b/src/tools/suggest-tests/src/main.rs
@@ -1,10 +1,17 @@
 use std::process::ExitCode;
 
-use build_helper::git::get_git_modified_files;
+use build_helper::git::{get_git_modified_files, GitConfig};
 use suggest_tests::get_suggestions;
 
 fn main() -> ExitCode {
-    let modified_files = get_git_modified_files(None, &Vec::new());
+    let modified_files = get_git_modified_files(
+        &GitConfig {
+            github_repository: &env("SUGGEST_TESTS_GITHUB_REPOSITORY"),
+            nightly_branch: &env("SUGGEST_TESTS_NIGHTLY_BRANCH"),
+        },
+        None,
+        &Vec::new(),
+    );
     let modified_files = match modified_files {
         Ok(Some(files)) => files,
         Ok(None) => {
@@ -24,4 +31,14 @@ fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+fn env(key: &str) -> String {
+    match std::env::var(key) {
+        Ok(var) => var,
+        Err(err) => {
+            eprintln!("suggest-tests: failed to read environment variable {key}: {err}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/tools/suggest-tests/src/main.rs
+++ b/src/tools/suggest-tests/src/main.rs
@@ -6,7 +6,7 @@ use suggest_tests::get_suggestions;
 fn main() -> ExitCode {
     let modified_files = get_git_modified_files(
         &GitConfig {
-            github_repository: &env("SUGGEST_TESTS_GITHUB_REPOSITORY"),
+            git_repository: &env("SUGGEST_TESTS_GIT_REPOSITORY"),
             nightly_branch: &env("SUGGEST_TESTS_NIGHTLY_BRANCH"),
         },
         None,

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-abort.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-abort.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
+++ b/tests/mir-opt/const_prop/inherit_overflow.main.ConstProp.panic-unwind.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-abort.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.main.DataflowConstProp.panic-unwind.diff
@@ -8,7 +8,7 @@
       let mut _3: u8;
       scope 1 {
       }
-      scope 2 (inlined <u8 as Add>::add) {
+      scope 2 (inlined #[track_caller] <u8 as Add>::add) {
           debug self => _2;
           debug other => _3;
           let mut _4: (u8, bool);

--- a/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
@@ -13,7 +13,7 @@ LL | impl<T> Windows {
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/issue-109071.rs:5:8
    |
-LL | struct Windows<T> {}
+LL | struct Windows<T> { t: T }
    |        ^^^^^^^ -
 help: add missing generic argument
    |
@@ -30,7 +30,7 @@ LL |     type Item = &[T];
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
 error[E0223]: ambiguous associated type
-  --> $DIR/issue-109071.rs:15:22
+  --> $DIR/issue-109071.rs:16:22
    |
 LL |     fn T() -> Option<Self::Item> {}
    |                      ^^^^^^^^^^ help: use fully-qualified syntax: `<Windows<T> as IntoIterator>::Item`

--- a/tests/ui/associated-inherent-types/issue-109071.rs
+++ b/tests/ui/associated-inherent-types/issue-109071.rs
@@ -2,18 +2,20 @@
 #![cfg_attr(with_gate, feature(inherent_associated_types))]
 #![cfg_attr(with_gate, allow(incomplete_features))]
 
-struct Windows<T> {}
+struct Windows<T> { t: T }
 
 impl<T> Windows { //~ ERROR: missing generics for struct `Windows`
     type Item = &[T]; //~ ERROR: `&` without an explicit lifetime name cannot be used here
     //[no_gate]~^ ERROR: inherent associated types are unstable
 
     fn next() -> Option<Self::Item> {}
+    //[with_gate]~^ ERROR type annotations needed
 }
 
 impl<T> Windows<T> {
     fn T() -> Option<Self::Item> {}
     //[no_gate]~^ ERROR: ambiguous associated type
+    //[with_gate]~^^ ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
@@ -13,14 +13,26 @@ LL | impl<T> Windows {
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/issue-109071.rs:5:8
    |
-LL | struct Windows<T> {}
+LL | struct Windows<T> { t: T }
    |        ^^^^^^^ -
 help: add missing generic argument
    |
 LL | impl<T> Windows<T> {
    |                +++
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/issue-109071.rs:11:18
+   |
+LL |     fn next() -> Option<Self::Item> {}
+   |                  ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
-Some errors have detailed explanations: E0107, E0637.
+error[E0282]: type annotations needed
+  --> $DIR/issue-109071.rs:16:15
+   |
+LL |     fn T() -> Option<Self::Item> {}
+   |               ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0282, E0637.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/associated-inherent-types/issue-109299-1.rs
+++ b/tests/ui/associated-inherent-types/issue-109299-1.rs
@@ -8,5 +8,6 @@ impl Lexer<i32> {
 }
 
 type X = impl for<T> Fn() -> Lexer<T>::Cursor; //~ ERROR associated type `Cursor` not found for `Lexer<T>` in the current scope
+//~^ ERROR: unconstrained opaque type
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109299-1.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299-1.stderr
@@ -10,6 +10,14 @@ LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
    = note: the associated type was found for
            - `Lexer<i32>`
 
-error: aborting due to previous error
+error: unconstrained opaque type
+  --> $DIR/issue-109299-1.rs:10:10
+   |
+LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `X` must be used in combination with a concrete type within the same module
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0220`.

--- a/tests/ui/associated-inherent-types/issue-109768.rs
+++ b/tests/ui/associated-inherent-types/issue-109768.rs
@@ -8,5 +8,6 @@ impl<T> Local { //~ ERROR missing generics for struct `Local`
     type AssocType3 = T; //~ ERROR inherent associated types are unstable
 
     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
+    //~^ ERROR: this struct takes 1 argument but 0 arguments were supplied
 }
 //~^ ERROR `main` function not found

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -1,5 +1,5 @@
 error[E0601]: `main` function not found in crate `issue_109768`
-  --> $DIR/issue-109768.rs:11:2
+  --> $DIR/issue-109768.rs:12:2
    |
 LL | }
    |  ^ consider adding a `main` function to `$DIR/issue-109768.rs`
@@ -29,7 +29,23 @@ LL |     type AssocType3 = T;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0061]: this struct takes 1 argument but 0 arguments were supplied
+  --> $DIR/issue-109768.rs:10:56
+   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
+   |                                                        ^^^^^^^-- an argument is missing
+   |
+note: tuple struct defined here
+  --> $DIR/issue-109768.rs:3:8
+   |
+LL | struct Wrapper<T>(T);
+   |        ^^^^^^^
+help: provide the argument
+   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper(/* value */);
+   |                                                               ~~~~~~~~~~~~~
 
-Some errors have detailed explanations: E0107, E0601, E0658.
-For more information about an error, try `rustc --explain E0107`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0061, E0107, E0601, E0658.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/associated-type-bounds/duplicate.rs
+++ b/tests/ui/associated-type-bounds/duplicate.rs
@@ -134,14 +134,17 @@ where
 fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
@@ -194,11 +197,14 @@ trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
 trait TRS1: Iterator<Item: Copy, Item: Send> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS2: Iterator<Item: Copy, Item: Copy> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS3: Iterator<Item: 'static, Item: 'static> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRW1<T>
 where
@@ -223,12 +229,14 @@ where
     Self: Iterator<Item: Copy, Item: Send>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRSW2
 where
     Self: Iterator<Item: Copy, Item: Copy>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
@@ -237,15 +245,19 @@ where
     Self: Iterator<Item: 'static, Item: 'static>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRA1 {
     type A: Iterator<Item: Copy, Item: Send>;
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+    //~| ERROR the trait bound `<<Self as TRA1>::A as Iterator>::Item: Copy` is not satisfied
 }
 trait TRA2 {
     type A: Iterator<Item: Copy, Item: Copy>;
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the trait bound `<<Self as TRA2>::A as Iterator>::Item: Copy` is not satisfied
 }
 trait TRA3 {
     type A: Iterator<Item: 'static, Item: 'static>;

--- a/tests/ui/associated-type-bounds/duplicate.stderr
+++ b/tests/ui/associated-type-bounds/duplicate.stderr
@@ -199,7 +199,7 @@ LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:138:42
+  --> $DIR/duplicate.rs:139:42
    |
 LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              ----------  ^^^^^^^^^^ re-bound here
@@ -207,7 +207,7 @@ LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:142:45
+  --> $DIR/duplicate.rs:144:45
    |
 LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              -------------  ^^^^^^^^^^^^^ re-bound here
@@ -215,7 +215,7 @@ LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:146:40
+  --> $DIR/duplicate.rs:149:40
    |
 LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -223,7 +223,7 @@ LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:148:40
+  --> $DIR/duplicate.rs:151:40
    |
 LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -231,7 +231,7 @@ LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:150:43
+  --> $DIR/duplicate.rs:153:43
    |
 LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -239,7 +239,7 @@ LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:153:35
+  --> $DIR/duplicate.rs:156:35
    |
 LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       ----------  ^^^^^^^^^^ re-bound here
@@ -247,7 +247,7 @@ LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:155:35
+  --> $DIR/duplicate.rs:158:35
    |
 LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       ----------  ^^^^^^^^^^ re-bound here
@@ -255,7 +255,7 @@ LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:157:38
+  --> $DIR/duplicate.rs:160:38
    |
 LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       -------------  ^^^^^^^^^^^^^ re-bound here
@@ -263,7 +263,7 @@ LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:161:29
+  --> $DIR/duplicate.rs:164:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -271,7 +271,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:166:29
+  --> $DIR/duplicate.rs:169:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -279,7 +279,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:171:32
+  --> $DIR/duplicate.rs:174:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 -------------  ^^^^^^^^^^^^^ re-bound here
@@ -287,7 +287,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:175:36
+  --> $DIR/duplicate.rs:178:36
    |
 LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -295,7 +295,7 @@ LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:177:36
+  --> $DIR/duplicate.rs:180:36
    |
 LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -303,7 +303,7 @@ LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:179:39
+  --> $DIR/duplicate.rs:182:39
    |
 LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        -------------  ^^^^^^^^^^^^^ re-bound here
@@ -311,7 +311,7 @@ LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:181:40
+  --> $DIR/duplicate.rs:184:40
    |
 LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -319,7 +319,7 @@ LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:183:40
+  --> $DIR/duplicate.rs:186:40
    |
 LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -327,7 +327,7 @@ LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:185:43
+  --> $DIR/duplicate.rs:188:43
    |
 LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -335,7 +335,7 @@ LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:188:36
+  --> $DIR/duplicate.rs:191:36
    |
 LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -343,7 +343,7 @@ LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:190:36
+  --> $DIR/duplicate.rs:193:36
    |
 LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -351,7 +351,7 @@ LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:192:39
+  --> $DIR/duplicate.rs:195:39
    |
 LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        -------------  ^^^^^^^^^^^^^ re-bound here
@@ -359,7 +359,7 @@ LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:194:34
+  --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -367,7 +367,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:194:34
+  --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -377,7 +377,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
+  --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -385,7 +385,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
+  --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -395,7 +395,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:200:37
+  --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
@@ -403,7 +403,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:200:37
+  --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
@@ -413,7 +413,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:205:29
+  --> $DIR/duplicate.rs:211:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -421,7 +421,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:211:29
+  --> $DIR/duplicate.rs:217:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -429,7 +429,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:217:32
+  --> $DIR/duplicate.rs:223:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 -------------  ^^^^^^^^^^^^^ re-bound here
@@ -437,7 +437,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:223:32
+  --> $DIR/duplicate.rs:229:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -445,7 +445,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:223:32
+  --> $DIR/duplicate.rs:229:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -455,7 +455,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:230:32
+  --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -463,7 +463,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:230:32
+  --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -473,7 +473,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:35
+  --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
@@ -481,7 +481,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:35
+  --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
@@ -491,7 +491,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:255:40
+  --> $DIR/duplicate.rs:267:40
    |
 LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -499,7 +499,7 @@ LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:257:44
+  --> $DIR/duplicate.rs:269:44
    |
 LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                ----------  ^^^^^^^^^^ re-bound here
@@ -507,7 +507,7 @@ LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:259:43
+  --> $DIR/duplicate.rs:271:43
    |
 LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -515,7 +515,7 @@ LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:243:34
+  --> $DIR/duplicate.rs:252:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -523,7 +523,7 @@ LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:247:34
+  --> $DIR/duplicate.rs:258:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -531,13 +531,141 @@ LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:251:37
+  --> $DIR/duplicate.rs:263:37
    |
 LL |     type A: Iterator<Item: 'static, Item: 'static>;
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
 
-error: aborting due to 66 previous errors
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:197:34
+   |
+LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-For more information about this error, try `rustc --explain E0719`.
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:201:34
+   |
+LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:205:37
+   |
+LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
+   |                      -------------  ^^^^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:229:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Send>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:237:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Copy>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:245:35
+   |
+LL |     Self: Iterator<Item: 'static, Item: 'static>,
+   |                    -------------  ^^^^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `<<Self as TRA1>::A as Iterator>::Item: Copy` is not satisfied
+  --> $DIR/duplicate.rs:252:28
+   |
+LL |     type A: Iterator<Item: Copy, Item: Send>;
+   |                            ^^^^ the trait `Copy` is not implemented for `<<Self as TRA1>::A as Iterator>::Item`
+   |
+help: consider further restricting the associated type
+   |
+LL | trait TRA1 where <<Self as TRA1>::A as Iterator>::Item: Copy {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+  --> $DIR/duplicate.rs:252:40
+   |
+LL |     type A: Iterator<Item: Copy, Item: Send>;
+   |                                        ^^^^ `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `<<Self as TRA1>::A as Iterator>::Item`
+help: consider further restricting the associated type
+   |
+LL | trait TRA1 where <<Self as TRA1>::A as Iterator>::Item: Send {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<<Self as TRA2>::A as Iterator>::Item: Copy` is not satisfied
+  --> $DIR/duplicate.rs:258:28
+   |
+LL |     type A: Iterator<Item: Copy, Item: Copy>;
+   |                            ^^^^ the trait `Copy` is not implemented for `<<Self as TRA2>::A as Iterator>::Item`
+   |
+help: consider further restricting the associated type
+   |
+LL | trait TRA2 where <<Self as TRA2>::A as Iterator>::Item: Copy {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:136:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:141:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:146:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error: aborting due to 78 previous errors
+
+Some errors have detailed explanations: E0277, E0282, E0719.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.rs
+++ b/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.rs
@@ -25,7 +25,7 @@ fn c<C>(_: C::Color) where C : Vehicle, C : Box {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-struct D<X>;
+struct D<X>(X);
 impl<X> D<X> where X : Vehicle {
     fn d(&self, _: X::Color) where X : Box { }
     //~^ ERROR ambiguous associated type `Color` in bounds of `X`

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
@@ -20,7 +20,7 @@ fn dent<C:BoxCar>(c: C, color: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
+fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
     //~^ ERROR ambiguous associated type
     //~| ERROR the value of the associated types
 }
@@ -29,7 +29,7 @@ fn paint<C:BoxCar>(c: C, d: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
     //~^ ERROR the value of the associated types
     //~| ERROR equality constraints are not yet supported in `where` clauses
 }

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -1,8 +1,8 @@
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:46
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:47
    |
-LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
+LL | fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
@@ -28,7 +28,7 @@ LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
    |                                ~~~~~~~~~~~~
 
 error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:38
    |
 LL |     type Color;
    |     ---------- ambiguous `Color` from `Vehicle`
@@ -36,8 +36,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- ambiguous `Color` from `Box`
 ...
-LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                                     ^^^^^^^^^^^ ambiguous associated type `Color`
+LL | fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
+   |                                      ^^^^^^^^^^^ ambiguous associated type `Color`
    |
    = help: consider introducing a new type parameter `T` and adding `where` constraints:
                where
@@ -46,7 +46,7 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
                    T: Box::Color = COLOR
 
 error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:31
    |
 LL |     type Color;
    |     ---------- `Vehicle::Color` defined here
@@ -54,8 +54,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- `Box::Color` defined here
 ...
-LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                              ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+LL | fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
+   |                               ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 
@@ -81,7 +81,7 @@ LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
    |                             ~~~~~~~~~~~~
 
 error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:33
    |
 LL |     type Color;
    |     ---------- `Vehicle::Color` defined here
@@ -89,8 +89,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- `Box::Color` defined here
 ...
-LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+LL | fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                 ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 

--- a/tests/ui/associated-types/issue-23595-1.rs
+++ b/tests/ui/associated-types/issue-23595-1.rs
@@ -7,6 +7,7 @@ trait Hierarchy {
     type ChildKey;
     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
     //~^ ERROR: the value of the associated types
+    //~| ERROR: the size for values of type
 
     fn data(&self) -> Option<(Self::Value, Self::Children)>;
 }

--- a/tests/ui/associated-types/issue-23595-1.stderr
+++ b/tests/ui/associated-types/issue-23595-1.stderr
@@ -8,6 +8,20 @@ LL |     type ChildKey;
 LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
    |     ------------- `Children` defined here                ^^^^^^^^^ help: specify the associated types: `Hierarchy<Value = Type, ChildKey = Type, Children = Type>`
 
-error: aborting due to previous error
+error[E0277]: the size for values of type `(dyn Index<<Self as Hierarchy>::ChildKey, Output = (dyn Hierarchy + 'static)> + 'static)` cannot be known at compilation time
+  --> $DIR/issue-23595-1.rs:8:21
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Index<<Self as Hierarchy>::ChildKey, Output = (dyn Hierarchy + 'static)> + 'static)`
+note: required by a bound in `Hierarchy::Children`
+  --> $DIR/issue-23595-1.rs:8:5
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Hierarchy::Children`
 
-For more information about this error, try `rustc --explain E0191`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0191, E0277.
+For more information about an error, try `rustc --explain E0191`.

--- a/tests/ui/async-await/issues/issue-65159.rs
+++ b/tests/ui/async-await/issues/issue-65159.rs
@@ -5,7 +5,7 @@
 async fn copy() -> Result<()>
 //~^ ERROR enum takes 2 generic arguments
 {
-    Ok(())
+    Ok(()) //~ ERROR: type annotations needed
 }
 
 fn main() { }

--- a/tests/ui/async-await/issues/issue-65159.stderr
+++ b/tests/ui/async-await/issues/issue-65159.stderr
@@ -11,6 +11,18 @@ help: add missing generic argument
 LL | async fn copy() -> Result<(), E>
    |                             +++
 
-error: aborting due to previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-65159.rs:8:5
+   |
+LL |     Ok(())
+   |     ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     Ok::<(), E>(())
+   |       +++++++++
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
@@ -9,5 +9,6 @@ trait Super1<'a> {
 
 impl Super1<'_, bar(): Send> for () {}
 //~^ ERROR associated type bindings are not allowed here
+//~| ERROR not all trait items implemented
 
 fn main() {}

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -13,6 +13,16 @@ error[E0229]: associated type bindings are not allowed here
 LL | impl Super1<'_, bar(): Send> for () {}
    |                 ^^^^^^^^^^^ associated type not allowed here
 
-error: aborting due to previous error; 1 warning emitted
+error[E0046]: not all trait items implemented, missing: `bar`
+  --> $DIR/rtn-in-impl-signature.rs:10:1
+   |
+LL |     fn bar<'b>() -> bool;
+   |     --------------------- `bar` from trait
+...
+LL | impl Super1<'_, bar(): Send> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bar` in implementation
 
-For more information about this error, try `rustc --explain E0229`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0046, E0229.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
@@ -26,7 +26,7 @@ LL |     let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:28:17
+  --> $DIR/async-closure-gate.rs:29:17
    |
 LL |         let _ = #[track_caller] || {
    |                 ^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |         let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:36:9
+  --> $DIR/async-closure-gate.rs:37:9
    |
 LL |         #[track_caller] || {
    |         ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:45:13
+  --> $DIR/async-closure-gate.rs:47:13
    |
 LL |             #[track_caller] || {
    |             ^^^^^^^^^^^^^^^
@@ -52,6 +52,40 @@ LL |             #[track_caller] || {
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:27:5
+   |
+LL |   fn foo3() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = #[track_caller] || {
+LL | |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:44:5
+   |
+LL |   fn foo5() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = || {
+LL | |             #[track_caller] || {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
@@ -26,7 +26,7 @@ LL |     let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:28:17
+  --> $DIR/async-closure-gate.rs:29:17
    |
 LL |         let _ = #[track_caller] || {
    |                 ^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |         let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:36:9
+  --> $DIR/async-closure-gate.rs:37:9
    |
 LL |         #[track_caller] || {
    |         ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:45:13
+  --> $DIR/async-closure-gate.rs:47:13
    |
 LL |             #[track_caller] || {
    |             ^^^^^^^^^^^^^^^
@@ -52,6 +52,40 @@ LL |             #[track_caller] || {
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:27:5
+   |
+LL |   fn foo3() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = #[track_caller] || {
+LL | |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:44:5
+   |
+LL |   fn foo5() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = || {
+LL | |             #[track_caller] || {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.rs
+++ b/tests/ui/async-await/track-caller/async-closure-gate.rs
@@ -25,6 +25,7 @@ async fn foo2() {
 
 fn foo3() {
     async {
+        //~^ ERROR mismatched types
         let _ = #[track_caller] || {
             //~^ ERROR `#[track_caller]` on closures is currently unstable [E0658]
         };
@@ -41,6 +42,7 @@ async fn foo4() {
 
 fn foo5() {
     async {
+        //~^ ERROR mismatched types
         let _ = || {
             #[track_caller] || {
                 //~^ ERROR `#[track_caller]` on closures is currently unstable [E0658]

--- a/tests/ui/auto-traits/has-arguments.rs
+++ b/tests/ui/auto-traits/has-arguments.rs
@@ -1,0 +1,10 @@
+#![feature(auto_traits)]
+
+auto trait Trait1<'outer> {}
+//~^ ERROR auto traits cannot have generic parameters
+
+fn f<'a>(x: impl Trait1<'a>) {}
+
+fn main() {
+    f("");
+}

--- a/tests/ui/auto-traits/has-arguments.stderr
+++ b/tests/ui/auto-traits/has-arguments.stderr
@@ -1,0 +1,11 @@
+error[E0567]: auto traits cannot have generic parameters
+  --> $DIR/has-arguments.rs:3:18
+   |
+LL | auto trait Trait1<'outer> {}
+   |            ------^^^^^^^^ help: remove the parameters
+   |            |
+   |            auto trait cannot have generic parameters
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0567`.

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
@@ -17,6 +17,7 @@ async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
     //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument was supplied
     //~^^ ERROR struct takes 1 generic argument but 0 generic arguments were supplied
     LockedMarket(coroutine.lock().unwrap().buy())
+    //~^ ERROR: cannot return value referencing temporary value
 }
 
 struct LockedMarket<T>(T);

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -7,7 +7,7 @@ LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> 
    |                                                           expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
-  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:22:8
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:23:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> 
    |                                                           ^^^^^^^^^^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:22:8
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:23:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^ -
@@ -28,6 +28,16 @@ help: add missing generic argument
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_, T> {
    |                                                                          +++
 
-error: aborting due to 2 previous errors
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:19:5
+   |
+LL |     LockedMarket(coroutine.lock().unwrap().buy())
+   |     ^^^^^^^^^^^^^-------------------------^^^^^^^
+   |     |            |
+   |     |            temporary value created here
+   |     returns a value referencing data owned by the current function
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0515.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
@@ -11,6 +11,7 @@ pub trait Parse {
 pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
 //~^ ERROR expected associated constant bound
 //~| ERROR expected associated constant bound
+//~| ERROR expected associated constant bound
 //~| ERROR expected type
 
 fn no_help() -> Mode::Cool {}

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
@@ -8,7 +8,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                                   help: try using the variant's enum: `Mode`
 
 error[E0573]: expected type, found variant `Mode::Cool`
-  --> $DIR/assoc_const_eq_diagnostic.rs:16:17
+  --> $DIR/assoc_const_eq_diagnostic.rs:17:17
    |
 LL | fn no_help() -> Mode::Cool {}
    |                 ^^^^^^^^^^
@@ -41,6 +41,19 @@ LL |     const MODE: Mode;
    |     ^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error: expected associated constant bound, found type
+  --> $DIR/assoc_const_eq_diagnostic.rs:11:28
+   |
+LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+   |                            ^^^^^^^^^^^^^^^^^ help: if equating a const, try wrapping with braces: `MODE = { const }`
+   |
+note: associated constant defined here
+  --> $DIR/assoc_const_eq_diagnostic.rs:8:5
+   |
+LL |     const MODE: Mode;
+   |     ^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0573`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
@@ -9,6 +9,11 @@ const _: () = {
     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
     //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
     //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR `X` cannot be made into an object
 };
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -28,6 +28,86 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
 
-error: aborting due to 2 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                                +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^--- help: remove these generics
+   |                              |
+   |                              expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                                +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^--- help: remove these generics
+   |                              |
+   |                              expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/issue-102768.rs:9:24
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                        ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-105257.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105257.rs
@@ -3,6 +3,7 @@
 
 trait Trait<T> {
     fn fnc<const N: usize = "">(&self) {} //~ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+    //~^ ERROR: mismatched types
     fn foo<const N: usize = { std::mem::size_of::<T>() }>(&self) {} //~ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-105257.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105257.stderr
@@ -5,10 +5,17 @@ LL |     fn fnc<const N: usize = "">(&self) {}
    |            ^^^^^^^^^^^^^^^^^^^
 
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/issue-105257.rs:6:12
+  --> $DIR/issue-105257.rs:7:12
    |
 LL |     fn foo<const N: usize = { std::mem::size_of::<T>() }>(&self) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-105257.rs:5:29
+   |
+LL |     fn fnc<const N: usize = "">(&self) {}
+   |                             ^^ expected `usize`, found `&str`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
+++ b/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
@@ -4,5 +4,14 @@ error: cannot capture late-bound lifetime in constant
 LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
    |        -- lifetime defined here                     ^^
 
-error: aborting due to previous error
+error: overly complex generic constant
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.rs
@@ -14,6 +14,7 @@ impl<const N: usize> Marker<N> for Example<N> {}
 fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
   //~^ ERROR: type provided when a constant was expected
   Example::<gimme_a_const!(marker)>
+  //~^ ERROR: type provided when a constant was expected
 }
 
 fn from_marker(_: impl Marker<{
@@ -33,7 +34,9 @@ fn main() {
   }>;
 
   let _fail = Example::<external_macro!()>;
+  //~^ ERROR: type provided when a constant was expected
 
   let _fail = Example::<gimme_a_const!()>;
   //~^ ERROR unexpected end of macro invocation
+  //~| ERROR: type provided when a constant was expected
 }

--- a/tests/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:28:27
+  --> $DIR/macro-fail.rs:29:27
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ----------------------
@@ -13,7 +13,7 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:28:27
+  --> $DIR/macro-fail.rs:29:27
    |
 LL |   Example::<gimme_a_const!(marker)>
    |             ----------------------
@@ -41,7 +41,7 @@ LL |   let _fail = Example::<external_macro!()>;
    = note: this error originates in the macro `external_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-  --> $DIR/macro-fail.rs:37:25
+  --> $DIR/macro-fail.rs:39:25
    |
 LL |     macro_rules! gimme_a_const {
    |     -------------------------- when calling this macro
@@ -50,7 +50,7 @@ LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$rusty:ident`
-  --> $DIR/macro-fail.rs:28:8
+  --> $DIR/macro-fail.rs:29:8
    |
 LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |        ^^^^^^^^^^^^^
@@ -61,6 +61,24 @@ error[E0747]: type provided when a constant was expected
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:16:13
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:36:25
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |                         ^^^^^^^^^^^^^^^^^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:39:25
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/consts/escaping-bound-var.rs
+++ b/tests/ui/consts/escaping-bound-var.rs
@@ -3,7 +3,7 @@
 
 fn test<'a>(
     _: &'a (),
-) -> [(); {
+) -> [(); { //~ ERROR: mismatched types
     let x: &'a ();
     //~^ ERROR cannot capture late-bound lifetime in constant
     1

--- a/tests/ui/consts/escaping-bound-var.stderr
+++ b/tests/ui/consts/escaping-bound-var.stderr
@@ -16,5 +16,23 @@ LL | fn test<'a>(
 LL |     let x: &'a ();
    |             ^^
 
-error: aborting due to previous error; 1 warning emitted
+error[E0308]: mismatched types
+  --> $DIR/escaping-bound-var.rs:6:6
+   |
+LL |   fn test<'a>(
+   |      ---- implicitly returns `()` as its body has no tail or `return` expression
+LL |       _: &'a (),
+LL |   ) -> [(); {
+   |  ______^
+LL | |     let x: &'a ();
+LL | |
+LL | |     1
+LL | | }] {
+   | |__^ expected `[(); {
+    let x: &'a ();
+    1
+}]`, found `()`
 
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-103790.rs
+++ b/tests/ui/consts/issue-103790.rs
@@ -6,5 +6,6 @@ struct S<const S: (), const S: S = { S }>;
 //~| ERROR missing generics for struct `S`
 //~| ERROR cycle detected when computing type of `S::S`
 //~| ERROR cycle detected when computing type of `S`
+//~| ERROR `()` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -61,7 +61,16 @@ LL | | fn main() {}
    | |____________^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 4 previous errors
+error: `()` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-103790.rs:4:19
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                   ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0107, E0391, E0403.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/derives/issue-97343.rs
+++ b/tests/ui/derives/issue-97343.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed on type parameter
+    //~^ ERROR `Irrelevant` must be used
     irrelevant: Irrelevant,
 }
 

--- a/tests/ui/derives/issue-97343.stderr
+++ b/tests/ui/derives/issue-97343.stderr
@@ -16,6 +16,16 @@ LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error[E0210]: type parameter `Irrelevant` must be used as the type parameter for some local type (e.g., `MyStruct<Irrelevant>`)
+  --> $DIR/issue-97343.rs:4:23
+   |
+LL | pub struct Irrelevant<Irrelevant> {
+   |                       ^^^^^^^^^^ type parameter `Irrelevant` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
-For more information about this error, try `rustc --explain E0109`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0109, E0210.
+For more information about an error, try `rustc --explain E0109`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -71,6 +71,7 @@ enum N<F> where F: Fn() -> _ {
 union O<F> where F: Fn() -> _ {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for unions
     foo: F,
+    //~^ ERROR must implement `Copy`
 }
 
 trait P<F> where F: Fn() -> _ {

--- a/tests/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.stderr
@@ -299,7 +299,7 @@ LL | union O<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
@@ -310,7 +310,7 @@ LL | trait P<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:81:38
+  --> $DIR/bad-assoc-ty.rs:82:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
    |                                      ^ not allowed in type signatures
@@ -320,7 +320,19 @@ help: use type parameters instead
 LL |     fn foo<F, T>(_: F) where F: Fn() -> T {}
    |             +++                         ~
 
-error: aborting due to 28 previous errors; 1 warning emitted
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/bad-assoc-ty.rs:73:5
+   |
+LL |     foo: F,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     foo: std::mem::ManuallyDrop<F>,
+   |          +++++++++++++++++++++++ +
 
-Some errors have detailed explanations: E0121, E0223.
+error: aborting due to 29 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0121, E0223, E0740.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
@@ -8,6 +8,7 @@ trait Foo<T>: Sized {
 impl Foo<usize> for () {
     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~| ERROR type annotations needed
         (1, 2)
     }
 }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
@@ -8,6 +8,7 @@ trait Foo<T>: Sized {
 impl Foo<usize> for () {
     fn bar(i: _, t: _, s: _) -> _ {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~| ERROR type annotations needed
         (1, 2)
     }
 }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
@@ -13,6 +13,13 @@ help: try replacing `_` with the types in the corresponding trait method signatu
 LL |     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
    |               ~~~     ~~~~~     ~~~     ~~~~~~~~~~~~
 
-error: aborting due to previous error
+error[E0282]: type annotations needed
+  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:12
+   |
+LL |     fn bar(i: _, t: _, s: _) -> _ {
+   |            ^ cannot infer type
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0121, E0282.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
@@ -4,6 +4,7 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
     let _x: &SomeTrait = todo!();
+    //~^ ERROR trait objects must include the `dyn` keyword
 }
 
 trait SomeTrait {}

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -20,6 +20,17 @@ help: add `dyn` keyword before this trait
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    |                                   +++
 
-error: aborting due to 2 previous errors
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/dyn-2021-edition-error.rs:6:14
+   |
+LL |     let _x: &SomeTrait = todo!();
+   |              ^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL |     let _x: &dyn SomeTrait = todo!();
+   |              +++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/error-codes/E0227.rs
+++ b/tests/ui/error-codes/E0227.rs
@@ -6,6 +6,7 @@ trait FooBar<'foo, 'bar>: Foo<'foo> + Bar<'bar> {}
 struct Baz<'foo, 'bar> {
     baz: dyn FooBar<'foo, 'bar>,
     //~^ ERROR ambiguous lifetime bound, explicit lifetime bound required
+    //~| ERROR lifetime bound not satisfied
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0227.stderr
+++ b/tests/ui/error-codes/E0227.stderr
@@ -4,6 +4,24 @@ error[E0227]: ambiguous lifetime bound, explicit lifetime bound required
 LL |     baz: dyn FooBar<'foo, 'bar>,
    |          ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/E0227.rs:7:10
+   |
+LL |     baz: dyn FooBar<'foo, 'bar>,
+   |          ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lifetime parameter instantiated with the lifetime `'bar` as defined here
+  --> $DIR/E0227.rs:6:18
+   |
+LL | struct Baz<'foo, 'bar> {
+   |                  ^^^^
+note: but lifetime parameter must outlive the lifetime `'foo` as defined here
+  --> $DIR/E0227.rs:6:12
+   |
+LL | struct Baz<'foo, 'bar> {
+   |            ^^^^
 
-For more information about this error, try `rustc --explain E0227`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0227, E0478.
+For more information about an error, try `rustc --explain E0227`.

--- a/tests/ui/error-codes/E0229.rs
+++ b/tests/ui/error-codes/E0229.rs
@@ -12,6 +12,9 @@ impl Foo for isize {
 
 fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
 //~^ ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR the trait bound `I: Foo` is not satisfied
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -4,6 +4,34 @@ error[E0229]: associated type bindings are not allowed here
 LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
    |                         ^^^^^ associated type not allowed here
 
-error: aborting due to previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/E0229.rs:13:25
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                         ^^^^^ associated type not allowed here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-For more information about this error, try `rustc --explain E0229`.
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/E0229.rs:13:25
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                         ^^^^^ associated type not allowed here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `I: Foo` is not satisfied
+  --> $DIR/E0229.rs:13:15
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |               ^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `I`
+   |
+help: consider restricting type parameter `I`
+   |
+LL | fn baz<I: Foo>(x: &<I as Foo<A=Bar>>::A) {}
+   |         +++++
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/error-codes/E0719.rs
+++ b/tests/ui/error-codes/E0719.rs
@@ -1,6 +1,7 @@
 trait Foo: Iterator<Item = i32, Item = i32> {}
 //~^ ERROR is already specified
 //~| ERROR is already specified
+//~| ERROR is already specified
 
 type Unit = ();
 
@@ -11,5 +12,6 @@ fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
 
 fn main() {
     let _: &dyn Iterator<Item = i32, Item = i32>;
+    //~^ ERROR already specified
     test();
 }

--- a/tests/ui/error-codes/E0719.stderr
+++ b/tests/ui/error-codes/E0719.stderr
@@ -17,13 +17,31 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/E0719.rs:7:42
+  --> $DIR/E0719.rs:8:42
    |
 LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
    |                               ---------  ^^^^^^^^^^^ re-bound here
    |                               |
    |                               `Item` bound here first
 
-error: aborting due to 3 previous errors
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:1:33
+   |
+LL | trait Foo: Iterator<Item = i32, Item = i32> {}
+   |                     ----------  ^^^^^^^^^^ re-bound here
+   |                     |
+   |                     `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:14:38
+   |
+LL |     let _: &dyn Iterator<Item = i32, Item = i32>;
+   |                          ----------  ^^^^^^^^^^ re-bound here
+   |                          |
+   |                          `Item` bound here first
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0719`.

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for () {
     type Bar = impl std::fmt::Debug;
     //~^ ERROR: `impl Trait` in associated types is unstable
+    //~| ERROR: unconstrained opaque type
 }
 
 struct Mop;
@@ -13,6 +14,7 @@ impl Mop {
     type Bop = impl std::fmt::Debug;
     //~^ ERROR: `impl Trait` in associated types is unstable
     //~| ERROR: inherent associated types are unstable
+    //~| ERROR: unconstrained opaque type
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
@@ -8,7 +8,7 @@ LL |     type Bar = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in associated types is unstable
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:16
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
    |
 LL |     type Bop = impl std::fmt::Debug;
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     type Bop = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: inherent associated types are unstable
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:5
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:5
    |
 LL |     type Bop = impl std::fmt::Debug;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,6 +25,22 @@ LL |     type Bop = impl std::fmt::Debug;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16
+   |
+LL |     type Bar = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bar` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
+   |
+LL |     type Bop = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bop` must be used in combination with a concrete type within the same impl
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
@@ -7,29 +7,35 @@
 
 struct Foo;
 impl Fn<()> for Foo {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `Fn` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `Fn` are experimental
+    //~| ERROR expected a `FnMut<()>` closure, found `Foo`
     extern "rust-call" fn call(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
+    //~| ERROR `call` has an incompatible type for trait
 }
 struct Foo1;
 impl FnOnce() for Foo1 {
-//~^ ERROR associated type bindings are not allowed here
-//~| ERROR manual implementations of `FnOnce` are experimental
+    //~^ ERROR associated type bindings are not allowed here
+    //~| ERROR manual implementations of `FnOnce` are experimental
+    //~| ERROR not all trait items implemented
     extern "rust-call" fn call_once(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }
 struct Bar;
 impl FnMut<()> for Bar {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `FnMut` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `FnMut` are experimental
+    //~| ERROR expected a `FnOnce<()>` closure, found `Bar`
     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
+    //~| ERROR incompatible type for trait
 }
 struct Baz;
 impl FnOnce<()> for Baz {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `FnOnce` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `FnOnce` are experimental
+    //~| ERROR not all trait items implemented
     extern "rust-call" fn call_once(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -1,5 +1,5 @@
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:12:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:12
    |
 LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:19:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:22:12
    |
 LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:12
    |
 LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:33:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:39:12
    |
 LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL | impl Fn<()> for Foo {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ manual implementations of `FnOnce` are experimental
@@ -60,19 +60,19 @@ LL | impl FnOnce() for Foo1 {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ associated type not allowed here
    |
 help: parenthesized trait syntax expands to `FnOnce<(), Output=()>`
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^
@@ -81,7 +81,7 @@ LL | impl FnMut<()> for Bar {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnMut` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^ manual implementations of `FnMut` are experimental
@@ -89,7 +89,7 @@ LL | impl FnMut<()> for Bar {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
    |
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^
@@ -98,14 +98,76 @@ LL | impl FnOnce<()> for Baz {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
    |
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 12 previous errors
+error[E0277]: expected a `FnMut<()>` closure, found `Foo`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:17
+   |
+LL | impl Fn<()> for Foo {
+   |                 ^^^ expected an `FnMut<()>` closure, found `Foo`
+   |
+   = help: the trait `FnMut<()>` is not implemented for `Foo`
+   = note: wrap the `Foo` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0229, E0658.
-For more information about an error, try `rustc --explain E0183`.
+error[E0277]: expected a `FnOnce<()>` closure, found `Bar`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:20
+   |
+LL | impl FnMut<()> for Bar {
+   |                    ^^^ expected an `FnOnce<()>` closure, found `Bar`
+   |
+   = help: the trait `FnOnce<()>` is not implemented for `Bar`
+   = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `FnMut`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error[E0053]: method `call` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:32
+   |
+LL |     extern "rust-call" fn call(self, args: ()) -> () {}
+   |                                ^^^^
+   |                                |
+   |                                expected `&Foo`, found `Foo`
+   |                                help: change the self-receiver type to match the trait: `&self`
+   |
+   = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
+              found signature `extern "rust-call" fn(Foo, ())`
+
+error[E0046]: not all trait items implemented, missing: `Output`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:1
+   |
+LL | impl FnOnce() for Foo1 {
+   | ^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+
+error[E0053]: method `call_mut` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:36
+   |
+LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
+   |                                    ^^^^^
+   |                                    |
+   |                                    types differ in mutability
+   |                                    help: change the self-receiver type to match the trait: `&mut self`
+   |
+   = note: expected signature `extern "rust-call" fn(&mut Bar, ()) -> _`
+              found signature `extern "rust-call" fn(&Bar, ())`
+
+error[E0046]: not all trait items implemented, missing: `Output`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:1
+   |
+LL | impl FnOnce<()> for Baz {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+
+error: aborting due to 18 previous errors
+
+Some errors have detailed explanations: E0046, E0053, E0183, E0229, E0277, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/fn/issue-39259.rs
+++ b/tests/ui/fn/issue-39259.rs
@@ -4,8 +4,10 @@
 struct S;
 
 impl Fn(u32) -> u32 for S {
-//~^ ERROR associated type bindings are not allowed here [E0229]
+    //~^ ERROR associated type bindings are not allowed here [E0229]
+    //~| ERROR expected a `FnMut<(u32,)>` closure, found `S`
     fn call(&self) -> u32 {
+        //~^ ERROR method `call` has 1 parameter but the declaration in trait `call` has 2
         5
     }
 }

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -10,6 +10,25 @@ help: parenthesized trait syntax expands to `Fn<(u32,), Output=u32>`
 LL | impl Fn(u32) -> u32 for S {
    |      ^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0277]: expected a `FnMut<(u32,)>` closure, found `S`
+  --> $DIR/issue-39259.rs:6:25
+   |
+LL | impl Fn(u32) -> u32 for S {
+   |                         ^ expected an `FnMut<(u32,)>` closure, found `S`
+   |
+   = help: the trait `FnMut<(u32,)>` is not implemented for `S`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0229`.
+error[E0050]: method `call` has 1 parameter but the declaration in trait `call` has 2
+  --> $DIR/issue-39259.rs:9:13
+   |
+LL |     fn call(&self) -> u32 {
+   |             ^^^^^ expected 2 parameters, found 1
+   |
+   = note: `call` from trait: `extern "rust-call" fn(&Self, Args) -> <Self as FnOnce<Args>>::Output`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0050, E0229, E0277.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
@@ -6,4 +6,7 @@ fn main() {
   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
     //~^ ERROR: use of undeclared lifetime name `'x`
     //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: the trait `X` cannot be made into an object
 }

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
@@ -20,7 +20,38 @@ error[E0582]: binding for associated type `Y` references lifetime `'a`, which do
 LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
    |                                 ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0582]: binding for associated type `Y` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:33
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-Some errors have detailed explanations: E0261, E0582.
-For more information about an error, try `rustc --explain E0261`.
+error[E0582]: binding for associated type `Y` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:33
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:19
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'x>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0038, E0261, E0582.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
@@ -4,10 +4,11 @@ trait X {
   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
 }
 
-impl<T> X for T {
+impl<T> X for T { //~ ERROR: not all trait items implemented
   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
     //~^ ERROR missing generics for associated type
     //~^^ ERROR missing generics for associated type
+    //~| ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
     t
   }
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -31,6 +31,27 @@ help: add missing lifetime argument
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
    |                     ++++
 
-error: aborting due to 2 previous errors
+error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/gat-trait-path-missing-lifetime.rs:8:10
+   |
+LL |   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
+   |          -- expected 0 type parameters
+...
+LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
+   |          ^^  ^^
+   |          |
+   |          found 1 type parameter
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0046]: not all trait items implemented, missing: `Y`
+  --> $DIR/gat-trait-path-missing-lifetime.rs:7:1
+   |
+LL |   type Y<'a>;
+   |   ---------- `Y` from trait
+...
+LL | impl<T> X for T {
+   | ^^^^^^^^^^^^^^^ missing `Y` in implementation
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0049, E0107.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
@@ -7,10 +7,19 @@ fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
   //~| ERROR: parenthesized generic arguments cannot be used
   //~| ERROR associated type takes 0 generic arguments but 1 generic argument
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR at least one trait is required
+  //~| ERROR: the trait `X` cannot be made into an object
 
 
 fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
   //~^ ERROR: parenthesized generic arguments cannot be used
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR: the trait `X` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -16,7 +16,7 @@ LL | fn foo<'a>(arg: Box<dyn X<Y<'a> = &'a ()>>) {}
    |                            ~  ~
 
 error: parenthesized generic arguments cannot be used in associated type constraints
-  --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                           ^--
@@ -54,7 +54,7 @@ LL |   type Y<'a>;
    |        ^
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                           ^ expected 1 lifetime argument
@@ -69,6 +69,141 @@ help: add missing lifetime argument
 LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
    |                             ++
 
-error: aborting due to 6 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
+   |                             +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^---- help: remove these generics
+   |                           |
+   |                           expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
+   |                             +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^---- help: remove these generics
+   |                           |
+   |                           expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:29
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                             ^^
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:21
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                     ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'a>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:21
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                     ^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'a>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0038, E0107, E0224.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-71176.rs
+++ b/tests/ui/generic-associated-types/issue-71176.rs
@@ -9,6 +9,9 @@ impl Provider for () {
 struct Holder<B> {
   inner: Box<dyn Provider<A = B>>,
   //~^ ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: the trait `Provider` cannot be made into an object
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-71176.stderr
+++ b/tests/ui/generic-associated-types/issue-71176.stderr
@@ -14,6 +14,57 @@ help: add missing lifetime argument
 LL |   inner: Box<dyn Provider<A<'a> = B>>,
    |                            ++++
 
-error: aborting due to previous error
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
+
+error[E0038]: the trait `Provider` cannot be made into an object
+  --> $DIR/issue-71176.rs:10:14
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |              ^^^^^^^^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL | trait Provider {
+   |       -------- this trait cannot be made into an object...
+LL |     type A<'a>;
+   |          ^ ...because it contains the generic associated type `A`
+   = help: consider moving `A` to another trait
+   = help: only type `()` implements the trait, consider using it directly instead
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-79636-1.rs
+++ b/tests/ui/generic-associated-types/issue-79636-1.rs
@@ -3,6 +3,7 @@ trait Monad {
     type Wrapped<B>;
 
     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+        //~^ ERROR: the size for values of type `Self` cannot be known
         todo!()
     }
 }
@@ -14,8 +15,10 @@ where
     //~^ ERROR: missing generics for associated type `Monad::Wrapped`
 {
     outer.bind(|inner| inner)
+    //~^ ERROR type annotations needed
 }
 
 fn main() {
     assert_eq!(join(Some(Some(true))), Some(true));
+    //~^ ERROR: `Option<Option<bool>>: Monad` is not satisfied
 }

--- a/tests/ui/generic-associated-types/issue-79636-1.stderr
+++ b/tests/ui/generic-associated-types/issue-79636-1.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for associated type `Monad::Wrapped`
-  --> $DIR/issue-79636-1.rs:13:34
+  --> $DIR/issue-79636-1.rs:14:34
    |
 LL |     MInner: Monad<Unwrapped = A, Wrapped = MOuter::Wrapped<A>>,
    |                                  ^^^^^^^ expected 1 generic argument
@@ -14,6 +14,56 @@ help: add missing generic argument
 LL |     MInner: Monad<Unwrapped = A, Wrapped<B> = MOuter::Wrapped<A>>,
    |                                         +++
 
-error: aborting due to previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-79636-1.rs:5:19
+   |
+LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+   |                   ^^^^ doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider further restricting `Self`
+   |
+LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> where Self: Sized {
+   |                                                   +++++++++++++++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     fn bind<B, F>(&self, f: F) -> Self::Wrapped<B> {
+   |                   +
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0282]: type annotations needed
+  --> $DIR/issue-79636-1.rs:17:17
+   |
+LL |     outer.bind(|inner| inner)
+   |                 ^^^^^
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     outer.bind(|inner: /* Type */| inner)
+   |                      ++++++++++++
+
+error[E0277]: the trait bound `Option<Option<bool>>: Monad` is not satisfied
+  --> $DIR/issue-79636-1.rs:22:21
+   |
+LL |     assert_eq!(join(Some(Some(true))), Some(true));
+   |                ---- ^^^^^^^^^^^^^^^^ the trait `Monad` is not implemented for `Option<Option<bool>>`
+   |                |
+   |                required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/issue-79636-1.rs:1:1
+   |
+LL | trait Monad {
+   | ^^^^^^^^^^^
+note: required by a bound in `join`
+  --> $DIR/issue-79636-1.rs:13:13
+   |
+LL | fn join<MOuter, MInner, A>(outer: MOuter) -> MOuter::Wrapped<A>
+   |    ---- required by a bound in this function
+LL | where
+LL |     MOuter: Monad<Unwrapped = MInner>,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `join`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0277, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -4,7 +4,7 @@ struct E<T> {
 }
 
 trait TestMut {
-    type Output<'a>;
+    type Output<'a>; //~ ERROR missing required bound
     fn test_mut<'a>(&'a mut self) -> Self::Output<'a>;
 }
 

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -14,6 +14,17 @@ help: add missing lifetime argument
 LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output<'a> = &'a mut f32>)
    |                                                     ++++
 
-error: aborting due to previous error
+error: missing required bound on `Output`
+  --> $DIR/issue-80433.rs:7:5
+   |
+LL |     type Output<'a>;
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/missing_lifetime_args.rs
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.rs
@@ -10,6 +10,9 @@ struct Foo<'a, 'b, 'c> {
 
 fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
 //~^ ERROR missing generics for associated type
+//~| ERROR missing generics for associated type
+//~| ERROR missing generics for associated type
+//~| ERROR the trait `X` cannot be made into an object
 
 fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
 //~^ ERROR struct takes 3 lifetime arguments but 2 lifetime

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -15,7 +15,7 @@ LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
    |                                 ++++++++
 
 error[E0107]: struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/missing_lifetime_args.rs:14:26
+  --> $DIR/missing_lifetime_args.rs:17:26
    |
 LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
    |                          ^^^ --  -- supplied 2 lifetime arguments
@@ -33,7 +33,7 @@ LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b, 'a>) {}
    |                                    ++++
 
 error[E0107]: struct takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing_lifetime_args.rs:17:16
+  --> $DIR/missing_lifetime_args.rs:20:16
    |
 LL | fn f<'a>(_arg: Foo<'a>) {}
    |                ^^^ -- supplied 1 lifetime argument
@@ -50,6 +50,56 @@ help: add missing lifetime arguments
 LL | fn f<'a>(_arg: Foo<'a, 'a, 'a>) {}
    |                      ++++++++
 
-error: aborting due to 3 previous errors
+error[E0107]: missing generics for associated type `X::Y`
+  --> $DIR/missing_lifetime_args.rs:11:32
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                                ^ expected 2 lifetime arguments
+   |
+note: associated type defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL |     type Y<'a, 'b>;
+   |          ^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime arguments
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
+   |                                 ++++++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `X::Y`
+  --> $DIR/missing_lifetime_args.rs:11:32
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                                ^ expected 2 lifetime arguments
+   |
+note: associated type defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL |     type Y<'a, 'b>;
+   |          ^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime arguments
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
+   |                                 ++++++++
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/missing_lifetime_args.rs:11:26
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a, 'b>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
@@ -6,6 +6,11 @@ const _: () = {
   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
       //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
       //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR the trait `X` cannot be made into an object
 };
 
 fn main() {}

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -28,6 +28,86 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
 
-error: aborting due to 2 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                               +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^--- help: remove these generics
+   |                             |
+   |                             expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                               +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^--- help: remove these generics
+   |                             |
+   |                             expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:23
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                       ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/type-param-defaults.rs
+++ b/tests/ui/generic-associated-types/type-param-defaults.rs
@@ -29,6 +29,8 @@ where
 fn main() {
     // errors
     foo::<()>();
+    //~^ ERROR type mismatch
+    //~| ERROR `u64: Other` is not satisfied
     // works
     foo::<u32>();
 }

--- a/tests/ui/generic-associated-types/type-param-defaults.stderr
+++ b/tests/ui/generic-associated-types/type-param-defaults.stderr
@@ -16,5 +16,43 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 LL |     type Assoc<T = u32> = T;
    |                ^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0271]: type mismatch resolving `<() as Trait>::Assoc == u32`
+  --> $DIR/type-param-defaults.rs:31:11
+   |
+LL |     foo::<()>();
+   |           ^^ type mismatch resolving `<() as Trait>::Assoc == u32`
+   |
+note: expected this to be `u32`
+  --> $DIR/type-param-defaults.rs:11:27
+   |
+LL |     type Assoc<T = u32> = u64;
+   |                           ^^^
+note: required by a bound in `foo`
+  --> $DIR/type-param-defaults.rs:25:14
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this function
+LL | where
+LL |     T: Trait<Assoc = u32>,
+   |              ^^^^^^^^^^^ required by this bound in `foo`
 
+error[E0277]: the trait bound `u64: Other` is not satisfied
+  --> $DIR/type-param-defaults.rs:31:11
+   |
+LL |     foo::<()>();
+   |           ^^ the trait `Other` is not implemented for `u64`
+   |
+   = help: the trait `Other` is implemented for `u32`
+note: required by a bound in `foo`
+  --> $DIR/type-param-defaults.rs:26:15
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this function
+...
+LL |     T::Assoc: Other {
+   |               ^^^^^ required by this bound in `foo`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/generic-const-items/parameter-defaults.rs
+++ b/tests/ui/generic-const-items/parameter-defaults.rs
@@ -11,4 +11,5 @@ const NONE<T = ()>: Option<T> = None::<T>; //~ ERROR defaults for type parameter
 
 fn main() {
     let _ = NONE;
+    //~^ ERROR type annotations needed
 }

--- a/tests/ui/generic-const-items/parameter-defaults.stderr
+++ b/tests/ui/generic-const-items/parameter-defaults.stderr
@@ -4,5 +4,17 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 LL | const NONE<T = ()>: Option<T> = None::<T>;
    |            ^^^^^^
 
-error: aborting due to previous error
+error[E0282]: type annotations needed for `Option<T>`
+  --> $DIR/parameter-defaults.rs:13:9
+   |
+LL |     let _ = NONE;
+   |         ^
+   |
+help: consider giving this pattern a type, where the type for type parameter `T` is specified
+   |
+LL |     let _: Option<T> = NONE;
+   |          +++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/generics/wrong-number-of-args.rs
+++ b/tests/ui/generics/wrong-number-of-args.rs
@@ -21,7 +21,7 @@ mod no_generics {
 }
 
 mod type_and_type {
-    struct Ty<A, B>;
+    struct Ty<A, B>(A, B);
 
     type A = Ty;
     //~^ ERROR missing generics for struct `type_and_type::Ty`
@@ -43,7 +43,7 @@ mod type_and_type {
 }
 
 mod lifetime_and_type {
-    struct Ty<'a, T>;
+    struct Ty<'a, T>(&'a T);
 
     type A = Ty;
     //~^ ERROR missing generics for struct
@@ -75,7 +75,7 @@ mod lifetime_and_type {
 }
 
 mod type_and_type_and_type {
-    struct Ty<A, B, C = &'static str>;
+    struct Ty<A, B, C = &'static str>(A, B, C);
 
     type A = Ty;
     //~^ ERROR missing generics for struct `type_and_type_and_type::Ty`

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -246,7 +246,7 @@ LL |     type A = Ty;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -264,7 +264,7 @@ LL |     type B = Ty<usize>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic argument
    |
@@ -282,7 +282,7 @@ LL |     type D = Ty<usize, String, char>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 
 error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
@@ -294,7 +294,7 @@ LL |     type E = Ty<>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -310,7 +310,7 @@ LL |     type A = Ty;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -326,7 +326,7 @@ LL |     type B = Ty<'static>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -342,7 +342,7 @@ LL |     type E = Ty<>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -360,7 +360,7 @@ LL |     type F = Ty<'static, usize, 'static, usize>;
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^ --
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
@@ -374,7 +374,7 @@ LL |     type F = Ty<'static, usize, 'static, usize>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
@@ -386,7 +386,7 @@ LL |     type A = Ty;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -404,7 +404,7 @@ LL |     type B = Ty<usize>;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic argument
    |
@@ -422,7 +422,7 @@ LL |     type E = Ty<usize, String, char, f64>;
 note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -  ----------------
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
@@ -434,7 +434,7 @@ LL |     type F = Ty<>;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic arguments
    |

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied
+  --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:13
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not implemented for `()`
+
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:24
    |
@@ -9,6 +15,7 @@ help: add `dyn` keyword before this trait
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0782`.
+Some errors have detailed explanations: E0277, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
@@ -6,6 +6,7 @@
 fn ice() -> impl AsRef<Fn(&())> {
     //[edition2015]~^ ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     //[edition2021]~^^ ERROR: trait objects must include the `dyn` keyword [E0782]
+    //[edition2021]~| ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     todo!()
 }
 

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -4,16 +4,19 @@ use std::fmt::Debug;
 fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn d() -> impl Fn() -> (impl Debug + '_) {

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-fn-hrtb-bounds.rs:19:38
+  --> $DIR/impl-fn-hrtb-bounds.rs:22:38
    |
 LL | fn d() -> impl Fn() -> (impl Debug + '_) {
    |                                      ^^ expected named lifetime parameter
@@ -23,29 +23,56 @@ LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
    |                   ^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:10:52
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:10:20
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:16:52
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:16:20
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                    ^^
 
-error: aborting due to 4 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:6:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:12:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:18:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
@@ -5,6 +5,7 @@ fn a() -> impl Fn(&u8) -> impl Debug + '_ {
     //~^ ERROR ambiguous `+` in a type
     //~| ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl Fn() -> impl Debug + Send {

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -5,7 +5,7 @@ LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
 
 error: ambiguous `+` in a type
-  --> $DIR/impl-fn-parsing-ambiguities.rs:10:24
+  --> $DIR/impl-fn-parsing-ambiguities.rs:11:24
    |
 LL | fn b() -> impl Fn() -> impl Debug + Send {
    |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
@@ -22,5 +22,14 @@ note: lifetime declared here
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                   ^
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-parsing-ambiguities.rs:7:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/impl-trait/impl_trait_projections.rs
+++ b/tests/ui/impl-trait/impl_trait_projections.rs
@@ -15,7 +15,7 @@ fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
     x.next().unwrap()
 }
 
-fn projection_with_named_trait_is_disallowed(x: impl Iterator)
+fn projection_with_named_trait_is_disallowed(mut x: impl Iterator)
     -> <impl Iterator as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
 {
@@ -25,7 +25,9 @@ fn projection_with_named_trait_is_disallowed(x: impl Iterator)
 fn projection_with_named_trait_inside_path_is_disallowed()
     -> <::std::ops::Range<impl Debug> as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
+//~| ERROR `impl Debug: Step` is not satisfied
 {
+    //~^ ERROR `impl Debug: Step` is not satisfied
     (1i32..100).next().unwrap()
 }
 

--- a/tests/ui/impl-trait/impl_trait_projections.stderr
+++ b/tests/ui/impl-trait/impl_trait_projections.stderr
@@ -17,7 +17,7 @@ LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
    |                           ^^^^^^^^^^
 
 error[E0667]: `impl Trait` is not allowed in path parameters
-  --> $DIR/impl_trait_projections.rs:33:29
+  --> $DIR/impl_trait_projections.rs:35:29
    |
 LL |     -> <dyn Iterator<Item = impl Debug> as Iterator>::Item
    |                             ^^^^^^^^^^
@@ -28,6 +28,46 @@ error[E0667]: `impl Trait` is not allowed in path parameters
 LL | fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
    |                                                   ^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0277]: the trait bound `impl Debug: Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:26:8
+   |
+LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Step` is not implemented for `impl Debug`
+   |
+   = help: the following other types implement trait `Step`:
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+           and 8 others
+   = note: required for `std::ops::Range<impl Debug>` to implement `Iterator`
 
-For more information about this error, try `rustc --explain E0667`.
+error[E0277]: the trait bound `impl Debug: Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:29:1
+   |
+LL | / {
+LL | |
+LL | |     (1i32..100).next().unwrap()
+LL | | }
+   | |_^ the trait `Step` is not implemented for `impl Debug`
+   |
+   = help: the following other types implement trait `Step`:
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+           and 8 others
+   = note: required for `std::ops::Range<impl Debug>` to implement `Iterator`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0667.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/issues/issue-67830.rs
+++ b/tests/ui/impl-trait/issues/issue-67830.rs
@@ -21,6 +21,8 @@ struct A;
 fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     Wrap(|a| Some(a).into_iter())
+    //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR implementation of `FnOnce` is not general enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-67830.stderr
+++ b/tests/ui/impl-trait/issues/issue-67830.stderr
@@ -10,5 +10,24 @@ note: lifetime declared here
 LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
    |                       ^^
 
-error: aborting due to previous error
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/issue-67830.rs:23:5
+   |
+LL |     Wrap(|a| Some(a).into_iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
+
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/issue-67830.rs:23:5
+   |
+LL |     Wrap(|a| Some(a).into_iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-88236-2.rs
+++ b/tests/ui/impl-trait/issues/issue-88236-2.rs
@@ -18,11 +18,16 @@ fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
 fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     &()
+    //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR implementation of `Hrtb` is not general enough
 }
 
 fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     x
+    //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236-2.stderr
@@ -23,16 +23,72 @@ LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Sen
    |                                               ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/issue-88236-2.rs:23:78
+  --> $DIR/issue-88236-2.rs:25:78
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                                                              ^^
    |
 note: lifetime declared here
-  --> $DIR/issue-88236-2.rs:23:45
+  --> $DIR/issue-88236-2.rs:25:45
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                             ^^
 
-error: aborting due to 3 previous errors
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:20:5
+   |
+LL |     &()
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:20:5
+   |
+LL |     &()
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                  -- lifetime `'b` defined here
+LL |
+LL |     x
+   |     ^ returning this value requires that `'b` must outlive `'static`
+   |
+help: to declare that `impl for<'a> Hrtb<'a, Assoc = impl Send + '_>` captures data from argument `x`, you can add an explicit `'b` lifetime bound
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> + 'b {
+   |                                                                                  ++++
+help: to declare that `impl Send + 'a` captures data from argument `x`, you can add an explicit `'b` lifetime bound
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a + 'b> {
+   |                                                                                 ++++
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL |     x
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL |     x
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-92305.rs
+++ b/tests/ui/impl-trait/issues/issue-92305.rs
@@ -5,6 +5,7 @@ use std::iter;
 fn f<T>(data: &[T]) -> impl Iterator<Item = Vec> {
     //~^ ERROR: missing generics for struct `Vec` [E0107]
     iter::empty()
+    //~^ ERROR: type annotations needed
 }
 
 fn g<T>(data: &[T], target: T) -> impl Iterator<Item = Vec<T>> {

--- a/tests/ui/impl-trait/issues/issue-92305.stderr
+++ b/tests/ui/impl-trait/issues/issue-92305.stderr
@@ -9,6 +9,18 @@ help: add missing generic argument
 LL | fn f<T>(data: &[T]) -> impl Iterator<Item = Vec<T>> {
    |                                                +++
 
-error: aborting due to previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-92305.rs:7:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -31,9 +31,11 @@ fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
 
 fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
 //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+//~| ERROR implementation of `Bar` is not general enough
 
 fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
 //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+//~| ERROR: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param<'b>() -> impl for<'a> Foo<'a, Assoc = impl Qux<'b>> {}
@@ -43,9 +45,11 @@ fn one_hrtb_mention_fn_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl Sized
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
+//~^ ERROR: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+//~^ ERROR implementation of `Bar` is not general enough
 
 // This should resolve.
 fn two_htrb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Qux<'b>> {}
@@ -56,9 +60,11 @@ fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> 
 
 // This should resolve.
 fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
+//~^ ERROR: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
 
 // `'b` is not in scope for the outlives bound.
 fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
 //~^ ERROR use of undeclared lifetime name `'b` [E0261]
+//~| ERROR implementation of `Bar` is not general enough
 
 fn main() {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:54:77
+  --> $DIR/nested-rpit-hrtb.rs:58:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:61:82
+  --> $DIR/nested-rpit-hrtb.rs:66:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -66,17 +66,72 @@ LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a
    |                                         ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/nested-rpit-hrtb.rs:35:73
+  --> $DIR/nested-rpit-hrtb.rs:36:73
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                                                         ^^
    |
 note: lifetime declared here
-  --> $DIR/nested-rpit-hrtb.rs:35:44
+  --> $DIR/nested-rpit-hrtb.rs:36:44
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
 
-error: aborting due to 6 previous errors
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:32:78
+   |
+LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
+   |                                                                              ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'0>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Bar<'1>`, for some specific lifetime `'1`
 
-For more information about this error, try `rustc --explain E0261`.
+error[E0277]: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:36:64
+   |
+LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
+   |                                                                ^^^^^^^^^^^^ the trait `for<'a> Qux<'_>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:47:79
+   |
+LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
+   |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:51:93
+   |
+LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+   |                                                                                             ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'0>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Bar<'1>`, for some specific lifetime `'1`
+
+error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:62:64
+   |
+LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
+   |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:66:86
+   |
+LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
+   |                                                                                      ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'0>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Bar<'1>`, for some specific lifetime `'1`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0261, E0277.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/intrinsics/safe-intrinsic-mismatch.rs
+++ b/tests/ui/intrinsics/safe-intrinsic-mismatch.rs
@@ -3,9 +3,11 @@
 
 extern "rust-intrinsic" {
     fn size_of<T>() -> usize; //~ ERROR intrinsic safety mismatch
+    //~^ ERROR intrinsic safety mismatch
 
     #[rustc_safe_intrinsic]
     fn assume(b: bool); //~ ERROR intrinsic safety mismatch
+    //~^ ERROR intrinsic safety mismatch
 }
 
 fn main() {}

--- a/tests/ui/intrinsics/safe-intrinsic-mismatch.stderr
+++ b/tests/ui/intrinsics/safe-intrinsic-mismatch.stderr
@@ -5,10 +5,26 @@ LL |     fn size_of<T>() -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `assume`
-  --> $DIR/safe-intrinsic-mismatch.rs:8:5
+  --> $DIR/safe-intrinsic-mismatch.rs:9:5
    |
 LL |     fn assume(b: bool);
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `size_of`
+  --> $DIR/safe-intrinsic-mismatch.rs:5:5
+   |
+LL |     fn size_of<T>() -> usize;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `assume`
+  --> $DIR/safe-intrinsic-mismatch.rs:9:5
+   |
+LL |     fn assume(b: bool);
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-31910.rs
+++ b/tests/ui/issues/issue-31910.rs
@@ -1,4 +1,5 @@
 enum Enum<T: Trait> {
+    //~^ ERROR: `T` is never used
     X = Trait::Number,
     //~^ ERROR mismatched types
     //~| expected `isize`, found `i32`

--- a/tests/ui/issues/issue-31910.stderr
+++ b/tests/ui/issues/issue-31910.stderr
@@ -1,9 +1,18 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-31910.rs:2:9
+  --> $DIR/issue-31910.rs:3:9
    |
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected `isize`, found `i32`
 
-error: aborting due to previous error
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-31910.rs:1:11
+   |
+LL | enum Enum<T: Trait> {
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0392.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/issues/issue-3214.rs
+++ b/tests/ui/issues/issue-3214.rs
@@ -5,6 +5,7 @@ fn foo<T>() {
 
     impl<T> Drop for Foo<T> {
         //~^ ERROR struct takes 0 generic arguments but 1 generic argument
+        //~| ERROR `T` is not constrained
         fn drop(&mut self) {}
     }
 }

--- a/tests/ui/issues/issue-3214.stderr
+++ b/tests/ui/issues/issue-3214.stderr
@@ -22,7 +22,13 @@ note: struct defined here, with 0 generic parameters
 LL |     struct Foo {
    |            ^^^
 
-error: aborting due to 2 previous errors
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-3214.rs:6:10
+   |
+LL |     impl<T> Drop for Foo<T> {
+   |          ^ unconstrained type parameter
 
-Some errors have detailed explanations: E0107, E0401.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0207, E0401.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/issues/issue-34373.rs
+++ b/tests/ui/issues/issue-34373.rs
@@ -5,6 +5,8 @@ trait Trait<T> {
 }
 
 pub struct Foo<T = Box<Trait<DefaultFoo>>>;  //~ ERROR cycle detected
+//~^ ERROR `T` is never used
+//~| ERROR `Trait` cannot be made into an object
 type DefaultFoo = Foo;
 
 fn main() {

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -5,7 +5,7 @@ LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
    |                              ^^^^^^^^^^
    |
 note: ...which requires expanding type alias `DefaultFoo`...
-  --> $DIR/issue-34373.rs:8:19
+  --> $DIR/issue-34373.rs:10:19
    |
 LL | type DefaultFoo = Foo;
    |                   ^^^
@@ -23,6 +23,38 @@ LL | | }
    | |_^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to previous error
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/issue-34373.rs:7:24
+   |
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   |                        ^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-34373.rs:4:8
+   |
+LL | trait Trait<T> {
+   |       ----- this trait cannot be made into an object...
+LL |     fn foo(_: T) {}
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self, _: T) {}
+   |            ++++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo(_: T) where Self: Sized {}
+   |                  +++++++++++++++++
 
-For more information about this error, try `rustc --explain E0391`.
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-34373.rs:7:16
+   |
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0391, E0392.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/lang-items/lang-item-generic-requirements.rs
+++ b/tests/ui/lang-items/lang-item-generic-requirements.rs
@@ -22,6 +22,8 @@ trait MyIndex<'a, T> {}
 #[lang = "phantom_data"]
 //~^ ERROR `phantom_data` language item must be applied to a struct with 1 generic argument
 struct MyPhantomData<T, U>;
+//~^ ERROR `T` is never used
+//~| ERROR `U` is never used
 
 #[lang = "owned_box"]
 //~^ ERROR `owned_box` language item must be applied to a struct with at least 1 generic argument
@@ -39,7 +41,7 @@ fn ice() {
     // Use add
     let r = 5;
     let a = 6;
-    r + a;
+    r + a; //~ ERROR cannot add
 
     // Use drop in place
     my_ptr_drop();

--- a/tests/ui/lang-items/lang-item-generic-requirements.stderr
+++ b/tests/ui/lang-items/lang-item-generic-requirements.stderr
@@ -33,7 +33,7 @@ LL | struct MyPhantomData<T, U>;
    |                     ------ this struct has 2 generic arguments
 
 error[E0718]: `owned_box` language item must be applied to a struct with at least 1 generic argument
-  --> $DIR/lang-item-generic-requirements.rs:26:1
+  --> $DIR/lang-item-generic-requirements.rs:28:1
    |
 LL | #[lang = "owned_box"]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL | struct Foo;
    |           - this struct has 0 generic arguments
 
 error[E0718]: `start` language item must be applied to a function with 1 generic argument
-  --> $DIR/lang-item-generic-requirements.rs:32:1
+  --> $DIR/lang-item-generic-requirements.rs:34:1
    |
 LL | #[lang = "start"]
    | ^^^^^^^^^^^^^^^^^
@@ -50,6 +50,35 @@ LL |
 LL | fn start(_: *const u8, _: isize, _: *const *const u8) -> isize {
    |         - this function has 0 generic arguments
 
-error: aborting due to 6 previous errors
+error[E0392]: parameter `T` is never used
+  --> $DIR/lang-item-generic-requirements.rs:24:22
+   |
+LL | struct MyPhantomData<T, U>;
+   |                      ^ unused parameter
+   |
+   = help: consider removing `T` or referring to it in a field
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
-For more information about this error, try `rustc --explain E0718`.
+error[E0392]: parameter `U` is never used
+  --> $DIR/lang-item-generic-requirements.rs:24:25
+   |
+LL | struct MyPhantomData<T, U>;
+   |                         ^ unused parameter
+   |
+   = help: consider removing `U` or referring to it in a field
+   = help: if you intended `U` to be a const parameter, use `const U: usize` instead
+
+error[E0369]: cannot add `{integer}` to `{integer}`
+  --> $DIR/lang-item-generic-requirements.rs:44:7
+   |
+LL |     r + a;
+   |     - ^ - {integer}
+   |     |
+   |     {integer}
+
+error: requires `copy` lang_item
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0369, E0392, E0718.
+For more information about an error, try `rustc --explain E0369`.

--- a/tests/ui/lifetimes/issue-95023.rs
+++ b/tests/ui/lifetimes/issue-95023.rs
@@ -3,7 +3,9 @@ struct Error(ErrorKind);
 impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental [E0183]
     //~^^ ERROR associated type bindings are not allowed here [E0229]
-    fn foo<const N: usize>(&self) -> Self::B<{N}>;
+    //~| ERROR not all trait items implemented
+    //~| ERROR expected a `FnMut<(&isize,)>` closure, found `Error`
+    fn foo<const N: usize>(&self) -> Self::B<{ N }>;
     //~^ ERROR associated function in `impl` without body
     //~^^ ERROR method `foo` is not a member of trait `Fn` [E0407]
     //~^^^ ERROR associated type `B` not found for `Self` [E0220]

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -1,16 +1,16 @@
 error: associated function in `impl` without body
-  --> $DIR/issue-95023.rs:6:5
+  --> $DIR/issue-95023.rs:8:5
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                                  |
-   |                                                  help: provide a definition for the function: `{ <body> }`
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                                    |
+   |                                                    help: provide a definition for the function: `{ <body> }`
 
 error[E0407]: method `foo` is not a member of trait `Fn`
-  --> $DIR/issue-95023.rs:6:5
+  --> $DIR/issue-95023.rs:8:5
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
 
 error[E0183]: manual implementations of `Fn` are experimental
   --> $DIR/issue-95023.rs:3:6
@@ -33,12 +33,30 @@ LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
 error[E0220]: associated type `B` not found for `Self`
-  --> $DIR/issue-95023.rs:6:44
+  --> $DIR/issue-95023.rs:8:44
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
    |                                            ^ help: `Self` has the following associated type: `Output`
 
-error: aborting due to 5 previous errors
+error[E0277]: expected a `FnMut<(&isize,)>` closure, found `Error`
+  --> $DIR/issue-95023.rs:3:21
+   |
+LL | impl Fn(&isize) for Error {
+   |                     ^^^^^ expected an `FnMut<(&isize,)>` closure, found `Error`
+   |
+   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0220, E0229, E0407.
-For more information about an error, try `rustc --explain E0183`.
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-95023.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0046, E0183, E0220, E0229, E0277, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.rs
@@ -4,6 +4,7 @@ trait Trait<'a> {
     type Bar<'b>
     //~^ NOTE associated type defined here, with 1 lifetime parameter
     //~| NOTE
+    //~| NOTE
     where
         Self: 'b;
 }
@@ -13,6 +14,8 @@ struct Impl<'a>(&'a ());
 impl<'a> Trait<'a> for Impl<'a> {
     type Foo = &'a ();
     type Bar<'b> = &'b ();
+    //~^ ERROR: does not fulfill the required lifetime
+    //~| NOTE: type must outlive the lifetime `'b`
 }
 
 type A<'a> = Impl<'a>;

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-alias.rs:20:24
+  --> $DIR/missing-lifetime-in-alias.rs:23:24
    |
 LL | type B<'a> = <A<'a> as Trait>::Foo;
    |                        ^^^^^ expected named lifetime parameter
@@ -10,13 +10,13 @@ LL | type B<'a> = <A<'a> as Trait<'a>>::Foo;
    |                             ++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-alias.rs:24:28
+  --> $DIR/missing-lifetime-in-alias.rs:27:28
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |                            ^^^^^ expected named lifetime parameter
    |
 note: these named lifetimes are available to use
-  --> $DIR/missing-lifetime-in-alias.rs:24:8
+  --> $DIR/missing-lifetime-in-alias.rs:27:8
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |        ^^  ^^
@@ -26,7 +26,7 @@ LL | type C<'a, 'b> = <A<'a> as Trait<'lifetime>>::Bar;
    |                                 +++++++++++
 
 error[E0107]: missing generics for associated type `Trait::Bar`
-  --> $DIR/missing-lifetime-in-alias.rs:24:36
+  --> $DIR/missing-lifetime-in-alias.rs:27:36
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |                                    ^^^ expected 1 lifetime argument
@@ -41,7 +41,26 @@ help: add missing lifetime argument
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar<'a>;
    |                                       ++++
 
-error: aborting due to 3 previous errors
+error[E0477]: the type `Impl<'a>` does not fulfill the required lifetime
+  --> $DIR/missing-lifetime-in-alias.rs:16:20
+   |
+LL |     type Bar<'b>
+   |     ------------ definition of `Bar` from trait
+...
+LL |     type Bar<'b> = &'b ();
+   |                    ^^^^^^
+   |
+note: type must outlive the lifetime `'b` as defined here
+  --> $DIR/missing-lifetime-in-alias.rs:16:14
+   |
+LL |     type Bar<'b> = &'b ();
+   |              ^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Bar<'b> = &'b () where Self: 'b;
+   |                           ++++++++++++++
 
-Some errors have detailed explanations: E0106, E0107.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0107, E0477.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/numbers-arithmetic/location-add-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-add-assign-overflow.rs
@@ -1,0 +1,7 @@
+// run-fail
+// error-pattern:location-add-assign-overflow.rs
+
+fn main() {
+    let mut a: u8 = 255;
+    a += &1;
+}

--- a/tests/ui/numbers-arithmetic/location-add-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-add-overflow.rs
@@ -1,0 +1,6 @@
+// run-fail
+// error-pattern:location-add-overflow.rs
+
+fn main() {
+    let _: u8 = 255 + &1;
+}

--- a/tests/ui/numbers-arithmetic/location-divide-assign-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-divide-assign-by-zero.rs
@@ -1,0 +1,7 @@
+// run-fail
+// error-pattern:location-divide-assign-by-zero.rs
+
+fn main() {
+    let mut a = 1;
+    a /= &0;
+}

--- a/tests/ui/numbers-arithmetic/location-divide-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-divide-by-zero.rs
@@ -1,0 +1,8 @@
+// run-fail
+// error-pattern:location-divide-by-zero.rs
+
+// https://github.com/rust-lang/rust/issues/114814
+
+fn main() {
+    let _ = 1 / &0;
+}

--- a/tests/ui/numbers-arithmetic/location-mod-assign-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-mod-assign-by-zero.rs
@@ -1,0 +1,7 @@
+// run-fail
+// error-pattern:location-mod-assign-by-zero.rs
+
+fn main() {
+    let mut a = 1;
+    a %= &0;
+}

--- a/tests/ui/numbers-arithmetic/location-mod-by-zero.rs
+++ b/tests/ui/numbers-arithmetic/location-mod-by-zero.rs
@@ -1,0 +1,6 @@
+// run-fail
+// error-pattern:location-mod-by-zero.rs
+
+fn main() {
+    let _ = 1 % &0;
+}

--- a/tests/ui/numbers-arithmetic/location-mul-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-mul-assign-overflow.rs
@@ -1,0 +1,7 @@
+// run-fail
+// error-pattern:location-mul-assign-overflow.rs
+
+fn main() {
+    let mut a: u8 = 255;
+    a *= &2;
+}

--- a/tests/ui/numbers-arithmetic/location-mul-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-mul-overflow.rs
@@ -1,0 +1,6 @@
+// run-fail
+// error-pattern:location-mul-overflow.rs
+
+fn main() {
+    let _: u8 = 255 * &2;
+}

--- a/tests/ui/numbers-arithmetic/location-sub-assign-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-sub-assign-overflow.rs
@@ -1,0 +1,7 @@
+// run-fail
+// error-pattern:location-sub-assign-overflow.rs
+
+fn main() {
+    let mut a: u8 = 0;
+    a -= &1;
+}

--- a/tests/ui/numbers-arithmetic/location-sub-overflow.rs
+++ b/tests/ui/numbers-arithmetic/location-sub-overflow.rs
@@ -1,0 +1,6 @@
+// run-fail
+// error-pattern:location-sub-overflow.rs
+
+fn main() {
+    let _: u8 = 0 - &1;
+}

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
@@ -15,6 +15,7 @@ fn is_static<T>(_: T) where T: 'static { }
 // code forces us into a conservative, hacky path.
 fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
 //~^ ERROR please supply an explicit bound
+//~| ERROR `(): Foo<'_>` is not satisfied
 
 fn main() {
     let s = format!("foo");

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
@@ -4,6 +4,20 @@ error[E0228]: the lifetime bound for this object type cannot be deduced from con
 LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
    |                                    ^^^^^^^
 
-error: aborting due to previous error
+error[E0277]: the trait bound `(): Foo<'_>` is not satisfied
+  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:16:47
+   |
+LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
+   |                                               ^^^ the trait `Foo<'_>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:4:1
+   |
+LL | trait Foo<'a> {
+   | ^^^^^^^^^^^^^
+   = note: required for the cast from `&()` to `&dyn Foo<'_, Item = dyn Bar>`
 
-For more information about this error, try `rustc --explain E0228`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0228, E0277.
+For more information about an error, try `rustc --explain E0228`.

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.rs
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.rs
@@ -6,6 +6,7 @@ trait Bar<T> {
 }
 
 trait Baz : Bar<Self> {
+    //~^ ERROR the size for values of type `Self` cannot be known
 }
 
 fn make_bar<T:Bar<u32>>(t: &T) -> &dyn Bar<u32> {

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Baz` cannot be made into an object
-  --> $DIR/object-safety-supertrait-mentions-Self.rs:15:31
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:16:31
    |
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ `Baz` cannot be made into an object
@@ -12,6 +12,27 @@ LL | trait Baz : Bar<Self> {
    |       |
    |       this trait cannot be made into an object...
 
-error: aborting due to previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
+   |
+LL | trait Baz : Bar<Self> {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Bar`
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
+   |
+LL | trait Bar<T> {
+   |           ^ required by this bound in `Bar`
+help: consider further restricting `Self`
+   |
+LL | trait Baz : Bar<Self> + Sized {
+   |                       +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Bar<T: ?Sized> {
+   |            ++++++++
 
-For more information about this error, try `rustc --explain E0038`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/panic-handler/panic-handler-std.stderr
+++ b/tests/ui/panic-handler/panic-handler-std.stderr
@@ -8,6 +8,16 @@ LL | fn panic(info: PanicInfo) -> ! {
    = note: first definition in `std` loaded from SYSROOT/libstd-*.rlib
    = note: second definition in the local crate (`panic_handler_std`)
 
-error: aborting due to previous error
+error[E0308]: `#[panic_handler]` function has wrong type
+  --> $DIR/panic-handler-std.rs:8:16
+   |
+LL | fn panic(info: PanicInfo) -> ! {
+   |                ^^^^^^^^^ expected `&PanicInfo<'_>`, found `PanicInfo<'_>`
+   |
+   = note: expected signature `for<'a, 'b> fn(&'a PanicInfo<'b>) -> _`
+              found signature `for<'a> fn(PanicInfo<'a>) -> _`
 
-For more information about this error, try `rustc --explain E0152`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0152, E0308.
+For more information about an error, try `rustc --explain E0152`.

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
@@ -17,4 +17,5 @@ impl X {
     type W where Self: Eq;
     //~^ ERROR associated type in `impl` without body
     //~| ERROR inherent associated types are unstable
+    //~| ERROR duplicate definitions
 }

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -78,6 +78,16 @@ LL |     type W where Self: Eq;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 10 previous errors
+error[E0592]: duplicate definitions with name `W`
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
+   |
+LL |     type W: Ord where Self: Eq;
+   |     ------ other definition for `W`
+...
+LL |     type W where Self: Eq;
+   |     ^^^^^^ duplicate definitions for `W`
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0592, E0658.
+For more information about an error, try `rustc --explain E0592`.

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
@@ -16,4 +16,5 @@ fn y<'a>(y: &mut 'a + Send) {
     //~| ERROR at least one trait is required for an object type
     let z = y as &mut 'a + Send;
     //~^ ERROR expected value, found trait `Send`
+    //~| ERROR at least one trait is required for an object type
 }

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
@@ -33,7 +33,13 @@ error[E0224]: at least one trait is required for an object type
 LL | fn y<'a>(y: &mut 'a + Send) {
    |                  ^^
 
-error: aborting due to 5 previous errors
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/issue-73568-lifetime-after-mut.rs:17:23
+   |
+LL |     let z = y as &mut 'a + Send;
+   |                       ^^
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0178, E0224, E0423.
 For more information about an error, try `rustc --explain E0178`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/cross-crate.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/cross-crate.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'a, T> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     bar: std::slice::IterMut<'a, T>
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/cross-crate.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/cross-crate.stderr
@@ -6,5 +6,15 @@ LL | struct Foo<'a, T> {
    |
    = note: T: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/cross-crate.rs:4:1
+   |
+LL | struct Foo<'a, T> {
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $SRC_DIR/core/src/slice/iter.rs:LL:COL
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/enum.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/enum.rs
@@ -5,18 +5,21 @@
 // Type T needs to outlive lifetime 'a.
 #[rustc_outlives]
 enum Foo<'a, T> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     One(Bar<'a, T>)
 }
 
 // Type U needs to outlive lifetime 'b
 #[rustc_outlives]
 struct Bar<'b, U> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     field2: &'b U
 }
 
 // Type K needs to outlive lifetime 'c.
 #[rustc_outlives]
 enum Ying<'c, K> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     One(&'c Yang<K>)
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/enum.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/enum.stderr
@@ -7,7 +7,7 @@ LL | enum Foo<'a, T> {
    = note: T: 'a
 
 error: rustc_outlives
-  --> $DIR/enum.rs:13:1
+  --> $DIR/enum.rs:14:1
    |
 LL | struct Bar<'b, U> {
    | ^^^^^^^^^^^^^^^^^
@@ -15,12 +15,49 @@ LL | struct Bar<'b, U> {
    = note: U: 'b
 
 error: rustc_outlives
-  --> $DIR/enum.rs:19:1
+  --> $DIR/enum.rs:21:1
    |
 LL | enum Ying<'c, K> {
    | ^^^^^^^^^^^^^^^^
    |
    = note: K: 'c
 
-error: aborting due to 3 previous errors
+error[E0640]: rustc_outlives
+  --> $DIR/enum.rs:7:1
+   |
+LL | enum Foo<'a, T> {
+   | ^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $DIR/enum.rs:16:5
+   |
+LL |     field2: &'b U
+   |     ^^^^^^^^^^^^^
 
+error[E0640]: rustc_outlives
+  --> $DIR/enum.rs:14:1
+   |
+LL | struct Bar<'b, U> {
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: U: 'b
+  --> $DIR/enum.rs:16:5
+   |
+LL |     field2: &'b U
+   |     ^^^^^^^^^^^^^
+
+error[E0640]: rustc_outlives
+  --> $DIR/enum.rs:21:1
+   |
+LL | enum Ying<'c, K> {
+   | ^^^^^^^^^^^^^^^^
+   |
+note: K: 'c
+  --> $DIR/enum.rs:23:9
+   |
+LL |     One(&'c Yang<K>)
+   |         ^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-dyn.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-dyn.rs
@@ -5,6 +5,7 @@ trait Trait<'x, T> where T: 'x {
 
 #[rustc_outlives]
 struct Foo<'a, A> //~ ERROR rustc_outlives
+//~^ ERROR rustc_outlives
 {
     foo: Box<dyn Trait<'a, A>>
 }

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-dyn.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-dyn.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, A>
    |
    = note: A: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/explicit-dyn.rs:7:1
+   |
+LL | struct Foo<'a, A>
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: A: 'a
+  --> $DIR/explicit-dyn.rs:3:29
+   |
+LL | trait Trait<'x, T> where T: 'x {
+   |                             ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-enum.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-enum.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 enum Foo<'a, U> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     One(Bar<'a, U>)
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-enum.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-enum.stderr
@@ -6,5 +6,18 @@ LL | enum Foo<'a, U> {
    |
    = note: U: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/explicit-enum.rs:4:1
+   |
+LL | enum Foo<'a, U> {
+   | ^^^^^^^^^^^^^^^
+   |
+note: U: 'a
+  --> $DIR/explicit-enum.rs:9:28
+   |
+LL | struct Bar<'x, T> where T: 'x {
+   |                            ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-projection.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-projection.rs
@@ -6,6 +6,7 @@ trait Trait<'x, T> where T: 'x {
 
 #[rustc_outlives]
 struct Foo<'a, A, B> where A: Trait<'a, B> //~ ERROR rustc_outlives
+//~^ ERROR rustc_outlives
 {
     foo: <A as Trait<'a, B>>::Type
 }

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-projection.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-projection.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, A, B> where A: Trait<'a, B>
    |
    = note: B: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/explicit-projection.rs:8:1
+   |
+LL | struct Foo<'a, A, B> where A: Trait<'a, B>
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+note: B: 'a
+  --> $DIR/explicit-projection.rs:3:29
+   |
+LL | trait Trait<'x, T> where T: 'x {
+   |                             ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-struct.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-struct.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'b, U> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     bar: Bar<'b, U>
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-struct.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-struct.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'b, U> {
    |
    = note: U: 'b
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/explicit-struct.rs:4:1
+   |
+LL | struct Foo<'b, U> {
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: U: 'b
+  --> $DIR/explicit-struct.rs:9:28
+   |
+LL | struct Bar<'a, T> where T: 'a {
+   |                            ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-union.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-union.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 union Foo<'b, U: Copy> { //~ ERROR rustc_outlives
+    //~^ ERROR: rustc_outlives
     bar: Bar<'b, U>
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-union.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/explicit-union.stderr
@@ -6,5 +6,18 @@ LL | union Foo<'b, U: Copy> {
    |
    = note: U: 'b
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/explicit-union.rs:4:1
+   |
+LL | union Foo<'b, U: Copy> {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: U: 'b
+  --> $DIR/explicit-union.rs:10:33
+   |
+LL | union Bar<'a, T: Copy> where T: 'a {
+   |                                 ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-enum.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-enum.rs
@@ -2,7 +2,7 @@
 
 #[rustc_outlives]
 enum Foo<'a, T> { //~ ERROR rustc_outlives
-
+    //~^ ERROR rustc_outlives
     One(Bar<'a, T>)
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-enum.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-enum.stderr
@@ -6,5 +6,18 @@ LL | enum Foo<'a, T> {
    |
    = note: T: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/nested-enum.rs:4:1
+   |
+LL | enum Foo<'a, T> {
+   | ^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $DIR/nested-enum.rs:10:5
+   |
+LL |     field2: &'b U
+   |     ^^^^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-regions.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-regions.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'a, 'b, T> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     x: &'a &'b T
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-regions.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-regions.stderr
@@ -8,5 +8,28 @@ LL | struct Foo<'a, 'b, T> {
    = note: T: 'a
    = note: T: 'b
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/nested-regions.rs:4:1
+   |
+LL | struct Foo<'a, 'b, T> {
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: 'b: 'a
+  --> $DIR/nested-regions.rs:6:5
+   |
+LL |     x: &'a &'b T
+   |     ^^^^^^^^^^^^
+note: T: 'a
+  --> $DIR/nested-regions.rs:6:5
+   |
+LL |     x: &'a &'b T
+   |     ^^^^^^^^^^^^
+note: T: 'b
+  --> $DIR/nested-regions.rs:6:5
+   |
+LL |     x: &'a &'b T
+   |     ^^^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-structs.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-structs.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'a, T> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     field1: Bar<'a, T>
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-structs.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-structs.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, T> {
    |
    = note: T: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/nested-structs.rs:4:1
+   |
+LL | struct Foo<'a, T> {
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $DIR/nested-structs.rs:10:5
+   |
+LL |     field2: &'b U
+   |     ^^^^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-union.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-union.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 union Foo<'a, T: Copy> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     field1: Bar<'a, T>
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/nested-union.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/nested-union.stderr
@@ -6,5 +6,18 @@ LL | union Foo<'a, T: Copy> {
    |
    = note: T: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/nested-union.rs:4:1
+   |
+LL | union Foo<'a, T: Copy> {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $DIR/nested-union.rs:12:5
+   |
+LL |     field2: &'b U
+   |     ^^^^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/projection.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/projection.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'a, T: Iterator> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     bar: &'a T::Item
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/projection.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/projection.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, T: Iterator> {
    |
    = note: <T as Iterator>::Item: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/projection.rs:4:1
+   |
+LL | struct Foo<'a, T: Iterator> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: <T as Iterator>::Item: 'a
+  --> $DIR/projection.rs:6:5
+   |
+LL |     bar: &'a T::Item
+   |     ^^^^^^^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/reference.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/reference.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'a, T> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     bar: &'a T,
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/reference.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/reference.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, T> {
    |
    = note: T: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/reference.rs:4:1
+   |
+LL | struct Foo<'a, T> {
+   | ^^^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $DIR/reference.rs:6:5
+   |
+LL |     bar: &'a T,
+   |     ^^^^^^^^^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/self-dyn.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/self-dyn.rs
@@ -6,6 +6,7 @@ trait Trait<'x, 's, T> where T: 'x,
 
 #[rustc_outlives]
 struct Foo<'a, 'b, A> //~ ERROR rustc_outlives
+//~^ ERROR: rustc_outlives
 {
     foo: Box<dyn Trait<'a, 'b, A>>
 }

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/self-dyn.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/self-dyn.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, 'b, A>
    |
    = note: A: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/self-dyn.rs:8:1
+   |
+LL | struct Foo<'a, 'b, A>
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: A: 'a
+  --> $DIR/self-dyn.rs:3:33
+   |
+LL | trait Trait<'x, 's, T> where T: 'x,
+   |                                 ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/self-structs.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/self-structs.rs
@@ -2,6 +2,7 @@
 
 #[rustc_outlives]
 struct Foo<'a, 'b, T> { //~ ERROR rustc_outlives
+    //~^ ERROR rustc_outlives
     field1: dyn Bar<'a, 'b, T>
 }
 

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/self-structs.stderr
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/self-structs.stderr
@@ -6,5 +6,18 @@ LL | struct Foo<'a, 'b, T> {
    |
    = note: T: 'a
 
-error: aborting due to previous error
+error[E0640]: rustc_outlives
+  --> $DIR/self-structs.rs:4:1
+   |
+LL | struct Foo<'a, 'b, T> {
+   | ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: T: 'a
+  --> $DIR/self-structs.rs:10:14
+   |
+LL |     where U: 'x,
+   |              ^^
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0640`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
@@ -10,5 +10,15 @@ LL | impl const A for () {}
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
 
-error: aborting due to previous error
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/const-impl-requires-const-trait.rs:8:6
+   |
+LL | impl const A for () {}
+   |      ^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-trait.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-trait.stderr
@@ -34,6 +34,14 @@ error: ~const can only be applied to `#[const_trait]` traits
 LL |     fn huh() -> impl ~const PartialEq + ~const Destruct + Copy {
    |                             ^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: ~const can only be applied to `#[const_trait]` traits
+  --> $DIR/const-impl-trait.rs:23:29
+   |
+LL |     fn huh() -> impl ~const PartialEq + ~const Destruct + Copy;
+   |                             ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0635`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
@@ -8,5 +8,11 @@ LL | #[derive_const(Default)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: ~const can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-2.rs:11:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: ~const can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-2.rs:11:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -13,10 +13,18 @@ LL | trait Bar: ~const Foo {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: ~const can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:17:24
+  --> $DIR/super-traits-fail-3.rs:18:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^
 
-error: aborting due to 3 previous errors
+error: ~const can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:13:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: ~const can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:13:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
@@ -13,6 +13,7 @@ trait Foo {
 trait Bar: ~const Foo {}
 //[ny,nn]~^ ERROR: ~const can only be applied to `#[const_trait]`
 //[ny,nn]~| ERROR: ~const can only be applied to `#[const_trait]`
+//[ny,nn]~| ERROR: ~const can only be applied to `#[const_trait]`
 
 const fn foo<T: ~const Bar>(x: &T) {
     //[yn,nn]~^ ERROR: ~const can only be applied to `#[const_trait]`

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
@@ -1,5 +1,5 @@
 error: ~const can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:17:24
+  --> $DIR/super-traits-fail-3.rs:18:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yy.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yy.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
-  --> $DIR/super-traits-fail-3.rs:19:7
+  --> $DIR/super-traits-fail-3.rs:20:7
    |
 LL |     x.a();
    |       ^^^

--- a/tests/ui/stability-attribute/generics-default-stability-where.rs
+++ b/tests/ui/stability-attribute/generics-default-stability-where.rs
@@ -5,6 +5,7 @@ extern crate unstable_generic_param;
 use unstable_generic_param::*;
 
 impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature 'unstable_default'
+//~^ ERROR `T` must be used as the type parameter for some local type
     fn foo() -> usize { T::foo() }
 }
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -6,6 +6,16 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/generics-default-stability-where.rs:7:6
+   |
+LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
+   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0210, E0658.
+For more information about an error, try `rustc --explain E0210`.

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.rs
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for () {
     fn bar(s: _) {}
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR has 1 parameter but the declaration in trait `Foo::bar` has 0
 }
 
 fn main() {}

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -9,6 +9,16 @@ help: use type parameters instead
 LL |     fn bar<T>(s: T) {}
    |           +++    ~
 
-error: aborting due to previous error
+error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 0
+  --> $DIR/bad-infer-in-trait-impl.rs:6:15
+   |
+LL |     fn bar();
+   |     --------- trait requires 0 parameters
+...
+LL |     fn bar(s: _) {}
+   |               ^ expected 0 parameters, found 1
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0050, E0121.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/suggestions/fn-trait-notation.fixed
+++ b/tests/ui/suggestions/fn-trait-notation.fixed
@@ -2,6 +2,7 @@
 fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
 where
     F: Fn(i32) -> i32, //~ ERROR E0658
+    //~^ ERROR E0059
     G: Fn(i32, i32) -> (i32, i32), //~ ERROR E0658
     H: Fn(i32) -> i32, //~ ERROR E0658
 {

--- a/tests/ui/suggestions/fn-trait-notation.rs
+++ b/tests/ui/suggestions/fn-trait-notation.rs
@@ -2,6 +2,7 @@
 fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
 where
     F: Fn<i32, Output = i32>, //~ ERROR E0658
+    //~^ ERROR E0059
     G: Fn<(i32, i32, ), Output = (i32, i32)>, //~ ERROR E0658
     H: Fn<(i32,), Output = i32>, //~ ERROR E0658
 {

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -8,7 +8,7 @@ LL |     F: Fn<i32, Output = i32>,
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/fn-trait-notation.rs:5:8
+  --> $DIR/fn-trait-notation.rs:6:8
    |
 LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32, i32) -> (i32, i32)`
@@ -17,7 +17,7 @@ LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/fn-trait-notation.rs:6:8
+  --> $DIR/fn-trait-notation.rs:7:8
    |
 LL |     H: Fn<(i32,), Output = i32>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32) -> i32`
@@ -25,6 +25,16 @@ LL |     H: Fn<(i32,), Output = i32>,
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0059]: type parameter to bare `Fn` trait must be a tuple
+  --> $DIR/fn-trait-notation.rs:4:8
+   |
+LL |     F: Fn<i32, Output = i32>,
+   |        ^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `i32`
+   |
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0059, E0658.
+For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
@@ -18,6 +18,7 @@ mod elided {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
     //~^ ERROR missing lifetime specifier
+    //~| ERROR lifetime may not live long enough
 }
 
 mod underscore {
@@ -36,6 +37,7 @@ mod underscore {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
     //~^ ERROR missing lifetime specifier
+    //~| ERROR lifetime may not live long enough
 }
 
 mod alone_in_path {
@@ -61,8 +63,8 @@ mod in_path {
 }
 
 // This must not err, as the `&` actually resolves to `'a`.
-fn resolved_anonymous<'a, T>(f: impl Fn(&'a str) -> &T) {
-    f("f")
+fn resolved_anonymous<'a, T: 'a>(f: impl Fn(&'a str) -> &T) {
+    f("f");
 }
 
 fn main() {}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -23,7 +23,7 @@ LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x
    |                                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:58
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:58
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                          ^^ expected named lifetime parameter
@@ -35,7 +35,7 @@ LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.ne
    |                                                          ~~~~~~~
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:64
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                                ^^ expected named lifetime parameter
@@ -47,7 +47,7 @@ LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> 
    |                                                                ~~~~~~~
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:37
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                                     ^ expected named lifetime parameter
@@ -59,7 +59,7 @@ LL |     fn g(mut x: impl Foo) -> Option<&'static ()> { x.next() }
    |                                      +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:41
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:41
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                                         ^ expected named lifetime parameter
@@ -95,7 +95,7 @@ LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next()
    |         ++++                              ++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:24:35
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:25:35
    |
 LL |     fn f(_: impl Iterator<Item = &'_ ()>) {}
    |                                   ^^ expected named lifetime parameter
@@ -107,7 +107,7 @@ LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
    |         ++++                          ~~
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:39
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:39
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                       ^^ expected named lifetime parameter
@@ -119,7 +119,7 @@ LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.nex
    |         ++++                              ~~
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:44:18
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:46:18
    |
 LL |     fn f(_: impl Foo) {}
    |                  ^^^ expected named lifetime parameter
@@ -131,7 +131,7 @@ LL |     fn f<'a>(_: impl Foo<'a>) {}
    |         ++++            ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:22
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                      ^^^ expected named lifetime parameter
@@ -143,7 +143,7 @@ LL |     fn g<'a>(mut x: impl Foo<'a>) -> Option<&()> { x.next() }
    |         ++++                ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:55:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:22
    |
 LL |     fn f(_: impl Foo<()>) {}
    |                      ^ expected named lifetime parameter
@@ -155,7 +155,7 @@ LL |     fn f<'a>(_: impl Foo<'a, ()>) {}
    |         ++++             +++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:26
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:26
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                          ^ expected named lifetime parameter
@@ -166,7 +166,23 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
    |         ++++                 +++
 
-error: aborting due to 14 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |     -----------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0106, E0658.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -42,10 +42,12 @@ thread_local! {
     //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
 }
 thread_local! {
     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -107,7 +107,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -119,7 +119,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -228,7 +228,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -246,7 +246,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -265,7 +265,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -284,7 +284,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -303,7 +303,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -321,7 +321,45 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error: aborting due to 20 previous errors
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
+   |
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
+   |
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       +++++++++
+
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:48:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        +++++++++
+
+error: aborting due to 22 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/tag-type-args.rs
+++ b/tests/ui/tag-type-args.rs
@@ -1,4 +1,5 @@
 enum Quux<T> { Bar }
+//~^ ERROR: parameter `T` is never used
 
 fn foo(c: Quux) { assert!((false)); } //~ ERROR missing generics for enum `Quux`
 

--- a/tests/ui/tag-type-args.stderr
+++ b/tests/ui/tag-type-args.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for enum `Quux`
-  --> $DIR/tag-type-args.rs:3:11
+  --> $DIR/tag-type-args.rs:4:11
    |
 LL | fn foo(c: Quux) { assert!((false)); }
    |           ^^^^ expected 1 generic argument
@@ -14,6 +14,16 @@ help: add missing generic argument
 LL | fn foo(c: Quux<T>) { assert!((false)); }
    |               +++
 
-error: aborting due to previous error
+error[E0392]: parameter `T` is never used
+  --> $DIR/tag-type-args.rs:1:11
+   |
+LL | enum Quux<T> { Bar }
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0392.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -86,6 +86,8 @@ static A: () = ();
 //~^ ERROR attribute should be applied to a function
 impl Quux for u8 {}
 //~^ NOTE not a function
+//~| NOTE missing `foo` in implementation
+//~| ERROR missing: `foo`
 
 #[target_feature(enable = "sse2")]
 //~^ ERROR attribute should be applied to a function
@@ -93,7 +95,7 @@ impl Foo {}
 //~^ NOTE not a function
 
 trait Quux {
-    fn foo();
+    fn foo(); //~ NOTE `foo` from trait
 }
 
 impl Quux for Foo {

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -117,7 +117,7 @@ LL | impl Quux for u8 {}
    | ------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:90:1
+  --> $DIR/invalid-attribute.rs:92:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL | impl Foo {}
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:108:5
+  --> $DIR/invalid-attribute.rs:110:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL | |     }
    | |_____- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:116:5
+  --> $DIR/invalid-attribute.rs:118:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +183,7 @@ LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:100:5
+  --> $DIR/invalid-attribute.rs:102:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,6 +194,16 @@ LL |     fn foo() {}
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
-error: aborting due to 22 previous errors
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/invalid-attribute.rs:87:1
+   |
+LL | impl Quux for u8 {}
+   | ^^^^^^^^^^^^^^^^ missing `foo` in implementation
+...
+LL |     fn foo();
+   |     --------- `foo` from trait
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 23 previous errors
+
+Some errors have detailed explanations: E0046, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
@@ -7,12 +7,14 @@ pub trait Trait<T> {
 }
 
 impl<T, S> Trait<T> for i32 {
+    //~^ ERROR `S` is not constrained
     type Assoc = String;
 }
 
 // Should not not trigger suggestion here...
 impl<T, S> Trait<T, S> for () {}
 //~^ ERROR trait takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR `S` is not constrained
 
 //... but should do so in all of the below cases except the last one
 fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
@@ -37,6 +39,7 @@ impl<T: Trait<u32, String>> Struct<T> {}
 trait YetAnotherTrait {}
 impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
 //~^ ERROR struct takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR `U` is not constrained
 
 
 fn main() {

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -1,5 +1,5 @@
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:14:12
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:12
    |
 LL | impl<T, S> Trait<T, S> for () {}
    |            ^^^^^ expected 1 generic argument
@@ -11,7 +11,7 @@ LL | pub trait Trait<T> {
    |           ^^^^^ -
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:18:12
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:12
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
    |            ^^^^^ expected 1 generic argument
@@ -27,7 +27,7 @@ LL | fn func<T: Trait<u32, Assoc = String>>(t: T) -> impl Trait<(), i32> {
    |                       +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:18:46
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:46
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
    |                                              ^^^^^ expected 1 generic argument
@@ -43,7 +43,7 @@ LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), Assoc = i32> {
    |                                                        +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:24:18
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:18
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |                  ^^^^^ expected 1 generic argument
@@ -59,7 +59,7 @@ LL | struct Struct<T: Trait<u32, Assoc = String>> {
    |                             +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:29:23
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:31:23
    |
 LL | trait AnotherTrait<T: Trait<T, i32>> {}
    |                       ^^^^^ expected 1 generic argument
@@ -75,7 +75,7 @@ LL | trait AnotherTrait<T: Trait<T, Assoc = i32>> {}
    |                                +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:32:9
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:34:9
    |
 LL | impl<T: Trait<u32, String>> Struct<T> {}
    |         ^^^^^ expected 1 generic argument
@@ -91,7 +91,7 @@ LL | impl<T: Trait<u32, Assoc = String>> Struct<T> {}
    |                    +++++++
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:38:58
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:58
    |
 LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          ^^^^^^    - help: remove this generic argument
@@ -99,11 +99,30 @@ LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:24:8
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:8
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
 
-error: aborting due to 7 previous errors
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
+   |
+LL | impl<T, S> Trait<T> for i32 {
+   |         ^ unconstrained type parameter
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:9
+   |
+LL | impl<T, S> Trait<T, S> for () {}
+   |         ^ unconstrained type parameter
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:35
+   |
+LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
+   |                                   ^ unconstrained type parameter
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0107, E0207.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/traits/issue-102989.rs
+++ b/tests/ui/traits/issue-102989.rs
@@ -7,8 +7,10 @@ trait Sized { } //~ ERROR found duplicate lang item `sized`
 fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
     //~^ ERROR `self` parameter is only allowed in associated functions
     //~| ERROR cannot find type `Struct` in this scope
+    //~| ERROR mismatched types
     let x = x << 1;
     //~^ ERROR cannot find value `x` in this scope
+    //~| ERROR the size for values of type `{integer}` cannot be known
 }
 
 fn main() {}

--- a/tests/ui/traits/issue-102989.stderr
+++ b/tests/ui/traits/issue-102989.stderr
@@ -13,7 +13,7 @@ LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                      ^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/issue-102989.rs:10:13
+  --> $DIR/issue-102989.rs:11:13
    |
 LL |     let x = x << 1;
    |             ^ help: a local variable with a similar name exists: `f`
@@ -28,7 +28,29 @@ LL | trait Sized { }
    = note: first definition in `core` loaded from SYSROOT/libcore-*.rlib
    = note: second definition in the local crate (`issue_102989`)
 
-error: aborting due to 4 previous errors
+error[E0277]: the size for values of type `{integer}` cannot be known at compilation time
+  --> $DIR/issue-102989.rs:11:15
+   |
+LL |     let x = x << 1;
+   |               ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `{integer}`
 
-Some errors have detailed explanations: E0152, E0412, E0425.
+error[E0308]: mismatched types
+  --> $DIR/issue-102989.rs:7:42
+   |
+LL | fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |    ----------                            ^^^^ expected `&u32`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+   |
+help: consider returning the local binding `f`
+   |
+LL ~     let x = x << 1;
+LL +     f
+   |
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0152, E0277, E0308, E0412, E0425.
 For more information about an error, try `rustc --explain E0152`.

--- a/tests/ui/traits/issue-106072.rs
+++ b/tests/ui/traits/issue-106072.rs
@@ -1,4 +1,5 @@
 #[derive(Clone)] //~  trait objects must include the `dyn` keyword
+//~^ ERROR: the size for values of type `(dyn Foo + 'static)` cannot be known
 struct Foo;
 trait Foo {} //~ the name `Foo` is defined multiple times
 fn main() {}

--- a/tests/ui/traits/issue-106072.stderr
+++ b/tests/ui/traits/issue-106072.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/issue-106072.rs:3:1
+  --> $DIR/issue-106072.rs:4:1
    |
 LL | struct Foo;
    | ----------- previous definition of the type `Foo` here
@@ -7,6 +7,17 @@ LL | trait Foo {}
    | ^^^^^^^^^ `Foo` redefined here
    |
    = note: `Foo` must be defined only once in the type namespace of this module
+
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/issue-106072.rs:1:10
+   |
+LL | #[derive(Clone)]
+   |          ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+note: required by a bound in `Clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-106072.rs:1:10
@@ -16,7 +27,7 @@ LL | #[derive(Clone)]
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0428, E0782.
-For more information about an error, try `rustc --explain E0428`.
+Some errors have detailed explanations: E0277, E0428, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-28576.rs
+++ b/tests/ui/traits/issue-28576.rs
@@ -3,6 +3,8 @@ pub trait Foo<RHS=Self> {
 }
 
 pub trait Bar: Foo<Assoc=()> {
+    //~^ ERROR: the size for values of type `Self` cannot be known
+    //~| ERROR: the size for values of type `Self` cannot be known
     fn new(&self, b: &
            dyn Bar //~ ERROR the trait `Bar` cannot be made into an object
               <Assoc=()>

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/issue-28576.rs:7:12
+  --> $DIR/issue-28576.rs:9:12
    |
 LL | /            dyn Bar
 LL | |               <Assoc=()>
@@ -15,6 +15,47 @@ LL | pub trait Bar: Foo<Assoc=()> {
    |           |    ...because it uses `Self` as a type parameter
    |           this trait cannot be made into an object...
 
-error: aborting due to previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by this bound in `Foo`
+help: consider further restricting `Self`
+   |
+LL | pub trait Bar: Foo<Assoc=()> + Sized {
+   |                              +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS=Self: ?Sized> {
+   |                       ++++++++
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by this bound in `Foo`
+help: consider further restricting `Self`
+   |
+LL |     ) where Self: Sized;
+   |       +++++++++++++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS=Self: ?Sized> {
+   |                       ++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/issue-38404.rs
+++ b/tests/ui/traits/issue-38404.rs
@@ -1,7 +1,8 @@
 trait A<T>: std::ops::Add<Self> + Sized {}
 trait B<T>: A<T> {}
-trait C<T>: A<dyn B<T, Output=usize>> {}
+trait C<T>: A<dyn B<T, Output = usize>> {}
 //~^ ERROR the trait `B` cannot be made into an object
+//~| ERROR the trait `B` cannot be made into an object
 //~| ERROR the trait `B` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/traits/issue-38404.stderr
+++ b/tests/ui/traits/issue-38404.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
-LL | trait C<T>: A<dyn B<T, Output=usize>> {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
@@ -15,8 +15,8 @@ LL | trait B<T>: A<T> {}
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
-LL | trait C<T>: A<dyn B<T, Output=usize>> {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
@@ -27,6 +27,21 @@ LL | trait B<T>: A<T> {}
    |       - this trait cannot be made into an object...
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `B` cannot be made into an object
+  --> $DIR/issue-38404.rs:3:15
+   |
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-38404.rs:1:13
+   |
+LL | trait A<T>: std::ops::Add<Self> + Sized {}
+   |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
+LL | trait B<T>: A<T> {}
+   |       - this trait cannot be made into an object...
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/issue-87558.rs
+++ b/tests/ui/traits/issue-87558.rs
@@ -3,6 +3,8 @@ struct Error(ErrorKind);
 impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental
     //~| ERROR associated type bindings are not allowed here
+    //~| ERROR closure, found `Error`
+    //~| ERROR not all trait items implemented, missing: `call`
     fn from() {} //~ ERROR method `from` is not a member of trait `Fn`
 }
 

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -1,5 +1,5 @@
 error[E0407]: method `from` is not a member of trait `Fn`
-  --> $DIR/issue-87558.rs:6:5
+  --> $DIR/issue-87558.rs:8:5
    |
 LL |     fn from() {}
    |     ^^^^^^^^^^^^ not a member of trait `Fn`
@@ -24,7 +24,25 @@ help: parenthesized trait syntax expands to `Fn<(&isize,), Output=()>`
 LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0277]: expected a `FnMut<(&isize,)>` closure, found `Error`
+  --> $DIR/issue-87558.rs:3:21
+   |
+LL | impl Fn(&isize) for Error {
+   |                     ^^^^^ expected an `FnMut<(&isize,)>` closure, found `Error`
+   |
+   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0229, E0407.
-For more information about an error, try `rustc --explain E0183`.
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-87558.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0046, E0183, E0229, E0277, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/traits/non_lifetime_binders/late-bound-in-anon-ct.rs
+++ b/tests/ui/traits/non_lifetime_binders/late-bound-in-anon-ct.rs
@@ -6,6 +6,6 @@ fn foo() -> usize
 where
     for<T> [i32; { let _: T = todo!(); 0 }]:,
     //~^ ERROR cannot capture late-bound type parameter in constant
-{}
+{ 42 }
 
 fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
@@ -3,5 +3,8 @@ trait Foo {
 }
 
 fn bar(x: &dyn Foo) {} //~ ERROR the trait `Foo` cannot be made into an object
+//~^ ERROR the trait `Foo` cannot be made into an object
+//~| ERROR the trait `Foo` cannot be made into an object
+//~| ERROR the trait `Foo` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
@@ -13,6 +13,53 @@ LL |     type Bar<T>;
    |          ^^^ ...because it contains the generic associated type `Bar`
    = help: consider moving `Bar` to another trait
 
-error: aborting due to previous error
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:12
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |            ^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -16,6 +16,7 @@ mod assert {
     >()
     where
         Dst: BikeshedIntrinsicFrom< //~ ERROR trait takes at most 3 generic arguments but 6 generic arguments were supplied
+        //~^ ERROR: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
             Src,
             Context,
             ASSUME_ALIGNMENT,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -9,6 +9,22 @@ LL | |             ASSUME_VALIDITY,
 LL | |             ASSUME_VISIBILITY,
    | |_____________________________- help: remove these generic arguments
 
-error: aborting due to previous error
+error: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
+  --> $DIR/issue-101739-2.rs:18:14
+   |
+LL |           Dst: BikeshedIntrinsicFrom<
+   |  ______________^
+LL | |
+LL | |             Src,
+LL | |             Context,
+...  |
+LL | |             ASSUME_VISIBILITY,
+LL | |         >,
+   | |_________^ expected `Assume`, found `bool`
+   |
+note: required by a bound in `BikeshedIntrinsicFrom`
+  --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -1,4 +1,4 @@
-// Regression test for #77179.
+// Regression test for the ICE in #77179.
 
 #![feature(type_alias_impl_trait)]
 
@@ -6,7 +6,9 @@ type Pointer<T> = impl std::ops::Deref<Target = T>;
 
 fn test() -> Pointer<_> {
     //~^ ERROR: the placeholder `_` is not allowed within types
+    //~| ERROR: non-defining opaque type use in defining scope
     Box::new(1)
+    //~^ ERROR expected generic type parameter, found `i32`
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -7,6 +7,28 @@ LL | fn test() -> Pointer<_> {
    |              |       not allowed in type signatures
    |              help: replace with the correct return type: `Pointer<i32>`
 
-error: aborting due to previous error
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/issue-77179.rs:7:14
+   |
+LL | fn test() -> Pointer<_> {
+   |              ^^^^^^^^^^ argument `i32` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/issue-77179.rs:5:19
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0792]: expected generic type parameter, found `i32`
+  --> $DIR/issue-77179.rs:10:5
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |              - this generic parameter must be used with a generic type parameter
+...
+LL |     Box::new(1)
+   |     ^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0121, E0792.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/typeck/escaping_bound_vars.rs
+++ b/tests/ui/typeck/escaping_bound_vars.rs
@@ -10,6 +10,10 @@ pub fn test()
 where
     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
     //~^ ERROR cannot capture late-bound lifetime in constant
+    //~| ERROR associated type bindings are not allowed here
+    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
+    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
+    //~| ERROR cannot add
 {
 }
 

--- a/tests/ui/typeck/escaping_bound_vars.stderr
+++ b/tests/ui/typeck/escaping_bound_vars.stderr
@@ -6,5 +6,55 @@ LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
    |                                  |
    |                                  lifetime defined here
 
-error: aborting due to previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/escaping_bound_vars.rs:11:28
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                            ^^^^^^^^^^ associated type not allowed here
 
+error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
+  --> $DIR/escaping_bound_vars.rs:11:22
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                      ^^ the trait `Elide<(&(),)>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/escaping_bound_vars.rs:5:1
+   |
+LL | trait Elide<T> {
+   | ^^^^^^^^^^^^^^
+
+error[E0277]: cannot add `fn() {<() as Elide<(&(),)>>::call}` to `{integer}`
+  --> $DIR/escaping_bound_vars.rs:11:18
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                  ^ no implementation for `{integer} + fn() {<() as Elide<(&(),)>>::call}`
+   |
+   = help: the trait `Add<fn() {<() as Elide<(&(),)>>::call}>` is not implemented for `{integer}`
+   = help: the following other types implement trait `Add<Rhs>`:
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
+           and 48 others
+
+error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
+  --> $DIR/escaping_bound_vars.rs:11:18
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                  ^ the trait `Elide<(&(),)>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/escaping_bound_vars.rs:5:1
+   |
+LL | trait Elide<T> {
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/typeck/issue-110052.rs
+++ b/tests/ui/typeck/issue-110052.rs
@@ -1,7 +1,7 @@
 // Makes sure we deal with escaping lifetimes *above* INNERMOST when
 // suggesting trait for ambiguous associated type.
 
-impl<I, V> Validator<I> for ()
+impl<I> Validator<I> for ()
 where
     for<'iter> dyn Validator<<&'iter I>::Item>:,
     //~^ ERROR ambiguous associated type

--- a/tests/ui/typeck/issue-79040.rs
+++ b/tests/ui/typeck/issue-79040.rs
@@ -1,5 +1,6 @@
 fn main() {
     const FOO = "hello" + 1; //~ ERROR cannot add `{integer}` to `&str`
     //~^ missing type for `const` item
+    //~| ERROR cannot add `{integer}` to `&str`
     println!("{}", FOO);
 }

--- a/tests/ui/typeck/issue-79040.stderr
+++ b/tests/ui/typeck/issue-79040.stderr
@@ -12,6 +12,16 @@ error: missing type for `const` item
 LL |     const FOO = "hello" + 1;
    |              ^ help: provide a type for the item: `: <type>`
 
-error: aborting due to 2 previous errors
+error[E0369]: cannot add `{integer}` to `&str`
+  --> $DIR/issue-79040.rs:2:25
+   |
+LL |     const FOO = "hello" + 1;
+   |                 ------- ^ - {integer}
+   |                 |
+   |                 &str
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
@@ -4,11 +4,12 @@ fn foo1<T:Copy<U>, U>(x: T) {}
 trait Trait: Copy<dyn Send> {}
 //~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 //~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
-struct MyStruct1<T: Copy<T>>;
+struct MyStruct1<T: Copy<T>>(T);
 //~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
-struct MyStruct2<'a, T: Copy<'a>>;
+struct MyStruct2<'a, T: Copy<'a>>(&'a T);
 //~^ ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -25,23 +25,23 @@ LL | trait Trait: Copy<dyn Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:8:21
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:9:21
    |
-LL | struct MyStruct1<T: Copy<T>>;
+LL | struct MyStruct1<T: Copy<T>>(T);
    |                     ^^^^--- help: remove these generics
    |                     |
    |                     expected 0 generic arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:11:25
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:12:25
    |
-LL | struct MyStruct2<'a, T: Copy<'a>>;
+LL | struct MyStruct2<'a, T: Copy<'a>>(&'a T);
    |                         ^^^^---- help: remove these generics
    |                         |
    |                         expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:14:15
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^ -- help: remove this lifetime argument
@@ -49,13 +49,23 @@ LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:14:15
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^     - help: remove this generic argument
    |               |
    |               expected 0 generic arguments
 
-error: aborting due to 7 previous errors
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
+   |
+LL | trait Trait: Copy<dyn Send> {}
+   |              ^^^^---------- help: remove these generics
+   |              |
+   |              expected 0 generic arguments
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -198,6 +198,7 @@ trait Qux {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
+    //~^ ERROR: not all trait items implemented, missing: `F`
     type A = _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
     type B = _;

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -29,7 +29,7 @@ LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:205:5
+  --> $DIR/typeck_type_placeholder_item.rs:206:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -411,7 +411,7 @@ LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:216:31
+  --> $DIR/typeck_type_placeholder_item.rs:217:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -420,7 +420,7 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:221:10
+  --> $DIR/typeck_type_placeholder_item.rs:222:10
    |
 LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
@@ -429,7 +429,7 @@ LL | const _: Option<_> = map(value);
    |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:224:31
+  --> $DIR/typeck_type_placeholder_item.rs:225:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -438,13 +438,13 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:229:10
+  --> $DIR/typeck_type_placeholder_item.rs:230:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:229:29}>, {closure@typeck_type_placeholder_item.rs:229:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:229:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:230:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -631,25 +631,25 @@ LL |         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
    |                                         ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:201:14
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
    |
 LL |     type A = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:203:14
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:208:14
+  --> $DIR/typeck_type_placeholder_item.rs:209:14
    |
 LL |     const D: _ = 42;
    |              ^
@@ -657,7 +657,16 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error: aborting due to 71 previous errors
+error[E0046]: not all trait items implemented, missing: `F`
+  --> $DIR/typeck_type_placeholder_item.rs:200:1
+   |
+LL |     type F: std::ops::Fn(_);
+   |     ----------------------- `F` from trait
+...
+LL | impl Qux for Struct {
+   | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
-Some errors have detailed explanations: E0121, E0282, E0403.
-For more information about an error, try `rustc --explain E0121`.
+error: aborting due to 72 previous errors
+
+Some errors have detailed explanations: E0046, E0121, E0282, E0403.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -27,7 +27,7 @@ impl Test6 {
 }
 
 pub fn main() {
-    let _: Option<usize> = test1();
-    let _: f64 = test1();
+    let _: Option<usize> = test1(); //~ ERROR mismatched types
+    let _: f64 = test1(); //~ ERROR mismatched types
     let _: Option<i32> = test1();
 }

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -55,6 +55,29 @@ LL |     const TEST6: _ = 13;
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
-error: aborting due to 7 previous errors
+error[E0308]: mismatched types
+  --> $DIR/typeck_type_placeholder_item_help.rs:30:28
+   |
+LL |     let _: Option<usize> = test1();
+   |            -------------   ^^^^^^^ expected `Option<usize>`, found `Option<i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<usize>`
+              found enum `Option<i32>`
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0308]: mismatched types
+  --> $DIR/typeck_type_placeholder_item_help.rs:31:18
+   |
+LL |     let _: f64 = test1();
+   |            ---   ^^^^^^^ expected `f64`, found `Option<i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+              found enum `Option<i32>`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0121, E0308.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -21,10 +21,12 @@ fn same_type<A,B:Eq<A>>(a: A, b: B) { }
 fn test<'a,'b>() {
     // Parens are equivalent to omitting default in angle.
     eq::< dyn Foo<(isize,),Output=()>,               dyn Foo(isize)                      >();
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
 
     // Here we specify 'static explicitly in angle-bracket version.
     // Parenthesized winds up getting inferred.
     eq::< dyn Foo<'static, (isize,),Output=()>,      dyn Foo(isize)                      >();
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
 }
 
 fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -1,5 +1,5 @@
 error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/unboxed-closure-sugar-region.rs:30:51
+  --> $DIR/unboxed-closure-sugar-region.rs:32:51
    |
 LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
    |                                                   ^^^ expected 1 lifetime argument
@@ -10,6 +10,30 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL | trait Foo<'a,T> {
    |       ^^^ --
 
-error: aborting due to previous error
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unboxed-closure-sugar-region.rs:23:58
+   |
+LL |     eq::< dyn Foo<(isize,),Output=()>,               dyn Foo(isize)                      >();
+   |                                                          ^^^ expected 1 lifetime argument
+   |
+note: trait defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/unboxed-closure-sugar-region.rs:10:7
+   |
+LL | trait Foo<'a,T> {
+   |       ^^^ --
+
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unboxed-closure-sugar-region.rs:28:58
+   |
+LL |     eq::< dyn Foo<'static, (isize,),Output=()>,      dyn Foo(isize)                      >();
+   |                                                          ^^^ expected 1 lifetime argument
+   |
+note: trait defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/unboxed-closure-sugar-region.rs:10:7
+   |
+LL | trait Foo<'a,T> {
+   |       ^^^ --
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -2,25 +2,25 @@
 
 trait Zero { fn dummy(&self); }
 
-fn foo1(_: dyn Zero()) {
+fn foo1(_: &dyn Zero()) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
-fn foo2(_: dyn Zero<usize>) {
+fn foo2(_: &dyn Zero<usize>) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
-fn foo3(_: dyn Zero <   usize   >) {
+fn foo3(_: &dyn Zero <   usize   >) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
-fn foo4(_: dyn Zero(usize)) {
+fn foo4(_: &dyn Zero(usize)) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
-fn foo5(_: dyn Zero (   usize   )) {
+fn foo5(_: &dyn Zero (   usize   )) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -1,58 +1,10 @@
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
-LL | fn foo1(_: dyn Zero()) {
-   |                ^^^^-- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
-   |
-LL | fn foo1(_: dyn Zero()) {
-   |                ^^^^^^ associated type `Output` not found
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:16
-   |
-LL | fn foo2(_: dyn Zero<usize>) {
-   |                ^^^^------- help: remove these generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:16
-   |
-LL | fn foo3(_: dyn Zero <   usize   >) {
-   |                ^^^^-------------- help: remove these generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
-   |
-LL | fn foo4(_: dyn Zero(usize)) {
-   |                ^^^^------- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
+LL | fn foo1(_: &dyn Zero()) {
+   |                 ^^^^-- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
@@ -61,18 +13,46 @@ LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
-LL | fn foo4(_: dyn Zero(usize)) {
-   |                ^^^^^^^^^^^ associated type `Output` not found
+LL | fn foo1(_: &dyn Zero()) {
+   |                 ^^^^^^ associated type `Output` not found
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:17
    |
-LL | fn foo5(_: dyn Zero (   usize   )) {
-   |                ^^^^-------------- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
+LL | fn foo2(_: &dyn Zero<usize>) {
+   |                 ^^^^------- help: remove these generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:17
+   |
+LL | fn foo3(_: &dyn Zero <   usize   >) {
+   |                 ^^^^-------------- help: remove these generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
+   |
+LL | fn foo4(_: &dyn Zero(usize)) {
+   |                 ^^^^------- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
@@ -81,10 +61,30 @@ LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
    |
-LL | fn foo5(_: dyn Zero (   usize   )) {
-   |                ^^^^^^^^^^^^^^^^^^ associated type `Output` not found
+LL | fn foo4(_: &dyn Zero(usize)) {
+   |                 ^^^^^^^^^^^ associated type `Output` not found
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
+   |
+LL | fn foo5(_: &dyn Zero (   usize   )) {
+   |                 ^^^^-------------- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0220]: associated type `Output` not found for `Zero`
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
+   |
+LL | fn foo5(_: &dyn Zero (   usize   )) {
+   |                 ^^^^^^^^^^^^^^^^^^ associated type `Output` not found
 
 error: aborting due to 8 previous errors
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -579,7 +579,7 @@ Otherwise, you can ignore this comment.
 message = "`src/tools/x` was changed. Bump version of Cargo.toml in `src/tools/x` so tidy will suggest installing the new version."
 
 [mentions."src/tools/tidy/src/deps.rs"]
-message = "Third-party dependency whitelist may have been modified! You must ensure that any new dependencies have compatible licenses before merging."
+message = "Third-party dependency allowlist may have been modified! You must ensure that any new dependencies have compatible licenses before merging."
 cc = ["@davidtwco", "@wesleywiser"]
 
 [mentions."src/bootstrap/src/core/config"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -579,7 +579,7 @@ Otherwise, you can ignore this comment.
 message = "`src/tools/x` was changed. Bump version of Cargo.toml in `src/tools/x` so tidy will suggest installing the new version."
 
 [mentions."src/tools/tidy/src/deps.rs"]
-message = "Third-party dependency allowlist may have been modified! You must ensure that any new dependencies have compatible licenses before merging."
+message = "The list of allowed third-party dependencies may have been modified! You must ensure that any new dependencies have compatible licenses before merging."
 cc = ["@davidtwco", "@wesleywiser"]
 
 [mentions."src/bootstrap/src/core/config"]


### PR DESCRIPTION
Successful merges:

 - #110494 (Use the LLVM option NoTrapAfterNoreturn)
 - #114841 (add track_caller for arith ops)
 - #116438 (Windows: Allow `File::create` to work on hidden files)
 - #116762 (Fixup `Atomic*::from_ptr` safety docs)
 - #117122 (Allow configuring the parent GitHub repository)
 - #117449 (Avoid silencing relevant follow-up errors)
 - #117645 (Extend builtin/auto trait args with error when they have >1 argument)
 - #117694 (Move `BorrowedBuf` and `BorrowedCursor` from `std:io` to `core::io`)
 - #117705 (triagebot.toml: use inclusive language)
 - #117723 (speed up `x clean`)
 - #117724 (Restore rustc shim error message)

Failed merges:

 - #109616 (rustdoc: use a template to generate Hrefs)
 - #110303 (Add `debug_assert_nounwind` and convert `assert_unsafe_precondition`)
 - #111658 (Refactor pre-getopts command line argument handling)
 - #116892 (Add `-Zfunction-return={keep,thunk-extern}` option)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=110494,114841,116438,116762,117122,117449,117645,117694,117705,117723,117724)
<!-- homu-ignore:end -->