### PR TITLE
Add -Zunpretty=stable-mir output test

### DIFF
--- a/compiler/stable_mir/src/mir/pretty.rs
+++ b/compiler/stable_mir/src/mir/pretty.rs
@@ -58,18 +58,35 @@ pub fn pretty_statement(statement: &StatementKind) -> String {
             pretty.push_str(format!("        _{} = ", place.local).as_str());
             pretty.push_str(format!("{}", &pretty_rvalue(rval)).as_str());
         }
-        StatementKind::FakeRead(_, _) => todo!(),
-        StatementKind::SetDiscriminant { .. } => todo!(),
-        StatementKind::Deinit(_) => todo!(),
-        StatementKind::StorageLive(_) => todo!(),
-        StatementKind::StorageDead(_) => todo!(),
-        StatementKind::Retag(_, _) => todo!(),
-        StatementKind::PlaceMention(_) => todo!(),
-        StatementKind::AscribeUserType { .. } => todo!(),
-        StatementKind::Coverage(_) => todo!(),
-        StatementKind::Intrinsic(_) => todo!(),
-        StatementKind::ConstEvalCounter => (),
-        StatementKind::Nop => (),
+        // FIXME: Add rest of the statements
+        StatementKind::FakeRead(_, _) => {
+            return String::from("StatementKind::FakeRead:Unimplemented");
+        }
+        StatementKind::SetDiscriminant { .. } => {
+            return String::from("StatementKind::SetDiscriminant:Unimplemented");
+        }
+        StatementKind::Deinit(_) => return String::from("StatementKind::Deinit:Unimplemented"),
+        StatementKind::StorageLive(_) => {
+            return String::from("StatementKind::StorageLive:Unimplemented");
+        }
+        StatementKind::StorageDead(_) => {
+            return String::from("StatementKind::StorageDead:Unimplemented");
+        }
+        StatementKind::Retag(_, _) => return String::from("StatementKind::Retag:Unimplemented"),
+        StatementKind::PlaceMention(_) => {
+            return String::from("StatementKind::PlaceMention:Unimplemented");
+        }
+        StatementKind::AscribeUserType { .. } => {
+            return String::from("StatementKind::AscribeUserType:Unimplemented");
+        }
+        StatementKind::Coverage(_) => return String::from("StatementKind::Coverage:Unimplemented"),
+        StatementKind::Intrinsic(_) => {
+            return String::from("StatementKind::Intrinsic:Unimplemented");
+        }
+        StatementKind::ConstEvalCounter => {
+            return String::from("StatementKind::ConstEvalCounter:Unimplemented");
+        }
+        StatementKind::Nop => return String::from("StatementKind::Nop:Unimplemented"),
     }
     pretty
 }
@@ -355,7 +372,7 @@ pub fn pretty_rvalue(rval: &Rvalue) -> String {
             pretty.push_str(" ");
             pretty.push_str(&pretty_ty(cnst.ty().kind()));
         }
-        Rvalue::ShallowInitBox(_, _) => todo!(),
+        Rvalue::ShallowInitBox(_, _) => (),
         Rvalue::ThreadLocalRef(item) => {
             pretty.push_str("thread_local_ref");
             pretty.push_str(format!("{:#?}", item).as_str());

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1852;
-const ROOT_ENTRY_LIMIT: usize = 866;
+const ROOT_ENTRY_LIMIT: usize = 867;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/stable-mir-print/basic_function.rs
+++ b/tests/ui/stable-mir-print/basic_function.rs
@@ -1,0 +1,15 @@
+// compile-flags: -Z unpretty=stable-mir -Z mir-opt-level=3
+// check-pass
+// only-x86_64
+
+fn foo(i:i32) -> i32 {
+    i + 1
+}
+
+fn bar(vec: &mut Vec<i32>) -> Vec<i32> {
+    let mut new_vec = vec.clone();
+    new_vec.push(1);
+    new_vec
+}
+
+fn main(){}

--- a/tests/ui/stable-mir-print/basic_function.stdout
+++ b/tests/ui/stable-mir-print/basic_function.stdout
@@ -1,0 +1,234 @@
+// WARNING: This is highly experimental output it's intended for stable-mir developers only.
+// If you find a bug or want to improve the output open a issue at https://github.com/rust-lang/project-stable-mir.
+fn foo(_0: i32) -> i32 {
+    let mut _0: (i32, bool);
+}
+    bb0: {
+        _2 = 1 Add const 1_i32
+        assert(!move _2 bool),"attempt to compute `{} + {}`, which would overflow", 1, const 1_i32) -> [success: bb1, unwind continue]
+    }
+    bb1: {
+        _0 = move _2
+        return
+    }
+fn bar(_0: &mut Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+}) -> Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+} {
+    let mut _0: Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+};
+    let mut _1: &Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+};
+    let _2: ();
+    let mut _3: &mut Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+};
+}
+    bb0: {
+        _3 = refShared1
+        _2 = const <Vec<i32> as Clone>::clone(move _3) -> [return: bb1, unwind continue]
+    }
+    bb1: {
+        _5 = refMut {
+    kind: TwoPhaseBorrow,
+}2
+        _4 = const Vec::<i32>::push(move _5, const 1_i32) -> [return: bb2, unwind: bb3]
+    }
+    bb2: {
+        _0 = move _2
+        return
+    }
+    bb3: {
+        drop(_2) -> [return: bb4, unwind terminate]
+    }
+    bb4: {
+        resume
+    }
+fn main() -> () {
+}
+    bb0: {
+        return
+    }


### PR DESCRIPTION
As strongly suggested here https://github.com/rust-lang/rust/pull/118364#issuecomment-1827974148 this adds output test for `-Zunpretty=stable-mir`, added test shows almost all the functionality of the current printer. 

r? @compiler-errors 