### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3064,7 +3064,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return None;
         };
 
-        self.commit_if_ok(|_| {
+        self.commit_if_ok(|snapshot| {
+            let outer_universe = self.universe();
+
             let ocx = ObligationCtxt::new(self);
             let impl_args = self.fresh_args_for_item(base_expr.span, impl_def_id);
             let impl_trait_ref =
@@ -3074,7 +3076,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Match the impl self type against the base ty. If this fails,
             // we just skip this impl, since it's not particularly useful.
             let impl_trait_ref = ocx.normalize(&cause, self.param_env, impl_trait_ref);
-            ocx.eq(&cause, self.param_env, impl_trait_ref.self_ty(), base_ty)?;
+            ocx.eq(&cause, self.param_env, base_ty, impl_trait_ref.self_ty())?;
 
             // Register the impl's predicates. One of these predicates
             // must be unsatisfied, or else we wouldn't have gotten here
@@ -3110,11 +3112,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Ty::new_projection(self.tcx, index_trait_output_def_id, impl_trait_ref.args),
             );
 
-            let errors = ocx.select_where_possible();
+            let true_errors = ocx.select_where_possible();
+
+            // Do a leak check -- we can't really report report a useful error here,
+            // but it at least avoids an ICE when the error has to do with higher-ranked
+            // lifetimes.
+            self.leak_check(outer_universe, Some(snapshot))?;
+
+            // Bail if we have ambiguity errors, which we can't report in a useful way.
+            let ambiguity_errors = ocx.select_all_or_error();
+            if true_errors.is_empty() && !ambiguity_errors.is_empty() {
+                return Err(NoSolution);
+            }
+
             // There should be at least one error reported. If not, we
             // will still delay a span bug in `report_fulfillment_errors`.
             Ok::<_, NoSolution>((
-                self.err_ctxt().report_fulfillment_errors(errors),
+                self.err_ctxt().report_fulfillment_errors(true_errors),
                 impl_trait_ref.args.type_at(1),
                 element_ty,
             ))

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -956,13 +956,26 @@ pub enum CodegenObligationError {
     FulfillmentError,
 }
 
+/// Defines the treatment of opaque types in a given inference context.
+///
+/// This affects both what opaques are allowed to be defined, but also whether
+/// opaques are replaced with inference vars eagerly in the old solver (e.g.
+/// in projection, and in the signature during function type-checking).
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub enum DefiningAnchor {
-    /// `DefId` of the item.
+    /// Define opaques which are in-scope of the `LocalDefId`. Also, eagerly
+    /// replace opaque types in `replace_opaque_types_with_inference_vars`.
     Bind(LocalDefId),
-    /// When opaque types are not resolved, we `Bubble` up, meaning
-    /// return the opaque/hidden type pair from query, for caller of query to handle it.
+    /// In contexts where we don't currently know what opaques are allowed to be
+    /// defined, such as (old solver) canonical queries, we will simply allow
+    /// opaques to be defined, but "bubble" them up in the canonical response or
+    /// otherwise treat them to be handled later.
+    ///
+    /// We do not eagerly replace opaque types in `replace_opaque_types_with_inference_vars`,
+    /// which may affect what predicates pass and fail in the old trait solver.
     Bubble,
-    /// Used to catch type mismatch errors when handling opaque types.
+    /// Do not allow any opaques to be defined. This is used to catch type mismatch
+    /// errors when handling opaque types, and also should be used when we would
+    /// otherwise reveal opaques (such as [`Reveal::All`] reveal mode).
     Error,
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -18,7 +18,10 @@ use rustc_middle::ty::{self, Instance, ParamEnv, ScalarInt, Ty, TyCtxt, Variance
 use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_target::abi::FieldIdx;
 use stable_mir::mir::mono::InstanceDef;
-use stable_mir::mir::{Body, CopyNonOverlapping, Statement, UserTypeProjection, VariantIdx};
+use stable_mir::mir::{
+    Body, ConstOperand, CopyNonOverlapping, Statement, UserTypeProjection, VarDebugInfoFragment,
+    VariantIdx,
+};
 use stable_mir::ty::{
     AdtDef, AdtKind, ClosureDef, ClosureKind, Const, ConstId, ConstantKind, EarlyParamRegion,
     FloatTy, FnDef, GenericArgs, GenericParamDef, IntTy, LineInfo, Movability, RigidTy, Span,
@@ -444,7 +447,47 @@ impl<'tcx> Stable<'tcx> for mir::Body<'tcx> {
                 })
                 .collect(),
             self.arg_count,
+            self.var_debug_info.iter().map(|info| info.stable(tables)).collect(),
         )
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::VarDebugInfo<'tcx> {
+    type T = stable_mir::mir::VarDebugInfo;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        stable_mir::mir::VarDebugInfo {
+            name: self.name.to_string(),
+            source_info: stable_mir::mir::SourceInfo {
+                span: self.source_info.span.stable(tables),
+                scope: self.source_info.scope.into(),
+            },
+            composite: {
+                if let Some(composite) = &self.composite {
+                    Some(VarDebugInfoFragment {
+                        ty: composite.ty.stable(tables),
+                        projection: composite.projection.iter().map(|e| e.stable(tables)).collect(),
+                    })
+                } else {
+                    None
+                }
+            },
+            value: {
+                match self.value {
+                    mir::VarDebugInfoContents::Place(place) => {
+                        stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
+                    }
+                    mir::VarDebugInfoContents::Const(const_operand) => {
+                        let op = ConstOperand {
+                            span: const_operand.span.stable(tables),
+                            user_ty: const_operand.user_ty.map(|index| index.as_usize()),
+                            const_: const_operand.const_.stable(tables),
+                        };
+                        stable_mir::mir::VarDebugInfoContents::Const(op)
+                    }
+                }
+            },
+            argument_index: self.argument_index,
+        }
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -457,35 +457,9 @@ impl<'tcx> Stable<'tcx> for mir::VarDebugInfo<'tcx> {
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
         stable_mir::mir::VarDebugInfo {
             name: self.name.to_string(),
-            source_info: stable_mir::mir::SourceInfo {
-                span: self.source_info.span.stable(tables),
-                scope: self.source_info.scope.into(),
-            },
-            composite: {
-                if let Some(composite) = &self.composite {
-                    Some(VarDebugInfoFragment {
-                        ty: composite.ty.stable(tables),
-                        projection: composite.projection.iter().map(|e| e.stable(tables)).collect(),
-                    })
-                } else {
-                    None
-                }
-            },
-            value: {
-                match self.value {
-                    mir::VarDebugInfoContents::Place(place) => {
-                        stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
-                    }
-                    mir::VarDebugInfoContents::Const(const_operand) => {
-                        let op = ConstOperand {
-                            span: const_operand.span.stable(tables),
-                            user_ty: const_operand.user_ty.map(|index| index.as_usize()),
-                            const_: const_operand.const_.stable(tables),
-                        };
-                        stable_mir::mir::VarDebugInfoContents::Const(op)
-                    }
-                }
-            },
+            source_info: self.source_info.stable(tables),
+            composite: self.composite.as_ref().map(|composite| composite.stable(tables)),
+            value: self.value.stable(tables),
             argument_index: self.argument_index,
         }
     }
@@ -495,6 +469,42 @@ impl<'tcx> Stable<'tcx> for mir::Statement<'tcx> {
     type T = stable_mir::mir::Statement;
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
         Statement { kind: self.kind.stable(tables), span: self.source_info.span.stable(tables) }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::SourceInfo {
+    type T = stable_mir::mir::SourceInfo;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        stable_mir::mir::SourceInfo { span: self.span.stable(tables), scope: self.scope.into() }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::VarDebugInfoFragment<'tcx> {
+    type T = stable_mir::mir::VarDebugInfoFragment;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        VarDebugInfoFragment {
+            ty: self.ty.stable(tables),
+            projection: self.projection.iter().map(|e| e.stable(tables)).collect(),
+        }
+    }
+}
+
+impl<'tcx> Stable<'tcx> for mir::VarDebugInfoContents<'tcx> {
+    type T = stable_mir::mir::VarDebugInfoContents;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            mir::VarDebugInfoContents::Place(place) => {
+                stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
+            }
+            mir::VarDebugInfoContents::Const(const_operand) => {
+                let op = ConstOperand {
+                    span: const_operand.span.stable(tables),
+                    user_ty: const_operand.user_ty.map(|index| index.as_usize()),
+                    const_: const_operand.const_.stable(tables),
+                };
+                stable_mir::mir::VarDebugInfoContents::Const(op)
+            }
+        }
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -69,15 +69,13 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn get_filename(&self, span: &Span) -> Filename {
         let tables = self.0.borrow();
-        opaque(
-            &tables
-                .tcx
-                .sess
-                .source_map()
-                .span_to_filename(tables[*span])
-                .display(rustc_span::FileNameDisplayPreference::Local)
-                .to_string(),
-        )
+        tables
+            .tcx
+            .sess
+            .source_map()
+            .span_to_filename(tables[*span])
+            .display(rustc_span::FileNameDisplayPreference::Local)
+            .to_string()
     }
 
     fn get_lines(&self, span: &Span) -> LineInfo {

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -110,7 +110,7 @@ pub enum ItemKind {
     Const,
 }
 
-pub type Filename = Opaque;
+pub type Filename = String;
 
 /// Holds information about an item in the crate.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -391,12 +391,14 @@ pub trait MirVisitor {
     }
 
     fn super_var_debug_info(&mut self, var_debug_info: &VarDebugInfo) {
-        self.visit_span(&var_debug_info.source_info.span);
-        let location = Location(var_debug_info.source_info.span);
-        if let Some(composite) = &var_debug_info.composite {
+        let VarDebugInfo { source_info, composite, value, name: _, argument_index: _ } =
+            var_debug_info;
+        self.visit_span(&source_info.span);
+        let location = Location(source_info.span);
+        if let Some(composite) = composite {
             self.visit_ty(&composite.ty, location);
         }
-        match &var_debug_info.value {
+        match value {
             VarDebugInfoContents::Place(place) => {
                 self.visit_place(place, PlaceContext::NON_USE, location);
             }

--- a/tests/ui/typeck/bad-index-modulo-higher-ranked-regions.rs
+++ b/tests/ui/typeck/bad-index-modulo-higher-ranked-regions.rs
@@ -1,0 +1,29 @@
+// Test against ICE in #118111
+
+use std::ops::Index;
+
+struct Map<T, F> {
+    f: F,
+    inner: T,
+}
+
+impl<T, F, Idx> Index<Idx> for Map<T, F>
+where
+    T: Index<Idx>,
+    F: FnOnce(&T, Idx) -> Idx,
+{
+    type Output = T::Output;
+
+    fn index(&self, index: Idx) -> &Self::Output {
+        todo!()
+    }
+}
+
+fn main() {
+    Map { inner: [0_usize], f: |_, i: usize| 1_usize }[0];
+    //~^ ERROR cannot index into a value of type
+    // Problem here is that
+    //   `f: |_, i: usize| ...`
+    // should be
+    //   `f: |_: &_, i: usize| ...`
+}

--- a/tests/ui/typeck/bad-index-modulo-higher-ranked-regions.stderr
+++ b/tests/ui/typeck/bad-index-modulo-higher-ranked-regions.stderr
@@ -1,0 +1,9 @@
+error[E0608]: cannot index into a value of type `Map<[usize; 1], {closure@$DIR/bad-index-modulo-higher-ranked-regions.rs:23:32: 23:45}>`
+  --> $DIR/bad-index-modulo-higher-ranked-regions.rs:23:55
+   |
+LL |     Map { inner: [0_usize], f: |_, i: usize| 1_usize }[0];
+   |                                                       ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0608`.


### PR DESCRIPTION
Successful merges:

 - #117972 (Add VarDebugInfo to Stable MIR)
 - #118110 (Document `DefiningAnchor` a bit more)
 - #118112 (Don't ICE when ambiguity is found when selecting `Index` implementation in typeck)
 - #118135 (Remove quotation from filename in stable_mir)

Failed merges:

 - #118012 (Add support for global allocation in smir)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117972,118110,118112,118135)
<!-- homu-ignore:end -->