### PR TITLE
std: Invert logic for inclusion of `sys_common::net`

### DIFF
--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -43,15 +43,15 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(target_os = "l4re",
-                 target_os = "uefi",
-                 feature = "restricted-std",
-                 all(target_family = "wasm", not(target_os = "emscripten")),
-                 target_os = "xous",
-                 all(target_vendor = "fortanix", target_env = "sgx")))] {
-        pub use crate::sys::net;
-    } else {
+    if #[cfg(any(
+        all(unix, not(target_os = "l4re")),
+        windows,
+        target_os = "hermit",
+        target_os = "solid_asp3"
+    ))] {
         pub mod net;
+    } else {
+        pub use crate::sys::net;
     }
 }
 


### PR DESCRIPTION
The `library/std/src/sys_common/net.rs` module is intended to define common implementations of networking-related APIs across a variety of platforms that share similar APIs (e.g. Berkeley-style sockets and all). This module is not included for more fringe targets however such as UEFI or "unknown" targets to libstd (those classified as `restricted-std`). Previously the `sys_common/net.rs` file was set up such that an allow-list indicated it shouldn't be used. This commit inverts the logic to have an allow-list of when it should be used instead.

The goal of this commit is to make it a bit easier to experiment with a new Rust target. Currently more esoteric targets are required to get an exception in this `cfg_if` block to use `crate::sys::net` such as for unsupported targets. With this inversion of logic only targets which actually support networking will be listed, where most of those are lumped under `cfg(unix)`.

Given that this change is likely to cause some breakage for some target by accident I've attempted to be somewhat robust with this by following these steps to defining the new predicate for inverted logic.

1. Take all supported targets and filter out all `cfg(unix)` ones as these should all support `sys_common/net.rs`.
2. Take remaining targets and filter out `cfg(windows)` ones.
3. The remaining dozen-or-so targets were all audited by hand. Mostly this included `target_os = "hermit"` and `target_os = "solid_asp3"` which required an allow-list entry, but remaining targets were all already excluded (didn't use `sys_common/net.rs` so they were left out.

If this causes breakage it should be relatively easy to fix and I'd be happy to follow-up with any PRs necessary.