### PR TITLE
Add `Span` to `TraitBoundModifier`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -301,7 +301,7 @@ pub enum TraitBoundModifier {
     Maybe,
 
     /// `~const Trait`
-    MaybeConst,
+    MaybeConst(Span),
 
     /// `~const !Trait`
     //
@@ -317,8 +317,7 @@ pub enum TraitBoundModifier {
 impl TraitBoundModifier {
     pub fn to_constness(self) -> Const {
         match self {
-            // FIXME(effects) span
-            Self::MaybeConst => Const::Yes(DUMMY_SP),
+            Self::MaybeConst(span) => Const::Yes(span),
             _ => Const::No,
         }
     }
@@ -3155,7 +3154,7 @@ mod size_asserts {
     static_assert_size!(ForeignItem, 96);
     static_assert_size!(ForeignItemKind, 24);
     static_assert_size!(GenericArg, 24);
-    static_assert_size!(GenericBound, 56);
+    static_assert_size!(GenericBound, 64);
     static_assert_size!(Generics, 40);
     static_assert_size!(Impl, 136);
     static_assert_size!(Item, 136);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1369,7 +1369,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             GenericBound::Trait(
                                 ty,
                                 modifier @ (TraitBoundModifier::None
-                                | TraitBoundModifier::MaybeConst
+                                | TraitBoundModifier::MaybeConst(_)
                                 | TraitBoundModifier::Negative),
                             ) => {
                                 Some(this.lower_poly_trait_ref(ty, itctx, modifier.to_constness()))
@@ -2227,7 +2227,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_trait_bound_modifier(&mut self, f: TraitBoundModifier) -> hir::TraitBoundModifier {
         match f {
             TraitBoundModifier::None => hir::TraitBoundModifier::None,
-            TraitBoundModifier::MaybeConst => hir::TraitBoundModifier::MaybeConst,
+            TraitBoundModifier::MaybeConst(_) => hir::TraitBoundModifier::MaybeConst,
 
             TraitBoundModifier::Negative => {
                 if self.tcx.features().negative_bounds {

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1203,7 +1203,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 (BoundKind::TraitObject, TraitBoundModifier::Maybe) => {
                     self.err_handler().emit_err(errors::OptionalTraitObject { span: poly.span });
                 }
-                (_, TraitBoundModifier::MaybeConst)
+                (_, &TraitBoundModifier::MaybeConst(span))
                     if let Some(reason) = &self.disallow_tilde_const =>
                 {
                     let reason = match reason {
@@ -1224,8 +1224,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         }
                         DisallowTildeConstContext::Item => errors::TildeConstReason::Item,
                     };
-                    self.err_handler()
-                        .emit_err(errors::TildeConstDisallowed { span: bound.span(), reason });
+                    self.err_handler().emit_err(errors::TildeConstDisallowed { span, reason });
                 }
                 (_, TraitBoundModifier::MaybeConstMaybe) => {
                     self.err_handler().emit_err(errors::OptionalConstExclusive {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1515,7 +1515,7 @@ impl<'a> State<'a> {
                         TraitBoundModifier::Maybe => {
                             self.word("?");
                         }
-                        TraitBoundModifier::MaybeConst => {
+                        TraitBoundModifier::MaybeConst(_) => {
                             self.word_space("~const");
                         }
                         TraitBoundModifier::MaybeConstNegative => {

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -4,7 +4,7 @@ use rustc_ast::{self as ast, AttrVec, BlockCheckMode, Expr, LocalKind, PatKind, 
 use rustc_ast::{attr, token, util::literal};
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
-use rustc_span::Span;
+use rustc_span::{Span, DUMMY_SP};
 use thin_vec::{thin_vec, ThinVec};
 
 impl<'a> ExtCtxt<'a> {
@@ -135,7 +135,7 @@ impl<'a> ExtCtxt<'a> {
         ast::GenericBound::Trait(
             self.poly_trait_ref(path.span, path),
             if is_const {
-                ast::TraitBoundModifier::MaybeConst
+                ast::TraitBoundModifier::MaybeConst(DUMMY_SP)
             } else {
                 ast::TraitBoundModifier::None
             },

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -37,7 +37,7 @@ impl BoundModifiers {
             (BoundPolarity::Positive, None) => TraitBoundModifier::None,
             (BoundPolarity::Negative(_), None) => TraitBoundModifier::Negative,
             (BoundPolarity::Maybe(_), None) => TraitBoundModifier::Maybe,
-            (BoundPolarity::Positive, Some(_)) => TraitBoundModifier::MaybeConst,
+            (BoundPolarity::Positive, Some(sp)) => TraitBoundModifier::MaybeConst(sp),
             (BoundPolarity::Negative(_), Some(_)) => TraitBoundModifier::MaybeConstNegative,
             (BoundPolarity::Maybe(_), Some(_)) => TraitBoundModifier::MaybeConstMaybe,
         }

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -546,7 +546,7 @@ impl Rewrite for ast::GenericBound {
                     ast::TraitBoundModifier::Maybe => poly_trait_ref
                         .rewrite(context, shape.offset_left(1)?)
                         .map(|s| format!("?{}", s)),
-                    ast::TraitBoundModifier::MaybeConst => poly_trait_ref
+                    ast::TraitBoundModifier::MaybeConst(_) => poly_trait_ref
                         .rewrite(context, shape.offset_left(7)?)
                         .map(|s| format!("~const {}", s)),
                     ast::TraitBoundModifier::MaybeConstMaybe => poly_trait_ref

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type-const-bound-usage.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type-const-bound-usage.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/assoc-type-const-bound-usage.rs:7:17
    |
 LL |     type Assoc: ~const Foo;
-   |                 ^^^^^^^^^^
+   |                 ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/assoc-type.rs:17:15
    |
 LL |     type Bar: ~const std::ops::Add;
-   |               ^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-bound-on-not-const-associated-fn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-bound-on-not-const-associated-fn.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/const-bound-on-not-const-associated-fn.rs:9:40
    |
 LL |     fn do_something_else() where Self: ~const MyTrait;
-   |                                        ^^^^^^^^^^^^^^
+   |                                        ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/const-bound-on-not-const-associated-fn.rs:9:8
@@ -14,7 +14,7 @@ error: `~const` is not allowed here
   --> $DIR/const-bound-on-not-const-associated-fn.rs:20:32
    |
 LL |     pub fn foo(&self) where T: ~const MyTrait {
-   |                                ^^^^^^^^^^^^^^
+   |                                ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/const-bound-on-not-const-associated-fn.rs:20:12

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/const-drop.rs:67:38
    |
 LL |     pub struct ConstDropWithBound<T: ~const SomeTrait>(pub core::marker::PhantomData<T>);
-   |                                      ^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.stock.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.stock.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/const-drop.rs:67:38
    |
 LL |     pub struct ConstDropWithBound<T: ~const SomeTrait>(pub core::marker::PhantomData<T>);
-   |                                      ^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: ~const Foo {}
-   |            ^^^^^^^^^^
+   |            ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
   --> $DIR/super-traits-fail-2.rs:11:1

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/super-traits-fail-2.rs:11:12
    |
 LL | trait Bar: ~const Foo {}
-   |            ^^^^^^^^^^
+   |            ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
   --> $DIR/super-traits-fail-2.rs:11:1

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/super-traits-fail-3.rs:13:12
    |
 LL | trait Bar: ~const Foo {}
-   |            ^^^^^^^^^^
+   |            ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
   --> $DIR/super-traits-fail-3.rs:13:1

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/super-traits-fail-3.rs:13:12
    |
 LL | trait Bar: ~const Foo {}
-   |            ^^^^^^^^^^
+   |            ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
   --> $DIR/super-traits-fail-3.rs:13:1

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-and-const-params.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-and-const-params.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-and-const-params.rs:9:15
    |
 LL |     fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
-   |               ^^^^^^^^^^^^
+   |               ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-and-const-params.rs:9:8
@@ -14,7 +14,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-and-const-params.rs:27:11
    |
 LL | fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
-   |           ^^^^^^^^^^^^
+   |           ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-and-const-params.rs:27:4

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:7:26
    |
 LL | fn non_const_function<T: ~const Trait>() {}
-   |                          ^^^^^^^^^^^^
+   |                          ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:7:4
@@ -14,7 +14,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:9:18
    |
 LL | struct Struct<T: ~const Trait> { field: T }
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -22,7 +22,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:10:23
    |
 LL | struct TupleStruct<T: ~const Trait>(T);
-   |                       ^^^^^^^^^^^^
+   |                       ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -30,7 +30,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:11:22
    |
 LL | struct UnitStruct<T: ~const Trait>;
-   |                      ^^^^^^^^^^^^
+   |                      ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -38,7 +38,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:13:14
    |
 LL | enum Enum<T: ~const Trait> { Variant(T) }
-   |              ^^^^^^^^^^^^
+   |              ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -46,7 +46,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:15:16
    |
 LL | union Union<T: ~const Trait> { field: T }
-   |                ^^^^^^^^^^^^
+   |                ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -54,7 +54,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:17:14
    |
 LL | type Type<T: ~const Trait> = T;
-   |              ^^^^^^^^^^^^
+   |              ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -62,7 +62,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:19:19
    |
 LL | const CONSTANT<T: ~const Trait>: () = ();
-   |                   ^^^^^^^^^^^^
+   |                   ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -70,7 +70,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:23:18
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -78,7 +78,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:23:33
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
-   |                                 ^^^^^^^^^^^^
+   |                                 ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -86,7 +86,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:26:30
    |
 LL |     fn non_const_function<T: ~const Trait>();
-   |                              ^^^^^^^^^^^^
+   |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:26:8
@@ -98,7 +98,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:27:23
    |
 LL |     const CONSTANT<T: ~const Trait>: ();
-   |                       ^^^^^^^^^^^^
+   |                       ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -106,7 +106,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:32:18
    |
 LL |     type Type<T: ~const Trait> = ();
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -114,7 +114,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:33:30
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
-   |                              ^^^^^^^^^^^^
+   |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:33:8
@@ -126,7 +126,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:34:23
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
-   |                       ^^^^^^^^^^^^
+   |                       ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -134,7 +134,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:41:18
    |
 LL |     type Type<T: ~const Trait> = ();
-   |                  ^^^^^^^^^^^^
+   |                  ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -142,7 +142,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:43:30
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
-   |                              ^^^^^^^^^^^^
+   |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:43:8
@@ -154,7 +154,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:44:23
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
-   |                       ^^^^^^^^^^^^
+   |                       ^^^^^^
    |
    = note: this item cannot have `~const` trait bounds
 
@@ -162,7 +162,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:49:15
    |
 LL | trait Child0: ~const Trait {}
-   |               ^^^^^^^^^^^^
+   |               ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:49:1
@@ -174,7 +174,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:50:26
    |
 LL | trait Child1 where Self: ~const Trait {}
-   |                          ^^^^^^^^^^^^
+   |                          ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:50:1
@@ -186,7 +186,7 @@ error: `~const` is not allowed here
   --> $DIR/tilde-const-invalid-places.rs:53:9
    |
 LL | impl<T: ~const Trait> Trait for T {}
-   |         ^^^^^^^^^^^^
+   |         ^^^^^^
    |
 note: this impl is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/tilde-const-invalid-places.rs:53:1

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause.stderr
@@ -2,7 +2,7 @@ error: `~const` is not allowed here
   --> $DIR/trait-where-clause.rs:8:24
    |
 LL |     fn b() where Self: ~const Bar;
-   |                        ^^^^^^^^^^
+   |                        ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/trait-where-clause.rs:8:8
@@ -14,7 +14,7 @@ error: `~const` is not allowed here
   --> $DIR/trait-where-clause.rs:10:13
    |
 LL |     fn c<T: ~const Bar>();
-   |             ^^^^^^^^^^
+   |             ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
   --> $DIR/trait-where-clause.rs:10:8

--- a/tests/ui/stats/hir-stats.stderr
+++ b/tests/ui/stats/hir-stats.stderr
@@ -21,31 +21,31 @@ ast-stats-1 - Local                     32 ( 0.5%)             1
 ast-stats-1 - MacCall                   32 ( 0.5%)             1
 ast-stats-1 - Expr                      96 ( 1.5%)             3
 ast-stats-1 Param                    160 ( 2.5%)             4            40
-ast-stats-1 Block                    192 ( 3.0%)             6            32
+ast-stats-1 Block                    192 ( 2.9%)             6            32
 ast-stats-1 Variant                  208 ( 3.2%)             2           104
-ast-stats-1 GenericBound             224 ( 3.5%)             4            56
-ast-stats-1 - Trait                    224 ( 3.5%)             4
+ast-stats-1 GenericBound             256 ( 3.9%)             4            64
+ast-stats-1 - Trait                    256 ( 3.9%)             4
 ast-stats-1 AssocItem                352 ( 5.4%)             4            88
 ast-stats-1 - Type                     176 ( 2.7%)             2
 ast-stats-1 - Fn                       176 ( 2.7%)             2
 ast-stats-1 GenericParam             480 ( 7.4%)             5            96
-ast-stats-1 Pat                      504 ( 7.8%)             7            72
+ast-stats-1 Pat                      504 ( 7.7%)             7            72
 ast-stats-1 - Struct                    72 ( 1.1%)             1
 ast-stats-1 - Wild                      72 ( 1.1%)             1
 ast-stats-1 - Ident                    360 ( 5.5%)             5
-ast-stats-1 Expr                     576 ( 8.9%)             8            72
+ast-stats-1 Expr                     576 ( 8.8%)             8            72
 ast-stats-1 - Path                      72 ( 1.1%)             1
 ast-stats-1 - Match                     72 ( 1.1%)             1
 ast-stats-1 - Struct                    72 ( 1.1%)             1
 ast-stats-1 - Lit                      144 ( 2.2%)             2
 ast-stats-1 - Block                    216 ( 3.3%)             3
-ast-stats-1 PathSegment              720 (11.1%)            30            24
-ast-stats-1 Ty                       896 (13.8%)            14            64
+ast-stats-1 PathSegment              720 (11.0%)            30            24
+ast-stats-1 Ty                       896 (13.7%)            14            64
 ast-stats-1 - Ptr                       64 ( 1.0%)             1
 ast-stats-1 - Ref                       64 ( 1.0%)             1
 ast-stats-1 - ImplicitSelf             128 ( 2.0%)             2
-ast-stats-1 - Path                     640 ( 9.9%)            10
-ast-stats-1 Item                   1_224 (18.9%)             9           136
+ast-stats-1 - Path                     640 ( 9.8%)            10
+ast-stats-1 Item                   1_224 (18.8%)             9           136
 ast-stats-1 - Trait                    136 ( 2.1%)             1
 ast-stats-1 - Enum                     136 ( 2.1%)             1
 ast-stats-1 - ForeignMod               136 ( 2.1%)             1
@@ -53,7 +53,7 @@ ast-stats-1 - Impl                     136 ( 2.1%)             1
 ast-stats-1 - Fn                       272 ( 4.2%)             2
 ast-stats-1 - Use                      408 ( 6.3%)             3
 ast-stats-1 ----------------------------------------------------------------
-ast-stats-1 Total                  6_488
+ast-stats-1 Total                  6_520
 ast-stats-1
 ast-stats-2 POST EXPANSION AST STATS
 ast-stats-2 Name                Accumulated Size         Count     Item Size
@@ -65,28 +65,28 @@ ast-stats-2 ExprField                 48 ( 0.7%)             1            48
 ast-stats-2 WherePredicate            56 ( 0.8%)             1            56
 ast-stats-2 - BoundPredicate            56 ( 0.8%)             1
 ast-stats-2 Local                     72 ( 1.0%)             1            72
-ast-stats-2 Arm                       96 ( 1.4%)             2            48
-ast-stats-2 ForeignItem               96 ( 1.4%)             1            96
-ast-stats-2 - Fn                        96 ( 1.4%)             1
+ast-stats-2 Arm                       96 ( 1.3%)             2            48
+ast-stats-2 ForeignItem               96 ( 1.3%)             1            96
+ast-stats-2 - Fn                        96 ( 1.3%)             1
 ast-stats-2 InlineAsm                120 ( 1.7%)             1           120
 ast-stats-2 FnDecl                   120 ( 1.7%)             5            24
 ast-stats-2 Attribute                128 ( 1.8%)             4            32
-ast-stats-2 - DocComment                32 ( 0.5%)             1
-ast-stats-2 - Normal                    96 ( 1.4%)             3
-ast-stats-2 FieldDef                 160 ( 2.3%)             2            80
-ast-stats-2 Stmt                     160 ( 2.3%)             5            32
-ast-stats-2 - Local                     32 ( 0.5%)             1
-ast-stats-2 - Semi                      32 ( 0.5%)             1
-ast-stats-2 - Expr                      96 ( 1.4%)             3
-ast-stats-2 Param                    160 ( 2.3%)             4            40
+ast-stats-2 - DocComment                32 ( 0.4%)             1
+ast-stats-2 - Normal                    96 ( 1.3%)             3
+ast-stats-2 FieldDef                 160 ( 2.2%)             2            80
+ast-stats-2 Stmt                     160 ( 2.2%)             5            32
+ast-stats-2 - Local                     32 ( 0.4%)             1
+ast-stats-2 - Semi                      32 ( 0.4%)             1
+ast-stats-2 - Expr                      96 ( 1.3%)             3
+ast-stats-2 Param                    160 ( 2.2%)             4            40
 ast-stats-2 Block                    192 ( 2.7%)             6            32
 ast-stats-2 Variant                  208 ( 2.9%)             2           104
-ast-stats-2 GenericBound             224 ( 3.2%)             4            56
-ast-stats-2 - Trait                    224 ( 3.2%)             4
-ast-stats-2 AssocItem                352 ( 5.0%)             4            88
+ast-stats-2 GenericBound             256 ( 3.6%)             4            64
+ast-stats-2 - Trait                    256 ( 3.6%)             4
+ast-stats-2 AssocItem                352 ( 4.9%)             4            88
 ast-stats-2 - Type                     176 ( 2.5%)             2
 ast-stats-2 - Fn                       176 ( 2.5%)             2
-ast-stats-2 GenericParam             480 ( 6.8%)             5            96
+ast-stats-2 GenericParam             480 ( 6.7%)             5            96
 ast-stats-2 Pat                      504 ( 7.1%)             7            72
 ast-stats-2 - Struct                    72 ( 1.0%)             1
 ast-stats-2 - Wild                      72 ( 1.0%)             1
@@ -98,22 +98,22 @@ ast-stats-2 - Struct                    72 ( 1.0%)             1
 ast-stats-2 - InlineAsm                 72 ( 1.0%)             1
 ast-stats-2 - Lit                      144 ( 2.0%)             2
 ast-stats-2 - Block                    216 ( 3.0%)             3
-ast-stats-2 PathSegment              792 (11.2%)            33            24
+ast-stats-2 PathSegment              792 (11.1%)            33            24
 ast-stats-2 Ty                       896 (12.6%)            14            64
 ast-stats-2 - Ptr                       64 ( 0.9%)             1
 ast-stats-2 - Ref                       64 ( 0.9%)             1
 ast-stats-2 - ImplicitSelf             128 ( 1.8%)             2
 ast-stats-2 - Path                     640 ( 9.0%)            10
-ast-stats-2 Item                   1_496 (21.1%)            11           136
+ast-stats-2 Item                   1_496 (21.0%)            11           136
 ast-stats-2 - Trait                    136 ( 1.9%)             1
 ast-stats-2 - Enum                     136 ( 1.9%)             1
 ast-stats-2 - ExternCrate              136 ( 1.9%)             1
 ast-stats-2 - ForeignMod               136 ( 1.9%)             1
 ast-stats-2 - Impl                     136 ( 1.9%)             1
 ast-stats-2 - Fn                       272 ( 3.8%)             2
-ast-stats-2 - Use                      544 ( 7.7%)             4
+ast-stats-2 - Use                      544 ( 7.6%)             4
 ast-stats-2 ----------------------------------------------------------------
-ast-stats-2 Total                  7_088
+ast-stats-2 Total                  7_120
 ast-stats-2
 hir-stats HIR STATS
 hir-stats Name                Accumulated Size         Count     Item Size


### PR DESCRIPTION
This improves diagnostics for the message "`~const` is not allowed here", and also fixes the span that we use when desugaring `~const Tr` into `Tr<host>` in effects desugaring.