### PR TITLE
test: Add test for async-move in 2015 Rust proc macro

### DIFF
--- a/tests/ui/proc-macro/auxiliary/edition-gated-async-move-syntax.rs
+++ b/tests/ui/proc-macro/auxiliary/edition-gated-async-move-syntax.rs
@@ -1,0 +1,39 @@
+// force-host
+// no-prefer-dynamic
+
+// Proc macro helper for issue #89699, used by tests/ui/proc-macro/edition-gated-async-move-
+// syntax-issue89699.rs, emitting an `async move` closure. This syntax is only available in
+// editions 2018 and up, but is used in edition 2015 in the test.
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro_attribute]
+pub fn foo(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let tt = item.into_iter().next().unwrap();
+    let sp = tt.span();
+    let mut arg = TokenStream::new();
+    let mut g = Group::new(Delimiter::Brace, TokenStream::new());
+    g.set_span(sp);
+    arg.extend([
+        TokenTree::Ident(Ident::new("async", sp)),
+        TokenTree::Ident(Ident::new("move", sp)),
+        TokenTree::Group(g),
+    ]);
+    let mut body = TokenStream::new();
+    body.extend([
+        TokenTree::Ident(Ident::new("async_main", sp)),
+        TokenTree::Group(Group::new(Delimiter::Parenthesis, arg)),
+    ]);
+
+    let mut ret = TokenStream::new();
+    ret.extend([
+        TokenTree::Ident(Ident::new("fn", sp)),
+        TokenTree::Ident(Ident::new("main", sp)),
+        TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
+        TokenTree::Group(Group::new(Delimiter::Brace, body)),
+    ]);
+    ret
+}

--- a/tests/ui/proc-macro/edition-gated-async-move-syntax-issue89699.rs
+++ b/tests/ui/proc-macro/edition-gated-async-move-syntax-issue89699.rs
@@ -1,0 +1,10 @@
+// aux-build:edition-gated-async-move-syntax.rs
+// edition: 2015
+
+// Non-regression test for issue #89699, where a proc-macro emitting syntax only available in
+// edition 2018 and up (`async move`) is used on edition 2015
+
+extern crate edition_gated_async_move_syntax;
+
+#[edition_gated_async_move_syntax::foo]
+fn foo() {} //~ ERROR `async move` blocks are only allowed in Rust 2018 or later

--- a/tests/ui/proc-macro/edition-gated-async-move-syntax-issue89699.stderr
+++ b/tests/ui/proc-macro/edition-gated-async-move-syntax-issue89699.stderr
@@ -1,0 +1,8 @@
+error: `async move` blocks are only allowed in Rust 2018 or later
+  --> $DIR/edition-gated-async-move-syntax-issue89699.rs:10:1
+   |
+LL | fn foo() {}
+   | ^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #89699

Ran cargo bisect-rustc to find when this was fixed exactly, which is in 474709a9a2a74a8bcf0055fadb335d0ca0d2d939
