### PR TITLE
Suggest swapping the order of `ref` and `box`

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -721,6 +721,9 @@ parse_sugg_wrap_pattern_in_parens = wrap the pattern in parentheses
 parse_switch_mut_let_order =
     switch the order of `mut` and `let`
 
+parse_switch_ref_box_order = switch the order of `ref` and `box`
+    .suggestion = swap them
+
 parse_ternary_operator = Rust has no ternary operator
     .help = use an `if-else` expression instead
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -138,6 +138,14 @@ pub(crate) enum InvalidVariableDeclarationSub {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_switch_ref_box_order)]
+pub(crate) struct SwitchRefBoxOrder {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable", code = "box ref")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_invalid_comparison_operator)]
 pub(crate) struct InvalidComparisonOperator {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -5,8 +5,8 @@ use crate::errors::{
     ExpectedCommaAfterPatternField, GenericArgsInPatRequireTurbofishSyntax,
     InclusiveRangeExtraEquals, InclusiveRangeMatchArrow, InclusiveRangeNoEnd, InvalidMutInPattern,
     PatternOnWrongSideOfAt, RefMutOrderIncorrect, RemoveLet, RepeatedMutInPattern,
-    TopLevelOrPatternNotAllowed, TopLevelOrPatternNotAllowedSugg, TrailingVertNotAllowed,
-    UnexpectedLifetimeInPattern, UnexpectedVertVertBeforeFunctionParam,
+    SwitchRefBoxOrder, TopLevelOrPatternNotAllowed, TopLevelOrPatternNotAllowedSugg,
+    TrailingVertNotAllowed, UnexpectedLifetimeInPattern, UnexpectedVertVertBeforeFunctionParam,
     UnexpectedVertVertInPattern,
 };
 use crate::{maybe_recover_from_interpolated_ty_qpath, maybe_whole};
@@ -374,6 +374,12 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Mut) {
             self.parse_pat_ident_mut(syntax_loc)?
         } else if self.eat_keyword(kw::Ref) {
+            if self.check_keyword(kw::Box) {
+                // Suggest `box ref` and quit parsing pattern to prevent series of
+                // misguided diagnostics from later stages of the compiler.
+                let span = self.prev_token.span.to(self.token.span);
+                return Err(self.sess.create_err(SwitchRefBoxOrder { span }));
+            }
             // Parse ref ident @ pat / ref mut ident @ pat
             let mutbl = self.parse_mutability();
             self.parse_pat_ident(BindingAnnotation(ByRef::Yes, mutbl), syntax_loc)?

--- a/tests/ui/pattern/pattern-bad-ref-box-order.fixed
+++ b/tests/ui/pattern/pattern-bad-ref-box-order.fixed
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![feature(box_patterns)]
+#![allow(dead_code)]
+
+fn foo(f: Option<Box<i32>>) {
+    match f {
+        Some(box ref _i) => {},
+        //~^ ERROR switch the order of `ref` and `box`
+        None => {}
+    }
+}
+
+fn main() { }

--- a/tests/ui/pattern/pattern-bad-ref-box-order.rs
+++ b/tests/ui/pattern/pattern-bad-ref-box-order.rs
@@ -1,0 +1,14 @@
+// run-rustfix
+
+#![feature(box_patterns)]
+#![allow(dead_code)]
+
+fn foo(f: Option<Box<i32>>) {
+    match f {
+        Some(ref box _i) => {},
+        //~^ ERROR switch the order of `ref` and `box`
+        None => {}
+    }
+}
+
+fn main() { }

--- a/tests/ui/pattern/pattern-bad-ref-box-order.stderr
+++ b/tests/ui/pattern/pattern-bad-ref-box-order.stderr
@@ -1,0 +1,8 @@
+error: switch the order of `ref` and `box`
+  --> $DIR/pattern-bad-ref-box-order.rs:8:14
+   |
+LL |         Some(ref box _i) => {},
+   |              ^^^^^^^ help: swap them: `box ref`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
It is not valid grammar to write `ref box <ident>` in patterns, but `box ref <ident>` is.
This patch adds a diagnostic to suggest swapping them, analogous to what we do for `mut let`.