### PR TITLE
When a local binding shadows a fn, point at fn def in call failure

### DIFF
--- a/tests/ui/issues/issue-22468.stderr
+++ b/tests/ui/issues/issue-22468.stderr
@@ -7,6 +7,9 @@ LL |     let x = foo("baz");
    |             ^^^-------
    |             |
    |             call expression requires function
+...
+LL | fn foo(file: &str) -> bool {
+   | -------------------------- this function of the same name is available here, but it's shadowed by the local binding
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When a local binding shadows a function that is then called, this local binding will cause an E0618 error. We now point not only at the binding definition, but also at the locally defined function of the same name.

```
error[E0618]: expected function, found `&str`
  --> $DIR/issue-22468.rs:3:13
   |
LL |     let foo = "bar";
   |         --- `foo` has type `&str`
LL |     let x = foo("baz");
   |             ^^^-------
   |             |
   |             call expression requires function
...
LL | fn foo(file: &str) -> bool {
   | -------------------------- this function of the same name is available here, but it shadowed by the local binding of the same name
```

Fix #53841