### PR TITLE
Fix coroutine validation for mixed panic strategy

### DIFF
--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -74,11 +74,13 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
                 let mut body = EarlyBinder::bind(body.clone()).instantiate(tcx, args);
                 debug!("make_shim({:?}) = {:?}", instance, body);
 
-                // Run empty passes to mark phase change and perform validation.
                 pm::run_passes(
                     tcx,
                     &mut body,
-                    &[],
+                    &[
+                        &abort_unwinding_calls::AbortUnwindingCalls,
+                        &add_call_guards::CriticalCallEdges,
+                    ],
                     Some(MirPhase::Runtime(RuntimePhase::Optimized)),
                 );
 

--- a/tests/ui/coroutine/auxiliary/unwind-aux.rs
+++ b/tests/ui/coroutine/auxiliary/unwind-aux.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Cpanic=unwind  --crate-type=lib
+// no-prefer-dynamic
+// edition:2021
+
+#![feature(coroutines)]
+pub fn run<T>(a: T) {
+    let _ = move || {
+        drop(a);
+        yield;
+    };
+}

--- a/tests/ui/coroutine/unwind-abort-mix.rs
+++ b/tests/ui/coroutine/unwind-abort-mix.rs
@@ -1,0 +1,13 @@
+// Ensure that coroutine drop glue is valid when mixing different panic
+// strategies. Regression test for #116953.
+//
+// no-prefer-dynamic
+// build-pass
+// aux-build:unwind-aux.rs
+// compile-flags: -Cpanic=abort
+// needs-unwind
+extern crate unwind_aux;
+
+pub fn main() {
+    unwind_aux::run(String::new());
+}


### PR DESCRIPTION
Validation introduced in #113124 allows `UnwindAction::Continue` and `TerminatorKind::Resume` to occur only in functions with ABI that can unwind. The function ABI depends on the panic strategy, which can vary across crates.

Usually MIR is built and validated in the same crate. The coroutine drop glue thus far was an exception. As a result validation could fail when mixing different panic strategies.

Avoid the problem by executing `AbortUnwindingCalls` along with the validation.

Fixes #116953.