### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you wish to _contribute_ to the compiler, you should read
 [CONTRIBUTING.md](CONTRIBUTING.md) instead.
 
 <details>
-<summary>Table of content</summary>
+<summary>Table of contents</summary>
 
 - [Quick Start](#quick-start)
 - [Installing from Source](#installing-from-source)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you wish to _contribute_ to the compiler, you should read
 [CONTRIBUTING.md](CONTRIBUTING.md) instead.
 
 <details>
-<summary>Table of contents</summary>
+<summary>Table of Contents</summary>
 
 - [Quick Start](#quick-start)
 - [Installing from Source](#installing-from-source)


### PR DESCRIPTION
The section formerly titled "Table of content" has been corrected and capitalized using title case. It's now "Table of Contents".