### PR TITLE
Eagerly expand bang macros within stability attributes

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -340,7 +340,9 @@ fn insert_or_error(sess: &Session, meta: &MetaItem, item: &mut Option<Symbol>) -
         *item = Some(v);
         Some(())
     } else {
-        sess.dcx().emit_err(session_diagnostics::IncorrectMetaItem { span: meta.span });
+        if !matches!(meta.kind, MetaItemKind::NameValue(MetaItemLit { kind: LitKind::Err, .. })) {
+            sess.dcx().emit_err(session_diagnostics::IncorrectMetaItem { span: meta.span });
+        }
         None
     }
 }

--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -132,6 +132,9 @@ expand_takes_no_arguments =
 
 expand_trace_macro = trace_macro
 
+expand_unsupported_expr_in_key_value =
+    expression in the value of this attribute must be a literal or macro call
+
 expand_unsupported_key_value =
     key-value macro attributes are not supported
 

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -277,6 +277,13 @@ pub(crate) struct WrongFragmentKind<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag(expand_unsupported_expr_in_key_value)]
+pub(crate) struct UnsupportedExprInKeyValue {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(expand_unsupported_key_value)]
 pub(crate) struct UnsupportedKeyValue {
     #[primary_span]

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -877,6 +877,23 @@ pub fn is_valid_for_get_attr(name: Symbol) -> bool {
     })
 }
 
+/// If true, bang macros are allowed and eagerly expanded within the value part
+/// of nested NameValue meta items. All such expansions must produce a literal.
+///
+/// `#[stable(feature = get_feature_name!($signedness))]`
+pub fn expand_nested_meta(name: Symbol) -> bool {
+    // Just these few for now. We can roll this out more broadly if it would be
+    // useful.
+    //
+    // WARNING: While it's all right to add nightly-only builtin attributes
+    // here, adding something that is available to stable (such as `deprecated`)
+    // would require the addition of a feature gate.
+    matches!(
+        name,
+        sym::stable | sym::unstable | sym::rustc_const_stable | sym::rustc_const_unstable
+    )
+}
+
 pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>> =
     LazyLock::new(|| {
         let mut map = FxHashMap::default();

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -125,9 +125,9 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZeroU3
 pub use accepted::ACCEPTED_FEATURES;
 pub use builtin_attrs::AttributeDuplicates;
 pub use builtin_attrs::{
-    deprecated_attributes, find_gated_cfg, is_builtin_attr_name, is_builtin_only_local,
-    is_valid_for_get_attr, AttributeGate, AttributeTemplate, AttributeType, BuiltinAttribute,
-    GatedCfg, BUILTIN_ATTRIBUTES, BUILTIN_ATTRIBUTE_MAP,
+    deprecated_attributes, expand_nested_meta, find_gated_cfg, is_builtin_attr_name,
+    is_builtin_only_local, is_valid_for_get_attr, AttributeGate, AttributeTemplate, AttributeType,
+    BuiltinAttribute, GatedCfg, BUILTIN_ATTRIBUTES, BUILTIN_ATTRIBUTE_MAP,
 };
 pub use removed::REMOVED_FEATURES;
 pub use unstable::{Features, INCOMPATIBLE_FEATURES, UNSTABLE_FEATURES};

--- a/tests/ui/stability-attribute/eager-expansion-fail.rs
+++ b/tests/ui/stability-attribute/eager-expansion-fail.rs
@@ -10,16 +10,10 @@ macro_rules! not_a_literal {
 
 macro_rules! m {
     () => {
-        #[stable(feature = 1 + 1, since = "?")]
-        //~^ expression in the value of this attribute must be a literal or macro call
-        //~^^ incorrect meta item
-        //~^^^ incorrect meta item
+        #[stable(feature = 1 + 1, since = "?")] //~ expression in the value of this attribute must be a literal or macro call
         pub struct Math; //~ struct has missing stability attribute
 
-        #[stable(feature = not_a_literal!(), since = "?")]
-        //~^ expression in the value of this attribute must be a literal or macro call
-        //~^^ incorrect meta item
-        //~^^^ incorrect meta item
+        #[stable(feature = not_a_literal!(), since = "?")] //~ expression in the value of this attribute must be a literal or macro call
         pub struct NotLiteral; //~ struct has missing stability attribute
     };
 }

--- a/tests/ui/stability-attribute/eager-expansion-fail.rs
+++ b/tests/ui/stability-attribute/eager-expansion-fail.rs
@@ -8,6 +8,12 @@ macro_rules! not_a_literal {
     };
 }
 
+macro_rules! deprecation_msg {
+    () => {
+        "..."
+    };
+}
+
 macro_rules! m {
     () => {
         #[stable(feature = 1 + 1, since = "?")] //~ expression in the value of this attribute must be a literal or macro call
@@ -15,6 +21,10 @@ macro_rules! m {
 
         #[stable(feature = not_a_literal!(), since = "?")] //~ expression in the value of this attribute must be a literal or macro call
         pub struct NotLiteral; //~ struct has missing stability attribute
+
+        #[unstable(feature = "deprecated", issue = "none")]
+        #[deprecated(reason = deprecation_msg!())] //~ expected unsuffixed literal or identifier, found `deprecation_msg`
+        pub struct Deprecated;
     };
 }
 

--- a/tests/ui/stability-attribute/eager-expansion-fail.rs
+++ b/tests/ui/stability-attribute/eager-expansion-fail.rs
@@ -1,0 +1,27 @@
+#![crate_type = "lib"]
+#![feature(staged_api)]
+#![stable(feature = "stable_test_feature", since = "3.3.3")]
+
+macro_rules! not_a_literal {
+    () => {
+        boohoo
+    };
+}
+
+macro_rules! m {
+    () => {
+        #[stable(feature = 1 + 1, since = "?")]
+        //~^ expression in the value of this attribute must be a literal or macro call
+        //~^^ incorrect meta item
+        //~^^^ incorrect meta item
+        pub struct Math; //~ struct has missing stability attribute
+
+        #[stable(feature = not_a_literal!(), since = "?")]
+        //~^ expression in the value of this attribute must be a literal or macro call
+        //~^^ incorrect meta item
+        //~^^^ incorrect meta item
+        pub struct NotLiteral; //~ struct has missing stability attribute
+    };
+}
+
+m!();

--- a/tests/ui/stability-attribute/eager-expansion-fail.stderr
+++ b/tests/ui/stability-attribute/eager-expansion-fail.stderr
@@ -10,7 +10,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expression in the value of this attribute must be a literal or macro call
-  --> $DIR/eager-expansion-fail.rs:19:28
+  --> $DIR/eager-expansion-fail.rs:16:28
    |
 LL |         #[stable(feature = not_a_literal!(), since = "?")]
    |                            ^^^^^^^^^^^^^^^^
@@ -20,54 +20,8 @@ LL | m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0539]: incorrect meta item
-  --> $DIR/eager-expansion-fail.rs:13:18
-   |
-LL |         #[stable(feature = 1 + 1, since = "?")]
-   |                  ^^^^^^^^^^^^^^^
-...
-LL | m!();
-   | ---- in this macro invocation
-   |
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0539]: incorrect meta item
-  --> $DIR/eager-expansion-fail.rs:13:18
-   |
-LL |         #[stable(feature = 1 + 1, since = "?")]
-   |                  ^^^^^^^^^^^^^^^
-...
-LL | m!();
-   | ---- in this macro invocation
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0539]: incorrect meta item
-  --> $DIR/eager-expansion-fail.rs:19:18
-   |
-LL |         #[stable(feature = not_a_literal!(), since = "?")]
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | m!();
-   | ---- in this macro invocation
-   |
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0539]: incorrect meta item
-  --> $DIR/eager-expansion-fail.rs:19:18
-   |
-LL |         #[stable(feature = not_a_literal!(), since = "?")]
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | m!();
-   | ---- in this macro invocation
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: struct has missing stability attribute
-  --> $DIR/eager-expansion-fail.rs:17:9
+  --> $DIR/eager-expansion-fail.rs:14:9
    |
 LL |         pub struct Math;
    |         ^^^^^^^^^^^^^^^^
@@ -78,7 +32,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: struct has missing stability attribute
-  --> $DIR/eager-expansion-fail.rs:23:9
+  --> $DIR/eager-expansion-fail.rs:17:9
    |
 LL |         pub struct NotLiteral;
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -88,6 +42,5 @@ LL | m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 8 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/stability-attribute/eager-expansion-fail.stderr
+++ b/tests/ui/stability-attribute/eager-expansion-fail.stderr
@@ -1,5 +1,5 @@
 error: expression in the value of this attribute must be a literal or macro call
-  --> $DIR/eager-expansion-fail.rs:13:28
+  --> $DIR/eager-expansion-fail.rs:19:28
    |
 LL |         #[stable(feature = 1 + 1, since = "?")]
    |                            ^^^^^
@@ -10,7 +10,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expression in the value of this attribute must be a literal or macro call
-  --> $DIR/eager-expansion-fail.rs:16:28
+  --> $DIR/eager-expansion-fail.rs:22:28
    |
 LL |         #[stable(feature = not_a_literal!(), since = "?")]
    |                            ^^^^^^^^^^^^^^^^
@@ -20,8 +20,19 @@ LL | m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error: expected unsuffixed literal or identifier, found `deprecation_msg`
+  --> $DIR/eager-expansion-fail.rs:26:31
+   |
+LL |         #[deprecated(reason = deprecation_msg!())]
+   |                               ^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: struct has missing stability attribute
-  --> $DIR/eager-expansion-fail.rs:14:9
+  --> $DIR/eager-expansion-fail.rs:20:9
    |
 LL |         pub struct Math;
    |         ^^^^^^^^^^^^^^^^
@@ -32,7 +43,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: struct has missing stability attribute
-  --> $DIR/eager-expansion-fail.rs:17:9
+  --> $DIR/eager-expansion-fail.rs:23:9
    |
 LL |         pub struct NotLiteral;
    |         ^^^^^^^^^^^^^^^^^^^^^^
@@ -42,5 +53,5 @@ LL | m!();
    |
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/stability-attribute/eager-expansion-fail.stderr
+++ b/tests/ui/stability-attribute/eager-expansion-fail.stderr
@@ -1,0 +1,93 @@
+error: expression in the value of this attribute must be a literal or macro call
+  --> $DIR/eager-expansion-fail.rs:13:28
+   |
+LL |         #[stable(feature = 1 + 1, since = "?")]
+   |                            ^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expression in the value of this attribute must be a literal or macro call
+  --> $DIR/eager-expansion-fail.rs:19:28
+   |
+LL |         #[stable(feature = not_a_literal!(), since = "?")]
+   |                            ^^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0539]: incorrect meta item
+  --> $DIR/eager-expansion-fail.rs:13:18
+   |
+LL |         #[stable(feature = 1 + 1, since = "?")]
+   |                  ^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0539]: incorrect meta item
+  --> $DIR/eager-expansion-fail.rs:13:18
+   |
+LL |         #[stable(feature = 1 + 1, since = "?")]
+   |                  ^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0539]: incorrect meta item
+  --> $DIR/eager-expansion-fail.rs:19:18
+   |
+LL |         #[stable(feature = not_a_literal!(), since = "?")]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0539]: incorrect meta item
+  --> $DIR/eager-expansion-fail.rs:19:18
+   |
+LL |         #[stable(feature = not_a_literal!(), since = "?")]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: struct has missing stability attribute
+  --> $DIR/eager-expansion-fail.rs:17:9
+   |
+LL |         pub struct Math;
+   |         ^^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: struct has missing stability attribute
+  --> $DIR/eager-expansion-fail.rs:23:9
+   |
+LL |         pub struct NotLiteral;
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | m!();
+   | ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/stability-attribute/eager-expansion.rs
+++ b/tests/ui/stability-attribute/eager-expansion.rs
@@ -1,0 +1,54 @@
+// check-pass
+
+#![crate_type = "lib"]
+#![feature(staged_api)]
+#![stable(feature = "stable_test_feature", since = "3.3.3")]
+
+macro_rules! sign_dependent_expr {
+    (unsigned ? if unsigned { $unsigned_case:expr } if signed { $signed_case:expr }) => {
+        $unsigned_case
+    };
+    (signed ? if unsigned { $unsigned_case:expr } if signed { $signed_case:expr }) => {
+        $signed_case
+    };
+}
+
+macro_rules! stable_feature {
+    ($signedness:ident) => {
+        sign_dependent_expr! {
+            $signedness ?
+            if unsigned { "nonzero" }
+            if signed { "signed_nonzero" }
+        }
+    };
+}
+
+macro_rules! stable_since {
+    ($signedness:ident) => {
+        sign_dependent_expr! {
+            $signedness ?
+            if unsigned { "1.28.0" }
+            if signed { "1.34.0" }
+        }
+    };
+}
+
+macro_rules! nonzero_integers {
+    ($($signedness:ident $NonZero:ident($primitive:ty))*) => {
+        $(
+            #[stable(feature = stable_feature!($signedness), since = stable_since!($signedness))]
+            pub struct $NonZero($primitive);
+        )*
+    };
+}
+
+nonzero_integers! {
+    unsigned NonZeroU8(u8)
+    unsigned NonZeroU16(u16)
+    unsigned NonZeroU32(u32)
+    unsigned NonZeroU64(u64)
+    signed NonZeroI8(i8)
+    signed NonZeroI16(i16)
+    signed NonZeroI32(i32)
+    signed NonZeroI64(i64)
+}


### PR DESCRIPTION
This PR implements support for macro invocations in the values of builtin stability attributes:

```diff
- #[stable(feature = "string literal")]
+ #[stable(feature = get_feature!($thing))]
```

This is analogous to how macro expansion is already supported in the value part of `doc` attributes since Rust 1.54 (https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros).

```rust
#[doc = include_str!("README.md")]
```

All such macro calls must expand to a literal, like for `doc` and `TokenStream::expand_expr`.

I have limited this feature to just the following 4 builtin attributes, none of which are available in stable Rust: **#\[stable(...)\]**, **#\[unstable(...)\]**, **#\[rustc_const_stable(...)\]**, **#\[rustc_const_unstable(...)\]**. Other builtin attributes, for example #\[deprecated(...)\], will continue to reject the above syntax.

## Context

I began looking into refactoring the macros which generate our NonZero\* integer types (https://github.com/rust-lang/rust/blob/1.74.0/library/core/src/num/nonzero.rs) in preparation for landing the refactor to `NonZero<T>` (https://github.com/rust-lang/rust/issues/82363#issuecomment-921513910).

Today there are 7 separate impl blocks per NonZero integer type. You can see this by counting the `impl` sections under "Implementations" in https://doc.rust-lang.org/1.74.0/std/num/struct.NonZeroU32.html. There isn't anything wrong with that today, but after the 12 different NonZero\* types all get melded into a NonZero\<T\>, there end up being **67** impl blocks in #100428 on that type.

<img src="https://github.com/rust-lang/rust/assets/1940490/5b68bd6f-8a36-4922-baa3-348e30dbfcc1" width="200"><img src="https://github.com/rust-lang/rust/assets/1940490/2cfec71e-c2cd-4361-a542-487f13f435d9" width="200"><img src="https://github.com/rust-lang/rust/assets/1940490/2fe00337-7307-405d-9036-6fe1e58b2627" width="200">

This is a usability regression compared to today's separate pages per type. With all those blocks expanded, Ctrl+F is obnoxious because you need to skip 12&times; past every match you don't care about. With all the blocks collapsed, Ctrl+F is useless. Getting to a state in which exactly one type's (e.g. `NonZero<u32>`) impl blocks are expanded while the rest are collapsed is annoying.

Ideally there would be one impl block per type.

Today's implementation in the standard library is arranged like this:

```rust
macro_rules! nonzero_leading_trailing_zeros {
    (...) => {
        $(
            impl $Ty { ... }
        )*
    };
}

nonzero_leading_trailing_zeros!(...);

macro_rules! nonzero_bits {
    (...) => {
        $(
            impl $Ty { ... }
        )*
    };
}

nonzero_bits!(...);
...
```

The thing that makes it difficult to transpose this into something that produces 1 impl block per type, while remaining maintainable, is that composing stability attributes using a macro is impossible.

https://github.com/rust-lang/rust/blob/c2ec90854a0d3a3e1570cf7acfdd2c9e50aa3b2a/library/core/src/num/nonzero.rs#L179-L192

The UI test added in this PR (*tests/ui/stability-attribute/eager-expansion.rs*) is illustrative of the direction I was headed before realizing this was not supported.