### PR TITLE
add comment about keeping flags in sync between bootstrap.py and bootstrap.rs

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -946,6 +946,8 @@ class RustBuild(object):
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += " -C linker=" + target_linker
+        # When changing this list, also update the corresponding list in `Builder::cargo`
+        # in `src/bootstrap/src/core/builder.rs`.
         env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
         if self.warnings == "default":
             deny_warnings = self.get_toml("deny-warnings", "rust") != "false"


### PR DESCRIPTION
They got out of sync, probably because this comment was missing on the Python side (it only exists on the Rust side). https://github.com/rust-lang/rust/pull/118642 brings the flags back in sync but does not fix the comment, so let's do that here.

r? clubby789