### PR TITLE
Use `usize::checked_mul` for `Layout::array` checks again

### DIFF
--- a/tests/codegen/layout-size-checks.rs
+++ b/tests/codegen/layout-size-checks.rs
@@ -11,11 +11,16 @@ type RGB48 = [u16; 3];
 // CHECK-LABEL: @layout_array_rgb48
 #[no_mangle]
 pub fn layout_array_rgb48(n: usize) -> Layout {
-    // CHECK-NOT: llvm.umul.with.overflow.i64
-    // CHECK: icmp ugt i64 %n, 1537228672809129301
-    // CHECK-NOT: llvm.umul.with.overflow.i64
-    // CHECK: mul nuw nsw i64 %n, 6
-    // CHECK-NOT: llvm.umul.with.overflow.i64
+    // CHECK-NOT: icmp
+    // CHECK-NOT: mul
+    // CHECK: %[[TUP:.+]] = tail call { i64, i1 } @llvm.umul.with.overflow.i64(i64 %n, i64 12)
+    // CHECK-NOT: icmp
+    // CHECK-NOT: mul
+    // CHECK: %[[PROD:.+]] = extractvalue { i64, i1 } %[[TUP]], 0
+    // CHECK-NEXT: lshr exact i64 %[[PROD]], 1
+    // CHECK-NOT: icmp
+    // CHECK-NOT: mul
+
     Layout::array::<RGB48>(n).unwrap()
 }
 
@@ -29,3 +34,5 @@ pub fn layout_array_i32(n: usize) -> Layout {
     // CHECK-NOT: llvm.umul.with.overflow.i64
     Layout::array::<i32>(n).unwrap()
 }
+
+// CHECK: declare { i64, i1 } @llvm.umul.with.overflow.i64(i64, i64)


### PR DESCRIPTION
I found a little trick that allows us to check the `isize::MAX` limit using `usize::checked_mul`.  No idea whether that's a good idea, but let's see what perf has to say...

Inspired by #118228
r? @ghost 
