### PR TITLE
Fix comment in compiler/rustc_ast/src/token.rs.

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -238,9 +238,9 @@ pub enum TokenKind {
     EqEq,
     /// `!=`
     Ne,
-    /// `>`
-    Ge,
     /// `>=`
+    Ge,
+    /// `>`
     Gt,
     /// `&&`
     AndAnd,


### PR DESCRIPTION
Gt -> Greater than -> `>`
Ge -> Greater equal -> `>=`