### PR TITLE
Suggest removal of borrow in index when appropriate

### DIFF
--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -98,7 +98,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// supports builtin indexing or overloaded indexing.
     /// This loop implements one step in that search; the autoderef loop
     /// is implemented by `lookup_indexing`.
-    fn try_index_step(
+    pub(super) fn try_index_step(
         &self,
         expr: &hir::Expr<'_>,
         base_expr: &hir::Expr<'_>,

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -331,6 +331,8 @@ pub enum ObligationCauseCode<'tcx> {
 
     DerivedObligation(DerivedObligationCause<'tcx>),
 
+    IndexExprDerivedObligation(Box<(DerivedObligationCause<'tcx>, Span)>),
+
     FunctionArgumentObligation {
         /// The node of the relevant argument in the function call.
         arg_hir_id: hir::HirId,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3399,6 +3399,25 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     )
                 });
             }
+            ObligationCauseCode::IndexExprDerivedObligation(ref data) => {
+                ensure_sufficient_stack(|| {
+                    self.note_obligation_cause_code(
+                        body_id,
+                        err,
+                        predicate,
+                        param_env,
+                        &data.0.parent_code,
+                        obligated_types,
+                        seen_requirements,
+                    )
+                });
+                err.span_suggestion_verbose(
+                    data.1,
+                    "remove this borrow",
+                    String::new(),
+                    Applicability::MaybeIncorrect,
+                );
+            }
             ObligationCauseCode::TypeAlias(ref nested, span, def_id) => {
                 // #74711: avoid a stack overflow
                 ensure_sufficient_stack(|| {

--- a/tests/ui/indexing/point-at-index-for-obligation-failure.fixed
+++ b/tests/ui/indexing/point-at-index-for-obligation-failure.fixed
@@ -3,6 +3,6 @@ fn main() {
     let a = std::collections::HashMap::<String,String>::new();
     let s = "hello";
     let _b = &a[
-        &s //~ ERROR E0277
+        s //~ ERROR E0277
     ];
 }

--- a/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
+++ b/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: Borrow<&str>` is not satisfied
-  --> $DIR/point-at-index-for-obligation-failure.rs:5:9
+  --> $DIR/point-at-index-for-obligation-failure.rs:6:9
    |
 LL |         &s
    |         ^^ the trait `Borrow<&str>` is not implemented for `String`
@@ -7,6 +7,11 @@ LL |         &s
    = help: the trait `Borrow<str>` is implemented for `String`
    = help: for that trait implementation, expected `str`, found `&str`
    = note: required for `HashMap<String, String>` to implement `Index<&&str>`
+help: remove this borrow
+   |
+LL -         &s
+LL +         s
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
When encountering

```rust
    let a = std::collections::HashMap::<String,String>::new();
    let s = "hello";
    let _b = &a[&s];
```
suggest `let _b = &a[s];`.

Fix #66023.

r? @compiler-errors