### PR TITLE
When using existing fn as module, don't claim it doesn't exist

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2028,7 +2028,19 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     },
                 )
             });
-            (format!("use of undeclared crate or module `{ident}`"), suggestion)
+            if let Ok(binding) = self.early_resolve_ident_in_lexical_scope(
+                ident,
+                ScopeSet::All(ValueNS),
+                parent_scope,
+                None,
+                false,
+                ignore_binding,
+            ) {
+                let descr = binding.res().descr();
+                (format!("{descr} `{ident}` is not a crate or module"), suggestion)
+            } else {
+                (format!("use of undeclared crate or module `{ident}`"), suggestion)
+            }
         }
     }
 

--- a/tests/ui/suggestions/crate-or-module-typo.rs
+++ b/tests/ui/suggestions/crate-or-module-typo.rs
@@ -3,7 +3,7 @@
 use st::cell::Cell; //~ ERROR failed to resolve: use of undeclared crate or module `st`
 
 mod bar {
-    pub fn bar() { bar::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `bar`
+    pub fn bar() { bar::baz(); } //~ ERROR failed to resolve: function `bar` is not a crate or module
 
     fn baz() {}
 }

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -42,11 +42,11 @@ LL -     bar: st::cell::Cell<bool>
 LL +     bar: cell::Cell<bool>
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `bar`
+error[E0433]: failed to resolve: function `bar` is not a crate or module
   --> $DIR/crate-or-module-typo.rs:6:20
    |
 LL |     pub fn bar() { bar::baz(); }
-   |                    ^^^ use of undeclared crate or module `bar`
+   |                    ^^^ function `bar` is not a crate or module
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Tweak wording of module not found in resolve, when the name exists but belongs to a non-`mod` item.

Fix #81232.