### PR TITLE
Visit `const` node in dead-code analysis

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -658,6 +658,12 @@ fn check_item<'tcx>(
             // global_asm! is always live.
             worklist.push((id.owner_id.def_id, ComesFromAllowExpect::No));
         }
+        DefKind::Const => {
+            let item = tcx.hir().item(id);
+            if let hir::ItemKind::Const(_, _, body_id) = item.kind {
+                worklist.push((tcx.hir().body_owner_def_id(body_id), ComesFromAllowExpect::No));
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
close #118424

I fixed to visit `const` node in dead-code analysis.

Before this PR, the body of `const` node is not visited in dead-code analysis.


```rust
type T = u32;
// std::mem::size_of::<T>() is not checked.
const _A: usize = std::mem::size_of::<T>();

fn main() {}
```

Therefore the type `T` is detected as a `dead_code`.

```
warning: type alias `T` is never used
 --> src/main.rs:1:6
  |
1 | type T = u32;
  |      ^
  |
  = note: `#[warn(dead_code)]` on by default
```