### PR TITLE
Don't print "private fields" on empty tuple structs

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1501,8 +1501,10 @@ fn print_tuple_struct_fields<'a, 'cx: 'a>(
     s: &'a [clean::Item],
 ) -> impl fmt::Display + 'a + Captures<'cx> {
     display_fn(|f| {
-        if s.iter()
-            .all(|field| matches!(*field.kind, clean::StrippedItem(box clean::StructFieldItem(..))))
+        if !s.is_empty()
+            && s.iter().all(|field| {
+                matches!(*field.kind, clean::StrippedItem(box clean::StructFieldItem(..)))
+            })
         {
             return f.write_str("/* private fields */");
         }
@@ -2275,9 +2277,11 @@ fn render_struct_fields(
         }
         Some(CtorKind::Fn) => {
             w.write_str("(");
-            if fields.iter().all(|field| {
-                matches!(*field.kind, clean::StrippedItem(box clean::StructFieldItem(..)))
-            }) {
+            if !fields.is_empty()
+                && fields.iter().all(|field| {
+                    matches!(*field.kind, clean::StrippedItem(box clean::StructFieldItem(..)))
+                })
+            {
                 write!(w, "/* private fields */");
             } else {
                 for (i, field) in fields.iter().enumerate() {

--- a/tests/rustdoc/issue-118180-empty-tuple-struct.rs
+++ b/tests/rustdoc/issue-118180-empty-tuple-struct.rs
@@ -1,0 +1,9 @@
+// @has issue_118180_empty_tuple_struct/enum.Enum.html
+pub enum Enum {
+    // @has - '//*[@id="variant.Empty"]//h3' 'Empty()'
+    Empty(),
+}
+
+// @has issue_118180_empty_tuple_struct/struct.Empty.html
+// @has - '//pre/code' 'Empty()'
+pub struct Empty();


### PR DESCRIPTION
Closes #118180.

While working on this I also noticed that empty struct variants are also rendered rather awkwardly. I'll make another issue for that, since I don't know what the correct rendering would be.