### PR TITLE
bootstrap: simplify setting unstable-options for tools

### DIFF
--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -463,10 +463,6 @@ macro_rules! tool_check_step {
                     cargo.arg("--all-targets");
                 }
 
-                // Enable internal lints for clippy and rustdoc
-                // NOTE: this doesn't enable lints for any other tools unless they explicitly add `#![warn(rustc::internal)]`
-                // See https://github.com/rust-lang/rust/pull/80573#issuecomment-754010776
-                cargo.rustflag("-Zunstable-options");
                 let _guard = builder.msg_check(&concat!(stringify!($name), " artifacts").to_lowercase(), target);
                 run_cargo(
                     builder,

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -203,6 +203,16 @@ pub fn prepare_tool_cargo(
     if !features.is_empty() {
         cargo.arg("--features").arg(&features.join(", "));
     }
+
+    // Enable internal lints for clippy and rustdoc
+    // NOTE: this doesn't enable lints for any other tools unless they explicitly add `#![warn(rustc::internal)]`
+    // See https://github.com/rust-lang/rust/pull/80573#issuecomment-754010776
+    //
+    // NOTE: We unconditionally set this here to avoid recompiling tools between `x check $tool`
+    // and `x test $tool` executions.
+    // See https://github.com/rust-lang/rust/issues/116538
+    cargo.rustflag("-Zunstable-options");
+
     cargo
 }
 


### PR DESCRIPTION
Previously, we unconditionally(instead of `if path == "src/tools/clippy" || ..`) set this (to prevent recompiling tools between `x check $tool` and '` check $another_tool` executions) specifically for tools in the `x check` step. This PR relocates that logic to `fn prepare_tool_cargo`, making it step-agnostic.

Fixes #116538
Fixes #117983