### PR TITLE
Add `deeply_normalize_for_diagnostics`, use it in coherence

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -41,7 +41,9 @@ mod trait_goals;
 
 pub use eval_ctxt::{EvalCtxt, GenerateProofTree, InferCtxtEvalExt, InferCtxtSelectExt};
 pub use fulfill::FulfillmentCtxt;
-pub(crate) use normalize::{deeply_normalize, deeply_normalize_with_skipped_universes};
+pub(crate) use normalize::{
+    deeply_normalize, deeply_normalize_for_diagnostics, deeply_normalize_with_skipped_universes,
+};
 
 #[derive(Debug, Clone, Copy)]
 enum SolverMode {

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -6,8 +6,8 @@
 
 use crate::infer::outlives::env::OutlivesEnvironment;
 use crate::infer::InferOk;
-use crate::solve::inspect;
 use crate::solve::inspect::{InspectGoal, ProofTreeInferCtxtExt, ProofTreeVisitor};
+use crate::solve::{deeply_normalize_for_diagnostics, inspect};
 use crate::traits::engine::TraitEngineExt;
 use crate::traits::query::evaluate_obligation::InferCtxtExt;
 use crate::traits::select::{IntercrateAmbiguityCause, TreatInductiveCycleAs};
@@ -308,7 +308,13 @@ fn overlap<'tcx>(
         .iter()
         .any(|c| c.0.involves_placeholders());
 
-    let impl_header = selcx.infcx.resolve_vars_if_possible(impl1_header);
+    let mut impl_header = infcx.resolve_vars_if_possible(impl1_header);
+
+    // Deeply normalize the impl header for diagnostics, ignoring any errors if this fails.
+    if infcx.next_trait_solver() {
+        impl_header = deeply_normalize_for_diagnostics(&infcx, param_env, impl_header);
+    }
+
     Some(OverlapResult { impl_header, intercrate_ambiguity_causes, involves_placeholder })
 }
 
@@ -1084,6 +1090,10 @@ impl<'a, 'tcx> ProofTreeVisitor<'tcx> for AmbiguityCausesVisitor<'a, 'tcx> {
                         Ok(Ok(())) => warn!("expected an unknowable trait ref: {trait_ref:?}"),
                         Ok(Err(conflict)) => {
                             if !trait_ref.references_error() {
+                                // Normalize the trait ref for diagnostics, ignoring any errors if this fails.
+                                let trait_ref =
+                                    deeply_normalize_for_diagnostics(infcx, param_env, trait_ref);
+
                                 let self_ty = trait_ref.self_ty();
                                 let self_ty = self_ty.has_concrete_skeleton().then(|| self_ty);
                                 ambiguity_cause = Some(match conflict {

--- a/tests/ui/coherence/normalize-for-errors.current.stderr
+++ b/tests/ui/coherence/normalize-for-errors.current.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
+  --> $DIR/normalize-for-errors.rs:17:1
+   |
+LL | impl<T: Copy> MyTrait for T {}
+   | --------------------------- first implementation here
+LL |
+LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+   |
+   = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/normalize-for-errors.current.stderr
+++ b/tests/ui/coherence/normalize-for-errors.current.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
-  --> $DIR/normalize-for-errors.rs:17:1
+error[E0119]: conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>, _)`
+  --> $DIR/normalize-for-errors.rs:16:1
    |
-LL | impl<T: Copy> MyTrait for T {}
-   | --------------------------- first implementation here
+LL | impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
+   | ------------------------------------------------------ first implementation here
 LL |
-LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+LL | impl<S: Iterator> MyTrait<S> for (Box<<(MyType,) as Mirror>::Assoc>, S::Item) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(Box<(MyType,)>, _)`
    |
    = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
 

--- a/tests/ui/coherence/normalize-for-errors.next.stderr
+++ b/tests/ui/coherence/normalize-for-errors.next.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
+  --> $DIR/normalize-for-errors.rs:17:1
+   |
+LL | impl<T: Copy> MyTrait for T {}
+   | --------------------------- first implementation here
+LL |
+LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+   |
+   = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/normalize-for-errors.next.stderr
+++ b/tests/ui/coherence/normalize-for-errors.next.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
-  --> $DIR/normalize-for-errors.rs:17:1
+error[E0119]: conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>, <_ as Iterator>::Item)`
+  --> $DIR/normalize-for-errors.rs:16:1
    |
-LL | impl<T: Copy> MyTrait for T {}
-   | --------------------------- first implementation here
+LL | impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
+   | ------------------------------------------------------ first implementation here
 LL |
-LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+LL | impl<S: Iterator> MyTrait<S> for (Box<<(MyType,) as Mirror>::Assoc>, S::Item) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(Box<(MyType,)>, <_ as Iterator>::Item)`
    |
    = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
 

--- a/tests/ui/coherence/normalize-for-errors.rs
+++ b/tests/ui/coherence/normalize-for-errors.rs
@@ -1,0 +1,22 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+
+struct MyType;
+trait MyTrait {
+}
+
+trait Mirror {
+    type Assoc;
+}
+impl<T> Mirror for T {
+    type Assoc = T;
+}
+
+impl<T: Copy> MyTrait for T {}
+//~^ NOTE first implementation here
+impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
+//~^ ERROR conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
+//~| NOTE conflicting implementation for `Box<(MyType,)>
+//~| NOTE upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
+
+fn main() {}

--- a/tests/ui/coherence/normalize-for-errors.rs
+++ b/tests/ui/coherence/normalize-for-errors.rs
@@ -2,8 +2,7 @@
 //[next] compile-flags: -Ztrait-solver=next
 
 struct MyType;
-trait MyTrait {
-}
+trait MyTrait<S> {}
 
 trait Mirror {
     type Assoc;
@@ -12,11 +11,11 @@ impl<T> Mirror for T {
     type Assoc = T;
 }
 
-impl<T: Copy> MyTrait for T {}
+impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
 //~^ NOTE first implementation here
-impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
-//~^ ERROR conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
-//~| NOTE conflicting implementation for `Box<(MyType,)>
+impl<S: Iterator> MyTrait<S> for (Box<<(MyType,) as Mirror>::Assoc>, S::Item) {}
+//~^ ERROR conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>,
+//~| NOTE conflicting implementation for `(Box<(MyType,)>,
 //~| NOTE upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
 
 fn main() {}


### PR DESCRIPTION
r? lcnr

Normalize trait refs used for coherence error reporting with `-Ztrait-solver=next-coherence`.

Two things:
1. I said before that we can't add this to `TyErrCtxt` because we compute `OverlapResult`s even if there are no diagnostics being emitted, e.g. for a reservation impl.
2. I didn't want to add this to an `InferCtxtExt` trait because I felt it was unnecessary. I don't particularly care about the API though.