### PR TITLE
Detect more `=>` typos

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -388,7 +388,8 @@ impl TokenKind {
         match *self {
             Comma => Some(vec![Dot, Lt, Semi]),
             Semi => Some(vec![Colon, Comma]),
-            FatArrow => Some(vec![Eq, RArrow]),
+            Colon => Some(vec![Semi]),
+            FatArrow => Some(vec![Eq, RArrow, Ge, Gt]),
             _ => None,
         }
     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2904,15 +2904,16 @@ impl<'a> Parser<'a> {
                         "=>",
                         Applicability::MachineApplicable,
                     );
-                    err.emit();
-                    this.bump();
-                } else if matches!(
-                    (&this.prev_token.kind, &this.token.kind),
-                    (token::DotDotEq, token::Gt)
-                ) {
-                    // `error_inclusive_range_match_arrow` handles cases like `0..=> {}`,
-                    // so we suppress the error here
-                    err.delay_as_bug();
+                    if matches!(
+                        (&this.prev_token.kind, &this.token.kind),
+                        (token::DotDotEq, token::Gt)
+                    ) {
+                        // `error_inclusive_range_match_arrow` handles cases like `0..=> {}`,
+                        // so we suppress the error here
+                        err.delay_as_bug();
+                    } else {
+                        err.emit();
+                    }
                     this.bump();
                 } else {
                     return Err(err);

--- a/tests/ui/parser/issues/recover-ge-as-fat-arrow.fixed
+++ b/tests/ui/parser/issues/recover-ge-as-fat-arrow.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+fn main() {
+    match 1 {
+        1 => {} //~ ERROR
+        _ => { let _: u16 = 2u16; } //~ ERROR
+    }
+}

--- a/tests/ui/parser/issues/recover-ge-as-fat-arrow.rs
+++ b/tests/ui/parser/issues/recover-ge-as-fat-arrow.rs
@@ -1,0 +1,7 @@
+// run-rustfix
+fn main() {
+    match 1 {
+        1 >= {} //~ ERROR
+        _ => { let _: u16 = 2u8; } //~ ERROR
+    }
+}

--- a/tests/ui/parser/issues/recover-ge-as-fat-arrow.stderr
+++ b/tests/ui/parser/issues/recover-ge-as-fat-arrow.stderr
@@ -1,0 +1,25 @@
+error: expected one of `...`, `..=`, `..`, `=>`, `if`, or `|`, found `>=`
+  --> $DIR/recover-ge-as-fat-arrow.rs:4:11
+   |
+LL |         1 >= {}
+   |           ^^
+   |           |
+   |           expected one of `...`, `..=`, `..`, `=>`, `if`, or `|`
+   |           help: use a fat arrow to start a match arm: `=>`
+
+error[E0308]: mismatched types
+  --> $DIR/recover-ge-as-fat-arrow.rs:5:29
+   |
+LL |         _ => { let _: u16 = 2u8; }
+   |                       ---   ^^^ expected `u16`, found `u8`
+   |                       |
+   |                       expected due to this
+   |
+help: change the type of the numeric literal from `u8` to `u16`
+   |
+LL |         _ => { let _: u16 = 2u16; }
+   |                              ~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Handle and recover `match expr { pat >= { arm } }`.