### PR TITLE
 Enable emutls by default for android

### DIFF
--- a/compiler/rustc_target/src/spec/base/android.rs
+++ b/compiler/rustc_target/src/spec/base/android.rs
@@ -6,7 +6,7 @@ pub fn opts() -> TargetOptions {
     base.is_like_android = true;
     base.default_dwarf_version = 2;
     base.tls_model = TlsModel::Emulated;
-    base.has_thread_local = false;
+    base.has_thread_local = true;
     base.supported_sanitizers = SanitizerSet::ADDRESS;
     // This is for backward compatibility, see https://github.com/rust-lang/rust/issues/49867
     // for context. (At that time, there was no `-C force-unwind-tables`, so the only solution


### PR DESCRIPTION
This is a split of https://github.com/rust-lang/rust/pull/117873

This is an attempt to enable emutls by default in android.

The current unresolved problem is that if use emutls provided by `compiler-builtins`, then each `so` will have its own emutls symbol during dynamic linking, causing thread_local of each `so` to be independent of each other.

One solution to this problem is to link against `libc++_shared.so` provided by android ndk, but this cause in additional runtime dependencies and looks a bit strange.