### PR TITLE
Tweak message on ADT with private fields building

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2090,7 +2090,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 [] => unreachable!(),
             };
             err.note(format!(
-                "... and other private field{s} {names}that {were} not provided",
+                "{}private field{s} {names}that {were} not provided",
+                if used_fields.is_empty() { "" } else { "...and other " },
                 s = pluralize!(remaining_private_fields_len),
                 were = pluralize!("was", remaining_private_fields_len),
             ));

--- a/tests/ui/issues/issue-76077.stderr
+++ b/tests/ui/issues/issue-76077.stderr
@@ -4,7 +4,7 @@ error: cannot construct `Foo` with struct literal syntax due to private fields
 LL |     foo::Foo {};
    |     ^^^^^^^^
    |
-   = note: ... and other private field `you_cant_use_this_field` that was not provided
+   = note: private field `you_cant_use_this_field` that was not provided
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/issue-79593.stderr
+++ b/tests/ui/privacy/issue-79593.stderr
@@ -16,7 +16,7 @@ error: cannot construct `Pub` with struct literal syntax due to private fields
 LL |     foo::Pub {};
    |     ^^^^^^^^
    |
-   = note: ... and other private field `private` that was not provided
+   = note: private field `private` that was not provided
 
 error[E0063]: missing field `y` in initializer of `Enum`
   --> $DIR/issue-79593.rs:23:5

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -56,7 +56,7 @@ error: cannot construct `HashMap<_, _, _>` with struct literal syntax due to pri
 LL |     let _ = std::collections::HashMap {};
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: ... and other private field `base` that was not provided
+   = note: private field `base` that was not provided
 help: you might have meant to use an associated function to build this type
    |
 LL |     let _ = std::collections::HashMap::new();
@@ -78,7 +78,7 @@ error: cannot construct `Box<_, _>` with struct literal syntax due to private fi
 LL |     let _ = Box {};
    |             ^^^
    |
-   = note: ... and other private fields `0` and `1` that were not provided
+   = note: private fields `0` and `1` that were not provided
 help: you might have meant to use an associated function to build this type
    |
 LL |     let _ = Box::new(_);

--- a/tests/ui/typeck/issue-87872-missing-inaccessible-field-literal.stderr
+++ b/tests/ui/typeck/issue-87872-missing-inaccessible-field-literal.stderr
@@ -4,7 +4,7 @@ error: cannot construct `Foo` with struct literal syntax due to private fields
 LL |     foo::Foo {};
    |     ^^^^^^^^
    |
-   = note: ... and other private field `you_cant_use_this_field` that was not provided
+   = note: private field `you_cant_use_this_field` that was not provided
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/missing-private-fields-in-struct-literal.stderr
+++ b/tests/ui/typeck/missing-private-fields-in-struct-literal.stderr
@@ -9,7 +9,7 @@ LL |         a: (),
 LL |         b: (),
    |         ----- private field
    |
-   = note: ... and other private fields `c`, `d` and `e` that were not provided
+   = note: ...and other private fields `c`, `d` and `e` that were not provided
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
When trying to create an inaccessible ADT due to private fields, handle the case when no fields were passed.

```
error: cannot construct `Foo` with struct literal syntax due to private fields
  --> $DIR/issue-76077.rs:8:5
   |
LL |     foo::Foo {};
   |     ^^^^^^^^
   |
   = note: private field `you_cant_use_this_field` that was not provided
```