### PR TITLE
Fix parser ICE when recovering `dyn`/`impl` after `for<...>`

### DIFF
--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -304,23 +304,25 @@ impl<'a> Parser<'a> {
                 if self.may_recover()
                     && (self.eat_keyword_noexpect(kw::Impl) || self.eat_keyword_noexpect(kw::Dyn))
                 {
-                    let kw = self.prev_token.ident().unwrap().0.name;
-                    let mut err = self.sess.create_err(errors::TransposeDynOrImpl {
-                        span: self.prev_token.span,
-                        kw: kw.as_str(),
-                        sugg: errors::TransposeDynOrImplSugg {
-                            removal_span: self.prev_token.span.with_hi(self.token.span.lo()),
-                            insertion_span: for_span.shrink_to_lo(),
-                            kw: kw.as_str(),
-                        },
-                    });
+                    let kw = self.prev_token.ident().unwrap().0;
+                    let removal_span = kw.span.with_hi(self.token.span.lo());
                     let path = self.parse_path(PathStyle::Type)?;
                     let parse_plus = allow_plus == AllowPlus::Yes && self.check_plus();
                     let kind =
                         self.parse_remaining_bounds_path(lifetime_defs, path, lo, parse_plus)?;
+                    let mut err = self.sess.create_err(errors::TransposeDynOrImpl {
+                        span: kw.span,
+                        kw: kw.name.as_str(),
+                        sugg: errors::TransposeDynOrImplSugg {
+                            removal_span,
+                            insertion_span: for_span.shrink_to_lo(),
+                            kw: kw.name.as_str(),
+                        },
+                    });
+
                     // Take the parsed bare trait object and turn it either
                     // into a `dyn` object or an `impl Trait`.
-                    let kind = match (kind, kw) {
+                    let kind = match (kind, kw.name) {
                         (TyKind::TraitObject(bounds, _), kw::Dyn) => {
                             TyKind::TraitObject(bounds, TraitObjectSyntax::Dyn)
                         }

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
@@ -6,4 +6,8 @@ fn test(_: &for<'a> dyn Trait) {}
 fn test2(_: for<'a> impl Trait) {}
 //~^ ERROR `for<...>` expected after `impl`, not before
 
+// Issue #118564
+type A2 = dyn<for<> dyn>;
+//~^ ERROR expected identifier, found `>`
+
 fn main() {}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
@@ -22,5 +22,11 @@ LL - fn test2(_: for<'a> impl Trait) {}
 LL + fn test2(_: impl for<'a> Trait) {}
    |
 
-error: aborting due to 2 previous errors
+error: expected identifier, found `>`
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:10:24
+   |
+LL | type A2 = dyn<for<> dyn>;
+   |                        ^ expected identifier
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #118564