### PR TITLE
Not warn unused symbols in default trait methods

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -670,7 +670,9 @@ fn check_trait_item(
     use hir::TraitItemKind::{Const, Fn};
     if matches!(tcx.def_kind(id.owner_id), DefKind::AssocConst | DefKind::AssocFn) {
         let trait_item = tcx.hir().trait_item(id);
-        if matches!(trait_item.kind, Const(_, Some(_)) | Fn(_, hir::TraitFn::Provided(_)))
+        if let Fn(_, hir::TraitFn::Provided(_)) = trait_item.kind {
+            worklist.push((trait_item.owner_id.def_id, ComesFromAllowExpect::No));
+        } else if let Const(_, Some(_)) = trait_item.kind
             && let Some(comes_from_allow) =
                 has_allow_dead_code_or_lang_attr(tcx, trait_item.owner_id.def_id)
         {

--- a/tests/ui/lint/dead-code/issue-118139.rs
+++ b/tests/ui/lint/dead-code/issue-118139.rs
@@ -1,0 +1,16 @@
+// run-pass
+
+enum Category {
+    A,
+    B,
+}
+
+trait Foo {
+    fn foo(&self) -> Category {
+        Category::A
+    }
+}
+
+fn main() {
+    let _c = Category::B;
+}


### PR DESCRIPTION
Fixes #118139

We are not sure default trait methods to be live or not, just like implementations of traits and trait methods. This change makes them consistent. 