### PR TITLE
bootstrap: please document why a config change requires migration

### DIFF
--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -79,8 +79,6 @@ fn main() {
             "HELP: consider running `./x.py setup` or copying `config.example.toml` by running \
             `cp config.example.toml config.toml`"
         );
-    } else if let Some(suggestion) = &changelog_suggestion {
-        println!("{suggestion}");
     }
 
     // Give a warning if the pre-commit script is in pre-commit and not pre-push.
@@ -96,7 +94,7 @@ fn main() {
         );
     }
 
-    if suggest_setup || changelog_suggestion.is_some() {
+    if suggest_setup {
         println!("NOTE: this message was printed twice to make it more likely to be seen");
     }
 }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -78,6 +78,9 @@ const LLD_FILE_NAMES: &[&str] = &["ld.lld", "ld64.lld", "lld-link", "wasm-ld"];
 /// If you make any major changes (such as adding new values or changing default values),
 /// please ensure that the associated PR ID is added to the end of this list.
 /// This is necessary because the list must be sorted by the merge date.
+/// Also make sure that your PR description tells people what they need to do
+/// to migrate their configuration. (If there's nothing to migrate, consider whether
+/// having *every rustc developer* open your PR page is really necessary.)
 pub const CONFIG_CHANGE_HISTORY: &[usize] = &[115898, 116998, 117435, 116881];
 
 /// Extra --check-cfg to add when building


### PR DESCRIPTION
Currently I go to these PRs to learn how to update my config, and then I am staring at a PR description that was clearly written for the reviewer, not the random rustc developer just updating their checkout. That's no good.