### PR TITLE
Use default params until effects in desugaring

### DIFF
--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/effect-param-infer.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/effect-param-infer.rs
@@ -1,0 +1,15 @@
+// Ensure that we don't get a mismatch error when inserting the host param
+// at the end of generic args when the generics have defaulted params.
+//
+// check-pass
+
+#![feature(const_trait_impl, effects)]
+
+#[const_trait]
+pub trait Foo<Rhs: ?Sized = Self> {
+    /* stuff */
+}
+
+impl const Foo for () {}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.rs
@@ -21,8 +21,7 @@ trait Add<Rhs = Self> {
     fn add(self, rhs: Rhs) -> Self::Output;
 }
 
-// FIXME(effects) we shouldn't need to have to specify `Rhs`.
-impl const Add<i32> for i32 {
+impl const Add for i32 {
     type Output = i32;
     fn add(self, rhs: i32) -> i32 {
         loop {}
@@ -353,8 +352,7 @@ where
     }
 }
 
-// FIXME(effects): again, this should not error without Rhs specified
-impl PartialEq<str> for str {
+impl PartialEq for str {
     fn eq(&self, other: &str) -> bool {
         loop {}
     }

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.stderr
@@ -1,5 +1,5 @@
 error[E0493]: destructor of `Self` cannot be evaluated at compile-time
-  --> $DIR/minicore.rs:503:9
+  --> $DIR/minicore.rs:501:9
    |
 LL |         *self = source.clone()
    |         ^^^^^
@@ -8,7 +8,7 @@ LL |         *self = source.clone()
    |         value is dropped here
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/minicore.rs:513:35
+  --> $DIR/minicore.rs:511:35
    |
 LL | const fn drop<T: ~const Destruct>(_: T) {}
    |                                   ^      - value is dropped here


### PR DESCRIPTION
See the comment and [this section](https://fee1-dead.github.io/devlog001/#effects-desugaring-with-default-type-params) from my blog post

r? @compiler-errors 