### PR TITLE
do not generate llvm stamp when invoked from outside of tty

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -105,6 +105,10 @@ pub fn prebuilt_llvm_config(
     let llvm_cmake_dir = out_dir.join("lib/cmake/llvm");
     let res = LlvmResult { llvm_config: build_llvm_config, llvm_cmake_dir };
 
+    if !builder.config.stdout_is_tty {
+        return Ok(res);
+    }
+
     let smart_stamp_hash = generate_smart_stamp_hash(
         &builder.config.src.join("src/llvm-project"),
         &builder.in_tree_llvm_info.sha().unwrap_or_default(),


### PR DESCRIPTION
For more info: https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/Massive.20regression.20in.20no-op.20.60x.20check.60

cc @Zalathar 