### PR TITLE
llvm-wrapper: Pass newly added param to DIBuilder::createStaticMemberType()

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -983,7 +983,7 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateStaticMemberType(
     unwrapDI<DIType>(Ty),
     fromRust(Flags),
     unwrap<llvm::ConstantInt>(val),
-#if LLVM_VERSION_GE(17, 0)
+#if LLVM_VERSION_GE(18, 0)
     llvm::dwarf::DW_TAG_member,
 #endif
     AlignInBits

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -983,6 +983,9 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateStaticMemberType(
     unwrapDI<DIType>(Ty),
     fromRust(Flags),
     unwrap<llvm::ConstantInt>(val),
+#if LLVM_VERSION_GE(17, 0)
+    llvm::dwarf::DW_TAG_member,
+#endif
     AlignInBits
   ));
 }


### PR DESCRIPTION
This was added in https://github.com/llvm/llvm-project/pull/72234.
DW_TAG_member was the implicit default before.

The LLVM change is quite sinister since due to weakly typed ints and default params, this was still successfully compiling against LLVM but was passing the wrong parameters.