### PR TITLE
Switch `fuchsia-test-runner.py` to `ffx product`

### DIFF
--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -692,10 +692,12 @@ Fuchsia's test runner interacts with the Fuchsia emulator and is located at
 test environment with:
 
 ```sh
-src/ci/docker/scripts/fuchsia-test-runner.py start                            \
+( \
+    src/ci/docker/scripts/fuchsia-test-runner.py start                        \
     --rust-build ${RUST_SRC_PATH}/build                                       \
     --sdk ${SDK_PATH}                                                         \
     --target {x86_64-unknown-fuchsia|aarch64-unknown-fuchsia}                 \
+)
 ```
 
 Where `${RUST_SRC_PATH}/build` is the `build-dir` set in `config.toml` and


### PR DESCRIPTION
The subcommand `ffx product-bundle` has been removed, and replaced with the subcommand `ffx product`. This changes `fuchsia-test-runner.py` to use it to download the SDK and product bundle for the latest release of Fuchsia.