### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -121,6 +121,7 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     ("similar", "Apache-2.0"),
     ("sized-chunks", "MPL-2.0+"),
     ("subtle", "BSD-3-Clause"),
+    ("supports-hyperlinks", "Apache-2.0"),
     ("unicode-bom", "Apache-2.0"),
     // tidy-alphabetical-end
 ];


### PR DESCRIPTION
12 commits in 7046d992f9f32ba209a8079f662ebccf9da8de25..6790a5127895debec95c24aefaeb18e059270df3
2023-11-08 03:24:57 +0000 to 2023-11-10 17:09:35 +0000
- refactor(source): Prepare for new PackageIDSpec syntax (rust-lang/cargo#12938)
- credential: include license files in all published crates (rust-lang/cargo#12953)
- fix: preserve jobserver file descriptors on rustc invocation in `fix_exec_rustc` (rust-lang/cargo#12951)
- refactor(resolver): Consolidate logic in `VersionPreferences` (rust-lang/cargo#12930)
- refactor(toml): Simplify code to make schema split easier (rust-lang/cargo#12948)
- Filter `cargo-credential-*` dependencies by OS (rust-lang/cargo#12949)
- refactor(util): Pull out `mod util_semver` (rust-lang/cargo#12940)
- Fix the invalidate feature name message (rust-lang/cargo#12939)
- refactor(util): Prepare for splitting out semver logic (rust-lang/cargo#12926)
- feat: Make browser links out of HTML file paths (rust-lang/cargo#12889)
- Do not allow empty feature name (rust-lang/cargo#12928)
- fix(timings): unnecessary backslash when error happens (rust-lang/cargo#12934)

r? ghost