### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1,5 +1,5 @@
 use rustc_errors::{
-    AddToDiagnostic, DiagnosticBuilder, EmissionGuarantee, Handler, IntoDiagnostic, MultiSpan,
+    AddToDiagnostic, DiagnosticBuilder, ErrorGuaranteed, Handler, IntoDiagnostic, MultiSpan,
     SingleLabelManySpans,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
@@ -446,9 +446,9 @@ pub(crate) struct EnvNotDefinedWithUserMessage {
 }
 
 // Hand-written implementation to support custom user messages.
-impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for EnvNotDefinedWithUserMessage {
+impl<'a> IntoDiagnostic<'a> for EnvNotDefinedWithUserMessage {
     #[track_caller]
-    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, G> {
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         #[expect(
             rustc::untranslatable_diagnostic,
             reason = "cannot translate user-provided messages"
@@ -801,8 +801,8 @@ pub(crate) struct AsmClobberNoReg {
     pub(crate) clobbers: Vec<Span>,
 }
 
-impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for AsmClobberNoReg {
-    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, G> {
+impl<'a> IntoDiagnostic<'a> for AsmClobberNoReg {
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut diag =
             handler.struct_diagnostic(crate::fluent_generated::builtin_macros_asm_clobber_no_reg);
         diag.set_span(self.spans.clone());

--- a/compiler/rustc_codegen_cranelift/src/concurrency_limiter.rs
+++ b/compiler/rustc_codegen_cranelift/src/concurrency_limiter.rs
@@ -64,7 +64,7 @@ impl ConcurrencyLimiter {
                     // Make sure to drop the mutex guard first to prevent poisoning the mutex.
                     drop(state);
                     if let Some(err) = err {
-                        handler.fatal(err).raise();
+                        handler.fatal(err);
                     } else {
                         // The error was already emitted, but compilation continued. Raise a silent
                         // fatal error.

--- a/compiler/rustc_codegen_gcc/src/errors.rs
+++ b/compiler/rustc_codegen_gcc/src/errors.rs
@@ -111,8 +111,8 @@ pub(crate) struct TargetFeatureDisableOrEnable<'a> {
 pub(crate) struct MissingFeatures;
 
 impl IntoDiagnostic<'_, ErrorGuaranteed> for TargetFeatureDisableOrEnable<'_> {
-    fn into_diagnostic(self, sess: &'_ Handler) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(fluent::codegen_gcc_target_feature_disable_or_enable);
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
+        let mut diag = handler.struct_err(fluent::codegen_gcc_target_feature_disable_or_enable);
         if let Some(span) = self.span {
             diag.set_span(span);
         };

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -101,9 +101,9 @@ pub(crate) struct DynamicLinkingWithLTO;
 
 pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
 
-impl<EM: EmissionGuarantee> IntoDiagnostic<'_, EM> for ParseTargetMachineConfig<'_> {
-    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, EM> {
-        let diag: DiagnosticBuilder<'_, EM> = self.0.into_diagnostic(handler);
+impl<G: EmissionGuarantee> IntoDiagnostic<'_, G> for ParseTargetMachineConfig<'_> {
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, G> {
+        let diag: DiagnosticBuilder<'_, G> = self.0.into_diagnostic(handler);
         let (message, _) = diag.styled_message().first().expect("`LlvmError` with no message");
         let message = handler.eagerly_translate_to_string(message.clone(), diag.args());
 
@@ -183,8 +183,8 @@ pub enum LlvmError<'a> {
 
 pub(crate) struct WithLlvmError<'a>(pub LlvmError<'a>, pub String);
 
-impl<EM: EmissionGuarantee> IntoDiagnostic<'_, EM> for WithLlvmError<'_> {
-    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, EM> {
+impl<G: EmissionGuarantee> IntoDiagnostic<'_, G> for WithLlvmError<'_> {
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, G> {
         use LlvmError::*;
         let msg_with_llvm_err = match &self.0 {
             WriteOutput { .. } => fluent::codegen_llvm_write_output_with_llvm_err,

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::fluent_generated as fluent;
 use rustc_data_structures::small_c_str::SmallCStr;
 use rustc_errors::{
-    DiagnosticBuilder, EmissionGuarantee, ErrorGuaranteed, Handler, IntoDiagnostic,
+    DiagnosticBuilder, EmissionGuarantee, ErrorGuaranteed, FatalError, Handler, IntoDiagnostic,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::Span;
@@ -101,9 +101,9 @@ pub(crate) struct DynamicLinkingWithLTO;
 
 pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
 
-impl<G: EmissionGuarantee> IntoDiagnostic<'_, G> for ParseTargetMachineConfig<'_> {
-    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, G> {
-        let diag: DiagnosticBuilder<'_, G> = self.0.into_diagnostic(handler);
+impl IntoDiagnostic<'_, FatalError> for ParseTargetMachineConfig<'_> {
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, FatalError> {
+        let diag: DiagnosticBuilder<'_, FatalError> = self.0.into_diagnostic(handler);
         let (message, _) = diag.styled_message().first().expect("`LlvmError` with no message");
         let message = handler.eagerly_translate_to_string(message.clone(), diag.args());
 

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -102,12 +102,12 @@ pub(crate) struct DynamicLinkingWithLTO;
 pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
 
 impl<EM: EmissionGuarantee> IntoDiagnostic<'_, EM> for ParseTargetMachineConfig<'_> {
-    fn into_diagnostic(self, sess: &'_ Handler) -> DiagnosticBuilder<'_, EM> {
-        let diag: DiagnosticBuilder<'_, EM> = self.0.into_diagnostic(sess);
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, EM> {
+        let diag: DiagnosticBuilder<'_, EM> = self.0.into_diagnostic(handler);
         let (message, _) = diag.styled_message().first().expect("`LlvmError` with no message");
-        let message = sess.eagerly_translate_to_string(message.clone(), diag.args());
+        let message = handler.eagerly_translate_to_string(message.clone(), diag.args());
 
-        let mut diag = sess.struct_diagnostic(fluent::codegen_llvm_parse_target_machine_config);
+        let mut diag = handler.struct_diagnostic(fluent::codegen_llvm_parse_target_machine_config);
         diag.set_arg("error", message);
         diag
     }
@@ -124,8 +124,8 @@ pub(crate) struct TargetFeatureDisableOrEnable<'a> {
 pub(crate) struct MissingFeatures;
 
 impl IntoDiagnostic<'_, ErrorGuaranteed> for TargetFeatureDisableOrEnable<'_> {
-    fn into_diagnostic(self, sess: &'_ Handler) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
-        let mut diag = sess.struct_err(fluent::codegen_llvm_target_feature_disable_or_enable);
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
+        let mut diag = handler.struct_err(fluent::codegen_llvm_target_feature_disable_or_enable);
         if let Some(span) = self.span {
             diag.set_span(span);
         };
@@ -184,7 +184,7 @@ pub enum LlvmError<'a> {
 pub(crate) struct WithLlvmError<'a>(pub LlvmError<'a>, pub String);
 
 impl<EM: EmissionGuarantee> IntoDiagnostic<'_, EM> for WithLlvmError<'_> {
-    fn into_diagnostic(self, sess: &'_ Handler) -> DiagnosticBuilder<'_, EM> {
+    fn into_diagnostic(self, handler: &'_ Handler) -> DiagnosticBuilder<'_, EM> {
         use LlvmError::*;
         let msg_with_llvm_err = match &self.0 {
             WriteOutput { .. } => fluent::codegen_llvm_write_output_with_llvm_err,
@@ -201,7 +201,7 @@ impl<EM: EmissionGuarantee> IntoDiagnostic<'_, EM> for WithLlvmError<'_> {
             PrepareThinLtoModule => fluent::codegen_llvm_prepare_thin_lto_module_with_llvm_err,
             ParseBitcode => fluent::codegen_llvm_parse_bitcode_with_llvm_err,
         };
-        let mut diag = self.0.into_diagnostic(sess);
+        let mut diag = self.0.into_diagnostic(handler);
         diag.set_primary_message(msg_with_llvm_err);
         diag.set_arg("llvm_err", self.1);
         diag

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -18,18 +18,18 @@ use std::thread::panicking;
 /// Trait implemented by error types. This should not be implemented manually. Instead, use
 /// `#[derive(Diagnostic)]` -- see [rustc_macros::Diagnostic].
 #[rustc_diagnostic_item = "IntoDiagnostic"]
-pub trait IntoDiagnostic<'a, T: EmissionGuarantee = ErrorGuaranteed> {
+pub trait IntoDiagnostic<'a, G: EmissionGuarantee = ErrorGuaranteed> {
     /// Write out as a diagnostic out of `Handler`.
     #[must_use]
-    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, T>;
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, G>;
 }
 
-impl<'a, T, E> IntoDiagnostic<'a, E> for Spanned<T>
+impl<'a, T, G> IntoDiagnostic<'a, G> for Spanned<T>
 where
-    T: IntoDiagnostic<'a, E>,
-    E: EmissionGuarantee,
+    T: IntoDiagnostic<'a, G>,
+    G: EmissionGuarantee,
 {
-    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, E> {
+    fn into_diagnostic(self, handler: &'a Handler) -> DiagnosticBuilder<'a, G> {
         let mut diag = self.node.into_diagnostic(handler);
         diag.set_span(self.span);
         diag

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -547,12 +547,6 @@ impl<'a, G: EmissionGuarantee> DiagnosticBuilder<'a, G> {
         found_extra: &dyn fmt::Display,
     ) -> &mut Self);
 
-    forward!(pub fn note_unsuccessful_coercion(
-        &mut self,
-        expected: DiagnosticStyledString,
-        found: DiagnosticStyledString,
-    ) -> &mut Self);
-
     forward!(pub fn note(&mut self, msg: impl Into<SubdiagnosticMessage>) -> &mut Self);
     forward!(pub fn note_once(&mut self, msg: impl Into<SubdiagnosticMessage>) -> &mut Self);
     forward!(pub fn span_note(
@@ -581,7 +575,6 @@ impl<'a, G: EmissionGuarantee> DiagnosticBuilder<'a, G> {
     forward!(pub fn set_is_lint(&mut self,) -> &mut Self);
 
     forward!(pub fn disable_suggestions(&mut self,) -> &mut Self);
-    forward!(pub fn clear_suggestions(&mut self,) -> &mut Self);
 
     forward!(pub fn multipart_suggestion(
         &mut self,

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -188,7 +188,7 @@ impl<'a> DiagnosticBuilder<'a, ()> {
         level: Level,
         message: M,
     ) -> Self {
-        let diagnostic = Diagnostic::new_with_code(level, None, message);
+        let diagnostic = Diagnostic::new(level, message);
         Self::new_diagnostic(handler, diagnostic)
     }
 
@@ -257,7 +257,7 @@ impl EmissionGuarantee for Noted {
         DiagnosticBuilder {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),
-                diagnostic: Box::new(Diagnostic::new_with_code(Level::Note, None, msg)),
+                diagnostic: Box::new(Diagnostic::new(Level::Note, msg)),
             },
             _marker: PhantomData,
         }
@@ -292,7 +292,7 @@ impl EmissionGuarantee for Bug {
         DiagnosticBuilder {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),
-                diagnostic: Box::new(Diagnostic::new_with_code(Level::Bug, None, msg)),
+                diagnostic: Box::new(Diagnostic::new(Level::Bug, msg)),
             },
             _marker: PhantomData,
         }
@@ -322,7 +322,7 @@ impl EmissionGuarantee for ! {
         DiagnosticBuilder {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),
-                diagnostic: Box::new(Diagnostic::new_with_code(Level::Fatal, None, msg)),
+                diagnostic: Box::new(Diagnostic::new(Level::Fatal, msg)),
             },
             _marker: PhantomData,
         }
@@ -352,7 +352,7 @@ impl EmissionGuarantee for rustc_span::fatal_error::FatalError {
         DiagnosticBuilder {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),
-                diagnostic: Box::new(Diagnostic::new_with_code(Level::Fatal, None, msg)),
+                diagnostic: Box::new(Diagnostic::new(Level::Fatal, msg)),
             },
             _marker: PhantomData,
         }

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -254,13 +254,6 @@ impl<'a> DiagnosticBuilder<'a, Noted> {
     /// `struct_*` methods on [`Handler`].
     pub(crate) fn new_note(handler: &'a Handler, message: impl Into<DiagnosticMessage>) -> Self {
         let diagnostic = Diagnostic::new_with_code(Level::Note, None, message);
-        Self::new_diagnostic_note(handler, diagnostic)
-    }
-
-    /// Creates a new `DiagnosticBuilder` with an already constructed
-    /// diagnostic.
-    pub(crate) fn new_diagnostic_note(handler: &'a Handler, diagnostic: Diagnostic) -> Self {
-        debug!("Created new diagnostic");
         Self {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),
@@ -305,13 +298,6 @@ impl<'a> DiagnosticBuilder<'a, Bug> {
     #[track_caller]
     pub(crate) fn new_bug(handler: &'a Handler, message: impl Into<DiagnosticMessage>) -> Self {
         let diagnostic = Diagnostic::new_with_code(Level::Bug, None, message);
-        Self::new_diagnostic_bug(handler, diagnostic)
-    }
-
-    /// Creates a new `DiagnosticBuilder` with an already constructed
-    /// diagnostic.
-    pub(crate) fn new_diagnostic_bug(handler: &'a Handler, diagnostic: Diagnostic) -> Self {
-        debug!("Created new diagnostic bug");
         Self {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),
@@ -394,16 +380,6 @@ impl<'a> DiagnosticBuilder<'a, rustc_span::fatal_error::FatalError> {
         message: impl Into<DiagnosticMessage>,
     ) -> Self {
         let diagnostic = Diagnostic::new_with_code(Level::Fatal, None, message);
-        Self::new_diagnostic_almost_fatal(handler, diagnostic)
-    }
-
-    /// Creates a new `DiagnosticBuilder` with an already constructed
-    /// diagnostic.
-    pub(crate) fn new_diagnostic_almost_fatal(
-        handler: &'a Handler,
-        diagnostic: Diagnostic,
-    ) -> Self {
-        debug!("Created new diagnostic");
         Self {
             inner: DiagnosticBuilderInner {
                 state: DiagnosticBuilderState::Emittable(handler),

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -776,7 +776,7 @@ impl Handler {
     #[rustc_lint_diagnostics]
     #[track_caller]
     pub fn struct_warn(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
-        DiagnosticBuilder::new(self, Level::Warning(None), msg)
+        <()>::make_diagnostic_builder(self, msg)
     }
 
     /// Construct a builder at the `Warning` level with the `msg`. The `id` is used for
@@ -847,7 +847,7 @@ impl Handler {
         &self,
         msg: impl Into<DiagnosticMessage>,
     ) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
-        DiagnosticBuilder::new_guaranteeing_error(self, msg)
+        ErrorGuaranteed::make_diagnostic_builder(self, msg)
     }
 
     /// This should only be used by `rustc_middle::lint::struct_lint_level`. Do not use it for hard errors.
@@ -914,7 +914,7 @@ impl Handler {
     #[rustc_lint_diagnostics]
     #[track_caller]
     pub fn struct_fatal(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, !> {
-        DiagnosticBuilder::new_fatal(self, msg)
+        <!>::make_diagnostic_builder(self, msg)
     }
 
     /// Construct a builder at the `Help` level with the `msg`.

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -776,7 +776,7 @@ impl Handler {
     #[rustc_lint_diagnostics]
     #[track_caller]
     pub fn struct_warn(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
-        <()>::make_diagnostic_builder(self, msg)
+        DiagnosticBuilder::new(self, Level::Warning(None), msg)
     }
 
     /// Construct a builder at the `Warning` level with the `msg`. The `id` is used for
@@ -847,7 +847,7 @@ impl Handler {
         &self,
         msg: impl Into<DiagnosticMessage>,
     ) -> DiagnosticBuilder<'_, ErrorGuaranteed> {
-        ErrorGuaranteed::make_diagnostic_builder(self, msg)
+        DiagnosticBuilder::new(self, Level::Error { lint: false }, msg)
     }
 
     /// This should only be used by `rustc_middle::lint::struct_lint_level`. Do not use it for hard errors.
@@ -914,7 +914,7 @@ impl Handler {
     #[rustc_lint_diagnostics]
     #[track_caller]
     pub fn struct_fatal(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, !> {
-        <!>::make_diagnostic_builder(self, msg)
+        DiagnosticBuilder::new(self, Level::Fatal, msg)
     }
 
     /// Construct a builder at the `Help` level with the `msg`.
@@ -1046,12 +1046,12 @@ impl Handler {
 
     #[rustc_lint_diagnostics]
     pub fn warn(&self, msg: impl Into<DiagnosticMessage>) {
-        DiagnosticBuilder::new(self, Warning(None), msg).emit();
+        DiagnosticBuilder::<()>::new(self, Warning(None), msg).emit();
     }
 
     #[rustc_lint_diagnostics]
     pub fn note(&self, msg: impl Into<DiagnosticMessage>) {
-        DiagnosticBuilder::new(self, Note, msg).emit();
+        DiagnosticBuilder::<()>::new(self, Note, msg).emit();
     }
 
     pub fn bug(&self, msg: impl Into<DiagnosticMessage>) -> ! {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1145,11 +1145,6 @@ impl<'a> ExtCtxt<'a> {
     pub fn span_err<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
         self.sess.diagnostic().span_err(sp, msg);
     }
-    #[rustc_lint_diagnostics]
-    #[track_caller]
-    pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<DiagnosticMessage>) {
-        self.sess.diagnostic().span_warn(sp, msg);
-    }
     pub fn span_bug<S: Into<MultiSpan>>(&self, sp: S, msg: impl Into<String>) -> ! {
         self.sess.diagnostic().span_bug(sp, msg);
     }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -54,8 +54,10 @@ macro_rules! declare_features {
         #[derive(Clone, Default, Debug)]
         pub struct Features {
             /// `#![feature]` attrs for language features, for error reporting.
+            /// "declared" here means that the feature is actually enabled in the current crate.
             pub declared_lang_features: Vec<(Symbol, Span, Option<Symbol>)>,
             /// `#![feature]` attrs for non-language (library) features.
+            /// "declared" here means that the feature is actually enabled in the current crate.
             pub declared_lib_features: Vec<(Symbol, Span)>,
             /// `declared_lang_features` + `declared_lib_features`.
             pub declared_features: FxHashSet<Symbol>,
@@ -125,9 +127,16 @@ macro_rules! declare_features {
                     $(
                         sym::$feature => status_to_enum!($status) == FeatureStatus::Internal,
                     )*
-                    // Accepted/removed features aren't in this file but are never internal
-                    // (a removed feature might have been internal, but that's now irrelevant).
-                    _ if self.declared_features.contains(&feature) => false,
+                    _ if self.declared_features.contains(&feature) => {
+                        // This could be accepted/removed, or a libs feature.
+                        // Accepted/removed features aren't in this file but are never internal
+                        // (a removed feature might have been internal, but that's now irrelevant).
+                        // Libs features are internal if they end in `_internal` or `_internals`.
+                        // We just always test the name; it's not a big deal if we accidentally hit
+                        // an accepted/removed lang feature that way.
+                        let name = feature.as_str();
+                        name.ends_with("_internal") || name.ends_with("_internals")
+                    }
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }
             }
@@ -207,9 +216,6 @@ declare_features! (
     (internal, test_2018_feature, "1.31.0", None, Some(Edition::Edition2018)),
     /// Added for testing unstable lints; perma-unstable.
     (internal, test_unstable_lint, "1.60.0", None, None),
-    /// Allows non-`unsafe` —and thus, unsound— access to `Pin` constructions.
-    /// Marked `internal` since perma-unstable and unsound.
-    (internal, unsafe_pin_internals, "1.60.0", None, None),
     /// Use for stable + negative coherence and strict coherence depending on trait's
     /// rustc_strict_coherence value.
     (unstable, with_negative_coherence, "1.60.0", None, None),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -132,10 +132,12 @@ macro_rules! declare_features {
                         // Accepted/removed features aren't in this file but are never internal
                         // (a removed feature might have been internal, but that's now irrelevant).
                         // Libs features are internal if they end in `_internal` or `_internals`.
+                        // As a special exception we also consider `core_intrinsics` internal;
+                        // renaming that age-old feature is just not worth the hassle.
                         // We just always test the name; it's not a big deal if we accidentally hit
                         // an accepted/removed lang feature that way.
                         let name = feature.as_str();
-                        name.ends_with("_internal") || name.ends_with("_internals")
+                        name == "core_intrinsics" || name.ends_with("_internal") || name.ends_with("_internals")
                     }
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -1182,10 +1182,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 if let Some(bound_span) = bound_span {
                     err.span_label(
                         bound_span,
-                        format!(
-                            "ambiguous `{assoc_name}` from `{}`",
-                            bound.print_only_trait_path(),
-                        ),
+                        format!("ambiguous `{assoc_name}` from `{}`", bound.print_trait_sugared(),),
                     );
                     if let Some(constraint) = &is_equality {
                         where_bounds.push(format!(

--- a/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
@@ -106,6 +106,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
              trait here instead: `trait NewTrait: {} {{}}`",
                 regular_traits
                     .iter()
+                    // FIXME: This should `print_sugared`, but also needs to integrate projection bounds...
                     .map(|t| t.trait_ref().print_only_trait_path().to_string())
                     .collect::<Vec<_>>()
                     .join(" + "),

--- a/compiler/rustc_hir_analysis/src/coherence/unsafety.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/unsafety.rs
@@ -23,7 +23,7 @@ pub(super) fn check_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     tcx.def_span(def_id),
                     E0199,
                     "implementing the trait `{}` is not unsafe",
-                    trait_ref.print_only_trait_path()
+                    trait_ref.print_trait_sugared()
                 )
                 .span_suggestion_verbose(
                     item.span.with_hi(item.span.lo() + rustc_span::BytePos(7)),
@@ -40,13 +40,13 @@ pub(super) fn check_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     tcx.def_span(def_id),
                     E0200,
                     "the trait `{}` requires an `unsafe impl` declaration",
-                    trait_ref.print_only_trait_path()
+                    trait_ref.print_trait_sugared()
                 )
                 .note(format!(
                     "the trait `{}` enforces invariants that the compiler can't check. \
                     Review the trait documentation and make sure this implementation \
                     upholds those invariants before adding the `unsafe` keyword",
-                    trait_ref.print_only_trait_path()
+                    trait_ref.print_trait_sugared()
                 ))
                 .span_suggestion_verbose(
                     item.span.shrink_to_lo(),
@@ -69,7 +69,7 @@ pub(super) fn check_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     "the trait `{}` enforces invariants that the compiler can't check. \
                     Review the trait documentation and make sure this implementation \
                     upholds those invariants before adding the `unsafe` keyword",
-                    trait_ref.print_only_trait_path()
+                    trait_ref.print_trait_sugared()
                 ))
                 .span_suggestion_verbose(
                     item.span.shrink_to_lo(),

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2288,7 +2288,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ty::Adt(def, _) if def.did().is_local() => {
                     spans.push_span_label(
                         self.tcx.def_span(def.did()),
-                        format!("must implement `{}`", pred.trait_ref.print_only_trait_path()),
+                        format!("must implement `{}`", pred.trait_ref.print_trait_sugared()),
                     );
                 }
                 _ => {}

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -2299,7 +2299,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let msg = if preds.len() == 1 {
                 format!(
                     "an implementation of `{}` might be missing for `{}`",
-                    preds[0].trait_ref.print_only_trait_path(),
+                    preds[0].trait_ref.print_trait_sugared(),
                     preds[0].self_ty()
                 )
             } else {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2219,8 +2219,8 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             infer::ExistentialProjection(exp_found) => self.expected_found_str(exp_found),
             infer::PolyTraitRefs(exp_found) => {
                 let pretty_exp_found = ty::error::ExpectedFound {
-                    expected: exp_found.expected.print_only_trait_path(),
-                    found: exp_found.found.print_only_trait_path(),
+                    expected: exp_found.expected.print_trait_sugared(),
+                    found: exp_found.found.print_trait_sugared(),
                 };
                 match self.expected_found_str(pretty_exp_found) {
                     Some((expected, found, _, _)) if expected == found => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2641,6 +2641,23 @@ impl<'tcx> fmt::Debug for TraitRefPrintOnlyTraitPath<'tcx> {
 }
 
 /// Wrapper type for `ty::TraitRef` which opts-in to pretty printing only
+/// the trait path, and additionally tries to "sugar" `Fn(...)` trait bounds.
+#[derive(Copy, Clone, TypeFoldable, TypeVisitable, Lift)]
+pub struct TraitRefPrintSugared<'tcx>(ty::TraitRef<'tcx>);
+
+impl<'tcx> rustc_errors::IntoDiagnosticArg for TraitRefPrintSugared<'tcx> {
+    fn into_diagnostic_arg(self) -> rustc_errors::DiagnosticArgValue<'static> {
+        self.to_string().into_diagnostic_arg()
+    }
+}
+
+impl<'tcx> fmt::Debug for TraitRefPrintSugared<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+/// Wrapper type for `ty::TraitRef` which opts-in to pretty printing only
 /// the trait name. That is, it will print `Trait` instead of
 /// `<T as Trait<U>>`.
 #[derive(Copy, Clone, TypeFoldable, TypeVisitable, Lift)]
@@ -2657,6 +2674,10 @@ impl<'tcx> ty::TraitRef<'tcx> {
         TraitRefPrintOnlyTraitPath(self)
     }
 
+    pub fn print_trait_sugared(self) -> TraitRefPrintSugared<'tcx> {
+        TraitRefPrintSugared(self)
+    }
+
     pub fn print_only_trait_name(self) -> TraitRefPrintOnlyTraitName<'tcx> {
         TraitRefPrintOnlyTraitName(self)
     }
@@ -2665,6 +2686,10 @@ impl<'tcx> ty::TraitRef<'tcx> {
 impl<'tcx> ty::Binder<'tcx, ty::TraitRef<'tcx>> {
     pub fn print_only_trait_path(self) -> ty::Binder<'tcx, TraitRefPrintOnlyTraitPath<'tcx>> {
         self.map_bound(|tr| tr.print_only_trait_path())
+    }
+
+    pub fn print_trait_sugared(self) -> ty::Binder<'tcx, TraitRefPrintSugared<'tcx>> {
+        self.map_bound(|tr| tr.print_trait_sugared())
     }
 }
 
@@ -2745,6 +2770,7 @@ forward_display_to_print! {
     ty::PolyExistentialTraitRef<'tcx>,
     ty::Binder<'tcx, ty::TraitRef<'tcx>>,
     ty::Binder<'tcx, TraitRefPrintOnlyTraitPath<'tcx>>,
+    ty::Binder<'tcx, TraitRefPrintSugared<'tcx>>,
     ty::Binder<'tcx, ty::FnSig<'tcx>>,
     ty::Binder<'tcx, ty::TraitPredicate<'tcx>>,
     ty::Binder<'tcx, TraitPredPrintModifiersAndPath<'tcx>>,
@@ -2844,6 +2870,24 @@ define_print_and_forward_display! {
         p!(print_def_path(self.0.def_id, self.0.args));
     }
 
+    TraitRefPrintSugared<'tcx> {
+        if !with_no_queries()
+            && let Some(kind) = cx.tcx().fn_trait_kind_from_def_id(self.0.def_id)
+            && let ty::Tuple(args) = self.0.args.type_at(1).kind()
+        {
+            p!(write("{}", kind.as_str()), "(");
+            for (i, arg) in args.iter().enumerate() {
+                if i > 0 {
+                    p!(", ");
+                }
+                p!(print(arg));
+            }
+            p!(")");
+        } else {
+            p!(print_def_path(self.0.def_id, self.0.args));
+        }
+    }
+
     TraitRefPrintOnlyTraitName<'tcx> {
         p!(print_def_path(self.0.def_id, &[]));
     }
@@ -2892,7 +2936,7 @@ define_print_and_forward_display! {
         if let ty::ImplPolarity::Negative = self.polarity {
             p!("!");
         }
-        p!(print(self.trait_ref.print_only_trait_path()))
+        p!(print(self.trait_ref.print_trait_sugared()))
     }
 
     ty::ProjectionPredicate<'tcx> {

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rustc_errors::{
     Applicability, DecorateLint, DiagnosticArgValue, DiagnosticBuilder, DiagnosticMessage,
-    EmissionGuarantee, Handler, IntoDiagnostic,
+    EmissionGuarantee, ErrorGuaranteed, Handler, IntoDiagnostic,
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::mir::{AssertKind, UnsafetyViolationDetails};
@@ -62,9 +62,9 @@ pub(crate) struct RequiresUnsafe {
 // so we need to eagerly translate the label here, which isn't supported by the derive API
 // We could also exhaustively list out the primary messages for all unsafe violations,
 // but this would result in a lot of duplication.
-impl<'sess, G: EmissionGuarantee> IntoDiagnostic<'sess, G> for RequiresUnsafe {
+impl<'sess> IntoDiagnostic<'sess> for RequiresUnsafe {
     #[track_caller]
-    fn into_diagnostic(self, handler: &'sess Handler) -> DiagnosticBuilder<'sess, G> {
+    fn into_diagnostic(self, handler: &'sess Handler) -> DiagnosticBuilder<'sess, ErrorGuaranteed> {
         let mut diag = handler.struct_diagnostic(fluent::mir_transform_requires_unsafe);
         diag.code(rustc_errors::DiagnosticId::Error("E0133".to_string()));
         diag.set_span(self.span);

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rustc_ast::token::Token;
 use rustc_ast::{Path, Visibility};
-use rustc_errors::{AddToDiagnostic, Applicability, EmissionGuarantee, IntoDiagnostic};
+use rustc_errors::{AddToDiagnostic, Applicability, ErrorGuaranteed, IntoDiagnostic};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_session::errors::ExprParenthesesNeeded;
 use rustc_span::edition::{Edition, LATEST_STABLE_EDITION};
@@ -1038,12 +1038,12 @@ pub(crate) struct ExpectedIdentifier {
     pub help_cannot_start_number: Option<HelpIdentifierStartsWithNumber>,
 }
 
-impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedIdentifier {
+impl<'a> IntoDiagnostic<'a> for ExpectedIdentifier {
     #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,
-    ) -> rustc_errors::DiagnosticBuilder<'a, G> {
+    ) -> rustc_errors::DiagnosticBuilder<'a, ErrorGuaranteed> {
         let token_descr = TokenDescription::from_token(&self.token);
 
         let mut diag = handler.struct_diagnostic(match token_descr {
@@ -1095,12 +1095,12 @@ pub(crate) struct ExpectedSemi {
     pub sugg: ExpectedSemiSugg,
 }
 
-impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for ExpectedSemi {
+impl<'a> IntoDiagnostic<'a> for ExpectedSemi {
     #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,
-    ) -> rustc_errors::DiagnosticBuilder<'a, G> {
+    ) -> rustc_errors::DiagnosticBuilder<'a, ErrorGuaranteed> {
         let token_descr = TokenDescription::from_token(&self.token);
 
         let mut diag = handler.struct_diagnostic(match token_descr {

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -304,23 +304,25 @@ impl<'a> Parser<'a> {
                 if self.may_recover()
                     && (self.eat_keyword_noexpect(kw::Impl) || self.eat_keyword_noexpect(kw::Dyn))
                 {
-                    let kw = self.prev_token.ident().unwrap().0.name;
-                    let mut err = self.sess.create_err(errors::TransposeDynOrImpl {
-                        span: self.prev_token.span,
-                        kw: kw.as_str(),
-                        sugg: errors::TransposeDynOrImplSugg {
-                            removal_span: self.prev_token.span.with_hi(self.token.span.lo()),
-                            insertion_span: for_span.shrink_to_lo(),
-                            kw: kw.as_str(),
-                        },
-                    });
+                    let kw = self.prev_token.ident().unwrap().0;
+                    let removal_span = kw.span.with_hi(self.token.span.lo());
                     let path = self.parse_path(PathStyle::Type)?;
                     let parse_plus = allow_plus == AllowPlus::Yes && self.check_plus();
                     let kind =
                         self.parse_remaining_bounds_path(lifetime_defs, path, lo, parse_plus)?;
+                    let mut err = self.sess.create_err(errors::TransposeDynOrImpl {
+                        span: kw.span,
+                        kw: kw.name.as_str(),
+                        sugg: errors::TransposeDynOrImplSugg {
+                            removal_span,
+                            insertion_span: for_span.shrink_to_lo(),
+                            kw: kw.name.as_str(),
+                        },
+                    });
+
                     // Take the parsed bare trait object and turn it either
                     // into a `dyn` object or an `impl Trait`.
-                    let kind = match (kind, kw) {
+                    let kind = match (kind, kw.name) {
                         (TyKind::TraitObject(bounds, _), kw::Dyn) => {
                             TyKind::TraitObject(bounds, TraitObjectSyntax::Dyn)
                         }

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(hash_raw_entry)]
 #![feature(min_specialization)]
 #![feature(let_chains)]
-#![allow(rustc::potential_query_instability)]
+#![allow(rustc::potential_query_instability, internal_features)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -13,12 +13,12 @@ pub struct FeatureGateError {
     pub explain: DiagnosticMessage,
 }
 
-impl<'a, T: EmissionGuarantee> IntoDiagnostic<'a, T> for FeatureGateError {
+impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for FeatureGateError {
     #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,
-    ) -> rustc_errors::DiagnosticBuilder<'a, T> {
+    ) -> rustc_errors::DiagnosticBuilder<'a, G> {
         let mut diag = handler.struct_diagnostic(self.explain);
         diag.set_span(self.span);
         diag.code(error_code!(E0658));

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU32;
 use crate::parse::ParseSess;
 use rustc_ast::token;
 use rustc_ast::util::literal::LitError;
-use rustc_errors::{error_code, DiagnosticMessage, EmissionGuarantee, IntoDiagnostic, MultiSpan};
+use rustc_errors::{error_code, DiagnosticMessage, ErrorGuaranteed, IntoDiagnostic, MultiSpan};
 use rustc_macros::Diagnostic;
 use rustc_span::{BytePos, Span, Symbol};
 use rustc_target::spec::{SplitDebuginfo, StackProtector, TargetTriple};
@@ -13,12 +13,12 @@ pub struct FeatureGateError {
     pub explain: DiagnosticMessage,
 }
 
-impl<'a, G: EmissionGuarantee> IntoDiagnostic<'a, G> for FeatureGateError {
+impl<'a> IntoDiagnostic<'a> for FeatureGateError {
     #[track_caller]
     fn into_diagnostic(
         self,
         handler: &'a rustc_errors::Handler,
-    ) -> rustc_errors::DiagnosticBuilder<'a, G> {
+    ) -> rustc_errors::DiagnosticBuilder<'a, ErrorGuaranteed> {
         let mut diag = handler.struct_diagnostic(self.explain);
         diag.set_span(self.span);
         diag.code(error_code!(E0658));

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -461,7 +461,7 @@ impl Session {
     }
     #[rustc_lint_diagnostics]
     pub fn fatal(&self, msg: impl Into<DiagnosticMessage>) -> ! {
-        self.diagnostic().fatal(msg).raise()
+        self.diagnostic().fatal(msg)
     }
     #[rustc_lint_diagnostics]
     #[track_caller]

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -41,7 +41,9 @@ mod trait_goals;
 
 pub use eval_ctxt::{EvalCtxt, GenerateProofTree, InferCtxtEvalExt, InferCtxtSelectExt};
 pub use fulfill::FulfillmentCtxt;
-pub(crate) use normalize::{deeply_normalize, deeply_normalize_with_skipped_universes};
+pub(crate) use normalize::{
+    deeply_normalize, deeply_normalize_for_diagnostics, deeply_normalize_with_skipped_universes,
+};
 
 #[derive(Debug, Clone, Copy)]
 enum SolverMode {

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -245,7 +245,7 @@ fn overlap<'tcx>(
                                     let trait_ref = infcx.resolve_vars_if_possible(trait_ref);
                                     format!(
                                         "of `{}` for `{}`",
-                                        trait_ref.print_only_trait_path(),
+                                        trait_ref.print_trait_sugared(),
                                         trait_ref.self_ty()
                                     )
                                 }

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -6,8 +6,8 @@
 
 use crate::infer::outlives::env::OutlivesEnvironment;
 use crate::infer::InferOk;
-use crate::solve::inspect;
 use crate::solve::inspect::{InspectGoal, ProofTreeInferCtxtExt, ProofTreeVisitor};
+use crate::solve::{deeply_normalize_for_diagnostics, inspect};
 use crate::traits::engine::TraitEngineExt;
 use crate::traits::query::evaluate_obligation::InferCtxtExt;
 use crate::traits::select::{IntercrateAmbiguityCause, TreatInductiveCycleAs};
@@ -308,7 +308,13 @@ fn overlap<'tcx>(
         .iter()
         .any(|c| c.0.involves_placeholders());
 
-    let impl_header = selcx.infcx.resolve_vars_if_possible(impl1_header);
+    let mut impl_header = infcx.resolve_vars_if_possible(impl1_header);
+
+    // Deeply normalize the impl header for diagnostics, ignoring any errors if this fails.
+    if infcx.next_trait_solver() {
+        impl_header = deeply_normalize_for_diagnostics(&infcx, param_env, impl_header);
+    }
+
     Some(OverlapResult { impl_header, intercrate_ambiguity_causes, involves_placeholder })
 }
 
@@ -1084,6 +1090,10 @@ impl<'a, 'tcx> ProofTreeVisitor<'tcx> for AmbiguityCausesVisitor<'a, 'tcx> {
                         Ok(Ok(())) => warn!("expected an unknowable trait ref: {trait_ref:?}"),
                         Ok(Err(conflict)) => {
                             if !trait_ref.references_error() {
+                                // Normalize the trait ref for diagnostics, ignoring any errors if this fails.
+                                let trait_ref =
+                                    deeply_normalize_for_diagnostics(infcx, param_env, trait_ref);
+
                                 let self_ty = trait_ref.self_ty();
                                 let self_ty = self_ty.has_concrete_skeleton().then(|| self_ty);
                                 ambiguity_cause = Some(match conflict {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -184,14 +184,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             flags.push((sym::cause, Some("MainFunctionType".to_string())));
         }
 
-        if let Some(kind) = self.tcx.fn_trait_kind_from_def_id(trait_ref.def_id)
-            && let ty::Tuple(args) = trait_ref.args.type_at(1).kind()
-        {
-            let args = args.iter().map(|ty| ty.to_string()).collect::<Vec<_>>().join(", ");
-            flags.push((sym::Trait, Some(format!("{}({args})", kind.as_str()))));
-        } else {
-            flags.push((sym::Trait, Some(trait_ref.print_only_trait_path().to_string())));
-        }
+        flags.push((sym::Trait, Some(trait_ref.print_trait_sugared().to_string())));
 
         // Add all types without trimmed paths or visible paths, ensuring they end up with
         // their "canonical" def path.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -1854,7 +1854,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             let end = if candidates.len() <= 9 { candidates.len() } else { 8 };
             err.help(format!(
                 "the following {other}types implement trait `{}`:{}{}",
-                trait_ref.print_only_trait_path(),
+                trait_ref.print_trait_sugared(),
                 candidates[..end].join(""),
                 if candidates.len() > 9 {
                     format!("\nand {} others", candidates.len() - 8)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -622,7 +622,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                     span.shrink_to_hi(),
                                     format!(
                                         "the trait `{}` is implemented for fn pointer `{}`, try casting using `as`",
-                                        cand.print_only_trait_path(),
+                                        cand.print_trait_sugared(),
                                         cand.self_ty(),
                                     ),
                                     format!(" as {}", cand.self_ty()),
@@ -1785,7 +1785,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         ct_op: |ct| ct.normalize(self.tcx, ty::ParamEnv::empty()),
                     });
                 err.highlighted_help(vec![
-                    (format!("the trait `{}` ", cand.print_only_trait_path()), Style::NoStyle),
+                    (format!("the trait `{}` ", cand.print_trait_sugared()), Style::NoStyle),
                     ("is".to_string(), Style::Highlight),
                     (" implemented for `".to_string(), Style::NoStyle),
                     (cand.self_ty().to_string(), Style::Highlight),
@@ -1821,7 +1821,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         _ => (" implemented for `", ""),
                     };
                 err.highlighted_help(vec![
-                    (format!("the trait `{}` ", cand.print_only_trait_path()), Style::NoStyle),
+                    (format!("the trait `{}` ", cand.print_trait_sugared()), Style::NoStyle),
                     ("is".to_string(), Style::Highlight),
                     (desc.to_string(), Style::NoStyle),
                     (cand.self_ty().to_string(), Style::Highlight),

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -78,7 +78,7 @@ impl<'tcx> IntercrateAmbiguityCause<'tcx> {
             IntercrateAmbiguityCause::DownstreamCrate { trait_ref, self_ty } => {
                 format!(
                     "downstream crates may implement trait `{trait_desc}`{self_desc}",
-                    trait_desc = trait_ref.print_only_trait_path(),
+                    trait_desc = trait_ref.print_trait_sugared(),
                     self_desc = if let Some(self_ty) = self_ty {
                         format!(" for type `{self_ty}`")
                     } else {
@@ -90,7 +90,7 @@ impl<'tcx> IntercrateAmbiguityCause<'tcx> {
                 format!(
                     "upstream crates may add a new impl of trait `{trait_desc}`{self_desc} \
                 in future versions",
-                    trait_desc = trait_ref.print_only_trait_path(),
+                    trait_desc = trait_ref.print_trait_sugared(),
                     self_desc = if let Some(self_ty) = self_ty {
                         format!(" for type `{self_ty}`")
                     } else {

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -412,7 +412,7 @@ fn report_conflicting_impls<'tcx>(
     let msg = DelayDm(|| {
         format!(
             "conflicting implementations of trait `{}`{}{}",
-            overlap.trait_ref.print_only_trait_path(),
+            overlap.trait_ref.print_trait_sugared(),
             overlap.self_ty.map_or_else(String::new, |ty| format!(" for type `{ty}`")),
             match used_to_be_allowed {
                 Some(FutureCompatOverlapErrorKind::Issue33140) => ": (E0119)",

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -40,6 +40,7 @@
 #![feature(thin_box)]
 #![feature(strict_provenance)]
 #![feature(drain_keep_rest)]
+#![allow(internal_features)]
 #![deny(fuzzy_provenance_casts)]
 #![deny(unsafe_op_in_unsafe_fn)]
 

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -143,17 +143,17 @@
 //!
 //! ```
 //! # #![allow(dead_code)]
-//! use std::cell::RefCell;
+//! use std::cell::OnceCell;
 //!
 //! struct Graph {
 //!     edges: Vec<(i32, i32)>,
-//!     span_tree_cache: RefCell<Option<Vec<(i32, i32)>>>
+//!     span_tree_cache: OnceCell<Vec<(i32, i32)>>
 //! }
 //!
 //! impl Graph {
 //!     fn minimum_spanning_tree(&self) -> Vec<(i32, i32)> {
-//!         self.span_tree_cache.borrow_mut()
-//!             .get_or_insert_with(|| self.calc_span_tree())
+//!         self.span_tree_cache
+//!             .get_or_init(|| self.calc_span_tree())
 //!             .clone()
 //!     }
 //!

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1900,6 +1900,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::ctlz;
     ///
@@ -1912,6 +1913,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::ctlz;
     ///
@@ -1933,6 +1935,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::ctlz_nonzero;
     ///
@@ -1959,6 +1962,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::cttz;
     ///
@@ -1971,6 +1975,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::cttz;
     ///
@@ -1992,6 +1997,7 @@ extern "rust-intrinsic" {
     ///
     /// ```
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     ///
     /// use std::intrinsics::cttz_nonzero;
     ///
@@ -2453,6 +2459,7 @@ extern "rust-intrinsic" {
     /// ```no_run
     /// #![feature(const_eval_select)]
     /// #![feature(core_intrinsics)]
+    /// # #![allow(internal_features)]
     /// use std::hint::unreachable_unchecked;
     /// use std::intrinsics::const_eval_select;
     ///

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -50,22 +50,19 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[unstable(feature = "structural_match", issue = "31434")]
-            impl<$($T: ConstParamTy),+> ConstParamTy for ($($T,)+)
-            {}
+            impl<$($T: ConstParamTy),+> ConstParamTy for ($($T,)+) {}
         }
 
         maybe_tuple_doc! {
             $($T)+ @
             #[unstable(feature = "structural_match", issue = "31434")]
-            impl<$($T),+> StructuralPartialEq for ($($T,)+)
-            {}
+            impl<$($T),+> StructuralPartialEq for ($($T,)+) {}
         }
 
         maybe_tuple_doc! {
             $($T)+ @
             #[unstable(feature = "structural_match", issue = "31434")]
-            impl<$($T),+> StructuralEq for ($($T,)+)
-            {}
+            impl<$($T),+> StructuralEq for ($($T,)+) {}
         }
 
         maybe_tuple_doc! {
@@ -118,7 +115,7 @@ macro_rules! tuple_impls {
             impl<$($T: Default),+> Default for ($($T,)+) {
                 #[inline]
                 fn default() -> ($($T,)+) {
-                    ($({ let x: $T = Default::default(); x},)+)
+                    ($($T::default(),)+)
                 }
             }
         }
@@ -196,7 +193,7 @@ macro_rules! lexical_partial_cmp {
     ($a:expr, $b:expr, $($rest_a:expr, $rest_b:expr),+) => {
         match ($a).partial_cmp(&$b) {
             Some(Equal) => lexical_partial_cmp!($($rest_a, $rest_b),+),
-            ordering   => ordering
+            ordering => ordering
         }
     };
     ($a:expr, $b:expr) => { ($a).partial_cmp(&$b) };
@@ -206,7 +203,7 @@ macro_rules! lexical_cmp {
     ($a:expr, $b:expr, $($rest_a:expr, $rest_b:expr),+) => {
         match ($a).cmp(&$b) {
             Equal => lexical_cmp!($($rest_a, $rest_b),+),
-            ordering   => ordering
+            ordering => ordering
         }
     };
     ($a:expr, $b:expr) => { ($a).cmp(&$b) };

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -116,6 +116,7 @@
 #![feature(get_many_mut)]
 #![feature(offset_of)]
 #![feature(iter_map_windows)]
+#![allow(internal_features)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(fuzzy_provenance_casts)]
 

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -180,7 +180,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
 }
 
 #[cfg(target_os = "espidf")]
-pub fn chdir(p: &path::Path) -> io::Result<()> {
+pub fn chdir(_p: &path::Path) -> io::Result<()> {
     super::unsupported::unsupported()
 }
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1872,7 +1872,6 @@ impl<'a> Builder<'a> {
             // some code doesn't go through this `rustc` wrapper.
             lint_flags.push("-Wrust_2018_idioms");
             lint_flags.push("-Wunused_lifetimes");
-            lint_flags.push("-Wsemicolon_in_expressions_from_macros");
 
             if self.config.deny_warnings {
                 lint_flags.push("-Dwarnings");

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg(feature = "sysroot-abi")]
 #![feature(proc_macro_internals, proc_macro_diagnostic, proc_macro_span)]
 #![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
-#![allow(unreachable_pub)]
+#![allow(unreachable_pub, internal_features)]
 
 extern crate proc_macro;
 

--- a/tests/ui/coherence/normalize-for-errors.current.stderr
+++ b/tests/ui/coherence/normalize-for-errors.current.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
+  --> $DIR/normalize-for-errors.rs:17:1
+   |
+LL | impl<T: Copy> MyTrait for T {}
+   | --------------------------- first implementation here
+LL |
+LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+   |
+   = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/normalize-for-errors.current.stderr
+++ b/tests/ui/coherence/normalize-for-errors.current.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
-  --> $DIR/normalize-for-errors.rs:17:1
+error[E0119]: conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>, _)`
+  --> $DIR/normalize-for-errors.rs:16:1
    |
-LL | impl<T: Copy> MyTrait for T {}
-   | --------------------------- first implementation here
+LL | impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
+   | ------------------------------------------------------ first implementation here
 LL |
-LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+LL | impl<S: Iterator> MyTrait<S> for (Box<<(MyType,) as Mirror>::Assoc>, S::Item) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(Box<(MyType,)>, _)`
    |
    = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
 

--- a/tests/ui/coherence/normalize-for-errors.next.stderr
+++ b/tests/ui/coherence/normalize-for-errors.next.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
+  --> $DIR/normalize-for-errors.rs:17:1
+   |
+LL | impl<T: Copy> MyTrait for T {}
+   | --------------------------- first implementation here
+LL |
+LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+   |
+   = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/normalize-for-errors.next.stderr
+++ b/tests/ui/coherence/normalize-for-errors.next.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
-  --> $DIR/normalize-for-errors.rs:17:1
+error[E0119]: conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>, <_ as Iterator>::Item)`
+  --> $DIR/normalize-for-errors.rs:16:1
    |
-LL | impl<T: Copy> MyTrait for T {}
-   | --------------------------- first implementation here
+LL | impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
+   | ------------------------------------------------------ first implementation here
 LL |
-LL | impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Box<(MyType,)>`
+LL | impl<S: Iterator> MyTrait<S> for (Box<<(MyType,) as Mirror>::Assoc>, S::Item) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(Box<(MyType,)>, <_ as Iterator>::Item)`
    |
    = note: upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
 

--- a/tests/ui/coherence/normalize-for-errors.rs
+++ b/tests/ui/coherence/normalize-for-errors.rs
@@ -1,0 +1,22 @@
+// revisions: current next
+//[next] compile-flags: -Ztrait-solver=next
+
+struct MyType;
+trait MyTrait {
+}
+
+trait Mirror {
+    type Assoc;
+}
+impl<T> Mirror for T {
+    type Assoc = T;
+}
+
+impl<T: Copy> MyTrait for T {}
+//~^ NOTE first implementation here
+impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
+//~^ ERROR conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
+//~| NOTE conflicting implementation for `Box<(MyType,)>
+//~| NOTE upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
+
+fn main() {}

--- a/tests/ui/coherence/normalize-for-errors.rs
+++ b/tests/ui/coherence/normalize-for-errors.rs
@@ -2,8 +2,7 @@
 //[next] compile-flags: -Ztrait-solver=next
 
 struct MyType;
-trait MyTrait {
-}
+trait MyTrait<S> {}
 
 trait Mirror {
     type Assoc;
@@ -12,11 +11,11 @@ impl<T> Mirror for T {
     type Assoc = T;
 }
 
-impl<T: Copy> MyTrait for T {}
+impl<T: Copy, S: Iterator> MyTrait<S> for (T, S::Item) {}
 //~^ NOTE first implementation here
-impl MyTrait for Box<<(MyType,) as Mirror>::Assoc> {}
-//~^ ERROR conflicting implementations of trait `MyTrait` for type `Box<(MyType,)>`
-//~| NOTE conflicting implementation for `Box<(MyType,)>
+impl<S: Iterator> MyTrait<S> for (Box<<(MyType,) as Mirror>::Assoc>, S::Item) {}
+//~^ ERROR conflicting implementations of trait `MyTrait<_>` for type `(Box<(MyType,)>,
+//~| NOTE conflicting implementation for `(Box<(MyType,)>,
 //~| NOTE upstream crates may add a new impl of trait `std::marker::Copy` for type `std::boxed::Box<(MyType,)>` in future versions
 
 fn main() {}

--- a/tests/ui/error-codes/E0401.stderr
+++ b/tests/ui/error-codes/E0401.stderr
@@ -55,7 +55,7 @@ error[E0283]: type annotations needed
 LL |     bfnr(x);
    |     ^^^^ cannot infer type of the type parameter `W` declared on the function `bfnr`
    |
-   = note: multiple `impl`s satisfying `_: Fn<()>` found in the following crates: `alloc`, `core`:
+   = note: multiple `impl`s satisfying `_: Fn()` found in the following crates: `alloc`, `core`:
            - impl<A, F> Fn<A> for &F
              where A: Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-71955.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-71955.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a &'b str,)>`
-              found trait `for<'a> FnOnce<(&'a &str,)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a &'b str)`
+              found trait `for<'a> FnOnce(&'a &str)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a &'b str,)>`
-              found trait `for<'a> FnOnce<(&'a &str,)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a &'b str)`
+              found trait `for<'a> FnOnce(&'a &str)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
    |
@@ -42,8 +42,8 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a Wrapper<'b>,)>`
-              found trait `for<'a> FnOnce<(&'a Wrapper<'_>,)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a Wrapper<'b>)`
+              found trait `for<'a> FnOnce(&'a Wrapper<'_>)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24
    |
@@ -61,8 +61,8 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a Wrapper<'b>,)>`
-              found trait `for<'a> FnOnce<(&'a Wrapper<'_>,)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a Wrapper<'b>)`
+              found trait `for<'a> FnOnce(&'a Wrapper<'_>)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24
    |

--- a/tests/ui/lifetimes/issue-105675.stderr
+++ b/tests/ui/lifetimes/issue-105675.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a u32, &'b u32, u32)>`
-              found trait `for<'a> FnOnce<(&u32, &'a u32, u32)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a u32, &'b u32, u32)`
+              found trait `for<'a> FnOnce(&u32, &'a u32, u32)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-105675.rs:4:13
    |
@@ -27,8 +27,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a u32, &'b u32, u32)>`
-              found trait `for<'a> FnOnce<(&u32, &'a u32, u32)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a u32, &'b u32, u32)`
+              found trait `for<'a> FnOnce(&u32, &'a u32, u32)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-105675.rs:4:13
    |
@@ -46,8 +46,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a u32, &'b u32, u32)>`
-              found trait `FnOnce<(&u32, &u32, u32)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a u32, &'b u32, u32)`
+              found trait `FnOnce(&u32, &u32, u32)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-105675.rs:8:13
    |
@@ -69,8 +69,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> FnOnce<(&'a u32, &'b u32, u32)>`
-              found trait `FnOnce<(&u32, &u32, u32)>`
+   = note: expected trait `for<'a, 'b> FnOnce(&'a u32, &'b u32, u32)`
+              found trait `FnOnce(&u32, &u32, u32)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-105675.rs:8:13
    |

--- a/tests/ui/lifetimes/issue-79187-2.stderr
+++ b/tests/ui/lifetimes/issue-79187-2.stderr
@@ -31,8 +31,8 @@ error[E0308]: mismatched types
 LL |     take_foo(|a| a);
    |     ^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> Fn<(&'a i32,)>`
-              found trait `Fn<(&i32,)>`
+   = note: expected trait `for<'a> Fn(&'a i32)`
+              found trait `Fn(&i32)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-79187-2.rs:8:14
    |

--- a/tests/ui/lifetimes/issue-79187.stderr
+++ b/tests/ui/lifetimes/issue-79187.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> FnOnce<(&'a u32,)>`
-              found trait `FnOnce<(&u32,)>`
+   = note: expected trait `for<'a> FnOnce(&'a u32)`
+              found trait `FnOnce(&u32)`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-79187.rs:4:13
    |

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -18,8 +18,8 @@ error[E0308]: mismatched types
 LL |     f(data, identity)
    |     ^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> Fn<(&'a T,)>`
-              found trait `Fn<(&T,)>`
+   = note: expected trait `for<'a> Fn(&'a T)`
+              found trait `Fn(&T)`
 note: the lifetime requirement is introduced here
   --> $DIR/issue_74400.rs:8:34
    |

--- a/tests/ui/lint/internal_features.rs
+++ b/tests/ui/lint/internal_features.rs
@@ -1,0 +1,11 @@
+#![forbid(internal_features)]
+// A lang feature and a lib feature.
+#![feature(intrinsics, panic_internals)]
+//~^ ERROR: internal
+//~| ERROR: internal
+
+extern "rust-intrinsic" {
+    fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+}
+
+fn main() {}

--- a/tests/ui/lint/internal_features.stderr
+++ b/tests/ui/lint/internal_features.stderr
@@ -1,0 +1,23 @@
+error: the feature `intrinsics` is internal to the compiler or standard library
+  --> $DIR/internal_features.rs:3:12
+   |
+LL | #![feature(intrinsics, panic_internals)]
+   |            ^^^^^^^^^^
+   |
+   = note: using it is strongly discouraged
+note: the lint level is defined here
+  --> $DIR/internal_features.rs:1:11
+   |
+LL | #![forbid(internal_features)]
+   |           ^^^^^^^^^^^^^^^^^
+
+error: the feature `panic_internals` is internal to the compiler or standard library
+  --> $DIR/internal_features.rs:3:24
+   |
+LL | #![feature(intrinsics, panic_internals)]
+   |                        ^^^^^^^^^^^^^^^
+   |
+   = note: using it is strongly discouraged
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/mismatched_types/closure-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-mismatch.stderr
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     baz(|_| ());
    |     ^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> Fn<(&'a (),)>`
-              found trait `Fn<(&(),)>`
+   = note: expected trait `for<'a> Fn(&'a ())`
+              found trait `Fn(&())`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/closure-mismatch.rs:8:9
    |
@@ -45,8 +45,8 @@ error[E0308]: mismatched types
 LL |     baz(|x| ());
    |     ^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> Fn<(&'a (),)>`
-              found trait `Fn<(&(),)>`
+   = note: expected trait `for<'a> Fn(&'a ())`
+              found trait `Fn(&())`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/closure-mismatch.rs:11:9
    |

--- a/tests/ui/nll/missing-universe-cause-issue-114907.stderr
+++ b/tests/ui/nll/missing-universe-cause-issue-114907.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     accept(callback);
    |     ^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> FnOnce<(&'a (),)>`
-              found trait `FnOnce<(&(),)>`
+   = note: expected trait `for<'a> FnOnce(&'a ())`
+              found trait `FnOnce(&())`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/missing-universe-cause-issue-114907.rs:32:20
    |
@@ -46,8 +46,8 @@ error[E0308]: mismatched types
 LL |     accept(callback);
    |     ^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> FnOnce<(&'a (),)>`
-              found trait `FnOnce<(&(),)>`
+   = note: expected trait `for<'a> FnOnce(&'a ())`
+              found trait `FnOnce(&())`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/missing-universe-cause-issue-114907.rs:32:20
    |

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.rs
@@ -6,4 +6,8 @@ fn test(_: &for<'a> dyn Trait) {}
 fn test2(_: for<'a> impl Trait) {}
 //~^ ERROR `for<...>` expected after `impl`, not before
 
+// Issue #118564
+type A2 = dyn<for<> dyn>;
+//~^ ERROR expected identifier, found `>`
+
 fn main() {}

--- a/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
+++ b/tests/ui/parser/recover-hrtb-before-dyn-impl-kw.stderr
@@ -22,5 +22,11 @@ LL - fn test2(_: for<'a> impl Trait) {}
 LL + fn test2(_: impl for<'a> Trait) {}
    |
 
-error: aborting due to 2 previous errors
+error: expected identifier, found `>`
+  --> $DIR/recover-hrtb-before-dyn-impl-kw.rs:10:24
+   |
+LL | type A2 = dyn<for<> dyn>;
+   |                        ^ expected identifier
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-1623-static/rfc1623-2.stderr
+++ b/tests/ui/rfcs/rfc-1623-static/rfc1623-2.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     f: &id,
    |        ^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found trait `Fn<(&Foo<'_>,)>`
+   = note: expected trait `for<'a, 'b> Fn(&'a Foo<'b>)`
+              found trait `Fn(&Foo<'_>)`
 
 error[E0308]: mismatched types
   --> $DIR/rfc1623-2.rs:28:8
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     f: &id,
    |        ^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found trait `Fn<(&Foo<'_>,)>`
+   = note: expected trait `for<'a, 'b> Fn(&'a Foo<'b>)`
+              found trait `Fn(&Foo<'_>)`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: implementation of `FnOnce` is not general enough

--- a/tests/ui/traits/issue-85735.stderr
+++ b/tests/ui/traits/issue-85735.stderr
@@ -1,10 +1,10 @@
-error[E0283]: type annotations needed: cannot satisfy `T: FnMut<(&'a (),)>`
+error[E0283]: type annotations needed: cannot satisfy `T: FnMut(&'a ())`
   --> $DIR/issue-85735.rs:7:8
    |
 LL |     T: FnMut(&'a ()),
    |        ^^^^^^^^^^^^^
    |
-note: multiple `impl`s or `where` clauses satisfying `T: FnMut<(&'a (),)>` found
+note: multiple `impl`s or `where` clauses satisfying `T: FnMut(&'a ())` found
   --> $DIR/issue-85735.rs:7:8
    |
 LL |     T: FnMut(&'a ()),


### PR DESCRIPTION
Successful merges:

 - #117793 (Update variable name to fix `unused_variables` warning)
 - #118123 (Add support for making lib features internal)
 - #118268 (Pretty print `Fn<(..., ...)>` trait refs with parentheses (almost) always)
 - #118346 (Add `deeply_normalize_for_diagnostics`, use it in coherence)
 - #118350 (Simplify Default for tuples)
 - #118450 (Use OnceCell in cell module documentation)
 - #118585 (Fix parser ICE when recovering `dyn`/`impl` after `for<...>`)
 - #118587 (Cleanup error handlers some more)
 - #118642 (bootstrap(builder.rs): Don't explicitly warn against `semicolon_in_expressions_from_macros`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117793,118123,118268,118346,118350,118450,118585,118587,118642)
<!-- homu-ignore:end -->