### PR TITLE
Sort unstable items last in rustdoc, instead of first

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -369,8 +369,8 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
         if let (Some(a), Some(b)) = (s1, s2) {
             match (a.is_stable(), b.is_stable()) {
                 (true, true) | (false, false) => {}
-                (false, true) => return Ordering::Less,
-                (true, false) => return Ordering::Greater,
+                (false, true) => return Ordering::Greater,
+                (true, false) => return Ordering::Less,
             }
         }
         let lhs = i1.name.unwrap_or(kw::Empty);

--- a/tests/rustdoc/stability.rs
+++ b/tests/rustdoc/stability.rs
@@ -2,6 +2,14 @@
 
 #![unstable(feature = "test", issue = "none")]
 
+// @has stability/index.html
+// @has - '//ul[@class="item-table"]/li[1]//a' Unstable
+// @has - '//ul[@class="item-table"]/li[2]//a' AaStable
+// @has - '//ul[@class="item-table"]/li[3]//a' ZzStable
+
+#[stable(feature = "rust2", since = "2.2.2")]
+pub struct AaStable;
+
 pub struct Unstable {
     // @has stability/struct.Unstable.html \
     //      '//span[@class="item-info"]//div[@class="stab unstable"]' \
@@ -10,3 +18,6 @@ pub struct Unstable {
     pub foo: u32,
     pub bar: u32,
 }
+
+#[stable(feature = "rust2", since = "2.2.2")]
+pub struct ZzStable;

--- a/tests/rustdoc/stability.rs
+++ b/tests/rustdoc/stability.rs
@@ -3,9 +3,9 @@
 #![unstable(feature = "test", issue = "none")]
 
 // @has stability/index.html
-// @has - '//ul[@class="item-table"]/li[1]//a' Unstable
-// @has - '//ul[@class="item-table"]/li[2]//a' AaStable
-// @has - '//ul[@class="item-table"]/li[3]//a' ZzStable
+// @has - '//ul[@class="item-table"]/li[1]//a' AaStable
+// @has - '//ul[@class="item-table"]/li[2]//a' ZzStable
+// @has - '//ul[@class="item-table"]/li[3]//a' Unstable
 
 #[stable(feature = "rust2", since = "2.2.2")]
 pub struct AaStable;


### PR DESCRIPTION
As far as I can tell, this is a bug introduced inadvertently by https://github.com/rust-lang/rust/pull/77817 in Rust 1.49. Older toolchains used to sort unstable items last.

Notice how in the code before that PR, `(Unstable, Stable) => return Ordering::Greater` in src/librustdoc/html/render/mod.rs. Whereas after that PR, `(Unstable, Stable) => return Ordering::Less`.

Compare https://doc.rust-lang.org/1.48.0/std/marker/index.html vs https://doc.rust-lang.org/1.49.0/std/marker/index.html.