### PR TITLE
Allow defining opaques in `check_coroutine_obligations`

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -567,7 +567,7 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    query check_coroutine_obligations(key: LocalDefId) {
+    query check_coroutine_obligations(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
         desc { |tcx| "verify auto trait bounds for coroutine interior type `{}`", tcx.def_path_str(key) }
     }
 

--- a/tests/ui/coroutine/clone-rpit.rs
+++ b/tests/ui/coroutine/clone-rpit.rs
@@ -1,0 +1,17 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+// check-pass
+
+#![feature(coroutines, coroutine_trait, coroutine_clone)]
+
+// This stalls the goal `{coroutine} <: impl Clone`, since that has a nested goal
+// of `{coroutine}: Clone`. That is only known if we can compute the generator
+// witness types, which we don't know until after borrowck. When we later check
+// the goal for correctness, we want to be able to bind the `impl Clone` opaque.
+pub fn foo<'a, 'b>() -> impl Clone {
+    move |_: ()| {
+        let () = yield ();
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
In the new trait solver, when an obligation stalls on an unresolved coroutine witness, we will stash away the *root* obligation, even if the stalled obligation is only a distant descendent of the root obligation, since the new solver is purely recursive.

This means that we may need to reprocess alias-relate obligations (and others) which may define opaque types in the new solver. Currently, we use the coroutine's def id as the defining anchor in `check_coroutine_obligations`, which will allow defining no opaque types, resulting in errors like:

```
error[E0271]: type mismatch resolving `{coroutine@<source>:6:5: 6:17} <: impl Clone`
 --> <source>:6:5
  |
6 | /     move |_: ()| {
7 | |         let () = yield ();
8 | |     }
  | |_____^ types differ
```

So this PR fixes the defining anchor and does the same trick as `check_opaque_well_formed`, where we manually compare opaques that were defined against their hidden types to make sure they weren't defined differently when processing these stalled coroutine obligations.

r? @lcnr cc @cjgillot 