### PR TITLE
rustc_hir_typeck: Fix ICE when probing for non-ASCII function alternative

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1799,9 +1799,10 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                         .iter()
                         .find(|cand| self.matches_by_doc_alias(cand.def_id))
                         .map(|cand| cand.name)
-                })
-                .unwrap();
-                Ok(applicable_close_candidates.into_iter().find(|method| method.name == best_name))
+                });
+                Ok(best_name.and_then(|best_name| {
+                    applicable_close_candidates.into_iter().find(|method| method.name == best_name)
+                }))
             }
         })
     }

--- a/tests/ui/suggestions/non_ascii_ident.rs
+++ b/tests/ui/suggestions/non_ascii_ident.rs
@@ -1,4 +1,7 @@
 fn main() {
     // There shall be no suggestions here. In particular not `Ok`.
     let _ = 读文; //~ ERROR cannot find value `读文` in this scope
+
+    let f = 0f32; // Important line to make this an ICE regression test
+    读文(f); //~ ERROR cannot find function `读文` in this scope
 }

--- a/tests/ui/suggestions/non_ascii_ident.stderr
+++ b/tests/ui/suggestions/non_ascii_ident.stderr
@@ -4,6 +4,12 @@ error[E0425]: cannot find value `读文` in this scope
 LL |     let _ = 读文;
    |             ^^^^ not found in this scope
 
-error: aborting due to 1 previous error
+error[E0425]: cannot find function `读文` in this scope
+  --> $DIR/non_ascii_ident.rs:6:5
+   |
+LL |     读文(f);
+   |     ^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Closes #118499

Apparently triggered by https://github.com/rust-lang/rust/pull/118381