### PR TITLE
A Proof-of-Concept for Struct Initialization Inference

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1252,6 +1252,7 @@ impl Expr {
             ExprKind::OffsetOf(..) => ExprPrecedence::OffsetOf,
             ExprKind::MacCall(..) => ExprPrecedence::Mac,
             ExprKind::Struct(..) => ExprPrecedence::Struct,
+            ExprKind::InferStruct(..) => ExprPrecedence::Struct,
             ExprKind::Repeat(..) => ExprPrecedence::Repeat,
             ExprKind::Paren(..) => ExprPrecedence::Paren,
             ExprKind::Try(..) => ExprPrecedence::Try,
@@ -1344,6 +1345,12 @@ pub enum StructRest {
 pub struct StructExpr {
     pub qself: Option<P<QSelf>>,
     pub path: Path,
+    pub fields: ThinVec<ExprField>,
+    pub rest: StructRest,
+}
+
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub struct InferStructExpr {
     pub fields: ThinVec<ExprField>,
     pub rest: StructRest,
 }
@@ -1459,6 +1466,7 @@ pub enum ExprKind {
     ///
     /// E.g., `Foo {x: 1, y: 2}`, or `Foo {x: 1, .. rest}`.
     Struct(P<StructExpr>),
+    InferStruct(P<InferStructExpr>),
 
     /// An array literal constructed from one repeated element.
     ///

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1491,6 +1491,15 @@ pub fn noop_visit_expr<T: MutVisitor>(
                 StructRest::None => {}
             }
         }
+        ExprKind::InferStruct(se) => {
+            let InferStructExpr { fields, rest } = se.deref_mut();
+            fields.flat_map_in_place(|field| vis.flat_map_expr_field(field));
+            match rest {
+                StructRest::Base(expr) => vis.visit_expr(expr),
+                StructRest::Rest(_span) => {}
+                StructRest::None => {}
+            }
+        }
         ExprKind::Paren(expr) => {
             vis.visit_expr(expr);
         }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -807,6 +807,14 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
                 StructRest::None => {}
             }
         }
+        ExprKind::InferStruct(se) => {
+            walk_list!(visitor, visit_expr_field, &se.fields);
+            match &se.rest {
+                StructRest::Base(expr) => visitor.visit_expr(expr),
+                StructRest::Rest(_span) => {}
+                StructRest::None => {}
+            }
+        }
         ExprKind::Tup(subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);
         }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -318,6 +318,22 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         rest,
                     )
                 }
+                ExprKind::InferStruct(se) => {
+                    let rest = match &se.rest {
+                        StructRest::Base(e) => Some(self.lower_expr(e)),
+                        StructRest::Rest(sp) => {
+                            let guar =
+                                self.tcx.sess.emit_err(BaseExpressionDoubleDot { span: *sp });
+                            Some(&*self.arena.alloc(self.expr_err(*sp, guar)))
+                        }
+                        StructRest::None => None,
+                    };
+                    hir::ExprKind::InferStruct(
+                        self.arena
+                            .alloc_from_iter(se.fields.iter().map(|x| self.lower_expr_field(x))),
+                        rest,
+                    )
+                }
                 ExprKind::Gen(capture_clause, block, GenBlockKind::Gen) => self.make_gen_expr(
                     *capture_clause,
                     e.id,

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -278,6 +278,14 @@ impl<'cx, 'a> Context<'cx, 'a> {
                     self.manage_cond_expr(local_expr);
                 }
             }
+            ExprKind::InferStruct(elem) => {
+                for field in &mut elem.fields {
+                    self.manage_cond_expr(&mut field.expr);
+                }
+                if let StructRest::Base(local_expr) = &mut elem.rest {
+                    self.manage_cond_expr(local_expr);
+                }
+            }
             ExprKind::Tup(local_exprs) => {
                 for local_expr in local_exprs {
                     self.manage_cond_expr(local_expr);

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -708,6 +708,10 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
             walk_list!(visitor, visit_expr_field, fields);
             walk_list!(visitor, visit_expr, optional_base);
         }
+        ExprKind::InferStruct(fields, ref optional_base) => {
+            walk_list!(visitor, visit_expr_field, fields);
+            walk_list!(visitor, visit_expr, optional_base);
+        }
         ExprKind::Tup(subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);
         }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1091,6 +1091,29 @@ impl<'a> State<'a> {
         self.word("}");
     }
 
+    fn print_expr_infer_struct(
+        &mut self,
+        fields: &[hir::ExprField<'_>],
+        wth: Option<&hir::Expr<'_>>,
+    ) {
+        self.word(".{");
+        self.commasep_cmnt(Consistent, fields, |s, field| s.print_expr_field(field), |f| f.span);
+        if let Some(expr) = wth {
+            self.ibox(INDENT_UNIT);
+            if !fields.is_empty() {
+                self.word(",");
+                self.space();
+            }
+            self.word("..");
+            self.print_expr(expr);
+            self.end();
+        } else if !fields.is_empty() {
+            self.word(",");
+        }
+
+        self.word("}");
+    }
+
     fn print_expr_field(&mut self, field: &hir::ExprField<'_>) {
         if self.attrs(field.hir_id).is_empty() {
             self.space();
@@ -1331,6 +1354,9 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::Struct(qpath, fields, wth) => {
                 self.print_expr_struct(qpath, fields, wth);
+            }
+            hir::ExprKind::InferStruct(fields, wth) => {
+                self.print_expr_infer_struct(fields, wth);
             }
             hir::ExprKind::Tup(exprs) => {
                 self.print_expr_tup(exprs);

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -233,6 +233,10 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                 self.walk_struct_expr(fields, opt_with);
             }
 
+            hir::ExprKind::InferStruct(fields, ref opt_with) => {
+                self.walk_struct_expr(fields, opt_with);
+            }
+
             hir::ExprKind::Tup(exprs) => {
                 self.consume_exprs(exprs);
             }

--- a/compiler/rustc_hir_typeck/src/mem_categorization.rs
+++ b/compiler/rustc_hir_typeck/src/mem_categorization.rs
@@ -378,6 +378,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             | hir::ExprKind::Break(..)
             | hir::ExprKind::Continue(..)
             | hir::ExprKind::Struct(..)
+            | hir::ExprKind::InferStruct(..)
             | hir::ExprKind::Repeat(..)
             | hir::ExprKind::InlineAsm(..)
             | hir::ExprKind::OffsetOf(..)

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -286,6 +286,11 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
                     self.visit_field_id(field.hir_id);
                 }
             }
+            hir::ExprKind::InferStruct(fields, _) => {
+                for field in fields {
+                    self.visit_field_id(field.hir_id);
+                }
+            }
             hir::ExprKind::Field(..) | hir::ExprKind::OffsetOf(..) => {
                 self.visit_field_id(e.hir_id);
             }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -278,7 +278,10 @@ impl<'tcx> TypeckResults<'tcx> {
     }
 
     pub fn field_index(&self, id: hir::HirId) -> FieldIdx {
-        self.field_indices().get(id).cloned().expect("no index for a field")
+        match self.field_indices().get(id).cloned() {
+            Some(id) => id,
+            None => panic!("No index for hir {}", id.to_string())
+        }
     }
 
     pub fn opt_field_index(&self, id: hir::HirId) -> Option<FieldIdx> {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1459,6 +1459,11 @@ impl<'a> Parser<'a> {
     pub fn approx_token_stream_pos(&self) -> usize {
         self.num_bump_calls
     }
+
+    fn check_struct_infer(&mut self) -> bool {
+        self.check(&token::Dot)
+            && self.look_ahead(1, |t| {*t == token::OpenDelim(Delimiter::Brace)})
+    }
 }
 
 pub(crate) fn make_unclosed_delims_error(

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -303,7 +303,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
                 ConstBlock, Array, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type,
                 DropTemps, Let, If, Loop, Match, Closure, Block, Assign, AssignOp, Field, Index,
                 Path, AddrOf, Break, Continue, Ret, Become, InlineAsm, OffsetOf, Struct, Repeat,
-                Yield, Err
+                Yield, Err, InferStruct
             ]
         );
         hir_visit::walk_expr(self, e)
@@ -569,8 +569,8 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 Array, ConstBlock, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type, Let,
                 If, While, ForLoop, Loop, Match, Closure, Block, Await, TryBlock, Assign,
                 AssignOp, Field, Index, Range, Underscore, Path, AddrOf, Break, Continue, Ret,
-                InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, Repeat, Paren, Try, Yield, Yeet,
-                Become, IncludedBytes, Gen, Err
+                InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, InferStruct, Repeat, Paren,
+                Try, Yield, Yeet, Become, IncludedBytes, Gen, Err
             ]
         );
         ast_visit::walk_expr(self, e)

--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -206,6 +206,7 @@ impl<'tcx> CheckInlineAssembly<'tcx> {
             | ExprKind::OffsetOf(..)
             | ExprKind::Become(..)
             | ExprKind::Struct(..)
+            | ExprKind::InferStruct(..)
             | ExprKind::Repeat(..)
             | ExprKind::Yield(..) => {
                 self.items.push((ItemKind::NonAsm, span));

--- a/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/never_loop.rs
@@ -173,6 +173,14 @@ fn never_loop_expr<'tcx>(
                 fields
             }
         },
+        ExprKind::InferStruct(fields, base) => {
+            let fields = never_loop_expr_all(cx, fields.iter().map(|f| f.expr), local_labels, main_loop_id);
+            if let Some(base) = base {
+                combine_seq(fields, || never_loop_expr(cx, base, local_labels, main_loop_id))
+            } else {
+                fields
+            }
+        },
         ExprKind::Call(e, es) => never_loop_expr_all(cx, once(e).chain(es.iter()), local_labels, main_loop_id),
         ExprKind::Binary(_, e1, e2)
         | ExprKind::Assign(e1, e2, _)

--- a/src/tools/clippy/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/significant_drop_in_scrutinee.rs
@@ -348,6 +348,7 @@ impl<'a, 'tcx> Visitor<'tcx> for SigDropHelper<'a, 'tcx> {
             ExprKind::Loop(_, _, _, _) |
             ExprKind::Path(_) |
             ExprKind::Struct(_, _, _) |
+            ExprKind::InferStruct(_, _) |
             ExprKind::Type(_, _) => {
                 return;
             }

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -584,6 +584,16 @@ impl<'a, 'tcx> PrintVisitor<'a, 'tcx> {
                 });
                 base.if_some(|e| self.expr(e));
             },
+            ExprKind::InferStruct(fields, base) => {
+                bind!(self, fields);
+                opt_bind!(self, base);
+                kind!("InferStruct({fields}, {base})");
+                self.slice(fields, |field| {
+                    self.ident(field!(field.ident));
+                    self.expr(field!(field.expr));
+                });
+                base.if_some(|e| self.expr(e));
+            },
             ExprKind::ConstBlock(_) => kind!("ConstBlock(_)"),
             ExprKind::Repeat(value, length) => {
                 bind!(self, value, length);

--- a/src/tools/clippy/clippy_utils/src/eager_or_lazy.rs
+++ b/src/tools/clippy/clippy_utils/src/eager_or_lazy.rs
@@ -242,6 +242,7 @@ fn expr_eagerness<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> EagernessS
                 | ExprKind::Field(..)
                 | ExprKind::AddrOf(..)
                 | ExprKind::Struct(..)
+                | ExprKind::InferStruct(..)
                 | ExprKind::Repeat(..)
                 | ExprKind::Block(Block { stmts: [], .. }, _)
                 | ExprKind::OffsetOf(..) => (),

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -866,6 +866,16 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
                     self.hash_expr(e);
                 }
             },
+            ExprKind::InferStruct(fields, ref expr) => {
+                for f in fields {
+                    self.hash_name(f.ident.name);
+                    self.hash_expr(f.expr);
+                }
+
+                if let Some(e) = *expr {
+                    self.hash_expr(e);
+                }
+            },
             ExprKind::Tup(tup) => {
                 self.hash_exprs(tup);
             },

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -149,6 +149,7 @@ impl<'a> Sugg<'a> {
             | hir::ExprKind::Ret(..)
             | hir::ExprKind::Become(..)
             | hir::ExprKind::Struct(..)
+            | hir::ExprKind::InferStruct(..)
             | hir::ExprKind::Tup(..)
             | hir::ExprKind::Err(_) => Sugg::NonParen(get_snippet(expr.span)),
             hir::ExprKind::DropTemps(inner) => Self::hir_from_snippet(inner, get_snippet),
@@ -216,6 +217,7 @@ impl<'a> Sugg<'a> {
             | ast::ExprKind::Yeet(..)
             | ast::ExprKind::FormatArgs(..)
             | ast::ExprKind::Struct(..)
+            | ast::ExprKind::InferStruct(..)
             | ast::ExprKind::Try(..)
             | ast::ExprKind::TryBlock(..)
             | ast::ExprKind::Tup(..)

--- a/src/tools/clippy/clippy_utils/src/visitors.rs
+++ b/src/tools/clippy/clippy_utils/src/visitors.rs
@@ -668,6 +668,14 @@ pub fn for_each_unconsumed_temporary<'tcx, B>(
                     helper(typeck, false, default, f)?;
                 }
             },
+            ExprKind::InferStruct(fields, default) => {
+                for field in fields {
+                    helper(typeck, true, field.expr, f)?;
+                }
+                if let Some(default) = default {
+                    helper(typeck, false, default, f)?;
+                }
+            },
             ExprKind::If(cond, then, else_expr) => {
                 helper(typeck, true, cond, f)?;
                 helper(typeck, true, then, f)?;

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -469,6 +469,7 @@ pub(crate) fn is_block_expr(context: &RewriteContext<'_>, expr: &ast::Expr, repr
         | ast::ExprKind::MethodCall(..)
         | ast::ExprKind::Array(..)
         | ast::ExprKind::Struct(..)
+        | ast::ExprKind::InferStruct(..)
         | ast::ExprKind::While(..)
         | ast::ExprKind::If(..)
         | ast::ExprKind::Block(..)


### PR DESCRIPTION
In zig, structs can be initialized shorthand by using a '.{' syntax, i.e.:
```zig
runConfig(.{
    .cfgPath = "cfg.txt"
})
```
Rust has a lot of cases that would benefit from the simplicity that having that sort of syntax brings - i.e, `wgpu` and its many, many configuration structs, or bindings to other languages.
```rust
let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
        label: None,
        layout: &bind_group_layout,
        entries: &[wgpu::BindGroupEntry {
            binding: 0,
            resource: storage_buffer.as_entire_binding(),
        }],
    });
```
With this PR, the above would be transformed into:
```rust
let bind_group = device.create_bind_group(&.{
        label: None,
        layout: &bind_group_layout,
        entries: &[.{
            binding: 0,
            resource: storage_buffer.as_entire_binding(),
        }],
    });
```
As far as I am aware, there is no other syntax in rust that uses '.' with a brace after it, so it should be completely backwards-compatible. The only thing that comes close is floating-point literals, but those are restricted to only ascii numeric characters after the '.' afaik.

One thing that may be able to be implemented in the future could also be enum shorthands, for example from:
```rust
call_with_enum(LongEnumName::Integer(10));
```
to:
```rust
call_with_enum(.Integer(10))
```

My implementation is incredibibly barebones at the moment (no tests, no rust-analyzer support), but the following code is an example that should successfully compile properly:
```rust
#[derive(Debug)]
struct Foo {
    a: usize,
    b: isize,
}

fn bar(foo: Foo) {
    dbg!(foo);
}

fn main() {
    bar(.{ a: 10, b: -10 });
}
```