### PR TITLE
Allow constants using an Abi::Vector layout to be passed to the backend

### DIFF
--- a/compiler/rustc_codegen_gcc/src/type_.rs
+++ b/compiler/rustc_codegen_gcc/src/type_.rs
@@ -10,22 +10,6 @@ use crate::context::CodegenCx;
 use crate::type_of::LayoutGccExt;
 
 impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
-    pub fn type_ix(&self, num_bits: u64) -> Type<'gcc> {
-        // gcc only supports 1, 2, 4 or 8-byte integers.
-        // FIXME(antoyo): this is misleading to use the next power of two as rustc_codegen_ssa
-        // sometimes use 96-bit numbers and the following code will give an integer of a different
-        // size.
-        let bytes = (num_bits / 8).next_power_of_two() as i32;
-        match bytes {
-            1 => self.i8_type,
-            2 => self.i16_type,
-            4 => self.i32_type,
-            8 => self.i64_type,
-            16 => self.i128_type,
-            _ => panic!("unexpected num_bits: {}", num_bits),
-        }
-    }
-
     pub fn type_void(&self) -> Type<'gcc> {
         self.context.new_type::<()>()
     }
@@ -90,6 +74,22 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
 }
 
 impl<'gcc, 'tcx> BaseTypeMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
+    fn type_ix(&self, num_bits: u64) -> Type<'gcc> {
+        // gcc only supports 1, 2, 4 or 8-byte integers.
+        // FIXME(antoyo): this is misleading to use the next power of two as rustc_codegen_ssa
+        // sometimes use 96-bit numbers and the following code will give an integer of a different
+        // size.
+        let bytes = (num_bits / 8).next_power_of_two() as i32;
+        match bytes {
+            1 => self.i8_type,
+            2 => self.i16_type,
+            4 => self.i32_type,
+            8 => self.i64_type,
+            16 => self.i128_type,
+            _ => panic!("unexpected num_bits: {}", num_bits),
+        }
+    }
+
     fn type_i1(&self) -> Type<'gcc> {
         self.bool_type
     }

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -60,11 +60,6 @@ impl<'ll> CodegenCx<'ll, '_> {
         unsafe { llvm::LLVMMetadataTypeInContext(self.llcx) }
     }
 
-    ///x Creates an integer type with the given number of bits, e.g., i24
-    pub(crate) fn type_ix(&self, num_bits: u64) -> &'ll Type {
-        unsafe { llvm::LLVMIntTypeInContext(self.llcx, num_bits as c_uint) }
-    }
-
     pub(crate) fn type_vector(&self, ty: &'ll Type, len: u64) -> &'ll Type {
         unsafe { llvm::LLVMVectorType(ty, len as c_uint) }
     }
@@ -128,6 +123,11 @@ impl<'ll> CodegenCx<'ll, '_> {
 }
 
 impl<'ll, 'tcx> BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
+    /// Creates an integer type with the given number of bits, e.g., i24
+    fn type_ix(&self, num_bits: u64) -> &'ll Type {
+        unsafe { llvm::LLVMIntTypeInContext(self.llcx, num_bits as c_uint) }
+    }
+
     fn type_i1(&self) -> &'ll Type {
         unsafe { llvm::LLVMInt1TypeInContext(self.llcx) }
     }

--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -11,6 +11,7 @@ use rustc_target::abi::{AddressSpace, Integer};
 // This depends on `Backend` and not `BackendTypes`, because consumers will probably want to use
 // `LayoutOf` or `HasTyCtxt`. This way, they don't have to add a constraint on it themselves.
 pub trait BaseTypeMethods<'tcx>: Backend<'tcx> {
+    fn type_ix(&self, num_bits: u64) -> Self::Type;
     fn type_i1(&self) -> Self::Type;
     fn type_i8(&self) -> Self::Type;
     fn type_i16(&self) -> Self::Type;

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -136,6 +136,10 @@ pub(super) fn op_to_const<'tcx>(
         // they can be stored as `ConstValue::Indirect`), but that's not relevant since we barely
         // ever have to do this. (`try_get_slice_bytes_for_diagnostics` exists to provide this
         // functionality.)
+        Abi::Vector {
+            element: abi::Scalar::Initialized { value: abi::Primitive::Int(..), .. },
+            ..
+        } => op.layout.size.bytes() <= 16,
         _ => false,
     };
     let immediate = if force_as_immediate {


### PR DESCRIPTION
This allows constant vectors using a repr(simd) type to be propagated through to the backend. This fixes a few issues with LLVM simd intrinsics where a constant vector is expected but cannot be produced by rust at opt-level=0.