### PR TITLE
fallible allocation experiment 2

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -12,6 +12,9 @@ use core::ptr::{self, NonNull};
 #[doc(inline)]
 pub use core::alloc::*;
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+pub mod failure_handling;
+
 #[cfg(test)]
 mod tests;
 

--- a/library/alloc/src/alloc/failure_handling.rs
+++ b/library/alloc/src/alloc/failure_handling.rs
@@ -1,0 +1,39 @@
+//! TBD
+//! 
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Describes the handling behavior in case of allocation failure.
+pub trait FailureHandling: sealed::Sealed + Send + Sync + Unpin {
+    /// The type returned by allocating functions.
+    /// 
+    /// `Fallible` functions will return `Result<T, E>`,
+    /// but `Fatal` functions will return `T`.
+    type Result<T, E>;
+}
+
+/// Handle allocation failure globally by panicking / aborting.
+#[derive(Debug)]
+pub struct Fatal;
+
+impl sealed::Sealed for Fatal {}
+impl FailureHandling for Fatal {
+    type Result<T, E> = T;
+}
+
+/// Handle allocation failure falliblyby returning a `Result`.
+#[derive(Debug)]
+pub struct Fallible;
+
+impl sealed::Sealed for Fallible {}
+impl FailureHandling for Fallible {
+    type Result<T, E> = Result<T, E>;
+}
+
+/// Type parameter default `FailureHandling` for use in containers.
+#[cfg(not(no_global_oom_handling))]
+pub type DefaultFailureHandling = Fatal;
+#[cfg(no_global_oom_handling)]
+pub type DefaultFailureHandling = Fallible;

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -165,6 +165,8 @@ use core::pin::Pin;
 use core::ptr::{self, NonNull, Unique};
 use core::task::{Context, Poll};
 
+use crate::alloc::failure_handling::Fallible;
+
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::{handle_alloc_error, WriteCloneIntoRaw};
 use crate::alloc::{AllocError, Allocator, Global, Layout};
@@ -692,7 +694,7 @@ impl<T> Box<[T]> {
             };
             Global.allocate(layout)?.cast()
         };
-        unsafe { Ok(RawVec::from_raw_parts_in(ptr.as_ptr(), len, Global).into_box(len)) }
+        unsafe { Ok(RawVec::<_, _, Fallible>::from_raw_parts_in(ptr.as_ptr(), len, Global).into_box(len)) }
     }
 
     /// Constructs a new boxed slice with uninitialized contents, with the memory
@@ -726,7 +728,7 @@ impl<T> Box<[T]> {
             };
             Global.allocate_zeroed(layout)?.cast()
         };
-        unsafe { Ok(RawVec::from_raw_parts_in(ptr.as_ptr(), len, Global).into_box(len)) }
+        unsafe { Ok(RawVec::<_, _, Fallible>::from_raw_parts_in(ptr.as_ptr(), len, Global).into_box(len)) }
     }
 }
 

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -22,6 +22,7 @@ use core::slice;
 #[allow(unused_imports)]
 use core::mem;
 
+use crate::alloc::failure_handling::Fatal;
 use crate::alloc::{Allocator, Global};
 use crate::collections::TryReserveError;
 use crate::collections::TryReserveErrorKind;
@@ -102,7 +103,7 @@ pub struct VecDeque<
     // if `len == 0`, the exact value of `head` is unimportant.
     // if `T` is zero-Sized, then `self.len <= usize::MAX`, otherwise `self.len <= isize::MAX as usize`.
     len: usize,
-    buf: RawVec<T, A>,
+    buf: RawVec<T, A, Fatal>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -263,6 +263,27 @@ pub mod __export {
     pub use core::format_args;
 }
 
+// HACK: so `std::vec::Vec` doesn't inherit the third `FailureHandling` parameter
+#[cfg(not(test))]
+#[doc(hidden)]
+#[unstable(feature = "std_internals", issue = "none", reason = "implementation detail")]
+pub mod std_vec {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub mod __export {
+        // FIXME: include `vec` module docs here
+
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub use crate::vec::*;
+        
+        // FIXME: include `Vec` docs here
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub type Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A = crate::alloc::Global> = crate::vec::Vec<T, A, crate::alloc::failure_handling::DefaultFailureHandling>;
+    }
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use vec as __export;
+}
+
 #[cfg(test)]
 #[allow(dead_code)] // Not used in all configurations
 pub(crate) mod test_helpers {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -241,6 +241,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::alloc::failure_handling::Fallible;
 #[cfg(not(test))]
 use crate::boxed::Box;
 #[cfg(test)]
@@ -2528,7 +2529,7 @@ impl<T, A: Allocator> From<Vec<T, A>> for Rc<[T], A> {
 
             // Create a `Vec<T, &A>` with length 0, to deallocate the buffer
             // without dropping its contents or the allocator
-            let _ = Vec::from_raw_parts_in(vec_ptr, 0, cap, &alloc);
+            let _ = Vec::<_, _, Fallible>::from_raw_parts_in(vec_ptr, 0, cap, &alloc);
 
             Self::from_ptr_in(rc_ptr, alloc)
         }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -30,6 +30,7 @@ use core::slice::from_raw_parts_mut;
 use core::sync::atomic;
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
+use crate::alloc::failure_handling::Fallible;
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
 #[cfg(not(no_global_oom_handling))]
@@ -3390,7 +3391,7 @@ impl<T, A: Allocator + Clone> From<Vec<T, A>> for Arc<[T], A> {
 
             // Create a `Vec<T, &A>` with length 0, to deallocate the buffer
             // without dropping its contents or the allocator
-            let _ = Vec::from_raw_parts_in(vec_ptr, 0, cap, &alloc);
+            let _ = Vec::<_, _, Fallible>::from_raw_parts_in(vec_ptr, 0, cap, &alloc);
 
             Self::from_ptr_in(rc_ptr, alloc)
         }

--- a/library/alloc/src/vec/extract_if.rs
+++ b/library/alloc/src/vec/extract_if.rs
@@ -1,3 +1,4 @@
+use crate::alloc::failure_handling::{FailureHandling, DefaultFailureHandling};
 use crate::alloc::{Allocator, Global};
 use core::ptr;
 use core::slice;
@@ -25,10 +26,11 @@ pub struct ExtractIf<
     T,
     F,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
+    #[unstable(feature = "allocator_api", issue = "32838")] FH: FailureHandling = DefaultFailureHandling,
 > where
     F: FnMut(&mut T) -> bool,
 {
-    pub(super) vec: &'a mut Vec<T, A>,
+    pub(super) vec: &'a mut Vec<T, A, FH>,
     /// The index of the item that will be inspected by the next call to `next`.
     pub(super) idx: usize,
     /// The number of items that have been drained (removed) thus far.
@@ -39,7 +41,7 @@ pub struct ExtractIf<
     pub(super) pred: F,
 }
 
-impl<T, F, A: Allocator> ExtractIf<'_, T, F, A>
+impl<T, F, A: Allocator, FH: FailureHandling> ExtractIf<'_, T, F, A, FH>
 where
     F: FnMut(&mut T) -> bool,
 {
@@ -52,7 +54,7 @@ where
 }
 
 #[unstable(feature = "extract_if", reason = "recently added", issue = "43244")]
-impl<T, F, A: Allocator> Iterator for ExtractIf<'_, T, F, A>
+impl<T, F, A: Allocator, FH: FailureHandling> Iterator for ExtractIf<'_, T, F, A, FH>
 where
     F: FnMut(&mut T) -> bool,
 {
@@ -88,7 +90,7 @@ where
 }
 
 #[unstable(feature = "extract_if", reason = "recently added", issue = "43244")]
-impl<T, F, A: Allocator> Drop for ExtractIf<'_, T, F, A>
+impl<T, F, A: Allocator, FH: FailureHandling> Drop for ExtractIf<'_, T, F, A, FH>
 where
     F: FnMut(&mut T) -> bool,
 {

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -1,5 +1,6 @@
 #[cfg(not(no_global_oom_handling))]
 use super::AsVecIntoIter;
+use crate::alloc::failure_handling::Fallible;
 use crate::alloc::{Allocator, Global};
 #[cfg(not(no_global_oom_handling))]
 use crate::collections::VecDeque;
@@ -356,7 +357,7 @@ where
     /// assert_eq!(iter.as_slice(), &[]);
     /// ```
     fn default() -> Self {
-        super::Vec::new_in(Default::default()).into_iter()
+        super::Vec::<_, _, Fallible>::new_in(Default::default()).into_iter()
     }
 }
 
@@ -405,7 +406,7 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for IntoIter<T, A> {
                     // `IntoIter::alloc` is not used anymore after this and will be dropped by RawVec
                     let alloc = ManuallyDrop::take(&mut self.0.alloc);
                     // RawVec handles deallocation
-                    let _ = RawVec::from_raw_parts_in(self.0.buf.as_ptr(), self.0.cap, alloc);
+                    let _ = RawVec::<_, _, Fallible>::from_raw_parts_in(self.0.buf.as_ptr(), self.0.cap, alloc);
                 }
             }
         }

--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -1,4 +1,4 @@
-use crate::alloc::Allocator;
+use crate::alloc::{Allocator, failure_handling::FailureHandling};
 #[cfg(not(no_global_oom_handling))]
 use crate::borrow::Cow;
 
@@ -20,21 +20,21 @@ macro_rules! __impl_slice_eq1 {
     }
 }
 
-__impl_slice_eq1! { [A1: Allocator, A2: Allocator] Vec<T, A1>, Vec<U, A2>, #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, &[U], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, &mut [U], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] &[T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
-__impl_slice_eq1! { [A: Allocator] &mut [T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, [U], #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
-__impl_slice_eq1! { [A: Allocator] [T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
+__impl_slice_eq1! { [A1: Allocator, A2: Allocator, FH1: FailureHandling, FH2: FailureHandling] Vec<T, A1, FH1>, Vec<U, A2, FH2>, #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] Vec<T, A, FH>, &[U], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] Vec<T, A, FH>, &mut [U], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] &[T], Vec<U, A, FH>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] &mut [T], Vec<U, A, FH>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] Vec<T, A, FH>, [U], #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] [T], Vec<U, A, FH>, #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
 #[cfg(not(no_global_oom_handling))]
-__impl_slice_eq1! { [A: Allocator] Cow<'_, [T]>, Vec<U, A> where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling] Cow<'_, [T]>, Vec<U, A, FH> where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling, const N: usize] Vec<T, A, FH>, [U; N], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { [A: Allocator, FH: FailureHandling, const N: usize] Vec<T, A, FH>, &[U; N], #[stable(feature = "rust1", since = "1.0.0")] }
 
 // NOTE: some less important impls are omitted to reduce code bloat
 // FIXME(Centril): Reconsider this?

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -1,4 +1,5 @@
 use crate::alloc::Allocator;
+use crate::alloc::failure_handling::Fatal;
 use core::iter::TrustedLen;
 use core::slice::{self};
 
@@ -9,7 +10,7 @@ pub(super) trait SpecExtend<T, I> {
     fn spec_extend(&mut self, iter: I);
 }
 
-impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A>
+impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A, Fatal>
 where
     I: Iterator<Item = T>,
 {
@@ -18,7 +19,7 @@ where
     }
 }
 
-impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A>
+impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A, Fatal>
 where
     I: TrustedLen<Item = T>,
 {
@@ -27,7 +28,7 @@ where
     }
 }
 
-impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A> {
+impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A, Fatal> {
     fn spec_extend(&mut self, mut iterator: IntoIter<T>) {
         unsafe {
             self.append_elements(iterator.as_slice() as _);
@@ -36,7 +37,7 @@ impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A> {
     }
 }
 
-impl<'a, T: 'a, I, A: Allocator> SpecExtend<&'a T, I> for Vec<T, A>
+impl<'a, T: 'a, I, A: Allocator> SpecExtend<&'a T, I> for Vec<T, A, Fatal>
 where
     I: Iterator<Item = &'a T>,
     T: Clone,
@@ -46,7 +47,7 @@ where
     }
 }
 
-impl<'a, T: 'a, A: Allocator> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A>
+impl<'a, T: 'a, A: Allocator> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A, Fatal>
 where
     T: Copy,
 {

--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -1,5 +1,6 @@
 use core::ptr;
 
+use crate::alloc::failure_handling::Fatal;
 use crate::alloc::Allocator;
 use crate::raw_vec::RawVec;
 
@@ -7,11 +8,11 @@ use super::{IsZero, Vec};
 
 // Specialization trait used for Vec::from_elem
 pub(super) trait SpecFromElem: Sized {
-    fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A>;
+    fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A, Fatal>;
 }
 
 impl<T: Clone> SpecFromElem for T {
-    default fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A> {
+    default fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A, Fatal> {
         let mut v = Vec::with_capacity_in(n, alloc);
         v.extend_with(n, elem);
         v
@@ -20,7 +21,7 @@ impl<T: Clone> SpecFromElem for T {
 
 impl<T: Clone + IsZero> SpecFromElem for T {
     #[inline]
-    default fn from_elem<A: Allocator>(elem: T, n: usize, alloc: A) -> Vec<T, A> {
+    default fn from_elem<A: Allocator>(elem: T, n: usize, alloc: A) -> Vec<T, A, Fatal> {
         if elem.is_zero() {
             return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
         }
@@ -32,7 +33,7 @@ impl<T: Clone + IsZero> SpecFromElem for T {
 
 impl SpecFromElem for i8 {
     #[inline]
-    fn from_elem<A: Allocator>(elem: i8, n: usize, alloc: A) -> Vec<i8, A> {
+    fn from_elem<A: Allocator>(elem: i8, n: usize, alloc: A) -> Vec<i8, A, Fatal> {
         if elem == 0 {
             return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
         }

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -2,7 +2,7 @@ use core::cmp;
 use core::iter::TrustedLen;
 use core::ptr;
 
-use crate::raw_vec::RawVec;
+use crate::{raw_vec::RawVec, alloc::{failure_handling::Fatal, Global}};
 
 use super::{SpecExtend, Vec};
 
@@ -28,7 +28,7 @@ where
             Some(element) => {
                 let (lower, _) = iterator.size_hint();
                 let initial_capacity =
-                    cmp::max(RawVec::<T>::MIN_NON_ZERO_CAP, lower.saturating_add(1));
+                    cmp::max(RawVec::<T, Global, Fatal>::MIN_NON_ZERO_CAP, lower.saturating_add(1));
                 let mut vector = Vec::with_capacity(initial_capacity);
                 unsafe {
                     // SAFETY: We requested capacity at least 1

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -1,3 +1,4 @@
+use crate::alloc::failure_handling::Fatal;
 use crate::alloc::{Allocator, Global};
 use core::ptr::{self};
 use core::slice::{self};
@@ -23,7 +24,7 @@ pub struct Splice<
     I: Iterator + 'a,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator + 'a = Global,
 > {
-    pub(super) drain: Drain<'a, I::Item, A>,
+    pub(super) drain: Drain<'a, I::Item, A, Fatal>,
     pub(super) replace_with: I,
 }
 

--- a/library/alloc/src/vec/try_spec_extend.rs
+++ b/library/alloc/src/vec/try_spec_extend.rs
@@ -1,0 +1,60 @@
+use crate::alloc::Allocator;
+use crate::alloc::failure_handling::Fallible;
+use crate::collections::TryReserveError;
+use core::iter::TrustedLen;
+use core::slice::{self};
+
+use super::{IntoIter, Vec};
+
+// Specialization trait used for Vec::extend
+pub(super) trait TrySpecExtend<T, I> {
+    fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError>;
+}
+
+impl<T, I, A: Allocator> TrySpecExtend<T, I> for Vec<T, A, Fallible>
+where
+    I: Iterator<Item = T>,
+{
+    default fn try_spec_extend(&mut self, iter: I) -> Result<(), TryReserveError> {
+        self.extend_desugared(iter)
+    }
+}
+
+impl<T, I, A: Allocator> TrySpecExtend<T, I> for Vec<T, A, Fallible>
+where
+    I: TrustedLen<Item = T>,
+{
+    default fn try_spec_extend(&mut self, iterator: I) -> Result<(), TryReserveError> {
+        self.extend_trusted(iterator)
+    }
+}
+
+impl<T, A: Allocator> TrySpecExtend<T, IntoIter<T>> for Vec<T, A, Fallible> {
+    fn try_spec_extend(&mut self, mut iterator: IntoIter<T>) -> Result<(), TryReserveError> {
+        unsafe {
+            self.append_elements(iterator.as_slice() as _)?;
+        }
+        iterator.forget_remaining_elements();
+        Ok(())
+    }
+}
+
+impl<'a, T: 'a, I, A: Allocator> TrySpecExtend<&'a T, I> for Vec<T, A, Fallible>
+where
+    I: Iterator<Item = &'a T>,
+    T: Clone,
+{
+    default fn try_spec_extend(&mut self, iterator: I) -> Result<(), TryReserveError> {
+        self.try_spec_extend(iterator.cloned())
+    }
+}
+
+impl<'a, T: 'a, A: Allocator> TrySpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A, Fallible>
+where
+    T: Copy,
+{
+    fn try_spec_extend(&mut self, iterator: slice::Iter<'a, T>) -> Result<(), TryReserveError> {
+        let slice = iterator.as_slice();
+        unsafe { self.append_elements(slice) }
+    }
+}

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -472,7 +472,7 @@ pub use alloc_crate::str;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::string;
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use alloc_crate::vec;
+pub use alloc_crate::std_vec::__export as vec;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
 #[stable(feature = "core_array", since = "1.36.0")]


### PR DESCRIPTION
supercedes #111970

The idea is to implement fallible allocation APIs using an extra generic parameter on the container type. Here that has been done for `Vec`. The docs turned out much better but there is still some room for improvement.

In order to limit the impact on the `std` docs, I used a type alias for `std::vec::Vec` as @matthieu-m suggested. This actually produced quite nice docs complete with all of the relevant impls, and excluding the duplicate functions for the irrelevant `Fallible` case.

There are a few things we'll need to handle on the rustdoc side before moving forward with this, some of which can be seen in the following image. I think we can address all of them by making `#[doc(inline)]` work on trait aliases. It would need to do the following:

1. Copy the item-level docs (in this case the `alloc::vec::Vec` docs)
2. Display a Struct / Enum documentation page, rather than a Type Alias page (in this case "Struct std::vec::Vec")
3. Hide any explicitly defined generic parameters from showing up in the `impl` headers (in this case, `FH` should be hidden)
4. And, I think it should generate a static html page rather than depending on the JS-based type alias inlining

Unrelated to `doc(inline)`, it would be really nice if there was a way to copy the docs of one module to another. As it is, I think the only way to make sure that `std::vec` stays up-to-date with the `alloc::vec` docs will be to extract the docs to a separate text file and use `include_str!`.

![image](https://github.com/rust-lang/rust/assets/803701/4fc700db-0e3a-4da1-8c78-d0bc138fb0ae)

[Documentation archive](https://github.com/rust-lang/rust/files/13303938/doc.zip)
(Hopefully that still mostly works, I had to delete a couple things)