### PR TITLE
Re-enable `rustc_codegen_gcc` tests in CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
@@ -50,7 +50,6 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-16 \
       --enable-llvm-link-shared \
-      $USE_NEW_MANGLING \
       --set rust.thin-lto-import-instr-limit=10
 
 COPY host-x86_64/x86_64-gnu-llvm-16/script.sh /tmp/

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-16/Dockerfile
@@ -24,7 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   nodejs \
   mingw-w64 \
+  libgccjit-12-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# Note: libgccjit needs to match the default gcc version for the linker to find it.
 
 # Install powershell (universal package) so we can test x.ps1 on Linux
 RUN curl -sL "https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/powershell_7.3.1-1.deb_amd64.deb" > powershell.deb && \
@@ -47,6 +50,7 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-16 \
       --enable-llvm-link-shared \
+      $USE_NEW_MANGLING \
       --set rust.thin-lto-import-instr-limit=10
 
 COPY host-x86_64/x86_64-gnu-llvm-16/script.sh /tmp/

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-17/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-17/Dockerfile
@@ -46,7 +46,6 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-17 \
       --enable-llvm-link-shared \
-      $USE_NEW_MANGLING \
       --set rust.thin-lto-import-instr-limit=10
 
 COPY host-x86_64/x86_64-gnu-llvm-16/script.sh /tmp/

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-17/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-17/Dockerfile
@@ -24,7 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   xz-utils \
   nodejs \
   mingw-w64 \
+  libgccjit-13-dev \
   && rm -rf /var/lib/apt/lists/*
+
+# Note: libgccjit needs to match the default gcc version for the linker to find it.
 
 # Install powershell (universal package) so we can test x.ps1 on Linux
 RUN curl -sL "https://github.com/PowerShell/PowerShell/releases/download/v7.3.1/powershell_7.3.1-1.deb_amd64.deb" > powershell.deb && \
@@ -43,6 +46,7 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-17 \
       --enable-llvm-link-shared \
+      $USE_NEW_MANGLING \
       --set rust.thin-lto-import-instr-limit=10
 
 COPY host-x86_64/x86_64-gnu-llvm-16/script.sh /tmp/

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -270,11 +270,6 @@ touch $objdir/${SUMMARY_FILE}
 extra_env=""
 if [ "$ENABLE_GCC_CODEGEN" = "1" ]; then
   extra_env="$extra_env --env ENABLE_GCC_CODEGEN=1"
-  # If `ENABLE_GCC_CODEGEN` is set and not empty, we add the `--enable-new-symbol-mangling`
-  # argument to `RUST_CONFIGURE_ARGS` and set the `GCC_EXEC_PREFIX` environment variable.
-  # `cg_gcc` doesn't support the legacy mangling so we need to enforce the new one
-  # if we run `cg_gcc` tests.
-  extra_env="$extra_env --env USE_NEW_MANGLING=--enable-new-symbol-mangling"
   # Fix rustc_codegen_gcc lto issues.
   extra_env="$extra_env --env GCC_EXEC_PREFIX=/usr/lib/gcc/"
   echo "Setting extra environment values for docker: $extra_env"

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -269,14 +269,14 @@ touch $objdir/${SUMMARY_FILE}
 
 extra_env=""
 if [ "$ENABLE_GCC_CODEGEN" = "1" ]; then
-  extra_env="$EXTRA_ENV --env ENABLE_GCC_CODEGEN=1"
+  extra_env="$extra_env --env ENABLE_GCC_CODEGEN=1"
   # If `ENABLE_GCC_CODEGEN` is set and not empty, we add the `--enable-new-symbol-mangling`
   # argument to `RUST_CONFIGURE_ARGS` and set the `GCC_EXEC_PREFIX` environment variable.
   # `cg_gcc` doesn't support the legacy mangling so we need to enforce the new one
   # if we run `cg_gcc` tests.
-  extra_env="$EXTRA_ENV --env USE_NEW_MANGLING=--enable-new-symbol-mangling"
+  extra_env="$extra_env --env USE_NEW_MANGLING=--enable-new-symbol-mangling"
   # Fix rustc_codegen_gcc lto issues.
-  extra_env="$EXTRA_ENV --env GCC_EXEC_PREFIX=/usr/lib/gcc/"
+  extra_env="$extra_env --env GCC_EXEC_PREFIX=/usr/lib/gcc/"
   echo "Setting extra environment values for docker: $extra_env"
 fi
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -163,6 +163,14 @@ if [ "$IS_NOT_LATEST_LLVM" = "" ]; then
   export COMPILETEST_NEEDS_ALL_LLVM_COMPONENTS=1
 fi
 
+if [ "$ENABLE_GCC_CODEGEN" = "1" ]; then
+  # If `ENABLE_GCC_CODEGEN` is set and not empty, we add the `--enable-new-symbol-mangling`
+  # argument to `RUST_CONFIGURE_ARGS` and set the `GCC_EXEC_PREFIX` environment variable.
+  # `cg_gcc` doesn't support the legacy mangling so we need to enforce the new one
+  # if we run `cg_gcc` tests.
+  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-new-symbol-mangling"
+fi
+
 # Print the date from the local machine and the date from an external source to
 # check for clock drifts. An HTTP URL is used instead of HTTPS since on Azure
 # Pipelines it happened that the certificates were marked as expired.


### PR DESCRIPTION
When #117947 dropped llvm-15 from CI, we neglected to copy #117313's changes to enable `rustc_codegen_gcc` testing to the new base llvm-16. This is now restored, as well as copying the setup to llvm-17 as well so we hopefully won't miss it next time.

In addition, due to case mismatch in `$extra_env` updates in `docker/run.sh`, I think it wasn't actually getting enabled before, but this should now be fixed. I also avoided the linker hack for `libgccjit.so` that was present before, because that's not needed if the version matches the base `gcc` used for linking.

r? GuillaumeGomez