### PR TITLE
 const-stabilize HashMap/HashSet::with_hasher (+ required compiller changes)

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -986,9 +986,9 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 // should be fixed later.
                 let callee_is_unstable_unmarked = tcx.lookup_const_stability(callee).is_none()
                     && tcx.lookup_stability(callee).is_some_and(|s| s.is_unstable());
-                let can_call_any_function =
-                    super::rustc_allow_const_fn_unstable(tcx, caller, sym::any);
-                if callee_is_unstable_unmarked && !can_call_any_function {
+                let can_call_unmarked_function =
+                    super::rustc_allow_const_fn_unstable(tcx, caller, sym::any_unmarked);
+                if callee_is_unstable_unmarked && !can_call_unmarked_function {
                     trace!("callee_is_unstable_unmarked");
                     // We do not use `const` modifiers for intrinsic "functions", as intrinsics are
                     // `extern` functions, and these have no way to get marked `const`. So instead we

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -986,7 +986,9 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 // should be fixed later.
                 let callee_is_unstable_unmarked = tcx.lookup_const_stability(callee).is_none()
                     && tcx.lookup_stability(callee).is_some_and(|s| s.is_unstable());
-                if callee_is_unstable_unmarked {
+                let can_call_any_function =
+                    super::rustc_allow_const_fn_unstable(tcx, caller, sym::any);
+                if callee_is_unstable_unmarked && !can_call_any_function {
                     trace!("callee_is_unstable_unmarked");
                     // We do not use `const` modifiers for intrinsic "functions", as intrinsics are
                     // `extern` functions, and these have no way to get marked `const`. So instead we

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -397,6 +397,7 @@ symbols! {
         anon,
         anonymous_lifetime_in_impl_trait,
         any,
+        any_unmarked,
         append_const_msg,
         arbitrary_enum_discriminant,
         arbitrary_self_types,

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -290,7 +290,7 @@ impl<K, V, S> HashMap<K, V, S> {
             since = "CURRENT_RUSTC_VERSION"
         )
     )]
-    #[rustc_allow_const_fn_unstable(any)]
+    #[rustc_allow_const_fn_unstable(any_unmarked)]
     pub const fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
         HashMap { base: base::HashMap::with_hasher(hash_builder) }
     }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -279,7 +279,18 @@ impl<K, V, S> HashMap<K, V, S> {
     /// ```
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    #[rustc_const_unstable(feature = "const_collections_with_hasher", issue = "102575")]
+    #[cfg_attr(
+        bootstrap,
+        rustc_const_unstable(feature = "const_collections_with_hasher", issue = "102575")
+    )]
+    #[cfg_attr(
+        not(bootstrap),
+        rustc_const_stable(
+            feature = "const_collections_with_hasher",
+            since = "CURRENT_RUSTC_VERSION"
+        )
+    )]
+    #[rustc_allow_const_fn_unstable(any)]
     pub const fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
         HashMap { base: base::HashMap::with_hasher(hash_builder) }
     }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -380,7 +380,7 @@ impl<T, S> HashSet<T, S> {
             since = "CURRENT_RUSTC_VERSION"
         )
     )]
-    #[rustc_allow_const_fn_unstable(any)]
+    #[rustc_allow_const_fn_unstable(any_unmarked)]
     pub const fn with_hasher(hasher: S) -> HashSet<T, S> {
         HashSet { base: base::HashSet::with_hasher(hasher) }
     }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -369,7 +369,18 @@ impl<T, S> HashSet<T, S> {
     /// ```
     #[inline]
     #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]
-    #[rustc_const_unstable(feature = "const_collections_with_hasher", issue = "102575")]
+    #[cfg_attr(
+        bootstrap,
+        rustc_const_unstable(feature = "const_collections_with_hasher", issue = "102575")
+    )]
+    #[cfg_attr(
+        not(bootstrap),
+        rustc_const_stable(
+            feature = "const_collections_with_hasher",
+            since = "CURRENT_RUSTC_VERSION"
+        )
+    )]
+    #[rustc_allow_const_fn_unstable(any)]
     pub const fn with_hasher(hasher: S) -> HashSet<T, S> {
         HashSet { base: base::HashSet::with_hasher(hasher) }
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -297,6 +297,7 @@
 #![feature(no_sanitize)]
 #![feature(platform_intrinsics)]
 #![feature(prelude_import)]
+#![feature(rustc_allow_const_fn_unstable)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
 #![feature(staged_api)]
@@ -388,7 +389,7 @@
 //
 // Only for const-ness:
 // tidy-alphabetical-start
-#![feature(const_collections_with_hasher)]
+#![cfg_attr(bootstrap, feature(const_collections_with_hasher))]
 #![feature(const_hash)]
 #![feature(const_io_structs)]
 #![feature(const_ip)]

--- a/tests/ui/stability-attribute/auxiliary/const-unstable.rs
+++ b/tests/ui/stability-attribute/auxiliary/const-unstable.rs
@@ -1,0 +1,8 @@
+#![feature(staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_identity", issue = "1")]
+pub const fn identity(x: i32) -> i32 {
+    x
+}

--- a/tests/ui/stability-attribute/auxiliary/normal-const-fn.rs
+++ b/tests/ui/stability-attribute/auxiliary/normal-const-fn.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Zforce-unstable-if-unmarked
+
+// This emulates a dep-of-std (eg hashbrown), that has const functions it
+// cannot mark as stable, and is build with force-unstable-if-unmarked.
+
+pub const fn do_something_else() {}

--- a/tests/ui/stability-attribute/const-stable-cross-crate.rs
+++ b/tests/ui/stability-attribute/const-stable-cross-crate.rs
@@ -16,7 +16,7 @@ extern crate normal_const_fn;
 
 #[rustc_const_stable(feature = "stable_feature", since = "1.0.0")]
 #[stable(feature = "stable_feature", since = "1.0.0")]
-#[rustc_allow_const_fn_unstable(any)]
+#[rustc_allow_const_fn_unstable(any_unmarked)]
 pub const fn do_something() {
     normal_const_fn::do_something_else()
 }

--- a/tests/ui/stability-attribute/const-stable-cross-crate.rs
+++ b/tests/ui/stability-attribute/const-stable-cross-crate.rs
@@ -1,0 +1,22 @@
+// aux-build:normal-const-fn.rs
+// check-pass
+#![crate_type = "lib"]
+#![feature(staged_api)]
+#![feature(rustc_attrs)]
+#![feature(rustc_private)]
+#![allow(internal_features)]
+#![feature(rustc_allow_const_fn_unstable)]
+#![stable(feature = "stable_feature", since = "1.0.0")]
+
+extern crate normal_const_fn;
+
+// This ensures std can call const functions in it's deps that don't have
+// access to rustc_const_stable annotations (and hense don't have a feature)
+// gate.
+
+#[rustc_const_stable(feature = "stable_feature", since = "1.0.0")]
+#[stable(feature = "stable_feature", since = "1.0.0")]
+#[rustc_allow_const_fn_unstable(any)]
+pub const fn do_something() {
+    normal_const_fn::do_something_else()
+}

--- a/tests/ui/stability-attribute/const-unstable-from-unmarked.rs
+++ b/tests/ui/stability-attribute/const-unstable-from-unmarked.rs
@@ -1,0 +1,16 @@
+// aux-build: const-unstable.rs
+// compile-flags: -Zforce-unstable-if-unmarked
+#![crate_type = "lib"]
+extern crate const_unstable;
+
+// Check that crates build with `-Zforce-unstable-if-unmarked` can't call
+// const-unstable functions, despite their functions sometimes being considerd
+// unstable.
+//
+// See https://github.com/rust-lang/rust/pull/118427#discussion_r1409914941 for
+// more context.
+
+pub const fn identity(x: i32) -> i32 {
+    const_unstable::identity(x)
+    //~^ ERROR `const_unstable::identity` is not yet stable as a const fn
+}

--- a/tests/ui/stability-attribute/const-unstable-from-unmarked.stderr
+++ b/tests/ui/stability-attribute/const-unstable-from-unmarked.stderr
@@ -1,0 +1,10 @@
+error: `const_unstable::identity` is not yet stable as a const fn
+  --> $DIR/const-unstable-from-unmarked.rs:14:5
+   |
+LL |     const_unstable::identity(x)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_identity)]` to the crate attributes to enable
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Closes #102575

FCP'd here: https://github.com/rust-lang/rust/issues/102575#issuecomment-1663153501

Best reviewed commit-by-commit

It's somewhat involved, as it needs to introduce new details to `rustc_allow_const_fn_unstable` to allow calling 3rd party code. CC @rust-lang/wg-const-eval 


