### PR TITLE
Fix depth check in ProofTreeVisitor.

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -58,7 +58,7 @@ impl<'a, 'tcx> InspectCandidate<'a, 'tcx> {
         visitor: &mut V,
     ) -> ControlFlow<V::BreakTy> {
         // HACK: An arbitrary cutoff to avoid dealing with overflow and cycles.
-        if self.goal.depth >= 10 {
+        if self.goal.depth <= 10 {
             let infcx = self.goal.infcx;
             infcx.probe(|_| {
                 let mut instantiated_goals = vec![];

--- a/tests/ui/impl-trait/auto-trait-coherence.next.stderr
+++ b/tests/ui/impl-trait/auto-trait-coherence.next.stderr
@@ -6,6 +6,8 @@ LL | impl<T: Send> AnotherTrait for T {}
 ...
 LL | impl AnotherTrait for D<OpaqueType> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `D<OpaqueType>`
+   |
+   = note: upstream crates may add a new impl of trait `std::marker::Send` for type `OpaqueType` in future versions
 
 error: aborting due to previous error
 


### PR DESCRIPTION
The hack to cutoff overflows and cycles in the new trait solver was incorrect. We want to inspect everything with depth [0..10].

This fix exposed a previously unseen bug, which caused the compiler to ICE when invoking `trait_ref` on a non-assoc type projection. I simply added the guard in the `AmbiguityCausesVisitor`, and updated the expected output for the `auto-trait-coherence` test which now includes the extra note:
```text
   |
   = note: upstream crates may add a new impl of trait `std::marker::Send` for type `OpaqueType` in future versions
```

r? @lcnr 