### PR TITLE
[perf] test size reduction from compressing libstd's debuginfo

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -2093,6 +2093,12 @@ impl<'a> Builder<'a> {
             // break when incremental compilation is enabled. So this overrides the "no inlining
             // during incremental builds" heuristic for the standard library.
             rustflags.arg("-Zinline-mir");
+
+            // Compress the debuginfo in the standard library on linux, to reduce its size, and
+            // speed up linking.
+            if target.contains("linux") && compiler.stage >= 1 {
+                rustflags.arg("-Zdebuginfo-compression=zlib");
+            }
         }
 
         // set rustc args passed from command line


### PR DESCRIPTION
In my local tests this reduces the size of `libstd.so` quite a bit (but my config is not the same as a `dist` build). The debugging experience at least on LLDB17 didn't seem to be different in any noticeable way, it's as good / as bad as without compression apparently. I also only tried with `zlib`, not `zstd` which would require more changes to CI.

Let's try on CI to see the actual size difference on real artifacts. We'll see if this would also slightly improve bfd linking times for regular programs, because there's less debuginfo to copy from the standard library (if the linker doesn't then decompress it, and which may depend on the compression used when compiling the program itself).

(Let's also see if some debuginfo tests are impacted on CI)

r? @ghost