### PR TITLE
Fix dangling ID when `pub use`ing item which is Doc(hidden) or inherits it in rustdoc JSON output

### DIFF
--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -245,7 +245,7 @@ pub(crate) struct ImportStripper<'tcx> {
 
 impl<'tcx> ImportStripper<'tcx> {
     fn import_should_be_hidden(&self, i: &Item, imp: &clean::Import) -> bool {
-        if self.is_json_output {
+        if self.is_json_output && imp.kind.is_glob() {
             // FIXME: This should be handled the same way as for HTML output.
             imp.imported_item_is_doc_hidden(self.tcx)
         } else {

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -669,9 +669,24 @@ pub struct Import {
     /// May be different from the last segment of `source` when renaming imports:
     /// `use source as name;`
     pub name: String,
-    /// The ID of the item being imported. Will be `None` in case of re-exports of primitives:
-    /// ```rust
+    /// The ID of the item being imported. Will be `None` in case of re-exports of primitives or
+    /// if the reexported item is `#[doc(hidden)]` or inherits it from one of its parents.
+    ///
+    /// Example of reexported primitive type:
+    ///
+    /// ```
     /// pub use i32 as my_i32;
+    /// ```
+    ///
+    /// Example of reexported item which inherits `doc(hidden)`:
+    ///
+    /// ```
+    /// #[doc(hidden)]
+    /// pub mod foo {
+    ///     pub struct Bar;
+    /// }
+    ///
+    /// pub use foo::Bar;
     /// ```
     pub id: Option<Id>,
     /// Whether this import uses a glob: `use source::*;`

--- a/tests/rustdoc-json/doc_hidden_reexports.rs
+++ b/tests/rustdoc-json/doc_hidden_reexports.rs
@@ -1,0 +1,19 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/117718>.
+// Ensures that the various "doc(hidden)" reexport cases are correctly handled.
+
+pub mod submodule {
+    #[doc(hidden)]
+    pub struct Hidden {}
+}
+
+#[doc(hidden)]
+mod x {
+    pub struct Y {}
+}
+
+// @has "$.index[*].inner[?(@.import.name=='UsedHidden')].import.source" '"submodule::Hidden"'
+// @has "$.index[*].inner[?(@.import.name=='UsedHidden')].import.id" "null"
+pub use submodule::Hidden as UsedHidden;
+// @has "$.index[*].inner[?(@.import.name=='Z')].import.source" '"x::Y"'
+// @has "$.index[*].inner[?(@.import.name=='Z')].import.id" 'null'
+pub use x::Y as Z;

--- a/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
+++ b/tests/rustdoc-json/reexport/pub_use_doc_hidden.rs
@@ -6,8 +6,9 @@ mod repeat_n {
     pub struct RepeatN {}
 }
 
-/// not here
+/// is here
 pub use repeat_n::RepeatN;
 
 // @count "$.index[*][?(@.name=='pub_use_doc_hidden')].inner.items[*]" 0
+// @has "$.index[*][?(@.docs == 'is here')]"
 // @!has "$.index[*][?(@.docs == 'not here')]"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/117718.

I changed a bit where we actually filter out some reexports to be done directly in the JSON conversion. When the reexport is public but the reexported item is doc hidden, it generates the reexport but with a `null` ID.

r? @aDotInTheVoid 