### PR TITLE
docs: remove #110800 from release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -89,7 +89,6 @@ Rustdoc
 -------
 
 - [Add warning block support in rustdoc](https://github.com/rust-lang/rust/pull/106561/)
-- [Accept additional user-defined syntax classes in fenced code blocks](https://github.com/rust-lang/rust/pull/110800/)
 - [rustdoc-search: add support for type parameters](https://github.com/rust-lang/rust/pull/112725/)
 - [rustdoc: show inner enum and struct in type definition for concrete type](https://github.com/rust-lang/rust/pull/114855/)
 


### PR DESCRIPTION
It's not stable yet, and shouldn't be mentioned here. At least, the message shouldn't be written like this.

I realize it's weird to go through an FCP, and then have the feature remain unstable, but this was an unusual case.

Rustdoc used to silently swallow unknown language tokens on code blocks, and now it produces a compatibility warning. The FCP got everyone's sign-off on the warning, not the finished feature, which remains unstable.