### PR TITLE
De-emphasize unstable items in rustdoc item table

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -819,6 +819,9 @@ table,
 .item-table > li > .item-name {
 	padding-right: 1.25rem;
 }
+.item-table > li.unstable > .item-name > a {
+	opacity: 0.70;
+}
 
 .search-results-title {
 	margin-top: 0;

--- a/tests/rustdoc/stability.rs
+++ b/tests/rustdoc/stability.rs
@@ -11,6 +11,7 @@
 pub struct AaStable;
 
 pub struct Unstable {
+    // @has stability/index.html '//ul[@class="item-table"]/li[@class="unstable"]//a' Unstable
     // @has stability/struct.Unstable.html \
     //      '//span[@class="item-info"]//div[@class="stab unstable"]' \
     //      'This is a nightly-only experimental API'


### PR DESCRIPTION
For many years, since https://github.com/rust-lang/rust/commit/0a46933c4d81573e78ce16cd215ba155a3114fce unstable APIs used to be shown in a faded color (both the item name and the description). See https://doc.rust-lang.org/1.54.0/std/marker/index.html.

In https://github.com/rust-lang/rust/pull/85651 the description became un-faded. See https://doc.rust-lang.org/1.55.0/std/marker/index.html.

In https://github.com/rust-lang/rust/pull/107336 the item name became un-faded too. Compare https://doc.rust-lang.org/1.68.0/std/marker/index.html vs https://doc.rust-lang.org/1.69.0/std/marker/index.html.

It is difficult for me to tell whether either of these changes was intentional. None of the PR descriptions or commit messages even mentions stability at all.

This PR restores fading the unstable item name. I find this visual separation to be helpful in getting oriented about the sort order of the items.

**Before:**

![Screenshot from 2023-11-23 18-53-18](https://github.com/rust-lang/rust/assets/1940490/3d726fa2-eaf3-422b-a31d-c5ef07f35cd4)

**After:**

![Screenshot from 2023-11-23 18-53-24](https://github.com/rust-lang/rust/assets/1940490/03b348c1-3ff5-4b5c-a8b9-e01d2ae96a03)

(the screenshots also include my other PR https://github.com/rust-lang/rust/pull/118224.)