### PR TITLE
Add some links and minor explanatory comments to `std::fmt`

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -188,6 +188,10 @@
 //!     * `#X` - precedes the argument with a `0x`
 //!     * `#b` - precedes the argument with a `0b`
 //!     * `#o` - precedes the argument with a `0o`
+//!   
+//!   See [Formatting traits](#formatting-traits) for a description of what the `?`, `x`, `X`,
+//!   `b`, and `o` flags do.
+//!   
 //! * `0` - This is used to indicate for integer formats that the padding to `width` should
 //!         both be done with a `0` character as well as be sign-aware. A format
 //!         like `{:08}` would yield `00000001` for the integer `1`, while the

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -188,10 +188,10 @@
 //!     * `#X` - precedes the argument with a `0x`
 //!     * `#b` - precedes the argument with a `0b`
 //!     * `#o` - precedes the argument with a `0o`
-//!   
+//!
 //!   See [Formatting traits](#formatting-traits) for a description of what the `?`, `x`, `X`,
 //!   `b`, and `o` flags do.
-//!   
+//!
 //! * `0` - This is used to indicate for integer formats that the padding to `width` should
 //!         both be done with a `0` character as well as be sign-aware. A format
 //!         like `{:08}` would yield `00000001` for the integer `1`, while the

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -201,6 +201,7 @@
 //!         and before the digits. When used together with the `#` flag, a similar
 //!         rule applies: padding zeros are inserted after the prefix but before
 //!         the digits. The prefix is included in the total width.
+//!         This flag overrides the [fill character and alignment flag](#fillalignment).
 //!
 //! ## Precision
 //!


### PR DESCRIPTION
I thought the documentation for the `#` flag could do with a link to the explanation of the `?xXbo` flags, because at that point they haven't been explained yet and it's a bit confusing.

I also added that the `0` flag overrides the fill character and alignment flag, here's a [Rust Playgrond](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=0d580b7b78b8a2d8c08a2fc7a936ef17) that shows what I mean.