### PR TITLE
Reenable effects in libcore

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -219,6 +219,7 @@
 #![feature(doc_cfg)]
 #![feature(doc_cfg_hide)]
 #![feature(doc_notable_trait)]
+#![feature(effects)]
 #![feature(exhaustive_patterns)]
 #![feature(extern_types)]
 #![feature(fundamental)]

--- a/tests/ui/consts/effect_param.rs
+++ b/tests/ui/consts/effect_param.rs
@@ -3,9 +3,13 @@
 fn main() {
     i8::checked_sub::<true>(42, 43);
     //~^ ERROR: method takes 0 generic arguments but 1 generic argument was supplied
+    i8::checked_sub::<false>(42, 43);
+    //~^ ERROR: method takes 0 generic arguments but 1 generic argument was supplied
 }
 
 const FOO: () = {
     i8::checked_sub::<false>(42, 43);
+    //~^ ERROR: method takes 0 generic arguments but 1 generic argument was supplied
+    i8::checked_sub::<true>(42, 43);
     //~^ ERROR: method takes 0 generic arguments but 1 generic argument was supplied
 };

--- a/tests/ui/consts/effect_param.stderr
+++ b/tests/ui/consts/effect_param.stderr
@@ -1,8 +1,16 @@
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/effect_param.rs:9:9
+  --> $DIR/effect_param.rs:11:9
    |
 LL |     i8::checked_sub::<false>(42, 43);
    |         ^^^^^^^^^^^--------- help: remove these generics
+   |         |
+   |         expected 0 generic arguments
+
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effect_param.rs:13:9
+   |
+LL |     i8::checked_sub::<true>(42, 43);
+   |         ^^^^^^^^^^^-------- help: remove these generics
    |         |
    |         expected 0 generic arguments
 
@@ -14,6 +22,14 @@ LL |     i8::checked_sub::<true>(42, 43);
    |         |
    |         expected 0 generic arguments
 
-error: aborting due to 2 previous errors
+error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/effect_param.rs:6:9
+   |
+LL |     i8::checked_sub::<false>(42, 43);
+   |         ^^^^^^^^^^^--------- help: remove these generics
+   |         |
+   |         expected 0 generic arguments
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
With #116670, #117531, and #117171, I think we would be comfortable with re-enabling the effects feature for more testing in libcore.

r? @oli-obk 
cc @fmease
cc #110395