### PR TITLE
PartialOrd: transitivity and duality are required only if the corresponding impls exist

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -916,14 +916,18 @@ pub macro Ord($item:item) {
 /// easy to accidentally make them disagree by deriving some of the traits and manually
 /// implementing others.
 ///
-/// The comparison must satisfy, for all `a`, `b` and `c`:
+/// The comparison relations must satisfy the following conditions
+/// (for all `a`, `b`, `c` of type `A`, `B`, `C`):
 ///
-/// - transitivity: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
-/// - duality: `a < b` if and only if `b > a`.
+/// - **Transitivity**: if `A: PartialOrd<B>` and `B: PartialOrd<C>` and `A:
+///   PartialOrd<C>`, then `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+///   This must also work for longer chains, such as when `A: PartialOrd<B>`, `B: PartialOrd<C>`,
+///   `C: PartialOrd<D>`, and `A: PartialOrd<D>` all exist.
+/// - **Duality**: if `A: PartialOrd<B>` and `B: PartialOrd<A>`, then `a < b` if and only if `b > a`.
 ///
-/// Note that these requirements mean that the trait itself must be implemented symmetrically and
-/// transitively: if `T: PartialOrd<U>` and `U: PartialOrd<V>` then `U: PartialOrd<T>` and `T:
-/// PartialOrd<V>`.
+/// Note that the `B: PartialOrd<A>` (dual) and `A: PartialOrd<C>`
+/// (transitive) impls are not forced to exist, but these requirements apply
+/// whenever they do exist.
 ///
 /// Violating these requirements is a logic error. The behavior resulting from a logic error is not
 /// specified, but users of the trait must ensure that such logic errors do *not* result in


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/87067. Currently, not even std itself upholds the requirements documented for `PartialOrd`.

This is basically doing for `PartialOrd` what https://github.com/rust-lang/rust/pull/81198 did for `PartialEq`. However, #81198 (likely accidentally) significantly weakened the transitivity requirement, which we are avoiding here: as of today, it is the case that if `A: PartialOrd<B>` and `B: PartialOrd<C>` and `C: PartialOrd<D>` and `A: PartialOrd<D>` all hold, then if `a < b < c < d`, we have `a < d`. If we just did the same thing as #81198, we would lose that property. Therefore, we explicitly require transitivity for longer chains as well.

Libs-api decided [here](https://github.com/rust-lang/rust/issues/87067#issuecomment-1041856663) that they are fine with applying #81198 to `PartialOrd` as well. I'm still nominating this for them again due to this change in how transitivity is handled.