### PR TITLE
Don't ask for a specific branch in cargotest

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -140,7 +140,7 @@ fn clone_repo(test: &Test, out_dir: &Path) -> PathBuf {
             let status = Command::new("git")
                 .arg("fetch")
                 .arg(test.repo)
-                .arg("master")
+                .arg(test.sha)
                 .arg(&format!("--depth={}", depth))
                 .current_dir(&out_dir)
                 .status()


### PR DESCRIPTION
Tentative fix for https://github.com/rust-lang/rust/pull/118592#issuecomment-1838180918.

`servo` [just renamed](https://github.com/servo/servo/pull/30788) their `master` branch to `main`, but `cargotest` does a `git fetch $URL master; git reset --hard $SHA`. Let's try to change that to `git fetch $URL $SHA; git reset --hard $SHA`, which appears to work, but I can't confirm for sure because I'm having some trouble with `x.py`:

```
 --> library/rustc-std-workspace-core/lib.rs:4:9
  |
4 | pub use core::*;
  |         ^^^^
  |
  = note: the following crate versions were found:
          crate `core` compiled by rustc 1.76.0-nightly (85a4bd8f5 2023-12-04): ./build/x86_64-unknown-linux-gnu/stage1-std/x86_64-unknown-linux-gnu/release/deps/libcore-70719e8645e6f000.rmeta
  = help: please recompile that crate using this compiler (rustc 1.76.0-nightly (5808b7248 2023-12-04)) (consider running `cargo clean` first)
```