### PR TITLE
Always display stability version even if it's the same as the containing item

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -592,13 +592,6 @@ impl Item {
         }
     }
 
-    pub(crate) fn const_stable_since(&self, tcx: TyCtxt<'_>) -> Option<StableSince> {
-        match self.const_stability(tcx)?.level {
-            StabilityLevel::Stable { since, .. } => Some(since),
-            StabilityLevel::Unstable { .. } => None,
-        }
-    }
-
     pub(crate) fn is_non_exhaustive(&self) -> bool {
         self.attrs.other_attrs.iter().any(|a| a.has_name(sym::non_exhaustive))
     }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -223,8 +223,6 @@ pub(super) fn print_item(
         &mut stability_since_raw,
         item.stable_since(cx.tcx()),
         item.const_stability(cx.tcx()),
-        None,
-        None,
     );
     let stability_since_raw: String = stability_since_raw.into_inner();
 
@@ -846,7 +844,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
             write!(w, "<details class=\"toggle{method_toggle_class}\" open><summary>");
         }
         write!(w, "<section id=\"{id}\" class=\"method\">");
-        render_rightside(w, cx, m, t, RenderMode::Normal);
+        render_rightside(w, cx, m, RenderMode::Normal);
         write!(w, "<h4 class=\"code-header\">");
         render_assoc_item(
             w,
@@ -1707,8 +1705,6 @@ fn item_variants(
             w,
             variant.stable_since(tcx),
             variant.const_stability(tcx),
-            it.stable_since(tcx),
-            it.const_stable_since(tcx),
             " rightside",
         );
         w.write_str("<h3 class=\"code-header\">");

--- a/tests/rustdoc/const-display.rs
+++ b/tests/rustdoc/const-display.rs
@@ -72,8 +72,8 @@ impl Foo {
 pub struct Bar;
 
 impl Bar {
-    // Do not show non-const stabilities that are the same as the enclosing item.
-    // @matches 'foo/struct.Bar.html' '//span[@class="since"]' '^const: 1.2.0$'
+    // Show non-const stabilities that are the same as the enclosing item.
+    // @has 'foo/struct.Bar.html' '//span[@class="since"]' '1.0.0 (const: 1.2.0)'
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const2", since = "1.2.0")]
     pub const fn stable_impl() -> u32 { 42 }

--- a/tests/rustdoc/deref/deref-const-fn.rs
+++ b/tests/rustdoc/deref/deref-const-fn.rs
@@ -26,7 +26,7 @@ pub struct Foo {
 
 // @has 'foo/struct.Foo.html'
 // @has - '//*[@id="method.len"]' 'pub fn len(&self) -> usize'
-// @!has - '//*[@id="method.len"]//span[@class="since"]' '1.0.0'
+// @has - '//*[@id="method.len"]//span[@class="since"]' '1.0.0'
 // @!has - '//*[@id="method.len"]//span[@class="since"]' '(const: 1.0.0)'
 #[stable(feature = "rust1", since = "1.0.0")]
 impl std::ops::Deref for Foo {

--- a/tests/rustdoc/ensure-src-link.rs
+++ b/tests/rustdoc/ensure-src-link.rs
@@ -2,5 +2,5 @@
 
 // This test ensures that the [src] link is present on traits items.
 
-// @has foo/trait.Iterator.html '//*[@id="method.zip"]//a[@class="src rightside"]' "source"
+// @has foo/trait.Iterator.html '//*[@id="method.zip"]//a[@class="src"]' "source"
 pub use std::iter::Iterator;

--- a/tests/rustdoc/implementor-stable-version.rs
+++ b/tests/rustdoc/implementor-stable-version.rs
@@ -16,6 +16,6 @@ pub struct Foo;
 #[stable(feature = "foobar", since = "4.4.4")]
 impl Bar for Foo {}
 
-// @!has foo/trait.Baz.html '//div[@id="implementors-list"]//span[@class="since"]' '3.3.3'
+// @has foo/trait.Baz.html '//div[@id="implementors-list"]//span[@class="since"]' '3.3.3'
 #[stable(feature = "foobaz", since = "3.3.3")]
 impl Baz for Foo {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/118439.

Currently, if the containing item's version is the same as the item's version (like a method), we don't display it on the item.

This was something done on purpose as you can see [here](https://github.com/rust-lang/rust/blob/e9b7bf011478aa8c19ac49afc99853a66ba04319/src/librustdoc/html/render/mod.rs#L949-L955). It was implemented in https://github.com/rust-lang/rust/pull/30686.

I think we should change this because on pages with a lot of items, if someone arrives (through the search or a link) to an item far below the page, they won't know the stability version unless they scroll to the top, which isn't great.

You can see the result [here](https://rustdoc.crud.net/imperio/display-stability-version/std/pin/struct.Pin.html#method.new).

r? @notriddle 