### PR TITLE
Set `CFG_OMIT_GIT_HASH=1` during builds when `omit-git-hash` is enabled

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -975,6 +975,13 @@ pub fn rustc_cargo_env(
         .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
         .env("CFG_VERSION", builder.rust_version());
 
+    // Some tools like Cargo detect their own git information in build scripts. When omit-git-hash
+    // is enabled in config.toml, we pass this environment variable to tell build scripts to avoid
+    // detecting git information on their own.
+    if builder.config.omit_git_hash {
+        cargo.env("CFG_OMIT_GIT_HASH", "1");
+    }
+
     if let Some(backend) = builder.config.default_codegen_backend() {
         cargo.env("CFG_DEFAULT_CODEGEN_BACKEND", backend);
     }


### PR DESCRIPTION
This environment variable will allow tools like Cargo to disable their own detection when `omit-git-hash` is set to `true`.

I created this PR because of https://github.com/rust-lang/cargo/pull/12968. There is not a dependency between the two PRs, they can land in any order. They just won't do anything until both of them are merged into the repo.