### PR TITLE
portable-simd: fix test suite build

### DIFF
--- a/library/portable-simd/crates/core_simd/tests/pointers.rs
+++ b/library/portable-simd/crates/core_simd/tests/pointers.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd, strict_provenance)]
+#![feature(portable_simd, strict_provenance, exposed_provenance)]
 
 use core_simd::simd::{
     ptr::{SimdConstPtr, SimdMutPtr},


### PR DESCRIPTION
@workingjubilee @calebzulawski don't we run these portable-simd tests on rustc CI? Currently they don't even build here.