### PR TITLE
fix regression in panic_misaligned_pointer_dereference

### DIFF
--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -209,7 +209,6 @@ fn panic_bounds_check(index: usize, len: usize) -> ! {
 }
 
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
-#[cfg_attr(feature = "panic_immediate_abort", inline)]
 #[track_caller]
 #[lang = "panic_misaligned_pointer_dereference"] // needed by codegen for panic on misaligned pointer deref
 #[rustc_nounwind] // `CheckAlignment` MIR pass requires this function to never unwind


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/118362 introduced a regression that breaks pointer dereferencing in `core`.

```
use std::ptr;

pub fn main() {
    let a: *const u8 = ptr::null();
    dbg!(unsafe { *a });
}
```

```
[profile.dev]
panic = "abort"
```

```
[build]
target = "x86_64-pc-windows-msvc"

[unstable]
build-std = ["std", "panic_abort"]
build-std-features = ["panic_immediate_abort"]

[target.x86_64-pc-windows-msvc]
linker = "rust-lld.exe"
```

Until 8de5bd0f6eb389c55d5e96a18ef21c5d025fce9f this worked totally fine.
However, since the commit ended up in master, the linker is quite unhappy about the symbol:

```
  = note: rust-lld: error: undefined symbol: core::panicking::panic_misaligned_pointer_dereference::h89d210946737113d
          >>> referenced by C:\Users\User\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\sys\windows\fs.rs:517
          >>>               libstd-93222e7335411a9e.rlib(std-93222e7335411a9e.std.f1f999d9f794207e-cgu.06.rcgu.o):(std::sys::windows::fs::File::readlink::ha67e29df7ba249d0)
          >>> referenced by C:\Users\User\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\sys\windows\fs.rs:518
          >>>               libstd-93222e7335411a9e.rlib(std-93222e7335411a9e.std.f1f999d9f794207e-cgu.06.rcgu.o):(std::sys::windows::fs::File::readlink::ha67e29df7ba249d0)
          >>> referenced by C:\Users\User\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\std\src\sys\windows\fs.rs:519
          >>>               libstd-93222e7335411a9e.rlib(std-93222e7335411a9e.std.f1f999d9f794207e-cgu.06.rcgu.o):(std::sys::windows::fs::File::readlink::ha67e29df7ba249d0)
          >>> referenced 33 more times
```

Is there a specific reason `panic_misaligned_pointer_dereference` is supposed to be inlined?
Otherwise I suggest we just avoid inlining it for `panic_immediate_abort`.

Perhaps this is also something to be added as an example for https://github.com/rust-lang/rust/issues/118393.

Best,
Thomas