### PR TITLE
Allow coercions from never-type when ref binding is involved

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -131,7 +131,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.check_expr_with_expectation(expr, ExpectHasType(expected))
     }
 
-    fn check_expr_with_expectation_and_needs(
+    pub(super) fn check_expr_with_expectation_and_needs(
         &self,
         expr: &'tcx hir::Expr<'tcx>,
         expected: Expectation<'tcx>,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1444,7 +1444,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // referent for the reference that results is *equal to* the
             // type of the place it is referencing, and not some
             // supertype thereof.
-            let init_ty = self.check_expr_with_needs(init, Needs::maybe_mut_place(m));
+            let mut init_ty = self.check_expr_with_expectation_and_needs(
+                init,
+                ExpectHasType(local_ty),
+                Needs::maybe_mut_place(m),
+            );
+            // The one exception to the above rule - we permit coercions when the expression has type !
+            // This allows `let Foo { ref my_field } = diverging_expr;`. The actual assignment is guaranteed
+            // to be unreachable, so the soundness concerns with 'ref mut' do not apply.
+            if init_ty.is_never() {
+                init_ty = self.demand_coerce(init, init_ty, local_ty, None, AllowTwoPhase::No);
+            };
+
             if let Some(mut diag) = self.demand_eqtype_diag(init.span, local_ty, init_ty) {
                 self.emit_type_mismatch_suggestions(
                     &mut diag,

--- a/tests/ui/pattern/issue-118113-ref-pattern-never-type.rs
+++ b/tests/ui/pattern/issue-118113-ref-pattern-never-type.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+pub struct Foo {
+    bar: u8
+}
+
+#[allow(unused_variables)]
+fn main() {
+    let Foo { ref bar } = loop {};
+}

--- a/tests/ui/pattern/ref-pattern-assoc-type.rs
+++ b/tests/ui/pattern/ref-pattern-assoc-type.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+trait Call {
+  type Out;
+  fn call(self) -> Self::Out;
+}
+
+impl<F: FnOnce() -> T, T> Call for F {
+  type Out = T;
+  fn call(self) -> T { (self)() }
+}
+
+pub struct Foo {
+    bar: u8
+}
+
+fn diverge() -> ! { todo!() }
+
+#[allow(unused_variables)]
+fn main() {
+    let Foo { ref bar } = diverge.call();
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/118113

When we type-check a binding that uses ref patterns, we do not perform coercions between the expression type and the pattern type.

However, this has the unfortunate result of disallow code like: `let Foo { ref my_field } = diverging_expr();`. This code is accepted without the `ref` keyword.

We now explicitly allow coercions when the expression type is ! In all other cases, we still avoid performing coersions. This avoids causing broader changes in type-checking (with potential soundness implications for 'ref mut'),