### PR TITLE
Request that rust-analyzer changes are sent upstream first if possible

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -533,6 +533,12 @@ message = "The Miri subtree was changed"
 cc = ["@rust-lang/miri"]
 
 [mentions."src/tools/rust-analyzer"]
+message = """
+rust-analyzer is developed in its own repository. If possible, consider making \
+this change to [rust-lang/rust-analyzer] instead.
+
+[rust-lang/rust-analyzer]: https://github.com/rust-lang/rust-analyzer
+"""
 cc = ["@rust-lang/rust-analyzer"]
 
 [mentions."src/tools/rustfmt"]


### PR DESCRIPTION
This automates @lnicola's comment https://github.com/rust-lang/rust/pull/118253#issuecomment-1825925242.

Rustbot will write a comment similar to https://github.com/rust-lang/rust/pull/116743#issuecomment-1763178813.