### PR TITLE
Don't throw away unused arguments of format_args

### DIFF
--- a/tests/ui/fmt/format-args-out-of-range.rs
+++ b/tests/ui/fmt/format-args-out-of-range.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("{}", 12345u8);
+    //~^ ERROR: literal out of range
+}

--- a/tests/ui/fmt/format-args-out-of-range.stderr
+++ b/tests/ui/fmt/format-args-out-of-range.stderr
@@ -1,0 +1,11 @@
+error: literal out of range for `u8`
+  --> $DIR/format-args-out-of-range.rs:2:20
+   |
+LL |     println!("{}", 12345u8);
+   |                    ^^^^^^^
+   |
+   = note: the literal `12345u8` does not fit into the type `u8` whose range is `0..=255`
+   = note: `#[deny(overflowing_literals)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -11,6 +11,9 @@ fn main() {
         {
                 ::std::io::_print(<#[lang = "format_arguments"]>::new_v1(&["a 123 b ",
                                     " xyz\n"],
-                        &[<#[lang = "format_argument"]>::new_display(&x)]));
+                        &match (&123, &x, &"xyz") {
+                                    args =>
+                                        [<#[lang = "format_argument"]>::new_display(args.1)],
+                                }));
             };
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/115423

`format_args!("{}", 12345u8)` was accidentally accepted, even though that literal is out of range. The literal didn't end up in the expansion of `format_args!()`, because it got simplified to `format_args!("12345")`.

This change is simply to *not* throw away those 'inlined' arguments. This actually simplifies the code in several ways. :)