### PR TITLE
Always make progress on `FnOnce` `ClosureKind` goals in the old solver

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -420,7 +420,13 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                 ProcessResult::Error(CodeSelectionError(Unimplemented))
                             }
                         }
-                        None => ProcessResult::Unchanged,
+                        None => {
+                            if kind == ty::ClosureKind::FnOnce {
+                                ProcessResult::Changed(vec![])
+                            } else {
+                                ProcessResult::Unchanged
+                            }
+                        }
                     }
                 }
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -894,7 +894,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 Ok(EvaluatedToErr)
                             }
                         }
-                        None => Ok(EvaluatedToAmbig),
+                        None => {
+                            if kind == ty::ClosureKind::FnOnce {
+                                Ok(EvaluatedToOk)
+                            } else {
+                                Ok(EvaluatedToAmbig)
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
All closures always implement `FnOnce`. IDK if this is worthwhile, but it does mean goals get flushed sooner.