### PR TITLE
Fix const-fn check in const_eval

### DIFF
--- a/tests/ui/consts/const-eval/const-fn-slice.rs
+++ b/tests/ui/consts/const-eval/const-fn-slice.rs
@@ -1,0 +1,11 @@
+//check-pass
+
+#![feature(const_trait_impl)]
+#![feature(fn_traits)]
+const fn f() -> usize {
+    5
+}
+
+const fn main() {
+    let _ = [0; Fn::call(&f, ())];
+}


### PR DESCRIPTION
We were unable to capture constness of the `f` and ended up with ICE, this PR checks constness of the `callee`. I also don't understand why we are not checking constness via calling `call_kind` and capturing `FnCall`.

Fixes https://github.com/rust-lang/rust/issues/117795