### PR TITLE
Add thinlto support to codegen, assembly and coverage tests

### DIFF
--- a/tests/assembly/thin-lto.rs
+++ b/tests/assembly/thin-lto.rs
@@ -1,0 +1,8 @@
+// compile-flags: -O -C lto=thin -C prefer-dynamic=no
+// only-x86_64-unknown-linux-gnu
+// assembly-output: emit-asm
+
+// CHECK: main
+
+pub fn main() {
+}

--- a/tests/codegen/thin-lto.rs
+++ b/tests/codegen/thin-lto.rs
@@ -1,0 +1,7 @@
+// compile-flags: -O -C lto=thin -C prefer-dynamic=no
+// only-x86_64-unknown-linux-gnu
+
+// CHECK: main
+
+pub fn main() {
+}

--- a/tests/coverage/thin-lto.cov-map
+++ b/tests/coverage/thin-lto.cov-map
@@ -1,0 +1,8 @@
+Function name: thin_lto::main
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 03, 01, 01, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 3, 1) to (start + 1, 2)
+

--- a/tests/coverage/thin-lto.coverage
+++ b/tests/coverage/thin-lto.coverage
@@ -1,0 +1,5 @@
+   LL|       |// compile-flags: -O -C lto=thin -C prefer-dynamic=no
+   LL|       |
+   LL|      1|pub fn main() {
+   LL|      1|}
+

--- a/tests/coverage/thin-lto.rs
+++ b/tests/coverage/thin-lto.rs
@@ -1,0 +1,4 @@
+// compile-flags: -O -C lto=thin -C prefer-dynamic=no
+
+pub fn main() {
+}


### PR DESCRIPTION
Using `--emit=llvm-ir` with thinlto usually result in multiple IR files.
Resolve test case failure issue reported in #113923.