### PR TITLE
Lint pinned `#[must_use]` pointers (in particular, `Box<T>` where `T` is `#[must_use]`) in `unused_must_use`.

### DIFF
--- a/tests/ui/lint/unused/must_use-pin.rs
+++ b/tests/ui/lint/unused/must_use-pin.rs
@@ -1,0 +1,45 @@
+#![deny(unused_must_use)]
+
+use std::{ops::Deref, pin::Pin};
+
+#[must_use]
+struct MustUse;
+
+#[must_use]
+struct MustUsePtr<'a, T>(&'a T);
+
+impl<'a, T> Deref for MustUsePtr<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+fn pin_ref() -> Pin<&'static ()> {
+    Pin::new(&())
+}
+
+fn pin_ref_mut() -> Pin<&'static mut ()> {
+    Pin::new(unimplemented!())
+}
+
+fn pin_must_use_ptr() -> Pin<MustUsePtr<'static, ()>> {
+    Pin::new(MustUsePtr(&()))
+}
+
+fn pin_box() -> Pin<Box<()>> {
+    Box::pin(())
+}
+
+fn pin_box_must_use() -> Pin<Box<MustUse>> {
+    Box::pin(MustUse)
+}
+
+fn main() {
+    pin_ref();
+    pin_ref_mut();
+    pin_must_use_ptr(); //~ ERROR unused pinned `MustUsePtr` that must be used
+    pin_box();
+    pin_box_must_use(); //~ ERROR unused pinned boxed `MustUse` that must be used
+}

--- a/tests/ui/lint/unused/must_use-pin.stderr
+++ b/tests/ui/lint/unused/must_use-pin.stderr
@@ -1,0 +1,20 @@
+error: unused pinned `MustUsePtr` that must be used
+  --> $DIR/must_use-pin.rs:42:5
+   |
+LL |     pin_must_use_ptr();
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/must_use-pin.rs:1:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: unused pinned boxed `MustUse` that must be used
+  --> $DIR/must_use-pin.rs:44:5
+   |
+LL |     pin_box_must_use();
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes: #111458

This is motivated by a common async/await pattern:

```rs
fn foo() -> Pin<Box<dyn Future<Output = i32>>> {
    Box::pin(async { 42 })
}

// call `foo`, but forget to await the result
foo();
```

Unlike with `async fn` or return position `impl Future`, this does not currently warn the user that the `Future` is unused.

To fix this, I've extended the `unused_must_use` lint to catch `Pin<P>`, where `P` must be used. In particular, this applies to `Pin<Box<T>>`, where `T` must be used. I'm not sure if there are other pointers where this applies, but I can't think of any situation the user wouldn't want to be warned.