### PR TITLE
Remove mention of rust to make the error message generic.

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -673,7 +673,7 @@ fn short_item_info(
                     format!("Deprecating in {version}")
                 }
             }
-            DeprecatedSince::Future => String::from("Deprecating in a future Rust version"),
+            DeprecatedSince::Future => String::from("Deprecating in a future version"),
             DeprecatedSince::NonStandard(since) => {
                 format!("Deprecated since {}", Escape(since.as_str()))
             }

--- a/tests/rustdoc/deprecated-future-staged-api.rs
+++ b/tests/rustdoc/deprecated-future-staged-api.rs
@@ -12,7 +12,7 @@ pub struct S1;
 // @has deprecated_future_staged_api/index.html '//*[@class="stab deprecated"]' \
 //      'Deprecation planned'
 // @has deprecated_future_staged_api/struct.S2.html '//*[@class="stab deprecated"]' \
-//      'Deprecating in a future Rust version: literally never'
+//      'Deprecating in a future version: literally never'
 #[deprecated(since = "TBD", note = "literally never")]
 #[stable(feature = "deprecated_future_staged_api", since = "1.0.0")]
 pub struct S2;


### PR DESCRIPTION
The deprecation notice is used when in crates as well. This applies to versions Rust or Crates.

Fixes #118148