### PR TITLE
explain a good reason for why LocalValue does not store the type of the local

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -173,6 +173,9 @@ impl<Prov: Provenance> std::fmt::Debug for LocalState<'_, Prov> {
 }
 
 /// Current value of a local variable
+///
+/// This does not store the type of the local; the type is given by `body.local_decls` and can never
+/// change, so by not storing here we avoid having to maintain that as an invariant.
 #[derive(Copy, Clone, Debug)] // Miri debug-prints these
 pub(super) enum LocalValue<Prov: Provenance = AllocId> {
     /// This local is not currently alive, and cannot be used at all.


### PR DESCRIPTION
As found out by @lcnr in https://github.com/rust-lang/rust/pull/112307, storing the type here can lead to subtle bugs when it gets out of sync with the MIR body. That's not the reason why the interpreter does it this way I think, but good thing we dodged that bullet. :)