### PR TITLE
Fix ambiguous cases of multiple & in elided self lifetimes

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2136,8 +2136,10 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                     // We found `self` elision.
                     Set1::One(lifetime) => Elision::Self_(lifetime),
                     // `self` itself had ambiguous lifetimes, e.g.
-                    // &Box<&Self>
-                    Set1::Many => Elision::None,
+                    // &Box<&Self>. In this case we won't consider
+                    // taking an alternative parameter lifetime; just avoid elision
+                    // entirely.
+                    Set1::Many => Elision::Err,
                     // We do not have `self` elision: disregard the `Elision::Param` that we may
                     // have found.
                     Set1::Empty => Elision::None,

--- a/tests/crashes/122903-1.rs
+++ b/tests/crashes/122903-1.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #122903
 impl Struct {
-    async fn box_box_ref_Struct(
-        self: Box<Box<Self, impl FnMut(&mut Box<Box<Self, impl FnMut(&mut Self)>>)>>,
+    fn box_box_ref_Struct(
+        self: impl FnMut(Box<impl FnMut(&mut Self)>),
     ) -> &u32 {
         f
     }

--- a/tests/crashes/122903-2.rs
+++ b/tests/crashes/122903-2.rs
@@ -1,9 +1,0 @@
-//@ known-bug: #122903
-
-impl Struct {
-    async fn box_box_ref_Struct(
-        self: Box<Box<Self, impl FnMut(&mut Box<Box<Self, impl FnMut(&mut Self)>>)>>
-    ) -> &u32 {
-        f
-    }
-}

--- a/tests/ui/self/elision/ignore-non-reference-lifetimes.rs
+++ b/tests/ui/self/elision/ignore-non-reference-lifetimes.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+struct Foo<'a>(&'a str);
+
+impl<'b> Foo<'b> {
+    fn a<'a>(self: Self, a: &'a str) -> &str {
+        a
+    }
+    fn b<'a>(self: Foo<'b>, a: &'a str) -> &str {
+        a
+    }
+}
+
+struct Foo2<'a>(&'a u32);
+impl<'a> Foo2<'a> {
+    fn foo(self: &Self) -> &u32 { self.0 } // ok
+    fn bar(self: &Foo2<'a>) -> &u32 { self.0 } // ok (do not look into `Foo`)
+    fn baz2(self: Self, arg: &u32) -> &u32 { arg } // use lt from `arg`
+    fn baz3(self: Foo2<'a>, arg: &u32) -> &u32 { arg } // use lt from `arg`
+}
+
+fn main() {}

--- a/tests/ui/self/elision/multiple-ref-self-async.rs
+++ b/tests/ui/self/elision/multiple-ref-self-async.rs
@@ -1,4 +1,3 @@
-//@ check-pass
 //@ edition:2018
 
 #![feature(arbitrary_self_types)]
@@ -21,22 +20,27 @@ impl Struct {
     // Test using multiple `&Self`:
 
     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 }

--- a/tests/ui/self/elision/multiple-ref-self-async.stderr
+++ b/tests/ui/self/elision/multiple-ref-self-async.stderr
@@ -1,0 +1,63 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:22:74
+   |
+LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+   |                                           ------------------     ---     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     async fn wrap_ref_Self_ref_Self<'a>(self: Wrap<&'a Self, &'a Self>, f: &'a u8) -> &'a u8 {
+   |                                    ++++             ++        ++            ++         ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:27:84
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                               -----------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self<'a>(self: Box<Wrap<&'a Self, &'a Self>>, f: &'a u32) -> &'a u32 {
+   |                                        ++++                 ++        ++             ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:32:84
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                               -----------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self<'a>(self: Pin<Wrap<&'a Self, &'a Self>>, f: &'a u32) -> &'a u32 {
+   |                                        ++++                 ++        ++             ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:37:93
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                   ----------------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self<'a>(self: Box<Box<Wrap<&'a Self, &'a Self>>>, f: &'a u32) -> &'a u32 {
+   |                                            ++++                     ++        ++              ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:42:93
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                   ----------------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self<'a>(self: Box<Pin<Wrap<&'a Self, &'a Self>>>, f: &'a u32) -> &'a u32 {
+   |                                            ++++                     ++        ++              ++          ++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/self/elision/multiple-ref-self.rs
+++ b/tests/ui/self/elision/multiple-ref-self.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 #![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
@@ -20,22 +18,27 @@ impl Struct {
     // Test using multiple `&Self`:
 
     fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 }

--- a/tests/ui/self/elision/multiple-ref-self.stderr
+++ b/tests/ui/self/elision/multiple-ref-self.stderr
@@ -1,0 +1,63 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self.rs:20:68
+   |
+LL |     fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+   |                                     ------------------     ---     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn wrap_ref_Self_ref_Self<'a>(self: Wrap<&'a Self, &'a Self>, f: &'a u8) -> &'a u8 {
+   |                              ++++             ++        ++            ++         ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self.rs:25:78
+   |
+LL |     fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                         -----------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn box_wrap_ref_Self_ref_Self<'a>(self: Box<Wrap<&'a Self, &'a Self>>, f: &'a u32) -> &'a u32 {
+   |                                  ++++                 ++        ++             ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self.rs:30:78
+   |
+LL |     fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                         -----------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn pin_wrap_ref_Self_ref_Self<'a>(self: Pin<Wrap<&'a Self, &'a Self>>, f: &'a u32) -> &'a u32 {
+   |                                  ++++                 ++        ++             ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self.rs:35:87
+   |
+LL |     fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                             ----------------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn box_box_wrap_ref_Self_ref_Self<'a>(self: Box<Box<Wrap<&'a Self, &'a Self>>>, f: &'a u32) -> &'a u32 {
+   |                                      ++++                     ++        ++              ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self.rs:40:87
+   |
+LL |     fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                             ----------------------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn box_pin_wrap_ref_Self_ref_Self<'a>(self: Box<Pin<Wrap<&'a Self, &'a Self>>>, f: &'a u32) -> &'a u32 {
+   |                                      ++++                     ++        ++              ++          ++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/self/elision/no-shadow-pin-self.rs
+++ b/tests/ui/self/elision/no-shadow-pin-self.rs
@@ -1,0 +1,17 @@
+use std::pin::Pin;
+trait Trait {
+    fn method<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
+        f
+    }
+}
+
+impl<P> Trait for Pin<P> {
+    // This should not hide `&Self`, which would cause this to compile.
+    fn method(self: Pin<&Self>, f: &u32) -> &u32 {
+        //~^ ERROR `impl` item signature doesn't match `trait`
+        f
+        //~^ ERROR lifetime may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/self/elision/no-shadow-pin-self.stderr
+++ b/tests/ui/self/elision/no-shadow-pin-self.stderr
@@ -1,0 +1,32 @@
+error: `impl` item signature doesn't match `trait` item signature
+  --> $DIR/no-shadow-pin-self.rs:10:5
+   |
+LL |     fn method<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
+   |     ------------------------------------------------------ expected `fn(Pin<&'1 Pin<P>>, &'a u32) -> &'a u32`
+...
+LL |     fn method(self: Pin<&Self>, f: &u32) -> &u32 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(Pin<&'1 Pin<P>>, &'2 u32) -> &'1 u32`
+   |
+   = note: expected signature `fn(Pin<&'1 Pin<P>>, &'a u32) -> &'a u32`
+              found signature `fn(Pin<&'1 Pin<P>>, &'2 u32) -> &'1 u32`
+   = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+   = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
+
+error: lifetime may not live long enough
+  --> $DIR/no-shadow-pin-self.rs:12:9
+   |
+LL |     fn method(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                         -          - let's call the lifetime of this reference `'1`
+   |                         |
+   |                         let's call the lifetime of this reference `'2`
+LL |
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn method<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
+   |              ++++                       ++          ++
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/self/elision/ref-assoc-async.rs
+++ b/tests/ui/self/elision/ref-assoc-async.rs
@@ -1,5 +1,4 @@
 //@ edition:2018
-//@ check-pass
 
 #![allow(non_snake_case)]
 
@@ -18,22 +17,27 @@ impl Trait for Struct {
 impl Struct {
     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 }
 

--- a/tests/ui/self/elision/ref-assoc-async.stderr
+++ b/tests/ui/self/elision/ref-assoc-async.stderr
@@ -1,0 +1,77 @@
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc-async.rs:19:9
+   |
+LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+   |                                  -                                 - let's call the lifetime of this reference `'1`
+   |                                  |
+   |                                  let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     async fn ref_AssocType<'a>(self: &'a <Struct as Trait>::AssocType, f: &'a u32) -> &u32 {
+   |                           ++++        ++                                   ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc-async.rs:24:9
+   |
+LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                          -                                  - let's call the lifetime of this reference `'1`
+   |                                          |
+   |                                          let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     async fn box_ref_AssocType<'a>(self: Box<&'a <Struct as Trait>::AssocType>, f: &'a u32) -> &u32 {
+   |                               ++++            ++                                    ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc-async.rs:29:9
+   |
+LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                          -                                  - let's call the lifetime of this reference `'1`
+   |                                          |
+   |                                          let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     async fn pin_ref_AssocType<'a>(self: Pin<&'a <Struct as Trait>::AssocType>, f: &'a u32) -> &u32 {
+   |                               ++++            ++                                    ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc-async.rs:34:9
+   |
+LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                  -                                   - let's call the lifetime of this reference `'1`
+   |                                                  |
+   |                                                  let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     async fn box_box_ref_AssocType<'a>(self: Box<Box<&'a <Struct as Trait>::AssocType>>, f: &'a u32) -> &u32 {
+   |                                   ++++                ++                                     ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc-async.rs:39:9
+   |
+LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                  -                                   - let's call the lifetime of this reference `'1`
+   |                                                  |
+   |                                                  let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     async fn box_pin_ref_AssocType<'a>(self: Box<Pin<&'a <Struct as Trait>::AssocType>>, f: &'a u32) -> &u32 {
+   |                                   ++++                ++                                     ++
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/self/elision/ref-assoc.rs
+++ b/tests/ui/self/elision/ref-assoc.rs
@@ -1,5 +1,3 @@
-//@ check-pass
-
 #![allow(non_snake_case)]
 
 use std::pin::Pin;
@@ -17,22 +15,27 @@ impl Trait for Struct {
 impl Struct {
     fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 
     fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
         f
+        //~^ ERROR lifetime may not live long enough
     }
 }
 

--- a/tests/ui/self/elision/ref-assoc.stderr
+++ b/tests/ui/self/elision/ref-assoc.stderr
@@ -1,0 +1,77 @@
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc.rs:17:9
+   |
+LL |     fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+   |                            -                                 - let's call the lifetime of this reference `'1`
+   |                            |
+   |                            let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn ref_AssocType<'a>(self: &<Struct as Trait>::AssocType, f: &'a u32) -> &'a u32 {
+   |                     ++++                                          ++          ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc.rs:22:9
+   |
+LL |     fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                    -                                  - let's call the lifetime of this reference `'1`
+   |                                    |
+   |                                    let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn box_ref_AssocType<'a>(self: Box<&<Struct as Trait>::AssocType>, f: &'a u32) -> &'a u32 {
+   |                         ++++                                               ++          ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc.rs:27:9
+   |
+LL |     fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                    -                                  - let's call the lifetime of this reference `'1`
+   |                                    |
+   |                                    let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn pin_ref_AssocType<'a>(self: Pin<&<Struct as Trait>::AssocType>, f: &'a u32) -> &'a u32 {
+   |                         ++++                                               ++          ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc.rs:32:9
+   |
+LL |     fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                            -                                   - let's call the lifetime of this reference `'1`
+   |                                            |
+   |                                            let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn box_box_ref_AssocType<'a>(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &'a u32) -> &'a u32 {
+   |                             ++++                                                    ++          ++
+
+error: lifetime may not live long enough
+  --> $DIR/ref-assoc.rs:37:9
+   |
+LL |     fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                            -                                   - let's call the lifetime of this reference `'1`
+   |                                            |
+   |                                            let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn box_pin_ref_AssocType<'a>(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &'a u32) -> &'a u32 {
+   |                             ++++                                                    ++          ++
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/self/elision/ref-self-multi.rs
+++ b/tests/ui/self/elision/ref-self-multi.rs
@@ -1,5 +1,3 @@
-//@ run-pass
-
 #![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 #![allow(unused)]
@@ -18,10 +16,12 @@ impl<T, P> Deref for Wrap<T, P> {
 
 impl Struct {
     fn ref_box_ref_Self(self: &Box<&Self>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 
     fn ref_wrap_ref_Self(self: &Wrap<&Self, u32>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
         f
     }
 }

--- a/tests/ui/self/elision/ref-self-multi.rs
+++ b/tests/ui/self/elision/ref-self-multi.rs
@@ -1,0 +1,29 @@
+//@ run-pass
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+use std::marker::PhantomData;
+use std::ops::Deref;
+
+struct Struct { }
+
+struct Wrap<T, P>(T, PhantomData<P>);
+
+impl<T, P> Deref for Wrap<T, P> {
+    type Target = T;
+    fn deref(&self) -> &T { &self.0 }
+}
+
+impl Struct {
+    fn ref_box_ref_Self(self: &Box<&Self>, f: &u32) -> &u32 {
+        f
+    }
+
+    fn ref_wrap_ref_Self(self: &Wrap<&Self, u32>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/tests/ui/self/elision/ref-self-multi.stderr
+++ b/tests/ui/self/elision/ref-self-multi.stderr
@@ -1,0 +1,27 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-multi.rs:18:56
+   |
+LL |     fn ref_box_ref_Self(self: &Box<&Self>, f: &u32) -> &u32 {
+   |                               -----------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn ref_box_ref_Self<'a>(self: &'a Box<&'a Self>, f: &'a u32) -> &'a u32 {
+   |                        ++++        ++      ++            ++          ++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-multi.rs:23:63
+   |
+LL |     fn ref_wrap_ref_Self(self: &Wrap<&Self, u32>, f: &u32) -> &u32 {
+   |                                -----------------     ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `self`'s 2 lifetimes or `f`
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn ref_wrap_ref_Self<'a>(self: &'a Wrap<&'a Self, u32>, f: &'a u32) -> &'a u32 {
+   |                         ++++        ++       ++                 ++          ++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/self/elision/ref-self.fixed
+++ b/tests/ui/self/elision/ref-self.fixed
@@ -1,4 +1,6 @@
 //@ run-rustfix
+//@ edition:2018
+
 #![feature(arbitrary_self_types)]
 #![allow(non_snake_case, dead_code)]
 
@@ -53,6 +55,11 @@ impl Struct {
     }
 
     fn wrap_ref_Self_Self<'a>(self: Wrap<&Self, Self>, f: &'a u8) -> &'a u8 {
+        f
+        //~^ ERROR lifetime may not live long enough
+    }
+
+    fn ref_box_Self<'a>(self: &Box<Self>, f: &'a u32) -> &'a u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-self.rs
+++ b/tests/ui/self/elision/ref-self.rs
@@ -1,4 +1,6 @@
 //@ run-rustfix
+//@ edition:2018
+
 #![feature(arbitrary_self_types)]
 #![allow(non_snake_case, dead_code)]
 
@@ -53,6 +55,11 @@ impl Struct {
     }
 
     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+        f
+        //~^ ERROR lifetime may not live long enough
+    }
+
+    fn ref_box_Self(self: &Box<Self>, f: &u32) -> &u32 {
         f
         //~^ ERROR lifetime may not live long enough
     }

--- a/tests/ui/self/elision/ref-self.stderr
+++ b/tests/ui/self/elision/ref-self.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:24:9
+  --> $DIR/ref-self.rs:26:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                 -         - let's call the lifetime of this reference `'1`
@@ -14,7 +14,7 @@ LL |     fn ref_self<'a>(&self, f: &'a u32) -> &'a u32 {
    |                ++++            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:31:9
+  --> $DIR/ref-self.rs:33:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                       -         - let's call the lifetime of this reference `'1`
@@ -29,7 +29,7 @@ LL |     fn ref_Self<'a>(self: &Self, f: &'a u32) -> &'a u32 {
    |                ++++                  ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:36:9
+  --> $DIR/ref-self.rs:38:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -44,7 +44,7 @@ LL |     fn box_ref_Self<'a>(self: Box<&Self>, f: &'a u32) -> &'a u32 {
    |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:41:9
+  --> $DIR/ref-self.rs:43:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                               -          - let's call the lifetime of this reference `'1`
@@ -59,7 +59,7 @@ LL |     fn pin_ref_Self<'a>(self: Pin<&Self>, f: &'a u32) -> &'a u32 {
    |                    ++++                       ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:46:9
+  --> $DIR/ref-self.rs:48:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -74,7 +74,7 @@ LL |     fn box_box_ref_Self<'a>(self: Box<Box<&Self>>, f: &'a u32) -> &'a u32 {
    |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:51:9
+  --> $DIR/ref-self.rs:53:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                       -           - let's call the lifetime of this reference `'1`
@@ -89,7 +89,7 @@ LL |     fn box_pin_ref_Self<'a>(self: Box<Pin<&Self>>, f: &'a u32) -> &'a u32 {
    |                        ++++                            ++          ++
 
 error: lifetime may not live long enough
-  --> $DIR/ref-self.rs:56:9
+  --> $DIR/ref-self.rs:58:9
    |
 LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                      -                - let's call the lifetime of this reference `'1`
@@ -103,5 +103,20 @@ help: consider introducing a named lifetime parameter and update trait if needed
 LL |     fn wrap_ref_Self_Self<'a>(self: Wrap<&Self, Self>, f: &'a u8) -> &'a u8 {
    |                          ++++                              ++         ++
 
-error: aborting due to 7 previous errors
+error: lifetime may not live long enough
+  --> $DIR/ref-self.rs:63:9
+   |
+LL |     fn ref_box_Self(self: &Box<Self>, f: &u32) -> &u32 {
+   |                           -              - let's call the lifetime of this reference `'1`
+   |                           |
+   |                           let's call the lifetime of this reference `'2`
+LL |         f
+   |         ^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter and update trait if needed
+   |
+LL |     fn ref_box_Self<'a>(self: &Box<Self>, f: &'a u32) -> &'a u32 {
+   |                    ++++                       ++          ++
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
This change proposes simpler rules to identify the lifetime on `self` parameters which may be used to elide a return type lifetime.

## The old rules

(copied from [this comment](https://github.com/rust-lang/rust/pull/117967#discussion_r1420554242))

Most of the code can be found in [late.rs](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_resolve/late.rs.html) and acts on AST types. The function [resolve_fn_params](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_resolve/late.rs.html#2006), in the success case, returns a single lifetime which can be used to elide the lifetime of return types.

Here's how:
* If the first parameter is called self then we search that parameter using "`self` search rules", below
* If no unique applicable lifetime was found, search all other parameters using "regular parameter search rules", below

(In practice the code does extra work to assemble good diagnostic information, so it's not quite laid out like the above.)

### `self` search rules

This is primarily handled in [find_lifetime_for_self](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_resolve/late.rs.html#2118) , and is described slightly [here](https://github.com/rust-lang/rust/issues/117715#issuecomment-1813115477) already. The code:

1. Recursively walks the type of the `self` parameter (there's some complexity about resolving various special cases, but it's essentially just walking the type as far as I can see)
2. Each time we find a reference anywhere in the type, if the **direct** referent is `Self` (either spelled `Self` or by some alias resolution which I don't fully understand), then we'll add that to a set of candidate lifetimes
3. If there's exactly one such unique lifetime candidate found, we return this lifetime.

### Regular parameter search rules

1. Find all the lifetimes in each parameter, including implicit, explicit etc.
2. If there's exactly one parameter containing lifetimes, and if that parameter contains exactly one (unique) lifetime, *and if we didn't find a `self` lifetime parameter already*, we'll return this lifetime.

## The new rules

There are no changes to the "regular parameter search rules" or to the overall flow, only to the `self` search rules which are now:

1. Recursively walks the type of the `self` parameter, searching for lifetimes of reference types whose referent **contains** `Self`.[^1]
2. Keep a record of:
   * Whether 0, 1 or n unique lifetimes are found on references encountered during the walk
4. If no lifetime was found, we don't return a lifetime. (This means other parameters' lifetimes may be used for return type lifetime elision).
5. If there's one lifetime found, we return the lifetime.
6. If multiple lifetimes were found, we abort elision entirely (other parameters' lifetimes won't be used).

[^1]: this prevents us from considering lifetimes from inside of the self-type

## Examples that were accepted before and will now be rejected

```rust
fn a(self: &Box<&Self>) -> &u32
fn b(self: &Pin<&mut Self>) -> &String
fn c(self: &mut &Self) -> Option<&Self>
fn d(self: &mut &Box<Self>, arg: &usize) -> &usize // previously used the lt from arg
```

### Examples that change the elided lifetime

```rust
fn e(self: &mut Box<Self>, arg: &usize) -> &usize
//         ^ new                ^ previous
```

## Examples that were rejected before and will now be accepted

```rust
fn f(self: &Box<Self>) -> &u32
```

---

*edit: old PR description:*

```rust
  struct Concrete(u32);

  impl Concrete {
      fn m(self: &Box<Self>) -> &u32 {
          &self.0
      }
  }
```

resulted in a confusing error.

```rust
  impl Concrete {
      fn n(self: &Box<&Self>) -> &u32 {
          &self.0
      }
  }
```

resulted in no error or warning, despite apparent ambiguity over the elided lifetime.

Fixes https://github.com/rust-lang/rust/issues/117715