### PR TITLE
rustdoc: Remove space from fake-variadic fn ptr impls

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1629,7 +1629,7 @@ mod prim_ref {}
 ///
 /// ### Trait implementations
 ///
-/// In this documentation the shorthand `fn (T₁, T₂, …, Tₙ)` is used to represent non-variadic
+/// In this documentation the shorthand `fn(T₁, T₂, …, Tₙ)` is used to represent non-variadic
 /// function pointers of varying length. Note that this is a convenience notation to avoid
 /// repetitive documentation, not valid Rust syntax.
 ///

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1305,7 +1305,7 @@ impl clean::Impl {
                 primitive_link_fragment(
                     f,
                     PrimitiveType::Tuple,
-                    format_args!("fn ({name}₁, {name}₂, …, {name}ₙ{ellipsis})"),
+                    format_args!("fn({name}₁, {name}₂, …, {name}ₙ{ellipsis})"),
                     "#trait-implementations-1",
                     cx,
                 )?;


### PR DESCRIPTION
before: `for fn (T₁, T₂, …, Tₙ) -> Ret`
after: `for fn(T₁, T₂, …, Tₙ) -> Ret`

I don't think we usually have spaces there, so it looks weird.

cc @notriddle since you added the space in https://github.com/rust-lang/rust/pull/98180 (or rather, added the feature with a space included).