### PR TITLE
Remove i686-apple-darwin cross-testing

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -49,9 +49,9 @@ const MIR_OPT_BLESS_TARGET_MAPPING: &[(&str, &str)] = &[
     ("i686-unknown-linux-musl", "x86_64-unknown-linux-musl"),
     ("i686-pc-windows-msvc", "x86_64-pc-windows-msvc"),
     ("i686-pc-windows-gnu", "x86_64-pc-windows-gnu"),
-    ("i686-apple-darwin", "x86_64-apple-darwin"),
     // ARM Macs don't have a corresponding 32-bit target that they can (easily)
     // build for, so there is no entry for "aarch64-apple-darwin" here.
+    // Likewise, i686 for macOS is no longer possible to build.
 ];
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
The Xcode SDK no longer ships with 32-bit Intel (i686-apple-darwin) support as of [Xcode 14](https://developer.apple.com/news/upcoming-requirements/?id=06062022a) (related, #112753).  On an up-to-date Intel Mac, `x.py test --bless` fails.

r? @rust-lang/bootstrap