### PR TITLE
targets: remove not-added {i386,i486}-unknown-linux-gnu

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i386_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/i386_unknown_linux_gnu.rs
@@ -1,8 +1,0 @@
-use crate::spec::Target;
-
-pub fn target() -> Target {
-    let mut base = super::i686_unknown_linux_gnu::target();
-    base.cpu = "i386".into();
-    base.llvm_target = "i386-unknown-linux-gnu".into();
-    base
-}

--- a/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
@@ -1,8 +1,0 @@
-use crate::spec::Target;
-
-pub fn target() -> Target {
-    let mut base = super::i686_unknown_linux_gnu::target();
-    base.cpu = "i486".into();
-    base.llvm_target = "i486-unknown-linux-gnu".into();
-    base
-}


### PR DESCRIPTION
These files were added to the repository but never wired up so they could be used - and that was a few years ago without anyone noticing - so let's remove these, they can be re-added if someone wants them.

cc #80662
r? @pnkfelix (familiar with the tier policy and Wesley is on vacation)