### PR TITLE
Experiment: Only track fingerprints for queries with reconstructible dep-nodes.

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1066,7 +1066,7 @@ rustc_queries! {
             "const-evaluating + checking `{}`",
             key.value.display(tcx)
         }
-        cache_on_disk_if { true }
+        // cache_on_disk_if { true }  Cannot cache this anymore
     }
 
     /// Evaluates const items or anonymous constants
@@ -1081,7 +1081,7 @@ rustc_queries! {
             "simplifying constant for the type system `{}`",
             key.value.display(tcx)
         }
-        cache_on_disk_if { true }
+        // cache_on_disk_if { true }  Cannot cache this anymore
     }
 
     /// Evaluate a constant and convert it to a type level constant or
@@ -1148,7 +1148,7 @@ rustc_queries! {
     /// look up the correct symbol name of instances from upstream crates.
     query symbol_name(key: ty::Instance<'tcx>) -> ty::SymbolName<'tcx> {
         desc { "computing the symbol for `{}`", key }
-        cache_on_disk_if { true }
+        // cache_on_disk_if { true }  Cannot cache this anymore
     }
 
     query def_kind(def_id: DefId) -> DefKind {
@@ -1284,7 +1284,7 @@ rustc_queries! {
     query codegen_select_candidate(
         key: (ty::ParamEnv<'tcx>, ty::TraitRef<'tcx>)
     ) -> Result<&'tcx ImplSource<'tcx, ()>, CodegenObligationError> {
-        cache_on_disk_if { true }
+        // cache_on_disk_if { true }  Cannot cache this anymore
         desc { |tcx| "computing candidate for `{}`", key.1 }
     }
 
@@ -1894,7 +1894,7 @@ rustc_queries! {
     }
 
     query unused_generic_params(key: ty::InstanceDef<'tcx>) -> UnusedGenericParams {
-        cache_on_disk_if { key.def_id().is_local() }
+        // cache_on_disk_if { key.def_id().is_local() }  Cannot cache this anymore
         desc {
             |tcx| "determining which generic parameters are unused by `{}`",
                 tcx.def_path_str(key.def_id())


### PR DESCRIPTION
This is an experiment to collect performance data about alternative ways to adapt https://github.com/rust-lang/rust/pull/109050. The PR makes the following change:

All queries with keys that are not reconstructible from their corresponding DepNode are now treated similar to anonymous queries. That is we don't compute a DepNode or result fingerprint for them. 

This has some implications:
- We save time because query keys and results don't have to be hashed.
- We can save space storing less data for these nodes in the on-disk dep-graph. (not implemented in this PR as I ran out of time. Maybe this would be a quick fix for @saethlin though?)
- We don't have to worry about hash collisions for DepNode in these cases (although we still have to worry about hash collisions for result fingerprints, which might include all the same HashStable impls)
- Same as with anonymous queries, the graph can grow additional nodes and edges in some situations because existing graph parts might be promoted while new parts are allocated for the same query if it is re-executed. I don't know how much this happens in practice.
- We cannot cache query results for queries with complex keys.

Given that that last point affects some heavy queries, I have my doubts that this strategy is a win. But let's run it through perf at least once.

cc @cjgillot, @Zoxc 

r? @ghost