### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -3,8 +3,9 @@ use rustc_errors::{Applicability, Diagnostic, DiagnosticBuilder, ErrorGuaranteed
 use rustc_hir as hir;
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::Node;
+use rustc_infer::traits;
 use rustc_middle::mir::{Mutability, Place, PlaceRef, ProjectionElem};
-use rustc_middle::ty::{self, InstanceDef, Ty, TyCtxt};
+use rustc_middle::ty::{self, InstanceDef, ToPredicate, Ty, TyCtxt};
 use rustc_middle::{
     hir::place::PlaceBase,
     mir::{self, BindingForm, Local, LocalDecl, LocalInfo, LocalKind, Location},
@@ -12,6 +13,8 @@ use rustc_middle::{
 use rustc_span::symbol::{kw, Symbol};
 use rustc_span::{sym, BytePos, DesugaringKind, Span};
 use rustc_target::abi::FieldIdx;
+use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::traits::error_reporting::suggestions::TypeErrCtxtExt;
 
 use crate::diagnostics::BorrowedContentSource;
 use crate::util::FindAssignments;
@@ -1213,6 +1216,103 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 if let Some(hir_id) = hir_id
                     && let Some(hir::Node::Local(local)) = hir_map.find(hir_id)
                 {
+                    let tables = self.infcx.tcx.typeck(def_id.as_local().unwrap());
+                    if let Some(clone_trait) = self.infcx.tcx.lang_items().clone_trait()
+                        && let Some(expr) = local.init
+                        && let ty = tables.node_type_opt(expr.hir_id)
+                        && let Some(ty) = ty
+                        && let ty::Ref(..) = ty.kind()
+                    {
+                        match self
+                            .infcx
+                            .could_impl_trait(clone_trait, ty.peel_refs(), self.param_env)
+                            .as_deref()
+                        {
+                            Some([]) => {
+                                // The type implements Clone.
+                                err.span_help(
+                                    expr.span,
+                                    format!(
+                                        "you can `clone` the `{}` value and consume it, but this \
+                                         might not be your desired behavior",
+                                        ty.peel_refs(),
+                                    ),
+                                );
+                            }
+                            None => {
+                                if let hir::ExprKind::MethodCall(segment, _rcvr, [], span) =
+                                    expr.kind
+                                    && segment.ident.name == sym::clone
+                                {
+                                    err.span_help(
+                                        span,
+                                        format!(
+                                            "`{}` doesn't implement `Clone`, so this call clones \
+                                             the reference `{ty}`",
+                                            ty.peel_refs(),
+                                        ),
+                                    );
+                                }
+                                // The type doesn't implement Clone.
+                                let trait_ref = ty::Binder::dummy(ty::TraitRef::new(
+                                    self.infcx.tcx,
+                                    clone_trait,
+                                    [ty.peel_refs()],
+                                ));
+                                let obligation = traits::Obligation::new(
+                                    self.infcx.tcx,
+                                    traits::ObligationCause::dummy(),
+                                    self.param_env,
+                                    trait_ref,
+                                );
+                                self.infcx.err_ctxt().suggest_derive(
+                                    &obligation,
+                                    err,
+                                    trait_ref.to_predicate(self.infcx.tcx),
+                                );
+                            }
+                            Some(errors) => {
+                                if let hir::ExprKind::MethodCall(segment, _rcvr, [], span) =
+                                    expr.kind
+                                    && segment.ident.name == sym::clone
+                                {
+                                    err.span_help(
+                                        span,
+                                        format!(
+                                            "`{}` doesn't implement `Clone` because its \
+                                             implementations trait bounds could not be met, so \
+                                             this call clones the reference `{ty}`",
+                                            ty.peel_refs(),
+                                        ),
+                                    );
+                                    err.note(format!(
+                                        "the following trait bounds weren't met: {}",
+                                        errors
+                                            .iter()
+                                            .map(|e| e.obligation.predicate.to_string())
+                                            .collect::<Vec<_>>()
+                                            .join("\n"),
+                                    ));
+                                }
+                                // The type doesn't implement Clone because of unmet obligations.
+                                for error in errors {
+                                    if let traits::FulfillmentErrorCode::CodeSelectionError(
+                                        traits::SelectionError::Unimplemented,
+                                    ) = error.code
+                                        && let ty::PredicateKind::Clause(ty::ClauseKind::Trait(
+                                            pred,
+                                        )) = error.obligation.predicate.kind().skip_binder()
+                                    {
+                                        self.infcx.err_ctxt().suggest_derive(
+                                            &error.obligation,
+                                            err,
+                                            error.obligation.predicate.kind().rebind(pred),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
                     let (changing, span, sugg) = match local.ty {
                         Some(ty) => ("changing", ty.span, message),
                         None => {

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -3,17 +3,22 @@
 //! and miri.
 
 use rustc_hir::def_id::DefId;
-use rustc_middle::mir::{
-    self,
-    interpret::{Allocation, ConstAllocation, GlobalId, InterpResult, PointerArithmetic, Scalar},
-    BinOp, ConstValue, NonDivergingIntrinsic,
-};
 use rustc_middle::ty;
 use rustc_middle::ty::layout::{LayoutOf as _, ValidityRequirement};
 use rustc_middle::ty::GenericArgsRef;
 use rustc_middle::ty::{Ty, TyCtxt};
+use rustc_middle::{
+    mir::{
+        self,
+        interpret::{
+            Allocation, ConstAllocation, GlobalId, InterpResult, PointerArithmetic, Scalar,
+        },
+        BinOp, ConstValue, NonDivergingIntrinsic,
+    },
+    ty::layout::TyAndLayout,
+};
 use rustc_span::symbol::{sym, Symbol};
-use rustc_target::abi::{Abi, Primitive, Size};
+use rustc_target::abi::Size;
 
 use super::{
     util::ensure_monomorphic_enough, CheckInAllocMsg, ImmTy, InterpCx, Machine, OpTy, PlaceTy,
@@ -21,23 +26,6 @@ use super::{
 };
 
 use crate::fluent_generated as fluent;
-
-fn numeric_intrinsic<Prov>(name: Symbol, bits: u128, kind: Primitive) -> Scalar<Prov> {
-    let size = match kind {
-        Primitive::Int(integer, _) => integer.size(),
-        _ => bug!("invalid `{}` argument: {:?}", name, bits),
-    };
-    let extra = 128 - u128::from(size.bits());
-    let bits_out = match name {
-        sym::ctpop => u128::from(bits.count_ones()),
-        sym::ctlz => u128::from(bits.leading_zeros()) - extra,
-        sym::cttz => u128::from((bits << extra).trailing_zeros()) - extra,
-        sym::bswap => (bits << extra).swap_bytes(),
-        sym::bitreverse => (bits << extra).reverse_bits(),
-        _ => bug!("not a numeric intrinsic: {}", name),
-    };
-    Scalar::from_uint(bits_out, size)
-}
 
 /// Directly returns an `Allocation` containing an absolute path representation of the given type.
 pub(crate) fn alloc_type_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> ConstAllocation<'tcx> {
@@ -179,30 +167,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | sym::bswap
             | sym::bitreverse => {
                 let ty = instance_args.type_at(0);
-                let layout_of = self.layout_of(ty)?;
+                let layout = self.layout_of(ty)?;
                 let val = self.read_scalar(&args[0])?;
-                let bits = val.to_bits(layout_of.size)?;
-                let kind = match layout_of.abi {
-                    Abi::Scalar(scalar) => scalar.primitive(),
-                    _ => span_bug!(
-                        self.cur_span(),
-                        "{} called on invalid type {:?}",
-                        intrinsic_name,
-                        ty
-                    ),
-                };
-                let (nonzero, actual_intrinsic_name) = match intrinsic_name {
-                    sym::cttz_nonzero => (true, sym::cttz),
-                    sym::ctlz_nonzero => (true, sym::ctlz),
-                    other => (false, other),
-                };
-                if nonzero && bits == 0 {
-                    throw_ub_custom!(
-                        fluent::const_eval_call_nonzero_intrinsic,
-                        name = intrinsic_name,
-                    );
-                }
-                let out_val = numeric_intrinsic(actual_intrinsic_name, bits, kind);
+                let out_val = self.numeric_intrinsic(intrinsic_name, val, layout)?;
                 self.write_scalar(out_val, dest)?;
             }
             sym::saturating_add | sym::saturating_sub => {
@@ -491,6 +458,29 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.copy_intrinsic(&src, &dst, &count, /* nonoverlapping */ true)
             }
         }
+    }
+
+    pub fn numeric_intrinsic(
+        &self,
+        name: Symbol,
+        val: Scalar<M::Provenance>,
+        layout: TyAndLayout<'tcx>,
+    ) -> InterpResult<'tcx, Scalar<M::Provenance>> {
+        assert!(layout.ty.is_integral(), "invalid type for numeric intrinsic: {}", layout.ty);
+        let bits = val.to_bits(layout.size)?;
+        let extra = 128 - u128::from(layout.size.bits());
+        let bits_out = match name {
+            sym::ctpop => u128::from(bits.count_ones()),
+            sym::ctlz_nonzero | sym::cttz_nonzero if bits == 0 => {
+                throw_ub_custom!(fluent::const_eval_call_nonzero_intrinsic, name = name,);
+            }
+            sym::ctlz | sym::ctlz_nonzero => u128::from(bits.leading_zeros()) - extra,
+            sym::cttz | sym::cttz_nonzero => u128::from((bits << extra).trailing_zeros()) - extra,
+            sym::bswap => (bits << extra).swap_bytes(),
+            sym::bitreverse => (bits << extra).reverse_bits(),
+            _ => bug!("not a numeric intrinsic: {}", name),
+        };
+        Ok(Scalar::from_uint(bits_out, layout.size))
     }
 
     pub fn exact_div(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -21,7 +21,7 @@ use rustc_hir::{
     StmtKind, TyKind, WherePredicate,
 };
 use rustc_hir_analysis::astconv::AstConv;
-use rustc_infer::traits::{self, StatementAsExpression, TraitEngineExt};
+use rustc_infer::traits::{self, StatementAsExpression};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::middle::stability::EvalResult;
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -34,7 +34,6 @@ use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::{Span, Symbol};
 use rustc_trait_selection::infer::InferCtxtExt;
-use rustc_trait_selection::solve::FulfillmentCtxt;
 use rustc_trait_selection::traits::error_reporting::suggestions::TypeErrCtxtExt;
 use rustc_trait_selection::traits::error_reporting::DefIdOrName;
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
@@ -1604,78 +1603,46 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     None,
                 );
             } else {
-                self.infcx.probe(|_snapshot| {
-                    if let ty::Adt(def, args) = expected_ty.kind()
-                        && let Some((def_id, _imp)) = self
-                            .tcx
-                            .all_impls(clone_trait_did)
-                            .filter_map(|def_id| {
-                                self.tcx.impl_trait_ref(def_id).map(|r| (def_id, r))
-                            })
-                            .map(|(def_id, imp)| (def_id, imp.skip_binder()))
-                            .filter(|(_, imp)| match imp.self_ty().peel_refs().kind() {
-                                ty::Adt(i_def, _) if i_def.did() == def.did() => true,
-                                _ => false,
-                            })
-                            .next()
-                    {
-                        let mut fulfill_cx = FulfillmentCtxt::new(&self.infcx);
-                        // We get all obligations from the impl to talk about specific
-                        // trait bounds.
-                        let obligations = self
-                            .tcx
-                            .predicates_of(def_id)
-                            .instantiate(self.tcx, args)
-                            .into_iter()
-                            .map(|(clause, span)| {
-                                traits::Obligation::new(
-                                    self.tcx,
-                                    traits::ObligationCause::misc(span, self.body_id),
-                                    self.param_env,
-                                    clause,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-                        fulfill_cx.register_predicate_obligations(&self.infcx, obligations);
-                        let errors = fulfill_cx.select_all_or_error(&self.infcx);
-                        match &errors[..] {
-                            [] => {}
-                            [error] => {
-                                diag.help(format!(
-                                    "`Clone` is not implemented because the trait bound `{}` is \
-                                     not satisfied",
-                                    error.obligation.predicate,
-                                ));
-                            }
-                            [errors @ .., last] => {
-                                diag.help(format!(
-                                    "`Clone` is not implemented because the following trait bounds \
-                                     could not be satisfied: {} and `{}`",
-                                    errors
-                                        .iter()
-                                        .map(|e| format!("`{}`", e.obligation.predicate))
-                                        .collect::<Vec<_>>()
-                                        .join(", "),
-                                    last.obligation.predicate,
-                                ));
-                            }
+                if let Some(errors) =
+                    self.could_impl_trait(clone_trait_did, expected_ty, self.param_env)
+                {
+                    match &errors[..] {
+                        [] => {}
+                        [error] => {
+                            diag.help(format!(
+                                "`Clone` is not implemented because the trait bound `{}` is \
+                                 not satisfied",
+                                error.obligation.predicate,
+                            ));
                         }
-                        for error in errors {
-                            if let traits::FulfillmentErrorCode::CodeSelectionError(
-                                traits::SelectionError::Unimplemented,
-                            ) = error.code
-                                && let ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) =
-                                    error.obligation.predicate.kind().skip_binder()
-                            {
-                                self.infcx.err_ctxt().suggest_derive(
-                                    &error.obligation,
-                                    diag,
-                                    error.obligation.predicate.kind().rebind(pred),
-                                );
-                            }
+                        [errors @ .., last] => {
+                            diag.help(format!(
+                                "`Clone` is not implemented because the following trait bounds \
+                                 could not be satisfied: {} and `{}`",
+                                errors
+                                    .iter()
+                                    .map(|e| format!("`{}`", e.obligation.predicate))
+                                    .collect::<Vec<_>>()
+                                    .join(", "),
+                                last.obligation.predicate,
+                            ));
                         }
                     }
-                });
+                    for error in errors {
+                        if let traits::FulfillmentErrorCode::CodeSelectionError(
+                            traits::SelectionError::Unimplemented,
+                        ) = error.code
+                            && let ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) =
+                                error.obligation.predicate.kind().skip_binder()
+                        {
+                            self.infcx.err_ctxt().suggest_derive(
+                                &error.obligation,
+                                diag,
+                                error.obligation.predicate.kind().rebind(pred),
+                            );
+                        }
+                    }
+                }
                 self.suggest_derive(diag, &[(trait_ref.to_predicate(self.tcx), None, None)]);
             }
         }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -21,7 +21,7 @@ use rustc_hir::{
     StmtKind, TyKind, WherePredicate,
 };
 use rustc_hir_analysis::astconv::AstConv;
-use rustc_infer::traits::{self, StatementAsExpression};
+use rustc_infer::traits::{self, StatementAsExpression, TraitEngineExt};
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::middle::stability::EvalResult;
 use rustc_middle::ty::print::with_no_trimmed_paths;
@@ -34,6 +34,7 @@ use rustc_span::source_map::Spanned;
 use rustc_span::symbol::{sym, Ident};
 use rustc_span::{Span, Symbol};
 use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::solve::FulfillmentCtxt;
 use rustc_trait_selection::traits::error_reporting::suggestions::TypeErrCtxtExt;
 use rustc_trait_selection::traits::error_reporting::DefIdOrName;
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
@@ -1603,6 +1604,78 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     None,
                 );
             } else {
+                self.infcx.probe(|_snapshot| {
+                    if let ty::Adt(def, args) = expected_ty.kind()
+                        && let Some((def_id, _imp)) = self
+                            .tcx
+                            .all_impls(clone_trait_did)
+                            .filter_map(|def_id| {
+                                self.tcx.impl_trait_ref(def_id).map(|r| (def_id, r))
+                            })
+                            .map(|(def_id, imp)| (def_id, imp.skip_binder()))
+                            .filter(|(_, imp)| match imp.self_ty().peel_refs().kind() {
+                                ty::Adt(i_def, _) if i_def.did() == def.did() => true,
+                                _ => false,
+                            })
+                            .next()
+                    {
+                        let mut fulfill_cx = FulfillmentCtxt::new(&self.infcx);
+                        // We get all obligations from the impl to talk about specific
+                        // trait bounds.
+                        let obligations = self
+                            .tcx
+                            .predicates_of(def_id)
+                            .instantiate(self.tcx, args)
+                            .into_iter()
+                            .map(|(clause, span)| {
+                                traits::Obligation::new(
+                                    self.tcx,
+                                    traits::ObligationCause::misc(span, self.body_id),
+                                    self.param_env,
+                                    clause,
+                                )
+                            })
+                            .collect::<Vec<_>>();
+                        fulfill_cx.register_predicate_obligations(&self.infcx, obligations);
+                        let errors = fulfill_cx.select_all_or_error(&self.infcx);
+                        match &errors[..] {
+                            [] => {}
+                            [error] => {
+                                diag.help(format!(
+                                    "`Clone` is not implemented because the trait bound `{}` is \
+                                     not satisfied",
+                                    error.obligation.predicate,
+                                ));
+                            }
+                            [errors @ .., last] => {
+                                diag.help(format!(
+                                    "`Clone` is not implemented because the following trait bounds \
+                                     could not be satisfied: {} and `{}`",
+                                    errors
+                                        .iter()
+                                        .map(|e| format!("`{}`", e.obligation.predicate))
+                                        .collect::<Vec<_>>()
+                                        .join(", "),
+                                    last.obligation.predicate,
+                                ));
+                            }
+                        }
+                        for error in errors {
+                            if let traits::FulfillmentErrorCode::CodeSelectionError(
+                                traits::SelectionError::Unimplemented,
+                            ) = error.code
+                                && let ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) =
+                                    error.obligation.predicate.kind().skip_binder()
+                            {
+                                self.infcx.err_ctxt().suggest_derive(
+                                    &error.obligation,
+                                    diag,
+                                    error.obligation.predicate.kind().rebind(pred),
+                                );
+                            }
+                        }
+                    }
+                });
                 self.suggest_derive(diag, &[(trait_ref.to_predicate(self.tcx), None, None)]);
             }
         }

--- a/compiler/rustc_trait_selection/src/infer.rs
+++ b/compiler/rustc_trait_selection/src/infer.rs
@@ -1,8 +1,10 @@
+use crate::solve::FulfillmentCtxt;
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
 use crate::traits::{self, DefiningAnchor, ObligationCtxt};
 
 use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items::LangItem;
+use rustc_infer::traits::{TraitEngine, TraitEngineExt};
 use rustc_middle::arena::ArenaAllocatable;
 use rustc_middle::infer::canonical::{Canonical, CanonicalQueryResponse, QueryResponse};
 use rustc_middle::traits::query::NoSolution;
@@ -35,6 +37,13 @@ pub trait InferCtxtExt<'tcx> {
         params: impl IntoIterator<Item: Into<GenericArg<'tcx>>>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> traits::EvaluationResult;
+
+    fn could_impl_trait(
+        &self,
+        trait_def_id: DefId,
+        ty: Ty<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+    ) -> Option<Vec<traits::FulfillmentError<'tcx>>>;
 }
 
 impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
@@ -75,6 +84,69 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
             predicate: ty::Binder::dummy(trait_ref).to_predicate(self.tcx),
         };
         self.evaluate_obligation(&obligation).unwrap_or(traits::EvaluationResult::EvaluatedToErr)
+    }
+
+    fn could_impl_trait(
+        &self,
+        trait_def_id: DefId,
+        ty: Ty<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+    ) -> Option<Vec<traits::FulfillmentError<'tcx>>> {
+        self.probe(|_snapshot| {
+            if let ty::Adt(def, args) = ty.kind()
+                && let Some((impl_def_id, _)) = self
+                    .tcx
+                    .all_impls(trait_def_id)
+                    .filter_map(|impl_def_id| {
+                        self.tcx.impl_trait_ref(impl_def_id).map(|r| (impl_def_id, r))
+                    })
+                    .map(|(impl_def_id, imp)| (impl_def_id, imp.skip_binder()))
+                    .filter(|(_, imp)| match imp.self_ty().peel_refs().kind() {
+                        ty::Adt(i_def, _) if i_def.did() == def.did() => true,
+                        _ => false,
+                    })
+                    .next()
+            {
+                let mut fulfill_cx = FulfillmentCtxt::new(self);
+                // We get all obligations from the impl to talk about specific
+                // trait bounds.
+                let obligations = self
+                    .tcx
+                    .predicates_of(impl_def_id)
+                    .instantiate(self.tcx, args)
+                    .into_iter()
+                    .map(|(clause, span)| {
+                        traits::Obligation::new(
+                            self.tcx,
+                            traits::ObligationCause::dummy_with_span(span),
+                            param_env,
+                            clause,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                fulfill_cx.register_predicate_obligations(self, obligations);
+                let trait_ref = ty::TraitRef::new(self.tcx, trait_def_id, [ty]);
+                let obligation = traits::Obligation::new(
+                    self.tcx,
+                    traits::ObligationCause::dummy(),
+                    param_env,
+                    trait_ref,
+                );
+                fulfill_cx.register_predicate_obligation(self, obligation);
+                let mut errors = fulfill_cx.select_all_or_error(self);
+                // We remove the last predicate failure, which corresponds to
+                // the top-level obligation, because most of the type we only
+                // care about the other ones, *except* when it is the only one.
+                // This seems to only be relevant for arbitrary self-types.
+                // Look at `tests/ui/moves/move-fn-self-receiver.rs`.
+                if errors.len() > 1 {
+                    errors.truncate(errors.len() - 1);
+                }
+                Some(errors)
+            } else {
+                None
+            }
+        })
     }
 }
 

--- a/library/portable-simd/crates/core_simd/tests/pointers.rs
+++ b/library/portable-simd/crates/core_simd/tests/pointers.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd, strict_provenance)]
+#![feature(portable_simd, strict_provenance, exposed_provenance)]
 
 use core_simd::simd::{
     ptr::{SimdConstPtr, SimdMutPtr},

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -38,3 +38,39 @@ impl<'a> fmt::Display for Escape<'a> {
         Ok(())
     }
 }
+
+/// Wrapper struct which will emit the HTML-escaped version of the contained
+/// string when passed to a format string.
+///
+/// This is only safe to use for text nodes. If you need your output to be
+/// safely contained in an attribute, use [`Escape`]. If you don't know the
+/// difference, use [`Escape`].
+pub(crate) struct EscapeBodyText<'a>(pub &'a str);
+
+impl<'a> fmt::Display for EscapeBodyText<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Because the internet is always right, turns out there's not that many
+        // characters to escape: http://stackoverflow.com/questions/7381974
+        let EscapeBodyText(s) = *self;
+        let pile_o_bits = s;
+        let mut last = 0;
+        for (i, ch) in s.char_indices() {
+            let s = match ch {
+                '>' => "&gt;",
+                '<' => "&lt;",
+                '&' => "&amp;",
+                _ => continue,
+            };
+            fmt.write_str(&pile_o_bits[last..i])?;
+            fmt.write_str(s)?;
+            // NOTE: we only expect single byte characters here - which is fine as long as we
+            // only match single byte characters
+            last = i + 1;
+        }
+
+        if last < s.len() {
+            fmt.write_str(&pile_o_bits[last..])?;
+        }
+        Ok(())
+    }
+}

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -6,7 +6,7 @@
 //! Use the `render_with_highlighting` to highlight some rust code.
 
 use crate::clean::PrimitiveType;
-use crate::html::escape::Escape;
+use crate::html::escape::EscapeBodyText;
 use crate::html::render::{Context, LinkFromSrc};
 
 use std::collections::VecDeque;
@@ -189,7 +189,7 @@ impl<'a, 'tcx, F: Write> TokenHandler<'a, 'tcx, F> {
             && can_merge(current_class, Some(*parent_class), "")
         {
             for (text, class) in self.pending_elems.iter() {
-                string(self.out, Escape(text), *class, &self.href_context, false);
+                string(self.out, EscapeBodyText(text), *class, &self.href_context, false);
             }
         } else {
             // We only want to "open" the tag ourselves if we have more than one pending and if the
@@ -202,7 +202,13 @@ impl<'a, 'tcx, F: Write> TokenHandler<'a, 'tcx, F> {
                 None
             };
             for (text, class) in self.pending_elems.iter() {
-                string(self.out, Escape(text), *class, &self.href_context, close_tag.is_none());
+                string(
+                    self.out,
+                    EscapeBodyText(text),
+                    *class,
+                    &self.href_context,
+                    close_tag.is_none(),
+                );
             }
             if let Some(close_tag) = close_tag {
                 exit_span(self.out, close_tag);

--- a/src/librustdoc/html/highlight/fixtures/dos_line.html
+++ b/src/librustdoc/html/highlight/fixtures/dos_line.html
@@ -1,3 +1,3 @@
 <span class="kw">pub fn </span>foo() {
-<span class="macro">println!</span>(<span class="string">&quot;foo&quot;</span>);
+<span class="macro">println!</span>(<span class="string">"foo"</span>);
 }

--- a/src/librustdoc/html/highlight/fixtures/sample.html
+++ b/src/librustdoc/html/highlight/fixtures/sample.html
@@ -8,12 +8,12 @@
 .lifetime { color: #B76514; }
 .question-mark { color: #ff9011; }
 </style>
-<pre><code><span class="attr">#![crate_type = <span class="string">&quot;lib&quot;</span>]
+<pre><code><span class="attr">#![crate_type = <span class="string">"lib"</span>]
 
 </span><span class="kw">use </span>std::path::{Path, PathBuf};
 
-<span class="attr">#[cfg(target_os = <span class="string">&quot;linux&quot;</span>)]
-#[cfg(target_os = <span class="string">&quot;windows&quot;</span>)]
+<span class="attr">#[cfg(target_os = <span class="string">"linux"</span>)]
+#[cfg(target_os = <span class="string">"windows"</span>)]
 </span><span class="kw">fn </span>main() -&gt; () {
     <span class="kw">let </span>foo = <span class="bool-val">true </span>&amp;&amp; <span class="bool-val">false </span>|| <span class="bool-val">true</span>;
     <span class="kw">let _</span>: <span class="kw-2">*const </span>() = <span class="number">0</span>;
@@ -22,7 +22,7 @@
     <span class="kw">let _ </span>= <span class="kw-2">*</span>foo;
     <span class="macro">mac!</span>(foo, <span class="kw-2">&amp;mut </span>bar);
     <span class="macro">assert!</span>(<span class="self">self</span>.length &lt; N &amp;&amp; index &lt;= <span class="self">self</span>.length);
-    ::std::env::var(<span class="string">&quot;gateau&quot;</span>).is_ok();
+    ::std::env::var(<span class="string">"gateau"</span>).is_ok();
     <span class="attr">#[rustfmt::skip]
     </span><span class="kw">let </span>s:std::path::PathBuf = std::path::PathBuf::new();
     <span class="kw">let </span><span class="kw-2">mut </span>s = String::new();

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1737,7 +1737,14 @@ fn item_variants(
         w.write_str("</h3></section>");
 
         let heading_and_fields = match &variant_data.kind {
-            clean::VariantKind::Struct(s) => Some(("Fields", &s.fields)),
+            clean::VariantKind::Struct(s) => {
+                // If there is no field to display, no need to add the heading.
+                if s.fields.iter().any(|f| !f.is_doc_hidden()) {
+                    Some(("Fields", &s.fields))
+                } else {
+                    None
+                }
+            }
             clean::VariantKind::Tuple(fields) => {
                 // Documentation on tuple variant fields is rare, so to reduce noise we only emit
                 // the section if at least one field is documented.

--- a/tests/rustdoc/enum-variant-fields-heading.rs
+++ b/tests/rustdoc/enum-variant-fields-heading.rs
@@ -1,0 +1,18 @@
+// This is a regression test for <https://github.com/rust-lang/rust/issues/118195>.
+// It ensures that the "Fields" heading is not generated if no field is displayed.
+
+#![crate_name = "foo"]
+
+// @has 'foo/enum.Foo.html'
+// @has - '//*[@id="variant.A"]' 'A'
+// @count - '//*[@id="variant.A.fields"]' 0
+// @has - '//*[@id="variant.B"]' 'B'
+// @count - '//*[@id="variant.B.fields"]' 0
+// @snapshot variants - '//*[@id="main-content"]/*[@class="variants"]'
+
+pub enum Foo {
+    /// A variant with no fields
+    A {},
+    /// A variant with hidden fields
+    B { #[doc(hidden)] a: u8 },
+}

--- a/tests/rustdoc/enum-variant-fields-heading.variants.html
+++ b/tests/rustdoc/enum-variant-fields-heading.variants.html
@@ -1,0 +1,3 @@
+<div class="variants"><section id="variant.A" class="variant"><a href="#variant.A" class="anchor">&#167;</a><h3 class="code-header">A</h3></section><div class="docblock"><p>A variant with no fields</p>
+</div><section id="variant.B" class="variant"><a href="#variant.B" class="anchor">&#167;</a><h3 class="code-header">B</h3></section><div class="docblock"><p>A variant with hidden fields</p>
+</div></div>

--- a/tests/ui/borrowck/accidentally-cloning-ref-borrow-error.rs
+++ b/tests/ui/borrowck/accidentally-cloning-ref-borrow-error.rs
@@ -1,0 +1,38 @@
+#[derive(Debug)]
+struct X<T>(T);
+
+impl<T: Clone> Clone for X<T> {
+    fn clone(&self) -> X<T> {
+        X(self.0.clone())
+    }
+}
+
+#[derive(Debug)]
+struct Y;
+
+#[derive(Debug)]
+struct Str {
+   x: Option<i32>,
+}
+
+fn foo(s: &mut Option<i32>) {
+    if s.is_none() {
+        *s = Some(0);
+    }
+    println!("{:?}", s);
+}
+
+fn bar<T: std::fmt::Debug>(s: &mut X<T>) {
+    println!("{:?}", s);
+}
+fn main() {
+    let s = Str { x: None };
+    let sr = &s;
+    let mut sm = sr.clone();
+    foo(&mut sm.x); //~ ERROR cannot borrow `sm.x` as mutable, as it is behind a `&` reference
+
+    let x = X(Y);
+    let xr = &x;
+    let mut xm = xr.clone();
+    bar(&mut xm); //~ ERROR cannot borrow data in a `&` reference as mutable
+}

--- a/tests/ui/borrowck/accidentally-cloning-ref-borrow-error.stderr
+++ b/tests/ui/borrowck/accidentally-cloning-ref-borrow-error.stderr
@@ -1,0 +1,30 @@
+error[E0596]: cannot borrow `sm.x` as mutable, as it is behind a `&` reference
+  --> $DIR/accidentally-cloning-ref-borrow-error.rs:32:9
+   |
+LL |     foo(&mut sm.x);
+   |         ^^^^^^^^^ `sm` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+   |
+help: `Str` doesn't implement `Clone`, so this call clones the reference `&Str`
+  --> $DIR/accidentally-cloning-ref-borrow-error.rs:31:21
+   |
+LL |     let mut sm = sr.clone();
+   |                     ^^^^^^^
+help: consider annotating `Str` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct Str {
+   |
+help: consider specifying this binding's type
+   |
+LL |     let mut sm: &mut Str = sr.clone();
+   |               ++++++++++
+
+error[E0596]: cannot borrow data in a `&` reference as mutable
+  --> $DIR/accidentally-cloning-ref-borrow-error.rs:37:9
+   |
+LL |     bar(&mut xm);
+   |         ^^^^^^^ cannot borrow as mutable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.fixed
+++ b/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+use std::rc::Rc;
+
+pub fn main() {
+    let _x = <Vec<i32> as Clone>::clone(&Rc::new(vec![1, 2])).into_iter();
+    //~^ ERROR [E0507]
+}

--- a/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.rs
+++ b/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.rs
@@ -1,3 +1,4 @@
+// run-rustfix
 use std::rc::Rc;
 
 pub fn main() {

--- a/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
+++ b/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of an `Rc`
-  --> $DIR/borrowck-move-out-of-overloaded-auto-deref.rs:4:14
+  --> $DIR/borrowck-move-out-of-overloaded-auto-deref.rs:5:14
    |
 LL |     let _x = Rc::new(vec![1, 2]).into_iter();
    |              ^^^^^^^^^^^^^^^^^^^ ----------- value moved due to this method call

--- a/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
+++ b/tests/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
@@ -10,8 +10,8 @@ note: `into_iter` takes ownership of the receiver `self`, which moves value
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |     let _x = Rc::new(vec![1, 2]).clone().into_iter();
-   |                                 ++++++++
+LL |     let _x = <Vec<i32> as Clone>::clone(&Rc::new(vec![1, 2])).into_iter();
+   |              ++++++++++++++++++++++++++++                   +
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/clone-span-on-try-operator.fixed
+++ b/tests/ui/borrowck/clone-span-on-try-operator.fixed
@@ -7,5 +7,5 @@ impl Foo {
 }
 fn main() {
     let foo = &Foo;
-    (*foo).clone().foo(); //~ ERROR cannot move out
+    <Foo as Clone>::clone(&(*foo)).foo(); //~ ERROR cannot move out
 }

--- a/tests/ui/borrowck/clone-span-on-try-operator.stderr
+++ b/tests/ui/borrowck/clone-span-on-try-operator.stderr
@@ -13,8 +13,8 @@ LL |     fn foo(self) {}
    |            ^^^^
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |     (*foo).clone().foo();
-   |           ++++++++
+LL |     <Foo as Clone>::clone(&(*foo)).foo();
+   |     +++++++++++++++++++++++      +
 
 error: aborting due to previous error
 

--- a/tests/ui/borrowck/issue-83760.fixed
+++ b/tests/ui/borrowck/issue-83760.fixed
@@ -1,13 +1,15 @@
 // run-rustfix
 #![allow(unused_variables, dead_code)]
+#[derive(Clone)]
 struct Struct;
+#[derive(Clone)]
 struct Struct2;
 // We use a second one here because otherwise when applying suggestions we'd end up with two
 // `#[derive(Clone)]` annotations.
 
 fn test1() {
     let mut val = Some(Struct);
-    while let Some(foo) = val { //~ ERROR use of moved value
+    while let Some(ref foo) = val { //~ ERROR use of moved value
         if true {
             val = None;
         } else {
@@ -18,7 +20,7 @@ fn test1() {
 
 fn test2() {
     let mut foo = Some(Struct);
-    let _x = foo.unwrap();
+    let _x = foo.clone().unwrap();
     if true {
         foo = Some(Struct);
     } else {
@@ -28,7 +30,7 @@ fn test2() {
 
 fn test3() {
     let mut foo = Some(Struct2);
-    let _x = foo.unwrap();
+    let _x = foo.clone().unwrap();
     if true {
         foo = Some(Struct2);
     } else if true {

--- a/tests/ui/borrowck/issue-83760.stderr
+++ b/tests/ui/borrowck/issue-83760.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value
-  --> $DIR/issue-83760.rs:5:20
+  --> $DIR/issue-83760.rs:10:20
    |
 LL |     while let Some(foo) = val {
    |                    ^^^ value moved here, in previous iteration of loop
@@ -14,7 +14,7 @@ LL |     while let Some(ref foo) = val {
    |                    +++
 
 error[E0382]: use of moved value: `foo`
-  --> $DIR/issue-83760.rs:21:14
+  --> $DIR/issue-83760.rs:26:14
    |
 LL |     let mut foo = Some(Struct);
    |         ------- move occurs because `foo` has type `Option<Struct>`, which does not implement the `Copy` trait
@@ -29,12 +29,21 @@ LL |     let _y = foo;
    |
 note: `Option::<T>::unwrap` takes ownership of the receiver `self`, which moves `foo`
   --> $SRC_DIR/core/src/option.rs:LL:COL
+help: you could `clone` the value and consume it, if the `Struct: Clone` trait bound could be satisfied
+   |
+LL |     let _x = foo.clone().unwrap();
+   |                 ++++++++
+help: consider annotating `Struct` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct Struct;
+   |
 
 error[E0382]: use of moved value: `foo`
-  --> $DIR/issue-83760.rs:37:14
+  --> $DIR/issue-83760.rs:42:14
    |
-LL |     let mut foo = Some(Struct);
-   |         ------- move occurs because `foo` has type `Option<Struct>`, which does not implement the `Copy` trait
+LL |     let mut foo = Some(Struct2);
+   |         ------- move occurs because `foo` has type `Option<Struct2>`, which does not implement the `Copy` trait
 LL |     let _x = foo.unwrap();
    |                  -------- `foo` moved due to this method call
 ...
@@ -42,18 +51,27 @@ LL |     let _y = foo;
    |              ^^^ value used here after move
    |
 note: these 3 reinitializations and 1 other might get skipped
-  --> $DIR/issue-83760.rs:30:9
+  --> $DIR/issue-83760.rs:35:9
    |
-LL |         foo = Some(Struct);
-   |         ^^^^^^^^^^^^^^^^^^
+LL |         foo = Some(Struct2);
+   |         ^^^^^^^^^^^^^^^^^^^
 LL |     } else if true {
-LL |         foo = Some(Struct);
-   |         ^^^^^^^^^^^^^^^^^^
+LL |         foo = Some(Struct2);
+   |         ^^^^^^^^^^^^^^^^^^^
 LL |     } else if true {
-LL |         foo = Some(Struct);
-   |         ^^^^^^^^^^^^^^^^^^
+LL |         foo = Some(Struct2);
+   |         ^^^^^^^^^^^^^^^^^^^
 note: `Option::<T>::unwrap` takes ownership of the receiver `self`, which moves `foo`
   --> $SRC_DIR/core/src/option.rs:LL:COL
+help: you could `clone` the value and consume it, if the `Struct2: Clone` trait bound could be satisfied
+   |
+LL |     let _x = foo.clone().unwrap();
+   |                 ++++++++
+help: consider annotating `Struct2` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct Struct2;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/borrowck/issue-85765-closure.rs
+++ b/tests/ui/borrowck/issue-85765-closure.rs
@@ -3,6 +3,7 @@ fn main() {
         let mut test = Vec::new();
         let rofl: &Vec<Vec<i32>> = &mut test;
         //~^ HELP consider changing this binding's type
+        //~| HELP you can `clone` the `Vec<Vec<i32>>` value and consume it, but this might not be your desired behavior
         rofl.push(Vec::new());
         //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
         //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -1,16 +1,21 @@
 error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-  --> $DIR/issue-85765-closure.rs:6:9
+  --> $DIR/issue-85765-closure.rs:7:9
    |
 LL |         rofl.push(Vec::new());
    |         ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
+help: you can `clone` the `Vec<Vec<i32>>` value and consume it, but this might not be your desired behavior
+  --> $DIR/issue-85765-closure.rs:4:36
+   |
+LL |         let rofl: &Vec<Vec<i32>> = &mut test;
+   |                                    ^^^^^^^^^
 help: consider changing this binding's type
    |
 LL |         let rofl: &mut Vec<Vec<i32>> = &mut test;
    |                   ~~~~~~~~~~~~~~~~~~
 
 error[E0594]: cannot assign to `*r`, which is behind a `&` reference
-  --> $DIR/issue-85765-closure.rs:13:9
+  --> $DIR/issue-85765-closure.rs:14:9
    |
 LL |         *r = 0;
    |         ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
@@ -21,7 +26,7 @@ LL |         let r = &mut mutvar;
    |                  +++
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
-  --> $DIR/issue-85765-closure.rs:20:9
+  --> $DIR/issue-85765-closure.rs:21:9
    |
 LL |         *x = 1;
    |         ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
@@ -32,7 +37,7 @@ LL |         let x: &mut usize = &mut{0};
    |                ~~~~~~~~~~
 
 error[E0594]: cannot assign to `*y`, which is behind a `&` reference
-  --> $DIR/issue-85765-closure.rs:27:9
+  --> $DIR/issue-85765-closure.rs:28:9
    |
 LL |         *y = 1;
    |         ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written

--- a/tests/ui/borrowck/issue-85765.rs
+++ b/tests/ui/borrowck/issue-85765.rs
@@ -2,6 +2,7 @@ fn main() {
     let mut test = Vec::new();
     let rofl: &Vec<Vec<i32>> = &mut test;
     //~^ HELP consider changing this binding's type
+    //~| HELP you can `clone` the `Vec<Vec<i32>>` value and consume it, but this might not be your desired behavior
     rofl.push(Vec::new());
     //~^ ERROR cannot borrow `*rofl` as mutable, as it is behind a `&` reference
     //~| NOTE `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -1,16 +1,21 @@
 error[E0596]: cannot borrow `*rofl` as mutable, as it is behind a `&` reference
-  --> $DIR/issue-85765.rs:5:5
+  --> $DIR/issue-85765.rs:6:5
    |
 LL |     rofl.push(Vec::new());
    |     ^^^^ `rofl` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
+help: you can `clone` the `Vec<Vec<i32>>` value and consume it, but this might not be your desired behavior
+  --> $DIR/issue-85765.rs:3:32
+   |
+LL |     let rofl: &Vec<Vec<i32>> = &mut test;
+   |                                ^^^^^^^^^
 help: consider changing this binding's type
    |
 LL |     let rofl: &mut Vec<Vec<i32>> = &mut test;
    |               ~~~~~~~~~~~~~~~~~~
 
 error[E0594]: cannot assign to `*r`, which is behind a `&` reference
-  --> $DIR/issue-85765.rs:12:5
+  --> $DIR/issue-85765.rs:13:5
    |
 LL |     *r = 0;
    |     ^^^^^^ `r` is a `&` reference, so the data it refers to cannot be written
@@ -21,7 +26,7 @@ LL |     let r = &mut mutvar;
    |              +++
 
 error[E0594]: cannot assign to `*x`, which is behind a `&` reference
-  --> $DIR/issue-85765.rs:19:5
+  --> $DIR/issue-85765.rs:20:5
    |
 LL |     *x = 1;
    |     ^^^^^^ `x` is a `&` reference, so the data it refers to cannot be written
@@ -32,7 +37,7 @@ LL |     let x: &mut usize = &mut{0};
    |            ~~~~~~~~~~
 
 error[E0594]: cannot assign to `*y`, which is behind a `&` reference
-  --> $DIR/issue-85765.rs:26:5
+  --> $DIR/issue-85765.rs:27:5
    |
 LL |     *y = 1;
    |     ^^^^^^ `y` is a `&` reference, so the data it refers to cannot be written

--- a/tests/ui/borrowck/issue-91206.rs
+++ b/tests/ui/borrowck/issue-91206.rs
@@ -10,6 +10,7 @@ fn main() {
     let client = TestClient;
     let inner = client.get_inner_ref();
     //~^ HELP consider specifying this binding's type
+    //~| HELP you can `clone` the `Vec<usize>` value and consume it, but this might not be your desired behavior
     inner.clear();
     //~^ ERROR cannot borrow `*inner` as mutable, as it is behind a `&` reference [E0596]
     //~| NOTE `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable

--- a/tests/ui/borrowck/issue-91206.stderr
+++ b/tests/ui/borrowck/issue-91206.stderr
@@ -1,9 +1,14 @@
 error[E0596]: cannot borrow `*inner` as mutable, as it is behind a `&` reference
-  --> $DIR/issue-91206.rs:13:5
+  --> $DIR/issue-91206.rs:14:5
    |
 LL |     inner.clear();
    |     ^^^^^ `inner` is a `&` reference, so the data it refers to cannot be borrowed as mutable
    |
+help: you can `clone` the `Vec<usize>` value and consume it, but this might not be your desired behavior
+  --> $DIR/issue-91206.rs:11:17
+   |
+LL |     let inner = client.get_inner_ref();
+   |                 ^^^^^^^^^^^^^^^^^^^^^^
 help: consider specifying this binding's type
    |
 LL |     let inner: &mut Vec<usize> = client.get_inner_ref();

--- a/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
+++ b/tests/ui/borrowck/suggest-as-ref-on-mut-closure.stderr
@@ -9,6 +9,10 @@ LL |     cb.map(|cb| cb());
    |
 note: `Option::<T>::map` takes ownership of the receiver `self`, which moves `*cb`
   --> $SRC_DIR/core/src/option.rs:LL:COL
+help: you could `clone` the value and consume it, if the `&mut dyn FnMut(): Clone` trait bound could be satisfied
+   |
+LL |     <Option<&mut dyn FnMut()> as Clone>::clone(&cb).map(|cb| cb());
+   |     ++++++++++++++++++++++++++++++++++++++++++++  +
 
 error[E0596]: cannot borrow `*cb` as mutable, as it is behind a `&` reference
   --> $DIR/suggest-as-ref-on-mut-closure.rs:12:26

--- a/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.fixed
+++ b/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.fixed
@@ -9,7 +9,7 @@ fn call<F>(f: F) where F : Fn() {
 fn main() {
     let y = vec![format!("World")];
     call(|| {
-        y.clone().into_iter();
+        <Vec<String> as Clone>::clone(&y).into_iter();
         //~^ ERROR cannot move out of `y`, a captured variable in an `Fn` closure
     });
 }

--- a/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
+++ b/tests/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
@@ -14,8 +14,8 @@ note: `into_iter` takes ownership of the receiver `self`, which moves `y`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |         y.clone().into_iter();
-   |          ++++++++
+LL |         <Vec<String> as Clone>::clone(&y).into_iter();
+   |         +++++++++++++++++++++++++++++++ +
 
 error: aborting due to previous error
 

--- a/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.fixed
+++ b/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.fixed
@@ -1,0 +1,30 @@
+// run-rustfix
+#![allow(unused_variables, dead_code)]
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+#[derive(Debug,Eq,PartialEq,Hash)]
+#[derive(Clone)]
+enum Day {
+    Mon,
+}
+
+struct Class {
+    days: BTreeMap<u32, HashSet<Day>>
+}
+
+impl Class {
+    fn do_stuff(&self) {
+        for (_, v) in &self.days {
+            let mut x: HashSet<Day> = v.clone(); //~ ERROR
+            let y: Vec<Day> = x.drain().collect();
+            println!("{:?}", x);
+        }
+    }
+}
+
+fn fail() {
+    let c = Class { days: BTreeMap::new() };
+    c.do_stuff();
+}
+fn main() {}

--- a/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.rs
+++ b/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.rs
@@ -1,0 +1,29 @@
+// run-rustfix
+#![allow(unused_variables, dead_code)]
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+#[derive(Debug,Eq,PartialEq,Hash)]
+enum Day {
+    Mon,
+}
+
+struct Class {
+    days: BTreeMap<u32, HashSet<Day>>
+}
+
+impl Class {
+    fn do_stuff(&self) {
+        for (_, v) in &self.days {
+            let mut x: HashSet<Day> = v.clone(); //~ ERROR
+            let y: Vec<Day> = x.drain().collect();
+            println!("{:?}", x);
+        }
+    }
+}
+
+fn fail() {
+    let c = Class { days: BTreeMap::new() };
+    c.do_stuff();
+}
+fn main() {}

--- a/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.stderr
+++ b/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/assignment-of-clone-call-on-ref-due-to-missing-bound.rs:18:39
+   |
+LL |             let mut x: HashSet<Day> = v.clone();
+   |                        ------------   ^^^^^^^^^ expected `HashSet<Day>`, found `&HashSet<Day>`
+   |                        |
+   |                        expected due to this
+   |
+   = note: expected struct `HashSet<Day>`
+           found reference `&HashSet<Day>`
+note: `HashSet<Day>` does not implement `Clone`, so `&HashSet<Day>` was cloned instead
+  --> $DIR/assignment-of-clone-call-on-ref-due-to-missing-bound.rs:18:39
+   |
+LL |             let mut x: HashSet<Day> = v.clone();
+   |                                       ^
+   = help: `Clone` is not implemented because the trait bound `Day: Clone` is not satisfied
+help: consider annotating `Day` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | enum Day {
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/moves/move-fn-self-receiver.stderr
+++ b/tests/ui/moves/move-fn-self-receiver.stderr
@@ -55,7 +55,7 @@ note: `Foo::use_box_self` takes ownership of the receiver `self`, which moves `b
    |
 LL |     fn use_box_self(self: Box<Self>) {}
    |                     ^^^^
-help: you can `clone` the value and consume it, but this might not be your desired behavior
+help: you could `clone` the value and consume it, if the `Box<Foo>: Clone` trait bound could be satisfied
    |
 LL |     boxed_foo.clone().use_box_self();
    |              ++++++++

--- a/tests/ui/moves/move-fn-self-receiver.stderr
+++ b/tests/ui/moves/move-fn-self-receiver.stderr
@@ -55,6 +55,10 @@ note: `Foo::use_box_self` takes ownership of the receiver `self`, which moves `b
    |
 LL |     fn use_box_self(self: Box<Self>) {}
    |                     ^^^^
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |     boxed_foo.clone().use_box_self();
+   |              ++++++++
 
 error[E0382]: use of moved value: `pin_box_foo`
   --> $DIR/move-fn-self-receiver.rs:46:5
@@ -71,6 +75,10 @@ note: `Foo::use_pin_box_self` takes ownership of the receiver `self`, which move
    |
 LL |     fn use_pin_box_self(self: Pin<Box<Self>>) {}
    |                         ^^^^
+help: you could `clone` the value and consume it, if the `Box<Foo>: Clone` trait bound could be satisfied
+   |
+LL |     pin_box_foo.clone().use_pin_box_self();
+   |                ++++++++
 
 error[E0505]: cannot move out of `mut_foo` because it is borrowed
   --> $DIR/move-fn-self-receiver.rs:50:5

--- a/tests/ui/moves/needs-clone-through-deref.fixed
+++ b/tests/ui/moves/needs-clone-through-deref.fixed
@@ -1,0 +1,18 @@
+// run-rustfix
+#![allow(dead_code, noop_method_call)]
+use std::ops::Deref;
+struct S(Vec<usize>);
+impl Deref for S {
+    type Target = Vec<usize>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl S {
+    fn foo(&self) {
+        // `self.clone()` returns `&S`, not `Vec`
+        for _ in <Vec<usize> as Clone>::clone(&self.clone()).into_iter() {} //~ ERROR cannot move out of dereference of `S`
+    }
+}
+fn main() {}

--- a/tests/ui/moves/needs-clone-through-deref.rs
+++ b/tests/ui/moves/needs-clone-through-deref.rs
@@ -1,0 +1,18 @@
+// run-rustfix
+#![allow(dead_code, noop_method_call)]
+use std::ops::Deref;
+struct S(Vec<usize>);
+impl Deref for S {
+    type Target = Vec<usize>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl S {
+    fn foo(&self) {
+        // `self.clone()` returns `&S`, not `Vec`
+        for _ in self.clone().into_iter() {} //~ ERROR cannot move out of dereference of `S`
+    }
+}
+fn main() {}

--- a/tests/ui/moves/needs-clone-through-deref.stderr
+++ b/tests/ui/moves/needs-clone-through-deref.stderr
@@ -1,0 +1,18 @@
+error[E0507]: cannot move out of dereference of `S`
+  --> $DIR/needs-clone-through-deref.rs:15:18
+   |
+LL |         for _ in self.clone().into_iter() {}
+   |                  ^^^^^^^^^^^^ ----------- value moved due to this method call
+   |                  |
+   |                  move occurs because value has type `Vec<usize>`, which does not implement the `Copy` trait
+   |
+note: `into_iter` takes ownership of the receiver `self`, which moves value
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+help: you can `clone` the value and consume it, but this might not be your desired behavior
+   |
+LL |         for _ in <Vec<usize> as Clone>::clone(&self.clone()).into_iter() {}
+   |                  ++++++++++++++++++++++++++++++            +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.fixed
+++ b/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.fixed
@@ -1,0 +1,28 @@
+// run-rustfix
+// Issue #109429
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+
+#[derive(Clone)]
+pub struct Hash128_1;
+
+impl BuildHasher for Hash128_1 {
+    type Hasher = DefaultHasher;
+    fn build_hasher(&self) -> DefaultHasher { DefaultHasher::default() }
+}
+
+#[allow(unused)]
+pub fn hashmap_copy<T, U>(
+    map: &HashMap<T, U, Hash128_1>,
+) where T: Hash + Clone, U: Clone
+{
+    let mut copy: Vec<U> = <HashMap<T, U, Hash128_1> as Clone>::clone(&map.clone()).into_values().collect(); //~ ERROR
+}
+
+pub fn make_map() -> HashMap<String, i64, Hash128_1>
+{
+    HashMap::with_hasher(Hash128_1)
+}
+fn main() {}

--- a/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.rs
+++ b/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.rs
@@ -1,0 +1,27 @@
+// run-rustfix
+// Issue #109429
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+
+pub struct Hash128_1;
+
+impl BuildHasher for Hash128_1 {
+    type Hasher = DefaultHasher;
+    fn build_hasher(&self) -> DefaultHasher { DefaultHasher::default() }
+}
+
+#[allow(unused)]
+pub fn hashmap_copy<T, U>(
+    map: &HashMap<T, U, Hash128_1>,
+) where T: Hash + Clone, U: Clone
+{
+    let mut copy: Vec<U> = map.clone().into_values().collect(); //~ ERROR
+}
+
+pub fn make_map() -> HashMap<String, i64, Hash128_1>
+{
+    HashMap::with_hasher(Hash128_1)
+}
+fn main() {}

--- a/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.stderr
+++ b/tests/ui/moves/suggest-clone-when-some-obligation-is-unmet.stderr
@@ -1,0 +1,23 @@
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/suggest-clone-when-some-obligation-is-unmet.rs:20:28
+   |
+LL |     let mut copy: Vec<U> = map.clone().into_values().collect();
+   |                            ^^^^^^^^^^^ ------------- value moved due to this method call
+   |                            |
+   |                            move occurs because value has type `HashMap<T, U, Hash128_1>`, which does not implement the `Copy` trait
+   |
+note: `HashMap::<K, V, S>::into_values` takes ownership of the receiver `self`, which moves value
+  --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
+help: you could `clone` the value and consume it, if the `Hash128_1: Clone` trait bound could be satisfied
+   |
+LL |     let mut copy: Vec<U> = <HashMap<T, U, Hash128_1> as Clone>::clone(&map.clone()).into_values().collect();
+   |                            ++++++++++++++++++++++++++++++++++++++++++++           +
+help: consider annotating `Hash128_1` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | pub struct Hash128_1;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/moves/suggest-clone.fixed
+++ b/tests/ui/moves/suggest-clone.fixed
@@ -7,5 +7,5 @@ impl Foo {
 }
 fn main() {
     let foo = &Foo;
-    foo.clone().foo(); //~ ERROR cannot move out
+    <Foo as Clone>::clone(&foo).foo(); //~ ERROR cannot move out
 }

--- a/tests/ui/moves/suggest-clone.stderr
+++ b/tests/ui/moves/suggest-clone.stderr
@@ -13,8 +13,8 @@ LL |     fn foo(self) {}
    |            ^^^^
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |     foo.clone().foo();
-   |        ++++++++
+LL |     <Foo as Clone>::clone(&foo).foo();
+   |     +++++++++++++++++++++++   +
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/as-ref-2.stderr
+++ b/tests/ui/suggestions/as-ref-2.stderr
@@ -12,6 +12,15 @@ LL |     let _y = foo;
    |
 note: `Option::<T>::map` takes ownership of the receiver `self`, which moves `foo`
   --> $SRC_DIR/core/src/option.rs:LL:COL
+help: you could `clone` the value and consume it, if the `Struct: Clone` trait bound could be satisfied
+   |
+LL |     let _x: Option<Struct> = foo.clone().map(|s| bar(&s));
+   |                                 ++++++++
+help: consider annotating `Struct` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct Struct;
+   |
 
 error: aborting due to previous error
 

--- a/tests/ui/suggestions/option-content-move.fixed
+++ b/tests/ui/suggestions/option-content-move.fixed
@@ -7,7 +7,7 @@ impl LipogramCorpora {
     pub fn validate_all(&mut self) -> Result<(), char> {
         for selection in &self.selections {
             if selection.1.is_some() {
-                if selection.1.unwrap().contains(selection.0) {
+                if <Option<String> as Clone>::clone(&selection.1).unwrap().contains(selection.0) {
                 //~^ ERROR cannot move out of `selection.1`
                     return Err(selection.0);
                 }
@@ -25,7 +25,7 @@ impl LipogramCorpora2 {
     pub fn validate_all(&mut self) -> Result<(), char> {
         for selection in &self.selections {
             if selection.1.is_ok() {
-                if selection.1.unwrap().contains(selection.0) {
+                if <Result<String, String> as Clone>::clone(&selection.1).unwrap().contains(selection.0) {
                 //~^ ERROR cannot move out of `selection.1`
                     return Err(selection.0);
                 }

--- a/tests/ui/suggestions/option-content-move.stderr
+++ b/tests/ui/suggestions/option-content-move.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
-  --> $DIR/option-content-move.rs:9:20
+  --> $DIR/option-content-move.rs:10:20
    |
 LL |                 if selection.1.unwrap().contains(selection.0) {
    |                    ^^^^^^^^^^^ -------- `selection.1` moved due to this method call
@@ -15,7 +15,7 @@ LL |                 if <Option<String> as Clone>::clone(&selection.1).unwrap().
    |                    ++++++++++++++++++++++++++++++++++           +
 
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
-  --> $DIR/option-content-move.rs:27:20
+  --> $DIR/option-content-move.rs:28:20
    |
 LL |                 if selection.1.unwrap().contains(selection.0) {
    |                    ^^^^^^^^^^^ -------- `selection.1` moved due to this method call

--- a/tests/ui/suggestions/option-content-move.stderr
+++ b/tests/ui/suggestions/option-content-move.stderr
@@ -11,8 +11,8 @@ note: `Option::<T>::unwrap` takes ownership of the receiver `self`, which moves 
   --> $SRC_DIR/core/src/option.rs:LL:COL
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |                 if selection.1.clone().unwrap().contains(selection.0) {
-   |                               ++++++++
+LL |                 if <Option<String> as Clone>::clone(&selection.1).unwrap().contains(selection.0) {
+   |                    ++++++++++++++++++++++++++++++++++           +
 
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
   --> $DIR/option-content-move.rs:27:20
@@ -27,8 +27,8 @@ note: `Result::<T, E>::unwrap` takes ownership of the receiver `self`, which mov
   --> $SRC_DIR/core/src/result.rs:LL:COL
 help: you can `clone` the value and consume it, but this might not be your desired behavior
    |
-LL |                 if selection.1.clone().unwrap().contains(selection.0) {
-   |                               ++++++++
+LL |                 if <Result<String, String> as Clone>::clone(&selection.1).unwrap().contains(selection.0) {
+   |                    ++++++++++++++++++++++++++++++++++++++++++           +
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #118076 (Tweak `.clone()` suggestion to work in more cases)
 - #118508 (rustdoc: do not escape quotes in body text)
 - #118565 (interpret: make numeric_intrinsic accessible from Miri)
 - #118591 (portable-simd: fix test suite build)
 - #118600 ([rustdoc] Don't generate the "Fields" heading if there is no field displayed)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118076,118508,118565,118591,118600)
<!-- homu-ignore:end -->