### PR TITLE
Bump `unicase` crate version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5767,9 +5767,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]


### PR DESCRIPTION
This bumps `unicase` crate to align with Unicode 15.

Closes #101840.