### PR TITLE
Remove an unneeded helper from the tuple library code

### DIFF
--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -161,18 +161,6 @@ macro_rules! maybe_tuple_doc {
     };
 }
 
-#[inline]
-const fn ordering_is_some(c: Option<Ordering>, x: Ordering) -> bool {
-    // FIXME: Just use `==` once that's const-stable on `Option`s.
-    // This is mapping `None` to 2 and then doing the comparison afterwards
-    // because it optimizes better (`None::<Ordering>` is represented as 2).
-    x as i8
-        == match c {
-            Some(c) => c as i8,
-            None => 2,
-        }
-}
-
 // Constructs an expression that performs a lexical ordering using method `$rel`.
 // The values are interleaved, so the macro invocation for
 // `(a1, a2, a3) < (b1, b2, b3)` would be `lexical_ord!(lt, opt_is_lt, a1, b1,
@@ -183,7 +171,7 @@ const fn ordering_is_some(c: Option<Ordering>, x: Ordering) -> bool {
 macro_rules! lexical_ord {
     ($rel: ident, $ne_rel: ident, $a:expr, $b:expr, $($rest_a:expr, $rest_b:expr),+) => {{
         let c = PartialOrd::partial_cmp(&$a, &$b);
-        if !ordering_is_some(c, Equal) { ordering_is_some(c, $ne_rel) }
+        if c != Some(Equal) { c == Some($ne_rel) }
         else { lexical_ord!($rel, $ne_rel, $($rest_a, $rest_b),+) }
     }};
     ($rel: ident, $ne_rel: ident, $a:expr, $b:expr) => {

--- a/tests/codegen/comparison-operators-2-tuple.rs
+++ b/tests/codegen/comparison-operators-2-tuple.rs
@@ -10,8 +10,10 @@ type TwoTuple = (i16, u16);
 //
 // The operators are all overridden directly, so should optimize easily.
 //
-// Yes, the `s[lg]t` is correct for the `[lg]e` version because it's only used
-// in the side of the select where we know the values are *not* equal.
+// slt-vs-sle and sgt-vs-sge don't matter because they're only used in the side
+// of the select where we know the values are not equal, and thus the tests
+// use a regex to allow either, since unimportant changes to the implementation
+// sometimes result in changing what LLVM decides to emit for this.
 //
 
 // CHECK-LABEL: @check_lt_direct
@@ -19,7 +21,7 @@ type TwoTuple = (i16, u16);
 #[no_mangle]
 pub fn check_lt_direct(a: TwoTuple, b: TwoTuple) -> bool {
     // CHECK-DAG: %[[EQ:.+]] = icmp eq i16 %[[A0]], %[[B0]]
-    // CHECK-DAG: %[[CMP0:.+]] = icmp slt i16 %[[A0]], %[[B0]]
+    // CHECK-DAG: %[[CMP0:.+]] = icmp {{slt|sle}} i16 %[[A0]], %[[B0]]
     // CHECK-DAG: %[[CMP1:.+]] = icmp ult i16 %[[A1]], %[[B1]]
     // CHECK: %[[R:.+]] = select i1 %[[EQ]], i1 %[[CMP1]], i1 %[[CMP0]]
     // CHECK: ret i1 %[[R]]
@@ -31,7 +33,7 @@ pub fn check_lt_direct(a: TwoTuple, b: TwoTuple) -> bool {
 #[no_mangle]
 pub fn check_le_direct(a: TwoTuple, b: TwoTuple) -> bool {
     // CHECK-DAG: %[[EQ:.+]] = icmp eq i16 %[[A0]], %[[B0]]
-    // CHECK-DAG: %[[CMP0:.+]] = icmp slt i16 %[[A0]], %[[B0]]
+    // CHECK-DAG: %[[CMP0:.+]] = icmp {{slt|sle}} i16 %[[A0]], %[[B0]]
     // CHECK-DAG: %[[CMP1:.+]] = icmp ule i16 %[[A1]], %[[B1]]
     // CHECK: %[[R:.+]] = select i1 %[[EQ]], i1 %[[CMP1]], i1 %[[CMP0]]
     // CHECK: ret i1 %[[R]]
@@ -43,7 +45,7 @@ pub fn check_le_direct(a: TwoTuple, b: TwoTuple) -> bool {
 #[no_mangle]
 pub fn check_gt_direct(a: TwoTuple, b: TwoTuple) -> bool {
     // CHECK-DAG: %[[EQ:.+]] = icmp eq i16 %[[A0]], %[[B0]]
-    // CHECK-DAG: %[[CMP0:.+]] = icmp sgt i16 %[[A0]], %[[B0]]
+    // CHECK-DAG: %[[CMP0:.+]] = icmp {{sgt|sge}} i16 %[[A0]], %[[B0]]
     // CHECK-DAG: %[[CMP1:.+]] = icmp ugt i16 %[[A1]], %[[B1]]
     // CHECK: %[[R:.+]] = select i1 %[[EQ]], i1 %[[CMP1]], i1 %[[CMP0]]
     // CHECK: ret i1 %[[R]]
@@ -55,7 +57,7 @@ pub fn check_gt_direct(a: TwoTuple, b: TwoTuple) -> bool {
 #[no_mangle]
 pub fn check_ge_direct(a: TwoTuple, b: TwoTuple) -> bool {
     // CHECK-DAG: %[[EQ:.+]] = icmp eq i16 %[[A0]], %[[B0]]
-    // CHECK-DAG: %[[CMP0:.+]] = icmp sgt i16 %[[A0]], %[[B0]]
+    // CHECK-DAG: %[[CMP0:.+]] = icmp {{sgt|sge}} i16 %[[A0]], %[[B0]]
     // CHECK-DAG: %[[CMP1:.+]] = icmp uge i16 %[[A1]], %[[B1]]
     // CHECK: %[[R:.+]] = select i1 %[[EQ]], i1 %[[CMP1]], i1 %[[CMP0]]
     // CHECK: ret i1 %[[R]]


### PR DESCRIPTION
Thanks to https://github.com/rust-lang/rust/pull/107022, this is just what `==` does, so we don't need the helper here anymore.