### PR TITLE
EvalCtxt::commit_if_ok don't inherit nested goals

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/commit_if_ok.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/commit_if_ok.rs
@@ -1,4 +1,4 @@
-use super::EvalCtxt;
+use super::{EvalCtxt, NestedGoals};
 use crate::solve::inspect;
 use rustc_middle::traits::query::NoSolution;
 
@@ -14,7 +14,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
             predefined_opaques_in_body: self.predefined_opaques_in_body,
             max_input_universe: self.max_input_universe,
             search_graph: self.search_graph,
-            nested_goals: self.nested_goals.clone(),
+            nested_goals: NestedGoals::new(),
             tainted: self.tainted,
             inspect: self.inspect.new_probe(),
         };
@@ -32,7 +32,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
                 tainted,
                 inspect,
             } = nested_ecx;
-            self.nested_goals = nested_goals;
+            self.nested_goals.extend(nested_goals);
             self.tainted = tainted;
             self.inspect.integrate_snapshot(inspect);
         } else {

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -108,13 +108,18 @@ pub(super) struct NestedGoals<'tcx> {
     pub(super) goals: Vec<Goal<'tcx, ty::Predicate<'tcx>>>,
 }
 
-impl NestedGoals<'_> {
+impl<'tcx> NestedGoals<'tcx> {
     pub(super) fn new() -> Self {
         Self { normalizes_to_hack_goal: None, goals: Vec::new() }
     }
 
     pub(super) fn is_empty(&self) -> bool {
         self.normalizes_to_hack_goal.is_none() && self.goals.is_empty()
+    }
+
+    pub(super) fn extend(&mut self, other: NestedGoals<'tcx>) {
+        assert_eq!(other.normalizes_to_hack_goal, None);
+        self.goals.extend(other.goals)
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -334,11 +334,6 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             }
         }
 
-        // FIXME(@lcnr): If the normalization of the alias adds an inference constraint which
-        // causes a previously added goal to fail, then we treat the alias as rigid.
-        //
-        // These feels like a potential issue, I should look into writing some tests here
-        // and then probably changing `commit_if_ok` to not inherit the parent goals.
         match self.commit_if_ok(|this| {
             let normalized_ty = this.next_ty_infer();
             let normalizes_to_goal = Goal::new(


### PR DESCRIPTION
we use it to check whether an alias is rigid, so we want to avoid considering an alias rigid simply because the inference constraints from normalizing it caused another nested goal fail

r? @compiler-errors 
