### PR TITLE
Merge `unused_tuple_struct_fields` into `dead_code`

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -328,6 +328,7 @@ fn register_builtins(store: &mut LintStore) {
     store.register_renamed("disjoint_capture_migration", "rust_2021_incompatible_closure_captures");
     store.register_renamed("or_patterns_back_compat", "rust_2021_incompatible_or_patterns");
     store.register_renamed("non_fmt_panic", "non_fmt_panics");
+    store.register_renamed("unused_tuple_struct_fields", "dead_code");
 
     // These were moved to tool lints, but rustc still sees them when compiling normally, before
     // tool lints are registered, so `check_tool_name_for_backwards_compat` doesn't work. Use

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -125,7 +125,6 @@ declare_lint_pass! {
         UNUSED_MACROS,
         UNUSED_MUT,
         UNUSED_QUALIFICATIONS,
-        UNUSED_TUPLE_STRUCT_FIELDS,
         UNUSED_UNSAFE,
         UNUSED_VARIABLES,
         USELESS_DEPRECATED,
@@ -697,8 +696,13 @@ declare_lint! {
     /// Dead code may signal a mistake or unfinished code. To silence the
     /// warning for individual items, prefix the name with an underscore such
     /// as `_foo`. If it was intended to expose the item outside of the crate,
-    /// consider adding a visibility modifier like `pub`. Otherwise consider
-    /// removing the unused code.
+    /// consider adding a visibility modifier like `pub`.
+    ///
+    /// To preserve the numbering of tuple structs with unused fields,
+    /// change the unused fields to have unit type or use
+    /// `PhantomData`.
+    ///
+    /// Otherwise consider removing the unused code.
     pub DEAD_CODE,
     Warn,
     "detect unused, unexported items"
@@ -730,32 +734,6 @@ declare_lint! {
     pub UNUSED_ATTRIBUTES,
     Warn,
     "detects attributes that were not used by the compiler"
-}
-
-declare_lint! {
-    /// The `unused_tuple_struct_fields` lint detects fields of tuple structs
-    /// that are never read.
-    ///
-    /// ### Example
-    ///
-    /// ```rust
-    /// #[warn(unused_tuple_struct_fields)]
-    /// struct S(i32, i32, i32);
-    /// let s = S(1, 2, 3);
-    /// let _ = (s.0, s.2);
-    /// ```
-    ///
-    /// {{produces}}
-    ///
-    /// ### Explanation
-    ///
-    /// Tuple struct fields that are never read anywhere may indicate a
-    /// mistake or unfinished code. To silence this warning, consider
-    /// removing the unused field(s) or, to preserve the numbering of the
-    /// remaining fields, change the unused field(s) to have unit type.
-    pub UNUSED_TUPLE_STRUCT_FIELDS,
-    Allow,
-    "detects tuple struct fields that are never read"
 }
 
 declare_lint! {

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -24,6 +24,7 @@
 //! Creating a recursive data structure:
 //!
 //! ```
+//! ##[allow(dead_code)]
 //! #[derive(Debug)]
 //! enum List<T> {
 //!     Cons(T, Box<List<T>>),

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -171,7 +171,7 @@ struct WithHeader<H>(NonNull<u8>, PhantomData<H>);
 /// An opaque representation of `WithHeader<H>` to avoid the
 /// projection invariance of `<T as Pointee>::Metadata`.
 #[repr(transparent)]
-#[allow(unused_tuple_struct_fields)] // Field only used through `WithHeader` type above.
+#[allow(dead_code)] // Field only used through `WithHeader` type above.
 struct WithOpaqueHeader(NonNull<u8>);
 
 impl WithOpaqueHeader {

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -524,7 +524,7 @@ fn test_extend_ref() {
 #[test]
 fn test_recovery() {
     #[derive(Debug)]
-    struct Foo(&'static str, i32);
+    struct Foo(&'static str, #[allow(dead_code)] i32);
 
     impl PartialEq for Foo {
         fn eq(&self, other: &Self) -> bool {

--- a/library/alloc/src/collections/vec_deque/tests.rs
+++ b/library/alloc/src/collections/vec_deque/tests.rs
@@ -1085,7 +1085,7 @@ fn test_clone_from() {
 fn test_vec_deque_truncate_drop() {
     static mut DROPS: u32 = 0;
     #[derive(Clone)]
-    struct Elem(i32);
+    struct Elem(#[allow(dead_code)] i32);
     impl Drop for Elem {
         fn drop(&mut self) {
             unsafe {

--- a/library/alloc/tests/autotraits.rs
+++ b/library/alloc/tests/autotraits.rs
@@ -1,7 +1,7 @@
 fn require_sync<T: Sync>(_: T) {}
 fn require_send_sync<T: Send + Sync>(_: T) {}
 
-struct NotSend(*const ());
+struct NotSend(#[allow(dead_code)] *const ());
 unsafe impl Sync for NotSend {}
 
 #[test]

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -547,7 +547,7 @@ fn test_cmp() {
 #[test]
 fn test_vec_truncate_drop() {
     static mut DROPS: u32 = 0;
-    struct Elem(i32);
+    struct Elem(#[allow(dead_code)] i32);
     impl Drop for Elem {
         fn drop(&mut self) {
             unsafe {
@@ -1089,7 +1089,7 @@ fn test_into_iter_advance_by() {
 
 #[test]
 fn test_into_iter_drop_allocator() {
-    struct ReferenceCountedAllocator<'a>(DropCounter<'a>);
+    struct ReferenceCountedAllocator<'a>(#[allow(dead_code)] DropCounter<'a>);
 
     unsafe impl Allocator for ReferenceCountedAllocator<'_> {
         fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
@@ -2407,7 +2407,7 @@ fn test_vec_dedup_multiple_ident() {
 #[test]
 fn test_vec_dedup_partialeq() {
     #[derive(Debug)]
-    struct Foo(i32, i32);
+    struct Foo(i32, #[allow(dead_code)] i32);
 
     impl PartialEq for Foo {
         fn eq(&self, other: &Foo) -> bool {

--- a/library/core/benches/slice.rs
+++ b/library/core/benches/slice.rs
@@ -91,7 +91,7 @@ fn binary_search_l3_worst_case(b: &mut Bencher) {
 }
 
 #[derive(Clone)]
-struct Rgb(u8, u8, u8);
+struct Rgb(#[allow(dead_code)] u8, #[allow(dead_code)] u8, #[allow(dead_code)] u8);
 
 impl Rgb {
     fn gen(i: usize) -> Self {
@@ -154,7 +154,7 @@ swap_with_slice!(swap_with_slice_5x_usize_3000, 3000, |i| [i; 5]);
 #[bench]
 fn fill_byte_sized(b: &mut Bencher) {
     #[derive(Copy, Clone)]
-    struct NewType(u8);
+    struct NewType(#[allow(dead_code)] u8);
 
     let mut ary = [NewType(0); 1024];
 

--- a/library/core/tests/any.rs
+++ b/library/core/tests/any.rs
@@ -122,7 +122,7 @@ fn any_unsized() {
 fn distinct_type_names() {
     // https://github.com/rust-lang/rust/issues/84666
 
-    struct Velocity(f32, f32);
+    struct Velocity(#[allow(dead_code)] f32, #[allow(dead_code)] f32);
 
     fn type_name_of_val<T>(_: T) -> &'static str {
         type_name::<T>()

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -262,7 +262,7 @@ fn array_default_impl_avoids_leaks_on_panic() {
     use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     #[derive(Debug)]
-    struct Bomb(usize);
+    struct Bomb(#[allow(dead_code)] usize);
 
     impl Default for Bomb {
         fn default() -> Bomb {

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -188,7 +188,7 @@ fn ptr_bitops() {
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
 fn ptr_bitops_tagging() {
     #[repr(align(16))]
-    struct Tagme(u128);
+    struct Tagme(#[allow(dead_code)] u128);
 
     let tagme = Tagme(1000);
     let ptr = &tagme as *const Tagme as *mut Tagme;

--- a/library/core/tests/intrinsics.rs
+++ b/library/core/tests/intrinsics.rs
@@ -4,7 +4,7 @@ use core::intrinsics::assume;
 #[test]
 fn test_typeid_sized_types() {
     struct X;
-    struct Y(u32);
+    struct Y(#[allow(dead_code)] u32);
 
     assert_eq!(TypeId::of::<X>(), TypeId::of::<X>());
     assert_eq!(TypeId::of::<Y>(), TypeId::of::<Y>());
@@ -14,8 +14,8 @@ fn test_typeid_sized_types() {
 #[test]
 fn test_typeid_unsized_types() {
     trait Z {}
-    struct X(str);
-    struct Y(dyn Z + 'static);
+    struct X(#[allow(dead_code)] str);
+    struct Y(#[allow(dead_code)] dyn Z + 'static);
 
     assert_eq!(TypeId::of::<X>(), TypeId::of::<X>());
     assert_eq!(TypeId::of::<Y>(), TypeId::of::<Y>());

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -451,34 +451,34 @@ fn align_offset_various_strides() {
         for ptr in 1usize..4 * align {
             unsafe {
                 #[repr(packed)]
-                struct A3(u16, u8);
+                struct A3(#[allow(dead_code)] u16, #[allow(dead_code)] u8);
                 x |= test_stride::<A3>(ptr::invalid::<A3>(ptr), align);
 
-                struct A4(u32);
+                struct A4(#[allow(dead_code)] u32);
                 x |= test_stride::<A4>(ptr::invalid::<A4>(ptr), align);
 
                 #[repr(packed)]
-                struct A5(u32, u8);
+                struct A5(#[allow(dead_code)] u32, #[allow(dead_code)] u8);
                 x |= test_stride::<A5>(ptr::invalid::<A5>(ptr), align);
 
                 #[repr(packed)]
-                struct A6(u32, u16);
+                struct A6(#[allow(dead_code)] u32, #[allow(dead_code)] u16);
                 x |= test_stride::<A6>(ptr::invalid::<A6>(ptr), align);
 
                 #[repr(packed)]
-                struct A7(u32, u16, u8);
+                struct A7(#[allow(dead_code)] u32, #[allow(dead_code)] u16, #[allow(dead_code)] u8);
                 x |= test_stride::<A7>(ptr::invalid::<A7>(ptr), align);
 
                 #[repr(packed)]
-                struct A8(u32, u32);
+                struct A8(#[allow(dead_code)] u32, #[allow(dead_code)] u32);
                 x |= test_stride::<A8>(ptr::invalid::<A8>(ptr), align);
 
                 #[repr(packed)]
-                struct A9(u32, u32, u8);
+                struct A9(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u8);
                 x |= test_stride::<A9>(ptr::invalid::<A9>(ptr), align);
 
                 #[repr(packed)]
-                struct A10(u32, u32, u16);
+                struct A10(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u16);
                 x |= test_stride::<A10>(ptr::invalid::<A10>(ptr), align);
 
                 x |= test_stride::<u32>(ptr::invalid::<u32>(ptr), align);
@@ -517,34 +517,34 @@ fn align_offset_various_strides_const() {
             while ptr < 4 * align {
                 unsafe {
                     #[repr(packed)]
-                    struct A3(u16, u8);
+                    struct A3(#[allow(dead_code)] u16, #[allow(dead_code)] u8);
                     test_stride::<A3>(ptr::invalid::<A3>(ptr), ptr, align);
 
-                    struct A4(u32);
+                    struct A4(#[allow(dead_code)] u32);
                     test_stride::<A4>(ptr::invalid::<A4>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A5(u32, u8);
+                    struct A5(#[allow(dead_code)] u32, #[allow(dead_code)] u8);
                     test_stride::<A5>(ptr::invalid::<A5>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A6(u32, u16);
+                    struct A6(#[allow(dead_code)] u32, #[allow(dead_code)] u16);
                     test_stride::<A6>(ptr::invalid::<A6>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A7(u32, u16, u8);
+                    struct A7(#[allow(dead_code)] u32, #[allow(dead_code)] u16, #[allow(dead_code)] u8);
                     test_stride::<A7>(ptr::invalid::<A7>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A8(u32, u32);
+                    struct A8(#[allow(dead_code)] u32, #[allow(dead_code)] u32);
                     test_stride::<A8>(ptr::invalid::<A8>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A9(u32, u32, u8);
+                    struct A9(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u8);
                     test_stride::<A9>(ptr::invalid::<A9>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A10(u32, u32, u16);
+                    struct A10(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u16);
                     test_stride::<A10>(ptr::invalid::<A10>(ptr), ptr, align);
 
                     test_stride::<u32>(ptr::invalid::<u32>(ptr), ptr, align);
@@ -672,7 +672,7 @@ fn align_offset_issue_103361() {
     const SIZE: usize = 1 << 30;
     #[cfg(target_pointer_width = "16")]
     const SIZE: usize = 1 << 13;
-    struct HugeSize([u8; SIZE - 1]);
+    struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
     let _ = ptr::invalid::<HugeSize>(SIZE).align_offset(SIZE);
 }
 
@@ -684,7 +684,7 @@ fn align_offset_issue_103361_const() {
     const SIZE: usize = 1 << 30;
     #[cfg(target_pointer_width = "16")]
     const SIZE: usize = 1 << 13;
-    struct HugeSize([u8; SIZE - 1]);
+    struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
 
     const {
         assert!(ptr::invalid::<HugeSize>(SIZE - 1).align_offset(SIZE) == SIZE - 1);
@@ -834,7 +834,7 @@ fn ptr_metadata_bounds() {
 fn dyn_metadata() {
     #[derive(Debug)]
     #[repr(align(32))]
-    struct Something([u8; 47]);
+    struct Something(#[allow(dead_code)] [u8; 47]);
 
     let value = Something([0; 47]);
     let trait_object: &dyn Debug = &value;

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2109,9 +2109,9 @@ fn test_align_to_zst() {
 #[test]
 fn test_align_to_non_trivial() {
     #[repr(align(8))]
-    struct U64(u64, u64);
+    struct U64(#[allow(dead_code)] u64, #[allow(dead_code)] u64);
     #[repr(align(8))]
-    struct U64U64U32(u64, u64, u32);
+    struct U64U64U32(#[allow(dead_code)] u64, #[allow(dead_code)] u64, #[allow(dead_code)] u32);
     let data = [
         U64(1, 2),
         U64(3, 4),
@@ -2196,7 +2196,7 @@ fn test_slice_partition_dedup_multiple_ident() {
 #[test]
 fn test_slice_partition_dedup_partialeq() {
     #[derive(Debug)]
-    struct Foo(i32, i32);
+    struct Foo(i32, #[allow(dead_code)] i32);
 
     impl PartialEq for Foo {
         fn eq(&self, other: &Foo) -> bool {

--- a/library/std/src/collections/hash/set/tests.rs
+++ b/library/std/src/collections/hash/set/tests.rs
@@ -352,7 +352,7 @@ fn test_replace() {
     use crate::hash;
 
     #[derive(Debug)]
-    struct Foo(&'static str, i32);
+    struct Foo(&'static str, #[allow(dead_code)] i32);
 
     impl PartialEq for Foo {
         fn eq(&self, other: &Self) -> bool {

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -4186,7 +4186,7 @@ impl Methods {
                             expr,
                             recv,
                             recv2,
-                            iter_overeager_cloned::Op::NeedlessMove(name, arg),
+                            iter_overeager_cloned::Op::NeedlessMove(arg),
                             false,
                         );
                     }
@@ -4204,7 +4204,7 @@ impl Methods {
                         expr,
                         recv,
                         recv2,
-                        iter_overeager_cloned::Op::NeedlessMove(name, arg),
+                        iter_overeager_cloned::Op::NeedlessMove(arg),
                         false,
                     ),
                     Some(("chars", recv, _, _, _))
@@ -4379,7 +4379,7 @@ impl Methods {
                         expr,
                         recv,
                         recv2,
-                        iter_overeager_cloned::Op::NeedlessMove(name, arg),
+                        iter_overeager_cloned::Op::NeedlessMove(arg),
                         false,
                     ),
                     _ => {},
@@ -4433,7 +4433,7 @@ impl Methods {
                                 expr,
                                 recv,
                                 recv2,
-                                iter_overeager_cloned::Op::NeedlessMove(name, m_arg),
+                                iter_overeager_cloned::Op::NeedlessMove(m_arg),
                                 false,
                             ),
                             _ => {},

--- a/src/tools/clippy/clippy_lints/src/question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/question_mark.rs
@@ -80,7 +80,6 @@ enum IfBlockType<'hir> {
         Ty<'hir>,
         Symbol,
         &'hir Expr<'hir>,
-        Option<&'hir Expr<'hir>>,
     ),
     /// An `if let Xxx(a) = b { c } else { d }` expression.
     ///
@@ -143,7 +142,7 @@ fn check_let_some_else_return_none(cx: &LateContext<'_>, stmt: &Stmt<'_>) {
 
 fn is_early_return(smbl: Symbol, cx: &LateContext<'_>, if_block: &IfBlockType<'_>) -> bool {
     match *if_block {
-        IfBlockType::IfIs(caller, caller_ty, call_sym, if_then, _) => {
+        IfBlockType::IfIs(caller, caller_ty, call_sym, if_then) => {
             // If the block could be identified as `if x.is_none()/is_err()`,
             // we then only need to check the if_then return to see if it is none/err.
             is_type_diagnostic_item(cx, caller_ty, smbl)
@@ -235,7 +234,7 @@ impl QuestionMark {
             && !is_else_clause(cx.tcx, expr)
             && let ExprKind::MethodCall(segment, caller, ..) = &cond.kind
             && let caller_ty = cx.typeck_results().expr_ty(caller)
-            && let if_block = IfBlockType::IfIs(caller, caller_ty, segment.ident.name, then, r#else)
+            && let if_block = IfBlockType::IfIs(caller, caller_ty, segment.ident.name, then)
             && (is_early_return(sym::Option, cx, &if_block) || is_early_return(sym::Result, cx, &if_block))
         {
             let mut applicability = Applicability::MachineApplicable;

--- a/src/tools/clippy/clippy_lints/src/transmute/transmute_undefined_repr.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/transmute_undefined_repr.rs
@@ -26,18 +26,18 @@ pub(super) fn check<'tcx>(
 
             // `Repr(C)` <-> unordered type.
             // If the first field of the `Repr(C)` type matches then the transmute is ok
-            (ReducedTy::OrderedFields(_, Some(from_sub_ty)), ReducedTy::UnorderedFields(to_sub_ty))
-            | (ReducedTy::UnorderedFields(from_sub_ty), ReducedTy::OrderedFields(_, Some(to_sub_ty))) => {
+            (ReducedTy::OrderedFields(Some(from_sub_ty)), ReducedTy::UnorderedFields(to_sub_ty))
+            | (ReducedTy::UnorderedFields(from_sub_ty), ReducedTy::OrderedFields(Some(to_sub_ty))) => {
                 from_ty = from_sub_ty;
                 to_ty = to_sub_ty;
                 continue;
             },
-            (ReducedTy::OrderedFields(_, Some(from_sub_ty)), ReducedTy::Other(to_sub_ty)) if reduced_tys.to_fat_ptr => {
+            (ReducedTy::OrderedFields(Some(from_sub_ty)), ReducedTy::Other(to_sub_ty)) if reduced_tys.to_fat_ptr => {
                 from_ty = from_sub_ty;
                 to_ty = to_sub_ty;
                 continue;
             },
-            (ReducedTy::Other(from_sub_ty), ReducedTy::OrderedFields(_, Some(to_sub_ty)))
+            (ReducedTy::Other(from_sub_ty), ReducedTy::OrderedFields(Some(to_sub_ty)))
                 if reduced_tys.from_fat_ptr =>
             {
                 from_ty = from_sub_ty;
@@ -235,8 +235,8 @@ enum ReducedTy<'tcx> {
     TypeErasure { raw_ptr_only: bool },
     /// The type is a struct containing either zero non-zero sized fields, or multiple non-zero
     /// sized fields with a defined order.
-    /// The second value is the first non-zero sized type.
-    OrderedFields(Ty<'tcx>, Option<Ty<'tcx>>),
+    /// The value is the first non-zero sized type.
+    OrderedFields(Option<Ty<'tcx>>),
     /// The type is a struct containing multiple non-zero sized fields with no defined order.
     UnorderedFields(Ty<'tcx>),
     /// Any other type.
@@ -259,7 +259,7 @@ fn reduce_ty<'tcx>(cx: &LateContext<'tcx>, mut ty: Ty<'tcx>) -> ReducedTy<'tcx> 
             ty::Tuple(args) => {
                 let mut iter = args.iter();
                 let Some(sized_ty) = iter.find(|&ty| !is_zero_sized_ty(cx, ty)) else {
-                    return ReducedTy::OrderedFields(ty, None);
+                    return ReducedTy::OrderedFields(None);
                 };
                 if iter.all(|ty| is_zero_sized_ty(cx, ty)) {
                     ty = sized_ty;
@@ -281,7 +281,7 @@ fn reduce_ty<'tcx>(cx: &LateContext<'tcx>, mut ty: Ty<'tcx>) -> ReducedTy<'tcx> 
                     continue;
                 }
                 if def.repr().inhibit_struct_field_reordering_opt() {
-                    ReducedTy::OrderedFields(ty, Some(sized_ty))
+                    ReducedTy::OrderedFields(Some(sized_ty))
                 } else {
                     ReducedTy::UnorderedFields(ty)
                 }

--- a/src/tools/clippy/tests/ui/borrow_interior_mutable_const/auxiliary/helper.rs
+++ b/src/tools/clippy/tests/ui/borrow_interior_mutable_const/auxiliary/helper.rs
@@ -2,7 +2,6 @@
 // As the most common case is the `http` crate, it replicates `http::HeaderName`'s structure.
 
 #![allow(clippy::declare_interior_mutable_const)]
-#![allow(unused_tuple_struct_fields)]
 
 use std::sync::atomic::AtomicUsize;
 

--- a/src/tools/clippy/tests/ui/format.fixed
+++ b/src/tools/clippy/tests/ui/format.fixed
@@ -1,6 +1,5 @@
 #![warn(clippy::useless_format)]
 #![allow(
-    unused_tuple_struct_fields,
     clippy::print_literal,
     clippy::redundant_clone,
     clippy::to_string_in_format_args,

--- a/src/tools/clippy/tests/ui/format.rs
+++ b/src/tools/clippy/tests/ui/format.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::useless_format)]
 #![allow(
-    unused_tuple_struct_fields,
     clippy::print_literal,
     clippy::redundant_clone,
     clippy::to_string_in_format_args,

--- a/src/tools/clippy/tests/ui/format.stderr
+++ b/src/tools/clippy/tests/ui/format.stderr
@@ -1,5 +1,5 @@
 error: useless use of `format!`
-  --> $DIR/format.rs:20:5
+  --> $DIR/format.rs:19:5
    |
 LL |     format!("foo");
    |     ^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
@@ -8,19 +8,19 @@ LL |     format!("foo");
    = help: to override `-D warnings` add `#[allow(clippy::useless_format)]`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:21:5
+  --> $DIR/format.rs:20:5
    |
 LL |     format!("{{}}");
    |     ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{}".to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:22:5
+  --> $DIR/format.rs:21:5
    |
 LL |     format!("{{}} abc {{}}");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"{} abc {}".to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:23:5
+  --> $DIR/format.rs:22:5
    |
 LL | /     format!(
 LL | |         r##"foo {{}}
@@ -35,67 +35,67 @@ LL ~ " bar"##.to_string();
    |
 
 error: useless use of `format!`
-  --> $DIR/format.rs:28:13
+  --> $DIR/format.rs:27:13
    |
 LL |     let _ = format!("");
    |             ^^^^^^^^^^^ help: consider using `String::new()`: `String::new()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:30:5
+  --> $DIR/format.rs:29:5
    |
 LL |     format!("{}", "foo");
    |     ^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"foo".to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:38:5
+  --> $DIR/format.rs:37:5
    |
 LL |     format!("{}", arg);
    |     ^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `arg.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:68:5
+  --> $DIR/format.rs:67:5
    |
 LL |     format!("{}", 42.to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `42.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:70:5
+  --> $DIR/format.rs:69:5
    |
 LL |     format!("{}", x.display().to_string());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.display().to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:74:18
+  --> $DIR/format.rs:73:18
    |
 LL |     let _ = Some(format!("{}", a + "bar"));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `a + "bar"`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:78:22
+  --> $DIR/format.rs:77:22
    |
 LL |     let _s: String = format!("{}", &*v.join("\n"));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `(&*v.join("\n")).to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:84:13
+  --> $DIR/format.rs:83:13
    |
 LL |     let _ = format!("{x}");
    |             ^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:86:13
+  --> $DIR/format.rs:85:13
    |
 LL |     let _ = format!("{y}", y = x);
    |             ^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `x.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:90:13
+  --> $DIR/format.rs:89:13
    |
 LL |     let _ = format!("{abc}");
    |             ^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `abc.to_string()`
 
 error: useless use of `format!`
-  --> $DIR/format.rs:92:13
+  --> $DIR/format.rs:91:13
    |
 LL |     let _ = format!("{xx}");
    |             ^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `xx.to_string()`

--- a/src/tools/clippy/tests/ui/from_iter_instead_of_collect.fixed
+++ b/src/tools/clippy/tests/ui/from_iter_instead_of_collect.fixed
@@ -1,5 +1,5 @@
 #![warn(clippy::from_iter_instead_of_collect)]
-#![allow(unused_imports, unused_tuple_struct_fields)]
+#![allow(unused_imports)]
 #![allow(clippy::useless_vec)]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};

--- a/src/tools/clippy/tests/ui/from_iter_instead_of_collect.rs
+++ b/src/tools/clippy/tests/ui/from_iter_instead_of_collect.rs
@@ -1,5 +1,5 @@
 #![warn(clippy::from_iter_instead_of_collect)]
-#![allow(unused_imports, unused_tuple_struct_fields)]
+#![allow(unused_imports)]
 #![allow(clippy::useless_vec)]
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};

--- a/src/tools/clippy/tests/ui/must_use_candidates.fixed
+++ b/src/tools/clippy/tests/ui/must_use_candidates.fixed
@@ -1,7 +1,6 @@
 #![feature(never_type)]
 #![allow(
     unused_mut,
-    unused_tuple_struct_fields,
     clippy::redundant_allocation,
     clippy::needless_pass_by_ref_mut
 )]

--- a/src/tools/clippy/tests/ui/must_use_candidates.rs
+++ b/src/tools/clippy/tests/ui/must_use_candidates.rs
@@ -1,7 +1,6 @@
 #![feature(never_type)]
 #![allow(
     unused_mut,
-    unused_tuple_struct_fields,
     clippy::redundant_allocation,
     clippy::needless_pass_by_ref_mut
 )]

--- a/src/tools/clippy/tests/ui/must_use_candidates.stderr
+++ b/src/tools/clippy/tests/ui/must_use_candidates.stderr
@@ -1,5 +1,5 @@
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:16:1
+  --> $DIR/must_use_candidates.rs:15:1
    |
 LL | pub fn pure(i: u8) -> u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn pure(i: u8) -> u8`
@@ -8,25 +8,25 @@ LL | pub fn pure(i: u8) -> u8 {
    = help: to override `-D warnings` add `#[allow(clippy::must_use_candidate)]`
 
 error: this method could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:21:5
+  --> $DIR/must_use_candidates.rs:20:5
    |
 LL |     pub fn inherent_pure(&self) -> u8 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn inherent_pure(&self) -> u8`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:52:1
+  --> $DIR/must_use_candidates.rs:51:1
    |
 LL | pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn with_marker(_d: std::marker::PhantomData<&mut u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:64:1
+  --> $DIR/must_use_candidates.rs:63:1
    |
 LL | pub fn rcd(_x: Rc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn rcd(_x: Rc<u32>) -> bool`
 
 error: this function could have a `#[must_use]` attribute
-  --> $DIR/must_use_candidates.rs:72:1
+  --> $DIR/must_use_candidates.rs:71:1
    |
 LL | pub fn arcd(_x: Arc<u32>) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add the attribute: `#[must_use] pub fn arcd(_x: Arc<u32>) -> bool`

--- a/src/tools/clippy/tests/ui/numbered_fields.fixed
+++ b/src/tools/clippy/tests/ui/numbered_fields.fixed
@@ -1,5 +1,4 @@
 #![warn(clippy::init_numbered_fields)]
-#![allow(unused_tuple_struct_fields)]
 
 #[derive(Default)]
 struct TupleStruct(u32, u32, u8);

--- a/src/tools/clippy/tests/ui/numbered_fields.rs
+++ b/src/tools/clippy/tests/ui/numbered_fields.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::init_numbered_fields)]
-#![allow(unused_tuple_struct_fields)]
 
 #[derive(Default)]
 struct TupleStruct(u32, u32, u8);

--- a/src/tools/clippy/tests/ui/numbered_fields.stderr
+++ b/src/tools/clippy/tests/ui/numbered_fields.stderr
@@ -1,5 +1,5 @@
 error: used a field initializer for a tuple struct
-  --> $DIR/numbered_fields.rs:18:13
+  --> $DIR/numbered_fields.rs:17:13
    |
 LL |       let _ = TupleStruct {
    |  _____________^
@@ -13,7 +13,7 @@ LL | |     };
    = help: to override `-D warnings` add `#[allow(clippy::init_numbered_fields)]`
 
 error: used a field initializer for a tuple struct
-  --> $DIR/numbered_fields.rs:25:13
+  --> $DIR/numbered_fields.rs:24:13
    |
 LL |       let _ = TupleStruct {
    |  _____________^

--- a/src/tools/clippy/tests/ui/option_if_let_else.fixed
+++ b/src/tools/clippy/tests/ui/option_if_let_else.fixed
@@ -1,6 +1,5 @@
 #![warn(clippy::option_if_let_else)]
 #![allow(
-    unused_tuple_struct_fields,
     clippy::ref_option_ref,
     clippy::equatable_if_let,
     clippy::let_unit_value,

--- a/src/tools/clippy/tests/ui/option_if_let_else.rs
+++ b/src/tools/clippy/tests/ui/option_if_let_else.rs
@@ -1,6 +1,5 @@
 #![warn(clippy::option_if_let_else)]
 #![allow(
-    unused_tuple_struct_fields,
     clippy::ref_option_ref,
     clippy::equatable_if_let,
     clippy::let_unit_value,

--- a/src/tools/clippy/tests/ui/option_if_let_else.stderr
+++ b/src/tools/clippy/tests/ui/option_if_let_else.stderr
@@ -1,5 +1,5 @@
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:11:5
+  --> $DIR/option_if_let_else.rs:10:5
    |
 LL | /     if let Some(x) = string {
 LL | |         (true, x)
@@ -12,19 +12,19 @@ LL | |     }
    = help: to override `-D warnings` add `#[allow(clippy::option_if_let_else)]`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:29:13
+  --> $DIR/option_if_let_else.rs:28:13
    |
 LL |     let _ = if let Some(s) = *string { s.len() } else { 0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `string.map_or(0, |s| s.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:30:13
+  --> $DIR/option_if_let_else.rs:29:13
    |
 LL |     let _ = if let Some(s) = &num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:31:13
+  --> $DIR/option_if_let_else.rs:30:13
    |
 LL |       let _ = if let Some(s) = &mut num {
    |  _____________^
@@ -44,13 +44,13 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:37:13
+  --> $DIR/option_if_let_else.rs:36:13
    |
 LL |     let _ = if let Some(ref s) = num { s } else { &0 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `num.as_ref().map_or(&0, |s| s)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:38:13
+  --> $DIR/option_if_let_else.rs:37:13
    |
 LL |       let _ = if let Some(mut s) = num {
    |  _____________^
@@ -70,7 +70,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:44:13
+  --> $DIR/option_if_let_else.rs:43:13
    |
 LL |       let _ = if let Some(ref mut s) = num {
    |  _____________^
@@ -90,7 +90,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:53:5
+  --> $DIR/option_if_let_else.rs:52:5
    |
 LL | /     if let Some(x) = arg {
 LL | |         let y = x * x;
@@ -109,7 +109,7 @@ LL +     })
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> $DIR/option_if_let_else.rs:66:13
+  --> $DIR/option_if_let_else.rs:65:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -121,7 +121,7 @@ LL | |     };
    | |_____^ help: try: `arg.map_or_else(side_effect, |x| x)`
 
 error: use Option::map_or_else instead of an if let/else
-  --> $DIR/option_if_let_else.rs:75:13
+  --> $DIR/option_if_let_else.rs:74:13
    |
 LL |       let _ = if let Some(x) = arg {
    |  _____________^
@@ -144,7 +144,7 @@ LL ~     }, |x| x * x * x * x);
    |
 
 error: use Option::map_or_else instead of an if let/else
-  --> $DIR/option_if_let_else.rs:108:13
+  --> $DIR/option_if_let_else.rs:107:13
    |
 LL | /             if let Some(idx) = s.find('.') {
 LL | |                 vec![s[..idx].to_string(), s[idx..].to_string()]
@@ -154,7 +154,7 @@ LL | |             }
    | |_____________^ help: try: `s.find('.').map_or_else(|| vec![s.to_string()], |idx| vec![s[..idx].to_string(), s[idx..].to_string()])`
 
 error: use Option::map_or_else instead of an if let/else
-  --> $DIR/option_if_let_else.rs:119:5
+  --> $DIR/option_if_let_else.rs:118:5
    |
 LL | /     if let Ok(binding) = variable {
 LL | |         println!("Ok {binding}");
@@ -177,13 +177,13 @@ LL +     })
    |
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:143:13
+  --> $DIR/option_if_let_else.rs:142:13
    |
 LL |     let _ = if let Some(x) = optional { x + 2 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `optional.map_or(5, |x| x + 2)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:153:13
+  --> $DIR/option_if_let_else.rs:152:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -205,13 +205,13 @@ LL ~         });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:181:13
+  --> $DIR/option_if_let_else.rs:180:13
    |
 LL |     let _ = if let Some(x) = Some(0) { s.len() + x } else { s.len() };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(0).map_or(s.len(), |x| s.len() + x)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:185:13
+  --> $DIR/option_if_let_else.rs:184:13
    |
 LL |       let _ = if let Some(x) = Some(0) {
    |  _____________^
@@ -231,7 +231,7 @@ LL ~     });
    |
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:224:13
+  --> $DIR/option_if_let_else.rs:223:13
    |
 LL |       let _ = match s {
    |  _____________^
@@ -241,7 +241,7 @@ LL | |     };
    | |_____^ help: try: `s.map_or(1, |string| string.len())`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:228:13
+  --> $DIR/option_if_let_else.rs:227:13
    |
 LL |       let _ = match Some(10) {
    |  _____________^
@@ -251,7 +251,7 @@ LL | |     };
    | |_____^ help: try: `Some(10).map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:234:13
+  --> $DIR/option_if_let_else.rs:233:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -261,7 +261,7 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:238:13
+  --> $DIR/option_if_let_else.rs:237:13
    |
 LL |       let _ = match res {
    |  _____________^
@@ -271,13 +271,13 @@ LL | |     };
    | |_____^ help: try: `res.map_or(1, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:242:13
+  --> $DIR/option_if_let_else.rs:241:13
    |
 LL |     let _ = if let Ok(a) = res { a + 1 } else { 5 };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `res.map_or(5, |a| a + 1)`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:259:17
+  --> $DIR/option_if_let_else.rs:258:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -287,7 +287,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_ref().map_or(42, |value| do_something(value))`
 
 error: use Option::map_or instead of an if let/else
-  --> $DIR/option_if_let_else.rs:266:17
+  --> $DIR/option_if_let_else.rs:265:17
    |
 LL |           let _ = match initial {
    |  _________________^
@@ -297,7 +297,7 @@ LL | |         };
    | |_________^ help: try: `initial.as_mut().map_or(42, |value| do_something2(value))`
 
 error: use Option::map_or_else instead of an if let/else
-  --> $DIR/option_if_let_else.rs:289:24
+  --> $DIR/option_if_let_else.rs:288:24
    |
 LL |       let mut _hashmap = if let Some(hm) = &opt {
    |  ________________________^
@@ -308,7 +308,7 @@ LL | |     };
    | |_____^ help: try: `opt.as_ref().map_or_else(HashMap::new, |hm| hm.clone())`
 
 error: use Option::map_or_else instead of an if let/else
-  --> $DIR/option_if_let_else.rs:295:19
+  --> $DIR/option_if_let_else.rs:294:19
    |
 LL |     let mut _hm = if let Some(hm) = &opt { hm.clone() } else { new_map!() };
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `opt.as_ref().map_or_else(|| new_map!(), |hm| hm.clone())`

--- a/src/tools/clippy/tests/ui/unreadable_literal.fixed
+++ b/src/tools/clippy/tests/ui/unreadable_literal.fixed
@@ -1,5 +1,4 @@
 #![warn(clippy::unreadable_literal)]
-#![allow(unused_tuple_struct_fields)]
 
 struct Foo(u64);
 

--- a/src/tools/clippy/tests/ui/unreadable_literal.rs
+++ b/src/tools/clippy/tests/ui/unreadable_literal.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::unreadable_literal)]
-#![allow(unused_tuple_struct_fields)]
 
 struct Foo(u64);
 

--- a/src/tools/clippy/tests/ui/unreadable_literal.stderr
+++ b/src/tools/clippy/tests/ui/unreadable_literal.stderr
@@ -1,5 +1,5 @@
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:32:17
+  --> $DIR/unreadable_literal.rs:31:17
    |
 LL |     let _bad = (0b110110_i64, 0x12345678_usize, 123456_f32, 1.234567_f32);
    |                 ^^^^^^^^^^^^ help: consider: `0b11_0110_i64`
@@ -8,55 +8,55 @@ LL |     let _bad = (0b110110_i64, 0x12345678_usize, 123456_f32, 1.234567_f32);
    = help: to override `-D warnings` add `#[allow(clippy::unreadable_literal)]`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:32:31
+  --> $DIR/unreadable_literal.rs:31:31
    |
 LL |     let _bad = (0b110110_i64, 0x12345678_usize, 123456_f32, 1.234567_f32);
    |                               ^^^^^^^^^^^^^^^^ help: consider: `0x1234_5678_usize`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:32:49
+  --> $DIR/unreadable_literal.rs:31:49
    |
 LL |     let _bad = (0b110110_i64, 0x12345678_usize, 123456_f32, 1.234567_f32);
    |                                                 ^^^^^^^^^^ help: consider: `123_456_f32`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:32:61
+  --> $DIR/unreadable_literal.rs:31:61
    |
 LL |     let _bad = (0b110110_i64, 0x12345678_usize, 123456_f32, 1.234567_f32);
    |                                                             ^^^^^^^^^^^^ help: consider: `1.234_567_f32`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:34:20
+  --> $DIR/unreadable_literal.rs:33:20
    |
 LL |     let _bad_sci = 1.123456e1;
    |                    ^^^^^^^^^^ help: consider: `1.123_456e1`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:36:18
+  --> $DIR/unreadable_literal.rs:35:18
    |
 LL |     let _fail1 = 0xabcdef;
    |                  ^^^^^^^^ help: consider: `0x00ab_cdef`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:37:23
+  --> $DIR/unreadable_literal.rs:36:23
    |
 LL |     let _fail2: u32 = 0xBAFEBAFE;
    |                       ^^^^^^^^^^ help: consider: `0xBAFE_BAFE`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:38:18
+  --> $DIR/unreadable_literal.rs:37:18
    |
 LL |     let _fail3 = 0xabcdeff;
    |                  ^^^^^^^^^ help: consider: `0x0abc_deff`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:39:24
+  --> $DIR/unreadable_literal.rs:38:24
    |
 LL |     let _fail4: i128 = 0xabcabcabcabcabcabc;
    |                        ^^^^^^^^^^^^^^^^^^^^ help: consider: `0x00ab_cabc_abca_bcab_cabc`
 
 error: long literal lacking separators
-  --> $DIR/unreadable_literal.rs:40:18
+  --> $DIR/unreadable_literal.rs:39:18
    |
 LL |     let _fail5 = 1.100300400;
    |                  ^^^^^^^^^^^ help: consider: `1.100_300_400`

--- a/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.rs
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.rs
@@ -3,7 +3,7 @@
 
 //@[stack]error-in-other-file: which is strongly protected
 //@[tree]error-in-other-file: /deallocation through .* is forbidden/
-struct Newtype<'a>(&'a mut i32, i32);
+struct Newtype<'a>(#[allow(dead_code)] &'a mut i32, #[allow(dead_code)] i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
     dealloc();

--- a/src/tools/miri/tests/fail/both_borrows/newtype_retagging.rs
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_retagging.rs
@@ -4,7 +4,7 @@
 //@[stack]error-in-other-file: which is strongly protected
 //@[tree]error-in-other-file: /deallocation through .* is forbidden/
 
-struct Newtype<'a>(&'a mut i32);
+struct Newtype<'a>(#[allow(dead_code)] &'a mut i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
     dealloc();

--- a/src/tools/miri/tests/fail/concurrency/read_only_atomic_load_large.rs
+++ b/src/tools/miri/tests/fail/concurrency/read_only_atomic_load_large.rs
@@ -6,7 +6,7 @@
 use std::sync::atomic::{AtomicI64, Ordering};
 
 #[repr(align(8))]
-struct AlignedI64(i64);
+struct AlignedI64(#[allow(dead_code)] i64);
 
 fn main() {
     static X: AlignedI64 = AlignedI64(0);

--- a/src/tools/miri/tests/fail/dangling_pointers/dyn_size.rs
+++ b/src/tools/miri/tests/fail/dangling_pointers/dyn_size.rs
@@ -1,7 +1,7 @@
 // should find the bug even without retagging
 //@compile-flags: -Zmiri-disable-stacked-borrows
 
-struct SliceWithHead(u8, [u8]);
+struct SliceWithHead(#[allow(dead_code)] u8, #[allow(dead_code)] [u8]);
 
 fn main() {
     let buf = [0u32; 1];

--- a/src/tools/miri/tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs
+++ b/src/tools/miri/tests/fail/function_pointers/abi_mismatch_array_vs_struct.rs
@@ -3,7 +3,7 @@
 // Some targets treat arrays and structs very differently. We would probably catch that on those
 // targets since we check the `PassMode`; here we ensure that we catch it on *all* targets
 // (in particular, on x86-64 the pass mode is `Indirect` for both of these).
-struct S(i32, i32, i32, i32);
+struct S(#[allow(dead_code)] i32, #[allow(dead_code)] i32, #[allow(dead_code)] i32, #[allow(dead_code)] i32);
 type A = [i32; 4];
 
 fn main() {

--- a/src/tools/miri/tests/fail/issue-miri-1112.rs
+++ b/src/tools/miri/tests/fail/issue-miri-1112.rs
@@ -1,7 +1,7 @@
 trait Empty {}
 
 #[repr(transparent)]
-pub struct FunnyPointer(dyn Empty);
+pub struct FunnyPointer(#[allow(dead_code)] dyn Empty);
 
 #[repr(C)]
 pub struct Meta {

--- a/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.rs
@@ -1,7 +1,7 @@
 //@compile-flags: -Cdebug-assertions=no
 
 #[repr(transparent)]
-struct HasDrop(u8);
+struct HasDrop(#[allow(dead_code)] u8);
 
 impl Drop for HasDrop {
     fn drop(&mut self) {}

--- a/src/tools/miri/tests/fail/unaligned_pointers/promise_alignment.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/promise_alignment.rs
@@ -7,7 +7,7 @@ mod utils;
 
 #[repr(align(8))]
 #[derive(Copy, Clone)]
-struct Align8(u64);
+struct Align8(#[allow(dead_code)] u64);
 
 fn main() {
     let buffer = [0u32; 128]; // get some 4-aligned memory
@@ -35,7 +35,7 @@ fn main() {
     if cfg!(read_unaligned_ptr) {
         #[repr(align(16))]
         #[derive(Copy, Clone)]
-        struct Align16(u128);
+        struct Align16(#[allow(dead_code)] u128);
 
         let align16 = if align8.addr() % 16 == 0 { align8 } else { align8.wrapping_add(2) };
         assert!(align16.addr() % 16 == 0);

--- a/src/tools/miri/tests/pass/align_offset_symbolic.rs
+++ b/src/tools/miri/tests/pass/align_offset_symbolic.rs
@@ -46,7 +46,7 @@ fn test_align_to() {
     {
         #[repr(align(8))]
         #[derive(Copy, Clone)]
-        struct Align8(u64);
+        struct Align8(#[allow(dead_code)] u64);
 
         let (_l, m, _r) = unsafe { s.align_to::<Align8>() };
         assert!(m.len() > 0);
@@ -97,7 +97,7 @@ fn huge_align() {
     const SIZE: usize = 1 << 30;
     #[cfg(target_pointer_width = "16")]
     const SIZE: usize = 1 << 13;
-    struct HugeSize([u8; SIZE - 1]);
+    struct HugeSize(#[allow(dead_code)] [u8; SIZE - 1]);
     let _ = std::ptr::invalid::<HugeSize>(SIZE).align_offset(SIZE);
 }
 

--- a/src/tools/miri/tests/pass/box-custom-alloc.rs
+++ b/src/tools/miri/tests/pass/box-custom-alloc.rs
@@ -57,7 +57,7 @@ fn test1() {
 }
 
 // Make the allocator itself so big that the Box is not even a ScalarPair any more.
-struct OnceAllocRef<'s, 'a>(&'s OnceAlloc<'a>, u64);
+struct OnceAllocRef<'s, 'a>(&'s OnceAlloc<'a>, #[allow(dead_code)] u64);
 
 unsafe impl<'shared, 'a: 'shared> Allocator for OnceAllocRef<'shared, 'a> {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {

--- a/src/tools/miri/tests/pass/box.rs
+++ b/src/tools/miri/tests/pass/box.rs
@@ -46,7 +46,7 @@ fn boxed_pair_to_vec() {
     }
 
     #[derive(Debug)]
-    struct Foo(u64);
+    struct Foo(#[allow(dead_code)] u64);
     fn reinterstruct(box_pair: Box<PairFoo>) -> Vec<Foo> {
         let ref_pair = Box::leak(box_pair) as *mut PairFoo;
         let ptr_foo = unsafe { std::ptr::addr_of_mut!((*ref_pair).fst) };

--- a/src/tools/miri/tests/pass/fat_ptr.rs
+++ b/src/tools/miri/tests/pass/fat_ptr.rs
@@ -1,6 +1,6 @@
 // test that ordinary fat pointer operations work.
 
-struct Wrapper<T: ?Sized>(u32, T);
+struct Wrapper<T: ?Sized>(#[allow(dead_code)] u32, T);
 
 struct FatPtrContainer<'a> {
     ptr: &'a [u8],

--- a/src/tools/miri/tests/pass/issues/issue-3200-packed2-field-offset.rs
+++ b/src/tools/miri/tests/pass/issues/issue-3200-packed2-field-offset.rs
@@ -2,7 +2,7 @@
 use std::mem;
 
 #[repr(packed(4))]
-struct Slice([u32]);
+struct Slice(#[allow(dead_code)] [u32]);
 
 #[repr(packed(2), C)]
 struct PackedSized {

--- a/src/tools/miri/tests/pass/issues/issue-34571.rs
+++ b/src/tools/miri/tests/pass/issues/issue-34571.rs
@@ -1,6 +1,6 @@
 #[repr(u8)]
 enum Foo {
-    Foo(u8),
+    Foo(#[allow(dead_code)] u8),
 }
 
 fn main() {

--- a/src/tools/miri/tests/pass/issues/issue-36278-prefix-nesting.rs
+++ b/src/tools/miri/tests/pass/issues/issue-36278-prefix-nesting.rs
@@ -4,7 +4,7 @@
 use std::mem;
 
 const SZ: usize = 100;
-struct P<T: ?Sized>([u8; SZ], T);
+struct P<T: ?Sized>(#[allow(dead_code)] [u8; SZ], T);
 
 type Ack<T> = P<P<T>>;
 

--- a/src/tools/miri/tests/pass/packed_struct.rs
+++ b/src/tools/miri/tests/pass/packed_struct.rs
@@ -102,7 +102,7 @@ fn test_inner_packed() {
     struct Inner(u32);
 
     #[derive(Clone, Copy)]
-    struct Outer(u8, Inner);
+    struct Outer(#[allow(dead_code)] u8, Inner);
 
     let o = Outer(0, Inner(42));
     let _x = o.1;

--- a/src/tools/miri/tests/pass/stacked-borrows/no_field_retagging.rs
+++ b/src/tools/miri/tests/pass/stacked-borrows/no_field_retagging.rs
@@ -1,6 +1,6 @@
 //@compile-flags: -Zmiri-retag-fields=none
 
-struct Newtype<'a>(&'a mut i32);
+struct Newtype<'a>(#[allow(dead_code)] &'a mut i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
     dealloc();

--- a/src/tools/miri/tests/pass/stacked-borrows/non_scalar_field_retagging.rs
+++ b/src/tools/miri/tests/pass/stacked-borrows/non_scalar_field_retagging.rs
@@ -1,6 +1,6 @@
 //@compile-flags: -Zmiri-retag-fields=scalar
 
-struct Newtype<'a>(&'a mut i32, i32, i32);
+struct Newtype<'a>(#[allow(dead_code)] &'a mut i32, #[allow(dead_code)] i32, #[allow(dead_code)] i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
     dealloc();

--- a/src/tools/miri/tests/pass/stacked-borrows/stacked-borrows.rs
+++ b/src/tools/miri/tests/pass/stacked-borrows/stacked-borrows.rs
@@ -226,7 +226,7 @@ fn not_unpin_not_protected() {
     // the self-referential-coroutine situation, it does not seem worth the potential trouble.)
     use std::marker::PhantomPinned;
 
-    pub struct NotUnpin(i32, PhantomPinned);
+    pub struct NotUnpin(#[allow(dead_code)] i32, PhantomPinned);
 
     fn inner(x: &mut NotUnpin, f: fn(&mut NotUnpin)) {
         // `f` may mutate, but it may not deallocate!

--- a/src/tools/miri/tests/pass/tree_borrows/tree-borrows.rs
+++ b/src/tools/miri/tests/pass/tree_borrows/tree-borrows.rs
@@ -318,7 +318,7 @@ fn not_unpin_not_protected() {
     // the self-referential-coroutine situation, it does not seem worth the potential trouble.)
     use std::marker::PhantomPinned;
 
-    pub struct NotUnpin(i32, PhantomPinned);
+    pub struct NotUnpin(#[allow(dead_code)] i32, PhantomPinned);
 
     fn inner(x: &mut NotUnpin, f: fn(&mut NotUnpin)) {
         // `f` may mutate, but it may not deallocate!

--- a/src/tools/miri/tests/pass/zst_variant_drop.rs
+++ b/src/tools/miri/tests/pass/zst_variant_drop.rs
@@ -10,7 +10,7 @@ impl Drop for Foo {
 static mut FOO: bool = false;
 
 enum Bar {
-    A(Box<i32>),
+    A(#[allow(dead_code)] Box<i32>),
     B(Foo),
 }
 

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -1947,7 +1947,7 @@ fn rewrite_unary_op(
 }
 
 pub(crate) enum RhsAssignKind<'ast> {
-    Expr(&'ast ast::ExprKind, #[allow(unused_tuple_struct_fields)] Span),
+    Expr(&'ast ast::ExprKind, #[allow(dead_code)] Span),
     Bounds,
     Ty,
 }

--- a/src/tools/rustfmt/src/expr.rs
+++ b/src/tools/rustfmt/src/expr.rs
@@ -1947,7 +1947,7 @@ fn rewrite_unary_op(
 }
 
 pub(crate) enum RhsAssignKind<'ast> {
-    Expr(&'ast ast::ExprKind, Span),
+    Expr(&'ast ast::ExprKind, #[allow(unused_tuple_struct_fields)] Span),
     Bounds,
     Ty,
 }

--- a/tests/codegen-units/item-collection/generic-drop-glue.rs
+++ b/tests/codegen-units/item-collection/generic-drop-glue.rs
@@ -34,9 +34,9 @@ enum EnumNoDrop<T1, T2> {
 }
 
 
-struct NonGenericNoDrop(#[allow(unused_tuple_struct_fields)] i32);
+struct NonGenericNoDrop(#[allow(dead_code)] i32);
 
-struct NonGenericWithDrop(#[allow(unused_tuple_struct_fields)] i32);
+struct NonGenericWithDrop(#[allow(dead_code)] i32);
 //~ MONO_ITEM fn std::ptr::drop_in_place::<NonGenericWithDrop> - shim(Some(NonGenericWithDrop)) @@ generic_drop_glue-cgu.0[Internal]
 
 impl Drop for NonGenericWithDrop {

--- a/tests/codegen-units/item-collection/transitive-drop-glue.rs
+++ b/tests/codegen-units/item-collection/transitive-drop-glue.rs
@@ -6,9 +6,9 @@
 #![feature(start)]
 
 //~ MONO_ITEM fn std::ptr::drop_in_place::<Root> - shim(Some(Root)) @@ transitive_drop_glue-cgu.0[Internal]
-struct Root(#[allow(unused_tuple_struct_fields)] Intermediate);
+struct Root(#[allow(dead_code)] Intermediate);
 //~ MONO_ITEM fn std::ptr::drop_in_place::<Intermediate> - shim(Some(Intermediate)) @@ transitive_drop_glue-cgu.0[Internal]
-struct Intermediate(#[allow(unused_tuple_struct_fields)] Leaf);
+struct Intermediate(#[allow(dead_code)] Leaf);
 //~ MONO_ITEM fn std::ptr::drop_in_place::<Leaf> - shim(Some(Leaf)) @@ transitive_drop_glue-cgu.0[Internal]
 struct Leaf;
 
@@ -17,9 +17,9 @@ impl Drop for Leaf {
     fn drop(&mut self) {}
 }
 
-struct RootGen<T>(#[allow(unused_tuple_struct_fields)] IntermediateGen<T>);
-struct IntermediateGen<T>(#[allow(unused_tuple_struct_fields)] LeafGen<T>);
-struct LeafGen<T>(#[allow(unused_tuple_struct_fields)] T);
+struct RootGen<T>(#[allow(dead_code)] IntermediateGen<T>);
+struct IntermediateGen<T>(#[allow(dead_code)] LeafGen<T>);
+struct LeafGen<T>(#[allow(dead_code)] T);
 
 impl<T> Drop for LeafGen<T> {
     fn drop(&mut self) {}

--- a/tests/codegen-units/item-collection/unsizing.rs
+++ b/tests/codegen-units/item-collection/unsizing.rs
@@ -40,7 +40,7 @@ impl Trait for u32 {
 }
 
 #[derive(Clone, Copy)]
-struct Wrapper<T: ?Sized>(#[allow(unused_tuple_struct_fields)] *const T);
+struct Wrapper<T: ?Sized>(#[allow(dead_code)] *const T);
 
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Wrapper<U>> for Wrapper<T> {}
 

--- a/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-custom.rs
@@ -74,7 +74,7 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
 extern "C" fn rust_eh_personality() {}
 
 #[derive(Default, Debug)]
-struct Page(#[allow(unused_tuple_struct_fields)] [[u64; 32]; 16]);
+struct Page(#[allow(dead_code)] [[u64; 32]; 16]);
 
 #[no_mangle]
 fn main(_argc: i32, _argv: *const *const u8) -> isize {

--- a/tests/ui/allocator/no_std-alloc-error-handler-default.rs
+++ b/tests/ui/allocator/no_std-alloc-error-handler-default.rs
@@ -61,7 +61,7 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
 extern "C" fn rust_eh_personality() {}
 
 #[derive(Default, Debug)]
-struct Page(#[allow(unused_tuple_struct_fields)] [[u64; 32]; 16]);
+struct Page(#[allow(dead_code)] [[u64; 32]; 16]);
 
 #[no_mangle]
 fn main(_argc: i32, _argv: *const *const u8) -> isize {

--- a/tests/ui/array-slice-vec/show-boxed-slice.rs
+++ b/tests/ui/array-slice-vec/show-boxed-slice.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #[derive(Debug)]
-struct Foo(#[allow(unused_tuple_struct_fields)] Box<[u8]>);
+struct Foo(#[allow(dead_code)] Box<[u8]>);
 
 pub fn main() {
     println!("{:?}", Foo(Box::new([0, 1, 2])));

--- a/tests/ui/associated-consts/associated-const-type-parameters.rs
+++ b/tests/ui/associated-consts/associated-const-type-parameters.rs
@@ -17,7 +17,7 @@ impl Foo for Def {
     const X: i32 = 97;
 }
 
-struct Proxy<T>(#[allow(unused_tuple_struct_fields)] T);
+struct Proxy<T>(#[allow(dead_code)] T);
 
 impl<T: Foo> Foo for Proxy<T> {
     const X: i32 = T::X;

--- a/tests/ui/associated-types/associated-types-method.rs
+++ b/tests/ui/associated-types/associated-types-method.rs
@@ -5,7 +5,7 @@
 trait Device {
     type Resources;
 }
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Foo<D, R>(D, R);
 
 trait Tr {

--- a/tests/ui/associated-types/associated-types-struct-field-numbered.rs
+++ b/tests/ui/associated-types/associated-types-struct-field-numbered.rs
@@ -9,7 +9,7 @@ pub trait UnifyKey {
     fn dummy(&self) { }
 }
 
-pub struct Node<K:UnifyKey>(#[allow(unused_tuple_struct_fields)] K, K::Value);
+pub struct Node<K:UnifyKey>(#[allow(dead_code)] K, K::Value);
 
 fn foo<K : UnifyKey<Value=Option<V>>,V : Clone>(node: &Node<K>) -> Option<V> {
     node.1.clone()

--- a/tests/ui/associated-types/issue-25700-1.rs
+++ b/tests/ui/associated-types/issue-25700-1.rs
@@ -1,5 +1,5 @@
 // run-pass
-struct S<T: 'static>(#[allow(unused_tuple_struct_fields)] Option<&'static T>);
+struct S<T: 'static>(#[allow(dead_code)] Option<&'static T>);
 
 trait Tr { type Out; }
 impl<T> Tr for T { type Out = T; }

--- a/tests/ui/associated-types/issue-25700-2.rs
+++ b/tests/ui/associated-types/issue-25700-2.rs
@@ -3,9 +3,9 @@ pub trait Parser {
     type Input;
 }
 
-pub struct Iter<P: Parser>(#[allow(unused_tuple_struct_fields)] P, P::Input);
+pub struct Iter<P: Parser>(#[allow(dead_code)] P, P::Input);
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 pub struct Map<P, F>(P, F);
 impl<P, F> Parser for Map<P, F> where F: FnMut(P) {
     type Input = u8;

--- a/tests/ui/associated-types/issue-25700.rs
+++ b/tests/ui/associated-types/issue-25700.rs
@@ -1,4 +1,4 @@
-struct S<T: 'static>(#[allow(unused_tuple_struct_fields)] Option<&'static T>);
+struct S<T: 'static>(#[allow(dead_code)] Option<&'static T>);
 
 trait Tr { type Out; }
 impl<T> Tr for T { type Out = T; }

--- a/tests/ui/async-await/async-fn-size-moved-locals.rs
+++ b/tests/ui/async-await/async-fn-size-moved-locals.rs
@@ -17,7 +17,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 const BIG_FUT_SIZE: usize = 1024;
-struct BigFut(#[allow(unused_tuple_struct_fields)] [u8; BIG_FUT_SIZE]);
+struct BigFut(#[allow(dead_code)] [u8; BIG_FUT_SIZE]);
 
 impl BigFut {
     fn new() -> Self {

--- a/tests/ui/async-await/async-fn-size-uninit-locals.rs
+++ b/tests/ui/async-await/async-fn-size-uninit-locals.rs
@@ -17,7 +17,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 const BIG_FUT_SIZE: usize = 1024;
-struct Big(#[allow(unused_tuple_struct_fields)] [u8; BIG_FUT_SIZE]);
+struct Big(#[allow(dead_code)] [u8; BIG_FUT_SIZE]);
 
 impl Big {
     fn new() -> Self {

--- a/tests/ui/auto-traits/auto-traits.rs
+++ b/tests/ui/auto-traits/auto-traits.rs
@@ -9,7 +9,7 @@ unsafe auto trait AutoUnsafe {}
 impl !Auto for bool {}
 impl !AutoUnsafe for bool {}
 
-struct AutoBool(#[allow(unused_tuple_struct_fields)] bool);
+struct AutoBool(#[allow(dead_code)] bool);
 
 impl Auto for AutoBool {}
 unsafe impl AutoUnsafe for AutoBool {}

--- a/tests/ui/bench/issue-32062.rs
+++ b/tests/ui/bench/issue-32062.rs
@@ -15,7 +15,7 @@ trait Parser {
     }
 }
 
-struct Token<T>(#[allow(unused_tuple_struct_fields)] T::Item) where T: Iterator;
+struct Token<T>(#[allow(dead_code)] T::Item) where T: Iterator;
 
 impl<T> Parser for Token<T> where T: Iterator {
     type Input = T;
@@ -25,7 +25,7 @@ impl<T> Parser for Token<T> where T: Iterator {
     }
 }
 
-struct Chain<L, R>(#[allow(unused_tuple_struct_fields)] L, #[allow(unused_tuple_struct_fields)] R);
+struct Chain<L, R>(#[allow(dead_code)] L, #[allow(dead_code)] R);
 
 impl<L, R> Parser for Chain<L, R> where L: Parser, R: Parser<Input = L::Input> {
     type Input = L::Input;

--- a/tests/ui/binding/match-tag.rs
+++ b/tests/ui/binding/match-tag.rs
@@ -3,7 +3,7 @@
 #![allow(non_camel_case_types)]
 
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 enum color {
     rgb(isize, isize, isize),
     rgba(isize, isize, isize, isize),

--- a/tests/ui/binding/or-pattern.rs
+++ b/tests/ui/binding/or-pattern.rs
@@ -1,7 +1,7 @@
 // run-pass
 #![allow(non_camel_case_types)]
 
-enum blah { a(isize, isize, #[allow(unused_tuple_struct_fields)] usize), b(isize, isize), c, }
+enum blah { a(isize, isize, #[allow(dead_code)] usize), b(isize, isize), c, }
 
 fn or_alt(q: blah) -> isize {
     match q { blah::a(x, y, _) | blah::b(x, y) => { return x + y; } blah::c => { return 0; } }

--- a/tests/ui/binding/simple-generic-match.rs
+++ b/tests/ui/binding/simple-generic-match.rs
@@ -3,6 +3,6 @@
 
 // pretty-expanded FIXME #23616
 
-enum clam<T> { a(#[allow(unused_tuple_struct_fields)] T), }
+enum clam<T> { a(#[allow(dead_code)] T), }
 
 pub fn main() { let c = clam::a(2); match c { clam::a::<isize>(_) => { } } }

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata2.rs
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata2.rs
@@ -12,7 +12,7 @@ use trait_superkinds_in_metadata::RequiresCopy;
 use std::marker;
 
 #[derive(Copy, Clone)]
-struct X<T>(#[allow(unused_tuple_struct_fields)] T);
+struct X<T>(#[allow(dead_code)] T);
 
 impl<T:Sync> RequiresShare for X<T> { }
 

--- a/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
+++ b/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.fixed
@@ -51,10 +51,10 @@ fn test_sync_trait() {
 }
 
 /* Test Clone Trait Migration */
-struct S(Foo);
+struct S(#[allow(dead_code)] Foo);
 struct T(i32);
 
-struct U(S, T);
+struct U(#[allow(dead_code)] S, T);
 
 impl Clone for U {
     fn clone(&self) -> Self {

--- a/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
+++ b/tests/ui/closures/2229_closure_analysis/migrations/auto_traits.rs
@@ -51,10 +51,10 @@ fn test_sync_trait() {
 }
 
 /* Test Clone Trait Migration */
-struct S(Foo);
+struct S(#[allow(dead_code)] Foo);
 struct T(i32);
 
-struct U(S, T);
+struct U(#[allow(dead_code)] S, T);
 
 impl Clone for U {
     fn clone(&self) -> Self {

--- a/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
+++ b/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.fixed
@@ -18,10 +18,10 @@ impl Foo {
     }
 }
 
-struct S(#[allow(unused_tuple_struct_fields)] Foo);
+struct S(#[allow(dead_code)] Foo);
 
 #[derive(Clone)]
-struct T(#[allow(unused_tuple_struct_fields)] i32);
+struct T(#[allow(dead_code)] i32);
 
 struct U(S, T);
 

--- a/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.rs
+++ b/tests/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.rs
@@ -18,10 +18,10 @@ impl Foo {
     }
 }
 
-struct S(#[allow(unused_tuple_struct_fields)] Foo);
+struct S(#[allow(dead_code)] Foo);
 
 #[derive(Clone)]
-struct T(#[allow(unused_tuple_struct_fields)] i32);
+struct T(#[allow(dead_code)] i32);
 
 struct U(S, T);
 

--- a/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -13,7 +13,7 @@ impl Drop for Foo {
 }
 
 #[derive(Debug)]
-struct ConstainsDropField(Foo, #[allow(unused_tuple_struct_fields)] Foo);
+struct ConstainsDropField(Foo, #[allow(dead_code)] Foo);
 
 // `t` needs Drop because one of its elements needs drop,
 // therefore precise capture might affect drop ordering

--- a/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/tests/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -13,7 +13,7 @@ impl Drop for Foo {
 }
 
 #[derive(Debug)]
-struct ConstainsDropField(Foo, #[allow(unused_tuple_struct_fields)] Foo);
+struct ConstainsDropField(Foo, #[allow(dead_code)] Foo);
 
 // `t` needs Drop because one of its elements needs drop,
 // therefore precise capture might affect drop ordering

--- a/tests/ui/codegen/issue-16602-3.rs
+++ b/tests/ui/codegen/issue-16602-3.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 #![allow(unused_assignments)]
 #[derive(Debug)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 enum Foo {
     Bar(u32, u32),
     Baz(&'static u32, &'static u32)

--- a/tests/ui/coercion/issue-14589.rs
+++ b/tests/ui/coercion/issue-14589.rs
@@ -20,5 +20,5 @@ impl<T> Test<T> {
 }
 
 trait Foo { fn dummy(&self) { }}
-struct Output(#[allow(unused_tuple_struct_fields)] isize);
+struct Output(#[allow(dead_code)] isize);
 impl Foo for Output {}

--- a/tests/ui/const-generics/const-argument-cross-crate.rs
+++ b/tests/ui/const-generics/const-argument-cross-crate.rs
@@ -4,7 +4,7 @@
 
 extern crate const_generic_lib;
 
-struct Container(#[allow(unused_tuple_struct_fields)] const_generic_lib::Alias);
+struct Container(#[allow(dead_code)] const_generic_lib::Alias);
 
 fn main() {
     let res = const_generic_lib::function(const_generic_lib::Struct([14u8, 1u8, 2u8]));

--- a/tests/ui/const-generics/generic_const_exprs/associated-consts.rs
+++ b/tests/ui/const-generics/generic_const_exprs/associated-consts.rs
@@ -16,7 +16,7 @@ impl BlockCipher for BarCipher {
     const BLOCK_SIZE: usize = 32;
 }
 
-pub struct Block<C>(#[allow(unused_tuple_struct_fields)] C);
+pub struct Block<C>(#[allow(dead_code)] C);
 
 pub fn test<C: BlockCipher, const M: usize>()
 where

--- a/tests/ui/const-generics/inhabited-assoc-ty-ice-1.rs
+++ b/tests/ui/const-generics/inhabited-assoc-ty-ice-1.rs
@@ -9,7 +9,7 @@ trait Foo {
     const ASSOC: usize = 1;
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Iced<T: Foo>(T, [(); T::ASSOC])
 where
     [(); T::ASSOC]: ;

--- a/tests/ui/const-generics/inhabited-assoc-ty-ice-2.rs
+++ b/tests/ui/const-generics/inhabited-assoc-ty-ice-2.rs
@@ -9,7 +9,7 @@ trait Foo {
     const ASSOC: usize = 1;
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Iced<T: Foo>(T, [(); T::ASSOC])
 where
     [(); T::ASSOC]: ;

--- a/tests/ui/consts/assoc-const.rs
+++ b/tests/ui/consts/assoc-const.rs
@@ -6,7 +6,7 @@ trait Nat {
 }
 
 struct Zero;
-struct Succ<N>(#[allow(unused_tuple_struct_fields)] N);
+struct Succ<N>(#[allow(dead_code)] N);
 
 impl Nat for Zero {
     const VALUE: usize = 0;

--- a/tests/ui/consts/const-needs_drop.rs
+++ b/tests/ui/consts/const-needs_drop.rs
@@ -2,10 +2,10 @@
 
 use std::mem;
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Trivial(u8, f32);
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct NonTrivial(u8, String);
 
 const CONST_U8: bool = mem::needs_drop::<u8>();

--- a/tests/ui/consts/const-size_of_val-align_of_val.rs
+++ b/tests/ui/consts/const-size_of_val-align_of_val.rs
@@ -5,7 +5,7 @@
 
 use std::{mem, ptr};
 
-struct Foo(#[allow(unused_tuple_struct_fields)] u32);
+struct Foo(#[allow(dead_code)] u32);
 
 #[derive(Clone, Copy)]
 struct Bar {

--- a/tests/ui/consts/const_in_pattern/null-raw-ptr-issue-119270.rs
+++ b/tests/ui/consts/const_in_pattern/null-raw-ptr-issue-119270.rs
@@ -1,7 +1,7 @@
 // run-pass
 // Eventually this will be rejected (when the future-compat lints are turned into hard errors), and
 // then this test can be removed. But meanwhile we should ensure that this works and does not ICE.
-struct NoDerive(i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 #[derive(PartialEq)]
 struct WrapEmbedded(*const NoDerive);

--- a/tests/ui/consts/const_in_pattern/warn_corner_cases.rs
+++ b/tests/ui/consts/const_in_pattern/warn_corner_cases.rs
@@ -15,7 +15,7 @@
 #![warn(indirect_structural_match)]
 
 #[derive(Copy, Clone, Debug)]
-struct NoDerive(#[allow(unused_tuple_struct_fields)] u32);
+struct NoDerive(#[allow(dead_code)] u32);
 
 // This impl makes `NoDerive` irreflexive.
 impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }

--- a/tests/ui/consts/issue-70773-mir-typeck-lt-norm.rs
+++ b/tests/ui/consts/issue-70773-mir-typeck-lt-norm.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 const HASH_LEN: usize = 20;
-struct Hash(#[allow(unused_tuple_struct_fields)] [u8; HASH_LEN]);
+struct Hash(#[allow(dead_code)] [u8; HASH_LEN]);
 fn init_hash(_: &mut [u8; HASH_LEN]) {}
 
 fn foo<'a>() -> &'a () {

--- a/tests/ui/consts/promoted_const_call4.rs
+++ b/tests/ui/consts/promoted_const_call4.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::*;
 
 static FLAG: AtomicBool = AtomicBool::new(false);
 
-struct NoisyDrop(&'static str);
+struct NoisyDrop(#[allow(dead_code)] &'static str);
 impl Drop for NoisyDrop {
     fn drop(&mut self) {
         FLAG.store(true, Ordering::SeqCst);

--- a/tests/ui/consts/rvalue-static-promotion.rs
+++ b/tests/ui/consts/rvalue-static-promotion.rs
@@ -4,7 +4,7 @@ use std::cell::Cell;
 
 const NONE_CELL_STRING: Option<Cell<String>> = None;
 
-struct Foo<T>(#[allow(unused_tuple_struct_fields)] T);
+struct Foo<T>(#[allow(dead_code)] T);
 impl<T> Foo<T> {
     const FOO: Option<Box<T>> = None;
 }

--- a/tests/ui/consts/transmute-const.rs
+++ b/tests/ui/consts/transmute-const.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 #[repr(transparent)]
-struct Foo(#[allow(unused_tuple_struct_fields)] u32);
+struct Foo(#[allow(dead_code)] u32);
 
 const TRANSMUTED_U32: u32 = unsafe { mem::transmute(Foo(3)) };
 

--- a/tests/ui/coroutine/size-moved-locals.rs
+++ b/tests/ui/coroutine/size-moved-locals.rs
@@ -18,7 +18,7 @@
 use std::ops::Coroutine;
 
 const FOO_SIZE: usize = 1024;
-struct Foo(#[allow(unused_tuple_struct_fields)] [u8; FOO_SIZE]);
+struct Foo(#[allow(dead_code)] [u8; FOO_SIZE]);
 
 impl Drop for Foo {
     fn drop(&mut self) {}

--- a/tests/ui/derive-uninhabited-enum-38885.rs
+++ b/tests/ui/derive-uninhabited-enum-38885.rs
@@ -9,7 +9,7 @@ enum Void {}
 
 #[derive(Debug)]
 enum Foo {
-    Bar(u8),
+    Bar(#[allow(dead_code)] u8),
     Void(Void), //~ WARN variant `Void` is never constructed
 }
 

--- a/tests/ui/derive-uninhabited-enum-38885.stderr
+++ b/tests/ui/derive-uninhabited-enum-38885.stderr
@@ -3,7 +3,7 @@ warning: variant `Void` is never constructed
    |
 LL | enum Foo {
    |      --- variant in this enum
-LL |     Bar(u8),
+LL |     Bar(#[allow(dead_code)] u8),
 LL |     Void(Void),
    |     ^^^^
    |

--- a/tests/ui/deriving/deriving-clone-generic-tuple-struct.rs
+++ b/tests/ui/deriving/deriving-clone-generic-tuple-struct.rs
@@ -2,7 +2,7 @@
 // pretty-expanded FIXME #23616
 
 #[derive(Clone)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S<T>(T, ());
 
 pub fn main() {

--- a/tests/ui/deriving/deriving-copyclone.rs
+++ b/tests/ui/deriving/deriving-copyclone.rs
@@ -23,7 +23,7 @@ impl Clone for Liar {
 
 /// This struct is actually Copy... at least, it thinks it is!
 #[derive(Copy, Clone)]
-struct Innocent(#[allow(unused_tuple_struct_fields)] Liar);
+struct Innocent(#[allow(dead_code)] Liar);
 
 impl Innocent {
     fn new() -> Self {

--- a/tests/ui/deriving/issue-58319.rs
+++ b/tests/ui/deriving/issue-58319.rs
@@ -3,7 +3,7 @@ fn main() {}
 #[derive(Clone)]
 pub struct Little;
 #[derive(Clone)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 pub struct Big(
     Little,
     Little,

--- a/tests/ui/drop/dropck-eyepatch-reorder.rs
+++ b/tests/ui/drop/dropck-eyepatch-reorder.rs
@@ -12,10 +12,10 @@ trait Foo { fn foo(&self, _: &str); }
 
 struct Dt<A: Foo>(&'static str, A);
 struct Dr<'a, B:'a+Foo>(&'static str, &'a B);
-struct Pt<A: Foo, B: Foo>(&'static str, #[allow(unused_tuple_struct_fields)] A, B);
-struct Pr<'a, 'b, B:'a+'b+Foo>(&'static str, #[allow(unused_tuple_struct_fields)] &'a B, &'b B);
-struct St<A: Foo>(&'static str, #[allow(unused_tuple_struct_fields)] A);
-struct Sr<'a, B:'a+Foo>(&'static str, #[allow(unused_tuple_struct_fields)] &'a B);
+struct Pt<A: Foo, B: Foo>(&'static str, #[allow(dead_code)] A, B);
+struct Pr<'a, 'b, B:'a+'b+Foo>(&'static str, #[allow(dead_code)] &'a B, &'b B);
+struct St<A: Foo>(&'static str, #[allow(dead_code)] A);
+struct Sr<'a, B:'a+Foo>(&'static str, #[allow(dead_code)] &'a B);
 
 impl<A: Foo> Drop for Dt<A> {
     fn drop(&mut self) { println!("drop {}", self.0); self.1.foo(self.0); }

--- a/tests/ui/drop/dropck-eyepatch.rs
+++ b/tests/ui/drop/dropck-eyepatch.rs
@@ -35,10 +35,10 @@ trait Foo { fn foo(&self, _: &str); }
 
 struct Dt<A: Foo>(&'static str, A);
 struct Dr<'a, B:'a+Foo>(&'static str, &'a B);
-struct Pt<A,B: Foo>(&'static str, #[allow(unused_tuple_struct_fields)] A, B);
-struct Pr<'a, 'b, B:'a+'b+Foo>(&'static str, #[allow(unused_tuple_struct_fields)] &'a B, &'b B);
-struct St<A: Foo>(&'static str, #[allow(unused_tuple_struct_fields)] A);
-struct Sr<'a, B:'a+Foo>(&'static str, #[allow(unused_tuple_struct_fields)] &'a B);
+struct Pt<A,B: Foo>(&'static str, #[allow(dead_code)] A, B);
+struct Pr<'a, 'b, B:'a+'b+Foo>(&'static str, #[allow(dead_code)] &'a B, &'b B);
+struct St<A: Foo>(&'static str, #[allow(dead_code)] A);
+struct Sr<'a, B:'a+Foo>(&'static str, #[allow(dead_code)] &'a B);
 
 impl<A: Foo> Drop for Dt<A> {
     fn drop(&mut self) { println!("drop {}", self.0); self.1.foo(self.0); }

--- a/tests/ui/drop/dynamic-drop.rs
+++ b/tests/ui/drop/dynamic-drop.rs
@@ -103,7 +103,7 @@ fn dynamic_drop(a: &Allocator, c: bool) {
     };
 }
 
-struct TwoPtrs<'a>(Ptr<'a>, #[allow(unused_tuple_struct_fields)] Ptr<'a>);
+struct TwoPtrs<'a>(Ptr<'a>, #[allow(dead_code)] Ptr<'a>);
 fn struct_dynamic_drop(a: &Allocator, c0: bool, c1: bool, c: bool) {
     for i in 0..2 {
         let x;

--- a/tests/ui/dropck/issue-24805-dropck-itemless.rs
+++ b/tests/ui/dropck/issue-24805-dropck-itemless.rs
@@ -19,7 +19,7 @@ impl<'a, T> UserDefined for &'a T { }
 //   ```
 macro_rules! impl_drop {
     ($Bound:ident, $Id:ident) => {
-        struct $Id<T: $Bound>(#[allow(unused_tuple_struct_fields)] T);
+        struct $Id<T: $Bound>(#[allow(dead_code)] T);
         unsafe impl <#[may_dangle] T: $Bound> Drop for $Id<T> {
             fn drop(&mut self) { }
         }

--- a/tests/ui/dropck/issue-28498-ugeh-with-passed-to-fn.rs
+++ b/tests/ui/dropck/issue-28498-ugeh-with-passed-to-fn.rs
@@ -21,7 +21,7 @@ impl Drop for ScribbleOnDrop {
     }
 }
 
-struct Foo<T>(u32, T, #[allow(unused_tuple_struct_fields)] Box<for <'r> fn(&'r T) -> String>);
+struct Foo<T>(u32, T, #[allow(dead_code)] Box<for <'r> fn(&'r T) -> String>);
 
 unsafe impl<#[may_dangle] T> Drop for Foo<T> {
     fn drop(&mut self) {

--- a/tests/ui/dyn-star/drop.rs
+++ b/tests/ui/dyn-star/drop.rs
@@ -6,7 +6,7 @@
 use std::fmt::Debug;
 
 #[derive(Debug)]
-struct Foo(usize);
+struct Foo(#[allow(dead_code)] usize);
 
 impl Drop for Foo {
     fn drop(&mut self) {

--- a/tests/ui/enum-discriminant/discriminant_value-wrapper.rs
+++ b/tests/ui/enum-discriminant/discriminant_value-wrapper.rs
@@ -4,7 +4,7 @@
 
 use std::mem;
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 enum ADT {
     First(u32, u32),
     Second(u64)

--- a/tests/ui/enum-discriminant/discriminant_value.rs
+++ b/tests/ui/enum-discriminant/discriminant_value.rs
@@ -27,14 +27,14 @@ enum CLike3 {
     D
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 enum ADT {
     First(u32, u32),
     Second(u64)
 }
 
 enum NullablePointer {
-    Something(#[allow(unused_tuple_struct_fields)] &'static u32),
+    Something(#[allow(dead_code)] &'static u32),
     Nothing
 }
 

--- a/tests/ui/generics/generic-default-type-params-cross-crate.rs
+++ b/tests/ui/generics/generic-default-type-params-cross-crate.rs
@@ -5,7 +5,7 @@
 
 extern crate default_type_params_xc;
 
-struct Vec<T, A = default_type_params_xc::Heap>(#[allow(unused_tuple_struct_fields)] Option<(T,A)>);
+struct Vec<T, A = default_type_params_xc::Heap>(#[allow(dead_code)] Option<(T,A)>);
 
 struct Foo;
 

--- a/tests/ui/generics/generic-ivec-leak.rs
+++ b/tests/ui/generics/generic-ivec-leak.rs
@@ -1,5 +1,5 @@
 // run-pass
 #![allow(non_camel_case_types)]
-enum wrapper<T> { wrapped(#[allow(unused_tuple_struct_fields)] T), }
+enum wrapper<T> { wrapped(#[allow(dead_code)] T), }
 
 pub fn main() { let _w = wrapper::wrapped(vec![1, 2, 3, 4, 5]); }

--- a/tests/ui/generics/generic-newtype-struct.rs
+++ b/tests/ui/generics/generic-newtype-struct.rs
@@ -1,7 +1,7 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-struct S<T>(#[allow(unused_tuple_struct_fields)] T);
+struct S<T>(#[allow(dead_code)] T);
 
 pub fn main() {
     let _s = S(2);

--- a/tests/ui/generics/generic-no-mangle.fixed
+++ b/tests/ui/generics/generic-no-mangle.fixed
@@ -76,7 +76,7 @@ impl<T> Trait2<T> for Foo {
     fn qux<'a>(x: &'a i32) -> &i32 { x } //~ ERROR functions generic over types or consts must be mangled
 }
 
-pub struct Bar<T>(#[allow(unused_tuple_struct_fields)] T);
+pub struct Bar<T>(#[allow(dead_code)] T);
 
 impl<T> Bar<T> {
     
@@ -111,7 +111,7 @@ impl<T> Trait3 for Bar<T> {
     fn baz<U>() {} //~ ERROR functions generic over types or consts must be mangled
 }
 
-pub struct Baz<'a>(#[allow(unused_tuple_struct_fields)] &'a i32);
+pub struct Baz<'a>(#[allow(dead_code)] &'a i32);
 
 impl<'a> Baz<'a> {
     #[no_mangle]

--- a/tests/ui/generics/generic-no-mangle.rs
+++ b/tests/ui/generics/generic-no-mangle.rs
@@ -76,7 +76,7 @@ impl<T> Trait2<T> for Foo {
     fn qux<'a>(x: &'a i32) -> &i32 { x } //~ ERROR functions generic over types or consts must be mangled
 }
 
-pub struct Bar<T>(#[allow(unused_tuple_struct_fields)] T);
+pub struct Bar<T>(#[allow(dead_code)] T);
 
 impl<T> Bar<T> {
     #[no_mangle]
@@ -111,7 +111,7 @@ impl<T> Trait3 for Bar<T> {
     fn baz<U>() {} //~ ERROR functions generic over types or consts must be mangled
 }
 
-pub struct Baz<'a>(#[allow(unused_tuple_struct_fields)] &'a i32);
+pub struct Baz<'a>(#[allow(dead_code)] &'a i32);
 
 impl<'a> Baz<'a> {
     #[no_mangle]

--- a/tests/ui/generics/generic-recursive-tag.rs
+++ b/tests/ui/generics/generic-recursive-tag.rs
@@ -1,7 +1,7 @@
 // run-pass
 #![allow(non_camel_case_types)]
 
-enum list<T> { #[allow(unused_tuple_struct_fields)] cons(Box<T>, Box<list<T>>), nil, }
+enum list<T> { #[allow(dead_code)] cons(Box<T>, Box<list<T>>), nil, }
 
 pub fn main() {
     let _a: list<isize> =

--- a/tests/ui/generics/generic-tag-corruption.rs
+++ b/tests/ui/generics/generic-tag-corruption.rs
@@ -5,6 +5,6 @@
 // This used to cause memory corruption in stage 0.
 // pretty-expanded FIXME #23616
 
-enum thing<K> { some(#[allow(unused_tuple_struct_fields)] K), }
+enum thing<K> { some(#[allow(dead_code)] K), }
 
 pub fn main() { let _x = thing::some("hi".to_string()); }

--- a/tests/ui/generics/generic-tag-local.rs
+++ b/tests/ui/generics/generic-tag-local.rs
@@ -3,6 +3,6 @@
 
 // pretty-expanded FIXME #23616
 
-enum clam<T> { a(#[allow(unused_tuple_struct_fields)] T), }
+enum clam<T> { a(#[allow(dead_code)] T), }
 
 pub fn main() { let _c = clam::a(3); }

--- a/tests/ui/generics/generic-tag.rs
+++ b/tests/ui/generics/generic-tag.rs
@@ -6,7 +6,7 @@
 
 #![allow(unused_variables)]
 
-enum option<T> { some(#[allow(unused_tuple_struct_fields)] Box<T>), none, }
+enum option<T> { some(#[allow(dead_code)] Box<T>), none, }
 
 pub fn main() {
     let mut a: option<isize> = option::some::<isize>(Box::new(10));

--- a/tests/ui/impl-trait/bounds_regression.rs
+++ b/tests/ui/impl-trait/bounds_regression.rs
@@ -15,7 +15,7 @@ pub fn future_from_coroutine<
     GenFuture(x)
 }
 
-struct GenFuture<T: FakeCoroutine<Yield = ()>>(#[allow(unused_tuple_struct_fields)] T);
+struct GenFuture<T: FakeCoroutine<Yield = ()>>(#[allow(dead_code)] T);
 
 impl<T: FakeCoroutine<Yield = ()>> FakeFuture for GenFuture<T> {
     type Output = T::Return;

--- a/tests/ui/inference/issue-36053.rs
+++ b/tests/ui/inference/issue-36053.rs
@@ -7,7 +7,7 @@
 
 use std::iter::FusedIterator;
 
-struct Thing<'a>(#[allow(unused_tuple_struct_fields)] &'a str);
+struct Thing<'a>(#[allow(dead_code)] &'a str);
 impl<'a> Iterator for Thing<'a> {
     type Item = &'a str;
     fn next(&mut self) -> Option<&'a str> {

--- a/tests/ui/issues/issue-13027.rs
+++ b/tests/ui/issues/issue-13027.rs
@@ -164,7 +164,7 @@ fn range_shadow_multi_pats() {
 
 fn misc() {
     enum Foo {
-        Bar(#[allow(unused_tuple_struct_fields)] usize, bool)
+        Bar(#[allow(dead_code)] usize, bool)
     }
     // This test basically mimics how trace_macros! macro is implemented,
     // which is a rare combination of vector patterns, multiple wild-card

--- a/tests/ui/issues/issue-14382.rs
+++ b/tests/ui/issues/issue-14382.rs
@@ -1,6 +1,6 @@
 // run-pass
 #[derive(Debug)]
-struct Matrix4<S>(#[allow(unused_tuple_struct_fields)] S);
+struct Matrix4<S>(#[allow(dead_code)] S);
 trait POrd<S> {}
 
 fn translate<S: POrd<S>>(s: S) -> Matrix4<S> { Matrix4(s) }

--- a/tests/ui/issues/issue-15858.rs
+++ b/tests/ui/issues/issue-15858.rs
@@ -12,7 +12,7 @@ impl Bar for BarImpl {
 }
 
 
-struct Foo<B: Bar>(#[allow(unused_tuple_struct_fields)] B);
+struct Foo<B: Bar>(#[allow(dead_code)] B);
 
 impl<B: Bar> Drop for Foo<B> {
     fn drop(&mut self) {

--- a/tests/ui/issues/issue-17905.rs
+++ b/tests/ui/issues/issue-17905.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 #[derive(Debug)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Pair<T, V> (T, V);
 
 impl Pair<

--- a/tests/ui/issues/issue-23491.rs
+++ b/tests/ui/issues/issue-23491.rs
@@ -1,7 +1,7 @@
 // run-pass
 #![allow(unused_variables)]
 
-struct Node<T: ?Sized>(#[allow(unused_tuple_struct_fields)] T);
+struct Node<T: ?Sized>(#[allow(dead_code)] T);
 
 fn main() {
     let x: Box<Node<[isize]>> = Box::new(Node([]));

--- a/tests/ui/issues/issue-24308.rs
+++ b/tests/ui/issues/issue-24308.rs
@@ -4,7 +4,7 @@ pub trait Foo {
     fn method2();
 }
 
-struct Slice<'a, T: 'a>(#[allow(unused_tuple_struct_fields)] &'a [T]);
+struct Slice<'a, T: 'a>(#[allow(dead_code)] &'a [T]);
 
 impl<'a, T: 'a> Foo for Slice<'a, T> {
     fn method2() {

--- a/tests/ui/issues/issue-25089.rs
+++ b/tests/ui/issues/issue-25089.rs
@@ -4,7 +4,7 @@
 
 use std::thread;
 
-struct Foo(#[allow(unused_tuple_struct_fields)] i32);
+struct Foo(#[allow(dead_code)] i32);
 
 impl Drop for Foo {
     fn drop(&mut self) {

--- a/tests/ui/issues/issue-25679.rs
+++ b/tests/ui/issues/issue-25679.rs
@@ -2,7 +2,7 @@
 trait Device {
     type Resources;
 }
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Foo<D, R>(D, R);
 
 impl<D: Device> Foo<D, D::Resources> {

--- a/tests/ui/issues/issue-26127.rs
+++ b/tests/ui/issues/issue-26127.rs
@@ -1,7 +1,7 @@
 // run-pass
 trait Tr { type T; }
 impl Tr for u8 { type T=(); }
-struct S<I: Tr>(#[allow(unused_tuple_struct_fields)] I::T);
+struct S<I: Tr>(#[allow(dead_code)] I::T);
 
 fn foo<I: Tr>(i: I::T) {
     S::<I>(i);

--- a/tests/ui/issues/issue-26641.rs
+++ b/tests/ui/issues/issue-26641.rs
@@ -1,5 +1,5 @@
 // run-pass
-struct Parser<'a>(#[allow(unused_tuple_struct_fields)] Box<dyn FnMut(Parser) + 'a>);
+struct Parser<'a>(#[allow(dead_code)] Box<dyn FnMut(Parser) + 'a>);
 
 fn main() {
     let _x = Parser(Box::new(|_|{}));

--- a/tests/ui/issues/issue-26709.rs
+++ b/tests/ui/issues/issue-26709.rs
@@ -1,5 +1,5 @@
 // run-pass
-struct Wrapper<'a, T: ?Sized>(&'a mut i32, #[allow(unused_tuple_struct_fields)] T);
+struct Wrapper<'a, T: ?Sized>(&'a mut i32, #[allow(dead_code)] T);
 
 impl<'a, T: ?Sized> Drop for Wrapper<'a, T> {
     fn drop(&mut self) {

--- a/tests/ui/issues/issue-27240.rs
+++ b/tests/ui/issues/issue-27240.rs
@@ -2,12 +2,12 @@
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
 use std::fmt;
-struct NoisyDrop<T: fmt::Debug>(#[allow(unused_tuple_struct_fields)] T);
+struct NoisyDrop<T: fmt::Debug>(#[allow(dead_code)] T);
 impl<T: fmt::Debug> Drop for NoisyDrop<T> {
     fn drop(&mut self) {}
 }
 
-struct Bar<T: fmt::Debug>(#[allow(unused_tuple_struct_fields)] [*const NoisyDrop<T>; 2]);
+struct Bar<T: fmt::Debug>(#[allow(dead_code)] [*const NoisyDrop<T>; 2]);
 
 fn fine() {
     let (u,b);
@@ -15,7 +15,7 @@ fn fine() {
     b = Bar([&NoisyDrop(&u), &NoisyDrop(&u)]);
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct Bar2<T: fmt::Debug>(*const NoisyDrop<T>, *const NoisyDrop<T>);
 
 fn lolwut() {

--- a/tests/ui/issues/issue-28498-must-work-ex1.rs
+++ b/tests/ui/issues/issue-28498-must-work-ex1.rs
@@ -6,7 +6,7 @@
 
 use std::cell::Cell;
 
-struct Concrete<'a>(#[allow(unused_tuple_struct_fields)] u32, Cell<Option<&'a Concrete<'a>>>);
+struct Concrete<'a>(#[allow(dead_code)] u32, Cell<Option<&'a Concrete<'a>>>);
 
 fn main() {
     let mut data = Vec::new();

--- a/tests/ui/issues/issue-28498-must-work-ex2.rs
+++ b/tests/ui/issues/issue-28498-must-work-ex2.rs
@@ -6,7 +6,7 @@
 
 use std::cell::Cell;
 
-struct Concrete<'a>(#[allow(unused_tuple_struct_fields)] u32, Cell<Option<&'a Concrete<'a>>>);
+struct Concrete<'a>(#[allow(dead_code)] u32, Cell<Option<&'a Concrete<'a>>>);
 
 struct Foo<T> { data: Vec<T> }
 

--- a/tests/ui/issues/issue-28498-ugeh-ex1.rs
+++ b/tests/ui/issues/issue-28498-ugeh-ex1.rs
@@ -8,7 +8,7 @@
 #![feature(dropck_eyepatch)]
 use std::cell::Cell;
 
-struct Concrete<'a>(#[allow(unused_tuple_struct_fields)] u32, Cell<Option<&'a Concrete<'a>>>);
+struct Concrete<'a>(#[allow(dead_code)] u32, Cell<Option<&'a Concrete<'a>>>);
 
 struct Foo<T> { data: Vec<T> }
 

--- a/tests/ui/issues/issue-31267-additional.rs
+++ b/tests/ui/issues/issue-31267-additional.rs
@@ -6,7 +6,7 @@ struct Bar;
 const BAZ: Bar = Bar;
 
 #[derive(Debug)]
-struct Foo(#[allow(unused_tuple_struct_fields)] [Bar; 1]);
+struct Foo(#[allow(dead_code)] [Bar; 1]);
 
 struct Biz;
 

--- a/tests/ui/issues/issue-31299.rs
+++ b/tests/ui/issues/issue-31299.rs
@@ -25,9 +25,9 @@ impl<T> Front for Vec<T> {
     type Back = Vec<T>;
 }
 
-struct PtrBack<T: Front>(#[allow(unused_tuple_struct_fields)] Vec<T::Back>);
+struct PtrBack<T: Front>(#[allow(dead_code)] Vec<T::Back>);
 
-struct M(#[allow(unused_tuple_struct_fields)] PtrBack<Vec<M>>);
+struct M(#[allow(dead_code)] PtrBack<Vec<M>>);
 
 #[allow(unused_must_use)]
 fn main() {

--- a/tests/ui/issues/issue-34571.rs
+++ b/tests/ui/issues/issue-34571.rs
@@ -1,7 +1,7 @@
 // run-pass
 #[repr(u8)]
 enum Foo {
-    Foo(#[allow(unused_tuple_struct_fields)] u8),
+    Foo(#[allow(dead_code)] u8),
 }
 
 fn main() {

--- a/tests/ui/issues/issue-36278-prefix-nesting.rs
+++ b/tests/ui/issues/issue-36278-prefix-nesting.rs
@@ -5,7 +5,7 @@
 use std::mem;
 
 const SZ: usize = 100;
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct P<T: ?Sized>([u8; SZ], T);
 
 type Ack<T> = P<P<T>>;

--- a/tests/ui/issues/issue-4252.rs
+++ b/tests/ui/issues/issue-4252.rs
@@ -7,7 +7,7 @@ trait X {
 }
 
 #[derive(Debug)]
-struct Y(#[allow(unused_tuple_struct_fields)] isize);
+struct Y(#[allow(dead_code)] isize);
 
 #[derive(Debug)]
 struct Z<T: X+std::fmt::Debug> {

--- a/tests/ui/issues/issue-46069.rs
+++ b/tests/ui/issues/issue-46069.rs
@@ -2,7 +2,7 @@
 use std::iter::{Fuse, Cloned};
 use std::slice::Iter;
 
-struct Foo<'a, T: 'a>(#[allow(unused_tuple_struct_fields)] &'a T);
+struct Foo<'a, T: 'a>(#[allow(dead_code)] &'a T);
 impl<'a, T: 'a> Copy for Foo<'a, T> {}
 impl<'a, T: 'a> Clone for Foo<'a, T> {
     fn clone(&self) -> Self { *self }

--- a/tests/ui/issues/issue-5315.rs
+++ b/tests/ui/issues/issue-5315.rs
@@ -1,7 +1,7 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-struct A(#[allow(unused_tuple_struct_fields)] bool);
+struct A(#[allow(dead_code)] bool);
 
 pub fn main() {
     let f = A;

--- a/tests/ui/issues/issue-61894.rs
+++ b/tests/ui/issues/issue-61894.rs
@@ -4,7 +4,7 @@
 
 use std::any::type_name;
 
-struct Bar<M>(#[allow(unused_tuple_struct_fields)] M);
+struct Bar<M>(#[allow(dead_code)] M);
 
 impl<M> Bar<M> {
     fn foo(&self) -> &'static str {

--- a/tests/ui/issues/issue-7911.rs
+++ b/tests/ui/issues/issue-7911.rs
@@ -6,7 +6,7 @@
 trait FooBar {
     fn dummy(&self) { }
 }
-struct Bar(#[allow(unused_tuple_struct_fields)] i32);
+struct Bar(#[allow(dead_code)] i32);
 struct Foo { bar: Bar }
 
 impl FooBar for Bar {}

--- a/tests/ui/issues/issue-99838.rs
+++ b/tests/ui/issues/issue-99838.rs
@@ -2,7 +2,7 @@
 
 use std::hint;
 
-struct U16(u16);
+struct U16(#[allow(dead_code)] u16);
 
 impl Drop for U16 {
     fn drop(&mut self) {
@@ -23,7 +23,7 @@ struct Wrapper {
 }
 
 #[repr(packed)]
-struct Misalign(u8, Wrapper);
+struct Misalign(#[allow(dead_code)] u8, Wrapper);
 
 fn main() {
     let m = Misalign(

--- a/tests/ui/layout/unsafe-cell-hides-niche.rs
+++ b/tests/ui/layout/unsafe-cell-hides-niche.rs
@@ -14,10 +14,10 @@ use std::mem::size_of;
 use std::num::NonZeroU32 as N32;
 use std::sync::{Mutex, RwLock};
 
-struct Wrapper<T>(#[allow(unused_tuple_struct_fields)] T);
+struct Wrapper<T>(#[allow(dead_code)] T);
 
 #[repr(transparent)]
-struct Transparent<T>(#[allow(unused_tuple_struct_fields)] T);
+struct Transparent<T>(#[allow(dead_code)] T);
 
 struct NoNiche<T>(UnsafeCell<T>);
 

--- a/tests/ui/lint/dead-code/lint-dead-code-1.rs
+++ b/tests/ui/lint/dead-code/lint-dead-code-1.rs
@@ -37,7 +37,7 @@ struct UsedStruct1 {
     #[allow(dead_code)]
     x: isize
 }
-struct UsedStruct2(isize);
+struct UsedStruct2(#[allow(dead_code)] isize);
 struct UsedStruct3;
 pub struct UsedStruct4;
 // this struct is never used directly, but its method is, so we don't want

--- a/tests/ui/lint/dead-code/lint-dead-code-5.rs
+++ b/tests/ui/lint/dead-code/lint-dead-code-5.rs
@@ -2,12 +2,12 @@
 #![deny(dead_code)]
 
 enum Enum1 {
-    Variant1(isize),
+    Variant1(#[allow(dead_code)] isize),
     Variant2 //~ ERROR: variant `Variant2` is never constructed
 }
 
 enum Enum2 {
-    Variant3(bool),
+    Variant3(#[allow(dead_code)] bool),
     #[allow(dead_code)]
     Variant4(isize),
     Variant5 { _x: isize }, //~ ERROR: variants `Variant5` and `Variant6` are never constructed
@@ -15,7 +15,7 @@ enum Enum2 {
     _Variant7,
     Variant8 { _field: bool },
     Variant9,
-    Variant10(usize)
+    Variant10(#[allow(dead_code)] usize)
 }
 
 impl Enum2 {

--- a/tests/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -3,7 +3,7 @@ error: variant `Variant2` is never constructed
    |
 LL | enum Enum1 {
    |      ----- variant in this enum
-LL |     Variant1(isize),
+LL |     Variant1(#[allow(dead_code)] isize),
 LL |     Variant2
    |     ^^^^^^^^
    |

--- a/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.rs
+++ b/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.rs
@@ -17,7 +17,7 @@ struct Bar {
 
 // Issue 119267: this should not ICE.
 #[derive(Debug)]
-struct Foo(usize, #[allow(unused)] usize);
+struct Foo(usize, #[allow(unused)] usize); //~ WARN field `0` is never read
 
 fn main() {
     Bar {

--- a/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
+++ b/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
@@ -51,5 +51,19 @@ note: the lint level is defined here
 LL |     #[forbid(dead_code)]
    |              ^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+warning: field `0` is never read
+  --> $DIR/multiple-dead-codes-in-the-same-struct.rs:20:12
+   |
+LL | struct Foo(usize, #[allow(unused)] usize);
+   |        --- ^^^^^
+   |        |
+   |        field in this struct
+   |
+   = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
+   |
+LL | struct Foo((), #[allow(unused)] usize);
+   |            ~~
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/lint/dead-code/tuple-struct-field.rs
+++ b/tests/ui/lint/dead-code/tuple-struct-field.rs
@@ -1,4 +1,4 @@
-#![deny(unused_tuple_struct_fields)]
+#![deny(dead_code)]
 //~^ NOTE: the lint level is defined here
 
 use std::marker::PhantomData;

--- a/tests/ui/lint/dead-code/tuple-struct-field.stderr
+++ b/tests/ui/lint/dead-code/tuple-struct-field.stderr
@@ -9,8 +9,8 @@ LL | struct SingleUnused(i32, [u8; LEN], String);
 note: the lint level is defined here
   --> $DIR/tuple-struct-field.rs:1:9
    |
-LL | #![deny(unused_tuple_struct_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
 help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
 LL | struct SingleUnused(i32, (), String);

--- a/tests/ui/lint/dead-code/with-impl.rs
+++ b/tests/ui/lint/dead-code/with-impl.rs
@@ -2,7 +2,7 @@
 
 #![deny(dead_code)]
 
-pub struct GenericFoo<T>(#[allow(unused_tuple_struct_fields)] T);
+pub struct GenericFoo<T>(#[allow(dead_code)] T);
 
 type Foo = GenericFoo<u32>;
 

--- a/tests/ui/lint/unused/issue-104397.rs
+++ b/tests/ui/lint/unused/issue-104397.rs
@@ -3,7 +3,7 @@
 #![warn(unused)]
 #![deny(warnings)]
 
-struct Inv<'a>(&'a mut &'a ());
+struct Inv<'a>(#[allow(dead_code)] &'a mut &'a ());
 
 trait Trait {}
 impl Trait for for<'a> fn(Inv<'a>) {}

--- a/tests/ui/lint/unused/issue-105061-should-lint.rs
+++ b/tests/ui/lint/unused/issue-105061-should-lint.rs
@@ -1,7 +1,7 @@
 #![warn(unused)]
 #![deny(warnings)]
 
-struct Inv<'a>(&'a mut &'a ());
+struct Inv<'a>(#[allow(dead_code)] &'a mut &'a ());
 
 trait Trait<'a> {}
 impl<'b> Trait<'b> for for<'a> fn(Inv<'a>) {}

--- a/tests/ui/lint/unused/issue-105061.rs
+++ b/tests/ui/lint/unused/issue-105061.rs
@@ -1,7 +1,7 @@
 #![warn(unused)]
 #![deny(warnings)]
 
-struct Inv<'a>(&'a mut &'a ());
+struct Inv<'a>(#[allow(dead_code)] &'a mut &'a ());
 
 trait Trait {}
 impl Trait for (for<'a> fn(Inv<'a>),) {}

--- a/tests/ui/list.rs
+++ b/tests/ui/list.rs
@@ -3,7 +3,7 @@
 #![allow(non_camel_case_types)]
 // pretty-expanded FIXME #23616
 
-enum list { #[allow(unused_tuple_struct_fields)] cons(isize, Box<list>), nil, }
+enum list { #[allow(dead_code)] cons(isize, Box<list>), nil, }
 
 pub fn main() {
     list::cons(10, Box::new(list::cons(11, Box::new(list::cons(12, Box::new(list::nil))))));

--- a/tests/ui/macros/html-literals.rs
+++ b/tests/ui/macros/html-literals.rs
@@ -88,7 +88,7 @@ pub fn main() {
     );
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 enum HTMLFragment {
     tag(String, Vec<HTMLFragment> ),
     text(String),

--- a/tests/ui/macros/macro-tt-followed-by-seq.rs
+++ b/tests/ui/macros/macro-tt-followed-by-seq.rs
@@ -5,7 +5,7 @@
 use self::Join::*;
 
 #[derive(Debug)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 enum Join<A,B> {
   Keep(A,B),
   Skip(A,B),

--- a/tests/ui/methods/method-argument-inference-associated-type.rs
+++ b/tests/ui/methods/method-argument-inference-associated-type.rs
@@ -7,7 +7,7 @@ pub trait Service {
     fn call(&self, _req: Self::Request);
 }
 
-pub struct S<T>(#[allow(unused_tuple_struct_fields)] T);
+pub struct S<T>(#[allow(dead_code)] T);
 
 impl Service for ClientMap {
     type Request = S<Box<dyn Fn(i32)>>;

--- a/tests/ui/methods/method-probe-no-guessing-dyn-trait.rs
+++ b/tests/ui/methods/method-probe-no-guessing-dyn-trait.rs
@@ -15,7 +15,7 @@ trait MyTrait1 {
 
 impl MyTrait1 for Foo<u32> {}
 
-struct Foo<T>(#[allow(unused_tuple_struct_fields)] T);
+struct Foo<T>(#[allow(dead_code)] T);
 
 impl Deref for Foo<()> {
     type Target = dyn MyTrait1 + 'static;
@@ -33,7 +33,7 @@ trait MyTrait2 {
 }
 
 impl MyTrait2 for u32 {}
-struct Bar<T>(#[allow(unused_tuple_struct_fields)] T, u32);
+struct Bar<T>(#[allow(dead_code)] T, u32);
 impl Deref for Bar<u8> {
     type Target = dyn MyTrait2 + 'static;
     fn deref(&self) -> &(dyn MyTrait2 + 'static) {

--- a/tests/ui/mir/mir_codegen_switch.rs
+++ b/tests/ui/mir/mir_codegen_switch.rs
@@ -1,7 +1,7 @@
 // run-pass
 enum Abc {
-    A(#[allow(unused_tuple_struct_fields)] u8),
-    B(#[allow(unused_tuple_struct_fields)] i8),
+    A(#[allow(dead_code)] u8),
+    B(#[allow(dead_code)] i8),
     C,
     D,
 }

--- a/tests/ui/mir/mir_fat_ptr.rs
+++ b/tests/ui/mir/mir_fat_ptr.rs
@@ -1,7 +1,7 @@
 // run-pass
 // test that ordinary fat pointer operations work.
 
-struct Wrapper<T: ?Sized>(#[allow(unused_tuple_struct_fields)] u32, T);
+struct Wrapper<T: ?Sized>(#[allow(dead_code)] u32, T);
 
 struct FatPtrContainer<'a> {
     ptr: &'a [u8]

--- a/tests/ui/mir/mir_raw_fat_ptr.rs
+++ b/tests/ui/mir/mir_raw_fat_ptr.rs
@@ -105,7 +105,7 @@ impl<T> Foo for T {
     }
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S<T:?Sized>(u32, T);
 
 fn main_ref() {

--- a/tests/ui/mir/mir_refs_correct.rs
+++ b/tests/ui/mir/mir_refs_correct.rs
@@ -3,7 +3,7 @@
 
 extern crate mir_external_refs as ext;
 
-struct S(#[allow(unused_tuple_struct_fields)] u8);
+struct S(#[allow(dead_code)] u8);
 #[derive(Debug, PartialEq, Eq)]
 struct Unit;
 
@@ -46,7 +46,7 @@ impl<I, O> T<I, O> for O {}
 impl X for S {}
 
 enum E {
-    U(#[allow(unused_tuple_struct_fields)] u8)
+    U(#[allow(dead_code)] u8)
 }
 
 #[derive(PartialEq, Debug, Eq)]

--- a/tests/ui/mismatched_types/suggest-removing-tuple-struct-field.fixed
+++ b/tests/ui/mismatched_types/suggest-removing-tuple-struct-field.fixed
@@ -4,7 +4,7 @@ macro_rules! my_wrapper {
     ($expr:expr) => { MyWrapper($expr) }
 }
 
-pub struct MyWrapper(u32);
+pub struct MyWrapper(#[allow(dead_code)] u32);
 
 fn main() {
     let value = MyWrapper(123);

--- a/tests/ui/mismatched_types/suggest-removing-tuple-struct-field.rs
+++ b/tests/ui/mismatched_types/suggest-removing-tuple-struct-field.rs
@@ -4,7 +4,7 @@ macro_rules! my_wrapper {
     ($expr:expr) => { MyWrapper($expr) }
 }
 
-pub struct MyWrapper(u32);
+pub struct MyWrapper(#[allow(dead_code)] u32);
 
 fn main() {
     let value = MyWrapper(123);

--- a/tests/ui/nullable-pointer-iotareduction.rs
+++ b/tests/ui/nullable-pointer-iotareduction.rs
@@ -8,7 +8,7 @@
 // trying to get assert failure messages that at least identify which case
 // failed.
 
-enum E<T> { Thing(isize, T), #[allow(unused_tuple_struct_fields)] Nothing((), ((), ()), [i8; 0]) }
+enum E<T> { Thing(isize, T), #[allow(dead_code)] Nothing((), ((), ()), [i8; 0]) }
 impl<T> E<T> {
     fn is_none(&self) -> bool {
         match *self {

--- a/tests/ui/optimization-fuel-0.rs
+++ b/tests/ui/optimization-fuel-0.rs
@@ -6,9 +6,9 @@ use std::mem::size_of;
 
 // compile-flags: -Z fuel=foo=0
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S1(u8, u16, u8);
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S2(u8, u16, u8);
 
 fn main() {

--- a/tests/ui/optimization-fuel-1.rs
+++ b/tests/ui/optimization-fuel-1.rs
@@ -6,9 +6,9 @@ use std::mem::size_of;
 
 // compile-flags: -Z fuel=foo=1
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S1(u8, u16, u8);
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S2(u8, u16, u8);
 
 fn main() {

--- a/tests/ui/packed/issue-118537-field-offset-ice.rs
+++ b/tests/ui/packed/issue-118537-field-offset-ice.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 #[repr(packed(4))]
-struct Slice([u32]);
+struct Slice(#[allow(dead_code)] [u32]);
 
 #[repr(packed(2), C)]
 struct PackedSized {

--- a/tests/ui/packed/packed-struct-drop-aligned.rs
+++ b/tests/ui/packed/packed-struct-drop-aligned.rs
@@ -24,7 +24,7 @@ impl<'a> Drop for Aligned<'a> {
 }
 
 #[repr(transparent)]
-struct NotCopy(#[allow(unused_tuple_struct_fields)] u8);
+struct NotCopy(#[allow(dead_code)] u8);
 
 #[repr(packed)]
 struct Packed<'a>(NotCopy, Aligned<'a>);

--- a/tests/ui/packed/packed-struct-optimized-enum.rs
+++ b/tests/ui/packed/packed-struct-optimized-enum.rs
@@ -1,6 +1,6 @@
 // run-pass
 #[repr(packed)]
-struct Packed<T: Copy>(#[allow(unused_tuple_struct_fields)] T);
+struct Packed<T: Copy>(#[allow(dead_code)] T);
 
 impl<T: Copy> Copy for Packed<T> {}
 impl<T: Copy> Clone for Packed<T> {

--- a/tests/ui/packed/packed-tuple-struct-layout.rs
+++ b/tests/ui/packed/packed-tuple-struct-layout.rs
@@ -2,11 +2,11 @@
 use std::mem;
 
 #[repr(packed)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S4(u8,[u8; 3]);
 
 #[repr(packed)]
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S5(u8,u32);
 
 pub fn main() {

--- a/tests/ui/parser/issues/issue-70388-without-witness.fixed
+++ b/tests/ui/parser/issues/issue-70388-without-witness.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // This is for checking if we can apply suggestions as-is.
 
-pub struct Foo(#[allow(unused_tuple_struct_fields)] i32);
+pub struct Foo(#[allow(dead_code)] i32);
 
 fn main() {
     let Foo(..) = Foo(0); //~ ERROR unexpected `...`

--- a/tests/ui/parser/issues/issue-70388-without-witness.rs
+++ b/tests/ui/parser/issues/issue-70388-without-witness.rs
@@ -1,7 +1,7 @@
 // run-rustfix
 // This is for checking if we can apply suggestions as-is.
 
-pub struct Foo(#[allow(unused_tuple_struct_fields)] i32);
+pub struct Foo(#[allow(dead_code)] i32);
 
 fn main() {
     let Foo(...) = Foo(0); //~ ERROR unexpected `...`

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.fixed
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.fixed
@@ -1,7 +1,7 @@
 // Regression test for issues #100790 and #106439.
 // run-rustfix
 
-pub struct Example(usize)
+pub struct Example(#[allow(dead_code)] usize)
 where
     (): Sized;
 //~^^^ ERROR where clauses are not allowed before tuple struct bodies

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.rs
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.rs
@@ -4,7 +4,7 @@
 pub struct Example
 where
     (): Sized,
-(usize);
+(#[allow(dead_code)] usize);
 //~^^^ ERROR where clauses are not allowed before tuple struct bodies
 
 struct _Demo

--- a/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.stderr
+++ b/tests/ui/parser/recover/recover-where-clause-before-tuple-struct-body-0.stderr
@@ -6,12 +6,12 @@ LL |   pub struct Example
 LL | / where
 LL | |     (): Sized,
    | |______________^ unexpected where clause
-LL |   (usize);
-   |   ------- the struct body
+LL |   (#[allow(dead_code)] usize);
+   |   --------------------------- the struct body
    |
 help: move the body before the where clause
    |
-LL ~ pub struct Example(usize)
+LL ~ pub struct Example(#[allow(dead_code)] usize)
 LL | where
 LL ~     (): Sized;
    |

--- a/tests/ui/pub/pub-ident-struct-4.fixed
+++ b/tests/ui/pub/pub-ident-struct-4.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
-pub struct T(String);
+pub struct T(#[allow(dead_code)] String);
 //~^ ERROR missing `struct` for struct definition
 
 fn main() {}

--- a/tests/ui/pub/pub-ident-struct-4.rs
+++ b/tests/ui/pub/pub-ident-struct-4.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
-pub T(String);
+pub T(#[allow(dead_code)] String);
 //~^ ERROR missing `struct` for struct definition
 
 fn main() {}

--- a/tests/ui/pub/pub-ident-struct-4.stderr
+++ b/tests/ui/pub/pub-ident-struct-4.stderr
@@ -1,12 +1,12 @@
 error: missing `struct` for struct definition
   --> $DIR/pub-ident-struct-4.rs:3:4
    |
-LL | pub T(String);
+LL | pub T(#[allow(dead_code)] String);
    |    ^
    |
 help: add `struct` here to parse `T` as a public struct
    |
-LL | pub struct T(String);
+LL | pub struct T(#[allow(dead_code)] String);
    |     ++++++
 
 error: aborting due to 1 previous error

--- a/tests/ui/range_inclusive.rs
+++ b/tests/ui/range_inclusive.rs
@@ -11,7 +11,7 @@ fn foo() -> isize { 42 }
 pub fn return_range_to() -> RangeToInclusive<i32> { return ..=1; }
 
 #[derive(Debug)]
-struct P(#[allow(unused_tuple_struct_fields)] u8);
+struct P(#[allow(dead_code)] u8);
 
 pub fn main() {
     let mut count = 0;

--- a/tests/ui/recursion_limit/issue-40003.rs
+++ b/tests/ui/recursion_limit/issue-40003.rs
@@ -153,7 +153,7 @@ mod stream {
     }
 
     enum Slot<T> {
-        Next(#[allow(unused_tuple_struct_fields)] usize),
+        Next(#[allow(dead_code)] usize),
         _Data { _a: T },
     }
 

--- a/tests/ui/repr/align-with-extern-c-fn.rs
+++ b/tests/ui/repr/align-with-extern-c-fn.rs
@@ -8,7 +8,7 @@
 #![feature(repr_align)]
 
 #[repr(align(16))]
-pub struct A(#[allow(unused_tuple_struct_fields)] i64);
+pub struct A(#[allow(dead_code)] i64);
 
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn foo(x: A) {}

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-embedded.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-embedded.rs
@@ -5,7 +5,7 @@
 
 #![warn(pointer_structural_match)]
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive
 // (which doesn't matter here because `<*const T>::eq` won't recur on `T`).

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-param.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-direct-unsafe-ptr-param.rs
@@ -5,7 +5,7 @@
 
 #![warn(pointer_structural_match)]
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive
 // (which doesn't matter here because `<*const T>::eq` won't recur on `T`).

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-embedded.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-embedded.rs
@@ -5,7 +5,7 @@
 
 #![warn(pointer_structural_match)]
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive
 // (which doesn't matter here because `<*const T>::eq` won't recur on `T`).

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-param.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/allow-hide-behind-indirect-unsafe-ptr-param.rs
@@ -5,7 +5,7 @@
 
 #![warn(pointer_structural_match)]
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive
 // (which doesn't matter here because `<*const T>::eq` won't recur on `T`).

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-direct-struct-embedded.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-direct-struct-embedded.rs
@@ -5,7 +5,7 @@
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive.
 impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-embedded.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-embedded.rs
@@ -7,7 +7,7 @@
 #![warn(indirect_structural_match)]
 // run-pass
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive.
 impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-param.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-doubly-indirect-param.rs
@@ -7,7 +7,7 @@
 #![warn(indirect_structural_match)]
 // run-pass
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive.
 impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-embedded.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-embedded.rs
@@ -7,7 +7,7 @@
 #![warn(indirect_structural_match)]
 // run-pass
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive.
 impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-param.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/cant-hide-behind-indirect-struct-param.rs
@@ -7,7 +7,7 @@
 #![warn(indirect_structural_match)]
 // run-pass
 
-struct NoDerive(#[allow(unused_tuple_struct_fields)] i32);
+struct NoDerive(#[allow(dead_code)] i32);
 
 // This impl makes NoDerive irreflexive.
 impl PartialEq for NoDerive { fn eq(&self, _: &Self) -> bool { false } }

--- a/tests/ui/rfcs/rfc-2151-raw-identifiers/attr.rs
+++ b/tests/ui/rfcs/rfc-2151-raw-identifiers/attr.rs
@@ -7,7 +7,7 @@ struct Test {
 }
 
 #[r#derive(r#Debug)]
-struct Test2(#[allow(unused_tuple_struct_fields)] u32);
+struct Test2(#[allow(dead_code)] u32);
 
 pub fn main() {
     assert_eq!(mem::size_of::<Test>(), 9);

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.rs
@@ -100,7 +100,7 @@ implements_const_drop! {
 }
 
 fn main() {
-    struct HasDropGlue(#[allow(unused_tuple_struct_fields)] Box<u8>);
+    struct HasDropGlue(#[allow(dead_code)] Box<u8>);
     struct HasDropImpl;
     impl Drop for HasDropImpl {
         fn drop(&mut self) {

--- a/tests/ui/specialization/specialization-cross-crate.rs
+++ b/tests/ui/specialization/specialization-cross-crate.rs
@@ -14,7 +14,7 @@ struct NotClone;
 struct MarkedAndClone;
 impl MyMarker for MarkedAndClone {}
 
-struct MyType<T>(#[allow(unused_tuple_struct_fields)] T);
+struct MyType<T>(#[allow(dead_code)] T);
 impl<T> Foo for MyType<T> {
     default fn foo(&self) -> &'static str {
         "generic MyType"

--- a/tests/ui/specialization/specialization-translate-projections-with-lifetimes.rs
+++ b/tests/ui/specialization/specialization-translate-projections-with-lifetimes.rs
@@ -14,7 +14,7 @@ impl<'a> WithAssoc for &'a () {
     type Item = &'a u32;
 }
 
-struct Cloned<I>(#[allow(unused_tuple_struct_fields)] I);
+struct Cloned<I>(#[allow(dead_code)] I);
 
 impl<'a, I, T: 'a> Iterator for Cloned<I>
     where I: WithAssoc<Item=&'a T>, T: Clone

--- a/tests/ui/stdlib-unit-tests/raw-fat-ptr.rs
+++ b/tests/ui/stdlib-unit-tests/raw-fat-ptr.rs
@@ -39,7 +39,7 @@ impl<T> Foo for T {
     }
 }
 
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 struct S<T:?Sized>(u32, T);
 
 fn main() {

--- a/tests/ui/struct-ctor-mangling.rs
+++ b/tests/ui/struct-ctor-mangling.rs
@@ -4,7 +4,7 @@ fn size_of_val<T>(_: &T) -> usize {
     std::mem::size_of::<T>()
 }
 
-struct Foo(#[allow(unused_tuple_struct_fields)] i64);
+struct Foo(#[allow(dead_code)] i64);
 
 // Test that the (symbol) mangling of `Foo` (the `struct` type) and that of
 // `typeof Foo` (the function type of the `struct` constructor) don't collide.

--- a/tests/ui/structs-enums/enum-null-pointer-opt.rs
+++ b/tests/ui/structs-enums/enum-null-pointer-opt.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 trait Trait { fn dummy(&self) { } }
 trait Mirror { type Image; }
 impl<T> Mirror for T { type Image = T; }
-struct ParamTypeStruct<T>(#[allow(unused_tuple_struct_fields)] T);
-struct AssocTypeStruct<T>(#[allow(unused_tuple_struct_fields)] <T as Mirror>::Image);
+struct ParamTypeStruct<T>(#[allow(dead_code)] T);
+struct AssocTypeStruct<T>(#[allow(dead_code)] <T as Mirror>::Image);
 #[repr(transparent)]
 union MaybeUninitUnion<T: Copy> {
     _value: T,
@@ -46,7 +46,7 @@ fn main() {
     struct Foo {
         _a: Box<isize>
     }
-    struct Bar(#[allow(unused_tuple_struct_fields)] Box<isize>);
+    struct Bar(#[allow(dead_code)] Box<isize>);
 
     // Should apply through structs
     assert_eq!(size_of::<Foo>(), size_of::<Option<Foo>>());

--- a/tests/ui/structs-enums/enum-nullable-simplifycfg-misopt.rs
+++ b/tests/ui/structs-enums/enum-nullable-simplifycfg-misopt.rs
@@ -6,7 +6,7 @@
  * represented with nullable pointers could be misoptimized in some cases.
  */
 
-enum List<X> { Nil, Cons(X, #[allow(unused_tuple_struct_fields)] Box<List<X>>) }
+enum List<X> { Nil, Cons(X, #[allow(dead_code)] Box<List<X>>) }
 pub fn main() {
     match List::Cons(10, Box::new(List::Nil)) {
         List::Cons(10, _) => {}

--- a/tests/ui/structs-enums/resource-in-struct.rs
+++ b/tests/ui/structs-enums/resource-in-struct.rs
@@ -25,7 +25,7 @@ fn close_res(i: closable) -> close_res {
     }
 }
 
-enum option<T> { none, some(#[allow(unused_tuple_struct_fields)] T), }
+enum option<T> { none, some(#[allow(dead_code)] T), }
 
 fn sink(_res: option<close_res>) { }
 

--- a/tests/ui/structs-enums/tuple-struct-construct.rs
+++ b/tests/ui/structs-enums/tuple-struct-construct.rs
@@ -1,5 +1,5 @@
 // run-pass
-#[allow(unused_tuple_struct_fields)]
+#[allow(dead_code)]
 #[derive(Debug)]
 struct Foo(isize, isize);
 

--- a/tests/ui/structs-enums/uninstantiable-struct.rs
+++ b/tests/ui/structs-enums/uninstantiable-struct.rs
@@ -1,4 +1,4 @@
 // run-pass
-pub struct Z(#[allow(unused_tuple_struct_fields)] &'static Z);
+pub struct Z(#[allow(dead_code)] &'static Z);
 
 pub fn main() {}

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.fixed
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.fixed
@@ -2,7 +2,7 @@
 // trait, impl or associated fn.
 // run-rustfix
 
-struct Inv<'a>(Option<*mut &'a u8>);
+struct Inv<'a>(#[allow(dead_code)] Option<*mut &'a u8>);
 
 fn check_bound<'a, A: 'a>(_: A, _: Inv<'a>) {}
 

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.rs
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.rs
@@ -2,7 +2,7 @@
 // trait, impl or associated fn.
 // run-rustfix
 
-struct Inv<'a>(Option<*mut &'a u8>);
+struct Inv<'a>(#[allow(dead_code)] Option<*mut &'a u8>);
 
 fn check_bound<'a, A: 'a>(_: A, _: Inv<'a>) {}
 

--- a/tests/ui/trailing-comma.rs
+++ b/tests/ui/trailing-comma.rs
@@ -3,7 +3,7 @@
 
 fn f<T,>(_: T,) {}
 
-struct Foo<T,>(#[allow(unused_tuple_struct_fields)] T);
+struct Foo<T,>(#[allow(dead_code)] T);
 
 struct Bar;
 
@@ -14,7 +14,7 @@ impl Bar {
 }
 
 enum Baz {
-    Qux(#[allow(unused_tuple_struct_fields)] isize,),
+    Qux(#[allow(dead_code)] isize,),
 }
 
 #[allow(unused,)]

--- a/tests/ui/traits/augmented-assignments-trait.rs
+++ b/tests/ui/traits/augmented-assignments-trait.rs
@@ -1,7 +1,7 @@
 // run-pass
 use std::ops::AddAssign;
 
-struct Int(#[allow(unused_tuple_struct_fields)] i32);
+struct Int(#[allow(dead_code)] i32);
 
 impl AddAssign for Int {
     fn add_assign(&mut self, _: Int) {

--- a/tests/ui/traits/negative-impls/negated-auto-traits-rpass.rs
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-rpass.rs
@@ -5,7 +5,7 @@
 pub struct WaitToken;
 impl !Send for WaitToken {}
 
-pub struct Test<T>(#[allow(unused_tuple_struct_fields)] T);
+pub struct Test<T>(#[allow(dead_code)] T);
 unsafe impl<T: 'static> Send for Test<T> {}
 
 pub fn spawn<F>(_: F) -> () where F: FnOnce(), F: Send + 'static {}

--- a/tests/ui/traits/object/exclusion.rs
+++ b/tests/ui/traits/object/exclusion.rs
@@ -8,7 +8,7 @@ trait Future: 'static {
     }
 }
 
-struct Map<A>(#[allow(unused_tuple_struct_fields)] A);
+struct Map<A>(#[allow(dead_code)] A);
 impl<A: Future> Future for Map<A> {}
 
 pub struct Promise;

--- a/tests/ui/traits/object/generics.rs
+++ b/tests/ui/traits/object/generics.rs
@@ -25,7 +25,7 @@ impl<A1, A2, A3> Impl<A1, A2, A3> {
 
 // test for #8601
 
-enum Type<T> { Constant(#[allow(unused_tuple_struct_fields)] T) }
+enum Type<T> { Constant(#[allow(dead_code)] T) }
 
 trait Trait<K,V> {
     fn method(&self, _: Type<(K,V)>) -> isize;

--- a/tests/ui/traits/pointee-deduction.rs
+++ b/tests/ui/traits/pointee-deduction.rs
@@ -13,8 +13,8 @@ impl Foo for () {
     type Bar = ();
 }
 
-struct Wrapper1<T: Foo>(#[allow(unused_tuple_struct_fields)] <T as Foo>::Bar);
-struct Wrapper2<T: Foo>(#[allow(unused_tuple_struct_fields)] <Wrapper1<T> as Pointee>::Metadata);
+struct Wrapper1<T: Foo>(#[allow(dead_code)] <T as Foo>::Bar);
+struct Wrapper2<T: Foo>(#[allow(dead_code)] <Wrapper1<T> as Pointee>::Metadata);
 
 fn main() {
     let _: Wrapper2<()> = Wrapper2(());

--- a/tests/ui/traits/principal-less-objects.rs
+++ b/tests/ui/traits/principal-less-objects.rs
@@ -7,7 +7,7 @@ use std::mem;
 // Array is to make sure the size is not exactly pointer-size, so
 // we can be sure we are measuring the right size in the
 // `size_of_val` test.
-struct SetOnDrop<'a>(&'a AtomicUsize, #[allow(unused_tuple_struct_fields)] [u8; 64]);
+struct SetOnDrop<'a>(&'a AtomicUsize, #[allow(dead_code)] [u8; 64]);
 impl<'a> Drop for SetOnDrop<'a> {
     fn drop(&mut self) {
         self.0.store(self.0.load(Ordering::Relaxed) + 1, Ordering::Relaxed);

--- a/tests/ui/type-alias-enum-variants/enum-variant-generic-args-pass.rs
+++ b/tests/ui/type-alias-enum-variants/enum-variant-generic-args-pass.rs
@@ -9,7 +9,7 @@
 
 #![allow(irrefutable_let_patterns)]
 
-enum Enum<T> { TSVariant(#[allow(unused_tuple_struct_fields)] T), SVariant { _v: T }, UVariant }
+enum Enum<T> { TSVariant(#[allow(dead_code)] T), SVariant { _v: T }, UVariant }
 type Alias<T> = Enum<T>;
 type AliasFixed = Enum<()>;
 

--- a/tests/ui/typeck/issue-2063.rs
+++ b/tests/ui/typeck/issue-2063.rs
@@ -3,7 +3,7 @@
 // cause compiler to loop.  Note that no instances
 // of such a type could ever be constructed.
 
-struct T(#[allow(unused_tuple_struct_fields)] Box<T>);
+struct T(#[allow(dead_code)] Box<T>);
 
 trait ToStr2 {
     fn my_to_string(&self) -> String;

--- a/tests/ui/unboxed-closures/type-id-higher-rank.rs
+++ b/tests/ui/unboxed-closures/type-id-higher-rank.rs
@@ -4,7 +4,7 @@
 
 use std::any::{Any, TypeId};
 
-struct Struct<'a>(#[allow(unused_tuple_struct_fields)] &'a ());
+struct Struct<'a>(#[allow(dead_code)] &'a ());
 trait Trait<'a> {}
 
 fn main() {

--- a/tests/ui/unsized-locals/unsized-exprs-rpass.rs
+++ b/tests/ui/unsized-locals/unsized-exprs-rpass.rs
@@ -2,7 +2,7 @@
 #![allow(incomplete_features, unused_braces, unused_parens)]
 #![feature(unsized_tuple_coercion, unsized_locals, unsized_fn_params)]
 
-struct A<X: ?Sized>(#[allow(unused_tuple_struct_fields)] X);
+struct A<X: ?Sized>(#[allow(dead_code)] X);
 
 fn udrop<T: ?Sized>(_x: T) {}
 fn foo() -> Box<[u8]> {

--- a/tests/ui/unsized/unchanged-param.rs
+++ b/tests/ui/unsized/unchanged-param.rs
@@ -1,8 +1,8 @@
 // run-pass
 // Test that we allow unsizing even if there is an unchanged param in the
 // field getting unsized.
-struct A<T, U: ?Sized + 'static>(#[allow(unused_tuple_struct_fields)] T, B<T, U>);
-struct B<T, U: ?Sized>(#[allow(unused_tuple_struct_fields)] T, U);
+struct A<T, U: ?Sized + 'static>(#[allow(dead_code)] T, B<T, U>);
+struct B<T, U: ?Sized>(#[allow(dead_code)] T, U);
 
 fn main() {
     let x: A<[u32; 1], [u32; 1]> = A([0; 1], B([0; 1], [0; 1]));


### PR DESCRIPTION
This implicitly upgrades the lint from `allow` to `warn` and places it into the `unused` lint group.

[Discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Moving.20.60unused_tuple_struct_fields.60.20from.20allow.20to.20warn)