### PR TITLE
Add ADT variant infomation to StableMIR and finish implementing TyKind::internal()

### DIFF
--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -9,7 +9,13 @@ use rustc_middle::ty::{self as rustc_ty, Ty as InternalTy};
 use rustc_span::Symbol;
 use stable_mir::mir::alloc::AllocId;
 use stable_mir::mir::mono::{Instance, MonoItem, StaticDef};
-use stable_mir::ty::{AdtDef, Binder, BoundRegionKind, BoundTyKind, BoundVariableKind, ClosureKind, Const, ExistentialTraitRef, FloatTy, GenericArgKind, GenericArgs, IndexedVal, IntTy, Region, RigidTy, Span, TraitRef, Ty, UintTy, VariantDef, VariantIdx};
+use stable_mir::mir::{Mutability, Safety};
+use stable_mir::ty::{
+    Abi, AdtDef, Binder, BoundRegionKind, BoundTyKind, BoundVariableKind, ClosureKind, Const,
+    DynKind, ExistentialPredicate, ExistentialProjection, ExistentialTraitRef, FloatTy, FnSig,
+    GenericArgKind, GenericArgs, IndexedVal, IntTy, Movability, Region, RigidTy, Span, TermKind,
+    TraitRef, Ty, UintTy, VariantDef, VariantIdx,
+};
 use stable_mir::{CrateItem, DefId};
 
 use super::RustcInternal;
@@ -80,17 +86,38 @@ impl<'tcx> RustcInternal<'tcx> for RigidTy {
             }
             RigidTy::Str => rustc_ty::TyKind::Str,
             RigidTy::Slice(ty) => rustc_ty::TyKind::Slice(ty.internal(tables)),
-            RigidTy::RawPtr(..)
-            | RigidTy::Ref(..)
-            | RigidTy::Foreign(_)
-            | RigidTy::FnDef(_, _)
-            | RigidTy::FnPtr(_)
-            | RigidTy::Closure(..)
-            | RigidTy::Coroutine(..)
-            | RigidTy::CoroutineWitness(..)
-            | RigidTy::Dynamic(..)
-            | RigidTy::Tuple(..) => {
-                todo!()
+            RigidTy::RawPtr(ty, mutability) => rustc_ty::TyKind::RawPtr(rustc_ty::TypeAndMut {
+                ty: ty.internal(tables),
+                mutbl: mutability.internal(tables),
+            }),
+            RigidTy::Ref(region, ty, mutability) => rustc_ty::TyKind::Ref(
+                region.internal(tables),
+                ty.internal(tables),
+                mutability.internal(tables),
+            ),
+            RigidTy::Foreign(def) => rustc_ty::TyKind::Foreign(def.0.internal(tables)),
+            RigidTy::FnDef(def, args) => {
+                rustc_ty::TyKind::FnDef(def.0.internal(tables), args.internal(tables))
+            }
+            RigidTy::FnPtr(sig) => rustc_ty::TyKind::FnPtr(sig.internal(tables)),
+            RigidTy::Closure(def, args) => {
+                rustc_ty::TyKind::Closure(def.0.internal(tables), args.internal(tables))
+            }
+            RigidTy::Coroutine(def, args, mov) => rustc_ty::TyKind::Coroutine(
+                def.0.internal(tables),
+                args.internal(tables),
+                mov.internal(tables),
+            ),
+            RigidTy::CoroutineWitness(def, args) => {
+                rustc_ty::TyKind::CoroutineWitness(def.0.internal(tables), args.internal(tables))
+            }
+            RigidTy::Dynamic(predicate, region, dyn_kind) => rustc_ty::TyKind::Dynamic(
+                tables.tcx.mk_poly_existential_predicates(&predicate.internal(tables)),
+                region.internal(tables),
+                dyn_kind.internal(tables),
+            ),
+            RigidTy::Tuple(tys) => {
+                rustc_ty::TyKind::Tuple(tables.tcx.mk_type_list(&tys.internal(tables)))
             }
         }
     }
@@ -133,6 +160,41 @@ impl<'tcx> RustcInternal<'tcx> for FloatTy {
         match self {
             FloatTy::F32 => rustc_ty::FloatTy::F32,
             FloatTy::F64 => rustc_ty::FloatTy::F64,
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for Mutability {
+    type T = rustc_ty::Mutability;
+
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            Mutability::Not => rustc_ty::Mutability::Not,
+            Mutability::Mut => rustc_ty::Mutability::Mut,
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for Movability {
+    type T = rustc_ty::Movability;
+
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            Movability::Static => rustc_ty::Movability::Static,
+            Movability::Movable => rustc_ty::Movability::Movable,
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for FnSig {
+    type T = rustc_ty::FnSig<'tcx>;
+
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        rustc_ty::FnSig {
+            inputs_and_output: tables.tcx.mk_type_list(&self.inputs_and_output.internal(tables)),
+            c_variadic: self.c_variadic,
+            unsafety: self.unsafety.internal(tables),
+            abi: self.abi.internal(tables),
         }
     }
 }
@@ -242,6 +304,58 @@ impl<'tcx> RustcInternal<'tcx> for BoundVariableKind {
     }
 }
 
+impl<'tcx> RustcInternal<'tcx> for DynKind {
+    type T = rustc_ty::DynKind;
+
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            DynKind::Dyn => rustc_ty::DynKind::Dyn,
+            DynKind::DynStar => rustc_ty::DynKind::DynStar,
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for ExistentialPredicate {
+    type T = rustc_ty::ExistentialPredicate<'tcx>;
+
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            ExistentialPredicate::Trait(trait_ref) => {
+                rustc_ty::ExistentialPredicate::Trait(trait_ref.internal(tables))
+            }
+            ExistentialPredicate::Projection(proj) => {
+                rustc_ty::ExistentialPredicate::Projection(proj.internal(tables))
+            }
+            ExistentialPredicate::AutoTrait(trait_def) => {
+                rustc_ty::ExistentialPredicate::AutoTrait(trait_def.0.internal(tables))
+            }
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for ExistentialProjection {
+    type T = rustc_ty::ExistentialProjection<'tcx>;
+
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        rustc_ty::ExistentialProjection {
+            def_id: self.def_id.0.internal(tables),
+            args: self.generic_args.internal(tables),
+            term: self.term.internal(tables),
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for TermKind {
+    type T = rustc_ty::Term<'tcx>;
+
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            TermKind::Type(ty) => ty.internal(tables).into(),
+            TermKind::Const(const_) => ty_const(const_, tables).into(),
+        }
+    }
+}
+
 impl<'tcx> RustcInternal<'tcx> for ExistentialTraitRef {
     type T = rustc_ty::ExistentialTraitRef<'tcx>;
 
@@ -291,6 +405,53 @@ impl<'tcx> RustcInternal<'tcx> for AdtDef {
     }
 }
 
+impl<'tcx> RustcInternal<'tcx> for Abi {
+    type T = rustc_target::spec::abi::Abi;
+
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        match *self {
+            Abi::Rust => rustc_target::spec::abi::Abi::Rust,
+            Abi::C { unwind } => rustc_target::spec::abi::Abi::C { unwind },
+            Abi::Cdecl { unwind } => rustc_target::spec::abi::Abi::Cdecl { unwind },
+            Abi::Stdcall { unwind } => rustc_target::spec::abi::Abi::Stdcall { unwind },
+            Abi::Fastcall { unwind } => rustc_target::spec::abi::Abi::Fastcall { unwind },
+            Abi::Vectorcall { unwind } => rustc_target::spec::abi::Abi::Vectorcall { unwind },
+            Abi::Thiscall { unwind } => rustc_target::spec::abi::Abi::Thiscall { unwind },
+            Abi::Aapcs { unwind } => rustc_target::spec::abi::Abi::Aapcs { unwind },
+            Abi::Win64 { unwind } => rustc_target::spec::abi::Abi::Win64 { unwind },
+            Abi::SysV64 { unwind } => rustc_target::spec::abi::Abi::SysV64 { unwind },
+            Abi::PtxKernel => rustc_target::spec::abi::Abi::PtxKernel,
+            Abi::Msp430Interrupt => rustc_target::spec::abi::Abi::Msp430Interrupt,
+            Abi::X86Interrupt => rustc_target::spec::abi::Abi::X86Interrupt,
+            Abi::AmdGpuKernel => rustc_target::spec::abi::Abi::AmdGpuKernel,
+            Abi::EfiApi => rustc_target::spec::abi::Abi::EfiApi,
+            Abi::AvrInterrupt => rustc_target::spec::abi::Abi::AvrInterrupt,
+            Abi::AvrNonBlockingInterrupt => rustc_target::spec::abi::Abi::AvrNonBlockingInterrupt,
+            Abi::CCmseNonSecureCall => rustc_target::spec::abi::Abi::CCmseNonSecureCall,
+            Abi::Wasm => rustc_target::spec::abi::Abi::Wasm,
+            Abi::System { unwind } => rustc_target::spec::abi::Abi::System { unwind },
+            Abi::RustIntrinsic => rustc_target::spec::abi::Abi::RustIntrinsic,
+            Abi::RustCall => rustc_target::spec::abi::Abi::RustCall,
+            Abi::PlatformIntrinsic => rustc_target::spec::abi::Abi::PlatformIntrinsic,
+            Abi::Unadjusted => rustc_target::spec::abi::Abi::Unadjusted,
+            Abi::RustCold => rustc_target::spec::abi::Abi::RustCold,
+            Abi::RiscvInterruptM => rustc_target::spec::abi::Abi::RiscvInterruptM,
+            Abi::RiscvInterruptS => rustc_target::spec::abi::Abi::RiscvInterruptS,
+        }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for Safety {
+    type T = rustc_hir::Unsafety;
+
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        match self {
+            Safety::Unsafe => rustc_hir::Unsafety::Unsafe,
+            Safety::Normal => rustc_hir::Unsafety::Normal,
+        }
+    }
+}
+
 impl<'tcx> RustcInternal<'tcx> for Span {
     type T = rustc_span::Span;
 
@@ -309,6 +470,7 @@ where
         (*self).internal(tables)
     }
 }
+
 impl<'tcx, T> RustcInternal<'tcx> for Option<T>
 where
     T: RustcInternal<'tcx>,
@@ -317,5 +479,16 @@ where
 
     fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
         self.as_ref().map(|inner| inner.internal(tables))
+    }
+}
+
+impl<'tcx, T> RustcInternal<'tcx> for Vec<T>
+where
+    T: RustcInternal<'tcx>,
+{
+    type T = Vec<T::T>;
+
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        self.iter().map(|e| e.internal(tables)).collect()
     }
 }

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -9,11 +9,7 @@ use rustc_middle::ty::{self as rustc_ty, Ty as InternalTy};
 use rustc_span::Symbol;
 use stable_mir::mir::alloc::AllocId;
 use stable_mir::mir::mono::{Instance, MonoItem, StaticDef};
-use stable_mir::ty::{
-    AdtDef, Binder, BoundRegionKind, BoundTyKind, BoundVariableKind, ClosureKind, Const,
-    ExistentialTraitRef, FloatTy, GenericArgKind, GenericArgs, IntTy, Region, RigidTy, Span,
-    TraitRef, Ty, UintTy,
-};
+use stable_mir::ty::{AdtDef, Binder, BoundRegionKind, BoundTyKind, BoundVariableKind, ClosureKind, Const, ExistentialTraitRef, FloatTy, GenericArgKind, GenericArgs, IndexedVal, IntTy, Region, RigidTy, Span, TraitRef, Ty, UintTy, VariantDef, VariantIdx};
 use stable_mir::{CrateItem, DefId};
 
 use super::RustcInternal;
@@ -138,6 +134,22 @@ impl<'tcx> RustcInternal<'tcx> for FloatTy {
             FloatTy::F32 => rustc_ty::FloatTy::F32,
             FloatTy::F64 => rustc_ty::FloatTy::F64,
         }
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for VariantIdx {
+    type T = rustc_target::abi::VariantIdx;
+
+    fn internal(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        rustc_target::abi::VariantIdx::from(self.to_index())
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for VariantDef {
+    type T = &'tcx rustc_ty::VariantDef;
+
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        self.adt_def.internal(tables).variant(self.idx.internal(tables))
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -13,7 +13,7 @@ use stable_mir::mir::mono::{InstanceDef, StaticDef};
 use stable_mir::mir::Body;
 use stable_mir::ty::{
     AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FnDef, GenericArgs, LineInfo,
-    PolyFnSig, RigidTy, Span, TyKind,
+    PolyFnSig, RigidTy, Span, TyKind, VariantDef,
 };
 use stable_mir::{self, Crate, CrateItem, DefId, Error, Filename, ItemKind, Symbol};
 use std::cell::RefCell;
@@ -207,6 +207,16 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         let def_id = def.0.internal(&mut *tables);
         let sig = tables.tcx.fn_sig(def_id).instantiate(tables.tcx, args.internal(&mut *tables));
         sig.stable(&mut *tables)
+    }
+
+    fn adt_variants_len(&self, def: AdtDef) -> usize {
+        let mut tables = self.0.borrow_mut();
+        def.internal(&mut *tables).variants().len()
+    }
+
+    fn variant_name(&self, def: VariantDef) -> Symbol {
+        let mut tables = self.0.borrow_mut();
+        def.internal(&mut *tables).name.to_string()
     }
 
     fn eval_target_usize(&self, cnst: &Const) -> Result<u64, Error> {

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -255,16 +255,11 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         tables.tcx.type_of(item.internal(&mut *tables)).instantiate_identity().stable(&mut *tables)
     }
 
-    fn def_ty_with_args(
-        &self,
-        item: stable_mir::DefId,
-        args: &GenericArgs,
-    ) -> Result<stable_mir::ty::Ty, Error> {
+    fn def_ty_with_args(&self, item: stable_mir::DefId, args: &GenericArgs) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
         let args = args.internal(&mut *tables);
         let def_ty = tables.tcx.type_of(item.internal(&mut *tables));
-        // FIXME(celinval): use try_fold instead to avoid crashing.
-        Ok(def_ty.instantiate(tables.tcx, args).stable(&mut *tables))
+        def_ty.instantiate(tables.tcx, args).stable(&mut *tables)
     }
 
     fn const_literal(&self, cnst: &stable_mir::ty::Const) -> String {

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -517,7 +517,7 @@ impl<'tcx> Stable<'tcx> for mir::AggregateKind<'tcx> {
             mir::AggregateKind::Adt(def_id, var_idx, generic_arg, user_ty_index, field_idx) => {
                 stable_mir::mir::AggregateKind::Adt(
                     tables.adt_def(*def_id),
-                    var_idx.index(),
+                    var_idx.stable(tables),
                     generic_arg.stable(tables),
                     user_ty_index.map(|idx| idx.index()),
                     field_idx.map(|idx| idx.index()),

--- a/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
@@ -75,24 +75,3 @@ impl<'tcx> Stable<'tcx> for rustc_span::Span {
         tables.create_span(*self)
     }
 }
-
-impl<'tcx, T> Stable<'tcx> for &[T]
-where
-    T: Stable<'tcx>,
-{
-    type T = Vec<T::T>;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
-        self.iter().map(|e| e.stable(tables)).collect()
-    }
-}
-
-impl<'tcx, T, U> Stable<'tcx> for (T, U)
-where
-    T: Stable<'tcx>,
-    U: Stable<'tcx>,
-{
-    type T = (T::T, U::T);
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
-        (self.0.stable(tables), self.1.stable(tables))
-    }
-}

--- a/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
@@ -60,11 +60,29 @@ impl<'tcx> Stable<'tcx> for rustc_hir::CoroutineKind {
     }
 }
 
+impl<'tcx> Stable<'tcx> for rustc_span::Symbol {
+    type T = stable_mir::Symbol;
+
+    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+        self.to_string()
+    }
+}
+
 impl<'tcx> Stable<'tcx> for rustc_span::Span {
     type T = stable_mir::ty::Span;
 
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
         tables.create_span(*self)
+    }
+}
+
+impl<'tcx, T> Stable<'tcx> for &[T]
+where
+    T: Stable<'tcx>,
+{
+    type T = Vec<T::T>;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        self.iter().map(|e| e.stable(tables)).collect()
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -137,6 +137,17 @@ impl<'tcx> Stable<'tcx> for ty::AdtKind {
     }
 }
 
+impl<'tcx> Stable<'tcx> for ty::FieldDef {
+    type T = stable_mir::ty::FieldDef;
+
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        stable_mir::ty::FieldDef {
+            def: tables.create_def_id(self.did),
+            name: self.name.stable(tables),
+        }
+    }
+}
+
 impl<'tcx> Stable<'tcx> for ty::GenericArgs<'tcx> {
     type T = stable_mir::ty::GenericArgs;
     fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -141,3 +141,24 @@ where
         }
     }
 }
+
+impl<'tcx, T> Stable<'tcx> for &[T]
+where
+    T: Stable<'tcx>,
+{
+    type T = Vec<T::T>;
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        self.iter().map(|e| e.stable(tables)).collect()
+    }
+}
+
+impl<'tcx, T, U> Stable<'tcx> for (T, U)
+where
+    T: Stable<'tcx>,
+    U: Stable<'tcx>,
+{
+    type T = (T::T, U::T);
+    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        (self.0.stable(tables), self.1.stable(tables))
+    }
+}

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -9,7 +9,7 @@ use crate::mir::alloc::{AllocId, GlobalAlloc};
 use crate::mir::mono::{Instance, InstanceDef, StaticDef};
 use crate::mir::Body;
 use crate::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FnDef, GenericArgs,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, GenericArgs,
     GenericPredicates, Generics, ImplDef, ImplTrait, LineInfo, PolyFnSig, RigidTy, Span, TraitDecl,
     TraitDef, Ty, TyKind, VariantDef,
 };
@@ -76,6 +76,7 @@ pub trait Context {
 
     /// The name of a variant.
     fn variant_name(&self, def: VariantDef) -> Symbol;
+    fn variant_fields(&self, def: VariantDef) -> Vec<FieldDef>;
 
     /// Evaluate constant as a target usize.
     fn eval_target_usize(&self, cnst: &Const) -> Result<u64, Error>;
@@ -88,6 +89,9 @@ pub trait Context {
 
     /// Returns the type of given crate item.
     fn def_ty(&self, item: DefId) -> Ty;
+
+    /// Returns the type of given definition instantiated with the given arguments.
+    fn def_ty_with_args(&self, item: DefId, args: &GenericArgs) -> Result<Ty, Error>;
 
     /// Returns literal value of a const as a string.
     fn const_literal(&self, cnst: &Const) -> String;

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -11,7 +11,7 @@ use crate::mir::Body;
 use crate::ty::{
     AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FnDef, GenericArgs,
     GenericPredicates, Generics, ImplDef, ImplTrait, LineInfo, PolyFnSig, RigidTy, Span, TraitDecl,
-    TraitDef, Ty, TyKind,
+    TraitDef, Ty, TyKind, VariantDef,
 };
 use crate::{
     mir, Crate, CrateItem, CrateItems, DefId, Error, Filename, ImplTraitDecls, ItemKind, Symbol,
@@ -70,6 +70,12 @@ pub trait Context {
 
     /// Retrieve the function signature for the given generic arguments.
     fn fn_sig(&self, def: FnDef, args: &GenericArgs) -> PolyFnSig;
+
+    /// The number of variants in this ADT.
+    fn adt_variants_len(&self, def: AdtDef) -> usize;
+
+    /// The name of a variant.
+    fn variant_name(&self, def: VariantDef) -> Symbol;
 
     /// Evaluate constant as a target usize.
     fn eval_target_usize(&self, cnst: &Const) -> Result<u64, Error>;

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -91,7 +91,7 @@ pub trait Context {
     fn def_ty(&self, item: DefId) -> Ty;
 
     /// Returns the type of given definition instantiated with the given arguments.
-    fn def_ty_with_args(&self, item: DefId, args: &GenericArgs) -> Result<Ty, Error>;
+    fn def_ty_with_args(&self, item: DefId, args: &GenericArgs) -> Ty;
 
     /// Returns literal value of a const as a string.
     fn const_literal(&self, cnst: &Const) -> String;

--- a/compiler/stable_mir/src/error.rs
+++ b/compiler/stable_mir/src/error.rs
@@ -28,7 +28,7 @@ pub enum CompilerError<T> {
 }
 
 /// A generic error to represent an API request that cannot be fulfilled.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Error(pub(crate) String);
 
 impl Error {

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -1,6 +1,7 @@
 use crate::mir::pretty::{function_body, pretty_statement, pretty_terminator};
 use crate::ty::{
     AdtDef, ClosureDef, Const, CoroutineDef, GenericArgs, Movability, Region, RigidTy, Ty, TyKind,
+    VariantIdx,
 };
 use crate::{Error, Opaque, Span, Symbol};
 use std::io;
@@ -9,17 +10,17 @@ use std::io;
 pub struct Body {
     pub blocks: Vec<BasicBlock>,
 
-    // Declarations of locals within the function.
-    //
-    // The first local is the return value pointer, followed by `arg_count`
-    // locals for the function arguments, followed by any user-declared
-    // variables and temporaries.
+    /// Declarations of locals within the function.
+    ///
+    /// The first local is the return value pointer, followed by `arg_count`
+    /// locals for the function arguments, followed by any user-declared
+    /// variables and temporaries.
     pub(super) locals: LocalDecls,
 
-    // The number of arguments this function takes.
+    /// The number of arguments this function takes.
     pub(super) arg_count: usize,
 
-    // Debug information pertaining to user variables, including captures.
+    /// Debug information pertaining to user variables, including captures.
     pub(super) var_debug_info: Vec<VarDebugInfo>,
 }
 
@@ -67,6 +68,11 @@ impl Body {
     /// `arg_locals`, and `inner_locals`.
     pub fn locals(&self) -> &[LocalDecl] {
         &self.locals
+    }
+
+    /// Get the local declaration for this local.
+    pub fn local_decl(&self, local: Local) -> Option<&LocalDecl> {
+        self.locals.get(local)
     }
 
     pub fn dump<W: io::Write>(&self, w: &mut W) -> io::Result<()> {
@@ -492,12 +498,32 @@ pub struct Place {
     pub projection: Vec<ProjectionElem>,
 }
 
+impl From<Local> for Place {
+    fn from(local: Local) -> Self {
+        Place { local, projection: vec![] }
+    }
+}
+
+/// Debug information pertaining to a user variable.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VarDebugInfo {
+    /// The variable name.
     pub name: Symbol,
+
+    /// Source info of the user variable, including the scope
+    /// within which the variable is visible (to debuginfo)
     pub source_info: SourceInfo,
+
+    /// The user variable's data is split across several fragments,
+    /// each described by a `VarDebugInfoFragment`.
     pub composite: Option<VarDebugInfoFragment>,
+
+    /// Where the data for this user variable is to be found.
     pub value: VarDebugInfoContents,
+
+    /// When present, indicates what argument number this variable is in the function that it
+    /// originated from (starting from 1). Note, if MIR inlining is enabled, then this is the
+    /// argument number in the original function before it was inlined.
     pub argument_index: Option<u16>,
 }
 
@@ -633,21 +659,6 @@ pub const RETURN_LOCAL: Local = 0;
 /// `c`'s `FieldIdx` is `0`, and
 /// `g`'s `FieldIdx` is `2`.
 type FieldIdx = usize;
-
-/// The source-order index of a variant in a type.
-///
-/// For example, in the following types,
-/// ```ignore(illustrative)
-/// enum Demo1 {
-///    Variant0 { a: bool, b: i32 },
-///    Variant1 { c: u8, d: u64 },
-/// }
-/// struct Demo2 { e: u8, f: u16, g: u8 }
-/// ```
-/// `a` is in the variant with the `VariantIdx` of `0`,
-/// `c` is in the variant with the `VariantIdx` of `1`, and
-/// `g` is in the variant with the `VariantIdx` of `0`.
-pub type VariantIdx = usize;
 
 type UserTypeAnnotationIndex = usize;
 

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -511,7 +511,7 @@ pub struct VarDebugInfo {
     pub name: Symbol,
 
     /// Source info of the user variable, including the scope
-    /// within which the variable is visible (to debuginfo)
+    /// within which the variable is visible (to debuginfo).
     pub source_info: SourceInfo,
 
     /// The user variable's data is split across several fragments,

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -658,7 +658,7 @@ pub const RETURN_LOCAL: Local = 0;
 /// `b`'s `FieldIdx` is `1`,
 /// `c`'s `FieldIdx` is `0`, and
 /// `g`'s `FieldIdx` is `2`.
-type FieldIdx = usize;
+pub type FieldIdx = usize;
 
 type UserTypeAnnotationIndex = usize;
 

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -452,7 +452,7 @@ impl Location {
 }
 
 /// Information about a place's usage.
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PlaceContext {
     /// Whether the access is mutable or not. Keep this private so we can increment the type in a
     /// backward compatible manner.

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -382,7 +382,9 @@ impl AdtDef {
     }
 
     /// Retrieve the type of this Adt instantiating the type with the given arguments.
-    pub fn ty_with_args(&self, args: &GenericArgs) -> Result<Ty, Error> {
+    ///
+    /// This will assume the type can be instantiated with these arguments.
+    pub fn ty_with_args(&self, args: &GenericArgs) -> Ty {
         with(|cx| cx.def_ty_with_args(self.0, args))
     }
 
@@ -441,6 +443,7 @@ impl VariantDef {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FieldDef {
     /// The field definition.
     ///
@@ -454,7 +457,9 @@ pub struct FieldDef {
 
 impl FieldDef {
     /// Retrieve the type of this field instantiating the type with the given arguments.
-    pub fn ty_with_args(&self, args: &GenericArgs) -> Result<Ty, Error> {
+    ///
+    /// This will assume the type can be instantiated with these arguments.
+    pub fn ty_with_args(&self, args: &GenericArgs) -> Ty {
         with(|cx| cx.def_ty_with_args(self.def, args))
     }
 

--- a/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
+++ b/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
@@ -1,0 +1,115 @@
+// run-pass
+//! Test that users are able to use stable mir APIs to retrieve monomorphized types, and that
+//! we have an error handling for trying to instantiate types with incorrect arguments.
+
+// ignore-stage1
+// ignore-cross-compile
+// ignore-remote
+// ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
+// edition: 2021
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+#![feature(control_flow_enum)]
+
+extern crate rustc_middle;
+#[macro_use]
+extern crate rustc_smir;
+extern crate rustc_driver;
+extern crate rustc_interface;
+extern crate stable_mir;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::rustc_internal;
+use stable_mir::ty::{RigidTy, TyKind, Ty, };
+use stable_mir::mir::{Body, MirVisitor, FieldIdx, Place, ProjectionElem, visit::{Location,
+                                                                            PlaceContext}};
+use std::io::Write;
+use std::ops::ControlFlow;
+
+const CRATE_NAME: &str = "input";
+
+/// This function uses the Stable MIR APIs to get information about the test crate.
+fn test_stable_mir(_tcx: TyCtxt<'_>) -> ControlFlow<()> {
+    let main_fn = stable_mir::entry_fn();
+    let body = main_fn.unwrap().body();
+    let mut visitor = PlaceVisitor{ body: &body, tested: false};
+    visitor.visit_body(&body);
+    assert!(visitor.tested);
+    ControlFlow::Continue(())
+}
+
+struct PlaceVisitor<'a> {
+    body: &'a Body,
+    /// Used to ensure that the test was reachable. Otherwise this test would vacuously succeed.
+    tested: bool,
+}
+
+/// Check that `wrapper.inner` place projection can be correctly interpreted.
+/// Ensure that instantiation is correct.
+fn check_tys(local_ty: Ty, idx: FieldIdx, expected_ty: Ty) {
+    let TyKind::RigidTy(RigidTy::Adt(def, args)) = local_ty.kind() else { unreachable!() };
+    assert_eq!(def.ty_with_args(&args), local_ty);
+
+    let field_def = &def.variants_iter().next().unwrap().fields()[idx];
+    let field_ty = field_def.ty_with_args(&args);
+    assert_eq!(field_ty, expected_ty);
+
+    // Check that the generic version is different than the instantiated one.
+    let field_ty_gen = field_def.ty();
+    assert_ne!(field_ty_gen, field_ty);
+}
+
+impl<'a> MirVisitor for PlaceVisitor<'a> {
+    fn visit_place(&mut self, place: &Place, _ptx: PlaceContext, _loc: Location) {
+        let start_ty = self.body.locals()[place.local].ty;
+        match place.projection.as_slice() {
+            [ProjectionElem::Field(idx, ty)] => {
+                check_tys(start_ty, *idx, *ty);
+                self.tested = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "ty_fold_input.rs";
+    generate_input(&path).unwrap();
+    let args = vec![
+        "rustc".to_string(),
+        "-Cpanic=abort".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, tcx, test_stable_mir(tcx)).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+        struct Wrapper<T: Default> {{
+            pub inner: T
+        }}
+
+        impl<T: Default> Wrapper<T> {{
+            pub fn new() -> Wrapper<T> {{
+                Wrapper {{ inner: T::default() }}
+            }}
+        }}
+
+        fn main() {{
+            let wrapper = Wrapper::<u8>::new();
+            let _inner = wrapper.inner;
+        }}
+    "#
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
Introduce a `VariantDef` type and a mechanism to retrieve the definition from an `AdtDef`.

The `VariantDef` representation itself is just a combination of `AdtDef` and `VariantIdx`, which allow us to retrieve further information of a variant. I don't think we need to cache extra information for now, and we can translate on an on demand manner. I am  leaving the fields public today due to https://github.com/rust-lang/project-stable-mir/issues/56, but they shouldn't. For this PR, I've only added a method to retrieve the variant name, and its fields. I also added an implementation of `RustcInternal` that allow users to retrieve more information using Rust internal APIs.

I have also finished the implementation of `RustcInternal` for `TyKind` which fixes https://github.com/rust-lang/project-stable-mir/issues/46.

## Motivation

Both of these changes are needed in order to properly interpret things like projections. For example,
- The variant definition is used to find out which variant we are downcasting to.
- Being able to create `Ty` from `TyKind` helps for example processing each stage of a projection, like the code in `place.ty()`.