### PR TITLE
Improve std::fs::read_to_string example

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -242,10 +242,10 @@ pub struct DirBuilder {
 ///
 /// ```no_run
 /// use std::fs;
-/// use std::net::SocketAddr;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
-///     let foo: SocketAddr = String::from_utf8_lossy(&fs::read("address.txt")?).parse()?;
+///     let address: String = String::from_utf8_lossy(&fs::read("address.txt")?).to_string();
+///     println!("{}", address);
 ///     Ok(())
 /// }
 /// ```

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -283,11 +283,11 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 ///
 /// ```no_run
 /// use std::fs;
-/// use std::net::SocketAddr;
 /// use std::error::Error;
 ///
 /// fn main() -> Result<(), Box<dyn Error>> {
-///     let foo: SocketAddr = fs::read_to_string("address.txt")?.parse()?;
+///     let address: String = fs::read_to_string("address.txt")?;
+///     println!("{}", address);
 ///     Ok(())
 /// }
 /// ```

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -286,8 +286,8 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// use std::error::Error;
 ///
 /// fn main() -> Result<(), Box<dyn Error>> {
-///     let address: String = fs::read_to_string("address.txt")?;
-///     println!("{}", address);
+///     let message: String = fs::read_to_string("message.txt")?;
+///     println!("{}", message);
 ///     Ok(())
 /// }
 /// ```

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -244,8 +244,8 @@ pub struct DirBuilder {
 /// use std::fs;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
-///     let address: String = String::from_utf8_lossy(&fs::read("address.txt")?).to_string();
-///     println!("{}", address);
+///     let data: Vec<u8> = fs::read("image.jpg")?;
+///     assert_eq!(data[0..3], [0xFF, 0xD8, 0xFF]);
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
Resolves  [#118621](https://github.com/rust-lang/rust/issues/118621)

For the original code to succeed it requires address.txt to contain a socketaddress, however it is much easier to follow if this is just any strong - eg address could be a street address or just text.  

Also changed the variable name from "foo" to something more meaningful as cargo clippy warns you against using foo as a placeholder. 

```
$ cat main.rs 
use std::fs;
use std::error::Error;

fn main() -> Result<(), Box<dyn Error>> {
    let addr: String = fs::read_to_string("address.txt")?.parse()?;
    println!("{}", addr);
    Ok(())
}

$ cat address.txt 
123 rusty lane
san francisco 94999

$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
     Running `/home/haydon/workspace/rust-test-pr/tester/target/debug/tester`
123 rusty lane
san francisco 94999

```