### PR TITLE
Fix ICE `ProjectionKinds Deref and Field were mismatched`

### DIFF
--- a/tests/ui/closures/2229_closure_analysis/issue-118144.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-118144.rs
@@ -1,0 +1,16 @@
+// Regression test for ICE #118144
+
+struct V(i32);
+
+fn func(func_arg: &mut V) {
+    || {
+        // Declaring `x` separately instead of using
+        // a destructuring binding like `let V(x) = ...`
+        // becaue only `V(x) = ...` triggers the ICE
+        let x;
+        V(x) = func_arg; //~ ERROR: mismatched types
+        func_arg.0 = 0;
+     };
+}
+
+fn main() {}

--- a/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-118144.rs:11:9
+   |
+LL |         V(x) = func_arg;
+   |         ^^^^   -------- this expression has type `&mut V`
+   |         |
+   |         expected `&mut V`, found `V`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #118144

Removed the check that ICEd if the sequence of projection kinds were different across captures. Instead we now sort based only on `Field` projection kinds.