### PR TITLE
Remap paths from other crates

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1726,6 +1726,12 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                 // on `try_to_translate_virtual_to_real`).
                 try_to_translate_virtual_to_real(&mut name);
 
+                // We may have had different remap-path-prefix flags at the time this file was loaded.
+                // Apply the remapping for the current session.
+                // NOTE: this does not "undo and redo" the mapping - any existing remapping from the old
+                // crate is retained unmodified. Only files which were never remapped are considered.
+                name = sess.source_map().path_mapping().map_filename_prefix(&name).0;
+
                 let local_version = sess.source_map().new_imported_source_file(
                     name,
                     src_hash,

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1730,7 +1730,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                 // Apply the remapping for the current session.
                 // NOTE: this does not "undo and redo" the mapping - any existing remapping from the old
                 // crate is retained unmodified. Only files which were never remapped are considered.
-                name = sess.source_map().path_mapping().map_filename_prefix(&name).0;
+                name = sess.source_map().path_mapping().map_filename_prefix(&name);
 
                 let local_version = sess.source_map().new_imported_source_file(
                     name,

--- a/tests/run-make/remap-path-prefix-inconsistent/Makefile
+++ b/tests/run-make/remap-path-prefix-inconsistent/Makefile
@@ -1,13 +1,22 @@
 
 include ../tools.mk
 
-all: inconsistent-mapping last-crate-only
+all: inconsistent-mapping last-crate-only remap-scope
 
 last-crate-only:
 	$(RUSTC) is_true.rs --crate-type lib
 	$(RUSTC) main.rs --remap-path-prefix=$(CURDIR)=/TEST_DIR 2>$(TMPDIR)/last-crate.txt --extern is_true=$(TMPDIR)/libis_true.rlib || true
 	$(RUSTC_TEST_OP) $(TMPDIR)/last-crate.txt expected-last-crate.txt
 	$(CGREP) "/TEST_DIR" < $(TMPDIR)/last-crate.txt
+
+# exactly like `last-crate-only`, but also uses `-Z remap-path-scope=diagnostics`
+remap-scope:
+	$(RUSTC) is_true.rs --crate-type lib
+	$(RUSTC) main.rs -Z remap-path-scope=diagnostics --remap-path-prefix=$(CURDIR)=/TEST_DIR 2>$(TMPDIR)/last-crate.txt --extern is_true=$(TMPDIR)/libis_true.rlib || true
+	$(RUSTC_TEST_OP) $(TMPDIR)/last-crate.txt expected-last-crate.txt
+	$(CGREP) "/TEST_DIR" < $(TMPDIR)/last-crate.txt
+	# Now again, but excluding diagnostics
+	$(RUSTC) main.rs -Z remap-path-scope=object --remap-path-prefix=$(CURDIR)=/TEST_DIR --extern is_true=$(TMPDIR)/libis_true.rlib 2>&1 | $(CGREP) tests/run-make/
 
 inconsistent-mapping:
 	$(RUSTC) is_true.rs --remap-path-prefix=$(CURDIR)=/TEST_DIR1 --crate-type lib

--- a/tests/run-make/remap-path-prefix-inconsistent/Makefile
+++ b/tests/run-make/remap-path-prefix-inconsistent/Makefile
@@ -1,0 +1,16 @@
+
+include ../tools.mk
+
+all: inconsistent-mapping last-crate-only
+
+last-crate-only:
+	$(RUSTC) is_true.rs --crate-type lib
+	$(RUSTC) main.rs --remap-path-prefix=$(CURDIR)=/TEST_DIR 2>$(TMPDIR)/last-crate.txt --extern is_true=$(TMPDIR)/libis_true.rlib || true
+	$(RUSTC_TEST_OP) $(TMPDIR)/last-crate.txt expected-last-crate.txt
+	$(CGREP) "/TEST_DIR" < $(TMPDIR)/last-crate.txt
+
+inconsistent-mapping:
+	$(RUSTC) is_true.rs --remap-path-prefix=$(CURDIR)=/TEST_DIR1 --crate-type lib
+	$(RUSTC) main.rs --remap-path-prefix=$(CURDIR)=/TEST_DIR2 2>$(TMPDIR)/inconsistent.txt --extern is_true=$(TMPDIR)/libis_true.rlib || true
+	$(RUSTC_TEST_OP) $(TMPDIR)/inconsistent.txt expected-inconsistent.txt
+	$(CGREP) "/TEST_DIR1" < $(TMPDIR)/inconsistent.txt

--- a/tests/run-make/remap-path-prefix-inconsistent/expected-inconsistent.txt
+++ b/tests/run-make/remap-path-prefix-inconsistent/expected-inconsistent.txt
@@ -1,0 +1,16 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+ --> main.rs:2:5
+  |
+2 |     is_true::query();
+  |     ^^^^^^^^^^^^^^-- an argument of type `bool` is missing
+  |
+note: function defined here
+ --> /TEST_DIR1/is_true.rs:1:8
+help: provide the argument
+  |
+2 |     is_true::query(/* bool */);
+  |                   ~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/run-make/remap-path-prefix-inconsistent/expected-last-crate.txt
+++ b/tests/run-make/remap-path-prefix-inconsistent/expected-last-crate.txt
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+ --> main.rs:2:5
+  |
+2 |     is_true::query();
+  |     ^^^^^^^^^^^^^^-- an argument of type `bool` is missing
+  |
+note: function defined here
+ --> /TEST_DIR/is_true.rs:1:8
+  |
+1 | pub fn query(_: bool) {}
+  |        ^^^^^
+help: provide the argument
+  |
+2 |     is_true::query(/* bool */);
+  |                   ~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/run-make/remap-path-prefix-inconsistent/is_true.rs
+++ b/tests/run-make/remap-path-prefix-inconsistent/is_true.rs
@@ -1,0 +1,1 @@
+pub fn query(_: bool) {}

--- a/tests/run-make/remap-path-prefix-inconsistent/main.rs
+++ b/tests/run-make/remap-path-prefix-inconsistent/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    is_true::query();
+}


### PR DESCRIPTION

Previously, `remap-path-prefix` only applied to files loaded *in the current session*. File names
loaded in a previous invocation were used unchanged. This is unfortunate for UI testing when some of
the crates involved are in the standard library (we don't want to recompile the standard library for
arbitrary tests).

Change it to apply to existing files as well. I believe this will eventually allow removing the
special-casing for `-Z simulate-remapped-rust-src-base`. I'm willing to make that change here if desired.

Fixes https://github.com/rust-lang/rust/issues/66251. This might allow me to unblock https://github.com/rust-lang/rust/pull/117609 without first waiting for https://github.com/rust-lang/rust/pull/113611 to land (need to test).