### PR TITLE
deprecate `if-available` value of `download-ci-llvm`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -42,18 +42,15 @@ change-id = 116881
 # Unless you're developing for a target where Rust CI doesn't build a compiler
 # toolchain or changing LLVM locally, you probably want to leave this enabled.
 #
-# Set this to `"if-available"` if you are not sure whether you're on a tier 1 
-# target. All tier 1 targets are currently supported;
-#
-# We also currently only support this when building LLVM for the build triple.
-#
-# Set this to `"if-unchanged"` to only download if the llvm-project have not 
-# been modified. (If there are no changes or if built from tarball source, 
-# the logic is the same as "if-available")
+# Set this to `"if-unchanged"` to download only if the llvm-project has not
+# been modified. You can also use this if you are unsure whether you're on a
+# tier 1 target. All tier 1 targets are currently supported.
+
+# Currently, we only support this when building LLVM for the build triple.
 #
 # Note that many of the LLVM options are not currently supported for
 # downloading. Currently only the "assertions" option can be toggled.
-#download-ci-llvm = if rust.channel == "dev" { "if-available" } else { false }
+#download-ci-llvm = if rust.channel == "dev" { "if-unchanged" } else { false }
 
 # Indicates whether the LLVM build is a Release or Debug build
 #optimize = true

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -17,4 +17,4 @@ lto = "off"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.
-download-ci-llvm = "if-available"
+download-ci-llvm = "if-unchanged"

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -13,4 +13,4 @@ lto = "off"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.
-download-ci-llvm = "if-available"
+download-ci-llvm = "if-unchanged"

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -21,4 +21,4 @@ compiler-docs = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.
-download-ci-llvm = "if-available"
+download-ci-llvm = "if-unchanged"

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2104,6 +2104,8 @@ impl Config {
         match download_ci_llvm {
             None => self.channel == "dev" && llvm::is_ci_llvm_available(&self, asserts),
             Some(StringOrBool::Bool(b)) => b,
+            // FIXME: "if-available" is deprecated. Remove this block later (around mid 2024)
+            // to not break builds between the recent-to-old checkouts.
             Some(StringOrBool::String(s)) if s == "if-available" => {
                 llvm::is_ci_llvm_available(&self, asserts)
             }

--- a/src/bootstrap/src/tests/config.rs
+++ b/src/bootstrap/src/tests/config.rs
@@ -24,19 +24,19 @@ fn download_ci_llvm() {
     }
 
     let parse_llvm = |s| parse(s).llvm_from_ci;
-    let if_available = parse_llvm("llvm.download-ci-llvm = \"if-available\"");
+    let if_unchanged = parse_llvm("llvm.download-ci-llvm = \"if-unchanged\"");
 
     assert!(parse_llvm("llvm.download-ci-llvm = true"));
     assert!(!parse_llvm("llvm.download-ci-llvm = false"));
-    assert_eq!(parse_llvm(""), if_available);
-    assert_eq!(parse_llvm("rust.channel = \"dev\""), if_available);
+    assert_eq!(parse_llvm(""), if_unchanged);
+    assert_eq!(parse_llvm("rust.channel = \"dev\""), if_unchanged);
     assert!(!parse_llvm("rust.channel = \"stable\""));
     assert!(parse_llvm("build.build = \"x86_64-unknown-linux-gnu\""));
     assert!(parse_llvm(
-        "llvm.assertions = true \r\n build.build = \"x86_64-unknown-linux-gnu\" \r\n llvm.download-ci-llvm = \"if-available\""
+        "llvm.assertions = true \r\n build.build = \"x86_64-unknown-linux-gnu\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
     ));
     assert!(!parse_llvm(
-        "llvm.assertions = true \r\n build.build = \"aarch64-apple-darwin\" \r\n llvm.download-ci-llvm = \"if-available\""
+        "llvm.assertions = true \r\n build.build = \"aarch64-apple-darwin\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
     ));
 }
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -145,7 +145,7 @@ else
   # LLVM continuously on at least some builders to ensure it works, though.
   # (And PGO is its own can of worms).
   if [ "$NO_DOWNLOAD_CI_LLVM" = "" ]; then
-    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set llvm.download-ci-llvm=if-available"
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set llvm.download-ci-llvm=if-unchanged"
   else
     # When building for CI we want to use the static C++ Standard library
     # included with LLVM, since a dynamic libstdcpp may not be available.

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -58,7 +58,7 @@ elif isWindows && [[ ${CUSTOM_MINGW-0} -ne 1 ]]; then
         "${RUST_CONFIGURE_ARGS} --set llvm.clang-cl=$(pwd)/clang-rust/bin/clang-cl.exe"
 
     # Disable downloading CI LLVM on this builder;
-    # setting up clang-cl just above conflicts with the default if-available option.
+    # setting up clang-cl just above conflicts with the default if-unchanged option.
     ciCommandSetEnv NO_DOWNLOAD_CI_LLVM 1
 fi
 


### PR DESCRIPTION
This PR deprecates the use of the `if-available` value for `download-ci-llvm` since `if-unchanged` serves the same purpose when no changes are detected. In cases where changes are present, it is assumed that compiling LLVM is acceptable (otherwise, why make changes there?).

This was probably missing in the #110087 issue before.

cc @RalfJung