### PR TITLE
miri: add test checking that aggregate assignments reset memory to uninit

### DIFF
--- a/src/tools/miri/tests/fail/uninit-after-aggregate-assign.rs
+++ b/src/tools/miri/tests/fail/uninit-after-aggregate-assign.rs
@@ -1,0 +1,27 @@
+#![feature(core_intrinsics)]
+#![feature(custom_mir)]
+
+use std::intrinsics::mir::*;
+use std::ptr;
+
+#[repr(C)]
+struct S(u8, u16);
+
+#[custom_mir(dialect = "runtime", phase = "optimized")]
+fn main() {
+    mir! {
+        let s: S;
+        let sptr;
+        let sptr2;
+        let _val;
+        {
+            sptr = ptr::addr_of_mut!(s);
+            sptr2 = sptr as *mut [u8; 4];
+            *sptr2 = [0; 4];
+            *sptr = S(0, 0); // should reset the padding
+            _val = *sptr2; // should hence be UB
+            //~^ERROR: encountered uninitialized memory
+            Return()
+        }
+    }
+}

--- a/src/tools/miri/tests/fail/uninit-after-aggregate-assign.stderr
+++ b/src/tools/miri/tests/fail/uninit-after-aggregate-assign.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
+  --> $DIR/uninit-after-aggregate-assign.rs:LL:CC
+   |
+LL |             _val = *sptr2; // should hence be UB
+   |             ^^^^^^^^^^^^^ constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/uninit-after-aggregate-assign.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Also, `write_aggregate` is really just a helper for evaluating `Aggregate` rvalues, so it should be in `step.rs`, not `place.rs`. Also factor out `Repeat` rvalues into their own function while we are at it.

r? @saethlin 
Fixes https://github.com/rust-lang/miri/issues/3195