### PR TITLE
Tweak unclosed generics errors

### DIFF
--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -279,7 +279,7 @@ impl<'a> Parser<'a> {
         let span_lo = self.token.span;
         let (params, span) = if self.eat_lt() {
             let params = self.parse_generic_params()?;
-            self.expect_gt()?;
+            self.expect_gt_or_maybe_suggest_closing_generics(&params)?;
             (params, span_lo.to(self.prev_token.span))
         } else {
             (ThinVec::new(), self.prev_token.span.shrink_to_hi())

--- a/tests/ui/generic-associated-types/parse/trait-path-expected-token.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-expected-token.stderr
@@ -2,9 +2,7 @@ error: expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `=`
   --> $DIR/trait-path-expected-token.rs:5:33
    |
 LL | fn f1<'a>(arg : Box<dyn X<Y = B = &'a ()>>) {}
-   |                               - ^ expected one of 7 possible tokens
-   |                               |
-   |                               maybe try to close unmatched angle bracket
+   |                                 ^ expected one of 7 possible tokens
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/parse/trait-path-expressions.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-expressions.stderr
@@ -10,9 +10,7 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/trait-path-expressions.rs:16:36
    |
 LL |   fn f2<'a>(arg : Box<dyn X< { 1 } = 32 >>) {}
-   |                                  - ^ expected one of `,`, `:`, or `>`
-   |                                  |
-   |                                  maybe try to close unmatched angle bracket
+   |                                    ^ expected one of `,`, `:`, or `>`
    |
 help: you might have meant to end the type parameters here
    |

--- a/tests/ui/generic-associated-types/parse/trait-path-missing-gen_arg.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-missing-gen_arg.stderr
@@ -8,9 +8,7 @@ error: expected one of `>`, a const expression, lifetime, or type, found `=`
   --> $DIR/trait-path-missing-gen_arg.rs:11:30
    |
 LL |   fn f1<'a>(arg : Box<dyn X< = 32 >>) {}
-   |                            - ^ expected one of `>`, a const expression, lifetime, or type
-   |                            |
-   |                            maybe try to close unmatched angle bracket
+   |                              ^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/parse/trait-path-segments.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-segments.stderr
@@ -2,9 +2,7 @@ error: expected one of `!`, `(`, `+`, `,`, `::`, `:`, `<`, or `>`, found `=`
   --> $DIR/trait-path-segments.rs:6:36
    |
 LL |     fn f1<'a>(arg : Box<dyn X<X::Y = u32>>) {}
-   |                                  - ^ expected one of 8 possible tokens
-   |                                  |
-   |                                  maybe try to close unmatched angle bracket
+   |                                    ^ expected one of 8 possible tokens
    |
 help: you might have meant to end the type parameters here
    |
@@ -15,9 +13,7 @@ error: expected one of `,`, `::`, `:`, or `>`, found `=`
   --> $DIR/trait-path-segments.rs:17:35
    |
 LL |     impl<T : X<<Self as X>::Y<'a> = &'a u32>> Z for T {}
-   |                                 - ^ expected one of `,`, `::`, `:`, or `>`
-   |                                 |
-   |                                 maybe try to close unmatched angle bracket
+   |                                   ^ expected one of `,`, `::`, `:`, or `>`
    |
 help: you might have meant to end the type parameters here
    |
@@ -28,9 +24,7 @@ error: expected one of `!`, `+`, `,`, `::`, `:`, or `>`, found `=`
   --> $DIR/trait-path-segments.rs:28:25
    |
 LL |     impl<T : X<X::Y<'a> = &'a u32>> Z for T {}
-   |                       - ^ expected one of `!`, `+`, `,`, `::`, `:`, or `>`
-   |                       |
-   |                       maybe try to close unmatched angle bracket
+   |                         ^ expected one of `!`, `+`, `,`, `::`, `:`, or `>`
    |
 help: you might have meant to end the type parameters here
    |

--- a/tests/ui/generic-associated-types/parse/trait-path-types.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-types.stderr
@@ -2,9 +2,7 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/trait-path-types.rs:6:37
    |
 LL |   fn f<'a>(arg : Box<dyn X< [u8; 1] = u32>>) {}
-   |                                   - ^ expected one of `,`, `:`, or `>`
-   |                                   |
-   |                                   maybe try to close unmatched angle bracket
+   |                                     ^ expected one of `,`, `:`, or `>`
    |
 help: you might have meant to end the type parameters here
    |
@@ -15,9 +13,7 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/trait-path-types.rs:11:37
    |
 LL |   fn f1<'a>(arg : Box<dyn X<(Y<'a>) = &'a ()>>) {}
-   |                                   - ^ expected one of `,`, `:`, or `>`
-   |                                   |
-   |                                   maybe try to close unmatched angle bracket
+   |                                     ^ expected one of `,`, `:`, or `>`
    |
 help: you might have meant to end the type parameters here
    |
@@ -28,9 +24,7 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/trait-path-types.rs:16:33
    |
 LL |   fn f1<'a>(arg : Box<dyn X< 'a = u32 >>) {}
-   |                              -- ^ expected one of `,`, `:`, or `>`
-   |                              |
-   |                              maybe try to close unmatched angle bracket
+   |                                 ^ expected one of `,`, `:`, or `>`
    |
 help: you might have meant to end the type parameters here
    |

--- a/tests/ui/generics/unclosed-generics-in-impl-def.rs
+++ b/tests/ui/generics/unclosed-generics-in-impl-def.rs
@@ -1,0 +1,2 @@
+impl<S: Into<std::borrow::Cow<'static, str>> From<S> for Canonical {} //~ ERROR expected
+fn main() {}

--- a/tests/ui/generics/unclosed-generics-in-impl-def.stderr
+++ b/tests/ui/generics/unclosed-generics-in-impl-def.stderr
@@ -1,0 +1,13 @@
+error: expected one of `+`, `,`, `::`, `=`, or `>`, found `From`
+  --> $DIR/unclosed-generics-in-impl-def.rs:1:46
+   |
+LL | impl<S: Into<std::borrow::Cow<'static, str>> From<S> for Canonical {}
+   |                                              ^^^^ expected one of `+`, `,`, `::`, `=`, or `>`
+   |
+help: you might have meant to end the type parameters here
+   |
+LL | impl<S: Into<std::borrow::Cow<'static, str>>> From<S> for Canonical {}
+   |                                             +
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/issues/issue-34334.stderr
+++ b/tests/ui/issues/issue-34334.stderr
@@ -2,9 +2,8 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/issue-34334.rs:2:29
    |
 LL |     let sr: Vec<(u32, _, _) = vec![];
-   |         --                - ^ expected one of `,`, `:`, or `>`
-   |         |                 |
-   |         |                 maybe try to close unmatched angle bracket
+   |         --                  ^ expected one of `,`, `:`, or `>`
+   |         |
    |         while parsing the type for `sr`
    |
 help: you might have meant to end the type parameters here

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
@@ -2,9 +2,8 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:7:23
    |
 LL |   let v : Vec<(u32,_) = vec![];
-   |       -             - ^ expected one of `,`, `:`, or `>`
-   |       |             |
-   |       |             maybe try to close unmatched angle bracket
+   |       -               ^ expected one of `,`, `:`, or `>`
+   |       |
    |       while parsing the type for `v`
    |
 help: you might have meant to end the type parameters here
@@ -29,9 +28,8 @@ error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:18:18
    |
 LL |   let v : Vec<'a = vec![];
-   |       -       -- ^ expected one of `,`, `:`, or `>`
-   |       |       |
-   |       |       maybe try to close unmatched angle bracket
+   |       -          ^ expected one of `,`, `:`, or `>`
+   |       |
    |       while parsing the type for `v`
    |
 help: you might have meant to end the type parameters here


### PR DESCRIPTION
Remove unnecessary span label for parse errors that already have a suggestion.

Provide structured suggestion to close generics in more cases.