### PR TITLE
Structured `use` suggestion on privacy error

### DIFF
--- a/tests/ui/imports/issue-55884-2.stderr
+++ b/tests/ui/imports/issue-55884-2.stderr
@@ -13,17 +13,21 @@ note: ...and refers to the struct import `ParseOptions` which is defined here...
   --> $DIR/issue-55884-2.rs:13:9
    |
 LL | pub use parser::ParseOptions;
-   |         ^^^^^^^^^^^^^^^^^^^^ consider importing it directly
+   |         ^^^^^^^^^^^^^^^^^^^^ you could import this re-export
 note: ...and refers to the struct import `ParseOptions` which is defined here...
   --> $DIR/issue-55884-2.rs:6:13
    |
 LL |     pub use options::*;
-   |             ^^^^^^^^^^ consider importing it directly
+   |             ^^^^^^^^^^ you could import this re-export
 note: ...and refers to the struct `ParseOptions` which is defined here
   --> $DIR/issue-55884-2.rs:2:5
    |
 LL |     pub struct ParseOptions {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ you could import this directly
+help: import `ParseOptions` through the re-export
+   |
+LL | pub use parser::ParseOptions;
+   |         ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/private-std-reexport-suggest-public.fixed
+++ b/tests/ui/imports/private-std-reexport-suggest-public.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+#![allow(unused_imports)]
+fn main() {
+    use std::mem; //~ ERROR module import `mem` is private
+}
+
+pub mod foo {
+    use std::mem;
+}

--- a/tests/ui/imports/private-std-reexport-suggest-public.rs
+++ b/tests/ui/imports/private-std-reexport-suggest-public.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+#![allow(unused_imports)]
+fn main() {
+    use foo::mem; //~ ERROR module import `mem` is private
+}
+
+pub mod foo {
+    use std::mem;
+}

--- a/tests/ui/imports/private-std-reexport-suggest-public.stderr
+++ b/tests/ui/imports/private-std-reexport-suggest-public.stderr
@@ -1,0 +1,23 @@
+error[E0603]: module import `mem` is private
+  --> $DIR/private-std-reexport-suggest-public.rs:4:14
+   |
+LL |     use foo::mem;
+   |              ^^^ private module import
+   |
+note: the module import `mem` is defined here...
+  --> $DIR/private-std-reexport-suggest-public.rs:8:9
+   |
+LL |     use std::mem;
+   |         ^^^^^^^^
+note: ...and refers to the module `mem` which is defined here
+  --> $SRC_DIR/std/src/lib.rs:LL:COL
+   |
+   = note: you could import this directly
+help: import `mem` through the re-export
+   |
+LL |     use std::mem;
+   |         ~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0603`.

--- a/tests/ui/privacy/privacy2.stderr
+++ b/tests/ui/privacy/privacy2.stderr
@@ -19,7 +19,7 @@ note: ...and refers to the function `foo` which is defined here
   --> $DIR/privacy2.rs:16:1
    |
 LL | pub fn foo() {}
-   | ^^^^^^^^^^^^ consider importing it directly
+   | ^^^^^^^^^^^^ you could import this directly
 
 error: requires `sized` lang_item
 

--- a/tests/ui/proc-macro/disappearing-resolution.stderr
+++ b/tests/ui/proc-macro/disappearing-resolution.stderr
@@ -19,7 +19,11 @@ note: ...and refers to the derive macro `Empty` which is defined here
   --> $DIR/auxiliary/test-macros.rs:25:1
    |
 LL | pub fn empty_derive(_: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider importing it directly
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ you could import this directly
+help: import `Empty` directly
+   |
+LL | use test_macros::Empty;
+   |     ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
When encoutering a privacy error on an item through a re-export that is accessible in an alternative path, provide a structured suggestion with that path.

```
error[E0603]: module import `mem` is private
  --> $DIR/private-std-reexport-suggest-public.rs:4:14
   |
LL |     use foo::mem;
   |              ^^^ private module import
   |
note: the module import `mem` is defined here...
  --> $DIR/private-std-reexport-suggest-public.rs:8:9
   |
LL |     use std::mem;
   |         ^^^^^^^^
note: ...and refers to the module `mem` which is defined here
  --> $SRC_DIR/std/src/lib.rs:LL:COL
   |
   = note: you could import this
help: import `mem` through the re-export
   |
LL |     use std::mem;
   |         ~~~~~~~~
```

Fix #42909.