### PR TITLE
skip rpit constraint checker if borrowck return type error

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
@@ -278,6 +278,10 @@ pub(super) fn find_opaque_ty_constraints_for_rpit<'tcx>(
 
     let mir_opaque_ty = tcx.mir_borrowck(owner_def_id).concrete_opaque_types.get(&def_id).copied();
     if let Some(mir_opaque_ty) = mir_opaque_ty {
+        if mir_opaque_ty.references_error() {
+            return mir_opaque_ty.ty;
+        }
+
         let scope = tcx.local_def_id_to_hir_id(owner_def_id);
         debug!(?scope);
         let mut locator = RpitConstraintChecker { def_id, tcx, found: mir_opaque_ty };

--- a/tests/ui/traits/issue-117794.rs
+++ b/tests/ui/traits/issue-117794.rs
@@ -1,0 +1,10 @@
+trait Foo {}
+
+trait T {
+    fn a(&self) -> impl Foo {
+        self.b(|| 0)
+        //~^ ERROR no method named `b` found for reference `&Self` in the current scope
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/issue-117794.stderr
+++ b/tests/ui/traits/issue-117794.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no method named `b` found for reference `&Self` in the current scope
+  --> $DIR/issue-117794.rs:5:14
+   |
+LL |         self.b(|| 0)
+   |              ^ help: there is a method with a similar name: `a`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes #117794
Fixes #117886
Fixes #119025


Prior to change #117418, the value of ﻿`concrete_opaque_types` for ﻿`mir_borrock(T::a::opaque)` was ﻿`None`. However, due to modifications in `﻿body.local_decls`, the return value had been changed.

The changed of `﻿body.local_decls` has let to the addition of `﻿ty:Error` to ﻿`infcx.opaque_type_storage.opaque_types` during ﻿`TypeChecker::equate_inputs_and_outputs`. This is due to it utilizing the output of a function signature that was appended during ﻿`construct_error`(which previously only appended a `ty::Error`) and then execute `TypeChecker::Related_types`.

Therefore, in this PR, I've implemented a condition to bypass the ﻿rpit check when an error is encountered.

r? @compiler-errors 