### PR TITLE
rustdoc: remove small from  `small-section-header`

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1145,7 +1145,7 @@ impl<'a> AssocItemLink<'a> {
 fn write_impl_section_heading(mut w: impl fmt::Write, title: &str, id: &str) {
     write!(
         w,
-        "<h2 id=\"{id}\" class=\"small-section-header\">\
+        "<h2 id=\"{id}\" class=\"section-header\">\
             {title}\
             <a href=\"#{id}\" class=\"anchor\">§</a>\
          </h2>"

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -430,7 +430,7 @@ fn item_module(w: &mut Buffer, cx: &mut Context<'_>, item: &clean::Item, items: 
             last_section = Some(my_section);
             write!(
                 w,
-                "<h2 id=\"{id}\" class=\"small-section-header\">\
+                "<h2 id=\"{id}\" class=\"section-header\">\
                     <a href=\"#{id}\">{name}</a>\
                  </h2>{ITEM_TABLE_OPEN}",
                 id = cx.derive_id(my_section.id()),
@@ -827,7 +827,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
     fn write_small_section_header(w: &mut Buffer, id: &str, title: &str, extra_content: &str) {
         write!(
             w,
-            "<h2 id=\"{0}\" class=\"small-section-header\">\
+            "<h2 id=\"{0}\" class=\"section-header\">\
                 {1}<a href=\"#{0}\" class=\"anchor\">§</a>\
              </h2>{2}",
             id, title, extra_content
@@ -1260,7 +1260,7 @@ fn item_type_alias(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &c
     if let Some(inner_type) = &t.inner_type {
         write!(
             w,
-            "<h2 id=\"aliased-type\" class=\"small-section-header\">\
+            "<h2 id=\"aliased-type\" class=\"section-header\">\
                 Aliased Type<a href=\"#aliased-type\" class=\"anchor\">§</a></h2>"
         );
 
@@ -1685,7 +1685,7 @@ fn item_variants(
     let tcx = cx.tcx();
     write!(
         w,
-        "<h2 id=\"variants\" class=\"variants small-section-header\">\
+        "<h2 id=\"variants\" class=\"variants section-header\">\
             Variants{}<a href=\"#variants\" class=\"anchor\">§</a>\
         </h2>\
         {}\
@@ -1772,7 +1772,7 @@ fn item_variants(
                         write!(
                             w,
                             "<div class=\"sub-variant-field\">\
-                                 <span id=\"{id}\" class=\"small-section-header\">\
+                                 <span id=\"{id}\" class=\"section-header\">\
                                      <a href=\"#{id}\" class=\"anchor field\">§</a>\
                                      <code>{f}: {t}</code>\
                                  </span>",
@@ -1929,7 +1929,7 @@ fn item_fields(
         if fields.peek().is_some() {
             write!(
                 w,
-                "<h2 id=\"fields\" class=\"fields small-section-header\">\
+                "<h2 id=\"fields\" class=\"fields section-header\">\
                      {}{}<a href=\"#fields\" class=\"anchor\">§</a>\
                  </h2>\
                  {}",
@@ -1943,7 +1943,7 @@ fn item_fields(
                 let id = cx.derive_id(format!("{typ}.{field_name}", typ = ItemType::StructField));
                 write!(
                     w,
-                    "<span id=\"{id}\" class=\"{item_type} small-section-header\">\
+                    "<span id=\"{id}\" class=\"{item_type} section-header\">\
                          <a href=\"#{id}\" class=\"anchor field\">§</a>\
                          <code>{field_name}: {ty}</code>\
                      </span>",

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -205,7 +205,7 @@ ul.all-items {
 
 #toggle-all-docs,
 a.anchor,
-.small-section-header a,
+.section-header a,
 #src-sidebar a,
 .rust a,
 .sidebar h2 a,
@@ -742,13 +742,13 @@ nav.sub {
 	margin: 0 0 15px 0;
 }
 
-.small-section-header {
+.section-header {
 	/* fields use <span> tags, but should get their own lines */
 	display: block;
 	position: relative;
 }
 
-.small-section-header:hover > .anchor, .impl:hover > .anchor,
+.section-header:hover > .anchor, .impl:hover > .anchor,
 .trait-impl:hover > .anchor, .variant:hover > .anchor {
 	display: initial;
 }
@@ -761,11 +761,11 @@ nav.sub {
 .anchor.field {
 	left: -5px;
 }
-.small-section-header > .anchor {
+.section-header > .anchor {
 	left: -15px;
 	padding-right: 8px;
 }
-h2.small-section-header > .anchor {
+h2.section-header > .anchor {
 	padding-right: 6px;
 }
 

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -4,13 +4,13 @@
 </code></pre>
 {{ self.document() | safe }}
 {% if self.fields_iter().peek().is_some() %}
-    <h2 id="fields" class="fields small-section-header"> {# #}
+    <h2 id="fields" class="fields section-header"> {# #}
         Fields<a href="#fields" class="anchor">§</a> {# #}
     </h2>
     {% for (field, ty) in self.fields_iter() %}
         {% let name = field.name.expect("union field name") %}
         <span id="structfield.{{ name }}" {#+ #}
-            class="{{ ItemType::StructField +}} small-section-header"> {# #}
+            class="{{ ItemType::StructField +}} section-header"> {# #}
             <a href="#structfield.{{ name }}" class="anchor field">§</a> {# #}
             <code>{{ name }}: {{+ self.print_ty(ty) | safe }}</code> {# #}
         </span>

--- a/src/librustdoc/html/templates/type_layout.html
+++ b/src/librustdoc/html/templates/type_layout.html
@@ -1,4 +1,4 @@
-<h2 id="layout" class="small-section-header"> {# #}
+<h2 id="layout" class="section-header"> {# #}
     Layout<a href="#layout" class="anchor">§</a> {# #}
 </h2> {# #}
 <div class="docblock"> {# #}

--- a/tests/rustdoc-gui/font-weight.goml
+++ b/tests/rustdoc-gui/font-weight.goml
@@ -2,7 +2,7 @@
 go-to: "file://" + |DOC_PATH| + "/lib2/struct.Foo.html"
 assert-css: ("//*[@class='rust item-decl']//a[text()='Alias']", {"font-weight": "400"})
 assert-css: (
-    "//*[@class='structfield small-section-header']//a[text()='Alias']",
+    "//*[@class='structfield section-header']//a[text()='Alias']",
     {"font-weight": "400"},
 )
 assert-css: ("#method\.a_method > .code-header", {"font-weight": "600"})

--- a/tests/rustdoc-gui/headers-color.goml
+++ b/tests/rustdoc-gui/headers-color.goml
@@ -31,7 +31,7 @@ define-function: (
             ALL,
         )
         go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-        assert-css: (".small-section-header a", {"color": |color|}, ALL)
+        assert-css: (".section-header a", {"color": |color|}, ALL)
         go-to: "file://" + |DOC_PATH| + "/test_docs/struct.HeavilyDocumentedStruct.html"
         // We select headings (h2, h3, h...).
         assert-css: (".docblock > :not(p) > a", {"color": |headings_color|}, ALL)

--- a/tests/rustdoc/async-fn-opaque-item.rs
+++ b/tests/rustdoc/async-fn-opaque-item.rs
@@ -9,7 +9,7 @@
 
 // Checking there is only a "Functions" header and no "Opaque types".
 // @has async_fn_opaque_item/index.html
-// @count - '//*[@class="small-section-header"]' 1
-// @has - '//*[@class="small-section-header"]' 'Functions'
+// @count - '//*[@class="section-header"]' 1
+// @has - '//*[@class="section-header"]' 'Functions'
 
 pub async fn test() {}

--- a/tests/rustdoc/compiler-derive-proc-macro.rs
+++ b/tests/rustdoc/compiler-derive-proc-macro.rs
@@ -5,9 +5,9 @@
 // @has 'foo/index.html'
 // Each compiler builtin proc-macro has a trait equivalent so we should have
 // a trait section as well.
-// @count - '//*[@id="main-content"]//*[@class="small-section-header"]' 2
-// @has - '//*[@id="main-content"]//*[@class="small-section-header"]' 'Traits'
-// @has - '//*[@id="main-content"]//*[@class="small-section-header"]' 'Derive Macros'
+// @count - '//*[@id="main-content"]//*[@class="section-header"]' 2
+// @has - '//*[@id="main-content"]//*[@class="section-header"]' 'Traits'
+// @has - '//*[@id="main-content"]//*[@class="section-header"]' 'Derive Macros'
 
 // Now checking the correct file is generated as well.
 // @has 'foo/derive.Clone.html'

--- a/tests/rustdoc/inline-private-with-intermediate-doc-hidden.rs
+++ b/tests/rustdoc/inline-private-with-intermediate-doc-hidden.rs
@@ -6,8 +6,8 @@
 
 // @has 'foo/index.html'
 // There should only be one struct displayed.
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 1
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 1
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Structs'
 // @has - '//*[@id="main-content"]//a[@href="struct.Reexport.html"]' 'Reexport'
 // @has - '//*[@id="main-content"]//*[@class="desc docblock-short"]' 'Visible. Original.'
 

--- a/tests/rustdoc/issue-105735-overlapping-reexport-2.rs
+++ b/tests/rustdoc/issue-105735-overlapping-reexport-2.rs
@@ -7,9 +7,9 @@
 // @has - '//*[@class="item-name"]/a[@class="type"]' 'AtomicU8'
 // @has - '//*[@class="item-name"]/a[@class="constant"]' 'AtomicU8'
 // We also ensure we don't have another item displayed.
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 2
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Type Aliases'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Constants'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 2
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Type Aliases'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Constants'
 
 mod other {
     pub type AtomicU8 = ();

--- a/tests/rustdoc/issue-105735-overlapping-reexport.rs
+++ b/tests/rustdoc/issue-105735-overlapping-reexport.rs
@@ -7,9 +7,9 @@
 // @has - '//*[@class="item-name"]/a[@class="struct"]' 'AtomicU8'
 // @has - '//*[@class="item-name"]/a[@class="constant"]' 'AtomicU8'
 // We also ensure we don't have another item displayed.
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 2
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Constants'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 2
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Constants'
 
 mod thing {
     pub use core::sync::atomic::AtomicU8;

--- a/tests/rustdoc/issue-109258-missing-private-inlining.rs
+++ b/tests/rustdoc/issue-109258-missing-private-inlining.rs
@@ -4,9 +4,9 @@
 
 // @has 'foo/index.html'
 // We should only have a "Re-exports" and a "Modules" headers.
-// @count - '//*[@id="main-content"]/h2[@class="small-section-header"]' 2
-// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Re-exports'
-// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Modules'
+// @count - '//*[@id="main-content"]/h2[@class="section-header"]' 2
+// @has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Re-exports'
+// @has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Modules'
 
 // @has - '//*[@id="reexport.Foo"]' 'pub use crate::issue_109258::Foo;'
 // @has - '//*[@id="reexport.Foo"]//a[@href="issue_109258/struct.Foo.html"]' 'Foo'
@@ -15,8 +15,8 @@ pub use crate::issue_109258::Foo;
 
 // @has 'foo/issue_109258/index.html'
 // We should only have a "Structs" header.
-// @count - '//*[@id="main-content"]/h2[@class="small-section-header"]' 1
-// @has - '//*[@id="main-content"]/h2[@class="small-section-header"]' 'Structs'
+// @count - '//*[@id="main-content"]/h2[@class="section-header"]' 1
+// @has - '//*[@id="main-content"]/h2[@class="section-header"]' 'Structs'
 // @has - '//*[@id="main-content"]//a[@href="struct.Foo.html"]' 'Foo'
 // @has 'foo/issue_109258/struct.Foo.html'
 pub mod issue_109258 {

--- a/tests/rustdoc/issue-109449-doc-hidden-reexports.rs
+++ b/tests/rustdoc/issue-109449-doc-hidden-reexports.rs
@@ -66,8 +66,8 @@ pub mod single_reexport_inherit_hidden {
 pub mod single_reexport_no_inline {
     // First we ensure that we only have re-exports and no inlined items.
     // @has 'foo/single_reexport_no_inline/index.html'
-    // @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 1
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Re-exports'
+    // @count - '//*[@id="main-content"]/*[@class="section-header"]' 1
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Re-exports'
 
     // Now we check that we don't have links to the items, just `pub use`.
     // @has - '//*[@id="main-content"]//*' 'pub use crate::private_module::Public as XFoo;'
@@ -101,10 +101,10 @@ pub mod glob_reexport {
     // With glob re-exports, we don't inline `#[doc(hidden)]` items so only `module` items
     // should be inlined.
     // @has 'foo/glob_reexport/index.html'
-    // @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 3
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Re-exports'
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Type Aliases'
+    // @count - '//*[@id="main-content"]/*[@class="section-header"]' 3
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Re-exports'
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Structs'
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Type Aliases'
 
     // Now we check we have 1 re-export and 2 inlined items.
     // If not item from a glob re-export is visible, we don't show the re-export.

--- a/tests/rustdoc/issue-110422-inner-private.rs
+++ b/tests/rustdoc/issue-110422-inner-private.rs
@@ -8,11 +8,11 @@
 
 // @has 'foo/index.html'
 // Checking there is no "trait" entry.
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 4
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Constants'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Functions'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Macros'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 4
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Constants'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Functions'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Macros'
 
 // @has - '//a[@href="fn.foo.html"]' 'foo'
 fn foo() {
@@ -50,11 +50,11 @@ const BAR: i32 = {
 
     // @has 'foo/struct.Bar.html'
     // @has - '//*[@id="method.foo"]/*[@class="code-header"]' 'pub(crate) fn foo()'
-    // @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 3
+    // @count - '//*[@id="main-content"]/*[@class="section-header"]' 3
     // We now check that the `Foo` trait is not documented nor visible on `Bar` page.
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Implementations'
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Auto Trait Implementations'
-    // @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Blanket Implementations'
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Implementations'
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Auto Trait Implementations'
+    // @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Blanket Implementations'
     // @!has - '//*[@href="trait.Foo.html#method.babar"]/*[@class="code-header"]' 'fn babar()'
     impl Bar {
         fn foo() {}

--- a/tests/rustdoc/issue-60522-duplicated-glob-reexport.rs
+++ b/tests/rustdoc/issue-60522-duplicated-glob-reexport.rs
@@ -5,8 +5,8 @@
 #![crate_name = "foo"]
 
 // @has 'foo/index.html'
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 1
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Modules'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 1
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Modules'
 // @count - '//*[@id="main-content"]/*[@class="item-table"]//*[@class="mod"]' 2
 // @has - '//*[@id="main-content"]//*[@class="mod"]' 'banana'
 // @has - '//*[@id="main-content"]//*[@href="banana/index.html"]' 'banana'

--- a/tests/rustdoc/nested-items-issue-111415.rs
+++ b/tests/rustdoc/nested-items-issue-111415.rs
@@ -5,10 +5,10 @@
 
 // @has 'foo/index.html'
 // Checking there are only three sections.
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 3
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Structs'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Functions'
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Traits'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 3
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Structs'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Functions'
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Traits'
 // Checking that there are only three items.
 // @count - '//*[@id="main-content"]//*[@class="item-name"]' 3
 // @has - '//*[@id="main-content"]//a[@href="struct.Bar.html"]' 'Bar'

--- a/tests/rustdoc/pub-reexport-of-pub-reexport-46506.rs
+++ b/tests/rustdoc/pub-reexport-of-pub-reexport-46506.rs
@@ -4,8 +4,8 @@
 #![crate_name = "foo"]
 
 // @has 'foo/associations/index.html'
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 1
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Traits'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 1
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Traits'
 // @has - '//*[@id="main-content"]//a[@href="trait.GroupedBy.html"]' 'GroupedBy'
 // @has 'foo/associations/trait.GroupedBy.html'
 pub mod associations {
@@ -16,8 +16,8 @@ pub mod associations {
 }
 
 // @has 'foo/prelude/index.html'
-// @count - '//*[@id="main-content"]/*[@class="small-section-header"]' 1
-// @has - '//*[@id="main-content"]/*[@class="small-section-header"]' 'Re-exports'
+// @count - '//*[@id="main-content"]/*[@class="section-header"]' 1
+// @has - '//*[@id="main-content"]/*[@class="section-header"]' 'Re-exports'
 // @has - '//*[@id="main-content"]//*[@id="reexport.GroupedBy"]' 'pub use associations::GroupedBy;'
 pub mod prelude {
     pub use associations::GroupedBy;

--- a/tests/rustdoc/typedef-inner-variants.rs
+++ b/tests/rustdoc/typedef-inner-variants.rs
@@ -65,7 +65,7 @@ pub union OneOr<A: Copy> {
 // @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
-// @count - '//*[@class="structfield small-section-header"]' 2
+// @count - '//*[@class="structfield section-header"]' 2
 // @matches - '//pre[@class="rust item-decl"]//code' "union OneOrF64"
 pub type OneOrF64 = OneOr<f64>;
 
@@ -81,7 +81,7 @@ pub struct One<T> {
 // @count - '//*[@id="aliased-type"]' 1
 // @count - '//*[@id="variants"]' 0
 // @count - '//*[@id="fields"]' 1
-// @count - '//*[@class="structfield small-section-header"]' 1
+// @count - '//*[@class="structfield section-header"]' 1
 // @matches - '//pre[@class="rust item-decl"]//code' "struct OneU64"
 // @matches - '//pre[@class="rust item-decl"]//code' "pub val"
 pub type OneU64 = One<u64>;


### PR DESCRIPTION
There's no such thing as a big section header, so I don't know why the name was used.