### PR TITLE
Add check for possible CStr literals in pre-2021

### DIFF
--- a/tests/ui/editions/edition-cstr-2015-2018.rs
+++ b/tests/ui/editions/edition-cstr-2015-2018.rs
@@ -1,0 +1,62 @@
+macro_rules! construct { ($x:ident) => { $x"str" } }
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+    //~| NOTE expected one of 8 possible tokens
+
+macro_rules! contain { () => { c"str" } }
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+    //~| NOTE expected one of 8 possible tokens
+    //~| NOTE you may be trying to write a c-string literal
+    //~| NOTE c-string literals require Rust 2021 or later
+    //~| HELP pass `--edition 2021` to `rustc`
+    //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
+
+fn check_macro_construct() {
+    construct!(c); //~ NOTE in this expansion of construct!
+}
+
+fn check_macro_contain() {
+    contain!();
+    //~^ NOTE in this expansion of contain!
+    //~| NOTE in this expansion of contain!
+    //~| NOTE in this expansion of contain!
+    //~| NOTE in this expansion of contain!
+    //~| NOTE in this expansion of contain!
+}
+
+fn check_basic() {
+    c"str";
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+    //~| NOTE expected one of 8 possible tokens
+    //~| NOTE you may be trying to write a c-string literal
+    //~| NOTE c-string literals require Rust 2021 or later
+    //~| HELP pass `--edition 2021` to `rustc`
+    //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
+}
+
+fn check_craw() {
+    cr"str";
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+    //~| NOTE expected one of 8 possible tokens
+    //~| NOTE you may be trying to write a c-string literal
+    //~| NOTE c-string literals require Rust 2021 or later
+    //~| HELP pass `--edition 2021` to `rustc`
+    //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
+}
+
+fn check_craw_hash() {
+    cr##"str"##;
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `#`
+    //~| NOTE expected one of 8 possible tokens
+    //~| NOTE you may be trying to write a c-string literal
+    //~| NOTE c-string literals require Rust 2021 or later
+    //~| HELP pass `--edition 2021` to `rustc`
+    //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
+}
+
+fn check_cstr_space() {
+    c "str";
+    //~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+    //~| NOTE expected one of 8 possible tokens
+}
+
+fn main() {}

--- a/tests/ui/editions/edition-cstr-2015-2018.stderr
+++ b/tests/ui/editions/edition-cstr-2015-2018.stderr
@@ -1,0 +1,67 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+  --> $DIR/edition-cstr-2015-2018.rs:27:6
+   |
+LL |     c"str";
+   |      ^^^^^ expected one of 8 possible tokens
+   |
+   = note: you may be trying to write a c-string literal
+   = note: c-string literals require Rust 2021 or later
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+  --> $DIR/edition-cstr-2015-2018.rs:37:7
+   |
+LL |     cr"str";
+   |       ^^^^^ expected one of 8 possible tokens
+   |
+   = note: you may be trying to write a c-string literal
+   = note: c-string literals require Rust 2021 or later
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `#`
+  --> $DIR/edition-cstr-2015-2018.rs:47:7
+   |
+LL |     cr##"str"##;
+   |       ^ expected one of 8 possible tokens
+   |
+   = note: you may be trying to write a c-string literal
+   = note: c-string literals require Rust 2021 or later
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+  --> $DIR/edition-cstr-2015-2018.rs:57:7
+   |
+LL |     c "str";
+   |       ^^^^^ expected one of 8 possible tokens
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+  --> $DIR/edition-cstr-2015-2018.rs:1:44
+   |
+LL | macro_rules! construct { ($x:ident) => { $x"str" } }
+   |                                            ^^^^^ expected one of 8 possible tokens
+...
+LL |     construct!(c);
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `construct` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
+  --> $DIR/edition-cstr-2015-2018.rs:5:33
+   |
+LL | macro_rules! contain { () => { c"str" } }
+   |                                 ^^^^^ expected one of 8 possible tokens
+...
+LL |     contain!();
+   |     ---------- in this macro invocation
+   |
+   = note: you may be trying to write a c-string literal
+   = note: c-string literals require Rust 2021 or later
+   = help: pass `--edition 2021` to `rustc`
+   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
+   = note: this error originates in the macro `contain` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Fixes [#118654](https://github.com/rust-lang/rust/issues/118654)

Adds information to errors caused by possible CStr literals in pre-2021.

The lexer separates `c"str"` into two tokens if the edition is less than 2021, which later causes an error when parsing. This error now has a more helpful message that directs them to information about editions. However, the user might also have written `c "str"` in a later edition, so to not confuse people who _are_ using a recent edition, I also added a note about whitespace.

We could probably figure out exactly which scenario has been encountered by examining spans and editions, but I figured it would be better not to overcomplicate the creation of the error too much.

This is my first code PR and I tried to follow existing conventions as much as possible, but I probably missed something, so let me know!