### PR TITLE
Add `x suggest` entries for testing `mir-opt` and `coverage`

### DIFF
--- a/src/tools/suggest-tests/src/lib.rs
+++ b/src/tools/suggest-tests/src/lib.rs
@@ -33,13 +33,15 @@ pub fn get_suggestions<T: AsRef<str>>(modified_files: &[T]) -> Vec<Suggestion> {
     let mut suggestions = Vec::new();
 
     // static suggestions
-    for sug in STATIC_SUGGESTIONS.iter() {
-        let glob = Pattern::new(&sug.0).expect("Found invalid glob pattern!");
+    for (globs, sugs) in STATIC_SUGGESTIONS.iter() {
+        let globs = globs
+            .iter()
+            .map(|glob| Pattern::new(glob).expect("Found invalid glob pattern!"))
+            .collect::<Vec<_>>();
+        let matches_some_glob = |file: &str| globs.iter().any(|glob| glob.matches(file));
 
-        for file in modified_files {
-            if glob.matches(file.as_ref()) {
-                suggestions.extend_from_slice(&sug.1);
-            }
+        if modified_files.iter().map(AsRef::as_ref).any(matches_some_glob) {
+            suggestions.extend_from_slice(sugs);
         }
     }
 

--- a/src/tools/suggest-tests/src/static_suggestions.rs
+++ b/src/tools/suggest-tests/src/static_suggestions.rs
@@ -2,7 +2,7 @@ use crate::{sug, Suggestion};
 
 // FIXME: perhaps this could use `std::lazy` when it is stablizied
 macro_rules! static_suggestions {
-    ($( $glob:expr => [ $( $suggestion:expr ),* ] ),*) => {
+    ($( $glob:expr => [ $( $suggestion:expr ),*  $(,)? ] ),* $(,)? ) => {
         pub(crate) const STATIC_SUGGESTIONS: ::once_cell::unsync::Lazy<Vec<(&'static str, Vec<Suggestion>)>>
             = ::once_cell::unsync::Lazy::new(|| vec![ $( ($glob, vec![ $($suggestion),* ]) ),*]);
     }
@@ -10,15 +10,15 @@ macro_rules! static_suggestions {
 
 static_suggestions! {
     "*.md" => [
-        sug!("test", 0, ["linkchecker"])
+        sug!("test", 0, ["linkchecker"]),
     ],
 
     "compiler/*" => [
         sug!("check"),
-        sug!("test", 1, ["tests/ui", "tests/run-make"])
+        sug!("test", 1, ["tests/ui", "tests/run-make"]),
     ],
 
     "src/librustdoc/*" => [
-        sug!("test", 1, ["rustdoc"])
-    ]
+        sug!("test", 1, ["rustdoc"]),
+    ],
 }

--- a/src/tools/suggest-tests/src/static_suggestions.rs
+++ b/src/tools/suggest-tests/src/static_suggestions.rs
@@ -2,23 +2,23 @@ use crate::{sug, Suggestion};
 
 // FIXME: perhaps this could use `std::lazy` when it is stablizied
 macro_rules! static_suggestions {
-    ($( $glob:expr => [ $( $suggestion:expr ),*  $(,)? ] ),* $(,)? ) => {
-        pub(crate) const STATIC_SUGGESTIONS: ::once_cell::unsync::Lazy<Vec<(&'static str, Vec<Suggestion>)>>
-            = ::once_cell::unsync::Lazy::new(|| vec![ $( ($glob, vec![ $($suggestion),* ]) ),*]);
+    ($( [ $( $glob:expr ),* $(,)? ] => [ $( $suggestion:expr ),* $(,)? ] ),* $(,)? ) => {
+        pub(crate) const STATIC_SUGGESTIONS: ::once_cell::unsync::Lazy<Vec<(Vec<&'static str>, Vec<Suggestion>)>>
+            = ::once_cell::unsync::Lazy::new(|| vec![ $( (vec![ $($glob),* ], vec![ $($suggestion),* ]) ),*]);
     }
 }
 
 static_suggestions! {
-    "*.md" => [
+    ["*.md"] => [
         sug!("test", 0, ["linkchecker"]),
     ],
 
-    "compiler/*" => [
+    ["compiler/*"] => [
         sug!("check"),
         sug!("test", 1, ["tests/ui", "tests/run-make"]),
     ],
 
-    "src/librustdoc/*" => [
+    ["src/librustdoc/*"] => [
         sug!("test", 1, ["rustdoc"]),
     ],
 }

--- a/src/tools/suggest-tests/src/static_suggestions.rs
+++ b/src/tools/suggest-tests/src/static_suggestions.rs
@@ -18,6 +18,17 @@ static_suggestions! {
         sug!("test", 1, ["tests/ui", "tests/run-make"]),
     ],
 
+    ["compiler/rustc_mir_transform/*"] => [
+        sug!("test", 1, ["mir-opt"]),
+    ],
+
+    [
+        "compiler/rustc_mir_transform/src/coverage/*",
+        "compiler/rustc_codegen_llvm/src/coverageinfo/*",
+    ] => [
+        sug!("test", 1, ["coverage"]),
+    ],
+
     ["src/librustdoc/*"] => [
         sug!("test", 1, ["rustdoc"]),
     ],


### PR DESCRIPTION
The `x suggest` subcommand uses git to find paths that have been modified, and uses those paths to suggest relevant test suites to run.

This PR adds suggestions for `x test mir-opt` and `x test coverage` .