### PR TITLE
OpenBSD fix long socket addresses

### DIFF
--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -112,9 +112,9 @@ impl SocketAddr {
             // linux returns zero bytes of address
             len = sun_path_offset(&addr) as libc::socklen_t; // i.e., zero-length address
         } else if cfg!(target_os = "openbsd") {
-            // OpenBSD has a bug where the socket name's length
-            // is more than what the buffer actually contains.
-            // Figure out the length for ourselves.
+            // OpenBSD implements getsockname in a way where the 
+            // socket name's length is more than what the buffer
+            // actually contains. Figure out the length for ourselves.
             // https://marc.info/?l=openbsd-bugs&m=170105481926736&w=2
             let sun_path: &[u8] = unsafe { crate::mem::transmute::<&[i8], &[u8]>(&addr.sun_path) };
             len = crate::sys::memchr::memchr(0, sun_path)

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -111,7 +111,17 @@ impl SocketAddr {
             // When there is a datagram from unnamed unix socket
             // linux returns zero bytes of address
             len = sun_path_offset(&addr) as libc::socklen_t; // i.e., zero-length address
-        } else if addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
+        } else if cfg!(target_os = "openbsd") {
+            // OpenBSD has a bug where the socket name's length
+            // is more than what the buffer actually contains.
+            // Figure out the length for ourselves.
+            // https://marc.info/?l=openbsd-bugs&m=170105481926736&w=2
+            let sun_path: &[u8] = unsafe { crate::mem::transmute::<&[i8], &[u8]>(&addr.sun_path) };
+            len = crate::sys::memchr::memchr(0, sun_path)
+                .map_or(len, |new_len| (new_len + sun_path_offset(&addr)) as libc::socklen_t);
+        }
+
+        if addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
             return Err(io::const_io_error!(
                 io::ErrorKind::InvalidInput,
                 "file descriptor did not correspond to a Unix socket",

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -122,7 +122,7 @@ impl SocketAddr {
                 .map_or(len, |new_len| (new_len + sun_path_offset(&addr)) as libc::socklen_t);
         }
 
-        if len != 0 && addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
+        if len == 0 && addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
             return Err(io::const_io_error!(
                 io::ErrorKind::InvalidInput,
                 "file descriptor did not correspond to a Unix socket",

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -112,11 +112,12 @@ impl SocketAddr {
             // linux returns zero bytes of address
             len = sun_path_offset(&addr) as libc::socklen_t; // i.e., zero-length address
         } else if cfg!(target_os = "openbsd") {
-            // OpenBSD implements getsockname in a way where the 
+            // OpenBSD implements getsockname in a way where the
             // socket name's length is more than what the buffer
             // actually contains. Figure out the length for ourselves.
             // https://marc.info/?l=openbsd-bugs&m=170105481926736&w=2
-            let sun_path: &[u8] = unsafe { crate::mem::transmute::<&[libc::c_char], &[u8]>(&addr.sun_path) };
+            let sun_path: &[u8] =
+                unsafe { crate::mem::transmute::<&[libc::c_char], &[u8]>(&addr.sun_path) };
             len = crate::sys::memchr::memchr(0, sun_path)
                 .map_or(len, |new_len| (new_len + sun_path_offset(&addr)) as libc::socklen_t);
         }

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -116,12 +116,12 @@ impl SocketAddr {
             // socket name's length is more than what the buffer
             // actually contains. Figure out the length for ourselves.
             // https://marc.info/?l=openbsd-bugs&m=170105481926736&w=2
-            let sun_path: &[u8] = unsafe { crate::mem::transmute::<&[i8], &[u8]>(&addr.sun_path) };
+            let sun_path: &[u8] = unsafe { crate::mem::transmute::<&[libc::c_char], &[u8]>(&addr.sun_path) };
             len = crate::sys::memchr::memchr(0, sun_path)
                 .map_or(len, |new_len| (new_len + sun_path_offset(&addr)) as libc::socklen_t);
         }
 
-        if addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
+        if len != 0 && addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
             return Err(io::const_io_error!(
                 io::ErrorKind::InvalidInput,
                 "file descriptor did not correspond to a Unix socket",


### PR DESCRIPTION
There is an OpenBSD bug where the "len" returned by functions like "getsockname" is too long and makes it so the resulting address contains zero bytes. While this isn't a problem for C code, where strings are null terminated anyways, it's a problem for Rust.

This commit fixes this issue by adding a check that truncates the address length to the first zero when OpenBSD is detected. If there are no zeroes, it just uses the original length provided by the system.

Closes https://github.com/rust-lang/rust/issues/116523