### PR TITLE
Enforce `must_use` on associated types and RPITITs that have a must-use trait in bounds

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -291,7 +291,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                         .map(|inner| MustUsePath::Pinned(Box::new(inner)))
                 }
                 ty::Adt(def, _) => is_def_must_use(cx, def.did(), span),
-                ty::Alias(ty::Opaque, ty::AliasTy { def_id: def, .. }) => {
+                ty::Alias(ty::Opaque | ty::Projection, ty::AliasTy { def_id: def, .. }) => {
                     elaborate(
                         cx.tcx,
                         cx.tcx.explicit_item_bounds(def).instantiate_identity_iter_copied(),

--- a/tests/ui/lint/unused/assoc-types.assoc_ty.stderr
+++ b/tests/ui/lint/unused/assoc-types.assoc_ty.stderr
@@ -1,0 +1,15 @@
+error: unused implementer of `Future` that must be used
+  --> $DIR/assoc-types.rs:19:5
+   |
+LL |     T::foo();
+   |     ^^^^^^^^
+   |
+   = note: futures do nothing unless you `.await` or poll them
+note: the lint level is defined here
+  --> $DIR/assoc-types.rs:4:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/unused/assoc-types.rpitit.stderr
+++ b/tests/ui/lint/unused/assoc-types.rpitit.stderr
@@ -1,0 +1,15 @@
+error: unused implementer of `Future` that must be used
+  --> $DIR/assoc-types.rs:19:5
+   |
+LL |     T::foo();
+   |     ^^^^^^^^
+   |
+   = note: futures do nothing unless you `.await` or poll them
+note: the lint level is defined here
+  --> $DIR/assoc-types.rs:4:9
+   |
+LL | #![deny(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/unused/assoc-types.rs
+++ b/tests/ui/lint/unused/assoc-types.rs
@@ -1,0 +1,23 @@
+// edition: 2021
+// revisions: rpitit assoc_ty
+
+#![deny(unused_must_use)]
+
+use std::future::Future;
+
+pub trait Tr {
+    type Fut: Future<Output = ()>;
+
+    #[cfg(rpitit)]
+    fn foo() -> impl Future<Output = ()>;
+
+    #[cfg(assoc_ty)]
+    fn foo() -> Self::Fut;
+}
+
+pub async fn bar<T: Tr>() {
+    T::foo();
+    //~^ ERROR unused implementer of `Future` that must be used
+}
+
+fn main() {}


### PR DESCRIPTION
Warn when an RPITIT or (un-normalized) associated type with a `#[must_use]` trait in its bounds is unused.

This is pending T-lang approval, since it changes the semantics of the `#[must_use]` attribute slightly, but I think it strictly catches more strange errors.

I could also limit this to just RPITITs, but that seems less useful.

Fixes #118444