### PR TITLE
fix(trim-paths): trim `SO` and `DW_AT_comp_dir` symbols for root DI node

### DIFF
--- a/tests/run-make/split-debuginfo/Makefile
+++ b/tests/run-make/split-debuginfo/Makefile
@@ -1,6 +1,10 @@
 # ignore-cross-compile
 include ../tools.mk
 
+export HERE := $(shell pwd)
+export REMAPPED_OUT := /my-remapped-out
+export REMAPPED_CWD := /my-remapped-cwd
+
 all: off packed unpacked
 
 ifeq ($(UNAME),Darwin)
@@ -11,23 +15,200 @@ off:
 	[ ! -d $(TMPDIR)/foo.dSYM ]
 
 # Packed by default, but only if debuginfo is requested
-packed:
-	rm -rf $(TMPDIR)/*.dSYM
-	$(RUSTC) foo.rs
-	[ ! -d $(TMPDIR)/foo.dSYM ]
-	rm -rf $(TMPDIR)/*.dSYM
-	$(RUSTC) foo.rs -g
+packed: packed-remapped-object-scope packed-remapped-macro-scope packed-remapped-split-debuginfo-scope
+
+# - Debuginfo in binary file
+# - `.o` deleted
+# - `.dSYM` present
+packed-remapped-object-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=object foo.rs -g
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	[ -d $(TMPDIR)/foo.dSYM ]
-	rm -rf $(TMPDIR)/*.dSYM
-	$(RUSTC) foo.rs -g -C split-debuginfo=packed
+
+	# binary contains remapped paths
+	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains no original paths
+	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# dSYM bundle contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+
+	# dSYM bundle contains original paths
+	grep --text $(HERE) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo || exit 1
+
+	rm -rf $(TMPDIR)/foo.dSYM
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in binary file
+# - `.o` deleted
+# - `.dSYM` present
+packed-remapped-macro-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=macro foo.rs -g
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	[ -d $(TMPDIR)/foo.dSYM ]
-	rm -rf $(TMPDIR)/*.dSYM
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# dSYM bundle contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+
+	# dSYM bundle contains original paths
+	grep --text $(HERE) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo || exit 1
+
+	rm -rf $(TMPDIR)/foo.dSYM
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in binary file
+# - `.o` deleted
+# - `.dSYM` present
+packed-remapped-split-debuginfo-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=split-debuginfo,split-debuginfo-path foo.rs -g
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
+	[ -d $(TMPDIR)/foo.dSYM ]
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
+	nm -pa $(TMPDIR)/foo | grep " SO " | grep $(REMAPPED_CWD) || exit 1
+	nm -pa $(TMPDIR)/foo | grep --invert-match " SO " | (! grep $(REMAPPED_CWD)) || exit 1
+
+	# binary contains original paths
+	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	## dSYM bundle contains remapped paths
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo || exit 1
+
+	## dSYM bundle contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+
+	rm -rf $(TMPDIR)/foo.dSYM
+	rm $(TMPDIR)/$(call BIN,foo)
 
 # Object files are preserved with unpacked and `dsymutil` isn't run
-unpacked:
-	$(RUSTC) foo.rs -g -C split-debuginfo=unpacked
+unpacked: unpacked-remapped-object-scope unpacked-remapped-macro-scope unpacked-remapped-split-debuginfo-scope
+
+# - Debuginfo in object files
+# - `.o` present
+# - `.dSYM` never created
+unpacked-remapped-object-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=object foo.rs -g
 	ls $(TMPDIR)/*.o
 	[ ! -d $(TMPDIR)/foo.dSYM ]
+
+	# binary contains remapped paths
+	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains no original paths
+	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# object file contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o) || exit 1
+
+	# object file contains original paths
+	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
+
+	rm $(TMPDIR)/*.o
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in object files
+# - `.o` present,
+# - `.dSYM` never created
+unpacked-remapped-macro-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=macro foo.rs -g
+	ls $(TMPDIR)/*.o
+	[ ! -d $(TMPDIR)/foo.dSYM ]
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# object file contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o) || exit 1
+
+	# object file contains original paths
+	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
+
+	rm $(TMPDIR)/*.o
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in object files
+# - `.o` present
+# - `.dSYM` never created
+unpacked-remapped-split-debuginfo-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=split-debuginfo,split-debuginfo-path foo.rs -g
+	ls $(TMPDIR)/*.o
+	[ ! -d $(TMPDIR)/foo.dSYM ]
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
+	nm -pa $(TMPDIR)/foo | grep " SO " | grep $(REMAPPED_CWD) || exit 1
+	nm -pa $(TMPDIR)/foo | grep --invert-match " SO " | (! grep $(REMAPPED_CWD)) || exit 1
+
+	# binary contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# object file contains remapped paths
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o || exit 1
+
+	# object file contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.o) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.*.o) || exit 1
+
+	rm $(TMPDIR)/*.o
+	rm $(TMPDIR)/$(call BIN,foo)
+
 else
 ifdef IS_WINDOWS
 # Windows only supports packed debuginfo - nothing to test.

--- a/tests/run-make/split-debuginfo/Makefile
+++ b/tests/run-make/split-debuginfo/Makefile
@@ -285,7 +285,9 @@ packed-lto-single:
 	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
 	rm $(TMPDIR)/libbaz.rlib
 
-packed-remapped: packed-remapped-split packed-remapped-single packed-remapped-scope packed-remapped-wrong-scope
+packed-remapped: packed-remapped-split packed-remapped-single \
+	packed-remapped-object-scope packed-remapped-macro-scope \
+	packed-remapped-split-debuginfo-scope
 
 # - Debuginfo in `.dwo` files
 # - `.o` and binary refer to remapped `.dwo` paths which do not exist
@@ -294,52 +296,160 @@ packed-remapped: packed-remapped-split packed-remapped-single packed-remapped-sc
 # - `.dwp` present
 packed-remapped-split:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
-		-Z split-dwarf-kind=split --remap-path-prefix $(TMPDIR)=/a foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
+		-Z split-dwarf-kind=split \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# dwp contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dwp || exit 1
+
+	# dwp contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.dwp) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.dwp) || exit 1
+
 	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
 	rm $(TMPDIR)/foo.dwp
 	rm $(TMPDIR)/$(call BIN,foo)
 
-# - Debuginfo in `.o` files
+# - Debuginfo in `.dwp` files
 # - `.o` and binary refer to remapped `.o` paths which do not exist
 # - `.o` deleted
 # - `.dwo` never created
 # - `.dwp` present
 packed-remapped-single:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
-		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
+		-Z split-dwarf-kind=single \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# dwp contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dwp || exit 1
+
+	# dwp contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.dwp) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.dwp) || exit 1
+
 	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
 	rm $(TMPDIR)/foo.dwp
 	rm $(TMPDIR)/$(call BIN,foo)
 
-# - Debuginfo in `.o` files
+# - Debuginfo in `.dwp` files
 # - `.o` and binary refer to remapped `.o` paths which do not exist
 # - `.o` deleted
 # - `.dwo` never created
 # - `.dwp` present
-packed-remapped-scope:
+packed-remapped-object-scope:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
-		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a \
-		-Z remap-path-scope=split-debuginfo-path foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=object foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	# FIXME: bnary contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(HERE) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(HERE)) || exit 1
+
+	# dwp contains no remapped paths
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dwp) || exit 1
+	# FIXME: dwp contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
+	readelf -wi $(TMPDIR)/foo.dwp | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
+	readelf -wi $(TMPDIR)/foo.dwp | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
+
+	# dwp contains original paths
+	# FIXME: dwp contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.dwp) || exit 1
+
 	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
 	rm $(TMPDIR)/foo.dwp
 	rm $(TMPDIR)/$(call BIN,foo)
 
-# - Debuginfo in `.o` files
+# - Debuginfo in `.dwp` files
 # - `.o` and binary refer to remapped `.o` paths which do not exist
 # - `.o` deleted
 # - `.dwo` never created
 # - `.dwp` present
-packed-remapped-wrong-scope:
+packed-remapped-macro-scope:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
-		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
 		-Z remap-path-scope=macro foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (grep $(TMPDIR)) || exit 1
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# dwp contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dwp) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dwp) || exit 1
+
+	# dwp contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo.dwp || exit 1
+
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
+	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
+	rm $(TMPDIR)/foo.dwp
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in `.dwp` files
+# - `.o` deleted
+# - `.dwo` never created
+# - `.dwp` present
+packed-remapped-split-debuginfo-scope:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=packed -C debuginfo=2 \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=split-debuginfo,split-debuginfo-path foo.rs -g
+
+	# binary contains remapped dwo path
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(REMAPPED_CWD) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(REMAPPED_CWD)) || exit 1
+
+	# binary contains no original --out-dir (DW_AT_GNU_dwo_name was remapped)
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# dwp contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dwp || exit 1
+
+	# dwp contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.dwp) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.dwp) || exit 1
+
 	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
 	rm $(TMPDIR)/foo.dwp
@@ -441,17 +551,108 @@ unpacked-lto-single:
 	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
 	rm $(TMPDIR)/libbaz.rlib
 
-unpacked-remapped: unpacked-remapped-split unpacked-remapped-single unpacked-remapped-scope unpacked-remapped-wrong-scope
+unpacked-remapped: unpacked-remapped-split unpacked-remapped-single \
+	unpacked-remapped-object-scope unpacked-remapped-macro-scope \
+	unpacked-remapped-split-debuginfo-scope
+
+# - Debuginfo in `.dwo` files
+# - `.o` deleted
+# - `.dwo` present
+# - `.dwp` never created
+unpacked-remapped-split:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		-Z split-dwarf-kind=split \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# dwo contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.dwo || exit 1
+
+	# dwo contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.dwo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.*.dwo) || exit 1
+
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
+	rm $(TMPDIR)/*.dwo
+	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in `.o` files
+# - `.o` present
+# - `.dwo` never created
+# - `.dwp` never created
+unpacked-remapped-single:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		-Z split-dwarf-kind=single \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# object file contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o || exit 1
+
+	# object file contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.o) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.*.o) || exit 1
+
+	rm $(TMPDIR)/*.o
+	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
+	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
+	rm $(TMPDIR)/$(call BIN,foo)
+
+unpacked-remapped-object-scope: unpacked-remapped-object-scope-split unpacked-remapped-object-scope-single
 
 # - Debuginfo in `.dwo` files
 # - `.o` and binary refer to remapped `.dwo` paths which do not exist
 # - `.o` deleted
 # - `.dwo` present
 # - `.dwp` never created
-unpacked-remapped-split:
+unpacked-remapped-object-scope-split:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
-		-Z split-dwarf-kind=split --remap-path-prefix $(TMPDIR)=/a foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
+		-Z split-dwarf-kind=split \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=object foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	# FIXME: binary should contains no cwd but now it got `DW_AT_comp_dir`
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which didn't get remapped.
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(HERE) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(HERE)) || exit 1
+
+	# dwo contains no remapped paths
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.dwo) || exit 1
+	# FIXME: dwo contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
+	readelf -wi $(TMPDIR)/foo.*.dwo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
+	readelf -wi $(TMPDIR)/foo.*.dwo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
+
+	# dwo contains original paths
+	# FIXME: dwo contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.dwo) || exit 1
+
 	ls $(TMPDIR)/*.o && exit 1 || exit 0
 	rm $(TMPDIR)/*.dwo
 	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
@@ -462,43 +663,176 @@ unpacked-remapped-split:
 # - `.o` present
 # - `.dwo` never created
 # - `.dwp` never created
-unpacked-remapped-single:
+unpacked-remapped-object-scope-single:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
-		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
+		-Z split-dwarf-kind=single \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=object foo.rs -g
+
+	# binary contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
+	# FIXME: binary should contains no cwd but now it got `DW_AT_comp_dir`
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which didn't get remapped.
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(HERE) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(HERE)) || exit 1
+
+	# object file contains no remapped paths
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o) || exit 1
+	# FIXME: object file contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
+	readelf -wi $(TMPDIR)/foo.*.o | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
+	readelf -wi $(TMPDIR)/foo.*.o | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
+
+	# object file contains original paths
+	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
+	# FIXME: object file contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.o) || exit 1
+
 	rm $(TMPDIR)/*.o
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
 	rm $(TMPDIR)/$(call BIN,foo)
 
-# - Debuginfo in `.o` files
-# - `.o` and binary refer to remapped `.o` paths which do not exist
-# - `.o` present
-# - `.dwo` never created
-# - `.dwp` never created
-unpacked-remapped-scope:
-	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
-		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a \
-		-Z remap-path-scope=split-debuginfo-path foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (! grep $(TMPDIR)) || exit 1
-	rm $(TMPDIR)/*.o
-	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
-	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
-	rm $(TMPDIR)/$(call BIN,foo)
+unpacked-remapped-macro-scope: unpacked-remapped-macro-scope-split unpacked-remapped-macro-scope-single
 
-# - Debuginfo in `.o` files
-# - `.o` and binary refer to remapped `.o` paths which do not exist
-# - `.o` present
-# - `.dwo` never created
+# - Debuginfo in `.dwo` files
+# - `.o` deleted
+# - `.dwo` present
 # - `.dwp` never created
-unpacked-remapped-wrong-scope:
+unpacked-remapped-macro-scope-split:
 	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
-		-Z split-dwarf-kind=single --remap-path-prefix $(TMPDIR)=/a \
+		-Z split-dwarf-kind=split \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
 		-Z remap-path-scope=macro foo.rs -g
-	objdump -Wi $(TMPDIR)/foo | grep DW_AT_GNU_dwo_name | (grep $(TMPDIR)) || exit 1
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# dwo contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.dwo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.dwo) || exit 1
+
+	# dwo contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo.*.dwo || exit 1
+
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
+	rm $(TMPDIR)/*.dwo
+	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in `.o` files
+# - `.o` present
+# - `.dwo` never created
+# - `.dwp` never created
+unpacked-remapped-macro-scope-single:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		-Z split-dwarf-kind=single \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=macro foo.rs -g
+
+	# binary contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+
+	# binary contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+
+	# object file contains no remapped paths
+	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o) || exit 1
+
+	# object file contains original paths
+	grep --text $(TMPDIR) $(TMPDIR)/foo.*.o || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
+
 	rm $(TMPDIR)/*.o
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
 	ls $(TMPDIR)/*.dwp && exit 1 || exit 0
+	rm $(TMPDIR)/$(call BIN,foo)
+
+unpacked-remapped-split-debuginfo-scope: unpacked-remapped-split-debuginfo-scope-split \
+	unpacked-remapped-split-debuginfo-scope-single
+
+# - Debuginfo in `.dwo` files
+# - `.o` deleted
+# - `.dwo` present
+# - `.dwp` never created
+unpacked-remapped-split-debuginfo-scope-split:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		-Z split-dwarf-kind=split \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=split-debuginfo,split-debuginfo-path foo.rs -g
+
+	# binary contains remapped dwo path
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(REMAPPED_CWD) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(REMAPPED_CWD)) || exit 1
+
+	# binary contains no original --out-dir (DW_AT_GNU_dwo_name was remapped)
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# dwo contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.dwo || exit 1
+
+	# dwo contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.dwo) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.*.dwo) || exit 1
+
+	ls $(TMPDIR)/*.o && exit 1 || exit 0
+	rm $(TMPDIR)/*.dwo
+	ls $(TMPDIR)/foo.dwp && exit 1 || exit 0
+	rm $(TMPDIR)/$(call BIN,foo)
+
+# - Debuginfo in `.o` files
+# - `.o` present
+# - `.dwo` never created
+# - `.dwp` never created
+unpacked-remapped-split-debuginfo-scope-single:
+	$(RUSTC) $(UNSTABLEOPTS) -C split-debuginfo=unpacked -C debuginfo=2 \
+		-Z split-dwarf-kind=single \
+		--remap-path-prefix $(TMPDIR)=$(REMAPPED_OUT) \
+		--remap-path-prefix $(HERE)=$(REMAPPED_CWD) \
+		-Z remap-path-scope=split-debuginfo,split-debuginfo-path foo.rs -g
+
+	# binary contains remapped dwo path
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
+	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(REMAPPED_CWD) || exit 1
+	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(REMAPPED_CWD)) || exit 1
+
+	# binary contains no original --out-dir (DW_AT_GNU_dwo_name was remapped)
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
+	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+
+	# object file contains remapped paths
+	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o || exit 1
+
+	# object file contains no original paths
+	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.o) || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo.*.o) || exit 1
+
+	rm $(TMPDIR)/*.o
+	ls $(TMPDIR)/*.dwo && exit 1 || exit 0
+	ls $(TMPDIR)/foo.dwp && exit 1 || exit 0
 	rm $(TMPDIR)/$(call BIN,foo)
 
 unpacked-crosscrate: unpacked-crosscrate-split unpacked-crosscrate-single

--- a/tests/run-make/split-debuginfo/Makefile
+++ b/tests/run-make/split-debuginfo/Makefile
@@ -31,18 +31,17 @@ packed-remapped-object-scope:
 	# binary contains remapped paths
 	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
 	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
-	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
 
 	# binary contains no original paths
 	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
 	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
-	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
-	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
 
 	# dSYM bundle contains no remapped paths
 	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+	# FIXME: dSYM bundle contains `DW_AT_comp_dir` in debug symbol, which shouldn't be remapped.
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo
 
 	# dSYM bundle contains original paths
 	grep --text $(HERE) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo || exit 1
@@ -92,22 +91,20 @@ packed-remapped-split-debuginfo-scope:
 
 	# binary contains no remapped paths
 	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
-	nm -pa $(TMPDIR)/foo | grep " SO " | grep $(REMAPPED_CWD) || exit 1
-	nm -pa $(TMPDIR)/foo | grep --invert-match " SO " | (! grep $(REMAPPED_CWD)) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
 
 	# binary contains original paths
 	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
 	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
-	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
-	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
 
 	## dSYM bundle contains remapped paths
 	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo || exit 1
 
 	## dSYM bundle contains no original paths
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
-	(! grep --text $(HERE) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo) || exit 1
+	# FIXME: dSYM bundle contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
+	grep --text $(HERE) $(TMPDIR)/foo.dSYM/Contents/Resources/DWARF/foo
 
 	rm -rf $(TMPDIR)/foo.dSYM
 	rm $(TMPDIR)/$(call BIN,foo)
@@ -129,18 +126,17 @@ unpacked-remapped-object-scope:
 	# binary contains remapped paths
 	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
 	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
-	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
 
 	# binary contains no original paths
 	# FIXME: As of 2023-12, `OSO` cannot be trimmed. See rust-lang/rust#116948
 	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
-	# FIXME: `SO` in the root debuginfo compile unit didn't get trimed. See rust-lang/rust#116948
-	grep --text $(HERE) $(TMPDIR)/foo || exit 1
+	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
 
 	# object file contains no remapped paths
 	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o) || exit 1
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o) || exit 1
+	# FIXME: object file contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o || exit 1
 
 	# object file contains original paths
 	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
@@ -190,21 +186,19 @@ unpacked-remapped-split-debuginfo-scope:
 
 	# binary contains no remapped paths
 	(! grep --text $(REMAPPED_OUT) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
-	nm -pa $(TMPDIR)/foo | grep " SO " | grep $(REMAPPED_CWD) || exit 1
-	nm -pa $(TMPDIR)/foo | grep --invert-match " SO " | (! grep $(REMAPPED_CWD)) || exit 1
+	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
 
 	# binary contains original paths
 	grep --text $(TMPDIR) $(TMPDIR)/foo || exit 1
-	# FIXME: binary contains `N_SO` (SO) in debug symbol, which got remapped.
-	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
 
 	# object file contains remapped paths
 	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o || exit 1
 
 	# object file contains no original paths
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.o) || exit 1
-	(! grep --text $(HERE) $(TMPDIR)/foo.*.o) || exit 1
+	# FIXME: object file contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
+	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
 
 	rm $(TMPDIR)/*.o
 	rm $(TMPDIR)/$(call BIN,foo)
@@ -366,14 +360,12 @@ packed-remapped-object-scope:
 
 	# binary contains remapped paths
 	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
 
 	# binary contains no original paths
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
-	# FIXME: bnary contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
-	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(HERE) || exit 1
-	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(HERE)) || exit 1
+	# FIXME: binary contains `.debug-line` in debug symbol, which didn't get remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(HERE) || exit 1
 
 	# dwp contains no remapped paths
 	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.dwp) || exit 1
@@ -434,14 +426,13 @@ packed-remapped-split-debuginfo-scope:
 	# binary contains remapped dwo path
 	readelf -wi $(TMPDIR)/foo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
 	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
-	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(REMAPPED_CWD) || exit 1
-	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(REMAPPED_CWD)) || exit 1
+	# binary contains no remapped cwd path
+	# FIXME: binary contains `.debug-line` in debug symbol, which got remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(REMAPPED_CWD) || exit 1
 
 	# binary contains no original --out-dir (DW_AT_GNU_dwo_name was remapped)
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
-	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
 
 	# dwp contains remapped paths
 	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.dwp || exit 1
@@ -634,14 +625,12 @@ unpacked-remapped-object-scope-split:
 
 	# binary contains remapped paths
 	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
-	# FIXME: binary should contains no cwd but now it got `DW_AT_comp_dir`
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
 
 	# binary contains no original paths
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which didn't get remapped.
-	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(HERE) || exit 1
-	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(HERE)) || exit 1
+	# FIXME: binary contains `.debug-line` in debug symbol, which didn't get remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(HERE) || exit 1
 
 	# dwo contains no remapped paths
 	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.dwo) || exit 1
@@ -672,17 +661,16 @@ unpacked-remapped-object-scope-single:
 
 	# binary contains remapped paths
 	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo || exit 1
-	# FIXME: binary should contains no cwd but now it got `DW_AT_comp_dir`
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo) || exit 1
+	grep --text $(REMAPPED_CWD) $(TMPDIR)/foo || exit 1
 
 	# binary contains no original paths
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which didn't get remapped.
-	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(HERE) || exit 1
-	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(HERE)) || exit 1
+	# FIXME: binary contains `.debug-line` in debug symbol, which didn't get remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(HERE) || exit 1
 
 	# object file contains no remapped paths
-	(! grep --text $(REMAPPED_CWD) $(TMPDIR)/foo.*.o) || exit 1
+	# FIXME: object file contains `.debug-line` in debug symbol, which didn't get remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(HERE) || exit 1
 	# FIXME: object file contains `DW_AT_GNU_dwo_name` in debug symbol, which got remapped.
 	readelf -wi $(TMPDIR)/foo.*.o | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
 	readelf -wi $(TMPDIR)/foo.*.o | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
@@ -779,14 +767,14 @@ unpacked-remapped-split-debuginfo-scope-split:
 	# binary contains remapped dwo path
 	readelf -wi $(TMPDIR)/foo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
 	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
-	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(REMAPPED_CWD) || exit 1
-	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(REMAPPED_CWD)) || exit 1
+	# binary contains no remapped cwd path
+	# FIXME: binary contains `.debug-line` in debug symbol, which got remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(REMAPPED_CWD) || exit 1
 
 	# binary contains no original --out-dir (DW_AT_GNU_dwo_name was remapped)
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
-	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+	# binary contains original cwd path
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
 
 	# dwo contains remapped paths
 	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.dwo || exit 1
@@ -814,21 +802,22 @@ unpacked-remapped-split-debuginfo-scope-single:
 	# binary contains remapped dwo path
 	readelf -wi $(TMPDIR)/foo | grep "DW_AT_GNU_dwo_name" | grep $(REMAPPED_OUT) || exit 1
 	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_GNU_dwo_name" | (! grep $(REMAPPED_OUT)) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
-	readelf -wi $(TMPDIR)/foo | grep "DW_AT_comp_dir" | grep $(REMAPPED_CWD) || exit 1
-	readelf -wi $(TMPDIR)/foo | grep --invert-match "DW_AT_comp_dir" | (! grep $(REMAPPED_CWD)) || exit 1
+	# binary contains no remapped cwd path
+	# FIXME: binary contains `.debug-line` in debug symbol, which got remapped.
+	readelf -wl $(TMPDIR)/foo | grep $(REMAPPED_CWD) || exit 1
 
 	# binary contains no original --out-dir (DW_AT_GNU_dwo_name was remapped)
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo) || exit 1
-	# FIXME: binary contains `DW_AT_comp_dir` in debug symbol, which got remapped.
-	(! grep --text $(HERE) $(TMPDIR)/foo) || exit 1
+	# binary contains original cwd path
+	grep --text $(HERE) $(TMPDIR)/foo || exit 1
 
 	# object file contains remapped paths
 	grep --text $(REMAPPED_OUT) $(TMPDIR)/foo.*.o || exit 1
 
 	# object file contains no original paths
 	(! grep --text $(TMPDIR) $(TMPDIR)/foo.*.o) || exit 1
-	(! grep --text $(HERE) $(TMPDIR)/foo.*.o) || exit 1
+	# FIXME: object file contains `DW_AT_comp_dir` in debug symbol, which should be remapped.
+	grep --text $(HERE) $(TMPDIR)/foo.*.o || exit 1
 
 	rm $(TMPDIR)/*.o
 	ls $(TMPDIR)/*.dwo && exit 1 || exit 0


### PR DESCRIPTION
This is one way to fix <https://github.com/rust-lang/rust/issues/117652>.

## The issue

When `--remap-path-scope=object` is specified, user expect that there is
no local path embedded in final executables. Under `object` scope, the
current implementation only remap debug symbols if debug info is
splitted into its own file. In other words, when
`split-debuginfo=packed|unpacked` is set, rustc assumes there is no
embedded path in the final executable needing to be remapped.

However, this doesn't work.

* On Linux, the root `DW_AT_comp_dir` of a compile unit seems to go into the binary executables.
* On macOS, `SO` symbols are embedded in binary executables and libraries regardless a split-debuginfo file is built. Each `SO` symbol contains a path to the root source file of a debug info compile unit.

## The approach

Path of working directory in the root DI node seems to be embedded in
executables. Hence, we trim them when the scope of `unsplit-debuginfo`
is present, as if it is kinda a "unsplit" debuginfo.


## Unresolved issue

* Not sure where to add more test to consolidate it.
* Haven't investigate if we should apply the same logic to cranelift [here](https://github.com/rust-lang/rust/blob/64d7e0d0b61c460fbc882ae37c0f236756dd9c39/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs#L68-L80).
* Not sure if there is any other consequence doing this, but AFAIK debugging still works on macOS and Linux  with `profile.dev.trim-paths="object"` fairly (with some extra tweaks in cargo).
* This might be related?
    from <https://github.com/llvm/llvm-project/blob/847d8457d16a7334ba39bdd35c70faa1b295304d/clang/lib/CodeGen/CGDebugInfo.cpp#L623-L631>
    ```
    The DIFile used by the CU is distinct from the main source
    file. Its directory part specifies what becomes the
    DW_AT_comp_dir (the compilation directory), even if the source
    file was specified with an absolute path.
    ```

