### PR TITLE
Add support for making lib features internal

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -54,8 +54,10 @@ macro_rules! declare_features {
         #[derive(Clone, Default, Debug)]
         pub struct Features {
             /// `#![feature]` attrs for language features, for error reporting.
+            /// "declared" here means that the feature is actually enabled in the current crate.
             pub declared_lang_features: Vec<(Symbol, Span, Option<Symbol>)>,
             /// `#![feature]` attrs for non-language (library) features.
+            /// "declared" here means that the feature is actually enabled in the current crate.
             pub declared_lib_features: Vec<(Symbol, Span)>,
             /// `declared_lang_features` + `declared_lib_features`.
             pub declared_features: FxHashSet<Symbol>,
@@ -125,9 +127,16 @@ macro_rules! declare_features {
                     $(
                         sym::$feature => status_to_enum!($status) == FeatureStatus::Internal,
                     )*
-                    // Accepted/removed features aren't in this file but are never internal
-                    // (a removed feature might have been internal, but that's now irrelevant).
-                    _ if self.declared_features.contains(&feature) => false,
+                    _ if self.declared_features.contains(&feature) => {
+                        // This could be accepted/removed, or a libs feature.
+                        // Accepted/removed features aren't in this file but are never internal
+                        // (a removed feature might have been internal, but that's now irrelevant).
+                        // Libs features are internal if they end in `_internal` or `_internals`.
+                        // We just always test the name; it's not a big deal if we accidentally hit
+                        // an accepted/removed lang feature that way.
+                        let name = feature.as_str();
+                        name.ends_with("_internal") || name.ends_with("_internals")
+                    }
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }
             }
@@ -207,9 +216,6 @@ declare_features! (
     (internal, test_2018_feature, "1.31.0", None, Some(Edition::Edition2018)),
     /// Added for testing unstable lints; perma-unstable.
     (internal, test_unstable_lint, "1.60.0", None, None),
-    /// Allows non-`unsafe` —and thus, unsound— access to `Pin` constructions.
-    /// Marked `internal` since perma-unstable and unsound.
-    (internal, unsafe_pin_internals, "1.60.0", None, None),
     /// Use for stable + negative coherence and strict coherence depending on trait's
     /// rustc_strict_coherence value.
     (unstable, with_negative_coherence, "1.60.0", None, None),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -132,10 +132,12 @@ macro_rules! declare_features {
                         // Accepted/removed features aren't in this file but are never internal
                         // (a removed feature might have been internal, but that's now irrelevant).
                         // Libs features are internal if they end in `_internal` or `_internals`.
+                        // As a special exception we also consider `core_intrinsics` internal;
+                        // renaming that age-old feature is just not worth the hassle.
                         // We just always test the name; it's not a big deal if we accidentally hit
                         // an accepted/removed lang feature that way.
                         let name = feature.as_str();
-                        name.ends_with("_internal") || name.ends_with("_internals")
+                        name == "core_intrinsics" || name.ends_with("_internal") || name.ends_with("_internals")
                     }
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(hash_raw_entry)]
 #![feature(min_specialization)]
 #![feature(let_chains)]
-#![allow(rustc::potential_query_instability)]
+#![allow(rustc::potential_query_instability, internal_features)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -40,6 +40,7 @@
 #![feature(thin_box)]
 #![feature(strict_provenance)]
 #![feature(drain_keep_rest)]
+#![allow(internal_features)]
 #![deny(fuzzy_provenance_casts)]
 #![deny(unsafe_op_in_unsafe_fn)]
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1900,6 +1900,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::ctlz;
     ///
@@ -1912,6 +1913,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::ctlz;
     ///
@@ -1933,6 +1935,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::ctlz_nonzero;
     ///
@@ -1959,6 +1962,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::cttz;
     ///
@@ -1971,6 +1975,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::cttz;
     ///
@@ -1992,6 +1997,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::cttz_nonzero;
     ///
@@ -2453,6 +2459,7 @@ extern "rust-intrinsic" {
     /// ```no_run
     /// #![feature(const_eval_select)]
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     /// use std::hint::unreachable_unchecked;
     /// use std::intrinsics::const_eval_select;
     ///

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -116,6 +116,7 @@
 #![feature(get_many_mut)]
 #![feature(offset_of)]
 #![feature(iter_map_windows)]
+#![allow(internal_features)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(fuzzy_provenance_casts)]
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg(feature = "sysroot-abi")]
 #![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span)]
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
-#![allow(unreachable_pub)]
+#![allow(unreachable_pub, internal_features)]
 
 extern crate proc_macro;
 

--- a/tests/ui/lint/internal_features.rs
+++ b/tests/ui/lint/internal_features.rs
@@ -1,0 +1,11 @@
+#![forbid(internal_features)]
+// A lang feature and a lib feature.
+#![feature(intrinsics, panic_internals)]
+//~^ ERROR: internal
+//~| ERROR: internal
+
+extern "rust-intrinsic" {
+    fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+}
+
+fn main() {}

--- a/tests/ui/lint/internal_features.stderr
+++ b/tests/ui/lint/internal_features.stderr
@@ -1,0 +1,23 @@
+error: the feature `intrinsics` is internal to the compiler or standard library
+  --> $DIR/internal_features.rs:3:12
+   |
+LL | #![feature(intrinsics, panic_internals)]
+   |            ^^^^^^^^^^
+   |
+   = note: using it is strongly discouraged
+note: the lint level is defined here
+  --> $DIR/internal_features.rs:1:11
+   |
+LL | #![forbid(internal_features)]
+   |           ^^^^^^^^^^^^^^^^^
+
+error: the feature `panic_internals` is internal to the compiler or standard library
+  --> $DIR/internal_features.rs:3:24
+   |
+LL | #![feature(intrinsics, panic_internals)]
+   |                        ^^^^^^^^^^^^^^^
+   |
+   = note: using it is strongly discouraged
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
We have the notion of an "internal" lang feature: a feature that is never intended to be stabilized, and using which can cause ICEs and other issues without that being considered a bug.

This extends that idea to lib features as well. It is an alternative to https://github.com/rust-lang/rust/pull/115623: instead of using an attribute to declare lib features internal, we simply do this based on the name. Everything ending in `_internals` or `_internal` is considered internal.

Then we rename `core_intrinsics` to `core_intrinsics_internal`, which fixes https://github.com/rust-lang/rust/issues/115597.