### PR TITLE
Specialize sleep_until implementation

### DIFF
--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -86,6 +86,14 @@ impl Thread {
         }
     }
 
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            sleep(delay);
+        }
+    }
+
     pub fn join(self) {
         unsafe {
             let _ = hermit_abi::join(self.tid);

--- a/library/std/src/sys/pal/itron/thread.rs
+++ b/library/std/src/sys/pal/itron/thread.rs
@@ -205,6 +205,14 @@ impl Thread {
         }
     }
 
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            sleep(delay);
+        }
+    }
+
     pub fn join(self) {
         // Safety: `ThreadInner` is alive at this point
         let inner = unsafe { self.p_inner.as_ref() };

--- a/library/std/src/sys/pal/sgx/thread.rs
+++ b/library/std/src/sys/pal/sgx/thread.rs
@@ -131,6 +131,14 @@ impl Thread {
         usercalls::wait_timeout(0, dur, || true);
     }
 
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            sleep(delay);
+        }
+    }
+
     pub fn join(self) {
         self.0.wait();
     }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -408,7 +408,7 @@ impl Thread {
 #[cfg(target_vendor = "apple")]
 const KERN_SUCCESS: libc::c_int = 0;
 #[cfg(target_vendor = "apple")]
-const KERN_SUCCESS: libc::c_int = 14;
+const KERN_ABORTED: libc::c_int = 14;
 
 #[cfg(target_vendor = "apple")]
 #[repr(C)]

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -385,7 +385,7 @@ impl Thread {
                 if ret == KERN_SUCCESS {
                     break;
                 }
-                assert_eq!(KERN_ABORTED, "mach_wait_until returned error, code: {}", ret);
+                assert_eq!(KERN_ABORTED, "mach_wait_until returned error");
             }
         }
     }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -313,6 +313,7 @@ impl Thread {
         target_os = "dragonfly",
         target_os = "hurd",
         target_os = "fuchsia",
+        target_os = "vxworks",
         target_vendor = "apple"
     )))]
     pub fn sleep_until(deadline: Instant) {
@@ -334,6 +335,7 @@ impl Thread {
         target_os = "dragonfly",
         target_os = "hurd",
         target_os = "fuchsia",
+        target_os = "vxworks",
     ))]
     pub fn sleep_until(deadline: crate::time::Instant) {
         let mut ts = deadline

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -385,7 +385,7 @@ impl Thread {
                 if ret == KERN_SUCCESS {
                     break;
                 }
-                assert_eq!(KERN_ABORTED, "mach_wait_until returned error, code: {ret}");
+                assert_eq!(KERN_ABORTED, "mach_wait_until returned error, code: {}", ret);
             }
         }
     }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -357,10 +357,6 @@ impl Thread {
 
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
     pub fn sleep_until(deadline: crate::time::Instant) {
-        // does not count during sleep/suspend same as clock monotonic
-        // does instant use mach_absolute_time?
-        // https://developer.apple.com/library/archive/technotes/tn2169/_index.html
-
         use super::time::Timespec;
         use core::mem::MaybeUninit;
 

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -355,7 +355,13 @@ impl Thread {
         }
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos"
+    ))]
     pub fn sleep_until(deadline: crate::time::Instant) {
         use core::mem::MaybeUninit;
 
@@ -372,7 +378,7 @@ impl Thread {
             let info = info.assume_init();
             let ticks = nanos * (info.denom as u64) / (info.numer as u64);
 
-            mach_wait_until(ticks);
+            let ret = mach_wait_until(ticks);
             assert_eq!(ret, KERN_SUCCESS);
         }
     }
@@ -392,17 +398,35 @@ impl Thread {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
 const KERN_SUCCESS: libc::c_int = 0;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
 #[repr(C)]
 struct mach_timebase_info_type {
     numer: u32,
     denom: u32,
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos",
+    target_os = "visionos"
+))]
 extern "C" {
     fn mach_wait_until(deadline: u64) -> libc::c_int;
     fn mach_timebase_info(info: *mut mach_timebase_info_type) -> libc::c_int;

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -310,10 +310,10 @@ impl Thread {
         target_os = "android",
         target_os = "solaris",
         target_os = "illumos",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos"
+        target_os = "dragonfly",
+        target_os = "hurd",
+        target_os = "fuchsia",
+        target_vendor = "apple"
     )))]
     pub fn sleep_until(deadline: Instant) {
         let now = Instant::now();
@@ -323,7 +323,7 @@ impl Thread {
         }
     }
 
-    // Note depends on clock_nanosleep (not supported on macos/ios/watchos/tvos)
+    // Note depends on clock_nanosleep (not supported on os's by apple)
     #[cfg(any(
         target_os = "freebsd",
         target_os = "netbsd",
@@ -331,6 +331,9 @@ impl Thread {
         target_os = "android",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "dragonfly",
+        target_os = "hurd",
+        target_os = "fuchsia",
     ))]
     pub fn sleep_until(deadline: crate::time::Instant) {
         let mut ts = deadline
@@ -355,13 +358,7 @@ impl Thread {
         }
     }
 
-    #[cfg(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "visionos"
-    ))]
+    #[cfg(target_vendor = "apple")]
     pub fn sleep_until(deadline: crate::time::Instant) {
         use core::mem::MaybeUninit;
 
@@ -398,35 +395,17 @@ impl Thread {
     }
 }
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos",
-    target_os = "visionos"
-))]
+#[cfg(target_vendor = "apple")]
 const KERN_SUCCESS: libc::c_int = 0;
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos",
-    target_os = "visionos"
-))]
+#[cfg(target_vendor = "apple")]
 #[repr(C)]
 struct mach_timebase_info_type {
     numer: u32,
     denom: u32,
 }
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "tvos",
-    target_os = "watchos",
-    target_os = "visionos"
-))]
+#[cfg(target_vendor = "apple")]
 extern "C" {
     fn mach_wait_until(deadline: u64) -> libc::c_int;
     fn mach_timebase_info(info: *mut mach_timebase_info_type) -> libc::c_int;

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -363,6 +363,7 @@ impl Thread {
     #[cfg(target_vendor = "apple")]
     pub fn sleep_until(deadline: crate::time::Instant) {
         use core::mem::MaybeUninit;
+
         use super::time::Timespec;
 
         let Timespec { tv_sec, tv_nsec } = deadline.into_inner().into_timespec();

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -385,7 +385,7 @@ impl Thread {
                 if ret == KERN_SUCCESS {
                     break;
                 }
-                assert_eq!(KERN_ABORTED, "mach_wait_until returned error");
+                assert_eq!(ret, KERN_ABORTED, "mach_wait_until returned error, code: {}", ret);
             }
         }
     }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -357,8 +357,9 @@ impl Thread {
 
     #[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos", target_os = "watchos"))]
     pub fn sleep_until(deadline: crate::time::Instant) {
-        use super::time::Timespec;
         use core::mem::MaybeUninit;
+
+        use super::time::Timespec;
 
         let Timespec { tv_sec, tv_nsec } = deadline.into_inner().into_timespec();
         let nanos = (tv_sec as u64).saturating_mul(1_000_000_000).saturating_add(tv_nsec.0 as u64);

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -385,7 +385,7 @@ impl Thread {
                 if ret == KERN_SUCCESS {
                     break;
                 }
-                assert_eq!(ret, KERN_ABORTED, "mach_wait_until returned error, code: {}", ret);
+                assert_eq!(ret, KERN_ABORTED);
             }
         }
     }

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -287,6 +287,10 @@ impl Instant {
     pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
         Some(Instant { t: self.t.checked_sub_duration(other)? })
     }
+
+    pub(in crate::sys::unix) fn into_timespec(self) -> Timespec {
+        self.t
+    }
 }
 
 impl fmt::Debug for Instant {

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -19,7 +19,7 @@ pub(in crate::sys) const TIMESPEC_MAX_CAPPED: libc::timespec = libc::timespec {
 #[repr(transparent)]
 #[rustc_layout_scalar_valid_range_start(0)]
 #[rustc_layout_scalar_valid_range_end(999_999_999)]
-pub(in crate::sys::unix) struct Nanoseconds(pub(in crate::sys::unix) u32);
+pub(crate) struct Nanoseconds(pub(crate) u32);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemTime {
@@ -28,8 +28,8 @@ pub struct SystemTime {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Timespec {
-    tv_sec: i64,
-    tv_nsec: Nanoseconds,
+    pub(crate) tv_sec: i64,
+    pub(crate) tv_nsec: Nanoseconds,
 }
 
 impl SystemTime {
@@ -288,7 +288,7 @@ impl Instant {
         Some(Instant { t: self.t.checked_sub_duration(other)? })
     }
 
-    pub(in crate::sys::unix) fn into_timespec(self) -> Timespec {
+    pub(crate) fn into_timespec(self) -> Timespec {
         self.t
     }
 }

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -19,7 +19,7 @@ pub(in crate::sys) const TIMESPEC_MAX_CAPPED: libc::timespec = libc::timespec {
 #[repr(transparent)]
 #[rustc_layout_scalar_valid_range_start(0)]
 #[rustc_layout_scalar_valid_range_end(999_999_999)]
-struct Nanoseconds(u32);
+pub(in crate::sys::unix) struct Nanoseconds(pub(in crate::sys::unix) u32);
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SystemTime {

--- a/library/std/src/sys/pal/wasi/thread.rs
+++ b/library/std/src/sys/pal/wasi/thread.rs
@@ -197,6 +197,6 @@ fn sleep_with(nanos: u64, clock_id: wasi::Clockid, flags: u16) {
     }
 }
 
-pub fn available_parallelism() -> io::Result<NonZeroUsize> {
+pub fn available_parallelism() -> io::Result<NonZero<usize>> {
     unsupported()
 }

--- a/library/std/src/sys/pal/wasi/thread.rs
+++ b/library/std/src/sys/pal/wasi/thread.rs
@@ -3,7 +3,7 @@
 use crate::ffi::CStr;
 use crate::num::NonZero;
 use crate::sys::unsupported;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{io, mem};
 
 cfg_if::cfg_if! {
@@ -136,39 +136,23 @@ impl Thread {
     }
 
     pub fn sleep(dur: Duration) {
-        let mut nanos = dur.as_nanos();
+        let mut nanos_all = dur.as_nanos();
         while nanos > 0 {
-            const USERDATA: wasi::Userdata = 0x0123_45678;
-
-            let clock = wasi::SubscriptionClock {
-                id: wasi::CLOCKID_MONOTONIC,
-                timeout: u64::try_from(nanos).unwrap_or(u64::MAX),
-                precision: 0,
-                flags: 0,
-            };
-            nanos -= u128::from(clock.timeout);
-
-            let in_ = wasi::Subscription {
-                userdata: USERDATA,
-                u: wasi::SubscriptionU { tag: 0, u: wasi::SubscriptionUU { clock } },
-            };
-            unsafe {
-                let mut event: wasi::Event = mem::zeroed();
-                let res = wasi::poll_oneoff(&in_, &mut event, 1);
-                match (res, event) {
-                    (
-                        Ok(1),
-                        wasi::Event {
-                            userdata: USERDATA,
-                            error: wasi::ERRNO_SUCCESS,
-                            type_: wasi::EVENTTYPE_CLOCK,
-                            ..
-                        },
-                    ) => {}
-                    _ => panic!("thread::sleep(): unexpected result of poll_oneoff"),
-                }
-            }
+            let nanos_sleepable = u64::try_from(full_nanos).unwrap_or(u64::MAX);
+            nanos_all -= u128::from(nanos_sleepable);
+            sleep_with(nanos_sleepable, wasi::CLOCKID_MONOTONIC, 0);
         }
+    }
+
+    pub fn sleep_until(deadline: Instant) {
+        let nanos = deadline.into_inner().into_inner().as_nanos();
+        assert!(nanos <= u64::MAX as u128);
+
+        sleep_with(
+            nanos as u64,
+            wasi::CLOCKID_MONOTONIC,
+            wasi::SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME,
+        );
     }
 
     pub fn join(self) {
@@ -186,6 +170,33 @@ impl Thread {
     }
 }
 
-pub fn available_parallelism() -> io::Result<NonZero<usize>> {
+fn sleep_with(nanos: u64, clock_id: wasi::Clockid, flags: u16) {
+    const USERDATA: wasi::Userdata = 0x0123_45678;
+
+    let clock = wasi::SubscriptionClock { id: clock_id, timeout: nanos, precision: 0, flags };
+
+    let in_ = wasi::Subscription {
+        userdata: USERDATA,
+        u: wasi::SubscriptionU { tag: 0, u: wasi::SubscriptionUU { clock } },
+    };
+    unsafe {
+        let mut event: wasi::Event = mem::zeroed();
+        let res = wasi::poll_oneoff(&in_, &mut event, 1);
+        match (res, event) {
+            (
+                Ok(1),
+                wasi::Event {
+                    userdata: USERDATA,
+                    error: wasi::ERRNO_SUCCESS,
+                    type_: wasi::EVENTTYPE_CLOCK,
+                    ..
+                },
+            ) => {}
+            _ => panic!("thread::sleep(): unexpected result of poll_oneoff"),
+        }
+    }
+}
+
+pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()
 }

--- a/library/std/src/sys/pal/wasi/time.rs
+++ b/library/std/src/sys/pal/wasi/time.rs
@@ -36,6 +36,10 @@ impl Instant {
     pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
         Some(Instant(self.0.checked_sub(*other)?))
     }
+
+    pub(crate) fn into_inner(self) -> Duration {
+        self.0
+    }
 }
 
 impl SystemTime {

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -105,6 +105,14 @@ impl Thread {
         }
     }
 
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            sleep(delay);
+        }
+    }
+
     pub fn handle(&self) -> &Handle {
         &self.handle
     }

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -19,7 +19,7 @@ use crate::os::windows::io::{AsRawHandle, HandleOrNull};
 use crate::sys::handle::Handle;
 use crate::sys::{c, stack_overflow};
 use crate::sys_common::FromInner;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{io, ptr};
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
@@ -120,7 +120,7 @@ impl Thread {
         let now = Instant::now();
 
         if let Some(delay) = deadline.checked_duration_since(now) {
-            sleep(delay);
+            Self::sleep(delay);
         }
     }
 

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -8,7 +8,7 @@ use crate::os::windows::io::{AsRawHandle, HandleOrNull};
 use crate::sys::handle::Handle;
 use crate::sys::{c, stack_overflow};
 use crate::sys_common::FromInner;
-use crate::time::Duration;
+use crate::time::{Duration, Instant};
 use crate::{io, ptr};
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -116,6 +116,14 @@ impl Thread {
         }
     }
 
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            sleep(delay);
+        }
+    }
+
     pub fn handle(&self) -> &Handle {
         &self.handle
     }

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -1,3 +1,14 @@
+use crate::io;
+use crate::num::NonZeroUsize;
+use crate::os::windows::io::AsRawHandle;
+use crate::os::windows::io::HandleOrNull;
+use crate::ptr;
+use crate::sys::c;
+use crate::sys::handle::Handle;
+use crate::sys::stack_overflow;
+use crate::sys_common::FromInner;
+use crate::time::{Duration, Instant};
+
 use core::ffi::c_void;
 
 use super::time::WaitableTimer;
@@ -106,11 +117,22 @@ impl Thread {
     }
 
     pub fn sleep_until(deadline: Instant) {
-        let now = Instant::now();
-
-        if let Some(delay) = deadline.checked_duration_since(now) {
-            sleep(delay);
+        fn high_precision_sleep(deadline: Instant) -> Result<(), ()> {
+            let timer = WaitableTimer::high_resolution()?;
+            timer.set_deadline(deadline.into_inner())?;
+            timer.wait()
         }
+        // Attempt to use high-precision sleep (Windows 10, version 1803+).
+        // On error fallback to the standard `Sleep` function.
+        // Also preserves the zero duration behaviour of `Sleep`.
+        if high_precision_sleep(deadline).is_ok() {
+            return;
+        }
+
+        let now = Instant::now();
+        if let Some(dur) = deadline.checked_duration_since(now) {
+            unsafe { c::Sleep(super::dur2timeout(dur)) }
+        };
     }
 
     pub fn handle(&self) -> &Handle {

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -1,14 +1,3 @@
-use crate::io;
-use crate::num::NonZeroUsize;
-use crate::os::windows::io::AsRawHandle;
-use crate::os::windows::io::HandleOrNull;
-use crate::ptr;
-use crate::sys::c;
-use crate::sys::handle::Handle;
-use crate::sys::stack_overflow;
-use crate::sys_common::FromInner;
-use crate::time::{Duration, Instant};
-
 use core::ffi::c_void;
 
 use super::time::WaitableTimer;
@@ -19,7 +8,7 @@ use crate::os::windows::io::{AsRawHandle, HandleOrNull};
 use crate::sys::handle::Handle;
 use crate::sys::{c, stack_overflow};
 use crate::sys_common::FromInner;
-use crate::time::{Duration, Instant};
+use crate::time::Duration;
 use crate::{io, ptr};
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -116,25 +116,6 @@ impl Thread {
         }
     }
 
-    pub fn sleep_until(deadline: Instant) {
-        fn high_precision_sleep(deadline: Instant) -> Result<(), ()> {
-            let timer = WaitableTimer::high_resolution()?;
-            timer.set_deadline(deadline.into_inner())?;
-            timer.wait()
-        }
-        // Attempt to use high-precision sleep (Windows 10, version 1803+).
-        // On error fallback to the standard `Sleep` function.
-        // Also preserves the zero duration behaviour of `Sleep`.
-        if high_precision_sleep(deadline).is_ok() {
-            return;
-        }
-
-        let now = Instant::now();
-        if let Some(dur) = deadline.checked_duration_since(now) {
-            unsafe { c::Sleep(super::dur2timeout(dur)) }
-        };
-    }
-
     pub fn handle(&self) -> &Handle {
         &self.handle
     }

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -248,6 +248,12 @@ impl WaitableTimer {
         let result = unsafe { c::SetWaitableTimer(self.handle, &time, 0, None, null(), c::FALSE) };
         if result != 0 { Ok(()) } else { Err(()) }
     }
+    pub fn set_deadline(&self, deadline: Instant) -> Result<(), ()> {
+        // Convert the Instant to a format similar to FILETIME.
+        let time = checked_dur2intervals(&deadline.t).ok_or(())?;
+        let result = unsafe { c::SetWaitableTimer(self.handle, &time, 0, None, null(), c::FALSE) };
+        if result != 0 { Ok(()) } else { Err(()) }
+    }
     pub fn wait(&self) -> Result<(), ()> {
         let result = unsafe { c::WaitForSingleObject(self.handle, c::INFINITE) };
         if result != c::WAIT_FAILED { Ok(()) } else { Err(()) }

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -248,12 +248,6 @@ impl WaitableTimer {
         let result = unsafe { c::SetWaitableTimer(self.handle, &time, 0, None, null(), c::FALSE) };
         if result != 0 { Ok(()) } else { Err(()) }
     }
-    pub fn set_deadline(&self, deadline: Instant) -> Result<(), ()> {
-        // Convert the Instant to a format similar to FILETIME.
-        let time = checked_dur2intervals(&deadline.t).ok_or(())?;
-        let result = unsafe { c::SetWaitableTimer(self.handle, &time, 0, None, null(), c::FALSE) };
-        if result != 0 { Ok(()) } else { Err(()) }
-    }
     pub fn wait(&self) -> Result<(), ()> {
         let result = unsafe { c::WaitForSingleObject(self.handle, c::INFINITE) };
         if result != c::WAIT_FAILED { Ok(()) } else { Err(()) }

--- a/library/std/src/sys/pal/xous/thread.rs
+++ b/library/std/src/sys/pal/xous/thread.rs
@@ -128,6 +128,14 @@ impl Thread {
         }
     }
 
+    pub fn sleep_until(deadline: Instant) {
+        let now = Instant::now();
+
+        if let Some(delay) = deadline.checked_duration_since(now) {
+            sleep(delay);
+        }
+    }
+
     pub fn join(self) {
         join_thread(self.tid).unwrap();
     }

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -896,14 +896,12 @@ pub fn sleep(dur: Duration) {
 /// | Illumos   | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Darwin    | [mach_wait_until]                                                    |
 /// | WASI      | [subscription_clock]                                                 |
-/// | Windows   | [SetWaitableTimer]                                                   |
 /// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |
 ///
 /// [currently]: crate::io#platform-specific-behavior
 /// [clock_nanosleep]: https://linux.die.net/man/3/clock_nanosleep
 /// [subscription_clock]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-subscription_clock-record
 /// [mach_wait_until]: https://developer.apple.com/library/archive/technotes/tn2169/_index.html
-/// [SetWaitableTimer]: https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setwaitabletimer
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -878,8 +878,34 @@ pub fn sleep(dur: Duration) {
 ///
 /// # Platform-specific behavior
 ///
-/// This function uses [`sleep`] internally, see its platform-specific behavior.
+/// In most cases this function will call an OS specific function. Where that
+/// is not supported [`sleep`] is used. Those platforms are referred to as other
+/// in the table below.
 ///
+/// # Underlying System calls
+///
+/// The following system calls are [currently] being used:
+///
+///
+/// |  Platform |               System call                                            |
+/// |-----------|----------------------------------------------------------------------|
+/// | Linux     | [clock_nanosleep] (Monotonic clock)                                  |
+/// | BSD except OpenBSD | [clock_nanosleep] (Monotonic Clock)]                        |
+/// | Android   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Solaris   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Illumos   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Darwin    | [mach_wait_until]                                                    |
+/// | WASI      | [subscription_clock]                                                 |
+/// | Windows   | [SetWaitableTimer]                                                   |
+/// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |
+///
+/// [currently]: crate::io#platform-specific-behavior
+/// [clock_nanosleep]: https://linux.die.net/man/3/clock_nanosleep
+/// [subscription_clock]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-subscription_clock-record
+/// [mach_wait_until]: https://developer.apple.com/library/archive/technotes/tn2169/_index.html
+/// [SetWaitableTimer]: https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-setwaitabletimer
+///
+/// **Disclaimer:** These system calls might change over time.
 ///
 /// # Examples
 ///
@@ -904,9 +930,9 @@ pub fn sleep(dur: Duration) {
 /// }
 /// ```
 ///
-/// A slow api we must not call too fast and which takes a few
+/// A slow API we must not call too fast and which takes a few
 /// tries before succeeding. By using `sleep_until` the time the
-/// api call takes does not influence when we retry or when we give up
+/// API call takes does not influence when we retry or when we give up
 ///
 /// ```no_run
 /// #![feature(thread_sleep_until)]

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -941,11 +941,7 @@ pub fn sleep(dur: Duration) {
 /// ```
 #[unstable(feature = "thread_sleep_until", issue = "113752")]
 pub fn sleep_until(deadline: Instant) {
-    let now = Instant::now();
-
-    if let Some(delay) = deadline.checked_duration_since(now) {
-        sleep(delay);
-    }
+    imp::Thread::sleep_until(deadline)
 }
 
 /// Used to ensure that `park` and `park_timeout` do not unwind, as that can

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -894,6 +894,9 @@ pub fn sleep(dur: Duration) {
 /// | Android   | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Solaris   | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Illumos   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Dragonfly | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Hurd      | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Fuchsia   | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Darwin    | [mach_wait_until]                                                    |
 /// | WASI      | [subscription_clock]                                                 |
 /// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -897,6 +897,7 @@ pub fn sleep(dur: Duration) {
 /// | Dragonfly | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Hurd      | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Fuchsia   | [clock_nanosleep] (Monotonic Clock)]                                 |
+/// | Vxworks   | [clock_nanosleep] (Monotonic Clock)]                                 |
 /// | Darwin    | [mach_wait_until]                                                    |
 /// | WASI      | [subscription_clock]                                                 |
 /// | Other     | `sleep_until` uses [`sleep`] and does not issue a syscall itself     |

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -403,6 +403,10 @@ impl Instant {
     pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
         self.0.checked_sub_duration(&duration).map(Instant)
     }
+
+    pub(crate) fn into_inner(self) -> time::Instant {
+        self.0
+    }
 }
 
 #[stable(feature = "time2", since = "1.8.0")]

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -404,6 +404,8 @@ impl Instant {
         self.0.checked_sub_duration(&duration).map(Instant)
     }
 
+    // used by platform specific sleep_until implementations, no every platform has one
+    #[allow(unused)]
     pub(crate) fn into_inner(self) -> time::Instant {
         self.0
     }

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -1,9 +1,8 @@
+#![feature(thread_sleep_until)]
 use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
-#[feature(thread_sleep_until)]
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_os = "wasi"), ignore)] // no threads

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -2,6 +2,8 @@ use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+#[feature(thread_sleep_until)]
+use std::time::Instant;
 
 #[test]
 #[cfg_attr(any(target_os = "emscripten", target_os = "wasi"), ignore)] // no threads
@@ -77,4 +79,15 @@ fn thread_local_hygeiene() {
 fn available_parallelism() {
     // check that std::thread::available_parallelism() returns a valid value
     assert!(thread::available_parallelism().is_ok());
+}
+
+#[test]
+fn sleep_until() {
+    let now = Instant::now();
+    let period = Duration::from_millis(100);
+    let deadline = now + period;
+    thread::sleep_until(deadline);
+
+    let elapsed = now.elapsed();
+    assert!(elapsed >= period);
 }


### PR DESCRIPTION
Draft (I need the CI tests, which will probably fail)
related tracking issue: https://github.com/rust-lang/rust/issues/113752

Replaces the generic catch all implementation with `target_os` specific ones for: linux/netbsd/freebsd/android/solaris/illumos, wasi, macos/ios/tvos/watchos and windows.

Points of attention:
 - Adds `extern "C"` calls to `mach_wait_until` and `mach_timebase_info` for macos etc. We could also import them from the mach2 crate, but then we depend on mach2 and we need to modify mach2 to work as an std dep (adding a feature `rustc-dep-of-std`).
 - The implementations need access to the `target_os` specific details of the Instant type. For that I added an into_inner and made some fields public. Is there a neater way?
 - All untested, I only have access to an linux install. I hope the CI catches any issues.