### PR TITLE
Stabilize `ptr::addr_eq`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -140,7 +140,6 @@
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(pattern)]
-#![feature(ptr_addr_eq)]
 #![feature(ptr_internals)]
 #![feature(ptr_metadata)]
 #![feature(ptr_sub_ptr)]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1898,14 +1898,15 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// # Examples
 ///
 /// ```
-/// #![feature(ptr_addr_eq)]
+/// use std::ptr;
 ///
 /// let whole: &[i32; 3] = &[1, 2, 3];
 /// let first: &i32 = &whole[0];
-/// assert!(std::ptr::addr_eq(whole, first));
-/// assert!(!std::ptr::eq::<dyn std::fmt::Debug>(whole, first));
+///
+/// assert!(ptr::addr_eq(whole, first));
+/// assert!(!ptr::eq::<dyn std::fmt::Debug>(whole, first));
 /// ```
-#[unstable(feature = "ptr_addr_eq", issue = "116324")]
+#[stable(feature = "ptr_addr_eq", since = "CURRENT_RUSTC_VERSION")]
 #[inline(always)]
 #[must_use = "pointer comparison produces a value"]
 pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {


### PR DESCRIPTION
This PR stabilize the `ptr_addr_eq` library feature, representing:

```rust
// core::ptr

pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool;
```

FCP has already started [on the tracking issue](https://github.com/rust-lang/rust/issues/116324#issuecomment-1813008697) and is waiting on the final period comment.

Note: stabilizing this feature is somewhat of requirement for a new T-lang lint, cf. https://github.com/rust-lang/rust/pull/117758#issuecomment-1813183686.