### PR TITLE
rustdoc: Change overflow to underflow when describing subtraction

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -479,7 +479,7 @@ macro_rules! int_impl {
         }
 
         /// Checked integer subtraction. Computes `self - rhs`, returning `None` if
-        /// overflow occurred.
+        /// underflow occurred.
         ///
         /// # Examples
         ///
@@ -499,7 +499,7 @@ macro_rules! int_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
-        /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
+        /// Unchecked integer subtraction. Computes `self - rhs`, assuming underflow 
         /// cannot occur.
         ///
         /// # Safety

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -490,7 +490,7 @@ macro_rules! uint_impl {
         }
 
         /// Checked integer subtraction. Computes `self - rhs`, returning
-        /// `None` if overflow occurred.
+        /// `None` if underflow occurred.
         ///
         /// # Examples
         ///
@@ -510,7 +510,7 @@ macro_rules! uint_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
-        /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
+        /// Unchecked integer subtraction. Computes `self - rhs`, assuming underflow 
         /// cannot occur.
         ///
         /// # Safety


### PR DESCRIPTION
Underflow is strictly better than using overflow when describing subtraction.  Also the num crate uses underflow [here](https://docs.rs/num/latest/num/trait.CheckedSub.html) and I think it's less confusing if Rust also uses underflow in the docs.