### PR TITLE
Make `rustc_parse_format` compile on stable again

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -9,13 +9,10 @@
     html_playground_url = "https://play.rust-lang.org/",
     test(attr(deny(warnings)))
 )]
-#![cfg_attr(not(bootstrap), doc(rust_logo))]
-#![cfg_attr(not(bootstrap), allow(internal_features))]
-#![cfg_attr(not(bootstrap), feature(rustdoc_internals))]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
-// We want to be able to build this crate with a stable compiler, so no
-// `#![feature]` attributes should be added.
+// WARNING: We want to be able to build this crate with a stable compiler,
+//          so no `#![feature]` attributes should be added!
 
 use rustc_lexer::unescape;
 pub use Alignment::*;


### PR DESCRIPTION
Fixes [#115948 (review comment)](https://github.com/rust-lang/rust/pull/115948/files/822233559619e7e77d984f9020d05302b784cf50#r1385932710).
cc @Veykril @notriddle

r? compiler