### PR TITLE
Miri: Skip over GlobalAllocs when sweeping

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/mod.rs
+++ b/compiler/rustc_const_eval/src/interpret/mod.rs
@@ -25,7 +25,7 @@ pub use self::intern::{
     intern_const_alloc_for_constprop, intern_const_alloc_recursive, InternKind,
 };
 pub use self::machine::{compile_time_machine, AllocMap, Machine, MayLeak, StackPopJump};
-pub use self::memory::{AllocKind, AllocRef, AllocRefMut, FnVal, Memory, MemoryKind};
+pub use self::memory::{AllocKind, AllocRef, AllocRefMut, FnVal, Liveness, Memory, MemoryKind};
 pub use self::operand::{ImmTy, Immediate, OpTy, Readable};
 pub use self::place::{MPlaceTy, MemPlaceMeta, PlaceTy, Writeable};
 pub use self::projection::{OffsetMode, Projectable};


### PR DESCRIPTION
Global allocations in the interpreter are never deallocated, so their AllocId is always in-use and cannot be removed by the GC. So when we are checking whether an AllocId can be removed, we really want to fast-path out if we know that the AllocId refers to a Global allocation.

In the interpreter we have a few HashMaps that map AllocId to something else, so in all those maps I've stuck a bool alongside the value which is a local cache of "Is this AllocId global". `LiveAllocs::is_live` now also takes a `&mut bool` so that it can set the flag if it deduces that the AllocId is in use because it is global.

`InterpCx::is_alloc_live` now returns a Liveness enum which is alive, dead, or global, so that we can populate local bool if we ever look up whether a Global allocation is live.

r? RalfJung

---

Ideally we could set this flag upon insertion into these maps, but eagerly setting the value for `base_ptr_tag` doesn't seem possible. It's also tempting to pack the bit we need here into AllocId, but users of these maps don't know if they are looking up a GlobalAlloc so we would need Hash+PartialEq that ignores the bit which seems cursed.