### PR TITLE
Shrink `mir::Location` to 8 bytes

### DIFF
--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -166,10 +166,10 @@ impl<'tcx> OutOfScopePrecomputer<'_, 'tcx> {
         if let Some(kill_stmt) = self.regioncx.first_non_contained_inclusive(
             borrow_region,
             first_block,
-            first_lo,
+            first_lo as usize,
             first_hi,
         ) {
-            let kill_location = Location { block: first_block, statement_index: kill_stmt };
+            let kill_location = Location { block: first_block, statement_index: kill_stmt as u32 };
             // If region does not contain a point at the location, then add to list and skip
             // successor locations.
             debug!("borrow {:?} gets killed at {:?}", borrow_index, kill_location);
@@ -198,7 +198,7 @@ impl<'tcx> OutOfScopePrecomputer<'_, 'tcx> {
             if let Some(kill_stmt) =
                 self.regioncx.first_non_contained_inclusive(borrow_region, block, 0, num_stmts)
             {
-                let kill_location = Location { block, statement_index: kill_stmt };
+                let kill_location = Location { block, statement_index: kill_stmt as u32 };
                 // If region does not contain a point at the location, then add to list and skip
                 // successor locations.
                 debug!("borrow {:?} gets killed at {:?}", borrow_index, kill_location);
@@ -313,9 +313,13 @@ impl<'tcx> PoloniusOutOfScopePrecomputer<'_, 'tcx> {
         let first_lo = loan_issued_at.statement_index;
         let first_hi = first_bb_data.statements.len();
 
-        if let Some(kill_location) =
-            self.loan_kill_location(loan_idx, loan_issued_at, first_block, first_lo, first_hi)
-        {
+        if let Some(kill_location) = self.loan_kill_location(
+            loan_idx,
+            loan_issued_at,
+            first_block,
+            first_lo as usize,
+            first_hi,
+        ) {
             debug!("loan {:?} gets killed at {:?}", loan_idx, kill_location);
             self.loans_out_of_scope_at_location.entry(kill_location).or_default().push(loan_idx);
 
@@ -373,7 +377,7 @@ impl<'tcx> PoloniusOutOfScopePrecomputer<'_, 'tcx> {
         end: usize,
     ) -> Option<Location> {
         for statement_index in start..=end {
-            let location = Location { block, statement_index };
+            let location = Location { block, statement_index: statement_index as u32 };
 
             // Check whether the issuing region can reach local regions that are live at this point:
             // - a loan is always live at its issuing location because it can reach the issuing

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2666,8 +2666,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
 
             // check for moves
-            let stmt_kind =
-                self.body[location.block].statements.get(location.statement_index).map(|s| &s.kind);
+            let stmt_kind = self.body[location.block]
+                .statements
+                .get(location.statement_index as usize)
+                .map(|s| &s.kind);
             if let Some(StatementKind::StorageDead(..)) = stmt_kind {
                 // this analysis only tries to find moves explicitly
                 // written by the user, so we ignore the move-outs
@@ -3059,7 +3061,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let location = borrow.reserve_location;
         debug!("annotate_argument_and_return_for_borrow: location={:?}", location);
         if let Some(Statement { kind: StatementKind::Assign(box (reservation, _)), .. }) =
-            &self.body[location.block].statements.get(location.statement_index)
+            &self.body[location.block].statements.get(location.statement_index as usize)
         {
             debug!("annotate_argument_and_return_for_borrow: reservation={:?}", reservation);
             // Check that the initial assignment of the reserve location is into a temporary.
@@ -3071,7 +3073,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             // Next, look through the rest of the block, checking if we are assigning the
             // `target` (that is, the place that contains our borrow) to anything.
             let mut annotated_closure = None;
-            for stmt in &self.body[location.block].statements[location.statement_index + 1..] {
+            for stmt in
+                &self.body[location.block].statements[(location.statement_index as usize) + 1..]
+            {
                 debug!(
                     "annotate_argument_and_return_for_borrow: target={:?} stmt={:?}",
                     target, stmt

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -336,6 +336,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             NllRegionVariableOrigin::FreeRegion,
             |r| self.regioncx.provides_universal_region(r, borrow_region, outlived_region),
         );
+
         let BlameConstraint { category, from_closure, cause, .. } = blame_constraint;
 
         let outlived_fr_name = self.give_region_a_name(outlived_region);
@@ -479,7 +480,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 let kind = if let Some(&Statement {
                     kind: StatementKind::FakeRead(box (FakeReadCause::ForLet(_), place)),
                     ..
-                }) = block.statements.get(location.statement_index)
+                }) = block.statements.get(location.statement_index as usize)
                 {
                     if let Some(l) = place.as_local()
                         && let local_decl = &self.body.local_decls[l]
@@ -491,7 +492,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     }
                 } else if self.was_captured_by_trait_object(borrow) {
                     LaterUseKind::TraitCapture
-                } else if location.statement_index == block.statements.len() {
+                } else if location.statement_index as usize == block.statements.len() {
                     if let TerminatorKind::Call { func, call_source: CallSource::Normal, .. } =
                         &block.terminator().kind
                     {
@@ -531,7 +532,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         // Start at the reserve location, find the place that we want to see cast to a trait object.
         let location = borrow.reserve_location;
         let block = &self.body[location.block];
-        let stmt = block.statements.get(location.statement_index);
+        let stmt = block.statements.get(location.statement_index as usize);
         debug!("was_captured_by_trait_object: location={:?} stmt={:?}", location, stmt);
 
         // We make a `queue` vector that has the locations we want to visit. As of writing, this
@@ -554,9 +555,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             debug!("was_captured_by_trait: target={:?}", target);
             let block = &self.body[current_location.block];
             // We need to check the current location to find out if it is a terminator.
-            let is_terminator = current_location.statement_index == block.statements.len();
+            let is_terminator = current_location.statement_index as usize == block.statements.len();
             if !is_terminator {
-                let stmt = &block.statements[current_location.statement_index];
+                let stmt = &block.statements[current_location.statement_index as usize];
                 debug!("was_captured_by_trait_object: stmt={:?}", stmt);
 
                 // The only kind of statement that we care about is assignments...

--- a/compiler/rustc_borrowck/src/diagnostics/find_use.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_use.rs
@@ -50,7 +50,7 @@ impl<'cx, 'tcx> UseFinder<'cx, 'tcx> {
 
             let block_data = &self.body[p.block];
 
-            match self.def_use(p, block_data.visitable(p.statement_index)) {
+            match self.def_use(p, block_data.visitable(p.statement_index as usize)) {
                 Some(DefUseResult::Def) => {}
 
                 Some(DefUseResult::UseLive { local }) => {
@@ -62,7 +62,7 @@ impl<'cx, 'tcx> UseFinder<'cx, 'tcx> {
                 }
 
                 None => {
-                    if p.statement_index < block_data.statements.len() {
+                    if (p.statement_index as usize) < block_data.statements.len() {
                         queue.push_back(p.successor_within_block());
                     } else {
                         queue.extend(

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -117,7 +117,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         if let Some(StatementKind::Assign(box (place, Rvalue::Use(Operand::Move(move_from))))) =
             self.body.basic_blocks[location.block]
                 .statements
-                .get(location.statement_index)
+                .get(location.statement_index as usize)
                 .map(|stmt| &stmt.kind)
         {
             if let Some(local) = place.as_local() {

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -296,7 +296,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                             ),
                         )),
                     ..
-                }) = &self.body[location.block].statements.get(location.statement_index)
+                }) = &self.body[location.block].statements.get(location.statement_index as usize)
                 {
                     match *decl.local_info() {
                         LocalInfo::User(BindingForm::Var(mir::VarBindingForm {
@@ -1107,7 +1107,9 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                                     _,
                                     mir::Rvalue::Use(mir::Operand::Copy(place)),
                                 )),
-                        }) = self.body[location.block].statements.get(location.statement_index)
+                        }) = self.body[location.block]
+                            .statements
+                            .get(location.statement_index as usize)
                         {
                             self.body.local_decls[place.local].source_info.span
                         } else {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1429,7 +1429,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
                         let body = self.body;
                         let bbd = &body[loc.block];
-                        let stmt = &bbd.statements[loc.statement_index];
+                        let stmt = &bbd.statements[loc.statement_index as usize];
                         debug!("temporary assigned in: stmt={:?}", stmt);
 
                         if let StatementKind::Assign(box (_, Rvalue::Ref(_, _, source))) = stmt.kind

--- a/compiler/rustc_borrowck/src/location.rs
+++ b/compiler/rustc_borrowck/src/location.rs
@@ -56,13 +56,13 @@ impl LocationTable {
     pub fn start_index(&self, location: Location) -> LocationIndex {
         let Location { block, statement_index } = location;
         let start_index = self.statements_before_block[block];
-        LocationIndex::from_usize(start_index + statement_index * 2)
+        LocationIndex::from_usize(start_index + statement_index as usize * 2)
     }
 
     pub fn mid_index(&self, location: Location) -> LocationIndex {
         let Location { block, statement_index } = location;
         let start_index = self.statements_before_block[block];
-        LocationIndex::from_usize(start_index + statement_index * 2 + 1)
+        LocationIndex::from_usize(start_index + statement_index as usize * 2 + 1)
     }
 
     pub fn to_location(&self, index: LocationIndex) -> RichLocation {
@@ -92,9 +92,9 @@ impl LocationTable {
 
         let statement_index = (point_index - first_index) / 2;
         if index.is_start() {
-            RichLocation::Start(Location { block, statement_index })
+            RichLocation::Start(Location { block, statement_index: statement_index as u32 })
         } else {
-            RichLocation::Mid(Location { block, statement_index })
+            RichLocation::Mid(Location { block, statement_index: statement_index as u32 })
         }
     }
 }

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -104,7 +104,8 @@ fn populate_polonius_move_facts(
         match init.location {
             InitLocation::Statement(location) => {
                 let block_data = &body[location.block];
-                let is_terminator = location.statement_index == block_data.statements.len();
+                let is_terminator =
+                    location.statement_index as usize == block_data.statements.len();
 
                 if is_terminator && init.kind == InitKind::NonPanicPathOnly {
                     // We are at the terminator of an init that has a panic path,

--- a/compiler/rustc_borrowck/src/region_infer/values.rs
+++ b/compiler/rustc_borrowck/src/region_infer/values.rs
@@ -55,7 +55,7 @@ impl RegionValueElements {
     pub(crate) fn point_from_location(&self, location: Location) -> PointIndex {
         let Location { block, statement_index } = location;
         let start_index = self.statements_before_block[block];
-        PointIndex::new(start_index + statement_index)
+        PointIndex::new(start_index + statement_index as usize)
     }
 
     /// Converts a `Location` into a `PointIndex`. O(1).
@@ -75,7 +75,7 @@ impl RegionValueElements {
         let block = self.basic_blocks[index];
         let start_index = self.statements_before_block[block];
         let statement_index = index.index() - start_index;
-        Location { block, statement_index }
+        Location { block, statement_index: statement_index as u32 }
     }
 
     /// Sometimes we get point-indices back from bitsets that may be

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -611,7 +611,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             // If this is a `Call` terminator, use the `fn_span` instead.
             let block = &frame.body.basic_blocks[loc.block];
-            if loc.statement_index == block.statements.len() {
+            if loc.statement_index as usize == block.statements.len() {
                 debug!(
                     "find_closest_untracked_caller_location: got terminator {:?} ({:?})",
                     block.terminator(),

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -32,7 +32,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         };
         let basic_block = &self.body().basic_blocks[loc.block];
 
-        if let Some(stmt) = basic_block.statements.get(loc.statement_index) {
+        if let Some(stmt) = basic_block.statements.get(loc.statement_index as usize) {
             let old_frames = self.frame_idx();
             self.statement(stmt)?;
             // Make sure we are not updating `statement_index` of the wrong frame.

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -131,7 +131,7 @@ pub enum ScopeData {
 
 rustc_index::newtype_index! {
     /// Represents a subscope of `block` for a binding that is introduced
-    /// by `block.stmts[first_statement_index]`. Such subscopes represent
+    /// by `block.stmts[first_statement_index as usize]`. Such subscopes represent
     /// a suffix of the block. Note that each subscope does not include
     /// the initializer expression, if any, for the statement indexed by
     /// `first_statement_index`.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -510,10 +510,10 @@ impl<'tcx> Body<'tcx> {
         let block = &self[location.block];
         let stmts = &block.statements;
         let idx = location.statement_index;
-        if idx < stmts.len() {
-            &stmts[idx].source_info
+        if (idx as usize) < stmts.len() {
+            &stmts[idx as usize].source_info
         } else {
-            assert_eq!(idx, stmts.len());
+            assert_eq!(idx as usize, stmts.len());
             &block.terminator().source_info
         }
     }
@@ -533,7 +533,7 @@ impl<'tcx> Body<'tcx> {
     /// Gets the location of the terminator for the given block.
     #[inline]
     pub fn terminator_loc(&self, bb: BasicBlock) -> Location {
-        Location { block: bb, statement_index: self[bb].statements.len() }
+        Location { block: bb, statement_index: self[bb].statements.len() as u32 }
     }
 
     pub fn stmt_at(&self, location: Location) -> Either<&Statement<'tcx>, &Terminator<'tcx>> {
@@ -541,7 +541,7 @@ impl<'tcx> Body<'tcx> {
         let block_data = &self.basic_blocks[block];
         block_data
             .statements
-            .get(statement_index)
+            .get(statement_index as usize)
             .map(Either::Left)
             .unwrap_or_else(|| Either::Right(block_data.terminator()))
     }
@@ -1545,7 +1545,7 @@ pub struct Location {
     /// The block that the location is within.
     pub block: BasicBlock,
 
-    pub statement_index: usize,
+    pub statement_index: u32,
 }
 
 impl fmt::Debug for Location {

--- a/compiler/rustc_middle/src/mir/patch.rs
+++ b/compiler/rustc_middle/src/mir/patch.rs
@@ -126,7 +126,7 @@ impl<'tcx> MirPatch<'tcx> {
             Some(index) => self.new_blocks[index].statements.len(),
             None => body[bb].statements.len(),
         };
-        Location { block: bb, statement_index: offset }
+        Location { block: bb, statement_index: offset as u32 }
     }
 
     pub fn new_local_with_info(
@@ -214,13 +214,13 @@ impl<'tcx> MirPatch<'tcx> {
             let source_info = Self::source_info_for_index(&body[loc.block], loc);
             body[loc.block]
                 .statements
-                .insert(loc.statement_index, Statement { source_info, kind: stmt });
+                .insert(loc.statement_index as usize, Statement { source_info, kind: stmt });
             delta += 1;
         }
     }
 
     pub fn source_info_for_index(data: &BasicBlockData<'_>, loc: Location) -> SourceInfo {
-        match data.statements.get(loc.statement_index) {
+        match data.statements.get(loc.statement_index as usize) {
             Some(stmt) => stmt.source_info,
             None => data.terminator().source_info,
         }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -941,13 +941,13 @@ macro_rules! make_mir_visitor {
                 location: Location
             ) {
                 let basic_block = & $($mutability)? basic_blocks!(body, $($mutability, true)?)[location.block];
-                if basic_block.statements.len() == location.statement_index {
+                if basic_block.statements.len() == (location.statement_index as usize) {
                     if let Some(ref $($mutability)? terminator) = basic_block.terminator {
                         self.visit_terminator(terminator, location)
                     }
                 } else {
                     let statement = & $($mutability)?
-                        basic_block.statements[location.statement_index];
+                        basic_block.statements[location.statement_index as usize];
                     self.visit_statement(statement, location)
                 }
             }

--- a/compiler/rustc_mir_dataflow/src/framework/cursor.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/cursor.rs
@@ -264,7 +264,7 @@ where
             )
         } else {
             self.pos.curr_effect_index.map_or_else(
-                || Effect::Before.at_index(block_data.statements.len()),
+                || Effect::Before.at_index(block_data.statements.len() as u32),
                 EffectIndex::next_in_backward_order,
             )
         };

--- a/compiler/rustc_mir_dataflow/src/framework/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/mod.rs
@@ -532,14 +532,14 @@ pub enum Effect {
 }
 
 impl Effect {
-    pub const fn at_index(self, statement_index: usize) -> EffectIndex {
+    pub const fn at_index(self, statement_index: u32) -> EffectIndex {
         EffectIndex { effect: self, statement_index }
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct EffectIndex {
-    statement_index: usize,
+    statement_index: u32,
     effect: Effect,
 }
 

--- a/compiler/rustc_mir_dataflow/src/framework/tests.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/tests.rs
@@ -116,8 +116,8 @@ impl<D: Direction> MockAnalysis<'_, D> {
             Effect::Primary => loc.statement_index * 2 + 1,
         };
 
-        assert!(idx < Self::BASIC_BLOCK_OFFSET, "Too many statements in basic block");
-        idx
+        assert!((idx as usize) < Self::BASIC_BLOCK_OFFSET, "Too many statements in basic block");
+        idx as usize
     }
 
     /// Returns the expected state at the given `SeekTarget`.
@@ -143,7 +143,7 @@ impl<D: Direction> MockAnalysis<'_, D> {
         let mut pos = if D::IS_FORWARD {
             Effect::Before.at_index(0)
         } else {
-            Effect::Before.at_index(self.body[block].statements.len())
+            Effect::Before.at_index(self.body[block].statements.len() as u32)
         };
 
         loop {
@@ -251,7 +251,7 @@ impl SeekTarget {
         let statements_and_terminator = (0..=body[block].statements.len())
             .flat_map(|i| (0..2).map(move |j| (i, j)))
             .map(move |(i, kind)| {
-                let loc = Location { block, statement_index: i };
+                let loc = Location { block, statement_index: i as u32 };
                 match kind {
                     0 => SeekTarget::Before(loc),
                     1 => SeekTarget::After(loc),

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -306,11 +306,11 @@ pub(super) fn gather_moves<'tcx>(
 
     for (bb, block) in body.basic_blocks.iter_enumerated() {
         for (i, stmt) in block.statements.iter().enumerate() {
-            let source = Location { block: bb, statement_index: i };
+            let source = Location { block: bb, statement_index: i as u32 };
             builder.gather_statement(source, stmt);
         }
 
-        let terminator_loc = Location { block: bb, statement_index: block.statements.len() };
+        let terminator_loc = Location { block: bb, statement_index: block.statements.len() as u32 };
         builder.gather_terminator(terminator_loc, block.terminator());
     }
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -197,13 +197,13 @@ pub struct LocationMap<T> {
 impl<T> Index<Location> for LocationMap<T> {
     type Output = T;
     fn index(&self, index: Location) -> &Self::Output {
-        &self.map[index.block][index.statement_index]
+        &self.map[index.block][index.statement_index as usize]
     }
 }
 
 impl<T> IndexMut<Location> for LocationMap<T> {
     fn index_mut(&mut self, index: Location) -> &mut Self::Output {
-        &mut self.map[index.block][index.statement_index]
+        &mut self.map[index.block][index.statement_index as usize]
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/rustc_peek.rs
+++ b/compiler/rustc_mir_dataflow/src/rustc_peek.rs
@@ -127,7 +127,7 @@ pub fn sanity_check_via_rustc_peek<'tcx, A>(
                 PeekCallKind::ByVal,
                 mir::Rvalue::Use(mir::Operand::Move(place) | mir::Operand::Copy(place)),
             ) => {
-                let loc = Location { block: bb, statement_index };
+                let loc = Location { block: bb, statement_index: statement_index as u32 };
                 cursor.seek_before_primary_effect(loc);
                 let (state, analysis) = cursor.get_with_analysis();
                 analysis.peek_at(tcx, *place, state, call);

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -55,7 +55,7 @@ fn add_moves_for_packed_drops_patch<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) 
     let param_env = tcx.param_env(def_id);
 
     for (bb, data) in body.basic_blocks.iter_enumerated() {
-        let loc = Location { block: bb, statement_index: data.statements.len() };
+        let loc = Location { block: bb, statement_index: data.statements.len() as u32 };
         let terminator = data.terminator();
 
         match terminator.kind {

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -38,8 +38,8 @@ impl<'tcx> MirPass<'tcx> for CheckAlignment {
         for block in (0..basic_blocks.len()).rev() {
             let block = block.into();
             for statement_index in (0..basic_blocks[block].statements.len()).rev() {
-                let location = Location { block, statement_index };
-                let statement = &basic_blocks[block].statements[statement_index];
+                let location = Location { block, statement_index: statement_index as u32 };
+                let statement = &basic_blocks[block].statements[statement_index as usize];
                 let source_info = statement.source_info;
 
                 let mut finder =
@@ -140,7 +140,7 @@ fn split_block(
 
     // Drain every statement after this one and move the current terminator to a new basic block
     let new_block = BasicBlockData {
-        statements: block_data.statements.split_off(location.statement_index),
+        statements: block_data.statements.split_off(location.statement_index as usize),
         terminator: block_data.terminator.take(),
         is_cleanup: block_data.is_cleanup,
     };

--- a/compiler/rustc_mir_transform/src/const_debuginfo.rs
+++ b/compiler/rustc_mir_transform/src/const_debuginfo.rs
@@ -72,12 +72,12 @@ fn find_optimization_opportunities<'tcx>(body: &Body<'tcx>) -> Vec<(Local, Const
             let bb = &body[location.block];
 
             // The value is assigned as the result of a call, not a constant
-            if bb.statements.len() == location.statement_index {
+            if bb.statements.len() == location.statement_index as usize {
                 continue;
             }
 
             if let StatementKind::Assign(box (p, Rvalue::Use(Operand::Constant(box c)))) =
-                &bb.statements[location.statement_index].kind
+                &bb.statements[location.statement_index as usize].kind
             {
                 if let Some(local) = p.as_local() {
                     eligible_locals.push((local, *c));

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -689,7 +689,7 @@ fn locals_live_across_suspend_points<'tcx>(
 
     for (block, data) in body.basic_blocks.iter_enumerated() {
         if let TerminatorKind::Yield { .. } = data.terminator().kind {
-            let loc = Location { block, statement_index: data.statements.len() };
+            let loc = Location { block, statement_index: data.statements.len() as u32 };
 
             liveness.seek_to_block_end(block);
             let mut live_locals: BitSet<_> = BitSet::new_empty(body.local_decls.len());

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -46,7 +46,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
 
     for (bb, bb_data) in traversal::preorder(body) {
         if let TerminatorKind::Call { ref args, .. } = bb_data.terminator().kind {
-            let loc = Location { block: bb, statement_index: bb_data.statements.len() };
+            let loc = Location { block: bb, statement_index: bb_data.statements.len() as u32 };
 
             // Position ourselves between the evaluation of `args` and the write to `destination`.
             live.seek_to_block_end(bb);
@@ -74,7 +74,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         }
 
         for (statement_index, statement) in bb_data.statements.iter().enumerate().rev() {
-            let loc = Location { block: bb, statement_index };
+            let loc = Location { block: bb, statement_index: statement_index as u32 };
             if let StatementKind::Assign(assign) = &statement.kind {
                 if !assign.1.is_safe_to_remove() {
                     continue;
@@ -113,7 +113,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
 
     let bbs = body.basic_blocks.as_mut_preserves_cfg();
     for Location { block, statement_index } in patch {
-        bbs[block].statements[statement_index].make_nop();
+        bbs[block].statements[statement_index as usize].make_nop();
     }
     for (block, argument_index) in call_operands_to_move {
         let TerminatorKind::Call { ref mut args, .. } = bbs[block].terminator_mut().kind else {

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -480,13 +480,13 @@ impl<'a, 'body, 'alloc, 'tcx> FilterInformation<'a, 'body, 'alloc, 'tcx> {
 
     fn internal_filter_liveness(&mut self) {
         for (block, data) in traversal::preorder(self.body) {
-            self.at = Location { block, statement_index: data.statements.len() };
+            self.at = Location { block, statement_index: data.statements.len() as u32 };
             self.live.seek_after_primary_effect(self.at);
             self.write_info.for_terminator(&data.terminator().kind);
             self.apply_conflicts();
 
             for (i, statement) in data.statements.iter().enumerate().rev() {
-                self.at = Location { block, statement_index: i };
+                self.at = Location { block, statement_index: i as u32 };
                 self.live.seek_after_primary_effect(self.at);
                 self.write_info.for_statement(&statement.kind, self.body);
                 self.apply_conflicts();

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -131,7 +131,7 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
             };
             let parent_ty = parent_op.ty(body.local_decls(), tcx);
             let statements_before = bbs[parent].statements.len();
-            let parent_end = Location { block: parent, statement_index: statements_before };
+            let parent_end = Location { block: parent, statement_index: statements_before as u32 };
 
             let mut patch = MirPatch::new(body);
 

--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -490,7 +490,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                         }
                     }
                 }
-                let loc = Location { block: bb, statement_index: i };
+                let loc = Location { block: bb, statement_index: i as u32 };
                 rustc_mir_dataflow::drop_flag_effects_for_location(
                     self.tcx,
                     self.body,
@@ -513,7 +513,7 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
             {
                 assert!(!self.patch.is_patched(bb));
 
-                let loc = Location { block: bb, statement_index: data.statements.len() };
+                let loc = Location { block: bb, statement_index: data.statements.len() as u32 };
                 let path = self.move_data().rev_lookup.find(destination.as_ref());
                 on_lookup_result_bits(self.tcx, self.body, self.move_data(), path, |child| {
                     self.set_drop_flag(loc, child, DropFlagState::Present)

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -223,7 +223,10 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
                 return;
             }
 
-            cost.visit_statement(stmt, Location { block: bb, statement_index });
+            cost.visit_statement(
+                stmt,
+                Location { block: bb, statement_index: statement_index as u32 },
+            );
             if cost.cost() > MAX_COST {
                 return;
             }

--- a/compiler/rustc_mir_transform/src/ssa.rs
+++ b/compiler/rustc_mir_transform/src/ssa.rs
@@ -136,9 +136,9 @@ impl SsaLocals {
                 ),
                 Set1::One(DefLocation::Body(loc)) => {
                     let bb = &mut basic_blocks[loc.block];
-                    let value = if loc.statement_index < bb.statements.len() {
+                    let value = if (loc.statement_index as usize) < bb.statements.len() {
                         // `loc` must point to a direct assignment to `local`.
-                        let stmt = &mut bb.statements[loc.statement_index];
+                        let stmt = &mut bb.statements[loc.statement_index as usize];
                         let StatementKind::Assign(box (target, ref mut rvalue)) = stmt.kind else {
                             bug!()
                         };
@@ -358,8 +358,10 @@ impl StorageLiveLocals {
         for (block, bbdata) in body.basic_blocks.iter_enumerated() {
             for (statement_index, statement) in bbdata.statements.iter().enumerate() {
                 if let StatementKind::StorageLive(local) = statement.kind {
-                    storage_live[local]
-                        .insert(DefLocation::Body(Location { block, statement_index }));
+                    storage_live[local].insert(DefLocation::Body(Location {
+                        block,
+                        statement_index: statement_index as u32,
+                    }));
                 }
             }
         }

--- a/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -340,7 +340,7 @@ fn referent_used_exactly_once<'tcx>(
         && let Some(local) = expr_local(cx.tcx, reference)
         && let [location] = *local_assignments(mir, local).as_slice()
         && let block_data = &mir.basic_blocks[location.block]
-        && let Some(statement) = block_data.statements.get(location.statement_index)
+        && let Some(statement) = block_data.statements.get(location.statement_index as usize)
         && let StatementKind::Assign(box (_, Rvalue::Ref(_, _, place))) = statement.kind
         && !place.is_indirect_first_projection()
     {

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -121,7 +121,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
 
             let loc = mir::Location {
                 block: bb,
-                statement_index: bbdata.statements.len(),
+                statement_index: bbdata.statements.len() as u32,
             };
 
             // `Local` to be cloned, and a local of `clone` call's destination
@@ -163,7 +163,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantClone {
                     unwrap_or_continue!(find_stmt_assigns_to(cx, mir, pred_arg, true, ps[0]));
                 let loc = mir::Location {
                     block: bb,
-                    statement_index: mir.basic_blocks[bb].statements.len(),
+                    statement_index: mir.basic_blocks[bb].statements.len() as u32,
                 };
 
                 // This can be turned into `res = move local` if `arg` and `cloned` are not borrowed
@@ -362,7 +362,7 @@ fn visit_clone_usage(cloned: mir::Local, clone: mir::Local, mir: &mir::Body<'_>,
         mir,
         mir::Location {
             block: bb,
-            statement_index: mir.basic_blocks[bb].statements.len(),
+            statement_index: mir.basic_blocks[bb].statements.len() as u32,
         },
     )
     .map(|mut vec| (vec.remove(0), vec.remove(0)))

--- a/src/tools/clippy/clippy_utils/src/mir/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/mir/mod.rs
@@ -163,7 +163,7 @@ pub fn local_assignments(mir: &Body<'_>, local: Local) -> Vec<Location> {
     let mut locations = Vec::new();
     for (block, data) in mir.basic_blocks.iter_enumerated() {
         for statement_index in 0..=data.statements.len() {
-            let location = Location { block, statement_index };
+            let location = Location { block, statement_index: statement_index as u32 };
             if is_local_assignment(mir, local, location) {
                 locations.push(location);
             }
@@ -177,8 +177,8 @@ pub fn local_assignments(mir: &Body<'_>, local: Local) -> Vec<Location> {
 fn is_local_assignment(mir: &Body<'_>, local: Local, location: Location) -> bool {
     let Location { block, statement_index } = location;
     let basic_block = &mir.basic_blocks[block];
-    if statement_index < basic_block.statements.len() {
-        let statement = &basic_block.statements[statement_index];
+    if (statement_index as usize) < basic_block.statements.len() {
+        let statement = &basic_block.statements[statement_index as usize];
         if let StatementKind::Assign(box (place, _)) = statement.kind {
             place.as_local() == Some(local)
         } else {


### PR DESCRIPTION
This type is used quite frequently and this shrinks it nicely to a single word. I don't think we should ever have more than 4 billion MIR statements in a single BB, that would be quite concerning.

This commit is the 1AM "just check perf" version implementation of that, it should use IndexVec instead, I just thought it would be easier to hack together like this (it was not).

r? @ghost