### PR TITLE
Fix `rustc_codegen_gcc` build and tests failure in CI

### DIFF
--- a/compiler/rustc_codegen_gcc/Cargo.lock
+++ b/compiler/rustc_codegen_gcc/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"

--- a/compiler/rustc_codegen_gcc/example/std_example.rs
+++ b/compiler/rustc_codegen_gcc/example/std_example.rs
@@ -1,3 +1,4 @@
+#![allow(internal_features)]
 #![feature(core_intrinsics, coroutines, coroutine_trait, is_sorted)]
 
 #[cfg(feature="master")]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/118463 seems to have broke the PR CI, more specificaly the `x86_64-gnu-llvm-16` builder which [fail with](https://github.com/rust-lang/rust/actions/runs/7128709674/job/19411205695?pr=118705#step:26:1668):

```
Building stage1 codegen backend gcc (x86_64-unknown-linux-gnu)
     Compiling libc v0.2.147
     Compiling rustix v0.38.8
     Compiling memchr v2.5.0
     Compiling bitflags v2.4.0
     Compiling linux-raw-sys v0.4.5
     Compiling fastrand v2.0.0
     Compiling smallvec v1.10.0
error: invalid `--check-cfg` argument: `values(freebsd10)` (expected `cfg(name, values("value1", "value2", ... "valueN"))`)
  
error: could not compile `libc` (lib) due to previous error
```

Updating to `libc` version 0.2.150 fixes the build issue since it includes the support for the new check-cfg syntax.

Then it [failed](https://github.com/rust-lang/rust/actions/runs/7129280743/job/19413025132?pr=118706#step:26:2218) with a missing `#![allow(internal_features)]` in one of the example.

r? @GuillaumeGomez