### PR TITLE
rustdoc: use `.rustdoc` class instead of `body`

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -54,7 +54,7 @@ function setMobileTopbar() {
     if (mobileTopbar) {
         const mobileTitle = document.createElement("h2");
         mobileTitle.className = "location";
-        if (hasClass(document.body, "crate")) {
+        if (hasClass(document.querySelector(".rustdoc"), "crate")) {
             mobileTitle.innerText = `Crate ${window.currentCrate}`;
         } else if (locationTitle) {
             mobileTitle.innerHTML = locationTitle.innerHTML;
@@ -485,7 +485,7 @@ function preLoadCss(cssUrl) {
                 return;
             }
 
-            const modpath = hasClass(document.body, "mod") ? "../" : "";
+            const modpath = hasClass(document.querySelector(".rustdoc"), "mod") ? "../" : "";
 
             const h3 = document.createElement("h3");
             h3.innerHTML = `<a href="${modpath}index.html#${id}">${longty}</a>`;


### PR DESCRIPTION
This didn't show up in our local tests, because the problem is actually caused by docs.rs rewritten HTML (which relocates the classes that this code looked for from the body tag to a child div).

Fixes #117290

r? @GuillaumeGomez 

Both problems are regressions introduced by #115948