### PR TITLE
Dont suggest `!` for path in function call if it has generic args

### DIFF
--- a/tests/ui/resolve/resolve-dont-hint-macro.rs
+++ b/tests/ui/resolve/resolve-dont-hint-macro.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let zero = assert_eq::<()>();
+    //~^ ERROR expected function, found macro `assert_eq`
+}

--- a/tests/ui/resolve/resolve-dont-hint-macro.stderr
+++ b/tests/ui/resolve/resolve-dont-hint-macro.stderr
@@ -1,0 +1,9 @@
+error[E0423]: expected function, found macro `assert_eq`
+  --> $DIR/resolve-dont-hint-macro.rs:2:16
+   |
+LL |     let zero = assert_eq::<()>();
+   |                ^^^^^^^^^^^^^^^ not a function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fixes #118335