### PR TITLE
Fix early param lifetimes in generic_const_exprs

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -35,7 +35,7 @@ use crate::session_diagnostics::{
     LifetimeReturnCategoryErr, RequireStaticErr, VarHereDenote,
 };
 
-use super::{OutlivesSuggestionBuilder, RegionName};
+use super::{OutlivesSuggestionBuilder, RegionName, RegionNameSource};
 use crate::region_infer::{BlameConstraint, ExtraConstraintInfo};
 use crate::{
     nll::ConstraintDescription,
@@ -763,7 +763,14 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         let err = LifetimeOutliveErr { span: *span };
         let mut diag = self.infcx.tcx.sess.create_err(err);
 
-        let fr_name = self.give_region_a_name(*fr).unwrap();
+        // In certain scenarios, such as the one described in issue #118021,
+        // we might encounter a lifetime that cannot be named.
+        // These situations are bound to result in errors.
+        // To prevent an immediate ICE, we opt to create a dummy name instead.
+        let fr_name = self.give_region_a_name(*fr).unwrap_or(RegionName {
+            name: kw::UnderscoreLifetime,
+            source: RegionNameSource::Static,
+        });
         fr_name.highlight_region_name(&mut diag);
         let outlived_fr_name = self.give_region_a_name(*outlived_fr).unwrap();
         outlived_fr_name.highlight_region_name(&mut diag);

--- a/tests/ui/borrowck/generic_const_early_param.rs
+++ b/tests/ui/borrowck/generic_const_early_param.rs
@@ -1,0 +1,16 @@
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete
+
+struct DataWrapper<'static> {
+    //~^ ERROR invalid lifetime parameter name: `'static`
+    data: &'a [u8; Self::SIZE],
+    //~^ ERROR use of undeclared lifetime name `'a`
+    //~^^ ERROR lifetime may not live long enough
+}
+
+impl DataWrapper<'a> {
+    //~^ ERROR undeclared lifetime
+    const SIZE: usize = 14;
+}
+
+fn main(){}

--- a/tests/ui/borrowck/generic_const_early_param.stderr
+++ b/tests/ui/borrowck/generic_const_early_param.stderr
@@ -1,0 +1,42 @@
+error[E0262]: invalid lifetime parameter name: `'static`
+  --> $DIR/generic_const_early_param.rs:4:20
+   |
+LL | struct DataWrapper<'static> {
+   |                    ^^^^^^^ 'static is a reserved lifetime name
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/generic_const_early_param.rs:6:12
+   |
+LL | struct DataWrapper<'static> {
+   |                    - help: consider introducing lifetime `'a` here: `'a,`
+LL |
+LL |     data: &'a [u8; Self::SIZE],
+   |            ^^ undeclared lifetime
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/generic_const_early_param.rs:11:18
+   |
+LL | impl DataWrapper<'a> {
+   |     -            ^^ undeclared lifetime
+   |     |
+   |     help: consider introducing lifetime `'a` here: `<'a>`
+
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/generic_const_early_param.rs:1:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: lifetime may not live long enough
+  --> $DIR/generic_const_early_param.rs:6:20
+   |
+LL |     data: &'a [u8; Self::SIZE],
+   |                    ^^^^^^^^^^ requires that `'_` must outlive `'static`
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0261, E0262.
+For more information about an error, try `rustc --explain E0261`.


### PR DESCRIPTION
In cases like below, we never actually be able to capture region name for two reasons, first `'static` becomes anonymous lifetime and second we never capture region if it doesn't have a name so this results in ICE. 
```
struct DataWrapper<'static> {
    data: &'a [u8; Self::SIZE],
}

impl DataWrapper<'a> {
```

Fixes https://github.com/rust-lang/rust/issues/118021