### PR TITLE
On outer attr not found, avoid knock-down errors

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1039,6 +1039,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             if let Ok((Some(ext), _)) = this.resolve_macro_path(
                                 derive,
                                 Some(MacroKind::Derive),
+                                ast::AttrStyle::Outer,
                                 parent_scope,
                                 false,
                                 false,

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -443,6 +443,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             match this.resolve_macro_path(
                                 derive,
                                 Some(MacroKind::Derive),
+                                ast::AttrStyle::Outer,
                                 parent_scope,
                                 true,
                                 force,

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3868,9 +3868,14 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         if qself.is_none() {
             let path_seg = |seg: &Segment| PathSegment::from_ident(seg.ident);
             let path = Path { segments: path.iter().map(path_seg).collect(), span, tokens: None };
-            if let Ok((_, res)) =
-                self.r.resolve_macro_path(&path, None, &self.parent_scope, false, false)
-            {
+            if let Ok((_, res)) = self.r.resolve_macro_path(
+                &path,
+                None,
+                AttrStyle::Outer,
+                &self.parent_scope,
+                false,
+                false,
+            ) {
                 return Ok(Some(PartialRes::new(res)));
             }
         }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1046,7 +1046,7 @@ pub struct Resolver<'a, 'tcx> {
     proc_macro_stubs: FxHashSet<LocalDefId>,
     /// Traces collected during macro resolution and validated when it's complete.
     single_segment_macro_resolutions:
-        Vec<(Ident, MacroKind, ParentScope<'a>, Option<NameBinding<'a>>)>,
+        Vec<(Ident, MacroKind, ast::AttrStyle, ParentScope<'a>, Option<NameBinding<'a>>)>,
     multi_segment_macro_resolutions:
         Vec<(Vec<Segment>, Span, MacroKind, ParentScope<'a>, Option<Res>)>,
     builtin_attrs: Vec<(Ident, ParentScope<'a>)>,

--- a/tests/ui/proc-macro/derive-helper-legacy-spurious.rs
+++ b/tests/ui/proc-macro/derive-helper-legacy-spurious.rs
@@ -5,8 +5,10 @@
 #[macro_use]
 extern crate test_macros;
 
-#[derive(Empty)] //~ ERROR cannot determine resolution for the attribute macro `derive`
+#[derive(Empty, Clone)] // no error emitted here
 #[empty_helper] //~ ERROR cannot find attribute `empty_helper` in this scope
 struct Foo {}
 
-fn main() {}
+fn main() {
+    let _ = Foo.clone(); // no error emitted here
+}

--- a/tests/ui/proc-macro/derive-helper-legacy-spurious.stderr
+++ b/tests/ui/proc-macro/derive-helper-legacy-spurious.stderr
@@ -4,19 +4,11 @@ error: cannot find attribute `dummy` in this scope
 LL | #![dummy]
    |    ^^^^^
 
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/derive-helper-legacy-spurious.rs:8:3
-   |
-LL | #[derive(Empty)]
-   |   ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: cannot find attribute `empty_helper` in this scope
   --> $DIR/derive-helper-legacy-spurious.rs:9:3
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
When we encounter code like

```rust
#![non_existent]

#[derive(Clone)]
struct S;

fn main() {
    S.clone();
}
```

we avoid emitting errors about the `derive` (which isn't early resolved as normal, but *has* a later resolution) and stop the compiler from advancing to later stages, to avoid knock down errors from the `derive` not being evaluated. Recovering these would be possible, but would produce incorrect errors in the cases where had the outer attribute been present it would have modified the behavior/evaluation of the `derive` attributes.

Furthermore, the fan-out of knock down errors caused by this case is incredibly high, easily causing thousands of errors by the introduction of a single incorrect outer attribute in the crate root.

Fix #118455.