### PR TITLE
fix: stop emitting `.debug_pubnames` and `.debug_pubtypes`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -5,7 +5,7 @@ use super::debuginfo::{
     DIArray, DIBasicType, DIBuilder, DICompositeType, DIDerivedType, DIDescriptor, DIEnumerator,
     DIFile, DIFlags, DIGlobalVariableExpression, DILexicalBlock, DILocation, DINameSpace,
     DISPFlags, DIScope, DISubprogram, DISubrange, DITemplateTypeParameter, DIType, DIVariable,
-    DebugEmissionKind,
+    DebugEmissionKind, DebugNameTableKind,
 };
 
 use libc::{c_char, c_int, c_uint, size_t};
@@ -793,6 +793,15 @@ pub mod debuginfo {
                 DebugInfo::Limited | DebugInfo::Full => DebugEmissionKind::FullDebug,
             }
         }
+    }
+
+    /// LLVMRustDebugNameTableKind
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    pub enum DebugNameTableKind {
+        Default,
+        Gnu,
+        None,
     }
 }
 
@@ -1812,6 +1821,7 @@ extern "C" {
         kind: DebugEmissionKind,
         DWOId: u64,
         SplitDebugInlining: bool,
+        DebugNameTableKind: DebugNameTableKind,
     ) -> &'a DIDescriptor;
 
     pub fn LLVMRustDIBuilderCreateFile<'a>(

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -697,6 +697,25 @@ static DICompileUnit::DebugEmissionKind fromRust(LLVMRustDebugEmissionKind Kind)
   }
 }
 
+enum class LLVMRustDebugNameTableKind {
+    Default,
+    GNU,
+    None,
+};
+
+static DICompileUnit::DebugNameTableKind fromRust(LLVMRustDebugNameTableKind Kind) {
+  switch (Kind) {
+  case LLVMRustDebugNameTableKind::Default:
+    return DICompileUnit::DebugNameTableKind::Default;
+  case LLVMRustDebugNameTableKind::GNU:
+    return DICompileUnit::DebugNameTableKind::GNU;
+  case LLVMRustDebugNameTableKind::None:
+    return DICompileUnit::DebugNameTableKind::None;
+  default:
+    report_fatal_error("bad DebugNameTableKind.");
+  }
+}
+
 enum class LLVMRustChecksumKind {
   None,
   MD5,
@@ -765,13 +784,15 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateCompileUnit(
     const char *Flags, unsigned RuntimeVer,
     const char *SplitName, size_t SplitNameLen,
     LLVMRustDebugEmissionKind Kind,
-    uint64_t DWOId, bool SplitDebugInlining) {
+    uint64_t DWOId, bool SplitDebugInlining,
+    LLVMRustDebugNameTableKind TableKind) {
   auto *File = unwrapDI<DIFile>(FileRef);
 
   return wrap(Builder->createCompileUnit(Lang, File, StringRef(Producer, ProducerLen),
                                          isOptimized, Flags, RuntimeVer,
                                          StringRef(SplitName, SplitNameLen),
-                                         fromRust(Kind), DWOId, SplitDebugInlining));
+                                         fromRust(Kind), DWOId, SplitDebugInlining,
+                                         false, fromRust(TableKind)));
 }
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateFile(

--- a/tests/assembly/dwarf4.rs
+++ b/tests/assembly/dwarf4.rs
@@ -1,0 +1,24 @@
+// Makes sure that `-Z dwarf-version=4` causes `rustc` to emit DWARF version 4.
+// assembly-output: emit-asm
+// compile-flags: -g --target x86_64-unknown-linux-gnu -Z dwarf-version=4 -Copt-level=0
+// needs-llvm-components: x86
+
+#![feature(no_core, lang_items)]
+#![crate_type = "rlib"]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+pub fn wibble() {}
+
+pub struct X;
+
+// CHECK: .section .debug_info
+// CHECK-NOT: .short 2
+// CHECK-NOT: .short 5
+// CHECK: .short 4
+// CHECK: .section .debug_pubnames
+// CHECK: .section .debug_pubtypes

--- a/tests/assembly/dwarf4.rs
+++ b/tests/assembly/dwarf4.rs
@@ -20,5 +20,5 @@ pub struct X;
 // CHECK-NOT: .short 2
 // CHECK-NOT: .short 5
 // CHECK: .short 4
-// CHECK: .section .debug_pubnames
-// CHECK: .section .debug_pubtypes
+// CHECK-NOT: .section .debug_pubnames
+// CHECK-NOT: .section .debug_pubtypes

--- a/tests/assembly/dwarf5.rs
+++ b/tests/assembly/dwarf5.rs
@@ -18,3 +18,4 @@ pub fn wibble() {}
 // CHECK-NOT: .short 2
 // CHECK-NOT: .short 4
 // CHECK: .short 5
+// CHECK: .section .debug_names


### PR DESCRIPTION
A continuation of #94181.
Fixes #48762
MCP can be found in <https://github.com/rust-lang/compiler-team/issues/688>.

`.debug_pubnames` and `.debug_pubtypes` are poorly designed and people
seldom use them. However, they take a considerable portion of size in
the final binary. This tells LLVM stop emitting those sections on
DWARFv4 or lower. DWARFv5 use `.debug_names` which is more concise
in size and performant for name lookup.

Some other no-really-useful personal notes: 

<details><summary>Details</summary>
<p>

## Pepole saying they are not useful

* https://github.com/rust-lang/rust/issues/48762
* https://rust-lang.zulipchat.com/#narrow/stream/317568-t-compiler.2Fwg-debugging/topic/investigating.20debuginfo.20size/near/342713604
* `DwarfCompileUnit::hasDwarfPubSections()` — https://github.com/llvm/llvm-project/blob/f633f325a1b808d33ca9653ed373353549ddcde6/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp#L1477-L1494
* clang default to no debug name table when no option provided — https://github.com/llvm/llvm-project/blob/f633f325a1b808d33ca9653ed373353549ddcde6/clang/lib/Frontend/CompilerInvocation.cpp#L1819-L1824
* GCC explicitly says GDB doesn't use pub sections (`TARGET_WANT_DEBUG_PUB_SECTIONS` only be true on Darwin) — https://github.com/gcc-mirror/gcc/blob/5d2a360f0a541646abb11efdbabc33c6a04de7ee/gcc/target.def#L6985-L6990 and https://github.com/bminor/binutils-gdb/blob/319b460545dc79280e2904dcc280057cf71fb753/gold/dwarf_reader.h#L424-L427
* Probably the only place that makes use of pub section in lldb — https://github.com/llvm/llvm-project/blob/725115d7bba2faf3d0c21442f4661dea77b8a77c/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp#L2117-L2135

* "The -gsplit-dwarf option requires -ggnu-pubnames." — https://github.com/gcc-mirror/gcc/blob/5d2a360f0a541646abb11efdbabc33c6a04de7ee/gcc/opts.cc#L1205

* LLVM: Always emit `.debug_names` with dwarf 5 for Apple platforms — https://reviews.llvm.org/D118754

</p>
</details> 