### PR TITLE
Document behavior of `<dyn Any as Any>::type_id()`

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -115,6 +115,11 @@ use crate::intrinsics;
 pub trait Any: 'static {
     /// Gets the `TypeId` of `self`.
     ///
+    /// If called on a `dyn Any` trait object
+    /// (or a trait object of a subtrait of `Any`),
+    /// this returns the `TypeId` of the underlying
+    /// concrete type, not that of `dyn Any` itself.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
See also #57893

@rustbot label A-docs T-libs