### PR TITLE
Enable the Arm Cortex-A53 errata mitigation on aarch64-unknown-none

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none.rs
@@ -14,6 +14,11 @@ pub fn target() -> Target {
     let opts = TargetOptions {
         linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
         linker: Some("rust-lld".into()),
+        // Enable the Cortex-A53 errata 843419 mitigation by default
+        pre_link_args: TargetOptions::link_args(
+            LinkerFlavor::Gnu(Cc::No, Lld::No),
+            &["--fix-cortex-a53-843419"],
+        ),
         features: "+v8a,+strict-align,+neon,+fp-armv8".into(),
         supported_sanitizers: SanitizerSet::KCFI | SanitizerSet::KERNELADDRESS,
         relocation_model: RelocModel::Static,


### PR DESCRIPTION
Arm Cortex-A53 CPUs have an errata related to a specific sequence of instructions - errata number 843419 (https://documentation-service.arm.com/static/5fa29fddb209f547eebd361d). There is a mitigation that can be applied at link-time which detects the when sequence of instructions exists at a specific alignment. When detected, the linker re-writes those instructions and either changes an ADRP to an ADR, or bounces to a veneer to break the sequence.

The linker argument to enable the mitigation is "--fix-cortex-a53-843419", and this is supported by GNU ld and LLVM lld. The gcc argument to enable the flag is "-mfix-cortex-a53-843419".

Because the aarch64-unknown-none target uses rust-lld directly, this patch causes rustc to emit the "--fix-cortex-a53-843419" argument when calling the linker, just like aarch64-linux-gnu-gcc on Ubuntu 22.04 does.

Failure to enable this mitigation in the linker can cause the production of instruction sequences that do not execute correctly on Arm Cortex-A53.