### PR TITLE
rustc_span: Use correct edit distance start length for suggestions

### DIFF
--- a/compiler/rustc_span/src/edit_distance.rs
+++ b/compiler/rustc_span/src/edit_distance.rs
@@ -188,7 +188,11 @@ fn find_best_match_for_name_impl(
         return Some(*c);
     }
 
-    let mut dist = dist.unwrap_or_else(|| cmp::max(lookup.len(), 3) / 3);
+    // `fn edit_distance()` use `chars()` to calculate edit distance, so we must
+    // also use `chars()` (and not `str::len()`) to calculate length here.
+    let lookup_len = lookup.chars().count();
+
+    let mut dist = dist.unwrap_or_else(|| cmp::max(lookup_len, 3) / 3);
     let mut best = None;
     // store the candidates with the same distance, only for `use_substring_score` current.
     let mut next_candidates = vec![];

--- a/tests/ui/suggestions/non_ascii_ident.rs
+++ b/tests/ui/suggestions/non_ascii_ident.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // There shall be no suggestions here. In particular not `Ok`.
+    let _ = 读文; //~ ERROR cannot find value `读文` in this scope
+}

--- a/tests/ui/suggestions/non_ascii_ident.stderr
+++ b/tests/ui/suggestions/non_ascii_ident.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `读文` in this scope
+  --> $DIR/non_ascii_ident.rs:3:13
+   |
+LL |     let _ = 读文;
+   |             ^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Otherwise the suggestions can be off-base for non-ASCII identifiers. For example suggesting that `Ok` is a name similar to `读文`.

Closes https://github.com/rust-lang/rust/issues/72553.