### PR TITLE
better build locks for bootstrap

### DIFF
--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,8 +47,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "cmake",
- "fd-lock",
  "filetime",
+ "fs2",
  "hex",
  "home",
  "ignore",
@@ -246,27 +240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "errno"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "fd-lock"
-version = "3.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +256,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "generic-array"
@@ -373,12 +356,6 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -509,7 +486,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -534,19 +511,6 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
-
-[[package]]
-name = "rustix"
-version = "0.38.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
-dependencies = [
- "bitflags 2.4.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
 
 [[package]]
 name = "ryu"
@@ -753,15 +717,6 @@ name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -39,6 +39,7 @@ clap = { version = "4.4.7", default-features = false, features = ["std", "usage"
 clap_complete = "4.4.3"
 cmake = "0.1.38"
 filetime = "0.2"
+fs2 = "0.4.3"
 hex = "0.4"
 home = "0.5.4"
 ignore = "0.4.10"
@@ -61,10 +62,6 @@ xz2 = "0.1"
 
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.26.0", optional = true }
-
-# Solaris doesn't support flock() and thus fd-lock is not option now
-[target.'cfg(not(target_os = "solaris"))'.dependencies]
-fd-lock = "3.0.13"
 
 [target.'cfg(windows)'.dependencies.junction]
 version = "1.0.0"

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -51,6 +51,7 @@ pub use core::builder::PathSet;
 pub use core::config::flags::Subcommand;
 pub use core::config::Config;
 pub use utils::change_tracker::{find_recent_config_change_ids, CONFIG_CHANGE_HISTORY};
+pub use utils::file_lock::FileLock;
 
 const LLVM_TOOLS: &[&str] = &[
     "llvm-cov",      // used to generate coverage report

--- a/src/bootstrap/src/utils/file_lock.rs
+++ b/src/bootstrap/src/utils/file_lock.rs
@@ -1,8 +1,7 @@
 //! This module provides a `FileLock` type, serving as a cross-platform file-locking wrapper
 //! for `std::fs::File`, built on top of the `fs2` crate.
 //!
-//! Locks are automatically released by the `Drop` trait implementation when the `FileLock`
-//! instance goes out of scope.
+//! Locks are automatically released with the `Drop` trait implementation.
 
 use std::{fs::File, io};
 
@@ -15,14 +14,12 @@ pub struct FileLock(File);
 impl FileLock {
     pub fn lock(&mut self) -> io::Result<&File> {
         self.0.lock_exclusive()?;
-
-        Ok(&mut self.0)
+        Ok(&self.0)
     }
 
     pub fn try_lock(&mut self) -> io::Result<&File> {
         self.0.try_lock_exclusive()?;
-
-        Ok(&mut self.0)
+        Ok(&self.0)
     }
 }
 

--- a/src/bootstrap/src/utils/file_lock.rs
+++ b/src/bootstrap/src/utils/file_lock.rs
@@ -1,0 +1,39 @@
+//! This module provides a `FileLock` type, serving as a cross-platform file-locking wrapper
+//! for `std::fs::File`, built on top of the `fs2` crate.
+//!
+//! Locks are automatically released by the `Drop` trait implementation when the `FileLock`
+//! instance goes out of scope.
+
+use std::{fs::File, io};
+
+use fs2::FileExt;
+
+use crate::t;
+
+pub struct FileLock(File);
+
+impl FileLock {
+    pub fn lock(&mut self) -> io::Result<&File> {
+        self.0.lock_exclusive()?;
+
+        Ok(&mut self.0)
+    }
+
+    pub fn try_lock(&mut self) -> io::Result<&File> {
+        self.0.try_lock_exclusive()?;
+
+        Ok(&mut self.0)
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        t!(self.0.unlock());
+    }
+}
+
+impl From<File> for FileLock {
+    fn from(file: File) -> Self {
+        Self(file)
+    }
+}

--- a/src/bootstrap/src/utils/mod.rs
+++ b/src/bootstrap/src/utils/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod change_tracker;
 pub(crate) mod channel;
 pub(crate) mod dylib;
 pub(crate) mod exec;
+pub(crate) mod file_lock;
 pub(crate) mod helpers;
 pub(crate) mod job;
 #[cfg(feature = "build-metrics")]


### PR DESCRIPTION
This PR improves the way bootstrap handles the build locks by supporting Solaris and removing many dependencies coming with `fd-lock`.

cc @psumbera