### PR TITLE
tests: update check for inferred nneg on zext

### DIFF
--- a/tests/codegen/unchecked_shifts.rs
+++ b/tests/codegen/unchecked_shifts.rs
@@ -31,7 +31,7 @@ pub unsafe fn unchecked_shl_unsigned_smaller(a: u16, b: u32) -> u16 {
 #[no_mangle]
 pub unsafe fn unchecked_shl_unsigned_bigger(a: u64, b: u32) -> u64 {
     // CHECK-NOT: assume
-    // CHECK: %[[EXT:.+]] = zext i32 %b to i64
+    // CHECK: %[[EXT:.+]] = zext{{( nneg)?}} i32 %b to i64
     // CHECK: shl i64 %a, %[[EXT]]
     a.unchecked_shl(b)
 }
@@ -63,7 +63,7 @@ pub unsafe fn unchecked_shr_signed_smaller(a: i16, b: u32) -> i16 {
 #[no_mangle]
 pub unsafe fn unchecked_shr_signed_bigger(a: i64, b: u32) -> i64 {
     // CHECK-NOT: assume
-    // CHECK: %[[EXT:.+]] = zext i32 %b to i64
+    // CHECK: %[[EXT:.+]] = zext{{( nneg)?}} i32 %b to i64
     // CHECK: ashr i64 %a, %[[EXT]]
     a.unchecked_shr(b)
 }


### PR DESCRIPTION
This was broken by upstream
llvm/llvm-project@dc6d0773960c664eee12a1ed871fad5c81a20a12. It's easy enough to use a regex match to support both, so we do that.

r? @nikic
@rustbot label: +llvm-main