### PR TITLE
tip for define macro name after `macro_rules!`

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -181,6 +181,8 @@ resolve_method_not_member_of_trait =
     method `{$method}` is not a member of trait `{$trait_}`
     .label = not a member of trait `{$trait_}`
 
+resolve_missing_macro_rules_name = maybe you have forgotten to define a name for this `macro_rules!`
+
 resolve_module_only =
     visibility must resolve to a module
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -666,6 +666,13 @@ pub(crate) struct ExplicitUnsafeTraits {
 }
 
 #[derive(Subdiagnostic)]
+#[note(resolve_missing_macro_rules_name)]
+pub(crate) struct MaybeMissingMacroRulesName {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(Subdiagnostic)]
 #[help(resolve_added_macro_use)]
 pub(crate) struct AddedMacroUse;
 

--- a/tests/ui/resolve/issue-118295.rs
+++ b/tests/ui/resolve/issue-118295.rs
@@ -1,0 +1,5 @@
+macro_rules! {}
+//~^ ERROR cannot find macro `macro_rules` in this scope
+//~| NOTE maybe you have forgotten to define a name for this `macro_rules!`
+
+fn main() {}

--- a/tests/ui/resolve/issue-118295.stderr
+++ b/tests/ui/resolve/issue-118295.stderr
@@ -1,0 +1,14 @@
+error: cannot find macro `macro_rules` in this scope
+  --> $DIR/issue-118295.rs:1:1
+   |
+LL | macro_rules! {}
+   | ^^^^^^^^^^^
+   |
+note: maybe you have forgotten to define a name for this `macro_rules!`
+  --> $DIR/issue-118295.rs:1:1
+   |
+LL | macro_rules! {}
+   | ^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #118295

~Note that there are some bad case such as `﻿macro_rules![]` or `﻿macro_rules!()`. However, I think these are acceptable as they are likely to be seldom used (feel free to close this if you think its shortcomings outweigh its benefits)~

Edit: this problem was resolved by utilizing the `﻿source_map.span_to_next_source`.

r? @petrochenkov