### PR TITLE
Use the glob binding in resolve_rustdoc_path process

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -477,6 +477,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             self.per_ns(|this, ns| {
                 let key = BindingKey::new(target, ns);
                 let _ = this.try_define(import.parent_scope.module, key, dummy_binding, false);
+                this.update_resolution(import.parent_scope.module, key, false, |_, resolution| {
+                    resolution.single_imports.remove(&import);
+                })
             });
             self.record_use(target, dummy_binding, false);
         } else if import.imported_module.get().is_none() {

--- a/tests/ui/resolve/issue-117920.rs
+++ b/tests/ui/resolve/issue-117920.rs
@@ -1,0 +1,11 @@
+#![crate_type = "lib"]
+
+use super::A; //~ ERROR failed to resolve
+
+mod b {
+    pub trait A {}
+    pub trait B {}
+}
+
+/// [`A`]
+pub use b::*;

--- a/tests/ui/resolve/issue-117920.stderr
+++ b/tests/ui/resolve/issue-117920.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: there are too many leading `super` keywords
+  --> $DIR/issue-117920.rs:3:5
+   |
+LL | use super::A;
+   |     ^^^^^ there are too many leading `super` keywords
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes #117920

Returning `None` seems enough.

I reproduces and tests this locally by `cargo +stage1 build`, but I cannot reproduce this ICE by putting [the following code](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=8b3ca8f4a7676eb90baf30437ba041a2) into `tests/ui/...` and then compiling it using `rustc +stage1 /path/to/test.rs` or `x.py test`:
```rust
#![crate_type = "lib"]

use super::Hasher;

/// [`Hasher`]
pub use core::hash::*;
```

r? @petrochenkov