### PR TITLE
Suppress warnings in LLVM wrapper when targeting MSVC

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -1,3 +1,5 @@
+#include "SuppressLLVMWarnings.h"
+
 #include "llvm-c/BitReader.h"
 #include "llvm-c/Core.h"
 #include "llvm-c/Object.h"

--- a/compiler/rustc_llvm/llvm-wrapper/Linker.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/Linker.cpp
@@ -1,3 +1,4 @@
+#include "SuppressLLVMWarnings.h"
 #include "llvm/Linker/Linker.h"
 
 #include "LLVMWrapper.h"

--- a/compiler/rustc_llvm/llvm-wrapper/SuppressLLVMWarnings.h
+++ b/compiler/rustc_llvm/llvm-wrapper/SuppressLLVMWarnings.h
@@ -1,0 +1,13 @@
+#ifndef _rustc_llvm_SuppressLLVMWarnings_h
+#define _rustc_llvm_SuppressLLVMWarnings_h
+
+// LLVM currently generates many warnings when compiled using MSVC. These warnings make it difficult
+// to diagnose real problems when working on C++ code, so we suppress them.
+
+#ifdef _MSC_VER
+#pragma warning(disable:4530) // C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
+#pragma warning(disable:4624) // 'xxx': destructor was implicitly defined as deleted
+#pragma warning(disable:4244) // 'initializing': conversion from 'xxx' to 'yyy', possible loss of data
+#endif
+
+#endif // _rustc_llvm_SuppressLLVMWarnings_h

--- a/compiler/rustc_llvm/llvm-wrapper/SuppressLLVMWarnings.h
+++ b/compiler/rustc_llvm/llvm-wrapper/SuppressLLVMWarnings.h
@@ -5,9 +5,9 @@
 // to diagnose real problems when working on C++ code, so we suppress them.
 
 #ifdef _MSC_VER
-#pragma warning(disable:4530) // C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
+#pragma warning(disable:4530) // C++ exception handler used, but unwind semantics are not enabled.
 #pragma warning(disable:4624) // 'xxx': destructor was implicitly defined as deleted
-#pragma warning(disable:4244) // 'initializing': conversion from 'xxx' to 'yyy', possible loss of data
+#pragma warning(disable:4244) // conversion from 'xxx' to 'yyy', possible loss of data
 #endif
 
 #endif // _rustc_llvm_SuppressLLVMWarnings_h

--- a/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
@@ -7,6 +7,7 @@
 // * https://github.com/llvm/llvm-project/blob/8ef3e895ad8ab1724e2b87cabad1dacdc7a397a3/llvm/include/llvm/Object/ArchiveWriter.h
 // * https://github.com/llvm/llvm-project/blob/8ef3e895ad8ab1724e2b87cabad1dacdc7a397a3/llvm/lib/Object/ArchiveWriter.cpp
 
+#include "SuppressLLVMWarnings.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Object/ObjectFile.h"


### PR DESCRIPTION
The LLVM header files generate many warnings when compiled using MSVC. This makes it difficult to work on the LLVM wrapper code, because the warnings and errors that are relevant to local edits are obscured by the hundreds of lines of warnings from the LLVM Headers.
