### PR TITLE
Add `core::fmt::WriteCursor` for formatting into a borrowed buffer.

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -557,6 +557,8 @@ pub use core::fmt::Alignment;
 pub use core::fmt::Error;
 #[unstable(feature = "debug_closure_helpers", issue = "117729")]
 pub use core::fmt::FormatterFn;
+#[unstable(feature = "fmt_write_cursor", issue = "none")]
+pub use core::fmt::WriteCursor;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::fmt::{write, Arguments};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -34,6 +34,7 @@
 #![feature(extern_types)]
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
+#![feature(fmt_write_cursor)]
 #![feature(float_minimum_maximum)]
 #![feature(future_join)]
 #![feature(generic_assert_internals)]


### PR DESCRIPTION
Proposed implementation for [ACP 278](https://github.com/rust-lang/libs-team/issues/278)