### PR TITLE
Provide a way for custom derives to know if they were invoked via `#[derive_const]`

### DIFF
--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -59,7 +59,7 @@ impl base::BangProcMacro for BangProcMacro {
 
         let proc_macro_backtrace = ecx.ecfg.proc_macro_backtrace;
         let strategy = exec_strategy(ecx);
-        let server = proc_macro_server::Rustc::new(ecx);
+        let server = proc_macro_server::Rustc::new(ecx, Default::default());
         self.client.run(&strategy, server, input, proc_macro_backtrace).map_err(|e| {
             ecx.dcx().emit_err(errors::ProcMacroPanicked {
                 span,
@@ -90,7 +90,7 @@ impl base::AttrProcMacro for AttrProcMacro {
 
         let proc_macro_backtrace = ecx.ecfg.proc_macro_backtrace;
         let strategy = exec_strategy(ecx);
-        let server = proc_macro_server::Rustc::new(ecx);
+        let server = proc_macro_server::Rustc::new(ecx, Default::default());
         self.client.run(&strategy, server, annotation, annotated, proc_macro_backtrace).map_err(
             |e| {
                 let mut err = ecx.dcx().struct_span_err(span, "custom attribute panicked");
@@ -114,7 +114,7 @@ impl MultiItemModifier for DeriveProcMacro {
         span: Span,
         _meta_item: &ast::MetaItem,
         item: Annotatable,
-        _is_derive_const: bool,
+        is_derive_const: bool,
     ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
         // We need special handling for statement items
         // (e.g. `fn foo() { #[derive(Debug)] struct Bar; }`)
@@ -142,7 +142,10 @@ impl MultiItemModifier for DeriveProcMacro {
                 });
             let proc_macro_backtrace = ecx.ecfg.proc_macro_backtrace;
             let strategy = exec_strategy(ecx);
-            let server = proc_macro_server::Rustc::new(ecx);
+            let server = proc_macro_server::Rustc::new(
+                ecx,
+                proc_macro_server::ExpansionOptions { is_derive_const },
+            );
             match self.client.run(&strategy, server, input, proc_macro_backtrace) {
                 Ok(stream) => stream,
                 Err(e) => {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -182,6 +182,7 @@ symbols! {
         DecorateLint,
         Default,
         Deref,
+        DeriveExpansionOptions,
         DiagnosticMessage,
         DirBuilder,
         Display,

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -60,6 +60,7 @@ macro_rules! with_api {
                 fn track_path(path: &str);
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;
                 fn emit_diagnostic(diagnostic: Diagnostic<$S::Span>);
+                fn is_derive_const() -> bool;
             },
             TokenStream {
                 fn drop($self: $S::TokenStream);

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -25,7 +25,9 @@
 #![feature(rustc_allow_const_fn_unstable)]
 #![feature(staged_api)]
 #![feature(allow_internal_unstable)]
+#![feature(const_trait_impl)]
 #![feature(decl_macro)]
+#![feature(effects)]
 #![feature(maybe_uninit_write_slice)]
 #![feature(negative_impls)]
 #![feature(new_uninit)]
@@ -84,6 +86,32 @@ pub struct TokenStream(Option<bridge::client::TokenStream>);
 impl !Send for TokenStream {}
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Sync for TokenStream {}
+
+/// Derive expansion options.
+#[rustc_diagnostic_item = "DeriveExpansionOptions"]
+#[unstable(feature = "derive_const", issue = "none")]
+#[derive(Default, Clone)]
+#[non_exhaustive]
+pub struct DeriveExpansionOptions;
+
+impl DeriveExpansionOptions {
+    /// Returns the default options.
+    #[unstable(feature = "derive_const", issue = "none")]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether this is a `#[derive_const]` or a `#[derive]`.
+    #[unstable(feature = "derive_const", issue = "none")]
+    pub fn is_const(&self) -> bool {
+        bridge::client::FreeFunctions::is_derive_const()
+    }
+}
+
+#[unstable(feature = "derive_const", issue = "none")]
+impl !Send for DeriveExpansionOptions {}
+#[unstable(feature = "derive_const", issue = "none")]
+impl !Sync for DeriveExpansionOptions {}
 
 /// Error returned from `TokenStream::from_str`.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/rust_analyzer_span.rs
@@ -82,6 +82,11 @@ impl server::FreeFunctions for RaSpanServer {
     fn emit_diagnostic(&mut self, _: bridge::Diagnostic<Self::Span>) {
         // FIXME handle diagnostic
     }
+
+    fn is_derive_const(&mut self) -> bool {
+        // FIXME: pass the correct information
+        false
+    }
 }
 
 impl server::TokenStream for RaSpanServer {

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/token_id.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server/token_id.rs
@@ -72,6 +72,11 @@ impl server::FreeFunctions for TokenIdServer {
     }
 
     fn emit_diagnostic(&mut self, _: bridge::Diagnostic<Self::Span>) {}
+
+    fn is_derive_const(&mut self) -> bool {
+        // FIXME: pass the correct information
+        false
+    }
 }
 
 impl server::TokenStream for TokenIdServer {

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/auxiliary/is-derive-const.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/auxiliary/is-derive-const.rs
@@ -1,0 +1,13 @@
+// force-host
+// no-prefer-dynamic
+#![crate_type = "proc-macro"]
+#![feature(derive_const)]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, DeriveExpansionOptions};
+
+#[proc_macro_derive(IsDeriveConst)]
+pub fn is_derive_const(_: TokenStream, options: DeriveExpansionOptions) -> TokenStream {
+    format!("const IS_DERIVE_CONST: bool = {};", options.is_const()).parse().unwrap()
+}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-custom.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-custom.rs
@@ -1,0 +1,20 @@
+// check-pass
+// edition: 2021
+// aux-crate:is_derive_const=is-derive-const.rs
+#![feature(derive_const)]
+
+const _: () = {
+    #[derive(is_derive_const::IsDeriveConst)]
+    struct _Type;
+
+    assert!(!IS_DERIVE_CONST);
+};
+
+const _: () = {
+    #[derive_const(is_derive_const::IsDeriveConst)]
+    struct _Type;
+
+    assert!(IS_DERIVE_CONST);
+};
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/signature-proc-macro-derive.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/signature-proc-macro-derive.rs
@@ -1,0 +1,19 @@
+// Check that we suggest *both* possible signatures of derive proc macros, namely
+//     fn(TokenStream) -> TokenStream
+// and
+//     fn(TokenStream, DeriveExpansionOptions) -> TokenStream
+// provided libs feature `derive_const` is enabled.
+
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![feature(derive_const)]
+
+extern crate proc_macro;
+
+#[proc_macro_derive(Blah)]
+pub fn bad_input() -> proc_macro::TokenStream {
+    //~^ ERROR derive proc macro has incorrect signature
+    Default::default()
+}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/signature-proc-macro-derive.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/signature-proc-macro-derive.stderr
@@ -1,0 +1,16 @@
+error: derive proc macro has incorrect signature
+  --> $DIR/signature-proc-macro-derive.rs:16:1
+   |
+LL | pub fn bad_input() -> proc_macro::TokenStream {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | incorrect number of function parameters
+   | incorrect number of function parameters
+   |
+   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+              found signature `fn() -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream, DeriveExpansionOptions) -> proc_macro::TokenStream`
+              found signature `fn() -> proc_macro::TokenStream`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #118304.

cc @rust-lang/wg-macros
r? compiler and libs-api
