### PR TITLE
Suppress unhelpful diagnostics for unresolved top level attributes

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -514,6 +514,7 @@ pub enum StashKey {
     MaybeForgetReturn,
     /// Query cycle detected, stashing in favor of a better error.
     Cycle,
+    UndeterminedMacroResolution,
 }
 
 fn default_track_diagnostic(diag: Diagnostic, f: &mut dyn FnMut(Diagnostic)) {

--- a/tests/ui/derives/issue-36617.rs
+++ b/tests/ui/derives/issue-36617.rs
@@ -1,16 +1,16 @@
-#![derive(Copy)] //~ ERROR cannot determine resolution for the attribute macro `derive`
+#![derive(Copy)]
 //~^ ERROR `derive` attribute cannot be used at crate level
 
-#![test]//~ ERROR cannot determine resolution for the attribute macro `test`
+#![test]
 //~^ ERROR `test` attribute cannot be used at crate level
 
-#![test_case]//~ ERROR cannot determine resolution for the attribute macro `test_case`
+#![test_case]
 //~^ ERROR `test_case` attribute cannot be used at crate level
 
-#![bench]//~ ERROR cannot determine resolution for the attribute macro `bench`
+#![bench]
 //~^ ERROR `bench` attribute cannot be used at crate level
 
-#![global_allocator]//~ ERROR cannot determine resolution for the attribute macro `global_allocator`
+#![global_allocator]
 //~^ ERROR `global_allocator` attribute cannot be used at crate level
 
 fn main() {}

--- a/tests/ui/derives/issue-36617.stderr
+++ b/tests/ui/derives/issue-36617.stderr
@@ -1,43 +1,3 @@
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/issue-36617.rs:1:4
-   |
-LL | #![derive(Copy)]
-   |    ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-36617.rs:4:4
-   |
-LL | #![test]
-   |    ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `test_case`
-  --> $DIR/issue-36617.rs:7:4
-   |
-LL | #![test_case]
-   |    ^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `bench`
-  --> $DIR/issue-36617.rs:10:4
-   |
-LL | #![bench]
-   |    ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `global_allocator`
-  --> $DIR/issue-36617.rs:13:4
-   |
-LL | #![global_allocator]
-   |    ^^^^^^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `derive` attribute cannot be used at crate level
   --> $DIR/issue-36617.rs:1:1
    |
@@ -113,5 +73,5 @@ LL - #![global_allocator]
 LL + #[global_allocator]
    |
 
-error: aborting due to 10 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/extenv/issue-55897.rs
+++ b/tests/ui/extenv/issue-55897.rs
@@ -4,7 +4,6 @@ mod unresolved_env {
     use env; //~ ERROR unresolved import `env`
 
     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
-    //~^ ERROR cannot determine resolution for the macro `env`
 }
 
 mod nonexistent_env {

--- a/tests/ui/extenv/issue-55897.stderr
+++ b/tests/ui/extenv/issue-55897.stderr
@@ -1,5 +1,5 @@
 error: environment variable `NON_EXISTENT` not defined at compile time
-  --> $DIR/issue-55897.rs:11:22
+  --> $DIR/issue-55897.rs:10:22
    |
 LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: suffixes on string literals are invalid
-  --> $DIR/issue-55897.rs:16:22
+  --> $DIR/issue-55897.rs:15:22
    |
 LL |     include!(concat!("NON_EXISTENT"suffix, "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
@@ -33,14 +33,6 @@ help: consider importing this module instead
 LL |     use std::env;
    |         ~~~~~~~~
 
-error: cannot determine resolution for the macro `env`
-  --> $DIR/issue-55897.rs:6:22
-   |
-LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
-   |                      ^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-bench.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-bench.rs
@@ -5,6 +5,5 @@
 #![feature(custom_inner_attributes)]
 
 #![bench                   = "4100"]
-//~^ ERROR cannot determine resolution for the attribute macro `bench`
-//~^^ ERROR `bench` attribute cannot be used at crate level
+//~^ ERROR `bench` attribute cannot be used at crate level
 fn main() {}

--- a/tests/ui/feature-gates/issue-43106-gating-of-bench.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-bench.stderr
@@ -1,17 +1,9 @@
-error: cannot determine resolution for the attribute macro `bench`
-  --> $DIR/issue-43106-gating-of-bench.rs:7:4
-   |
-LL | #![bench                   = "4100"]
-   |    ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `bench` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-bench.rs:7:1
    |
 LL | #![bench                   = "4100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+LL |
 LL | fn main() {}
    |    ---- the inner attribute doesn't annotate this function
    |
@@ -21,5 +13,5 @@ LL - #![bench                   = "4100"]
 LL + #[bench                   = "4100"]
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-test.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-test.rs
@@ -2,6 +2,5 @@
 
 #![allow(soft_unstable)]
 #![test                    = "4200"]
-//~^ ERROR cannot determine resolution for the attribute macro `test`
-//~^^ ERROR `test` attribute cannot be used at crate level
+//~^ ERROR `test` attribute cannot be used at crate level
 fn main() {}

--- a/tests/ui/feature-gates/issue-43106-gating-of-test.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-test.stderr
@@ -1,17 +1,9 @@
-error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-43106-gating-of-test.rs:4:4
-   |
-LL | #![test                    = "4200"]
-   |    ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `test` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-test.rs:4:1
    |
 LL | #![test                    = "4200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+LL |
 LL | fn main() {}
    |    ---- the inner attribute doesn't annotate this function
    |
@@ -21,5 +13,5 @@ LL - #![test                    = "4200"]
 LL + #[test                    = "4200"]
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-28134.rs
+++ b/tests/ui/imports/issue-28134.rs
@@ -1,5 +1,5 @@
 // compile-flags: --test
 
 #![allow(soft_unstable)]
-#![test] //~ ERROR cannot determine resolution for the attribute macro `test`
+#![test]
 //~^ ERROR 4:1: 4:9: `test` attribute cannot be used at crate level

--- a/tests/ui/imports/issue-28134.stderr
+++ b/tests/ui/imports/issue-28134.stderr
@@ -1,11 +1,3 @@
-error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-28134.rs:4:4
-   |
-LL | #![test]
-   |    ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `test` attribute cannot be used at crate level
   --> $DIR/issue-28134.rs:4:1
    |
@@ -18,5 +10,5 @@ LL - #![test]
 LL + #[test]
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-55457.rs
+++ b/tests/ui/imports/issue-55457.rs
@@ -1,10 +1,9 @@
 use NonExistent; //~ ERROR unresolved import `NonExistent`
 use non_existent::non_existent; //~ ERROR unresolved import `non_existent`
 
-#[non_existent] //~ ERROR cannot determine resolution for the attribute macro `non_existent`
-#[derive(NonExistent)] //~ ERROR cannot determine resolution for the derive macro `NonExistent`
-                       //~| ERROR cannot determine resolution for the derive macro `NonExistent`
-                       //~| ERROR cannot determine resolution for the derive macro `NonExistent`
+#[non_existent]
+#[derive(NonExistent)]
+
 struct S;
 
 fn main() {}

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -15,40 +15,6 @@ LL | use non_existent::non_existent;
    |
    = help: consider adding `extern crate non_existent` to use the `non_existent` crate
 
-error: cannot determine resolution for the derive macro `NonExistent`
-  --> $DIR/issue-55457.rs:5:10
-   |
-LL | #[derive(NonExistent)]
-   |          ^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `non_existent`
-  --> $DIR/issue-55457.rs:4:3
-   |
-LL | #[non_existent]
-   |   ^^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the derive macro `NonExistent`
-  --> $DIR/issue-55457.rs:5:10
-   |
-LL | #[derive(NonExistent)]
-   |          ^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: cannot determine resolution for the derive macro `NonExistent`
-  --> $DIR/issue-55457.rs:5:10
-   |
-LL | #[derive(NonExistent)]
-   |          ^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 6 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/issue-59764.rs
+++ b/tests/ui/imports/issue-59764.rs
@@ -128,7 +128,6 @@ use issue_59764::foo::makro;
 //~^ ERROR unresolved import `issue_59764::foo::makro` [E0432]
 
 makro!(bar);
-//~^ ERROR cannot determine resolution for the macro `makro`
 
 fn main() {
     bar();

--- a/tests/ui/imports/issue-59764.stderr
+++ b/tests/ui/imports/issue-59764.stderr
@@ -226,21 +226,13 @@ help: a macro with this name exists at the root of the crate
 LL | use issue_59764::makro;
    |     ~~~~~~~~~~~~~~~~~~
 
-error: cannot determine resolution for the macro `makro`
-  --> $DIR/issue-59764.rs:130:1
-   |
-LL | makro!(bar);
-   | ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/issue-59764.rs:134:5
+  --> $DIR/issue-59764.rs:133:5
    |
 LL |     bar();
    |     ^^^ not found in this scope
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 
 Some errors have detailed explanations: E0425, E0432.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/derive-helper-legacy-spurious.rs
+++ b/tests/ui/proc-macro/derive-helper-legacy-spurious.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 extern crate test_macros;
 
-#[derive(Empty)] //~ ERROR cannot determine resolution for the attribute macro `derive`
+#[derive(Empty)]
 #[empty_helper] //~ ERROR cannot find attribute `empty_helper` in this scope
 struct Foo {}
 

--- a/tests/ui/proc-macro/derive-helper-legacy-spurious.stderr
+++ b/tests/ui/proc-macro/derive-helper-legacy-spurious.stderr
@@ -4,19 +4,11 @@ error: cannot find attribute `dummy` in this scope
 LL | #![dummy]
    |    ^^^^^
 
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/derive-helper-legacy-spurious.rs:8:3
-   |
-LL | #[derive(Empty)]
-   |   ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: cannot find attribute `empty_helper` in this scope
   --> $DIR/derive-helper-legacy-spurious.rs:9:3
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/proc-macro/issue-118455-skip-err-builtin.rs
+++ b/tests/ui/proc-macro/issue-118455-skip-err-builtin.rs
@@ -1,0 +1,6 @@
+#![some_nonexistent_attribute]
+//~^ ERROR cannot find attribute `some_nonexistent_attribute` in this scope
+#[derive(Debug)]
+pub struct SomeUserCode;
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-118455-skip-err-builtin.stderr
+++ b/tests/ui/proc-macro/issue-118455-skip-err-builtin.stderr
@@ -1,0 +1,8 @@
+error: cannot find attribute `some_nonexistent_attribute` in this scope
+  --> $DIR/issue-118455-skip-err-builtin.rs:1:4
+   |
+LL | #![some_nonexistent_attribute]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.fixed
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+
+#[derive(Debug)] //~ ERROR `derive` attribute cannot be used at crate level
+struct Test {}
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.rs
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.rs
@@ -1,0 +1,6 @@
+// run-rustfix
+
+#![derive(Debug)] //~ ERROR `derive` attribute cannot be used at crate level
+struct Test {}
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.stderr
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.stderr
@@ -1,0 +1,16 @@
+error: `derive` attribute cannot be used at crate level
+  --> $DIR/issue-89566-suggest-fix-invalid-top-level-macro-attr.rs:3:1
+   |
+LL | #![derive(Debug)]
+   | ^^^^^^^^^^^^^^^^^
+LL | struct Test {}
+   |        ---- the inner attribute doesn't annotate this struct
+   |
+help: perhaps you meant to use an outer attribute
+   |
+LL - #![derive(Debug)]
+LL + #[derive(Debug)]
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/reserved/reserved-attr-on-macro.rs
+++ b/tests/ui/reserved/reserved-attr-on-macro.rs
@@ -7,5 +7,5 @@ macro_rules! foo {
 }
 
 fn main() {
-    foo!(); //~ ERROR cannot determine resolution for the macro `foo`
+    foo!();
 }

--- a/tests/ui/reserved/reserved-attr-on-macro.stderr
+++ b/tests/ui/reserved/reserved-attr-on-macro.stderr
@@ -4,19 +4,11 @@ error: attributes starting with `rustc` are reserved for use by the `rustc` comp
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: cannot determine resolution for the macro `foo`
-  --> $DIR/reserved-attr-on-macro.rs:10:5
-   |
-LL |     foo!();
-   |     ^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: cannot find attribute `rustc_attribute_should_be_reserved` in this scope
   --> $DIR/reserved-attr-on-macro.rs:1:3
    |
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/rust-2018/issue-54006.rs
+++ b/tests/ui/rust-2018/issue-54006.rs
@@ -8,6 +8,5 @@ use alloc::vec;
 
 pub fn foo() {
     let mut xs = vec![];
-    //~^ ERROR cannot determine resolution for the macro `vec`
     xs.push(0);
 }

--- a/tests/ui/rust-2018/issue-54006.stderr
+++ b/tests/ui/rust-2018/issue-54006.stderr
@@ -4,14 +4,6 @@ error[E0432]: unresolved import `alloc`
 LL | use alloc::vec;
    |     ^^^^^ help: a similar path exists: `core::alloc`
 
-error: cannot determine resolution for the macro `vec`
-  --> $DIR/issue-54006.rs:10:18
-   |
-LL |     let mut xs = vec![];
-   |                  ^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/span/issue-43927-non-ADT-derive.rs
+++ b/tests/ui/span/issue-43927-non-ADT-derive.rs
@@ -1,6 +1,5 @@
 #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-//~^ ERROR cannot determine resolution for the attribute macro `derive`
-//~^^ ERROR `derive` attribute cannot be used at crate level
+//~^ ERROR `derive` attribute cannot be used at crate level
 struct DerivedOn;
 
 fn main() {}

--- a/tests/ui/span/issue-43927-non-ADT-derive.stderr
+++ b/tests/ui/span/issue-43927-non-ADT-derive.stderr
@@ -1,17 +1,9 @@
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/issue-43927-non-ADT-derive.rs:1:4
-   |
-LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-   |    ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `derive` attribute cannot be used at crate level
   --> $DIR/issue-43927-non-ADT-derive.rs:1:1
    |
 LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+LL |
 LL | struct DerivedOn;
    |        --------- the inner attribute doesn't annotate this struct
    |
@@ -21,5 +13,5 @@ LL - #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
 LL + #[derive(Debug, PartialEq, Eq)] // should be an outer attribute!
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
Fixes #118455, unresolved top level attribute error didn't imported prelude and already have emitted an error, report builtin macro and attributes error by the way, so `check_invalid_crate_level_attr` in can ignore them.

Also fixes #89566, fixes #67107.

r? @petrochenkov 