### PR TITLE
Improve display of crate name when hovered

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -638,7 +638,7 @@ ul.block, .block li {
 
 .sidebar-crate h2 a {
 	display: block;
-	margin: 0 calc(-24px + 0.25rem) 0 -0.5rem;
+	margin: 0 calc(-24px + 0.25rem) 0 -0.2rem;
 	/* Align the sidebar crate link with the search bar, which have different
 		font sizes.
 
@@ -653,7 +653,7 @@ ul.block, .block li {
 		x = ( 16px - 0.57rem ) / 2
 	*/
 	padding: calc( ( 16px - 0.57rem ) / 2 ) 0.25rem;
-	padding-left: 0.5rem;
+	padding-left: 0.2rem;
 }
 
 .sidebar-crate h2 .version {
@@ -661,8 +661,6 @@ ul.block, .block li {
 	font-weight: normal;
 	font-size: 1rem;
 	overflow-wrap: break-word;
-	/* opposite of the link padding, cut in half again */
-	margin-top: calc( ( -16px + 0.57rem ) / 2 );
 }
 
 .sidebar-crate + .version {


### PR DESCRIPTION
Currently when we hover the crate name, the background is stuck to the version and to the logo (when there is one):

![Screenshot from 2023-11-14 11-42-39](https://github.com/rust-lang/rust/assets/3050060/717190cd-483d-45a1-a462-e9ba342d4376)
![Screenshot from 2023-11-14 11-43-19](https://github.com/rust-lang/rust/assets/3050060/23f8bc9b-1304-4f91-ae1e-96bc508e9da6)

I find it very unpleasant so I reduced the padding size and increased the margin (left and top) to keep the same positioning but not making it stuck anymore:

![Screenshot from 2024-01-29 20-40-11](https://github.com/rust-lang/rust/assets/3050060/82cf266c-7f99-4a46-a62b-ebe2445f52be)
![Screenshot from 2024-01-29 20-48-01](https://github.com/rust-lang/rust/assets/3050060/e7097c10-6e09-4bdc-a37f-070b6dac671d)

[online docs](https://rustdoc.crud.net/imperio/improve-crate-name-hover/std/index.html)

r? @notriddle 