### PR TITLE
Recover `dyn` and `impl` after `for<...>`

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -739,6 +739,9 @@ parse_trailing_vert_not_allowed = a trailing `|` is not allowed in an or-pattern
 parse_trait_alias_cannot_be_auto = trait aliases cannot be `auto`
 parse_trait_alias_cannot_be_unsafe = trait aliases cannot be `unsafe`
 
+parse_transpose_dyn_or_impl = `for<...>` expected after `{$kw}`, not before
+    .suggestion = move `{$kw}` before the `for<...>`
+
 parse_type_ascription_removed =
     if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2828,3 +2828,23 @@ pub(crate) struct GenericArgsInPatRequireTurbofishSyntax {
     )]
     pub suggest_turbofish: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(parse_transpose_dyn_or_impl)]
+pub(crate) struct TransposeDynOrImpl<'a> {
+    #[primary_span]
+    pub span: Span,
+    pub kw: &'a str,
+    #[subdiagnostic]
+    pub sugg: TransposeDynOrImplSugg<'a>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(parse_suggestion, applicability = "machine-applicable")]
+pub(crate) struct TransposeDynOrImplSugg<'a> {
+    #[suggestion_part(code = "")]
+    pub removal_span: Span,
+    #[suggestion_part(code = "{kw} ")]
+    pub insertion_span: Span,
+    pub kw: &'a str,
+}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
@@ -1,0 +1,9 @@
+trait Trait {}
+
+fn test(_: &for<'a> dyn Trait) {}
+//~^ ERROR `for<...>` expected after `dyn`, not before
+
+fn test2(_: for<'a> impl Trait) {}
+//~^ ERROR `for<...>` expected after `impl`, not before
+
+fn main() {}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
@@ -1,0 +1,26 @@
+error: `for<...>` expected after `dyn`, not before
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:3:21
+   |
+LL | fn test(_: &for<'a> dyn Trait) {}
+   |                     ^^^
+   |
+help: move `dyn` before the `for<...>`
+   |
+LL - fn test(_: &for<'a> dyn Trait) {}
+LL + fn test(_: &dyn for<'a> Trait) {}
+   |
+
+error: `for<...>` expected after `impl`, not before
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:6:21
+   |
+LL | fn test2(_: for<'a> impl Trait) {}
+   |                     ^^^^
+   |
+help: move `impl` before the `for<...>`
+   |
+LL - fn test2(_: for<'a> impl Trait) {}
+LL + fn test2(_: impl for<'a> Trait) {}
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Recover `dyn` and `impl` after `for<...>` in types. Reuses the logic for parsing bare trait objects, so it doesn't fix cases like `for<'a> dyn Trait + dyn Trait` or anything, but that seems somewhat of a different issue.

Parsing recovery logic is a bit involved, but I couldn't find a way to simplify it.

Fixes #117882