### PR TITLE
Add `std::process::Child::terminate` as an alternative to `std::process::Child::kill`

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2019,6 +2019,47 @@ impl Child {
         self.handle.kill()
     }
 
+    /// Ask a child process to exit.
+    ///
+    /// On Unix platforms this sends SIGTERM, which can be blocked, handled, or ignored.
+    ///
+    /// On Windows, and other platforms where there isn't something analogous to SIGTERM, this just
+    /// executes `Child::kill`.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```no_run
+    /// #![feature(process_terminate)]
+    /// use std::process::{Child, Command};
+    /// use std::thread::sleep;
+    /// use std::time::Duration;
+    ///
+    /// let mut command = Command::new("yes");
+    /// let Ok(mut child) = command.spawn() else {
+    ///     println!("yes command didn't start");
+    ///     return;
+    /// };
+    /// 'outer: for kill in [Child::terminate, Child::kill] {
+    ///     kill(&mut child).expect("unable to send signal");
+    ///     for _ in 0..3 {
+    ///         if child.try_wait().unwrap().is_none() {
+    ///             sleep(Duration::from_secs(1));
+    ///             continue;
+    ///         }
+    ///         break 'outer;
+    ///     }
+    /// }
+    /// if child.try_wait().unwrap().is_none() {
+    ///     println!("child still hasn't exited");
+    /// }
+    /// ```
+    #[unstable(feature = "process_terminate", issue = "none")]
+    pub fn terminate(&mut self) -> io::Result<()> {
+        self.handle.terminate()
+    }
+
     /// Returns the OS-assigned process identifier associated with this child.
     ///
     /// # Examples

--- a/library/std/src/sys/unix/process/process_fuchsia.rs
+++ b/library/std/src/sys/unix/process/process_fuchsia.rs
@@ -165,6 +165,10 @@ impl Process {
         Ok(())
     }
 
+    pub fn terminate(&mut self) -> io::Result<()> {
+        self.kill()
+    }
+
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         use crate::sys::process::zircon::*;
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -812,13 +812,21 @@ impl Process {
     }
 
     pub fn kill(&mut self) -> io::Result<()> {
+        self.send_signal(libc::SIGKILL)
+    }
+
+    pub fn terminate(&mut self) -> io::Result<()> {
+        self.send_signal(libc::SIGTERM)
+    }
+
+    fn send_signal(&mut self, signal: c_int) -> io::Result<()> {
         // If we've already waited on this process then the pid can be recycled
         // and used for another process, and we probably shouldn't be killing
         // random processes, so return Ok because the process has exited already.
         if self.status.is_some() {
             Ok(())
         } else {
-            cvt(unsafe { libc::kill(self.pid, libc::SIGKILL) }).map(drop)
+            cvt(unsafe { libc::kill(self.pid, signal) }).map(drop)
         }
     }
 

--- a/library/std/src/sys/unix/process/process_vxworks.rs
+++ b/library/std/src/sys/unix/process/process_vxworks.rs
@@ -142,13 +142,21 @@ impl Process {
     }
 
     pub fn kill(&mut self) -> io::Result<()> {
+        self.send_signal(libc::SIGKILL)
+    }
+
+    pub fn terminate(&mut self) -> io::Result<()> {
+        self.send_signal(libc::SIGTERM)
+    }
+
+    fn send_signal(&mut self, signal: c_int) -> io::Result<()> {
         // If we've already waited on this process then the pid can be recycled
         // and used for another process, and we probably shouldn't be killing
         // random processes, so return Ok because the process has exited already.
         if self.status.is_some() {
             Ok(())
         } else {
-            cvt(unsafe { libc::kill(self.pid, libc::SIGKILL) }).map(drop)
+            cvt(unsafe { libc::kill(self.pid, signal) }).map(drop)
         }
     }
 

--- a/library/std/src/sys/unsupported/process.rs
+++ b/library/std/src/sys/unsupported/process.rs
@@ -207,6 +207,10 @@ impl Process {
         self.0
     }
 
+    pub fn terminate(&mut self) -> io::Result<()> {
+        self.0
+    }
+
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         self.0
     }

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -656,6 +656,10 @@ impl Process {
         Ok(())
     }
 
+    pub fn terminate(&mut self) -> io::Result<()> {
+        self.kill()
+    }
+
     pub fn id(&self) -> u32 {
         unsafe { c::GetProcessId(self.handle.as_raw_handle()) as u32 }
     }


### PR DESCRIPTION
I have frequently used `std::process::Child::kill` and/or `kill_on_drop(true)` since it's in the standard library, but I think it's probably better for people to use `SIGTERM` if they can. There's lots of use-cases where a subprocess might want to do some last-minute stuff before exiting, right?

Many cleanup steps, like closing files, are handled in Linux automatically, but sometimes a process might want to cleanup something through the network (logging, shared resources between machines).

Also, the standard Linux utility `kill` sends `SIGTERM` by default, and I've always understood that this is because `SIGKILL` should only be used if a process doesn't respond to `SIGTERM`.

The Python standard library module `subprocess` has some precedent for this: it provides `kill`, `terminate`, and `send_signal`. [1] I figure we could start by adding `terminate`, because that's probably the next-most-common signal that people use.

Let me know what you guys think: my understanding from the dev-guide is that making API Change Proposals is optional, and this is a pretty small change, so I figured I'd just send a PR.

By the way, I did consider implementing this as an extension to the Linux `ChildExt`, since `SIGTERM` is only applicable on Unix, but the Python library avoids this complexity by just implementing `terminate()` the same way as `kill()` on Windows and other platforms. I figured we might as well just follow the Python standard library here, it seems reasonable.

[1] https://docs.python.org/3/library/subprocess.html#subprocess.Popen.terminatehttps://docs.python.org/3/library/subprocess.html#subprocess.Popen.terminate