### PR TITLE
bootstrap: only show PGO warnings when verbose

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -887,7 +887,9 @@ impl Step for Rustc {
         } else if let Some(path) = &builder.config.rust_profile_use {
             if compiler.stage == 1 {
                 cargo.rustflag(&format!("-Cprofile-use={path}"));
-                cargo.rustflag("-Cllvm-args=-pgo-warn-missing-function");
+                if builder.is_verbose() {
+                    cargo.rustflag("-Cllvm-args=-pgo-warn-missing-function");
+                }
                 true
             } else {
                 false


### PR DESCRIPTION
Building rustc with `--rust-profile-use` is currently dumping a lot of
warnings of "no profile data available for function" from `rustc_smir`
and `stable_mir`. These simply aren't exercised by the current profile-
gathering steps, but that's to be expected for new or experimental
functionality. I think for most people, these warnings will be just
noise, so it makes sense to only have them in verbose builds.
