### PR TITLE
docs: publish nightly doc for `rustfix`

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1004,8 +1004,6 @@ tool_doc!(
         "crates-io",
         "mdman",
         "rustfix",
-        // FIXME: this trips a license check in tidy.
-        // "resolver-tests",
     ]
 );
 tool_doc!(Tidy, "tidy", "src/tools/tidy", rustc_tool = false, crates = ["tidy"]);

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -996,14 +996,14 @@ tool_doc!(
     in_tree = false,
     crates = [
         "cargo",
+        "cargo-credential",
         "cargo-platform",
-        "cargo-util",
-        "crates-io",
         "cargo-test-macro",
         "cargo-test-support",
-        "cargo-credential",
-        "rustfix",
+        "cargo-util",
+        "crates-io",
         "mdman",
+        "rustfix",
         // FIXME: this trips a license check in tidy.
         // "resolver-tests",
     ]

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -1002,6 +1002,7 @@ tool_doc!(
         "cargo-test-macro",
         "cargo-test-support",
         "cargo-credential",
+        "rustfix",
         "mdman",
         // FIXME: this trips a license check in tidy.
         // "resolver-tests",


### PR DESCRIPTION
`rustfix `has migrated into rust-lang/cargo in <https://github.com/rust-lang/cargo/issues/13005>. We now can publish nightly doc for it.