### PR TITLE
Explicitly unset $CARGO for compiletest

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1932,6 +1932,11 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
                 }
             }
         }
+
+        // Some UI tests trigger behavior in rustc where it reads $CARGO and changes behavior if it exists.
+        // To make the tests work that rely on it not being set, make sure it is not set.
+        cmd.env_remove("CARGO");
+
         cmd.env("RUSTC_BOOTSTRAP", "1");
         // Override the rustc version used in symbol hashes to reduce the amount of normalization
         // needed when diffing test output.


### PR DESCRIPTION
Some UI tests trigger behavior in rustc where it reads $CARGO and changes behavior if it exists. To make the tests work that rely on it not being set, make sure it is not set.

By default, this is not set, but people may do weird hacks that cause it to be set.

closes #118058