### PR TITLE
Adjust frame IP in backtraces relative to image base for SGX target

### DIFF
--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -327,6 +327,11 @@ impl Backtrace {
         let _lock = lock();
         let mut frames = Vec::new();
         let mut actual_start = None;
+        #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
+        {
+            let image_base = crate::os::fortanix_sgx::mem::image_base();
+            backtrace_rs::set_image_base(crate::ptr::from_exposed_addr_mut(image_base as _));
+        }
         unsafe {
             backtrace_rs::trace_unsynchronized(|frame| {
                 frames.push(BacktraceFrame {

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -95,7 +95,7 @@ use crate::fmt;
 use crate::panic::UnwindSafe;
 use crate::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use crate::sync::LazyLock;
-use crate::sys_common::backtrace::{lock, output_filename};
+use crate::sys_common::backtrace::{lock, output_filename, set_image_base};
 use crate::vec::Vec;
 
 /// A captured OS thread stack backtrace.
@@ -327,11 +327,7 @@ impl Backtrace {
         let _lock = lock();
         let mut frames = Vec::new();
         let mut actual_start = None;
-        #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
-        {
-            let image_base = crate::os::fortanix_sgx::mem::image_base();
-            backtrace_rs::set_image_base(crate::ptr::from_exposed_addr_mut(image_base as _));
-        }
+        set_image_base();
         unsafe {
             backtrace_rs::trace_unsynchronized(|frame| {
                 frames.push(BacktraceFrame {

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -64,6 +64,11 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
     let mut first_omit = true;
     // Start immediately if we're not using a short backtrace.
     let mut start = print_fmt != PrintFmt::Short;
+    #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
+    {
+        let image_base = crate::os::fortanix_sgx::mem::image_base();
+        backtrace_rs::set_image_base(crate::ptr::from_exposed_addr_mut(image_base as _));
+    }
     backtrace_rs::trace_unsynchronized(|frame| {
         if print_fmt == PrintFmt::Short && idx > MAX_NB_FRAMES {
             return false;

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -218,7 +218,7 @@ pub fn output_filename(
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 pub fn set_image_base() {
     let image_base = crate::os::fortanix_sgx::mem::image_base();
-    backtrace_rs::set_image_base(crate::ptr::from_exposed_addr_mut(image_base as _));
+    backtrace_rs::set_image_base(crate::ptr::invalid_mut(image_base as _));
 }
 
 #[cfg(not(all(target_vendor = "fortanix", target_env = "sgx")))]


### PR DESCRIPTION
This is followup to https://github.com/rust-lang/backtrace-rs/pull/566.

The backtraces printed by `panic!` or generated by `std::backtrace::Backtrace` in SGX target are not usable. The frame addresses need to be relative to image base address so they can be used for symbol resolution. Here's an example panic backtrace generated before this change:

```
$ cargo r --target x86_64-fortanix-unknown-sgx
...
stack backtrace:
   0:     0x7f8fe401d3a5 - <unknown>
   1:     0x7f8fe4034780 - <unknown>
   2:     0x7f8fe401c5a3 - <unknown>
   3:     0x7f8fe401d1f5 - <unknown>
   4:     0x7f8fe401e6f6 - <unknown>
```
Here's the same panic after this change:
```
$ cargo +stage1 r --target x86_64-fortanix-unknown-sgx
stack backtrace:
   0:            0x198bf - <unknown>
   1:            0x3d181 - <unknown>
   2:            0x26164 - <unknown>
   3:            0x19705 - <unknown>
   4:            0x1ef36 - <unknown>
```
cc @jethrogb and @workingjubilee 