### PR TITLE
[rustdoc] Add `no-hidden-lines` codeblock attribute

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/what-to-include.md
+++ b/src/doc/rustdoc/src/write-documentation/what-to-include.md
@@ -85,6 +85,34 @@ The example is the same on the doc page, but has that extra information
 available to anyone trying to use your crate.  More about tests in the
 upcoming [Documentation tests] chapter.
 
+In case you're writing documentation for a macro, it might be useful to use
+the `no-hidden-lines` attribute in order to prevent some `#` characters to be
+stripped:
+
+``````rust
+//! ```rust,no-hidden-lines
+//!
+//! test!(
+//!     # a,
+//!     ##b,
+//!     ###c
+//! );
+//! ```
+macro_rules! test {
+    (# a,##b,###c) => {}
+}
+``````
+
+Without using the `no-hidden-lines` attribute, the generated code example would
+look like this:
+
+```text
+test!(
+    #b,
+    ##c
+);
+```
+
 ## What to Exclude
 
 Certain parts of your public interface may be included by default in the output

--- a/tests/rustdoc/no-hidden-lines-codeblock-format.codeblock-non-raw.html
+++ b/tests/rustdoc/no-hidden-lines-codeblock-format.codeblock-non-raw.html
@@ -1,0 +1,8 @@
+<code><span class="macro">macro_rules! </span>test {
+    (# a,##b,###c) =&gt; {}
+}
+
+<span class="macro">test!</span>(
+    #b,
+    ##c
+);</code>

--- a/tests/rustdoc/no-hidden-lines-codeblock-format.codeblock.html
+++ b/tests/rustdoc/no-hidden-lines-codeblock-format.codeblock.html
@@ -1,0 +1,9 @@
+<code><span class="macro">macro_rules! </span>test {
+    (# a,##b,###c) =&gt; {}
+}
+
+<span class="macro">test!</span>(
+    # a,
+    ##b,
+    ###c
+);</code>

--- a/tests/rustdoc/no-hidden-lines-codeblock-format.rs
+++ b/tests/rustdoc/no-hidden-lines-codeblock-format.rs
@@ -1,0 +1,54 @@
+// Test that the `no_hidden_lines` codeblock attribute prevents lines starting with `#` to
+// be stripped.
+
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// @matches - '//*[@class="rust rust-example-rendered"]/code' '\(\s+# a,\s+##b,\s+###c\s+\);'
+// @snapshot 'codeblock' - '//*[@class="rust rust-example-rendered"]/code'
+
+//! ```rust,no_hidden_lines
+//! macro_rules! test {
+//!     (# a,##b,###c) => {}
+//! }
+//!
+//! test!(
+//!     # a,
+//!     ##b,
+//!     ###c
+//! );
+//! ```
+
+// @has 'foo/fn.foo.html'
+// @matches - '//*[@class="rust rust-example-rendered"]/code' '\(\s+#b,\s+##c\s+\);'
+// @snapshot 'codeblock-non-raw' - '//*[@class="rust rust-example-rendered"]/code'
+
+/// ```
+/// macro_rules! test {
+///     (# a,##b,###c) => {}
+/// }
+///
+/// test!(
+///     # a,
+///     ##b,
+///     ###c
+/// );
+/// ```
+pub fn foo() {}
+
+// Testing that `raw` means that it is a rust code block by default.
+// @has 'foo/fn.bar.html'
+// @matches - '//*[@class="rust rust-example-rendered"]/code' '\(\s+#a,\s+##b,\s+###c\s+\);'
+
+/// ```no_hidden_lines
+/// macro_rules! test {
+///     (#a,##b,###c) => {}
+/// }
+///
+/// test!(
+///     #a,
+///     ##b,
+///     ###c
+/// );
+/// ```
+pub fn bar() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/118027.

# Motivation

When documentation macro and proc-macro, there is currently an extra layer of complexity to take into account when it uses `#` characters. Allowing to disable this rustdoc behaviour with a codeblock attribute would make this task much simpler for (proc) macro documentation writers.

Example from #118027:

```
define_component!(
    #[derive(Debug)]
    ##[min(0.0))]
    ##[max(100.0))]
    ##[default(50.0)]
    pub Fuel(pub f32);
);
```

in documentation codeblocks becomes:

```
define_component!(
    #[derive(Debug)]
    #[min(0.0))]
    #[max(100.0))]
    #[default(50.0)]
    pub Fuel(pub f32);
);
```

Generating invalid documentation for end users.

# What is this feature about?

It is about adding a new `no-hidden-lines` codeblock attribute which would remove this `#` character cleanup pass in order to make it easier for (proc) macro API to have code examples.

The `no-hidden-lines` attribute works just like `should_panic` or `ignore` attributes: if there are no other tags, it'll consider the code block as a rust one and hence will test it.

Example of usage:

``````rust
```no-hidden-lines
define_component!(
    #[derive(Debug)]
    ##[min(0.0))]
    ##[max(100.0))]
    ##[default(50.0)]
    pub Fuel(pub f32);
);
```
``````

# Concerns

 * Is `no-hidden-lines` the right name for this codeblock attribute?
 * Is this codeblock attribute  really necessary?

r? @notriddle 