### PR TITLE
Make -Clinker-plugin-lto compatible with ld64

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -319,15 +319,11 @@ impl<'a> GccLinker<'a> {
 
             // Apple clang 15 does not seem to tell the linker about -mcpu. Unlike -O3 etc,
             // ld64 does not accept -mcpu or GNU-style -plugin-opt=mcpu=.
-            // But it surely can't hurt to tell cc about -mcpu anyway.
             //
             // It's possible this has something to do with platform minimum versions AKA
             // deployment targets; Apple drops support for CPU subfamilies at defined iOS
             // versions, for example. Either that or ld64 is meant to infer a target CPU
             // from the object files.
-            if !self.is_ld {
-                self.cmd.args(&[&format!("-mcpu={}", self.target_cpu)]);
-            }
         } else {
             if let Some(path) = &self.sess.opts.unstable_opts.profile_sample_use {
                 self.linker_arg(&format!("-plugin-opt=sample-profile={}", path.display()));


### PR DESCRIPTION
Fixes (partially) #60059. Works with ld64 and ld64.lld. There are other linkers that also need some attention here.

There are also a few warnings we could emit that could make `-Clinker-plugin-lto` easier to use correctly, in particular for Apple toolchains:

- warning: ignoring LTO plugin path in `-Clinker-plugin-lto=<path to libLTO>`, because using LLD, which will use its built-in LLVM
- warning: using `-Clinker-plugin-lto` with Apple ld64, but no path to libLTO.dylib provided. LLVM versions likely incompatible
    - .help: Use `-Clinker-plugin-lto=path/to/libLTO.dylib` from an appropriate LLVM toolchain. See \[version compatibility table\]

This PR keeps it to what's necessary to make linker plugin LTO work, but I'm happy to deliver some warnings, seeing as I've just messed around with this particular code.