### PR TITLE
Update variable name to fix `unused_variables` warning

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -180,7 +180,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
 }
 
 #[cfg(target_os = "espidf")]
-pub fn chdir(p: &path::Path) -> io::Result<()> {
+pub fn chdir(_p: &path::Path) -> io::Result<()> {
     super::unsupported::unsupported()
 }
 


### PR DESCRIPTION
This PR fixes an `unused_variables` warning within `os.rs` when targeting `espidf`.