### PR TITLE
[PERF EXPERIMENT] Test out a Vec with no alignment requirements

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -235,6 +235,8 @@ pub mod alloc;
 // to allow code to have `use boxed::Box;` declarations.
 #[cfg(not(test))]
 pub mod boxed;
+mod unaligned;
+
 #[cfg(test)]
 mod boxed {
     pub use std::boxed::Box;

--- a/library/alloc/src/unaligned.rs
+++ b/library/alloc/src/unaligned.rs
@@ -1,0 +1,2 @@
+#[cfg_attr(target_arch = "x86_64", repr(packed))]
+pub(crate) struct Unaligned<T: Copy>(pub T);

--- a/library/alloc/src/vec/set_len_on_drop.rs
+++ b/library/alloc/src/vec/set_len_on_drop.rs
@@ -1,17 +1,19 @@
+use crate::unaligned::Unaligned;
+
 // Set the length of the vec when the `SetLenOnDrop` value goes out of scope.
 //
 // The idea is: The length field in SetLenOnDrop is a local variable
 // that the optimizer will see does not alias with any stores through the Vec's data
 // pointer. This is a workaround for alias analysis issue #32155
 pub(super) struct SetLenOnDrop<'a> {
-    len: &'a mut usize,
+    len: &'a mut Unaligned<usize>,
     local_len: usize,
 }
 
 impl<'a> SetLenOnDrop<'a> {
     #[inline]
-    pub(super) fn new(len: &'a mut usize) -> Self {
-        SetLenOnDrop { local_len: *len, len }
+    pub(super) fn new(len: &'a mut Unaligned<usize>) -> Self {
+        SetLenOnDrop { local_len: len.0, len }
     }
 
     #[inline]
@@ -28,6 +30,6 @@ impl<'a> SetLenOnDrop<'a> {
 impl Drop for SetLenOnDrop<'_> {
     #[inline]
     fn drop(&mut self) {
-        *self.len = self.local_len;
+        self.len.0 = self.local_len;
     }
 }

--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -2,6 +2,7 @@ use core::ptr;
 
 use crate::alloc::Allocator;
 use crate::raw_vec::RawVec;
+use crate::unaligned::Unaligned;
 
 use super::{IsZero, Vec};
 
@@ -22,7 +23,7 @@ impl<T: Clone + IsZero> SpecFromElem for T {
     #[inline]
     default fn from_elem<A: Allocator>(elem: T, n: usize, alloc: A) -> Vec<T, A> {
         if elem.is_zero() {
-            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: Unaligned(n) };
         }
         let mut v = Vec::with_capacity_in(n, alloc);
         v.extend_with(n, elem);
@@ -34,7 +35,7 @@ impl SpecFromElem for i8 {
     #[inline]
     fn from_elem<A: Allocator>(elem: i8, n: usize, alloc: A) -> Vec<i8, A> {
         if elem == 0 {
-            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: Unaligned(n) };
         }
         let mut v = Vec::with_capacity_in(n, alloc);
         unsafe {
@@ -49,7 +50,7 @@ impl SpecFromElem for u8 {
     #[inline]
     fn from_elem<A: Allocator>(elem: u8, n: usize, alloc: A) -> Vec<u8, A> {
         if elem == 0 {
-            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: Unaligned(n) };
         }
         let mut v = Vec::with_capacity_in(n, alloc);
         unsafe {

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -105,7 +105,7 @@ impl<T, A: Allocator> Drain<'_, T, A> {
     /// Returns `true` if we filled the entire range. (`replace_with.next()` didn’t return `None`.)
     unsafe fn fill<I: Iterator<Item = T>>(&mut self, replace_with: &mut I) -> bool {
         let vec = unsafe { self.vec.as_mut() };
-        let range_start = vec.len;
+        let range_start = vec.len.0;
         let range_end = self.tail_start;
         let range_slice = unsafe {
             slice::from_raw_parts_mut(vec.as_mut_ptr().add(range_start), range_end - range_start)
@@ -114,7 +114,7 @@ impl<T, A: Allocator> Drain<'_, T, A> {
         for place in range_slice {
             if let Some(new_item) = replace_with.next() {
                 unsafe { ptr::write(place, new_item) };
-                vec.len += 1;
+                vec.len.0 += 1;
             } else {
                 return false;
             }

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.rs
@@ -1,5 +1,9 @@
 // edition:2021
 
+// Type that requires alignment and is not Copy.
+#[derive(Debug)]
+struct NeedsAlignment(u64);
+
 // Given how the closure desugaring is implemented (at least at the time of writing this test),
 // we don't need to truncate the captured path to a reference into a packed-struct if the field
 // being referenced will be moved into the closure, since it's safe to move out a field from a
@@ -13,12 +17,12 @@
 // into a packed-struct. Here we test that the compiler still detects that case.
 fn test_missing_unsafe_warning_on_repr_packed() {
     #[repr(packed)]
-    struct Foo { x: String }
+    struct Foo { x: NeedsAlignment }
 
-    let foo = Foo { x: String::new() };
+    let foo = Foo { x: NeedsAlignment(0) };
 
     let c = || {
-        println!("{}", foo.x);
+        println!("{:?}", foo.x);
         //~^ ERROR: reference to packed field is unaligned
         let _z = foo.x;
     };

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -1,8 +1,8 @@
 error[E0793]: reference to packed field is unaligned
-  --> $DIR/repr_packed.rs:21:24
+  --> $DIR/repr_packed.rs:25:26
    |
-LL |         println!("{}", foo.x);
-   |                        ^^^^^
+LL |         println!("{:?}", foo.x);
+   |                          ^^^^^
    |
    = note: packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses
    = note: creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)

--- a/tests/ui/hygiene/panic-location.run.stderr
+++ b/tests/ui/hygiene/panic-location.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at library/alloc/src/raw_vec.rs:545:5:
+thread 'main' panicked at library/alloc/src/raw_vec.rs:550:5:
 capacity overflow
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
I request a perf run on this branch, to see the trade offs of memory vs runtime of a Vec that has no alignment requirements. I've gated the actual `repr(packed)` behind only `x64` platforms, as others may respond a lot more negatively to unaligned values.