### PR TITLE
Rename `{collections=>alloc}{tests,benches}`

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -17,11 +17,11 @@ rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.3.0"
 
 [[test]]
-name = "collectionstests"
+name = "alloctests"
 path = "tests/lib.rs"
 
 [[bench]]
-name = "collectionsbenches"
+name = "allocbenches"
 path = "benches/lib.rs"
 test = true
 


### PR DESCRIPTION
The crate is named `alloc` so this makes more sense. Ig this is fallout from #42648?