### PR TITLE
Implement `{Rc, Arc}::new_cyclic_unsize`

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -676,6 +676,72 @@ impl<T> Arc<T> {
     }
 }
 
+impl<T: ?Sized> Arc<T> {
+    /// See [`Arc::new_cyclic`]
+    ///
+    /// The only difference is that the closure is allowed to return a type
+    /// that can be [`Unsize`]d to `T`
+    #[cfg(not(no_global_oom_handling))]
+    #[inline]
+    #[stable(feature = "arc_new_cyclic", since = "1.60.0")]
+    pub fn new_cyclic_unsize<F, U>(data_fn: F) -> Arc<T>
+    where
+        F: FnOnce(&Weak<T>) -> U,
+        U: Unsize<T>,
+    {
+        // Construct the inner in the "uninitialized" state with a single
+        // weak reference.
+        let uninit_ptr: NonNull<_> = Box::leak(Box::new(ArcInner {
+            strong: atomic::AtomicUsize::new(0),
+            weak: atomic::AtomicUsize::new(1),
+            data: mem::MaybeUninit::<U>::uninit(),
+        }))
+        .into();
+        let init_ptr: NonNull<ArcInner<U>> = uninit_ptr.cast();
+
+        //unsize
+        let weak: Weak<T> = Weak { ptr: init_ptr, alloc: Global };
+
+        // It's important we don't give up ownership of the weak pointer, or
+        // else the memory might be freed by the time `data_fn` returns. If
+        // we really wanted to pass ownership, we could create an additional
+        // weak pointer for ourselves, but this would result in additional
+        // updates to the weak reference count which might not be necessary
+        // otherwise.
+        let data = data_fn(&weak);
+
+        // Now we can properly initialize the inner value and turn our weak
+        // reference into a strong reference.
+        let strong = unsafe {
+            let inner = init_ptr.as_ptr();
+            ptr::write(ptr::addr_of_mut!((*inner).data), data);
+
+            // The above write to the data field must be visible to any threads which
+            // observe a non-zero strong count. Therefore we need at least "Release" ordering
+            // in order to synchronize with the `compare_exchange_weak` in `Weak::upgrade`.
+            //
+            // "Acquire" ordering is not required. When considering the possible behaviours
+            // of `data_fn` we only need to look at what it could do with a reference to a
+            // non-upgradeable `Weak`:
+            // - It can *clone* the `Weak`, increasing the weak reference count.
+            // - It can drop those clones, decreasing the weak reference count (but never to zero).
+            //
+            // These side effects do not impact us in any way, and no other side effects are
+            // possible with safe code alone.
+            let prev_value = (*inner).strong.fetch_add(1, Release);
+            debug_assert_eq!(prev_value, 0, "No prior strong references should exist");
+
+            Arc::from_inner(init_ptr)
+        };
+
+        // Strong references should collectively own a shared weak reference,
+        // so don't run the destructor for our old weak reference.
+        mem::forget(weak);
+        //unsize
+        strong
+    }
+}
+
 impl<T, A: Allocator> Arc<T, A> {
     /// Returns a reference to the underlying allocator.
     ///


### PR DESCRIPTION
`new_cyclic_unsize` is just like `new_cyclic`, except that it unsizes the type returned by the closure. The most useful for unnamable types e.g. it allows you to easily create recursive `Rc<dyn Fn()>` closures (example below) which is otherwise only possible with unsafe hacks or interior mutablility (as far as I'm aware).
This is still incomplete, (it definitely needs it's own feature and such) so I don't expect it to be merged right away.
```rs
use std::rc::{Rc, Weak};
use std::sync::atomic::AtomicU32;
use std::sync::atomic::Ordering;
let counter = AtomicU32::new(0);
let counter_ref = &counter;
let factorial = Rc::new_cyclic_unsize(move |rec: &Weak<dyn Fn(u32) -> u32>| {
    let rec = rec.clone();
    move |x| {
        // can capture env
        counter_ref.fetch_add(1, Ordering::Relaxed);
        match x {
            0 => 1,
            x => x * rec.upgrade().unwrap()(x - 1),
        }
    }
});
println!("{}", factorial(5)); // 120
println!("{}", counter.load(Ordering::Relaxed)); // 6
println!("{}", factorial(7)); // 5040
println!("{}", counter.load(Ordering::Relaxed)); // 14
```