### PR TITLE
Don't ICE when encountering placeholders in implied bounds computation

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -207,8 +207,10 @@ fn implied_bounds_from_components<'tcx>(
                 Component::Region(r) => Some(OutlivesBound::RegionSubRegion(sub_region, r)),
                 Component::Param(p) => Some(OutlivesBound::RegionSubParam(sub_region, p)),
                 Component::Alias(p) => Some(OutlivesBound::RegionSubAlias(sub_region, p)),
-                Component::Placeholder(_) => {
-                    unimplemented!("Shouldn't expect a placeholder type in implied bounds (yet)")
+                Component::Placeholder(_p) => {
+                    // FIXME(non_lifetime_binders): Placeholders don't currently
+                    // imply anything for outlives, though they could easily.
+                    None
                 }
                 Component::EscapingAlias(_) =>
                 // If the projection has escaping regions, don't

--- a/tests/ui/impl-trait/in-trait/placeholder-implied-bounds.rs
+++ b/tests/ui/impl-trait/in-trait/placeholder-implied-bounds.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+pub fn main() {}
+
+pub trait Iced {
+    fn get(&self) -> &impl Sized;
+}
+
+/// Impl causes ICE
+impl Iced for () {
+    fn get(&self) -> &impl Sized {
+        &()
+    }
+}


### PR DESCRIPTION
I *could* fix this the right way, though I don't really want to think about the implications of the change. This should have minimal side-effects.

r? @aliemjay 

Fixes #118286