### PR TITLE
rustdoc-json: Fix test so it actually checks things

### DIFF
--- a/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
+++ b/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
@@ -2,11 +2,12 @@
 
 mod repeat_n {
     #[doc(hidden)]
+    /// not here
     pub struct RepeatN {}
 }
 
+/// not here
 pub use repeat_n::RepeatN;
 
 // @count "$.index[*][?(@.name=='pub_use_doc_hidden')].inner.items[*]" 0
-// @!has "$.index[*][?(@.kind=='struct')]"
-// @!has "$.index[*][?(@.kind=='import')]"
+// @!has "$.index[*][?(@.docs == 'not here')]"


### PR DESCRIPTION
After #111427, no item has a `kind` field, so these assertions could never fail. Instead, assert that those two items arn't present.

r? @GuillaumeGomez 