### PR TITLE
update test for new LLVM 18 codegen

### DIFF
--- a/tests/codegen/ascii-char.rs
+++ b/tests/codegen/ascii-char.rs
@@ -14,7 +14,7 @@ pub fn unwrap_digit_from_remainder(v: u32) -> AsciiChar {
 
     // CHECK: %[[R:.+]] = urem i32 %v, 10
     // CHECK-NEXT: %[[T:.+]] = trunc i32 %[[R]] to i8
-    // CHECK-NEXT: %[[D:.+]] = or i8 %[[T]], 48
+    // CHECK-NEXT: %[[D:.+]] = or{{( disjoint)?}} i8 %[[T]], 48
     // CHECK-NEXT: ret i8 %[[D]]
 
     // CHECK-NOT: icmp


### PR DESCRIPTION
LLVM at HEAD now emits `or disjoint`: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/24076#018c1596-8153-488e-b622-951266a02f6c/741-774