### PR TITLE
[stable] Backport fix for malformed coverage

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -427,6 +427,12 @@ impl<'a, 'tcx> CoverageSpans<'a, 'tcx> {
                 let merged_prefix_len = self.curr_original_span.lo() - self.curr().span.lo();
                 let after_macro_bang =
                     merged_prefix_len + BytePos(visible_macro.as_str().len() as u32 + 1);
+                if self.curr().span.lo() + after_macro_bang > self.curr().span.hi() {
+                    // Something is wrong with the macro name span;
+                    // return now to avoid emitting malformed mappings.
+                    // FIXME(#117788): Track down why this happens.
+                    return;
+                }
                 let mut macro_name_cov = self.curr().clone();
                 self.curr_mut().span =
                     self.curr().span.with_lo(self.curr().span.lo() + after_macro_bang);

--- a/tests/run-coverage/auxiliary/macro_name_span_helper.rs
+++ b/tests/run-coverage/auxiliary/macro_name_span_helper.rs
@@ -1,0 +1,10 @@
+// edition: 2021
+
+#[macro_export]
+macro_rules! macro_that_defines_a_function {
+    (fn $name:ident () $body:tt) => {
+        fn $name () -> () $body
+    }
+}
+
+// Non-executable comment.

--- a/tests/run-coverage/macro_name_span.coverage
+++ b/tests/run-coverage/macro_name_span.coverage
@@ -1,0 +1,39 @@
+$DIR/auxiliary/macro_name_span_helper.rs:
+   LL|       |// edition: 2021
+   LL|       |
+   LL|       |#[macro_export]
+   LL|       |macro_rules! macro_that_defines_a_function {
+   LL|       |    (fn $name:ident () $body:tt) => {
+   LL|      1|        fn $name () -> () $body
+   LL|       |    }
+   LL|       |}
+   LL|       |
+   LL|       |// Non-executable comment.
+
+$DIR/macro_name_span.rs:
+   LL|       |// edition: 2021
+   LL|       |
+   LL|       |// Regression test for <https://github.com/rust-lang/rust/issues/117788>.
+   LL|       |// Under some circumstances, the heuristics that detect macro name spans can
+   LL|       |// get confused and produce incorrect spans beyond the bounds of the span
+   LL|       |// being processed.
+   LL|       |
+   LL|       |// aux-build: macro_name_span_helper.rs
+   LL|       |extern crate macro_name_span_helper;
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    affected_function();
+   LL|      1|}
+   LL|       |
+   LL|       |macro_rules! macro_with_an_unreasonably_and_egregiously_long_name {
+   LL|       |    () => {
+   LL|       |        println!("hello");
+   LL|       |    };
+   LL|       |}
+   LL|       |
+   LL|       |macro_name_span_helper::macro_that_defines_a_function! {
+   LL|       |    fn affected_function() {
+   LL|       |        macro_with_an_unreasonably_and_egregiously_long_name!();
+   LL|       |    }
+   LL|       |}
+

--- a/tests/run-coverage/macro_name_span.rs
+++ b/tests/run-coverage/macro_name_span.rs
@@ -1,0 +1,25 @@
+// edition: 2021
+
+// Regression test for <https://github.com/rust-lang/rust/issues/117788>.
+// Under some circumstances, the heuristics that detect macro name spans can
+// get confused and produce incorrect spans beyond the bounds of the span
+// being processed.
+
+// aux-build: macro_name_span_helper.rs
+extern crate macro_name_span_helper;
+
+fn main() {
+    affected_function();
+}
+
+macro_rules! macro_with_an_unreasonably_and_egregiously_long_name {
+    () => {
+        println!("hello");
+    };
+}
+
+macro_name_span_helper::macro_that_defines_a_function! {
+    fn affected_function() {
+        macro_with_an_unreasonably_and_egregiously_long_name!();
+    }
+}


### PR DESCRIPTION
Backport of #117827.

Discussion at <https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/backport.20.23117827.20to.201.2E74>.