### PR TITLE
add `field_of!` macro and field representing types

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2093,6 +2093,8 @@ pub enum TyKind {
     /// generate `NodeId`s on the fly, which would complicate
     /// the generation of opaque `type Foo = impl Trait` items significantly.
     ImplTrait(NodeId, GenericBounds),
+    /// `field_of!($ty, $field)` type.
+    FieldInfo(P<Ty>, Ident),
     /// No-op; kept solely so that we can pretty-print faithfully.
     Paren(P<Ty>),
     /// Unused for now.

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -513,6 +513,10 @@ pub fn noop_visit_ty<T: MutVisitor>(ty: &mut P<Ty>, vis: &mut T) {
             vis.visit_id(id);
             visit_vec(bounds, |bound| vis.visit_param_bound(bound));
         }
+        TyKind::FieldInfo(container, field) => {
+            vis.visit_ty(container);
+            vis.visit_ident(field);
+        }
         TyKind::MacCall(mac) => vis.visit_mac_call(mac),
         TyKind::AnonStruct(fields) | TyKind::AnonUnion(fields) => {
             fields.flat_map_in_place(|field| vis.flat_map_field_def(field));

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -437,6 +437,10 @@ pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) {
         TyKind::ImplTrait(_, bounds) => {
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Impl);
         }
+        TyKind::FieldInfo(container, field) => {
+            visitor.visit_ty(container);
+            visitor.visit_ident(*field);
+        }
         TyKind::Typeof(expression) => visitor.visit_anon_const(expression),
         TyKind::Infer | TyKind::ImplicitSelf | TyKind::Err => {}
         TyKind::MacCall(mac) => visitor.visit_mac_call(mac),

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1373,6 +1373,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             TyKind::Path(qself, path) => {
                 return self.lower_path_ty(t, qself, path, ParamMode::Explicit, itctx);
             }
+            TyKind::FieldInfo(container, field) => {
+                hir::TyKind::FieldInfo(self.lower_ty(container, itctx), self.lower_ident(*field))
+            }
             TyKind::ImplicitSelf => {
                 let hir_id = self.next_id();
                 let res = self.expect_full_res(t.id);

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1003,6 +1003,14 @@ impl<'a> State<'a> {
                 self.word_nbsp("impl");
                 self.print_type_bounds(bounds);
             }
+            ast::TyKind::FieldInfo(container, field) => {
+                self.word("builtin # field_of!");
+                self.popen();
+                self.print_type(container);
+                self.word(",");
+                self.print_ident(*field);
+                self.pclose();
+            }
             ast::TyKind::Array(ty, length) => {
                 self.word("[");
                 self.print_type(ty);

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1621,7 +1621,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
-                    | ty::Placeholder(_) => {
+                    | ty::Placeholder(_)
+                    | ty::FieldInfo(..) => {
                         bug!("When Place is Deref it's type shouldn't be {place_ty:#?}")
                     }
                 },
@@ -1658,7 +1659,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
-                    | ty::Placeholder(_) => bug!(
+                    | ty::Placeholder(_)
+                    | ty::FieldInfo(..) => bug!(
                         "When Place contains ProjectionElem::Field it's type shouldn't be {place_ty:#?}"
                     ),
                 },

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -426,7 +426,8 @@ fn push_debuginfo_type_name<'tcx>(
         | ty::Placeholder(..)
         | ty::Alias(..)
         | ty::Bound(..)
-        | ty::CoroutineWitness(..) => {
+        | ty::CoroutineWitness(..)
+        | ty::FieldInfo(..) => {
             bug!(
                 "debuginfo: Trying to create type name for \
                   unexpected type: {:?}",

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -173,7 +173,8 @@ pub(crate) fn const_to_valtree_inner<'tcx>(
         // FIXME(oli-obk): we can probably encode closures just like structs
         | ty::Closure(..)
         | ty::Coroutine(..)
-        | ty::CoroutineWitness(..) => Err(ValTreeCreationError::NonSupportedType),
+        | ty::CoroutineWitness(..)
+        | ty::FieldInfo(..) => Err(ValTreeCreationError::NonSupportedType),
     }
 }
 
@@ -306,7 +307,8 @@ pub fn valtree_to_const_value<'tcx>(
         | ty::FnPtr(_)
         | ty::Str
         | ty::Slice(_)
-        | ty::Dynamic(..) => bug!("no ValTree should have been created for type {:?}", ty.kind()),
+        | ty::Dynamic(..)
+        | ty::FieldInfo(..) => bug!("no ValTree should have been created for type {:?}", ty.kind()),
     }
 }
 

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -1013,7 +1013,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 | ty::Array(..)
                 | ty::Closure(..)
                 | ty::Never
-                | ty::Error(_) => true,
+                | ty::Error(_)
+                | ty::FieldInfo(..) => true,
 
                 ty::Str | ty::Slice(_) | ty::Dynamic(..) | ty::Foreign(..) => false,
 

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -89,7 +89,8 @@ pub(crate) fn eval_nullary_intrinsic<'tcx>(
             | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
-            | ty::Error(_) => ConstValue::from_target_usize(0u64, &tcx),
+            | ty::Error(_)
+            | ty::FieldInfo(..) => ConstValue::from_target_usize(0u64, &tcx),
         },
         other => bug!("`{}` is not a zero arg intrinsic", other),
     })

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -580,7 +580,8 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
             | ty::Str
             | ty::Dynamic(..)
             | ty::Closure(..)
-            | ty::Coroutine(..) => Ok(false),
+            | ty::Coroutine(..)
+            | ty::FieldInfo(..) => Ok(false),
             // Some types only occur during typechecking, they have no layout.
             // We should not see them here and we could not check them anyway.
             ty::Error(_)

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -38,7 +38,8 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
             | ty::FnPtr(_)
             | ty::Never
             | ty::Tuple(_)
-            | ty::Dynamic(_, _, _) => self.pretty_print_type(ty),
+            | ty::Dynamic(_, _, _)
+            | ty::FieldInfo(..) => self.pretty_print_type(ty),
 
             // Placeholders (all printed as `_` to uniformize them).
             ty::Param(_) | ty::Bound(..) | ty::Placeholder(_) | ty::Infer(_) | ty::Error(_) => {

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -116,6 +116,8 @@ pub enum DefKind {
         of_trait: bool,
     },
     Closure,
+    /// Field Representing type from `field_of!`.
+    FieldInfo,
 }
 
 impl DefKind {
@@ -160,6 +162,7 @@ impl DefKind {
             DefKind::Closure => "closure",
             DefKind::ExternCrate => "extern crate",
             DefKind::GlobalAsm => "global assembly block",
+            DefKind::FieldInfo => "field info type",
         }
     }
 
@@ -197,7 +200,8 @@ impl DefKind {
             | DefKind::ForeignTy
             | DefKind::TraitAlias
             | DefKind::AssocTy
-            | DefKind::TyParam => Some(Namespace::TypeNS),
+            | DefKind::TyParam
+            | DefKind::FieldInfo => Some(Namespace::TypeNS),
 
             DefKind::Fn
             | DefKind::Const
@@ -236,7 +240,8 @@ impl DefKind {
             | DefKind::TraitAlias
             | DefKind::AssocTy
             | DefKind::TyParam
-            | DefKind::ExternCrate => DefPathData::TypeNs(name),
+            | DefKind::ExternCrate
+            | DefKind::FieldInfo => DefPathData::TypeNs(name),
             DefKind::Fn
             | DefKind::Const
             | DefKind::ConstParam
@@ -295,7 +300,8 @@ impl DefKind {
             | DefKind::AnonConst
             | DefKind::InlineConst
             | DefKind::GlobalAsm
-            | DefKind::ExternCrate => false,
+            | DefKind::ExternCrate
+            | DefKind::FieldInfo => false,
         }
     }
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2542,6 +2542,8 @@ pub enum TyKind<'hir> {
     /// A trait object type `Bound1 + Bound2 + Bound3`
     /// where `Bound` is a trait or a lifetime.
     TraitObject(&'hir [PolyTraitRef<'hir>], &'hir Lifetime, TraitObjectSyntax),
+    /// `field_of!($ty, $field)`.
+    FieldInfo(&'hir Ty<'hir>, Ident),
     /// Unused for now.
     Typeof(AnonConst),
     /// `TyKind::Infer` means the type should be inferred instead of it having been

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -860,6 +860,10 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty<'v>) {
             }
             visitor.visit_lifetime(lifetime);
         }
+        TyKind::FieldInfo(container, field) => {
+            visitor.visit_ty(container);
+            visitor.visit_ident(field);
+        }
         TyKind::Typeof(ref expression) => visitor.visit_anon_const(expression),
         TyKind::Infer | TyKind::Err(_) => {}
     }

--- a/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/inherent_impls.rs
@@ -130,6 +130,7 @@ impl<'tcx> InherentCollect<'tcx> {
         let self_ty = self.tcx.type_of(id).instantiate_identity();
         match *self_ty.kind() {
             ty::Adt(def, _) => self.check_def_id(id, self_ty, def.did()),
+            ty::FieldInfo(def, ..) => self.check_def_id(id, self_ty, def.did()),
             ty::Foreign(did) => self.check_def_id(id, self_ty, did),
             ty::Dynamic(data, ..) if data.principal_def_id().is_some() => {
                 self.check_def_id(id, self_ty, data.principal_def_id().unwrap());

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -172,6 +172,14 @@ fn do_orphan_check_impl<'tcx>(
                     NonlocalImpl::DisallowBecauseNonlocal
                 },
             ),
+            ty::FieldInfo(def, ..) => (
+                LocalImpl::Allow,
+                if def.container().is_local() {
+                    NonlocalImpl::Allow
+                } else {
+                    NonlocalImpl::DisallowBecauseNonlocal
+                },
+            ),
 
             // extern { type OpaqueType; }
             // impl AutoTrait for OpaqueType {}

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -502,6 +502,13 @@ pub(super) fn explicit_predicates_of<'tcx>(
             }
         }
     } else {
+        if matches!(def_kind, DefKind::FieldInfo) {
+            let parent = tcx.parent(def_id.to_def_id());
+            let parent_hir_id = tcx.local_def_id_to_hir_id(parent.as_local().unwrap());
+            let item_def_id = tcx.hir().get_parent_item(parent_hir_id);
+
+            return tcx.explicit_predicates_of(item_def_id);
+        }
         if matches!(def_kind, DefKind::AnonConst) && tcx.features().generic_const_exprs {
             let hir_id = tcx.local_def_id_to_hir_id(def_id);
             let parent_def_id = tcx.hir().get_parent_item(hir_id);

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -350,6 +350,18 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<Ty
         }
     }
 
+    if let crate::DefKind::FieldInfo = tcx.def_kind(def_id.to_def_id()) {
+        let parent_field = tcx.parent(def_id.to_def_id());
+        let field = tcx.local_def_id_to_hir_id(parent_field.as_local().unwrap());
+        let parent_struct = tcx.hir().get_parent_item(field).to_def_id();
+        let args = ty::GenericArgs::identity_for_item(tcx, parent_struct);
+        return ty::EarlyBinder::bind(Ty::new_field_of(
+            tcx,
+            tcx.field_info_def(def_id.to_def_id()),
+            args,
+        ));
+    }
+
     let hir_id = tcx.local_def_id_to_hir_id(def_id);
 
     let icx = ItemCtxt::new(tcx, def_id);

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -307,6 +307,10 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                 self.add_constraints_from_sig(current, sig, variance);
             }
 
+            ty::FieldInfo(_, args) => {
+                self.add_constraints_from_invariant_args(current, args, variance);
+            }
+
             ty::Error(_) => {
                 // we encounter this when walking the trait references for object
                 // types, where we use Error as the Self type

--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -61,6 +61,14 @@ fn variances_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[ty::Variance] {
             let crate_map = tcx.crate_variances(());
             return crate_map.variances.get(&item_def_id.to_def_id()).copied().unwrap_or(&[]);
         }
+        DefKind::FieldInfo => {
+            // These are inferred.
+            let crate_map = tcx.crate_variances(());
+            let parent_field = tcx.parent(item_def_id.to_def_id());
+            let field_hir = tcx.local_def_id_to_hir_id(parent_field.as_local().unwrap());
+            let parent_struct = tcx.hir().get_parent_item(field_hir);
+            return crate_map.variances.get(&parent_struct.to_def_id()).copied().unwrap_or(&[]);
+        }
         DefKind::OpaqueTy => {
             return variance_of_opaque(tcx, item_def_id);
         }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -310,6 +310,13 @@ impl<'a> State<'a> {
                 self.print_array_length(length);
                 self.word("]");
             }
+            hir::TyKind::FieldInfo(container, field) => {
+                self.word("field_of!");
+                self.popen();
+                self.print_type(container);
+                self.print_ident(field);
+                self.pclose();
+            }
             hir::TyKind::Typeof(ref e) => {
                 self.word("typeof(");
                 self.print_anon_const(e);

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -138,7 +138,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | ty::Adt(..)
             | ty::Never
             | ty::Dynamic(_, _, ty::DynStar)
-            | ty::Error(_) => {
+            | ty::Error(_)
+            | ty::FieldInfo(..) => {
                 let reported = self
                     .tcx
                     .sess

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -474,7 +474,8 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
             | ty::Tuple(..)
             | ty::Alias(..)
             | ty::Foreign(..)
-            | ty::Param(..) => {
+            | ty::Param(..)
+            | ty::FieldInfo(..) => {
                 if t.flags().intersects(self.needs_canonical_flags) {
                     t.super_fold_with(self)
                 } else {

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -173,6 +173,7 @@ fn compute_components<'tcx>(
             ty::Float(..) |       // OutlivesScalar
             ty::Never |           // ...
             ty::Adt(..) |         // OutlivesNominalType
+            ty::FieldInfo(..) |   // OutlivesNominalType
             ty::Foreign(..) |     // OutlivesNominalType
             ty::Str |             // OutlivesScalar (ish)
             ty::Slice(..) |       // ...

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1275,7 +1275,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             | ty::Coroutine(..)
             | ty::CoroutineWitness(..)
             | ty::Placeholder(..)
-            | ty::FnDef(..) => bug!("unexpected type in foreign function: {:?}", ty),
+            | ty::FnDef(..)
+            | ty::FieldInfo(..) => bug!("unexpected type in foreign function: {:?}", ty),
         }
     }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1093,6 +1093,14 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
                 self.get_associated_item_or_field_def_ids(index)
                     .map(|did| ty::FieldDef {
                         did,
+                        field_repr: self.local_def_id(
+                            self.root
+                                .tables
+                                .field_info_def_ids
+                                .get(self, did.index)
+                                .unwrap()
+                                .decode(self),
+                        ),
                         name: self.item_name(did.index),
                         vis: self.get_visibility(did.index),
                     })

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -856,7 +856,8 @@ fn should_encode_span(def_kind: DefKind) -> bool {
         | DefKind::OpaqueTy
         | DefKind::Field
         | DefKind::Impl { .. }
-        | DefKind::Closure => true,
+        | DefKind::Closure
+        | DefKind::FieldInfo => true,
         DefKind::ForeignMod | DefKind::GlobalAsm => false,
     }
 }
@@ -896,7 +897,8 @@ fn should_encode_attrs(def_kind: DefKind) -> bool {
         | DefKind::InlineConst
         | DefKind::OpaqueTy
         | DefKind::LifetimeParam
-        | DefKind::GlobalAsm => false,
+        | DefKind::GlobalAsm
+        | DefKind::FieldInfo => false,
     }
 }
 
@@ -931,7 +933,8 @@ fn should_encode_expn_that_defined(def_kind: DefKind) -> bool {
         | DefKind::Field
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::Closure => false,
+        | DefKind::Closure
+        | DefKind::FieldInfo => false,
     }
 }
 
@@ -954,7 +957,8 @@ fn should_encode_visibility(def_kind: DefKind) -> bool {
         | DefKind::AssocFn
         | DefKind::AssocConst
         | DefKind::Macro(..)
-        | DefKind::Field => true,
+        | DefKind::Field
+        | DefKind::FieldInfo => true,
         DefKind::Use
         | DefKind::ForeignMod
         | DefKind::TyParam
@@ -1001,7 +1005,8 @@ fn should_encode_stability(def_kind: DefKind) -> bool {
         | DefKind::InlineConst
         | DefKind::GlobalAsm
         | DefKind::Closure
-        | DefKind::ExternCrate => false,
+        | DefKind::ExternCrate
+        | DefKind::FieldInfo => false,
     }
 }
 
@@ -1072,7 +1077,8 @@ fn should_encode_variances<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, def_kind: Def
         | DefKind::OpaqueTy
         | DefKind::Fn
         | DefKind::Ctor(..)
-        | DefKind::AssocFn => true,
+        | DefKind::AssocFn
+        | DefKind::FieldInfo => true,
         DefKind::Mod
         | DefKind::Field
         | DefKind::AssocTy
@@ -1121,7 +1127,8 @@ fn should_encode_generics(def_kind: DefKind) -> bool {
         | DefKind::Impl { .. }
         | DefKind::Field
         | DefKind::TyParam
-        | DefKind::Closure => true,
+        | DefKind::Closure
+        | DefKind::FieldInfo => true,
         DefKind::Mod
         | DefKind::ForeignMod
         | DefKind::ConstParam
@@ -1152,7 +1159,8 @@ fn should_encode_type(tcx: TyCtxt<'_>, def_id: LocalDefId, def_kind: DefKind) ->
         | DefKind::Closure
         | DefKind::ConstParam
         | DefKind::AnonConst
-        | DefKind::InlineConst => true,
+        | DefKind::InlineConst
+        | DefKind::FieldInfo => true,
 
         DefKind::OpaqueTy => {
             let origin = tcx.opaque_type_origin(def_id);
@@ -1223,7 +1231,8 @@ fn should_encode_fn_sig(def_kind: DefKind) -> bool {
         | DefKind::Use
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::ExternCrate => false,
+        | DefKind::ExternCrate
+        | DefKind::FieldInfo => false,
     }
 }
 
@@ -1260,7 +1269,8 @@ fn should_encode_constness(def_kind: DefKind) -> bool {
         | DefKind::Use
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::ExternCrate => false,
+        | DefKind::ExternCrate
+        | DefKind::FieldInfo => false,
     }
 }
 
@@ -1293,7 +1303,8 @@ fn should_encode_const(def_kind: DefKind) -> bool {
         | DefKind::Use
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::ExternCrate => false,
+        | DefKind::ExternCrate
+        | DefKind::FieldInfo => false,
     }
 }
 
@@ -1530,6 +1541,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 assert!(f.did.is_local());
                 f.did.index
             }));
+            for f in variant.fields.iter() {
+                record!(self.tables.field_info_def_ids[f.did] <- f.field_repr.index)
+            }
 
             if let Some((CtorKind::Fn, ctor_def_id)) = variant.ctor {
                 let fn_sig = tcx.fn_sig(ctor_def_id);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -405,6 +405,7 @@ define_tables! {
     // so we can take their names, visibilities etc from other encoded tables.
     module_children_non_reexports: Table<DefIndex, LazyArray<DefIndex>>,
     associated_item_or_field_def_ids: Table<DefIndex, LazyArray<DefIndex>>,
+    field_info_def_ids: Table<DefIndex, LazyValue<DefIndex>>,
     def_kind: Table<DefIndex, DefKind>,
     visibility: Table<DefIndex, LazyValue<ty::Visibility<DefIndex>>>,
     def_span: Table<DefIndex, LazyValue<Span>>,

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -176,6 +176,7 @@ fixed_size_enum! {
         ( Macro(MacroKind::Bang)                   )
         ( Macro(MacroKind::Attr)                   )
         ( Macro(MacroKind::Derive)                 )
+        ( FieldInfo                                )
     }
 }
 

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -12,6 +12,8 @@ macro_rules! arena_types {
             [] fn_abi: rustc_target::abi::call::FnAbi<'tcx, rustc_middle::ty::Ty<'tcx>>,
             // AdtDef are interned and compared by address
             [decode] adt_def: rustc_middle::ty::AdtDefData,
+            // FieldInfoDef are interned and compared by address
+            [decode] field_info_def: rustc_middle::ty::FieldInfoDefData,
             [] steal_thir: rustc_data_structures::steal::Steal<rustc_middle::thir::Thir<'tcx>>,
             [] steal_mir: rustc_data_structures::steal::Steal<rustc_middle::mir::Body<'tcx>>,
             [decode] mir: rustc_middle::mir::Body<'tcx>,

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -333,6 +333,7 @@ tcx_lifetime! {
     rustc_middle::traits::query::type_op::ProvePredicate,
     rustc_middle::traits::query::type_op::Subtype,
     rustc_middle::ty::AdtDef,
+    rustc_middle::ty::FieldInfoDef,
     rustc_middle::ty::AliasTy,
     rustc_middle::ty::ClauseKind,
     rustc_middle::ty::ClosureTypeInfo,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -705,6 +705,11 @@ rustc_queries! {
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }
+    query field_info_def(key: DefId) -> ty::FieldInfoDef<'tcx> {
+        desc { |tcx| "computing FieldInfo definition for `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { key.is_local() }
+        separate_provide_extern
+    }
     query adt_destructor(key: DefId) -> Option<ty::Destructor> {
         desc { |tcx| "computing `Drop` impl for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -14,7 +14,7 @@ use crate::mir::{
 };
 use crate::traits;
 use crate::ty::GenericArgsRef;
-use crate::ty::{self, AdtDef, Ty};
+use crate::ty::{self, AdtDef, FieldInfoDef, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::{Decodable, Encodable};
@@ -153,6 +153,12 @@ impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for ConstAllocation<'tcx
 }
 
 impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for AdtDef<'tcx> {
+    fn encode(&self, e: &mut E) {
+        self.0.0.encode(e)
+    }
+}
+
+impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for FieldInfoDef<'tcx> {
     fn encode(&self, e: &mut E) {
         self.0.0.encode(e)
     }
@@ -364,6 +370,12 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for ConstAllocation<'tcx
 impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for AdtDef<'tcx> {
     fn decode(decoder: &mut D) -> Self {
         decoder.interner().mk_adt_def_from_data(Decodable::decode(decoder))
+    }
+}
+
+impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for FieldInfoDef<'tcx> {
+    fn decode(decoder: &mut D) -> Self {
+        decoder.interner().mk_field_info_def_from_data(Decodable::decode(decoder))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -25,10 +25,10 @@ use crate::traits::solve::{
     ExternalConstraints, ExternalConstraintsData, PredefinedOpaques, PredefinedOpaquesData,
 };
 use crate::ty::{
-    self, AdtDef, AdtDefData, AdtKind, Binder, Clause, Const, ConstData, GenericParamDefKind,
-    ImplPolarity, List, ParamConst, ParamTy, PolyExistentialPredicate, PolyFnSig, Predicate,
-    PredicateKind, Region, RegionKind, ReprOptions, TraitObjectVisitor, Ty, TyKind, TyVid,
-    TypeAndMut, Visibility,
+    self, AdtDef, AdtDefData, AdtKind, Binder, Clause, Const, ConstData, FieldInfoDef,
+    FieldInfoDefData, GenericParamDefKind, ImplPolarity, List, ParamConst, ParamTy,
+    PolyExistentialPredicate, PolyFnSig, Predicate, PredicateKind, Region, RegionKind, ReprOptions,
+    TraitObjectVisitor, Ty, TyKind, TyVid, TypeAndMut, Visibility,
 };
 use crate::ty::{GenericArg, GenericArgs, GenericArgsRef};
 use rustc_ast::{self as ast, attr};
@@ -81,6 +81,7 @@ use std::ops::{Bound, Deref};
 impl<'tcx> Interner for TyCtxt<'tcx> {
     type DefId = DefId;
     type AdtDef = ty::AdtDef<'tcx>;
+    type FieldInfoDef = ty::FieldInfoDef<'tcx>;
     type GenericArgs = ty::GenericArgsRef<'tcx>;
     type GenericArg = ty::GenericArg<'tcx>;
     type Term = ty::Term<'tcx>;
@@ -156,6 +157,7 @@ pub struct CtxtInterners<'tcx> {
     bound_variable_kinds: InternedSet<'tcx, List<ty::BoundVariableKind>>,
     layout: InternedSet<'tcx, LayoutS<FieldIdx, VariantIdx>>,
     adt_def: InternedSet<'tcx, AdtDefData>,
+    field_info_def: InternedSet<'tcx, FieldInfoDefData>,
     external_constraints: InternedSet<'tcx, ExternalConstraintsData<'tcx>>,
     predefined_opaques_in_body: InternedSet<'tcx, PredefinedOpaquesData<'tcx>>,
     fields: InternedSet<'tcx, List<FieldIdx>>,
@@ -183,6 +185,7 @@ impl<'tcx> CtxtInterners<'tcx> {
             bound_variable_kinds: Default::default(),
             layout: Default::default(),
             adt_def: Default::default(),
+            field_info_def: Default::default(),
             external_constraints: Default::default(),
             predefined_opaques_in_body: Default::default(),
             fields: Default::default(),
@@ -684,6 +687,10 @@ impl<'tcx> TyCtxt<'tcx> {
         repr: ReprOptions,
     ) -> ty::AdtDef<'tcx> {
         self.mk_adt_def_from_data(ty::AdtDefData::new(self, did, kind, variants, repr))
+    }
+
+    pub fn mk_field_info_def(self, did: DefId, container: DefId) -> ty::FieldInfoDef<'tcx> {
+        self.mk_field_info_def_from_data(ty::FieldInfoDefData::new(did, container))
     }
 
     /// Allocates a read-only byte or string literal for `mir::interpret`.
@@ -1450,6 +1457,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     Closure,
                     Tuple,
                     Bound,
+                    FieldInfo,
                     Param,
                     Infer,
                     Alias,
@@ -1584,6 +1592,7 @@ direct_interners! {
     const_allocation: pub mk_const_alloc(Allocation): ConstAllocation -> ConstAllocation<'tcx>,
     layout: pub mk_layout(LayoutS<FieldIdx, VariantIdx>): Layout -> Layout<'tcx>,
     adt_def: pub mk_adt_def_from_data(AdtDefData): AdtDef -> AdtDef<'tcx>,
+    field_info_def: pub mk_field_info_def_from_data(FieldInfoDefData): FieldInfoDef -> FieldInfoDef<'tcx>,
     external_constraints: pub mk_external_constraints(ExternalConstraintsData<'tcx>):
         ExternalConstraints -> ExternalConstraints<'tcx>,
     predefined_opaques_in_body: pub mk_predefined_opaques_in_body(PredefinedOpaquesData<'tcx>):

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -307,6 +307,7 @@ impl<'tcx> Ty<'tcx> {
             ty::Tuple(..) => "tuple".into(),
             ty::Placeholder(..) => "higher-ranked type".into(),
             ty::Bound(..) => "bound type variable".into(),
+            ty::FieldInfo(..) => "field info type".into(),
             ty::Alias(ty::Projection | ty::Inherent, _) => "associated type".into(),
             ty::Alias(ty::Weak, _) => "type alias".into(),
             ty::Param(_) => "type parameter".into(),

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -141,6 +141,10 @@ impl FlagComputation {
                 self.add_flags(TypeFlags::HAS_TY_BOUND);
             }
 
+            &ty::FieldInfo(_, args) => {
+                self.add_args(args);
+            }
+
             &ty::Placeholder(..) => {
                 self.add_flags(TypeFlags::HAS_TY_PLACEHOLDER);
                 self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -811,6 +811,7 @@ where
                 | ty::FnDef(..)
                 | ty::CoroutineWitness(..)
                 | ty::Foreign(..)
+                | ty::FieldInfo(..)
                 | ty::Dynamic(_, _, ty::Dyn) => {
                     bug!("TyAndLayout::field({:?}): not applicable", this)
                 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1914,6 +1914,7 @@ pub struct FieldDef {
     pub did: DefId,
     pub name: Symbol,
     pub vis: Visibility<DefId>,
+    pub field_repr: DefId,
 }
 
 impl PartialEq for FieldDef {
@@ -1926,9 +1927,9 @@ impl PartialEq for FieldDef {
         // of `FieldDef` changes, a compile-error will be produced, reminding
         // us to revisit this assumption.
 
-        let Self { did: lhs_did, name: _, vis: _ } = &self;
+        let Self { did: lhs_did, name: _, vis: _, field_repr: _ } = &self;
 
-        let Self { did: rhs_did, name: _, vis: _ } = other;
+        let Self { did: rhs_did, name: _, vis: _, field_repr: _ } = other;
 
         let res = lhs_did == rhs_did;
 
@@ -1954,7 +1955,7 @@ impl Hash for FieldDef {
         // of `FieldDef` changes, a compile-error will be produced, reminding
         // us to revisit this assumption.
 
-        let Self { did, name: _, vis: _ } = &self;
+        let Self { did, name: _, vis: _, field_repr: _ } = &self;
 
         did.hash(s)
     }

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -274,6 +274,7 @@ fn characteristic_def_id_of_type_cached<'a>(
         | ty::Param(_)
         | ty::Infer(_)
         | ty::Bound(..)
+        | ty::FieldInfo(..)
         | ty::Error(_)
         | ty::Never
         | ty::Float(_) => None,

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -704,6 +704,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     false => p!(write("{s}")),
                 },
             },
+            ty::FieldInfo(def, args) => p!(print_def_path(def.did(), args)),
             ty::Adt(def, args) => {
                 p!(print_def_path(def.did(), args));
             }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -44,6 +44,19 @@ impl<'tcx> fmt::Debug for ty::AdtDef<'tcx> {
     }
 }
 
+impl<'tcx> fmt::Debug for ty::FieldInfoDef<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        ty::tls::with(|tcx| {
+            with_no_trimmed_paths!({
+                let s = FmtPrinter::print_string(tcx, Namespace::TypeNS, |cx| {
+                    cx.print_def_path(self.did(), &[])
+                })?;
+                f.write_str(&s)
+            })
+        })
+    }
+}
+
 impl fmt::Debug for ty::UpvarId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = ty::tls::with(|tcx| tcx.hir().name(self.var_path.hir_id));
@@ -580,6 +593,7 @@ impl<'tcx> TypeSuperFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
             }
             ty::Closure(did, args) => ty::Closure(did, args.try_fold_with(folder)?),
             ty::Alias(kind, data) => ty::Alias(kind, data.try_fold_with(folder)?),
+            ty::FieldInfo(def, args) => ty::FieldInfo(def, args.try_fold_with(folder)?),
 
             ty::Bool
             | ty::Char
@@ -628,6 +642,7 @@ impl<'tcx> TypeSuperVisitable<TyCtxt<'tcx>> for Ty<'tcx> {
             ty::CoroutineWitness(_did, ref args) => args.visit_with(visitor),
             ty::Closure(_did, ref args) => args.visit_with(visitor),
             ty::Alias(_, ref data) => data.visit_with(visitor),
+            ty::FieldInfo(_, args) => args.visit_with(visitor),
 
             ty::Bool
             | ty::Char

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2261,6 +2261,15 @@ impl<'tcx> Ty<'tcx> {
         let context_ty = Ty::new_adt(tcx, context_adt_ref, context_args);
         Ty::new_mut_ref(tcx, tcx.lifetimes.re_erased, context_ty)
     }
+
+    #[inline]
+    pub fn new_field_of(
+        tcx: TyCtxt<'tcx>,
+        def: ty::FieldInfoDef<'tcx>,
+        args: &'tcx GenericArgs<'tcx>,
+    ) -> Ty<'tcx> {
+        Ty::new(tcx, FieldInfo(def, args))
+    }
 }
 
 /// Type utilities
@@ -2724,7 +2733,8 @@ impl<'tcx> Ty<'tcx> {
             | ty::Never
             | ty::Tuple(_)
             | ty::Error(_)
-            | ty::Infer(IntVar(_) | FloatVar(_)) => tcx.types.u8,
+            | ty::Infer(IntVar(_) | FloatVar(_))
+            | ty::FieldInfo(..) => tcx.types.u8,
 
             ty::Bound(..)
             | ty::Placeholder(_)
@@ -2759,6 +2769,7 @@ impl<'tcx> Ty<'tcx> {
             | ty::Array(..)
             | ty::Closure(..)
             | ty::Never
+                | ty::FieldInfo(..)
             | ty::Error(_)
             // Extern types have metadata = ().
             | ty::Foreign(..)
@@ -2847,7 +2858,8 @@ impl<'tcx> Ty<'tcx> {
             | ty::Array(..)
             | ty::Closure(..)
             | ty::Never
-            | ty::Error(_) => true,
+            | ty::Error(_)
+            | ty::FieldInfo(..) => true,
 
             ty::Str | ty::Slice(_) | ty::Dynamic(..) | ty::Foreign(..) => false,
 
@@ -2876,6 +2888,8 @@ impl<'tcx> Ty<'tcx> {
     pub fn is_trivially_pure_clone_copy(self) -> bool {
         match self.kind() {
             ty::Bool | ty::Char | ty::Never => true,
+
+            ty::FieldInfo(..) => true,
 
             // These aren't even `Clone`
             ty::Str | ty::Slice(..) | ty::Foreign(..) | ty::Dynamic(..) => false,
@@ -2984,6 +2998,7 @@ impl<'tcx> Ty<'tcx> {
             | Coroutine(_, _, _)
             | CoroutineWitness(..)
             | Never
+            | FieldInfo(..)
             | Tuple(_) => true,
             Error(_) | Infer(_) | Alias(_, _) | Param(_) | Bound(_, _) | Placeholder(_) => false,
         }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1064,7 +1064,8 @@ impl<'tcx> Ty<'tcx> {
             | ty::RawPtr(_)
             | ty::FnDef(..)
             | ty::Error(_)
-            | ty::FnPtr(_) => true,
+            | ty::FnPtr(_)
+            | ty::FieldInfo(..) => true,
             ty::Tuple(fields) => fields.iter().all(Self::is_trivially_freeze),
             ty::Slice(elem_ty) | ty::Array(elem_ty, _) => elem_ty.is_trivially_freeze(),
             ty::Adt(..)
@@ -1103,7 +1104,8 @@ impl<'tcx> Ty<'tcx> {
             | ty::RawPtr(_)
             | ty::FnDef(..)
             | ty::Error(_)
-            | ty::FnPtr(_) => true,
+            | ty::FnPtr(_)
+            | ty::FieldInfo(..) => true,
             ty::Tuple(fields) => fields.iter().all(Self::is_trivially_unpin),
             ty::Slice(elem_ty) | ty::Array(elem_ty, _) => elem_ty.is_trivially_unpin(),
             ty::Adt(..)
@@ -1232,7 +1234,11 @@ impl<'tcx> Ty<'tcx> {
             // Conservatively return `false` for all others...
 
             // Anonymous function types
-            ty::FnDef(..) | ty::Closure(..) | ty::Dynamic(..) | ty::Coroutine(..) => false,
+            ty::FnDef(..)
+            | ty::Closure(..)
+            | ty::Dynamic(..)
+            | ty::Coroutine(..)
+            | ty::FieldInfo(..) => false,
 
             // Generic or inferred types
             //
@@ -1344,6 +1350,8 @@ pub fn needs_drop_components<'tcx>(
         // Foreign types can never have destructors.
         ty::Foreign(..) => Ok(SmallVec::new()),
 
+        ty::FieldInfo(..) => Ok(SmallVec::new()),
+
         ty::Dynamic(..) | ty::Error(_) => Err(AlwaysRequiresDrop),
 
         ty::Slice(ty) => needs_drop_components(tcx, ty),
@@ -1396,7 +1404,8 @@ pub fn is_trivially_const_drop(ty: Ty<'_>) -> bool {
         | ty::FnDef(..)
         | ty::FnPtr(_)
         | ty::Never
-        | ty::Foreign(_) => true,
+        | ty::Foreign(_)
+        | ty::FieldInfo(..) => true,
 
         ty::Alias(..)
         | ty::Dynamic(..)

--- a/compiler/rustc_middle/src/ty/walk.rs
+++ b/compiler/rustc_middle/src/ty/walk.rs
@@ -191,7 +191,8 @@ fn push_inner<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent: GenericArg<'tcx>)
             | ty::Closure(_, args)
             | ty::Coroutine(_, args, _)
             | ty::CoroutineWitness(_, args)
-            | ty::FnDef(_, args) => {
+            | ty::FnDef(_, args)
+            | ty::FieldInfo(_, args) => {
                 stack.extend(args.iter().rev());
             }
             ty::Tuple(ts) => stack.extend(ts.iter().rev().map(GenericArg::from)),

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -164,6 +164,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
+                    | ty::FieldInfo(..)
                     | ty::Placeholder(_) => {
                         bug!("When Place is Deref it's type shouldn't be {place_ty:#?}")
                     }
@@ -199,6 +200,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
                     | ty::Bound(_, _)
                     | ty::Infer(_)
                     | ty::Error(_)
+                    | ty::FieldInfo(..)
                     | ty::Placeholder(_) => bug!(
                         "When Place contains ProjectionElem::Field it's type shouldn't be {place_ty:#?}"
                     ),

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -697,7 +697,8 @@ fn try_write_constant<'tcx>(
         | ty::Placeholder(..)
         | ty::Closure(..)
         | ty::Coroutine(..)
-        | ty::Dynamic(..) => throw_machine_stop_str!("unsupported type"),
+        | ty::Dynamic(..)
+        | ty::FieldInfo(..) => throw_machine_stop_str!("unsupported type"),
 
         ty::Error(_) | ty::Infer(..) | ty::CoroutineWitness(..) => bug!(),
     }

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -165,7 +165,8 @@ fn mark_used_by_default_parameters<'tcx>(
         | DefKind::Field
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::Impl { .. } => {
+        | DefKind::Impl { .. }
+        | DefKind::FieldInfo => {
             for param in &generics.params {
                 debug!(?param, "(other)");
                 if let ty::GenericParamDefKind::Lifetime = param.kind {

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -347,6 +347,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
                 Path,
                 OpaqueDef,
                 TraitObject,
+                FieldInfo,
                 Typeof,
                 Infer,
                 Err
@@ -607,6 +608,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 Path,
                 TraitObject,
                 ImplTrait,
+                FieldInfo,
                 Paren,
                 Typeof,
                 Infer,

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -282,7 +282,8 @@ where
             | ty::Param(..)
             | ty::Bound(..)
             | ty::Error(_)
-            | ty::CoroutineWitness(..) => {}
+            | ty::CoroutineWitness(..)
+            | ty::FieldInfo(..) => {}
             ty::Placeholder(..) | ty::Infer(..) => {
                 bug!("unexpected type: {:?}", ty)
             }
@@ -653,7 +654,8 @@ impl<'tcx> EmbargoVisitor<'tcx> {
             | DefKind::Field
             | DefKind::GlobalAsm
             | DefKind::Impl { .. }
-            | DefKind::Closure => (),
+            | DefKind::Closure
+            | DefKind::FieldInfo => (),
         }
     }
 }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -944,7 +944,8 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
                 | DefKind::ForeignTy
                 | DefKind::OpaqueTy
                 | DefKind::TraitAlias
-                | DefKind::AssocTy,
+                | DefKind::AssocTy
+                | DefKind::FieldInfo,
                 _,
             )
             | Res::PrimTy(..)

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -11,8 +11,8 @@ use stable_mir::mir::alloc::AllocId;
 use stable_mir::mir::mono::{Instance, MonoItem, StaticDef};
 use stable_mir::ty::{
     AdtDef, Binder, BoundRegionKind, BoundTyKind, BoundVariableKind, ClosureKind, Const,
-    ExistentialTraitRef, FloatTy, GenericArgKind, GenericArgs, IntTy, Region, RigidTy, Span,
-    TraitRef, Ty, UintTy,
+    ExistentialTraitRef, FieldInfoDef, FloatTy, GenericArgKind, GenericArgs, IntTy, Region,
+    RigidTy, Span, TraitRef, Ty, UintTy,
 };
 use stable_mir::{CrateItem, DefId};
 
@@ -93,7 +93,8 @@ impl<'tcx> RustcInternal<'tcx> for RigidTy {
             | RigidTy::Coroutine(..)
             | RigidTy::CoroutineWitness(..)
             | RigidTy::Dynamic(..)
-            | RigidTy::Tuple(..) => {
+            | RigidTy::Tuple(..)
+            | RigidTy::FieldInfo(..) => {
                 todo!()
             }
         }
@@ -276,6 +277,13 @@ impl<'tcx> RustcInternal<'tcx> for AdtDef {
     type T = rustc_ty::AdtDef<'tcx>;
     fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
         tables.tcx.adt_def(self.0.internal(&mut *tables))
+    }
+}
+
+impl<'tcx> RustcInternal<'tcx> for FieldInfoDef {
+    type T = rustc_ty::FieldInfoDef<'tcx>;
+    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T {
+        tables.tcx.field_info_def(self.0.internal(&mut *tables))
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -58,6 +58,10 @@ impl<'tcx> Tables<'tcx> {
         stable_mir::ty::AdtDef(self.create_def_id(did))
     }
 
+    pub fn field_info_def(&mut self, did: DefId) -> stable_mir::ty::FieldInfoDef {
+        stable_mir::ty::FieldInfoDef(self.create_def_id(did))
+    }
+
     pub fn foreign_def(&mut self, did: DefId) -> stable_mir::ty::ForeignDef {
         stable_mir::ty::ForeignDef(self.create_def_id(did))
     }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -391,6 +391,11 @@ impl<'tcx> Stable<'tcx> for ty::TyKind<'tcx> {
             ty::Bound(debruijn_idx, bound_ty) => {
                 TyKind::Bound(debruijn_idx.as_usize(), bound_ty.stable(tables))
             }
+            ty::FieldInfo(def, args) => TyKind::RigidTy(RigidTy::FieldInfo(
+                tables.field_info_def(def.did()),
+                args.stable(tables),
+            )),
+
             ty::CoroutineWitness(def_id, args) => TyKind::RigidTy(RigidTy::CoroutineWitness(
                 tables.coroutine_witness_def(*def_id),
                 args.stable(tables),

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -86,7 +86,8 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
         | DefKind::LifetimeParam
         | DefKind::Impl { .. }
         | DefKind::Ctor(_, _)
-        | DefKind::GlobalAsm => {
+        | DefKind::GlobalAsm
+        | DefKind::FieldInfo => {
             unreachable!("Not a valid item kind: {kind:?}");
         }
         DefKind::Closure | DefKind::AssocFn | DefKind::Fn => ItemKind::Fn,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -760,6 +760,7 @@ symbols! {
         ffi_returns_twice,
         field,
         field_init_shorthand,
+        field_of,
         file,
         float,
         float_to_int_unchecked,

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -721,6 +721,7 @@ fn encode_ty<'tcx>(
         | ty::Error(..)
         | ty::CoroutineWitness(..)
         | ty::Infer(..)
+        | ty::FieldInfo(..)
         | ty::Placeholder(..) => {
             bug!("encode_ty: unexpected `{:?}`", ty.kind());
         }
@@ -972,7 +973,12 @@ fn transform_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, options: TransformTyOptio
             );
         }
 
-        ty::Bound(..) | ty::Error(..) | ty::Infer(..) | ty::Param(..) | ty::Placeholder(..) => {
+        ty::Bound(..)
+        | ty::Error(..)
+        | ty::Infer(..)
+        | ty::Param(..)
+        | ty::Placeholder(..)
+        | ty::FieldInfo(..) => {
             bug!("transform_ty: unexpected `{:?}`", ty.kind());
         }
     }

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -424,6 +424,10 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
 
             // Mangle all nominal types as paths.
             ty::Adt(ty::AdtDef(Interned(&ty::AdtDefData { did: def_id, .. }, _)), args)
+            | ty::FieldInfo(
+                ty::FieldInfoDef(Interned(&ty::FieldInfoDefData { did: def_id, .. }, _)),
+                args,
+            )
             | ty::FnDef(def_id, args)
             | ty::Alias(ty::Projection | ty::Opaque, ty::AliasTy { def_id, args, .. })
             | ty::Closure(def_id, args)

--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -424,7 +424,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::Closure(_, _)
             | ty::Coroutine(_, _, _)
             | ty::Never
-            | ty::Tuple(_) => {
+            | ty::Tuple(_)
+            | ty::FieldInfo(..) => {
                 let simp =
                     fast_reject::simplify_type(tcx, self_ty, TreatParams::ForLookup).unwrap();
                 consider_impls_for_simplified_type(simp);
@@ -646,7 +647,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::Alias(ty::Weak, _)
             | ty::Error(_) => return,
             ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
-            | ty::Bound(..) => bug!("unexpected self type for `{goal:?}`"),
+            | ty::Bound(..)
+            | ty::FieldInfo(..) => bug!("unexpected self type for `{goal:?}`"),
             // Excluding IATs and type aliases here as they don't have meaningful item bounds.
             ty::Alias(ty::Projection | ty::Opaque, alias_ty) => alias_ty,
         };
@@ -800,7 +802,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
             | ty::Error(_) => return,
             ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
-            | ty::Bound(..) => bug!("unexpected self type for `{goal:?}`"),
+            | ty::Bound(..)
+            | ty::FieldInfo(..) => bug!("unexpected self type for `{goal:?}`"),
             ty::Dynamic(bounds, ..) => bounds,
         };
 

--- a/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
@@ -29,7 +29,8 @@ pub(in crate::solve) fn instantiate_constituent_tys_for_auto_trait<'tcx>(
         | ty::FnPtr(_)
         | ty::Error(_)
         | ty::Never
-        | ty::Char => Ok(vec![]),
+        | ty::Char
+        | ty::FieldInfo(..) => Ok(vec![]),
 
         // Treat `str` like it's defined as `struct str([u8]);`
         ty::Str => Ok(vec![Ty::new_slice(tcx, tcx.types.u8)]),
@@ -130,7 +131,8 @@ pub(in crate::solve) fn instantiate_constituent_tys_for_sized_trait<'tcx>(
         | ty::Closure(..)
         | ty::Never
         | ty::Dynamic(_, _, ty::DynStar)
-        | ty::Error(_) => Ok(vec![]),
+        | ty::Error(_)
+        | ty::FieldInfo(..) => Ok(vec![]),
 
         ty::Str
         | ty::Slice(_)
@@ -183,7 +185,8 @@ pub(in crate::solve) fn instantiate_constituent_tys_for_copy_clone_trait<'tcx>(
         | ty::Adt(_, _)
         | ty::Alias(_, _)
         | ty::Param(_)
-        | ty::Placeholder(..) => Err(NoSolution),
+        | ty::Placeholder(..)
+        | ty::FieldInfo(..) => Err(NoSolution),
 
         ty::Bound(..)
         | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
@@ -286,7 +289,8 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_callable<'tcx>(
         | ty::Param(_)
         | ty::Placeholder(..)
         | ty::Infer(ty::IntVar(_) | ty::FloatVar(_))
-        | ty::Error(_) => Err(NoSolution),
+        | ty::Error(_)
+        | ty::FieldInfo(..) => Err(NoSolution),
 
         ty::Bound(..)
         | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {

--- a/compiler/rustc_trait_selection/src/solve/canonicalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/canonicalize.rs
@@ -343,7 +343,8 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'_, 'tcx> {
             | ty::Tuple(_)
             | ty::Alias(_, _)
             | ty::Bound(_, _)
-            | ty::Error(_) => return t.super_fold_with(self),
+            | ty::Error(_)
+            | ty::FieldInfo(_, _) => return t.super_fold_with(self),
         };
 
         let var = ty::BoundVar::from(

--- a/compiler/rustc_trait_selection/src/solve/project_goals/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals/mod.rs
@@ -395,7 +395,8 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
                 | ty::Coroutine(..)
                 | ty::CoroutineWitness(..)
                 | ty::Never
-                | ty::Foreign(..) => tcx.types.unit,
+                | ty::Foreign(..)
+                | ty::FieldInfo(..) => tcx.types.unit,
 
                 ty::Error(e) => Ty::new_error(tcx, *e),
 
@@ -601,7 +602,8 @@ impl<'tcx> assembly::GoalKind<'tcx> for ProjectionPredicate<'tcx> {
             | ty::Slice(_)
             | ty::Dynamic(_, _, _)
             | ty::Tuple(_)
-            | ty::Error(_) => self_ty.discriminant_ty(ecx.tcx()),
+            | ty::Error(_)
+            | ty::FieldInfo(..) => self_ty.discriminant_ty(ecx.tcx()),
 
             // We do not call `Ty::discriminant_ty` on alias, param, or placeholder
             // types, which return `<self_ty as DiscriminantKind>::Discriminant`

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -918,6 +918,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             | ty::Never
             | ty::Tuple(_)
             | ty::Adt(_, _)
+            | ty::FieldInfo(..)
             // FIXME: Handling opaques here is kinda sus. Especially because we
             // simplify them to SimplifiedType::Placeholder.
             | ty::Alias(ty::Opaque, _) => {

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -893,6 +893,13 @@ where
                     self.found_non_local_ty(ty)
                 }
             }
+            ty::FieldInfo(def, _) => {
+                if self.def_id_is_local(def.did()) {
+                    ControlFlow::Break(OrphanCheckEarlyExit::LocalTy(ty))
+                } else {
+                    self.found_non_local_ty(ty)
+                }
+            }
             ty::Foreign(def_id) => {
                 if self.def_id_is_local(def_id) {
                     ControlFlow::Break(OrphanCheckEarlyExit::LocalTy(ty))

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -1635,6 +1635,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 ty::Coroutine(..) => Some(18),
                 ty::Foreign(..) => Some(19),
                 ty::CoroutineWitness(..) => Some(20),
+                ty::FieldInfo(..) => Some(21),
                 ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) | ty::Error(_) => None,
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1850,7 +1850,9 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         | ty::Never
                         | ty::Tuple(..)
                         // Integers and floats always have `u8` as their discriminant.
-                        | ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(..)) => true,
+                        | ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(..))
+                        // FieldInfo has unit metadata.
+                        | ty::FieldInfo(..) => true,
 
                          // type parameters, opaques, and unnormalized projections have pointer
                         // metadata if they're known (e.g. by the param_env) to be sized
@@ -1905,7 +1907,9 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                         // If returned by `struct_tail_without_normalization` this is the empty tuple.
                         | ty::Tuple(..)
                         // Integers and floats are always Sized, and so have unit type metadata.
-                        | ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(..)) => true,
+                        | ty::Infer(ty::InferTy::IntVar(_) | ty::InferTy::FloatVar(..))
+                        // FieldInfo has unit metadata.
+                        | ty::FieldInfo(..)=> true,
 
                         // type parameters, opaques, and unnormalized projections have pointer
                         // metadata if they're known (e.g. by the param_env) to be sized

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -70,7 +70,8 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::Placeholder(..)
         | ty::Infer(_)
         | ty::Bound(..)
-        | ty::Coroutine(..) => false,
+        | ty::Coroutine(..)
+        | ty::FieldInfo(..) => false,
     }
 }
 
@@ -325,7 +326,7 @@ pub fn dtorck_constraint_for_ty_inner<'tcx>(
         }
 
         // Types that can't be resolved. Pass them forward.
-        ty::Alias(..) | ty::Param(..) => {
+        ty::Alias(..) | ty::Param(..) | ty::FieldInfo(..) => {
             constraints.dtorck_types.push(ty);
         }
 

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -141,6 +141,7 @@ where
     type Output = Q::QueryResponse;
     type ErrorInfo = Canonical<'tcx, ParamEnvAnd<'tcx, Q>>;
 
+    #[instrument(level = "debug", skip(infcx))]
     fn fully_perform(
         self,
         infcx: &InferCtxt<'tcx>,

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -457,7 +457,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 | ty::CoroutineWitness(..)
                 | ty::Never
                 | ty::Tuple(_)
-                | ty::Error(_) => return true,
+                | ty::Error(_)
+                | ty::FieldInfo(..) => return true,
                 // FIXME: Function definitions could actually implement `FnPtr` by
                 // casting the ZST function def to a function pointer.
                 ty::FnDef(_, _) => return true,
@@ -591,7 +592,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 | ty::Coroutine(..)
                 | ty::Never
                 | ty::Tuple(_)
-                | ty::CoroutineWitness(..) => {
+                | ty::CoroutineWitness(..)
+                | ty::FieldInfo(..) => {
                     // Only consider auto impls if there are no manual impls for the root of `self_ty`.
                     //
                     // For example, we only consider auto candidates for `&i32: Auto` if no explicit impl
@@ -914,7 +916,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 candidates.vec.push(ConstDestructCandidate(None));
             }
 
-            ty::Adt(..) => {
+            ty::Adt(..) | ty::FieldInfo(..) => {
                 let mut relevant_impl = None;
                 self.tcx().for_each_relevant_impl(
                     self.tcx().require_lang_item(LangItem::Drop, None),
@@ -989,7 +991,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             | ty::Bound(_, _)
             | ty::Error(_)
             | ty::Infer(_)
-            | ty::Placeholder(_) => {}
+            | ty::Placeholder(_)
+            | ty::FieldInfo(..) => {}
         }
     }
 
@@ -1056,7 +1059,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 | ty::InferTy::FloatVar(_)
                 | ty::InferTy::FreshIntTy(_)
                 | ty::InferTy::FreshFloatTy(_),
-            ) => {}
+            )
+            | ty::FieldInfo(..) => {}
             ty::Infer(ty::InferTy::TyVar(_) | ty::InferTy::FreshTy(_)) => {
                 candidates.ambiguous = true;
             }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2105,6 +2105,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             | ty::CoroutineWitness(..)
             | ty::Array(..)
             | ty::Closure(..)
+            | ty::FieldInfo(..)
             | ty::Never
             | ty::Dynamic(_, _, ty::DynStar)
             | ty::Error(_) => {
@@ -2222,7 +2223,11 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
                 }
             }
 
-            ty::Adt(..) | ty::Alias(..) | ty::Param(..) | ty::Placeholder(..) => {
+            ty::Adt(..)
+            | ty::Alias(..)
+            | ty::Param(..)
+            | ty::Placeholder(..)
+            | ty::FieldInfo(..) => {
                 // Fallback to whatever user-defined impls exist in this case.
                 None
             }
@@ -2280,7 +2285,8 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             | ty::Foreign(..)
             | ty::Alias(ty::Projection | ty::Inherent | ty::Weak, ..)
             | ty::Bound(..)
-            | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
+            | ty::Infer(ty::TyVar(_) | ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_))
+            | ty::FieldInfo(..) => {
                 bug!("asked to assemble constituent types of unexpected type: {:?}", t);
             }
 

--- a/compiler/rustc_trait_selection/src/traits/structural_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_match.rs
@@ -101,6 +101,10 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for Search<'tcx> {
                 return ControlFlow::Continue(());
             }
 
+            ty::FieldInfo(..) => {
+                return ControlFlow::Break(ty);
+            }
+
             ty::FnPtr(..) => {
                 return ControlFlow::Continue(());
             }

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -609,6 +609,8 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     // WfScalar, WfParameter, etc
                 }
 
+                ty::FieldInfo(..) => {}
+
                 // Can only infer to `ty::Int(_) | ty::Uint(_)`.
                 ty::Infer(ty::IntVar(_)) => {}
 

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -156,7 +156,8 @@ fn assumed_wf_types<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx [(Ty<'
         | DefKind::Field
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::Closure => ty::List::empty(),
+        | DefKind::Closure
+        | DefKind::FieldInfo => ty::List::empty(),
     }
 }
 

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -155,7 +155,7 @@ fn layout_of_uncached<'tcx>(
         }
 
         // The never type.
-        ty::Never => tcx.mk_layout(cx.layout_of_never_type()),
+        ty::Never | ty::FieldInfo(..) => tcx.mk_layout(cx.layout_of_never_type()),
 
         // Potentially-wide pointers.
         ty::Ref(_, pointee, _) | ty::RawPtr(ty::TypeAndMut { ty: pointee, .. }) => {

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -220,7 +220,8 @@ where
                     | ty::Bound(..)
                     | ty::Never
                     | ty::Infer(_)
-                    | ty::Error(_) => {
+                    | ty::Error(_)
+                    | ty::FieldInfo(..) => {
                         bug!("unexpected type returned by `needs_drop_components`: {component}")
                     }
                 }

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -310,7 +310,8 @@ fn opaque_types_defined_by<'tcx>(
         | DefKind::Field
         | DefKind::LifetimeParam
         | DefKind::GlobalAsm
-        | DefKind::Impl { .. } => {}
+        | DefKind::Impl { .. }
+        | DefKind::FieldInfo => {}
         // Closures and coroutines are type checked with their parent, so we need to allow all
         // opaques from the closure signature *and* from the parent body.
         DefKind::Closure | DefKind::InlineConst => {

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -94,7 +94,9 @@ pub(crate) fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
         | DefKind::ConstParam
         | DefKind::Ctor(_, _)
         | DefKind::Field
-        | DefKind::LifetimeParam => {
+        | DefKind::LifetimeParam
+        // TODO(y86-dev): is this correct?
+        | DefKind::FieldInfo => {
             span_bug!(
                 tcx.def_span(item),
                 "{kind:?} has not seen any uses of `walk_types` yet, ping oli-obk if you'd like any help"

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -18,7 +18,7 @@ fn sized_constraint_for_ty<'tcx>(
 
     let result = match ty.kind() {
         Bool | Char | Int(..) | Uint(..) | Float(..) | RawPtr(..) | Ref(..) | FnDef(..)
-        | FnPtr(_) | Array(..) | Closure(..) | Coroutine(..) | Never => vec![],
+        | FnPtr(_) | Array(..) | Closure(..) | Coroutine(..) | Never | FieldInfo(..) => vec![],
 
         Str | Dynamic(..) | Slice(_) | Foreign(..) | Error(_) | CoroutineWitness(..) => {
             // these are never sized - return the target type

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -7,6 +7,7 @@ use crate::{BoundVar, DebugWithInfcx, Mutability, UniverseIndex};
 pub trait Interner: Sized {
     type DefId: Clone + Debug + Hash + Ord;
     type AdtDef: Clone + Debug + Hash + Ord;
+    type FieldInfoDef: Clone + Debug + Hash + Ord;
 
     type GenericArgs: Clone
         + DebugWithInfcx<Self>

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -286,6 +286,9 @@ pub enum TyKind<I: Interner> {
     /// A placeholder for a type which could not be computed; this is
     /// propagated to avoid useless error messages.
     Error(I::ErrorGuaranteed),
+
+    /// `field_of!` type.
+    FieldInfo(I::FieldInfoDef, I::GenericArgs),
 }
 
 impl<I: Interner> TyKind<I> {
@@ -326,6 +329,7 @@ const fn tykind_discriminant<I: Interner>(value: &TyKind<I>) -> usize {
         Placeholder(_) => 23,
         Infer(_) => 24,
         Error(_) => 25,
+        FieldInfo(_, _) => 26,
     }
 }
 
@@ -461,6 +465,21 @@ impl<I: Interner> DebugWithInfcx<I> for TyKind<I> {
             Placeholder(p) => write!(f, "{p:?}"),
             Infer(t) => write!(f, "{:?}", this.wrap(t)),
             TyKind::Error(_) => write!(f, "{{type error}}"),
+            FieldInfo(d, s) => {
+                write!(f, "{d:?}")?;
+                let mut s = s.clone().into_iter();
+                let first = s.next();
+                match first {
+                    Some(first) => write!(f, "<{:?}", first)?,
+                    None => return Ok(()),
+                };
+
+                for arg in s {
+                    write!(f, ", {:?}", arg)?;
+                }
+
+                write!(f, ">")
+            }
         }
     }
 }

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -277,6 +277,7 @@ pub enum RigidTy {
     Never,
     Tuple(Vec<Ty>),
     CoroutineWitness(CoroutineWitnessDef, GenericArgs),
+    FieldInfo(FieldInfoDef, GenericArgs),
 }
 
 impl From<RigidTy> for TyKind {
@@ -421,6 +422,10 @@ crate_def! {
 
 crate_def! {
     pub CoroutineWitnessDef;
+}
+
+crate_def! {
+    pub FieldInfoDef;
 }
 
 /// A list of generic arguments.

--- a/compiler/stable_mir/src/visitor.rs
+++ b/compiler/stable_mir/src/visitor.rs
@@ -156,6 +156,7 @@ impl Visitable for RigidTy {
             }
             RigidTy::Tuple(fields) => fields.visit(visitor),
             RigidTy::Adt(_, args) => args.visit(visitor),
+            RigidTy::FieldInfo(_, args) => args.visit(visitor),
         }
     }
 }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1401,3 +1401,10 @@ pub macro offset_of($Container:ty, $($fields:tt).+ $(,)?) {
     // The `{}` is for better error messages
     crate::hint::must_use({builtin # offset_of($Container, $($fields).+)})
 }
+
+/// Gets the field type.
+#[unstable(feature = "field_project", issue = "106655")]
+#[allow_internal_unstable(builtin_syntax, hint_must_use)]
+pub macro field_of($Container:ty, $($fields:tt).+ $(,)?) {
+    builtin # field_of($Container, $($fields).+)
+}


### PR DESCRIPTION
I implemented the core of https://github.com/rust-lang/rfcs/pull/3318 for personal experimentation and found out that you can get experimental features merged easier than a whole RFC. I do not know the correct process to do this, but I thought a PR would be the way to go.

This PR introduces field info types. These types are generated for every field of every struct. They can be named by using the `core::mem::field_of!()` macro also introduced by this PR.

I have not had any experience modifying the Rust compiler, so there will be mistakes. I could definitely use some help refining this, so any comments are welcomed. The way I implemented was by first looking at `offset_of!` then realizing I want something that resolves to a type and not an expression, I then went and took a look at how `impl Trait` types are implemented and copied a lot from that. At some point I also realized that type equality and trait resolution were incorrect, so I went digging and I think I fixed it.

Here a list of things to complete before even thinking about merging:
- create an issue to use for the unstability attribute on `field_of!`
- handle TODOs in the code
- bikeshed the name `FieldInfo`: should the `hir` version be named `FieldOf`?
- how to handle enums/unions?
- can this also handle slices/arrays?
- fix type inference, i.e. allow `field_of!(_, foo)`
- remove some debugging stuff
- solve ICEs when using `cargo` instead of `rustc`

<details>
<summary>Example Code</summary>

```rust
#![feature(field_project, offset_of)]
use std::mem::{field_of, offset_of, MaybeUninit};

unsafe trait Field {
    type Base;
    type Type;
    const OFFSET: usize;
}

trait Project<F: Field> {
    type Output;
    fn project(self) -> Self::Output;
}

impl<'a, F: Field> Project<F> for &'a mut MaybeUninit<F::Base>
where
    F::Type: 'a,
{
    type Output = &'a mut MaybeUninit<F::Type>;
    fn project(self) -> Self::Output {
        let ptr = self.as_mut_ptr().cast::<u8>().wrapping_add(F::OFFSET);
        unsafe { &mut *ptr.cast() }
    }
}

#[derive(Debug)]
struct Foo {
    value: usize,
    next: Option<Box<Foo>>,
}

unsafe impl Field for field_of!(Foo, value) {
    type Base = Foo;
    type Type = usize;
    const OFFSET: usize = offset_of!(Foo, value);
}

unsafe impl Field for field_of!(Foo, next) {
    type Base = Foo;
    type Type = Option<Box<Foo>>;
    const OFFSET: usize = offset_of!(Foo, next);
}

fn main() {
    let mut foo = MaybeUninit::uninit();
    Project::<field_of!(Foo, value)>::project(&mut foo).write(42);
    Project::<field_of!(Foo, next)>::project(&mut foo).write(Some(Box::new(Foo {
        value: 84,
        next: None,
    })));
    println!("{:?}", unsafe { foo.assume_init_ref() });
}
```
Output: `Foo { value: 42, next: Some(Foo { value: 84, next: None }) }`
</details>