### PR TITLE
Add VarDebugInfo to Stable MIR

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -18,7 +18,10 @@ use rustc_middle::ty::{self, Instance, ParamEnv, ScalarInt, Ty, TyCtxt, Variance
 use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_target::abi::FieldIdx;
 use stable_mir::mir::mono::InstanceDef;
-use stable_mir::mir::{Body, CopyNonOverlapping, Statement, UserTypeProjection, VariantIdx};
+use stable_mir::mir::{
+    Body, ConstOperand, CopyNonOverlapping, Statement, UserTypeProjection, VarDebugInfoFragment,
+    VariantIdx,
+};
 use stable_mir::ty::{
     AdtDef, AdtKind, ClosureDef, ClosureKind, Const, ConstId, ConstantKind, EarlyParamRegion,
     FloatTy, FnDef, GenericArgs, GenericParamDef, IntTy, LineInfo, Movability, RigidTy, Span,
@@ -444,7 +447,47 @@ impl<'tcx> Stable<'tcx> for mir::Body<'tcx> {
                 })
                 .collect(),
             self.arg_count,
+            self.var_debug_info.iter().map(|info| info.stable(tables)).collect(),
         )
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::VarDebugInfo<'tcx> {
+    type T = stable_mir::mir::VarDebugInfo;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        stable_mir::mir::VarDebugInfo {
+            name: self.name.to_string(),
+            source_info: stable_mir::mir::SourceInfo {
+                span: self.source_info.span.stable(tables),
+                scope: self.source_info.scope.into(),
+            },
+            composite: {
+                if let Some(composite) = &self.composite {
+                    Some(VarDebugInfoFragment {
+                        ty: composite.ty.stable(tables),
+                        projection: composite.projection.iter().map(|e| e.stable(tables)).collect(),
+                    })
+                } else {
+                    None
+                }
+            },
+            value: {
+                match self.value {
+                    mir::VarDebugInfoContents::Place(place) => {
+                        stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
+                    }
+                    mir::VarDebugInfoContents::Const(const_operand) => {
+                        let op = ConstOperand {
+                            span: const_operand.span.stable(tables),
+                            user_ty: const_operand.user_ty.map(|index| index.as_usize()),
+                            const_: const_operand.const_.stable(tables),
+                        };
+                        stable_mir::mir::VarDebugInfoContents::Const(op)
+                    }
+                }
+            },
+            argument_index: self.argument_index,
+        }
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -457,35 +457,9 @@ impl<'tcx> Stable<'tcx> for mir::VarDebugInfo<'tcx> {
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
         stable_mir::mir::VarDebugInfo {
             name: self.name.to_string(),
-            source_info: stable_mir::mir::SourceInfo {
-                span: self.source_info.span.stable(tables),
-                scope: self.source_info.scope.into(),
-            },
-            composite: {
-                if let Some(composite) = &self.composite {
-                    Some(VarDebugInfoFragment {
-                        ty: composite.ty.stable(tables),
-                        projection: composite.projection.iter().map(|e| e.stable(tables)).collect(),
-                    })
-                } else {
-                    None
-                }
-            },
-            value: {
-                match self.value {
-                    mir::VarDebugInfoContents::Place(place) => {
-                        stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
-                    }
-                    mir::VarDebugInfoContents::Const(const_operand) => {
-                        let op = ConstOperand {
-                            span: const_operand.span.stable(tables),
-                            user_ty: const_operand.user_ty.map(|index| index.as_usize()),
-                            const_: const_operand.const_.stable(tables),
-                        };
-                        stable_mir::mir::VarDebugInfoContents::Const(op)
-                    }
-                }
-            },
+            source_info: self.source_info.stable(tables),
+            composite: self.composite.as_ref().map(|composite| composite.stable(tables)),
+            value: self.value.stable(tables),
             argument_index: self.argument_index,
         }
     }
@@ -495,6 +469,42 @@ impl<'tcx> Stable<'tcx> for mir::Statement<'tcx> {
     type T = stable_mir::mir::Statement;
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
         Statement { kind: self.kind.stable(tables), span: self.source_info.span.stable(tables) }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::SourceInfo {
+    type T = stable_mir::mir::SourceInfo;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        stable_mir::mir::SourceInfo { span: self.span.stable(tables), scope: self.scope.into() }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::VarDebugInfoFragment<'tcx> {
+    type T = stable_mir::mir::VarDebugInfoFragment;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        VarDebugInfoFragment {
+            ty: self.ty.stable(tables),
+            projection: self.projection.iter().map(|e| e.stable(tables)).collect(),
+        }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::VarDebugInfoContents<'tcx> {
+    type T = stable_mir::mir::VarDebugInfoContents;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            mir::VarDebugInfoContents::Place(place) => {
+                stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
+            }
+            mir::VarDebugInfoContents::Const(const_operand) => {
+                let op = ConstOperand {
+                    span: const_operand.span.stable(tables),
+                    user_ty: const_operand.user_ty.map(|index| index.as_usize()),
+                    const_: const_operand.const_.stable(tables),
+                };
+                stable_mir::mir::VarDebugInfoContents::Const(op)
+            }
+        }
     }
 }
 

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -391,12 +391,14 @@ pub trait MirVisitor {
     }
 
     fn super_var_debug_info(&mut self, var_debug_info: &VarDebugInfo) {
-        self.visit_span(&var_debug_info.source_info.span);
-        let location = Location(var_debug_info.source_info.span);
-        if let Some(composite) = &var_debug_info.composite {
+        let VarDebugInfo { source_info, composite, value, name: _, argument_index: _ } =
+            var_debug_info;
+        self.visit_span(&source_info.span);
+        let location = Location(source_info.span);
+        if let Some(composite) = composite {
             self.visit_ty(&composite.ty, location);
         }
-        match &var_debug_info.value {
+        match value {
             VarDebugInfoContents::Place(place) => {
                 self.visit_place(place, PlaceContext::NON_USE, location);
             }


### PR DESCRIPTION
Previously we omitted `VarDebugInfo` because we didn't have `Projection` now that https://github.com/rust-lang/rust/pull/117517 is merged it's possible to add `VarDebugInfo` information in `Body`. This PR adds stable version of the `VarDebugInfo` to `Body`

r? @celinval 