### PR TITLE
feed `def_span` in resolver

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -804,12 +804,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     /// Intercept all spans entering HIR.
     /// Mark a span as relative to the current owning item.
     fn lower_span(&self, span: Span) -> Span {
-        if self.tcx.sess.opts.incremental.is_some() {
-            span.with_parent(Some(self.current_hir_id_owner.def_id))
-        } else {
-            // Do not make spans relative when not using incremental compilation.
-            span
-        }
+        rustc_middle::util::lower_span(self.tcx, span, self.current_hir_id_owner.def_id)
     }
 
     fn lower_ident(&self, ident: Ident) -> Ident {

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -170,11 +170,14 @@ impl<'tcx> Queries<'tcx> {
                     &pre_configured_attrs,
                     crate_name,
                 )));
+                let span = krate.spans.inner_span;
                 feed.crate_for_resolver(tcx.arena.alloc(Steal::new((krate, pre_configured_attrs))));
                 feed.output_filenames(Arc::new(outputs));
 
-                let feed = tcx.feed_local_def_id(CRATE_DEF_ID);
+                let def_id = CRATE_DEF_ID;
+                let feed = tcx.feed_local_def_id(def_id);
                 feed.def_kind(DefKind::Mod);
+                feed.def_span(rustc_middle::util::lower_span(tcx, span, def_id));
             });
             Ok(qcx)
         })

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -14,7 +14,7 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
 use rustc_hir::*;
 use rustc_query_system::ich::StableHashingContext;
-use rustc_span::{ErrorGuaranteed, ExpnId, DUMMY_SP};
+use rustc_span::{ErrorGuaranteed, ExpnId};
 
 /// Top-level HIR node for current owner. This only contains the node for which
 /// `HirId::local_id == 0`, and excludes bodies.
@@ -174,10 +174,6 @@ pub fn provide(providers: &mut Providers) {
     };
     providers.hir_attrs = |tcx, id| {
         tcx.hir_crate(()).owners[id.def_id].as_owner().map_or(AttributeMap::EMPTY, |o| &o.attrs)
-    };
-    providers.def_span = |tcx, def_id| {
-        let hir_id = tcx.local_def_id_to_hir_id(def_id);
-        tcx.hir().opt_span(hir_id).unwrap_or(DUMMY_SP)
     };
     providers.def_ident_span = |tcx, def_id| {
         let hir_id = tcx.local_def_id_to_hir_id(def_id);

--- a/compiler/rustc_middle/src/util/lower_span.rs
+++ b/compiler/rustc_middle/src/util/lower_span.rs
@@ -1,0 +1,13 @@
+use rustc_hir::def_id::LocalDefId;
+use rustc_span::Span;
+
+use crate::ty::TyCtxt;
+
+pub fn lower_span(tcx: TyCtxt<'_>, span: Span, parent: LocalDefId) -> Span {
+    if tcx.sess.opts.incremental.is_some() {
+        span.with_parent(Some(parent))
+    } else {
+        // Do not make spans relative when not using incremental compilation.
+        span
+    }
+}

--- a/compiler/rustc_middle/src/util/mod.rs
+++ b/compiler/rustc_middle/src/util/mod.rs
@@ -2,9 +2,11 @@ pub mod bug;
 pub mod call_kind;
 pub mod common;
 pub mod find_self_call;
+mod lower_span;
 
 pub use call_kind::{call_kind, CallDesugaringKind, CallKind};
 pub use find_self_call::find_self_call;
+pub use lower_span::lower_span;
 
 #[derive(Default, Copy, Clone)]
 pub struct Providers {

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1441,7 +1441,7 @@ fn collect_used_items<'tcx>(
     // and abort compilation if any of them errors.
     MirUsedCollector {
         tcx,
-        body: body,
+        body,
         output,
         instance,
         move_size_spans: vec![],


### PR DESCRIPTION
Fixes #118552

This PR removes ﻿`provider.def_span` and instead introduces it during the definition collection process

r? @cjgillot 