### PR TITLE
Fix tracking issue of Windows ExitCodeExt

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -347,7 +347,7 @@ impl ChildExt for process::Child {
 ///
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
-#[unstable(feature = "windows_process_exit_code_from", issue = "none")]
+#[unstable(feature = "windows_process_exit_code_from", issue = "111688")]
 pub trait ExitCodeExt: Sealed {
     /// Creates a new `ExitCode` from the raw underlying `u32` return value of
     /// a process.
@@ -355,11 +355,11 @@ pub trait ExitCodeExt: Sealed {
     /// The exit code should not be 259, as this conflicts with the `STILL_ACTIVE`
     /// macro returned from the `GetExitCodeProcess` function to signal that the
     /// process has yet to run to completion.
-    #[unstable(feature = "windows_process_exit_code_from", issue = "none")]
+    #[unstable(feature = "windows_process_exit_code_from", issue = "111688")]
     fn from_raw(raw: u32) -> Self;
 }
 
-#[unstable(feature = "windows_process_exit_code_from", issue = "none")]
+#[unstable(feature = "windows_process_exit_code_from", issue = "111688")]
 impl ExitCodeExt for process::ExitCode {
     fn from_raw(raw: u32) -> Self {
         process::ExitCode::from_inner(From::from(raw))


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/111688

This was left out of the initial ExitCodeExt implementation in https://github.com/rust-lang/rust/pull/97917.