### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -575,7 +575,8 @@ Val Markovic <val@markovic.io>
 Valerii Lashmanov <vflashm@gmail.com>
 Vitali Haravy <HumaneProgrammer@gmail.com> Vitali Haravy <humaneprogrammer@gmail.com>
 Vitaly Shukela <vi0oss@gmail.com>
-Waffle Maybe <waffle.lapkin@gmail.com>
+Waffle Lapkin <waffle.lapkin@gmail.com>
+Waffle Lapkin <waffle.lapkin@tasking.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1629,7 +1629,7 @@ mod prim_ref {}
 ///
 /// ### Trait implementations
 ///
-/// In this documentation the shorthand `fn (T₁, T₂, …, Tₙ)` is used to represent non-variadic
+/// In this documentation the shorthand `fn(T₁, T₂, …, Tₙ)` is used to represent non-variadic
 /// function pointers of varying length. Note that this is a convenience notation to avoid
 /// repetitive documentation, not valid Rust syntax.
 ///

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1305,7 +1305,7 @@ impl clean::Impl {
                 primitive_link_fragment(
                     f,
                     PrimitiveType::Tuple,
-                    format_args!("fn ({name}₁, {name}₂, …, {name}ₙ{ellipsis})"),
+                    format_args!("fn({name}₁, {name}₂, …, {name}ₙ{ellipsis})"),
                     "#trait-implementations-1",
                     cx,
                 )?;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1328,8 +1328,7 @@ function preLoadCss(cssUrl) {
 
         const infos = [
             `For a full list of all search features, take a look <a \
-href="https://doc.rust-lang.org/${channel}/rustdoc/how-to-read-rustdoc.html\
-#the-search-interface">here</a>.`,
+href="https://doc.rust-lang.org/${channel}/rustdoc/read-documentation/search.html">here</a>.`,
             "Prefix searches with a type followed by a colon (e.g., <code>fn:</code>) to \
              restrict the search to a given item kind.",
             "Accepted kinds are: <code>fn</code>, <code>mod</code>, <code>struct</code>, \


### PR DESCRIPTION
Successful merges:

 - #118321 (rustdoc: Remove space from fake-variadic fn ptr impls)
 - #118322 (skip {tidy,compiletest,rustdoc-gui} based tests for `DocTests::Only`)
 - #118325 (Fix Rustdoc search docs link)
 - #118327 (Add my work email to the mailmap)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118321,118322,118325,118327)
<!-- homu-ignore:end -->