### PR TITLE
[Core] Add `is_xxx_or` for `Result` and `Option`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -650,6 +650,32 @@ impl<T> Option<T> {
         !self.is_some()
     }
 
+    /// Returns `true` if the option is a [`None`] value or the value inside the [`Some`] matches a predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(is_none_or)]
+    /// let x: Option<u32> = Some(2);
+    /// assert_eq!(x.is_none_or(|x| x > 1), true);
+    ///
+    /// let x: Option<u32> = None;
+    /// assert_eq!(x.is_none_or(|x| x > 1), true);
+    ///
+    /// let x: Option<u32> = Some(0);
+    /// assert_eq!(x.is_none_or(|x| x > 1), false);
+    /// ```
+    #[must_use = "if you intended to assert that there's no value or the value matches \
+                  a predicate, considier use `and_then` with a `panic` instead"]
+    #[inline]
+    #[unstable(feature = "is_none_or", issue = "none")]
+    pub fn is_none_or(self, f: impl FnOnce(T) -> bool) -> bool {
+        match self {
+            None => true,
+            Some(x) => f(x),
+        }
+    }
+
     /////////////////////////////////////////////////////////////////////////
     // Adapter for working with references
     /////////////////////////////////////////////////////////////////////////

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -563,6 +563,32 @@ impl<T, E> Result<T, E> {
         }
     }
 
+    /// Returns `true` if the result is [`Ok`] or the value inside of the [`Err`] matches a predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(is_none_or)]
+    /// let x: Result<&'static str, u32> = Err(5);
+    /// assert_eq!(x.is_ok_or(|x| x > 1), true);
+    ///
+    /// let x: Result<&'static str, u32> = Err(0);
+    /// assert_eq!(x.is_ok_or(|x| x > 1), false);
+    ///
+    /// let x: Result<&'static str, u32> = Ok("some result");
+    /// assert_eq!(x.is_ok_or(|x| x > 1), true);
+    /// ```
+    #[must_use = "if you intended to assert that this is an ok or the error value matches \
+                  a predicate, considier use `and_then` with a `panic` instead"]
+    #[inline]
+    #[unstable(feature = "is_none_or", issue = "none")]
+    pub fn is_ok_or(self, f: impl FnOnce(E) -> bool) -> bool {
+        match self {
+            Ok(_) => true,
+            Err(e) => f(e),
+        }
+    }
+
     /// Returns `true` if the result is [`Err`].
     ///
     /// # Examples
@@ -605,6 +631,32 @@ impl<T, E> Result<T, E> {
         match self {
             Ok(_) => false,
             Err(e) => f(e),
+        }
+    }
+
+    /// Returns `true` if the result is [`Err`] or the value inside of the [`Ok`] matches a predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(is_none_or)]
+    /// let x: Result<u32, &'static str> = Err("some error");
+    /// assert_eq!(x.is_err_or(|x| x > 1), true);
+    ///
+    /// let x: Result<u32, &'static str> = Ok(0);
+    /// assert_eq!(x.is_err_or(|x| x > 1), false);
+    ///
+    /// let x: Result<u32, &'static str> = Ok(5);
+    /// assert_eq!(x.is_err_or(|x| x > 1), true);
+    /// ```
+    #[must_use = "if you intended to assert that this is an error or the ok value matches \
+                  a predicate, considier use `and_then` with a `panic` instead"]
+    #[inline]
+    #[unstable(feature = "is_none_or", issue = "none")]
+    pub fn is_err_or(self, f: impl FnOnce(T) -> bool) -> bool {
+        match self {
+            Ok(x) => f(x),
+            Err(_) => true,
         }
     }
 


### PR DESCRIPTION
These supplements are akin to the current `is_xxx_and` APIs.

# `[must_use]`

We generally utilize these methods to verify an option or result, thus necessitating the use of `must_use`.

# ACP

ACP is likely to be a trivial task, given that this modification is likely smaller than the accompanying documentation.