### PR TITLE
llvm: Default new RunTimeLang to 0 for enums

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1105,7 +1105,11 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateEnumerationType(
       unwrapDI<DIDescriptor>(Scope), StringRef(Name, NameLen),
       unwrapDI<DIFile>(File), LineNumber,
       SizeInBits, AlignInBits, DINodeArray(unwrapDI<MDTuple>(Elements)),
-      unwrapDI<DIType>(ClassTy), "", IsScoped));
+      unwrapDI<DIType>(ClassTy),
+#if LLVM_VERSION_GE(18, 0)
+      /*RunTimeLang=*/0,
+#endif
+      "", IsScoped));
 }
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateUnionType(


### PR DESCRIPTION
In LLVM-18, RunTimeLang is added to enums and classes: https://github.com/llvm/llvm-project/pull/72011

Rather than passing the parameter through, we default it to 0 since it will not reliably do anything until Rust requires LLVM 18, and we always pass 0 to the APIs for similar debug structures.