### PR TITLE
Fix misc printing issues in `emit=stable_mir`

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -3,7 +3,7 @@
 //! This trait is currently the main interface between the Rust compiler,
 //! and the `stable_mir` crate.
 
-use crate::rustc_smir::stable_mir::opaque;
+use rustc_middle::ty;
 use rustc_middle::ty::print::{with_forced_trimmed_paths, with_no_trimmed_paths};
 use rustc_middle::ty::{
     GenericPredicates, Instance, ParamEnv, ScalarInt, TypeVisitableExt, ValTree,
@@ -18,8 +18,9 @@ use stable_mir::ty::{
     AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, GenericArgs,
     LineInfo, PolyFnSig, RigidTy, Span, Ty, TyKind, VariantDef,
 };
-use stable_mir::Opaque;
-use stable_mir::{self, Crate, CrateItem, Error, Filename, ItemKind, Symbol};
+use stable_mir::{
+    self, opaque, Crate, CrateItem, DefId, Error, Filename, ItemKind, Opaque, Symbol,
+};
 use std::cell::RefCell;
 
 use crate::rustc_internal::{internal, RustcInternal};

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -3,7 +3,7 @@
 //! This trait is currently the main interface between the Rust compiler,
 //! and the `stable_mir` crate.
 
-use rustc_middle::ty;
+use crate::rustc_smir::stable_mir::opaque;
 use rustc_middle::ty::print::{with_forced_trimmed_paths, with_no_trimmed_paths};
 use rustc_middle::ty::{
     GenericPredicates, Instance, ParamEnv, ScalarInt, TypeVisitableExt, ValTree,
@@ -18,7 +18,8 @@ use stable_mir::ty::{
     AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, GenericArgs,
     LineInfo, PolyFnSig, RigidTy, Span, Ty, TyKind, VariantDef,
 };
-use stable_mir::{Crate, CrateItem, DefId, Error, Filename, ItemKind, Symbol};
+use stable_mir::Opaque;
+use stable_mir::{self, Crate, CrateItem, Error, Filename, ItemKind, Symbol};
 use std::cell::RefCell;
 
 use crate::rustc_internal::{internal, RustcInternal};
@@ -295,6 +296,12 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn const_literal(&self, cnst: &stable_mir::ty::Const) -> String {
         internal(cnst).to_string()
+    }
+
+    fn adt_literal(&self, adt: &AdtDef) -> Opaque {
+        let mut tables = self.0.borrow_mut();
+        let internal = adt.internal(&mut *tables);
+        opaque(&internal)
     }
 
     fn span_of_an_item(&self, def_id: stable_mir::DefId) -> Span {

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -15,8 +15,8 @@ use crate::ty::{
     TraitDef, Ty, TyKind, VariantDef,
 };
 use crate::{
-    mir, Crate, CrateItem, CrateItems, DefId, Error, Filename, ImplTraitDecls, ItemKind, Symbol,
-    TraitDecls,
+    mir, Crate, CrateItem, CrateItems, DefId, Error, Filename, ImplTraitDecls, ItemKind, Opaque,
+    Symbol, TraitDecls,
 };
 
 /// This trait defines the interface between stable_mir and the Rust compiler.
@@ -105,6 +105,9 @@ pub trait Context {
 
     /// Returns literal value of a const as a string.
     fn const_literal(&self, cnst: &Const) -> String;
+
+    /// Returns literal version of a Adt as a Opaque
+    fn adt_literal(&self, adt: &AdtDef) -> Opaque;
 
     /// `Span` of an item
     fn span_of_an_item(&self, def_id: DefId) -> Span;

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -107,6 +107,7 @@ impl Body {
                 Ok(())
             })
             .collect::<Result<Vec<_>, _>>()?;
+        writeln!(w, "}}")?;
         Ok(())
     }
 

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1852;
-const ROOT_ENTRY_LIMIT: usize = 867;
+const ROOT_ENTRY_LIMIT: usize = 868;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1852;
-const ROOT_ENTRY_LIMIT: usize = 868;
+const ROOT_ENTRY_LIMIT: usize = 867;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/stable-mir-print/basic_function.rs
+++ b/tests/ui/stable-mir-print/basic_function.rs
@@ -1,9 +1,6 @@
 // compile-flags: -Z unpretty=stable-mir -Z mir-opt-level=3
 // check-pass
-<<<<<<< HEAD
 // only-x86_64
-=======
->>>>>>> 9a9a3a91e41 (add stable_mir output test)
 
 fn foo(i:i32) -> i32 {
     i + 1
@@ -13,6 +10,15 @@ fn bar(vec: &mut Vec<i32>) -> Vec<i32> {
     let mut new_vec = vec.clone();
     new_vec.push(1);
     new_vec
+}
+
+pub fn demux(input: u8) -> u8 {
+    match input {
+        0 => 10,
+        1 => 6,
+        2 => 8,
+        _ => 0,
+    }
 }
 
 fn main(){}

--- a/tests/ui/stable-mir-print/basic_function.rs
+++ b/tests/ui/stable-mir-print/basic_function.rs
@@ -1,6 +1,9 @@
 // compile-flags: -Z unpretty=stable-mir -Z mir-opt-level=3
 // check-pass
+<<<<<<< HEAD
 // only-x86_64
+=======
+>>>>>>> 9a9a3a91e41 (add stable_mir output test)
 
 fn foo(i:i32) -> i32 {
     i + 1

--- a/tests/ui/stable-mir-print/basic_function.stdout
+++ b/tests/ui/stable-mir-print/basic_function.stdout
@@ -2,219 +2,28 @@
 // If you find a bug or want to improve the output open a issue at https://github.com/rust-lang/project-stable-mir.
 fn foo(_0: i32) -> i32 {
     let mut _0: (i32, bool);
-}
+
     bb0: {
-        _2 = 1 Add const 1_i32
-        assert(!move _2 bool),"attempt to compute `{} + {}`, which would overflow", 1, const 1_i32) -> [success: bb1, unwind continue]
+        _2 = CheckedAdd(_1, const 1_i32)
+        assert(!move _2 bool),"attempt to compute `{} + {}`, which would overflow", _1, const 1_i32) -> [success: bb1, unwind continue]
     }
     bb1: {
         _0 = move _2
         return
     }
-fn bar(_0: &mut Ty {
-    id: 10,
-    kind: RigidTy(
-        Adt(
-            AdtDef(
-                DefId {
-                    id: 3,
-                    name: "std::vec::Vec",
-                },
-            ),
-            GenericArgs(
-                [
-                    Type(
-                        Ty {
-                            id: 11,
-                            kind: Param(
-                                ParamTy {
-                                    index: 0,
-                                    name: "T",
-                                },
-                            ),
-                        },
-                    ),
-                    Type(
-                        Ty {
-                            id: 12,
-                            kind: Param(
-                                ParamTy {
-                                    index: 1,
-                                    name: "A",
-                                },
-                            ),
-                        },
-                    ),
-                ],
-            ),
-        ),
-    ),
-}) -> Ty {
-    id: 10,
-    kind: RigidTy(
-        Adt(
-            AdtDef(
-                DefId {
-                    id: 3,
-                    name: "std::vec::Vec",
-                },
-            ),
-            GenericArgs(
-                [
-                    Type(
-                        Ty {
-                            id: 11,
-                            kind: Param(
-                                ParamTy {
-                                    index: 0,
-                                    name: "T",
-                                },
-                            ),
-                        },
-                    ),
-                    Type(
-                        Ty {
-                            id: 12,
-                            kind: Param(
-                                ParamTy {
-                                    index: 1,
-                                    name: "A",
-                                },
-                            ),
-                        },
-                    ),
-                ],
-            ),
-        ),
-    ),
-} {
-    let mut _0: Ty {
-    id: 10,
-    kind: RigidTy(
-        Adt(
-            AdtDef(
-                DefId {
-                    id: 3,
-                    name: "std::vec::Vec",
-                },
-            ),
-            GenericArgs(
-                [
-                    Type(
-                        Ty {
-                            id: 11,
-                            kind: Param(
-                                ParamTy {
-                                    index: 0,
-                                    name: "T",
-                                },
-                            ),
-                        },
-                    ),
-                    Type(
-                        Ty {
-                            id: 12,
-                            kind: Param(
-                                ParamTy {
-                                    index: 1,
-                                    name: "A",
-                                },
-                            ),
-                        },
-                    ),
-                ],
-            ),
-        ),
-    ),
-};
-    let mut _1: &Ty {
-    id: 10,
-    kind: RigidTy(
-        Adt(
-            AdtDef(
-                DefId {
-                    id: 3,
-                    name: "std::vec::Vec",
-                },
-            ),
-            GenericArgs(
-                [
-                    Type(
-                        Ty {
-                            id: 11,
-                            kind: Param(
-                                ParamTy {
-                                    index: 0,
-                                    name: "T",
-                                },
-                            ),
-                        },
-                    ),
-                    Type(
-                        Ty {
-                            id: 12,
-                            kind: Param(
-                                ParamTy {
-                                    index: 1,
-                                    name: "A",
-                                },
-                            ),
-                        },
-                    ),
-                ],
-            ),
-        ),
-    ),
-};
-    let _2: ();
-    let mut _3: &mut Ty {
-    id: 10,
-    kind: RigidTy(
-        Adt(
-            AdtDef(
-                DefId {
-                    id: 3,
-                    name: "std::vec::Vec",
-                },
-            ),
-            GenericArgs(
-                [
-                    Type(
-                        Ty {
-                            id: 11,
-                            kind: Param(
-                                ParamTy {
-                                    index: 0,
-                                    name: "T",
-                                },
-                            ),
-                        },
-                    ),
-                    Type(
-                        Ty {
-                            id: 12,
-                            kind: Param(
-                                ParamTy {
-                                    index: 1,
-                                    name: "A",
-                                },
-                            ),
-                        },
-                    ),
-                ],
-            ),
-        ),
-    ),
-};
 }
+fn bar(_0: &mut std::vec::Vec) -> std::vec::Vec {
+    let mut _0: std::vec::Vec;
+    let mut _1: &std::vec::Vec;
+    let _2: ();
+    let mut _3: &mut std::vec::Vec;
+
     bb0: {
-        _3 = refShared1
+        _3 = &1
         _2 = const <Vec<i32> as Clone>::clone(move _3) -> [return: bb1, unwind continue]
     }
     bb1: {
-        _5 = refMut {
-    kind: TwoPhaseBorrow,
-}2
+        _5 = &mut 2
         _4 = const Vec::<i32>::push(move _5, const 1_i32) -> [return: bb2, unwind: bb3]
     }
     bb2: {
@@ -227,8 +36,35 @@ fn bar(_0: &mut Ty {
     bb4: {
         resume
     }
-fn main() -> () {
 }
+fn demux(_0: u8) -> u8 {
+
+    bb0: {
+        switchInt(__1) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb1]
+    }
+    bb1: {
+        _0 = const 0_u8
+        goto -> bb5
+    }
+    bb2: {
+        _0 = const 10_u8
+        goto -> bb5
+    }
+    bb3: {
+        _0 = const 6_u8
+        goto -> bb5
+    }
+    bb4: {
+        _0 = const 8_u8
+        goto -> bb5
+    }
+    bb5: {
+        return
+    }
+}
+fn main() -> () {
+
     bb0: {
         return
     }
+}


### PR DESCRIPTION
Previously our `}` closed early and looked bit weird, now it closes when function call ends, and previously `Adt` printing was too verbose now it's similar to mir output


r? @celinval 