### PR TITLE
chore: remove unnecessary drop

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -409,8 +409,7 @@ impl<T> Cell<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn set(&self, val: T) {
-        let old = self.replace(val);
-        drop(old);
+        self.replace(val);
     }
 
     /// Swaps the values of two `Cell`s.


### PR DESCRIPTION
 No need to manually drop since it's implicit.