### PR TITLE
On resolve error of `[rest..]`, suggest `[rest @ ..]`

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -603,6 +603,8 @@ struct DiagnosticMetadata<'ast> {
     /// Only used for better errors on `let <pat>: <expr, not type>;`.
     current_let_binding: Option<(Span, Option<Span>, Option<Span>)>,
 
+    current_pat: Option<&'ast Pat>,
+
     /// Used to detect possible `if let` written without `let` and to provide structured suggestion.
     in_if_condition: Option<&'ast Expr>,
 
@@ -702,6 +704,12 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
     }
     fn visit_expr(&mut self, expr: &'ast Expr) {
         self.resolve_expr(expr, None);
+    }
+    fn visit_pat(&mut self, p: &'ast Pat) {
+        let prev = self.diagnostic_metadata.current_pat;
+        self.diagnostic_metadata.current_pat = Some(p);
+        visit::walk_pat(self, p);
+        self.diagnostic_metadata.current_pat = prev;
     }
     fn visit_local(&mut self, local: &'ast Local) {
         let local_spans = match local.pat.kind {

--- a/tests/ui/match/issue-92100.stderr
+++ b/tests/ui/match/issue-92100.stderr
@@ -3,6 +3,11 @@ error[E0425]: cannot find value `a` in this scope
    |
 LL |         [a.., a] => {}
    |          ^ not found in this scope
+   |
+help: if you meant to collect the rest of the slice in `a`, use the at operator
+   |
+LL |         [a @ .., a] => {}
+   |            +
 
 error: aborting due to previous error
 

--- a/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.rs
+++ b/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.rs
@@ -1,0 +1,9 @@
+fn main() {
+    match &[1, 2, 3][..] {
+        [1, rest..] => println!("{rest:?}"),
+        //~^ ERROR cannot find value `rest` in this scope
+        //~| ERROR cannot find value `rest` in this scope
+        //~| ERROR `X..` patterns in slices are experimental
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.stderr
+++ b/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.stderr
@@ -1,0 +1,30 @@
+error[E0425]: cannot find value `rest` in this scope
+  --> $DIR/range-pattern-meant-to-be-slice-rest-pattern.rs:3:13
+   |
+LL |         [1, rest..] => println!("{rest:?}"),
+   |             ^^^^ not found in this scope
+   |
+help: if you meant to collect the rest of the slice in `rest`, use the at operator
+   |
+LL |         [1, rest @ ..] => println!("{rest:?}"),
+   |                  +
+
+error[E0425]: cannot find value `rest` in this scope
+  --> $DIR/range-pattern-meant-to-be-slice-rest-pattern.rs:3:35
+   |
+LL |         [1, rest..] => println!("{rest:?}"),
+   |                                   ^^^^ not found in this scope
+
+error[E0658]: `X..` patterns in slices are experimental
+  --> $DIR/range-pattern-meant-to-be-slice-rest-pattern.rs:3:13
+   |
+LL |         [1, rest..] => println!("{rest:?}"),
+   |             ^^^^^^
+   |
+   = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
+   = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0425, E0658.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/typeck/issue-105946.stderr
+++ b/tests/ui/typeck/issue-105946.stderr
@@ -3,6 +3,11 @@ error[E0425]: cannot find value `_y` in this scope
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |          ^^ not found in this scope
+   |
+help: if you meant to collect the rest of the slice in `_y`, use the at operator
+   |
+LL |     let [_y @ ..] = [Box::new(1), Box::new(2)];
+   |             +
 
 error[E0658]: `X..` patterns in slices are experimental
   --> $DIR/issue-105946.rs:6:10


### PR DESCRIPTION
When writing a pattern to collect multiple entries of a slice in a single binding, it is easy to misremember or typo the appropriate syntax to do so, instead writing the experimental `X..` pattern syntax. When we encounter a resolve error because `X` isn't available, we suggest `X @ ..` as an alternative.

```
error[E0425]: cannot find value `rest` in this scope
  --> $DIR/range-pattern-meant-to-be-slice-rest-pattern.rs:3:13
   |
LL |         [1, rest..] => println!("{rest:?}"),
   |             ^^^^ not found in this scope
   |
help: if you meant to collect the rest of the slice in `rest`, use the at operator
   |
LL |         [1, rest @ ..] => println!("{rest:?}"),
   |                  +
```

Fix #88404.