### PR TITLE
Set TaKO8Ki off from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -627,7 +627,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "oli-obk", "wesleywiser"]
+users_on_vacation = ["jyn514", "oli-obk", "wesleywiser", "TaKO8Ki"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
If my understanding is correct, user @TaKO8Ki is not actively reviewing pull requests at this time, so it should be safe to remove them from the rotation.

Am I correct @TaKO8Ki ? 

Thanks