### PR TITLE
Suggest `let` or `==` on typo'd let-chain

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -492,8 +492,12 @@ parse_match_arm_body_without_braces = `match` arm body without braces
         } with a body
     .suggestion_use_comma_not_semicolon = replace `;` with `,` to end a `match` arm expression
 
+parse_maybe_comparison = you might have meant to compare for equality
+
 parse_maybe_fn_typo_with_impl = you might have meant to write `impl` instead of `fn`
     .suggestion = replace `fn` with `impl` here
+
+parse_maybe_missing_let = you might have meant to continue the let-chain
 
 parse_maybe_recover_from_bad_qpath_stage_2 =
     missing angle brackets in associated item path

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -407,6 +407,32 @@ pub(crate) struct ExpectedExpressionFoundLet {
     pub span: Span,
     #[subdiagnostic]
     pub reason: ForbiddenLetReason,
+    #[subdiagnostic]
+    pub missing_let: Option<MaybeMissingLet>,
+    #[subdiagnostic]
+    pub comparison: Option<MaybeComparison>,
+}
+
+#[derive(Subdiagnostic, Clone, Copy)]
+#[multipart_suggestion(
+    parse_maybe_missing_let,
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct MaybeMissingLet {
+    #[suggestion_part(code = "let ")]
+    pub span: Span,
+}
+
+#[derive(Subdiagnostic, Clone, Copy)]
+#[multipart_suggestion(
+    parse_maybe_comparison,
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
+pub(crate) struct MaybeComparison {
+    #[suggestion_part(code = "=")]
+    pub span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/expr/if/bad-if-let-suggestion.rs
+++ b/tests/ui/expr/if/bad-if-let-suggestion.rs
@@ -1,6 +1,3 @@
-// FIXME(compiler-errors): This really should suggest `let` on the RHS of the
-// `&&` operator, but that's kinda hard to do because of precedence.
-// Instead, for now we just make sure not to suggest `if let let`.
 fn a() {
     if let x = 1 && i = 2 {}
     //~^ ERROR cannot find value `i` in this scope

--- a/tests/ui/expr/if/bad-if-let-suggestion.stderr
+++ b/tests/ui/expr/if/bad-if-let-suggestion.stderr
@@ -1,19 +1,27 @@
 error: expected expression, found `let` statement
-  --> $DIR/bad-if-let-suggestion.rs:5:8
+  --> $DIR/bad-if-let-suggestion.rs:2:8
    |
 LL |     if let x = 1 && i = 2 {}
    |        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to continue the let-chain
+   |
+LL |     if let x = 1 && let i = 2 {}
+   |                     +++
+help: you might have meant to compare for equality
+   |
+LL |     if let x = 1 && i == 2 {}
+   |                        +
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:5:21
+  --> $DIR/bad-if-let-suggestion.rs:2:21
    |
 LL |     if let x = 1 && i = 2 {}
    |                     ^ not found in this scope
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:12:9
+  --> $DIR/bad-if-let-suggestion.rs:9:9
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -22,7 +30,7 @@ LL |     if (i + j) = i {}
    |         ^ help: a function with a similar name exists: `a`
 
 error[E0425]: cannot find value `j` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:12:13
+  --> $DIR/bad-if-let-suggestion.rs:9:13
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -31,7 +39,7 @@ LL |     if (i + j) = i {}
    |             ^ help: a function with a similar name exists: `a`
 
 error[E0425]: cannot find value `i` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:12:18
+  --> $DIR/bad-if-let-suggestion.rs:9:18
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -40,7 +48,7 @@ LL |     if (i + j) = i {}
    |                  ^ help: a function with a similar name exists: `a`
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/bad-if-let-suggestion.rs:19:8
+  --> $DIR/bad-if-let-suggestion.rs:16:8
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -49,7 +57,7 @@ LL |     if x[0] = 1 {}
    |        ^ help: a function with a similar name exists: `a`
 
 error[E0308]: mismatched types
-  --> $DIR/bad-if-let-suggestion.rs:5:8
+  --> $DIR/bad-if-let-suggestion.rs:2:8
    |
 LL |     if let x = 1 && i = 2 {}
    |        ^^^^^^^^^^^^^^^^^^ expected `bool`, found `()`

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.stderr
@@ -29,6 +29,10 @@ LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(
    |            ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to compare for equality
+   |
+LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = &&let Some(x) = Some(42)] == 1 {
+   |                                                                                  +
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:24:23
@@ -53,6 +57,10 @@ LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] = 1 {
    |            ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
+help: you might have meant to compare for equality
+   |
+LL |         if let Some(elem) = _opt && [1, 2, 3][let _ = ()] == 1 {
+   |                                                            +
 
 error: expected expression, found `let` statement
   --> $DIR/invalid-let-in-a-valid-let-context.rs:42:21


### PR DESCRIPTION
When encountering a bare assignment in a let-chain, suggest turning the
assignment into a `let` expression or an equality check.

```
error: expected expression, found `let` statement
  --> $DIR/bad-if-let-suggestion.rs:5:8
   |
LL |     if let x = 1 && i = 2 {}
   |        ^^^^^^^^^
   |
   = note: only supported directly in conditions of `if` and `while` expressions
help: you might have meant to continue the let-chain
   |
LL |     if let x = 1 && let i = 2 {}
   |                     +++
help: you might have meant to compare for equality
   |
LL |     if let x = 1 && i == 2 {}
   |                        +
```