### PR TITLE
Don't expect a rcvr in `print_disambiguation_help`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3264,8 +3264,12 @@ fn print_disambiguation_help<'tcx>(
         {
             let def_kind_descr = tcx.def_kind_descr(item.kind.as_def_kind(), item.def_id);
             let item_name = item.ident(tcx);
-            let rcvr_ref = tcx.fn_sig(item.def_id).skip_binder().skip_binder().inputs()[0]
-                .ref_mutability()
+            let rcvr_ref = tcx.fn_sig(item.def_id)
+                .skip_binder()
+                .skip_binder()
+                .inputs()
+                .get(0)
+                .and_then(|ty| ty.ref_mutability())
                 .map_or("", |mutbl| mutbl.ref_prefix_str());
             let args = format!(
                 "({}{})",

--- a/tests/ui/methods/method-ambiguity-no-rcvr.rs
+++ b/tests/ui/methods/method-ambiguity-no-rcvr.rs
@@ -1,0 +1,14 @@
+struct Qux;
+
+trait Foo {
+    fn foo();
+}
+
+trait FooBar {
+    fn foo() {}
+}
+
+fn main() {
+    Qux.foo();
+    //~^ ERROR no method named `foo` found for struct `Qux` in the current scope
+}

--- a/tests/ui/methods/method-ambiguity-no-rcvr.stderr
+++ b/tests/ui/methods/method-ambiguity-no-rcvr.stderr
@@ -1,0 +1,32 @@
+error[E0599]: no method named `foo` found for struct `Qux` in the current scope
+  --> $DIR/method-ambiguity-no-rcvr.rs:12:9
+   |
+LL | struct Qux;
+   | ---------- method `foo` not found for this struct
+...
+LL |     Qux.foo();
+   |         ^^^ this is an associated function, not a method
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: candidate #1 is defined in the trait `Foo`
+  --> $DIR/method-ambiguity-no-rcvr.rs:4:5
+   |
+LL |     fn foo();
+   |     ^^^^^^^^^
+note: candidate #2 is defined in the trait `FooBar`
+  --> $DIR/method-ambiguity-no-rcvr.rs:8:5
+   |
+LL |     fn foo() {}
+   |     ^^^^^^^^
+help: disambiguate the associated function for candidate #1
+   |
+LL |     <Qux as Foo>::foo(Qux);
+   |     ~~~~~~~~~~~~~~~~~~~~~~
+help: disambiguate the associated function for candidate #2
+   |
+LL |     <Qux as FooBar>::foo(Qux);
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
We don't necessarily have a receiver when we are both accidentally using the `.` operator *AND* we have more than one ambiguous method candidate.

Fixes #117728