### PR TITLE
Detect and reject malformed `repr(Rust)` hints

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -985,7 +985,7 @@ pub fn parse_repr_attr(sess: &Session, attr: &Attribute) -> Vec<ReprAttr> {
                         Ok(literal) => acc.push(ReprPacked(literal)),
                         Err(message) => literal_error = Some(message),
                     };
-                } else if matches!(name, sym::C | sym::simd | sym::transparent)
+                } else if matches!(name, sym::Rust | sym::C | sym::simd | sym::transparent)
                     || int_type_of_word(name).is_some()
                 {
                     recognised = true;
@@ -1018,7 +1018,7 @@ pub fn parse_repr_attr(sess: &Session, attr: &Attribute) -> Vec<ReprAttr> {
                             });
                         } else if matches!(
                             meta_item.name_or_empty(),
-                            sym::C | sym::simd | sym::transparent
+                            sym::Rust | sym::C | sym::simd | sym::transparent
                         ) || int_type_of_word(meta_item.name_or_empty()).is_some()
                         {
                             recognised = true;
@@ -1043,7 +1043,7 @@ pub fn parse_repr_attr(sess: &Session, attr: &Attribute) -> Vec<ReprAttr> {
                             );
                         } else if matches!(
                             meta_item.name_or_empty(),
-                            sym::C | sym::simd | sym::transparent
+                            sym::Rust | sym::C | sym::simd | sym::transparent
                         ) || int_type_of_word(meta_item.name_or_empty()).is_some()
                         {
                             recognised = true;

--- a/tests/ui/repr/malformed-repr-hints.rs
+++ b/tests/ui/repr/malformed-repr-hints.rs
@@ -19,6 +19,15 @@ struct S3;
 //~^ ERROR: incorrect `repr(align)` attribute format
 struct S4;
 
+// Regression test for issue #118334:
+#[repr(Rust(u8))]
+//~^ ERROR: invalid representation hint
+#[repr(Rust(0))]
+//~^ ERROR: invalid representation hint
+#[repr(Rust = 0)]
+//~^ ERROR: invalid representation hint
+struct S5;
+
 #[repr(i8())]
 //~^ ERROR: invalid representation hint
 enum E1 { A, B }

--- a/tests/ui/repr/malformed-repr-hints.stderr
+++ b/tests/ui/repr/malformed-repr-hints.stderr
@@ -1,46 +1,64 @@
 error[E0552]: incorrect `repr(packed)` attribute format: `packed` takes exactly one parenthesized argument, or no parentheses at all
-  --> $DIR/issue-83921-ice.rs:6:8
+  --> $DIR/malformed-repr-hints.rs:6:8
    |
 LL | #[repr(packed())]
    |        ^^^^^^^^
 
 error[E0589]: invalid `repr(align)` attribute: `align` needs an argument
-  --> $DIR/issue-83921-ice.rs:10:8
+  --> $DIR/malformed-repr-hints.rs:10:8
    |
 LL | #[repr(align)]
    |        ^^^^^ help: supply an argument here: `align(...)`
 
 error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
-  --> $DIR/issue-83921-ice.rs:14:8
+  --> $DIR/malformed-repr-hints.rs:14:8
    |
 LL | #[repr(align(2, 4))]
    |        ^^^^^^^^^^^
 
 error[E0693]: incorrect `repr(align)` attribute format: `align` takes exactly one argument in parentheses
-  --> $DIR/issue-83921-ice.rs:18:8
+  --> $DIR/malformed-repr-hints.rs:18:8
    |
 LL | #[repr(align())]
    |        ^^^^^^^
 
+error[E0552]: invalid representation hint: `Rust` does not take a parenthesized argument list
+  --> $DIR/malformed-repr-hints.rs:23:8
+   |
+LL | #[repr(Rust(u8))]
+   |        ^^^^^^^^
+
+error[E0552]: invalid representation hint: `Rust` does not take a parenthesized argument list
+  --> $DIR/malformed-repr-hints.rs:25:8
+   |
+LL | #[repr(Rust(0))]
+   |        ^^^^^^^
+
+error[E0552]: invalid representation hint: `Rust` does not take a value
+  --> $DIR/malformed-repr-hints.rs:27:8
+   |
+LL | #[repr(Rust = 0)]
+   |        ^^^^^^^^
+
 error[E0552]: invalid representation hint: `i8` does not take a parenthesized argument list
-  --> $DIR/issue-83921-ice.rs:22:8
+  --> $DIR/malformed-repr-hints.rs:31:8
    |
 LL | #[repr(i8())]
    |        ^^^^
 
 error[E0552]: invalid representation hint: `u32` does not take a parenthesized argument list
-  --> $DIR/issue-83921-ice.rs:26:8
+  --> $DIR/malformed-repr-hints.rs:35:8
    |
 LL | #[repr(u32(42))]
    |        ^^^^^^^
 
 error[E0552]: invalid representation hint: `i64` does not take a value
-  --> $DIR/issue-83921-ice.rs:30:8
+  --> $DIR/malformed-repr-hints.rs:39:8
    |
 LL | #[repr(i64 = 2)]
    |        ^^^^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0552, E0589, E0693.
 For more information about an error, try `rustc --explain E0552`.


### PR DESCRIPTION
Fixes #118334.