### PR TITLE
Making `User<T>` and `User<[T]>` `Send`

### DIFF
--- a/library/std/src/sys/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/alloc.rs
@@ -185,6 +185,12 @@ pub struct UserRef<T: ?Sized>(UnsafeCell<T>);
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub struct User<T: UserSafe + ?Sized>(NonNull<UserRef<T>>);
 
+#[unstable(feature = "sgx_platform", issue = "56975")]
+unsafe impl<T: UserSafeSized> Send for User<T> {}
+
+#[unstable(feature = "sgx_platform", issue = "56975")]
+unsafe impl<T: UserSafeSized> Send for User<[T]> {}
+
 trait NewUserRef<T: ?Sized> {
     unsafe fn new_userref(v: T) -> Self;
 }


### PR DESCRIPTION
All `User` types in SGX point to owned memory in userspace. Special care is always needed when accessing this memory as it must be assumed that an attacker is always able to change its content. Therefore, we can also easily transfer this memory between thread boundaries.

cc: @mzohreva @vn971 @belalH @jethrogb 