### PR TITLE
Fix comments for unsigned non-zero `checked_add`, `saturating_add`

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -355,7 +355,7 @@ macro_rules! nonzero_unsigned_operations {
                     if let Some(result) = self.get().checked_add(other) {
                         // SAFETY:
                         // - `checked_add` returns `None` on overflow
-                        // - `self` and `other` are non-zero
+                        // - `self` is non-zero
                         // - the only way to get zero from an addition without overflow is for both
                         //   sides to be zero
                         //
@@ -393,7 +393,7 @@ macro_rules! nonzero_unsigned_operations {
                 pub const fn saturating_add(self, other: $Int) -> $Ty {
                     // SAFETY:
                     // - `saturating_add` returns `u*::MAX` on overflow, which is non-zero
-                    // - `self` and `other` are non-zero
+                    // - `self` is non-zero
                     // - the only way to get zero from an addition without overflow is for both
                     //   sides to be zero
                     //


### PR DESCRIPTION
While looking at #118313, I happened to notice that two of the expanded comments appear to be slightly inaccurate.

For these two methods, `other` is an ordinary unsigned integer, so it can be zero.

Since the sum of non-zero and zero is always non-zero, the safety argument holds even when `other` is zero.
