### PR TITLE
On borrow return type, suggest borrowing from arg or owned return type

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3012,7 +3012,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                 sugg,
                                 Applicability::MaybeIncorrect,
                             );
-                            "...or alternatively,"
+                            "...or alternatively, you might want"
                         } else if let Some((kind, _span)) =
                             self.diagnostic_metadata.current_function
                             && let FnKind::Fn(_, _, sig, _, _, _) = kind
@@ -3070,9 +3070,9 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                     higher_ranked
                                 },
                             );
-                            "...or alternatively,"
+                            "alternatively, you might want"
                         } else {
-                            "instead, you are more likely"
+                            "instead, you are more likely to want"
                         };
                         let mut sugg = vec![(lt.span, String::new())];
                         if let Some((kind, _span)) =
@@ -3105,7 +3105,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                             }
                         };
                         err.multipart_suggestion_verbose(
-                            format!("{pre} to want to return an owned value"),
+                            format!("{pre} to return an owned value"),
                             sugg,
                             Applicability::MaybeIncorrect,
                         );

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3105,59 +3105,64 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                 owned_sugg = true;
                             }
                             if let Some(ty) = lt_finder.found {
-                                if let TyKind::Path(None, path @ Path { segments, .. }) = &ty.kind
-                                    && segments.len() == 1
-                                {
-                                    if segments[0].ident.name == sym::str {
-                                        // Don't suggest `-> str`, suggest `-> String`.
-                                        sugg = vec![
-                                            (lt.span.with_hi(ty.span.hi()), "String".to_string()),
-                                        ];
-                                    } else {
-                                        // Check if the path being borrowed is likely to be owned.
-                                        let path: Vec<_> = Segment::from_path(path);
-                                        match self.resolve_path(&path, Some(TypeNS), None) {
-                                            PathResult::Module(
-                                                ModuleOrUniformRoot::Module(module),
-                                            ) => {
-                                                match module.res() {
-                                                    Some(Res::PrimTy(..)) => {}
-                                                    Some(Res::Def(
-                                                        DefKind::Struct
-                                                        | DefKind::Union
-                                                        | DefKind::Enum
-                                                        | DefKind::ForeignTy
-                                                        | DefKind::AssocTy
-                                                        | DefKind::OpaqueTy
-                                                        | DefKind::TyParam,
-                                                        _,
-                                                    )) => {}
-                                                    _ => { // Do not suggest in all other cases.
-                                                        owned_sugg = false;
-                                                    }
+                                if let TyKind::Path(None, path) = &ty.kind {
+                                    // Check if the path being borrowed is likely to be owned.
+                                    let path: Vec<_> = Segment::from_path(path);
+                                    match self.resolve_path(&path, Some(TypeNS), None) {
+                                        PathResult::Module(
+                                            ModuleOrUniformRoot::Module(module),
+                                        ) => {
+                                            match module.res() {
+                                                Some(Res::PrimTy(PrimTy::Str)) => {
+                                                    // Don't suggest `-> str`, suggest `-> String`.
+                                                    sugg = vec![(
+                                                        lt.span.with_hi(ty.span.hi()),
+                                                        "String".to_string(),
+                                                    )];
+                                                }
+                                                Some(Res::PrimTy(..)) => {}
+                                                Some(Res::Def(
+                                                    DefKind::Struct
+                                                    | DefKind::Union
+                                                    | DefKind::Enum
+                                                    | DefKind::ForeignTy
+                                                    | DefKind::AssocTy
+                                                    | DefKind::OpaqueTy
+                                                    | DefKind::TyParam,
+                                                    _,
+                                                )) => {}
+                                                _ => { // Do not suggest in all other cases.
+                                                    owned_sugg = false;
                                                 }
                                             }
-                                            PathResult::NonModule(res) => {
-                                                match res.base_res() {
-                                                    Res::PrimTy(..) => {}
-                                                    Res::Def(
-                                                        DefKind::Struct
-                                                        | DefKind::Union
-                                                        | DefKind::Enum
-                                                        | DefKind::ForeignTy
-                                                        | DefKind::AssocTy
-                                                        | DefKind::OpaqueTy
-                                                        | DefKind::TyParam,
-                                                        _,
-                                                    ) => {}
-                                                    _ => { // Do not suggest in all other cases.
-                                                        owned_sugg = false;
-                                                    }
+                                        }
+                                        PathResult::NonModule(res) => {
+                                            match res.base_res() {
+                                                Res::PrimTy(PrimTy::Str) => {
+                                                    // Don't suggest `-> str`, suggest `-> String`.
+                                                    sugg = vec![(
+                                                        lt.span.with_hi(ty.span.hi()),
+                                                        "String".to_string(),
+                                                    )];
+                                                }
+                                                Res::PrimTy(..) => {}
+                                                Res::Def(
+                                                    DefKind::Struct
+                                                    | DefKind::Union
+                                                    | DefKind::Enum
+                                                    | DefKind::ForeignTy
+                                                    | DefKind::AssocTy
+                                                    | DefKind::OpaqueTy
+                                                    | DefKind::TyParam,
+                                                    _,
+                                                ) => {}
+                                                _ => { // Do not suggest in all other cases.
+                                                    owned_sugg = false;
                                                 }
                                             }
-                                            _ => { // Do not suggest in all other cases.
-                                                owned_sugg = false;
-                                            }
+                                        }
+                                        _ => { // Do not suggest in all other cases.
+                                            owned_sugg = false;
                                         }
                                     }
                                 }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2853,8 +2853,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     "this function's return type contains a borrowed value, but there is no value \
                      for it to be borrowed from",
                 );
-                maybe_static = true;
                 if in_scope_lifetimes.is_empty() {
+                    maybe_static = true;
                     in_scope_lifetimes = vec![(
                         Ident::with_dummy_span(kw::StaticLifetime),
                         (DUMMY_NODE_ID, LifetimeRes::Static),
@@ -2865,8 +2865,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     "this function's return type contains a borrowed value with an elided \
                      lifetime, but the lifetime cannot be derived from the arguments",
                 );
-                maybe_static = true;
                 if in_scope_lifetimes.is_empty() {
+                    maybe_static = true;
                     in_scope_lifetimes = vec![(
                         Ident::with_dummy_span(kw::StaticLifetime),
                         (DUMMY_NODE_ID, LifetimeRes::Static),

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2976,8 +2976,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                             || lt.kind == MissingLifetimeKind::Underscore)
                     {
                         let pre = if lt.kind == MissingLifetimeKind::Ampersand
-                            && let Some((kind, _span)) =
-                                self.diagnostic_metadata.current_function
+                            && let Some((kind, _span)) = self.diagnostic_metadata.current_function
                             && let FnKind::Fn(_, _, sig, _, _, _) = kind
                             && !sig.decl.inputs.is_empty()
                             && let sugg = sig
@@ -3002,7 +3001,6 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                 .collect::<Vec<_>>()
                             && !sugg.is_empty()
                         {
-
                             let (the, s) = if sig.decl.inputs.len() == 1 {
                                 ("the", "")
                             } else {
@@ -3018,9 +3016,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                             );
                             "...or alternatively, you might want"
                         } else if (lt.kind == MissingLifetimeKind::Ampersand
-                                || lt.kind == MissingLifetimeKind::Underscore)
-                            && let Some((kind, _span)) =
-                                self.diagnostic_metadata.current_function
+                            || lt.kind == MissingLifetimeKind::Underscore)
+                            && let Some((kind, _span)) = self.diagnostic_metadata.current_function
                             && let FnKind::Fn(_, _, sig, _, _, _) = kind
                             && let ast::FnRetTy::Ty(ret_ty) = &sig.decl.output
                             && !sig.decl.inputs.is_empty()
@@ -3041,26 +3038,25 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                             // So we look at every ref in the trait bound. If there's any, we
                             // suggest
                             // fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()>
-                            let mut lt_finder = LifetimeFinder {
-                                lifetime: lt.span,
-                                found: None,
-                                seen: vec![],
-                            };
+                            let mut lt_finder =
+                                LifetimeFinder { lifetime: lt.span, found: None, seen: vec![] };
                             for bound in arg_refs {
                                 if let ast::GenericBound::Trait(trait_ref, _) = bound {
                                     lt_finder.visit_trait_ref(&trait_ref.trait_ref);
                                 }
                             }
                             lt_finder.visit_ty(ret_ty);
-                            let spans_suggs: Vec<_> = lt_finder.seen.iter().filter_map(|ty| {
-                                match &ty.kind {
+                            let spans_suggs: Vec<_> = lt_finder
+                                .seen
+                                .iter()
+                                .filter_map(|ty| match &ty.kind {
                                     TyKind::Ref(_, mut_ty) => {
                                         let span = ty.span.with_hi(mut_ty.ty.span.lo());
                                         Some((span, "&'a ".to_string()))
                                     }
-                                    _ => None
-                                }
-                            }).collect();
+                                    _ => None,
+                                })
+                                .collect();
                             self.suggest_introducing_lifetime(
                                 err,
                                 None,
@@ -3081,20 +3077,16 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                         };
                         let mut owned_sugg = lt.kind == MissingLifetimeKind::Ampersand;
                         let mut sugg = vec![(lt.span, String::new())];
-                        if let Some((kind, _span)) =
-                            self.diagnostic_metadata.current_function
+                        if let Some((kind, _span)) = self.diagnostic_metadata.current_function
                             && let FnKind::Fn(_, _, sig, _, _, _) = kind
                             && let ast::FnRetTy::Ty(ty) = &sig.decl.output
                         {
-                            let mut lt_finder = LifetimeFinder {
-                                lifetime: lt.span,
-                                found: None,
-                                seen: vec![],
-                            };
+                            let mut lt_finder =
+                                LifetimeFinder { lifetime: lt.span, found: None, seen: vec![] };
                             lt_finder.visit_ty(&ty);
 
-                            if let [Ty { span, kind: TyKind::Ref(_, mut_ty), ..}]
-                                = &lt_finder.seen[..]
+                            if let [Ty { span, kind: TyKind::Ref(_, mut_ty), .. }] =
+                                &lt_finder.seen[..]
                             {
                                 // We might have a situation like
                                 // fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()>
@@ -3109,9 +3101,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                     // Check if the path being borrowed is likely to be owned.
                                     let path: Vec<_> = Segment::from_path(path);
                                     match self.resolve_path(&path, Some(TypeNS), None) {
-                                        PathResult::Module(
-                                            ModuleOrUniformRoot::Module(module),
-                                        ) => {
+                                        PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
                                             match module.res() {
                                                 Some(Res::PrimTy(PrimTy::Str)) => {
                                                     // Don't suggest `-> str`, suggest `-> String`.
@@ -3131,7 +3121,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                                     | DefKind::TyParam,
                                                     _,
                                                 )) => {}
-                                                _ => { // Do not suggest in all other cases.
+                                                _ => {
+                                                    // Do not suggest in all other cases.
                                                     owned_sugg = false;
                                                 }
                                             }
@@ -3156,12 +3147,14 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                                     | DefKind::TyParam,
                                                     _,
                                                 ) => {}
-                                                _ => { // Do not suggest in all other cases.
+                                                _ => {
+                                                    // Do not suggest in all other cases.
                                                     owned_sugg = false;
                                                 }
                                             }
                                         }
-                                        _ => { // Do not suggest in all other cases.
+                                        _ => {
+                                            // Do not suggest in all other cases.
                                             owned_sugg = false;
                                         }
                                     }

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1852;
-const ROOT_ENTRY_LIMIT: usize = 867;
+const ROOT_ENTRY_LIMIT: usize = 866;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
+++ b/tests/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
@@ -5,10 +5,15 @@ LL | fn elision<T: Fn() -> &i32>() {
    |                       ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn elision<T: Fn() -> &'static i32>() {
    |                        +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL - fn elision<T: Fn() -> &i32>() {
+LL + fn elision<T: Fn() -> i32>() {
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
+++ b/tests/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
@@ -5,10 +5,15 @@ LL | fn elision(_: fn() -> &i32) {
    |                       ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn elision(_: fn() -> &'static i32) {
    |                        +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL - fn elision(_: fn() -> &i32) {
+LL + fn elision(_: fn() -> i32) {
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/c-variadic/variadic-ffi-6.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-6.stderr
@@ -13,7 +13,7 @@ help: instead, you are more likely to want to change one of the arguments to be 
    |
 LL |     x: &usize,
    |        +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL - ) -> &usize {
 LL + ) -> usize {

--- a/tests/ui/c-variadic/variadic-ffi-6.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-6.stderr
@@ -5,10 +5,19 @@ LL | ) -> &usize {
    |      ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | ) -> &'static usize {
    |       +++++++
+help: instead, you are more likely to want to change one of the arguments to be borrowed...
+   |
+LL |     x: &usize,
+   |        +
+help: ...or alternatively, to want to return an owned value
+   |
+LL - ) -> &usize {
+LL + ) -> usize {
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/foreign-fn-return-lifetime.fixed
+++ b/tests/ui/foreign-fn-return-lifetime.fixed
@@ -1,8 +1,0 @@
-// run-rustfix
-
-extern "C" {
-    pub fn g(_: &u8) -> &u8; // OK
-    pub fn f() -> &'static u8; //~ ERROR missing lifetime specifier
-}
-
-fn main() {}

--- a/tests/ui/foreign-fn-return-lifetime.rs
+++ b/tests/ui/foreign-fn-return-lifetime.rs
@@ -1,5 +1,3 @@
-// run-rustfix
-
 extern "C" {
     pub fn g(_: &u8) -> &u8; // OK
     pub fn f() -> &u8; //~ ERROR missing lifetime specifier

--- a/tests/ui/foreign-fn-return-lifetime.stderr
+++ b/tests/ui/foreign-fn-return-lifetime.stderr
@@ -1,14 +1,19 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/foreign-fn-return-lifetime.rs:5:19
+  --> $DIR/foreign-fn-return-lifetime.rs:3:19
    |
 LL |     pub fn f() -> &u8;
    |                   ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     pub fn f() -> &'static u8;
    |                    +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL -     pub fn f() -> &u8;
+LL +     pub fn f() -> u8;
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/generic-associated-types/issue-70304.stderr
+++ b/tests/ui/generic-associated-types/issue-70304.stderr
@@ -11,7 +11,7 @@ LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
    |                                                             ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'static>> {
    |                                                             ~~~~~~~

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -5,7 +5,7 @@ LL | fn d() -> impl Fn() -> (impl Debug + '_) {
    |                                      ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL | fn d() -> impl Fn() -> (impl Debug + 'static) {
    |                                      ~~~~~~~

--- a/tests/ui/issues/issue-13497.stderr
+++ b/tests/ui/issues/issue-13497.stderr
@@ -5,10 +5,14 @@ LL |     &str
    |     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     &'static str
    |      +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL |     String
+   |     ~~~~~~
 
 error: aborting due to previous error
 

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -17,10 +17,18 @@ LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    |                                        ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &'static str { iter() }
    |                                         +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL | fn parse_type_2(iter: &fn(&u8)->&u8) -> &str { iter() }
+   |                       +
+help: ...or alternatively, to want to return an owned value
+   |
+LL | fn parse_type_2(iter: fn(&u8)->&u8) -> String { iter() }
+   |                                        ~~~~~~
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-26638.rs:10:22
@@ -29,10 +37,14 @@ LL | fn parse_type_3() -> &str { unimplemented!() }
    |                      ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn parse_type_3() -> &'static str { unimplemented!() }
    |                       +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL | fn parse_type_3() -> String { unimplemented!() }
+   |                      ~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-26638.rs:1:69

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -25,7 +25,7 @@ help: instead, you are more likely to want to change the argument to be borrowed
    |
 LL | fn parse_type_2(iter: &fn(&u8)->&u8) -> &str { iter() }
    |                       +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> String { iter() }
    |                                        ~~~~~~

--- a/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -5,10 +5,15 @@ LL | fn f() -> &isize {
    |           ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn f() -> &'static isize {
    |            +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL - fn f() -> &isize {
+LL + fn f() -> isize {
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:7:33
@@ -41,10 +46,19 @@ LL | fn i(_x: isize) -> &isize {
    |                    ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn i(_x: isize) -> &'static isize {
    |                     +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL | fn i(_x: &isize) -> &isize {
+   |          +
+help: ...or alternatively, to want to return an owned value
+   |
+LL - fn i(_x: isize) -> &isize {
+LL + fn i(_x: isize) -> isize {
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:34:24
@@ -53,10 +67,19 @@ LL | fn j(_x: StaticStr) -> &isize {
    |                        ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn j(_x: StaticStr) -> &'static isize {
    |                         +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL | fn j(_x: &StaticStr) -> &isize {
+   |          +
+help: ...or alternatively, to want to return an owned value
+   |
+LL - fn j(_x: StaticStr) -> &isize {
+LL + fn j(_x: StaticStr) -> isize {
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:40:49
@@ -65,10 +88,19 @@ LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
    |                                                 ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'a` lifetime
+help: consider using the `'a` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &'a isize {
    |                                                  ++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL | fn k<'a, T: WithLifetime<'a>>(_x: &T::Output) -> &isize {
+   |                                   +
+help: ...or alternatively, to want to return an owned value
+   |
+LL - fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
+LL + fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> isize {
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:45:37
@@ -77,10 +109,18 @@ LL | fn l<'a>(_: &'a str, _: &'a str) -> &str { "" }
    |             -------     -------     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-help: consider using the `'a` lifetime
+help: consider using the `'a` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn l<'a>(_: &'a str, _: &'a str) -> &'a str { "" }
    |                                      ++
+help: instead, you are more likely to want to change one of the arguments to be borrowed...
+   |
+LL | fn l<'a>(_: &&'a str, _: &&'a str) -> &str { "" }
+   |             +            +
+help: ...or alternatively, to want to return an owned value
+   |
+LL | fn l<'a>(_: &'a str, _: &'a str) -> String { "" }
+   |                                     ~~~~~~
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -88,19 +88,10 @@ LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
    |                                                 ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'a` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
+help: consider using the `'a` lifetime
    |
 LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &'a isize {
    |                                                  ++
-help: instead, you are more likely to want to change the argument to be borrowed...
-   |
-LL | fn k<'a, T: WithLifetime<'a>>(_x: &T::Output) -> &isize {
-   |                                   +
-help: ...or alternatively, you might want to return an owned value
-   |
-LL - fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
-LL + fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> isize {
-   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:45:37
@@ -109,18 +100,10 @@ LL | fn l<'a>(_: &'a str, _: &'a str) -> &str { "" }
    |             -------     -------     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-help: consider using the `'a` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
+help: consider using the `'a` lifetime
    |
 LL | fn l<'a>(_: &'a str, _: &'a str) -> &'a str { "" }
    |                                      ++
-help: instead, you are more likely to want to change one of the arguments to be borrowed...
-   |
-LL | fn l<'a>(_: &&'a str, _: &&'a str) -> &str { "" }
-   |             +            +
-help: ...or alternatively, you might want to return an owned value
-   |
-LL | fn l<'a>(_: &'a str, _: &'a str) -> String { "" }
-   |                                     ~~~~~~
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -54,7 +54,7 @@ help: instead, you are more likely to want to change the argument to be borrowed
    |
 LL | fn i(_x: &isize) -> &isize {
    |          +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL - fn i(_x: isize) -> &isize {
 LL + fn i(_x: isize) -> isize {
@@ -75,7 +75,7 @@ help: instead, you are more likely to want to change the argument to be borrowed
    |
 LL | fn j(_x: &StaticStr) -> &isize {
    |          +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL - fn j(_x: StaticStr) -> &isize {
 LL + fn j(_x: StaticStr) -> isize {
@@ -96,7 +96,7 @@ help: instead, you are more likely to want to change the argument to be borrowed
    |
 LL | fn k<'a, T: WithLifetime<'a>>(_x: &T::Output) -> &isize {
    |                                   +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL - fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
 LL + fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> isize {
@@ -117,7 +117,7 @@ help: instead, you are more likely to want to change one of the arguments to be 
    |
 LL | fn l<'a>(_: &&'a str, _: &&'a str) -> &str { "" }
    |             +            +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL | fn l<'a>(_: &'a str, _: &'a str) -> String { "" }
    |                                     ~~~~~~

--- a/tests/ui/self/elision/nested-item.stderr
+++ b/tests/ui/self/elision/nested-item.stderr
@@ -29,7 +29,7 @@ help: instead, you are more likely to want to change the argument to be borrowed
    |
 LL | fn wrap(self: &Wrap<{ fn bar(&self) {} }>) -> &() {
    |               +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL - fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
 LL + fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> () {

--- a/tests/ui/self/elision/nested-item.stderr
+++ b/tests/ui/self/elision/nested-item.stderr
@@ -21,10 +21,19 @@ LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
    |                                              ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &'static () {
    |                                               +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL | fn wrap(self: &Wrap<{ fn bar(&self) {} }>) -> &() {
+   |               +
+help: ...or alternatively, to want to return an owned value
+   |
+LL - fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> &() {
+LL + fn wrap(self: Wrap<{ fn bar(&self) {} }>) -> () {
+   |
 
 error[E0412]: cannot find type `Wrap` in this scope
   --> $DIR/nested-item.rs:5:15

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -5,10 +5,19 @@ LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
    |                                                      ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x.next() }
    |                                                       +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL |     fn g(mut x: &impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |                 +
+help: ...or alternatively, to want to return an owned value
+   |
+LL -     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+LL +     fn g(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:19:60
@@ -17,10 +26,19 @@ LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() 
    |                                                            ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x.next() }
    |                                                             +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL |     async fn i(mut x: &impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |                       +
+help: ...or alternatively, to want to return an owned value
+   |
+LL -     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+LL +     async fn i(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:27:58
@@ -29,7 +47,7 @@ LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() 
    |                                                          ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                          ~~~~~~~
@@ -41,7 +59,7 @@ LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.n
    |                                                                ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                                ~~~~~~~
@@ -53,10 +71,19 @@ LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                                     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     fn g(mut x: impl Foo) -> Option<&'static ()> { x.next() }
    |                                      +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL |     fn g(mut x: &impl Foo) -> Option<&()> { x.next() }
+   |                 +
+help: ...or alternatively, to want to return an owned value
+   |
+LL -     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
+LL +     fn g(mut x: impl Foo) -> Option<()> { x.next() }
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:58:41
@@ -65,10 +92,19 @@ LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                                         ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&'static ()> { x.next() }
    |                                          +++++++
+help: instead, you are more likely to want to change the argument to be borrowed...
+   |
+LL |     fn g(mut x: &impl Foo<()>) -> Option<&()> { x.next() }
+   |                 +
+help: ...or alternatively, to want to return an owned value
+   |
+LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
+LL +     fn g(mut x: impl Foo<()>) -> Option<()> { x.next() }
+   |
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
   --> $DIR/impl-trait-missing-lifetime-gated.rs:6:35

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -9,10 +9,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x.next() }
    |                                                       +++++++
-help: instead, you are more likely to want to change the argument to be borrowed...
+help: consider introducing a named lifetime parameter
    |
-LL |     fn g(mut x: &impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-   |                 +
+LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |         ++++                             ~~~                ~~~
 help: ...or alternatively, to want to return an owned value
    |
 LL -     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
@@ -30,10 +30,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x.next() }
    |                                                             +++++++
-help: instead, you are more likely to want to change the argument to be borrowed...
+help: consider introducing a named lifetime parameter
    |
-LL |     async fn i(mut x: &impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-   |                       +
+LL |     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |               ++++                             ~~~                ~~~
 help: ...or alternatively, to want to return an owned value
    |
 LL -     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
@@ -75,10 +75,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     fn g(mut x: impl Foo) -> Option<&'static ()> { x.next() }
    |                                      +++++++
-help: instead, you are more likely to want to change the argument to be borrowed...
+help: consider introducing a named lifetime parameter
    |
-LL |     fn g(mut x: &impl Foo) -> Option<&()> { x.next() }
-   |                 +
+LL |     fn g<'a>(mut x: impl Foo) -> Option<&'a ()> { x.next() }
+   |         ++++                            ~~~
 help: ...or alternatively, to want to return an owned value
    |
 LL -     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
@@ -96,10 +96,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&'static ()> { x.next() }
    |                                          +++++++
-help: instead, you are more likely to want to change the argument to be borrowed...
+help: consider introducing a named lifetime parameter
    |
-LL |     fn g(mut x: &impl Foo<()>) -> Option<&()> { x.next() }
-   |                 +
+LL |     fn g<'a>(mut x: impl Foo<()>) -> Option<&'a ()> { x.next() }
+   |         ++++                                ~~~
 help: ...or alternatively, to want to return an owned value
    |
 LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -51,6 +51,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                          ~~~~~~~
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |         ++++                             ~~~                ~~~
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
@@ -63,6 +67,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                                ~~~~~~~
+help: consider introducing a named lifetime parameter
+   |
+LL |     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |               ++++                             ~~~                ~~~
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -13,7 +13,7 @@ help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
    |         ++++                             ~~~                ~~~
-help: ...or alternatively, to want to return an owned value
+help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
 LL +     fn g(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
@@ -34,7 +34,7 @@ help: consider introducing a named lifetime parameter
    |
 LL |     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
    |               ++++                             ~~~                ~~~
-help: ...or alternatively, to want to return an owned value
+help: alternatively, you might want to return an owned value
    |
 LL -     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
 LL +     async fn i(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
@@ -79,7 +79,7 @@ help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo) -> Option<&'a ()> { x.next() }
    |         ++++                            ~~~
-help: ...or alternatively, to want to return an owned value
+help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
 LL +     fn g(mut x: impl Foo) -> Option<()> { x.next() }
@@ -100,7 +100,7 @@ help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo<()>) -> Option<&'a ()> { x.next() }
    |         ++++                                ~~~
-help: ...or alternatively, to want to return an owned value
+help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
 LL +     fn g(mut x: impl Foo<()>) -> Option<()> { x.next() }

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -55,6 +55,11 @@ help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
    |         ++++                             ~~~                ~~~
+help: alternatively, you might want to return an owned value
+   |
+LL -     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+LL +     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
@@ -71,6 +76,11 @@ help: consider introducing a named lifetime parameter
    |
 LL |     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
    |               ++++                             ~~~                ~~~
+help: alternatively, you might want to return an owned value
+   |
+LL -     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+LL +     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -9,6 +9,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL | fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                      ~~~~~~~
+help: consider introducing a named lifetime parameter
+   |
+LL | fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |     ++++                             ~~~                ~~~
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime.rs:16:60
@@ -21,6 +25,10 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                            ~~~~~~~
+help: consider introducing a named lifetime parameter
+   |
+LL | async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |           ++++                             ~~~                ~~~
 
 error: lifetime may not live long enough
   --> $DIR/impl-trait-missing-lifetime.rs:16:69

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -5,7 +5,7 @@ LL | fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                      ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL | fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                      ~~~~~~~
@@ -17,7 +17,7 @@ LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next(
    |                                                            ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                            ~~~~~~~

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -13,6 +13,11 @@ help: consider introducing a named lifetime parameter
    |
 LL | fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
    |     ++++                             ~~~                ~~~
+help: alternatively, you might want to return an owned value
+   |
+LL - fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+LL + fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/impl-trait-missing-lifetime.rs:16:60
@@ -29,6 +34,11 @@ help: consider introducing a named lifetime parameter
    |
 LL | async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
    |           ++++                             ~~~                ~~~
+help: alternatively, you might want to return an owned value
+   |
+LL - async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+LL + async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
+   |
 
 error: lifetime may not live long enough
   --> $DIR/impl-trait-missing-lifetime.rs:16:69

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -117,11 +117,6 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             +++++++
-help: instead, you are more likely to want to return an owned value
-   |
-LL -     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-LL +     static f: RefCell<HashMap<i32, Vec<Vec<Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:47:44

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -5,7 +5,7 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::
    |                                            ^^^ expected 2 lifetime parameters
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefCell::new(HashMap::new());
    |                                               ++++++++++++++++++
@@ -32,7 +32,7 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap:
    |                                            expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>>> = RefCell::new(HashMap::new());
    |                                             +++++++    ++++++++++++++++++
@@ -59,7 +59,7 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(Hash
    |                                               ^ expected 2 lifetime parameters
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                +++++++++++++++++
@@ -86,7 +86,7 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(Has
    |                                            expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             +++++++     +++++++++++++++++
@@ -113,10 +113,15 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell
    |                                            ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL -     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+LL +     static f: RefCell<HashMap<i32, Vec<Vec<Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:47:44

--- a/tests/ui/suggestions/return-elided-lifetime.stderr
+++ b/tests/ui/suggestions/return-elided-lifetime.stderr
@@ -5,10 +5,15 @@ LL | fn f1() -> &i32 { loop {} }
    |            ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn f1() -> &'static i32 { loop {} }
    |             +++++++
+help: instead, you are more likely to want to return an owned value
+   |
+LL - fn f1() -> &i32 { loop {} }
+LL + fn f1() -> i32 { loop {} }
+   |
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/return-elided-lifetime.rs:8:14
@@ -19,7 +24,7 @@ LL | fn f1_() -> (&i32, &i32) { loop {} }
    |              expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn f1_() -> (&'static i32, &'static i32) { loop {} }
    |               +++++++       +++++++
@@ -31,10 +36,19 @@ LL | fn f2(a: i32, b: i32) -> &i32 { loop {} }
    |                          ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn f2(a: i32, b: i32) -> &'static i32 { loop {} }
    |                           +++++++
+help: instead, you are more likely to want to change one of the arguments to be borrowed...
+   |
+LL | fn f2(a: &i32, b: &i32) -> &i32 { loop {} }
+   |          +        +
+help: ...or alternatively, to want to return an owned value
+   |
+LL - fn f2(a: i32, b: i32) -> &i32 { loop {} }
+LL + fn f2(a: i32, b: i32) -> i32 { loop {} }
+   |
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/return-elided-lifetime.rs:13:28
@@ -45,7 +59,7 @@ LL | fn f2_(a: i32, b: i32) -> (&i32, &i32) { loop {} }
    |                            expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
    |
 LL | fn f2_(a: i32, b: i32) -> (&'static i32, &'static i32) { loop {} }
    |                             +++++++       +++++++

--- a/tests/ui/suggestions/return-elided-lifetime.stderr
+++ b/tests/ui/suggestions/return-elided-lifetime.stderr
@@ -44,7 +44,7 @@ help: instead, you are more likely to want to change one of the arguments to be 
    |
 LL | fn f2(a: &i32, b: &i32) -> &i32 { loop {} }
    |          +        +
-help: ...or alternatively, to want to return an owned value
+help: ...or alternatively, you might want to return an owned value
    |
 LL - fn f2(a: i32, b: i32) -> &i32 { loop {} }
 LL + fn f2(a: i32, b: i32) -> i32 { loop {} }

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -28,7 +28,7 @@ LL | fn meh() -> Box<dyn for<'_> Meh<'_>>
    |                                 ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
+help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
    |
 LL | fn meh() -> Box<dyn for<'_> Meh<'static>>
    |                                 ~~~~~~~


### PR DESCRIPTION
When we encounter a function with a return type that has an anonymous lifetime with no argument to borrow from, besides suggesting the `'static` lifetime we now also suggest changing the arguments to be borrows or changing the return type to be an owned type.

```
error[E0106]: missing lifetime specifier
  --> $DIR/variadic-ffi-6.rs:7:6
   |
LL | ) -> &usize {
   |      ^ expected named lifetime parameter
   |
   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`
   |
LL | ) -> &'static usize {
   |       +++++++
help: instead, you are more likely to want to change one of the arguments to be borrowed...
   |
LL |     x: &usize,
   |        +
help: ...or alternatively, to want to return an owned value
   |
LL - ) -> &usize {
LL + ) -> usize {
   |
```

Fix #85843.