### PR TITLE
Add new solver / old solver opaque type tests

### DIFF
--- a/tests/ui/impl-trait/inference/README.md
+++ b/tests/ui/impl-trait/inference/README.md
@@ -1,0 +1,43 @@
+# Inference tests on opaque types in defining items
+
+When considering an opaque type within a body that is permitted to
+define the hidden type for that opaque, we're expecting the new trait
+solver to sometimes produce different results.
+
+Sometimes this is due to the fact that the new trait solver considers
+more cases to be defining, such as when defining the hidden type
+allows an impl for some wrapper type to be matched.
+
+In other cases, this is due to lazy normalization, which e.g. allows
+the new trait solver to more consistently handle as a concrete type
+the return value of...
+
+```rust
+id2<T>(_: T, x: T ) -> T { x }
+```
+
+...when it is called with a value of the opaque type and a value of
+the corresponding hidden type.
+
+However, the new trait solver is not yet done, and it does not
+consistently produce the results we expect that it will once
+complete.
+
+As we work toward stabilizing type alias impl Trait (TAIT), we need to
+plan for what the behavior of the new trait solver will be.
+Similarly, since return position impl Trait (RPIT) is already stable
+but will see inference differences with the new trait solver, we need
+to begin to plan for that also.
+
+To help enable this planning, this directory contains test cases that
+define what the correct inference behavior should be when handling
+opaue types.
+
+Where the correct behavior does not match the behavior of either the
+new or the old trait solver, we've chosen to mark that as a known
+bug.  For the new solver, we've done this since it is still a work in
+progress and is expected to eventually model the correct behavior.
+For the old solver, we've done this since the behavior is inconsistent
+and often surprising, and since we may need to add future-incompat
+lints or take other steps to prepare the ecosystem for the transition
+to the new solver.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-inner-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-inner-id-left.old.stderr
@@ -1,0 +1,23 @@
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-inner-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-notsend-inner-id-left.rs:33:61
+   |
+LL |     let _: OnWShow = (&&W(id2(test(!n), &() as *const ()))).show();
+   |                                                             ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<test::{opaque#0}>: OnWSend`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-inner-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-inner-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-inner-id-left.rs
@@ -1,0 +1,37 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return &() as *const () };
+    let _: OnWShow = (&&W(id2(test(!n), &() as *const ()))).show();
+    &() as *const ()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-inner-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-inner-id-right.rs
@@ -1,0 +1,36 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return &() as *const () };
+    let _: OnWShow = (&&W(id2(&() as *const (), test(!n)))).show();
+    &() as *const ()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-outer-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-outer-id-left.old.stderr
@@ -1,0 +1,23 @@
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-outer-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-notsend-outer-id-left.rs:33:64
+   |
+LL |     let _: OnWShow = id2(&&W(test(!n)), &&W(&() as *const ())).show();
+   |                                                                ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<test::{opaque#0}>: OnWSend`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-outer-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-outer-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-outer-id-left.rs
@@ -1,0 +1,37 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return &() as *const () };
+    let _: OnWShow = id2(&&W(test(!n)), &&W(&() as *const ())).show();
+    &() as *const ()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-outer-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend-outer-id-right.rs
@@ -1,0 +1,36 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return &() as *const () };
+    let _: OnWShow = id2(&&W(&() as *const ()), &&W(test(!n))).show();
+    &() as *const ()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend.old.stderr
@@ -1,0 +1,23 @@
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend.rs:27:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-notsend.rs:29:38
+   |
+LL |     let _: OnWShow = (&&W(test(!n))).show();
+   |                                      ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<test::{opaque#0}>: OnWSend`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend.rs:27:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-notsend.rs
@@ -1,0 +1,33 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return &() as *const () };
+    let _: OnWShow = (&&W(test(!n))).show();
+    &() as *const ()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-inner-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-inner-id-left.old.stderr
@@ -1,0 +1,32 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:33:26
+   |
+LL |     let _: OnWSendShow = (&&W(id2(test(!n), ()))).show();
+   |            -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `OnWSendShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:33:51
+   |
+LL |     let _: OnWSendShow = (&&W(id2(test(!n), ()))).show();
+   |                                                   ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<test::{opaque#0}>: OnWSend`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0391.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-inner-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-inner-id-left.rs
@@ -1,0 +1,36 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: OnWSendShow = (&&W(id2(test(!n), ()))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-inner-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-inner-id-right.rs
@@ -1,0 +1,35 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: OnWSendShow = (&&W(id2((), test(!n)))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-outer-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-outer-id-left.old.stderr
@@ -1,0 +1,32 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:33:26
+   |
+LL |     let _: OnWSendShow = id2(&&W(test(!n)), &&W(())).show();
+   |            -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `OnWSendShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:33:54
+   |
+LL |     let _: OnWSendShow = id2(&&W(test(!n)), &&W(())).show();
+   |                                                      ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<test::{opaque#0}>: OnWSend`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:31:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0391.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-outer-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-outer-id-left.rs
@@ -1,0 +1,36 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: OnWSendShow = id2(&&W(test(!n)), &&W(())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-outer-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send-outer-id-right.rs
@@ -1,0 +1,35 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: OnWSendShow = id2(&&W(()), &&W(test(!n))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send.old.stderr
@@ -1,0 +1,32 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-send.rs:29:26
+   |
+LL |     let _: OnWSendShow = (&&W(test(!n))).show();
+   |            -----------   ^^^^^^^^^^^^^^^^^^^^^^ expected `OnWSendShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send.rs:27:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-send.rs:29:42
+   |
+LL |     let _: OnWSendShow = (&&W(test(!n))).show();
+   |                                          ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<test::{opaque#0}>: OnWSend`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send.rs:27:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0391.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-auto-trait-send.rs
@@ -1,0 +1,32 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: OnWSendShow = (&&W(test(!n))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-left.new.stderr
@@ -1,0 +1,9 @@
+error[E0609]: no field `field` on type `impl Sized`
+  --> $DIR/reveal-hidden-via-field-access-id-left.rs:18:34
+   |
+LL |     let _: () = id2(test(!n), I).field;
+   |                                  ^^^^^ unknown field
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-left.old.stderr
@@ -1,0 +1,9 @@
+error[E0609]: no field `field` on type `impl Sized`
+  --> $DIR/reveal-hidden-via-field-access-id-left.rs:18:34
+   |
+LL |     let _: () = id2(test(!n), I).field;
+   |                                  ^^^^^ unknown field
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-left.rs
@@ -1,0 +1,22 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+struct I {
+    field: (),
+}
+const I: I = I { field: () };
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return I };
+    let _: () = id2(test(!n), I).field;
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access-id-right.rs
@@ -1,0 +1,22 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I {
+    field: (),
+}
+const I: I = I { field: () };
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return I };
+    let _: () = id2(I, test(!n)).field;
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access.new.stderr
@@ -1,0 +1,9 @@
+error[E0609]: no field `field` on type `impl Sized`
+  --> $DIR/reveal-hidden-via-field-access.rs:14:26
+   |
+LL |     let _: () = test(!n).field;
+   |                          ^^^^^ unknown field
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access.old.stderr
@@ -1,0 +1,9 @@
+error[E0609]: no field `field` on type `impl Sized`
+  --> $DIR/reveal-hidden-via-field-access.rs:14:26
+   |
+LL |     let _: () = test(!n).field;
+   |                          ^^^^^ unknown field
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-field-access.rs
@@ -1,0 +1,18 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+struct I {
+    field: (),
+}
+const I: I = I { field: () };
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return I };
+    let _: () = test(!n).field;
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-left.new.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-match-at-binding-unwrapped-id-left.rs:32:18
+   |
+LL |         x @ I => x.show(),
+   |                  ^^^^^^^^ expected `IShow`, found `OnIShow`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-left.old.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-match-at-binding-unwrapped-id-left.rs:32:18
+   |
+LL |         x @ I => x.show(),
+   |                  ^^^^^^^^ expected `IShow`, found `OnIShow`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-left.rs
@@ -1,0 +1,37 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl OnI {
+    let true = n else { return I };
+    // This should be a defining use, but is not currently.
+    let _: IShow = match id2(test(!n), I) {
+        x @ I => x.show(),
+    };
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped-id-right.rs
@@ -1,0 +1,36 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl OnI {
+    let true = n else { return I };
+    let _: IShow = match id2(I, test(!n)) {
+        x @ I => x.show(),
+    };
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped.new.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-match-at-binding-unwrapped.rs:28:18
+   |
+LL |         x @ I => x.show(),
+   |                  ^^^^^^^^ expected `IShow`, found `OnIShow`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped.old.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-match-at-binding-unwrapped.rs:28:18
+   |
+LL |         x @ I => x.show(),
+   |                  ^^^^^^^^ expected `IShow`, found `OnIShow`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-unwrapped.rs
@@ -1,0 +1,33 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn test(n: bool) -> impl OnI {
+    let true = n else { return I };
+    // This should be a defining use, but is not currently.
+    let _: IShow = match test(!n) {
+        x @ I => x.show(),
+    };
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw-id-left.old.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-onw-id-left.rs:33:21
+   |
+LL |         x @ W(I) => x.show(),
+   |                     ^^^^^^^^ expected `WIShow`, found `OnWShow`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw-id-left.rs
@@ -1,0 +1,38 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct I;
+
+struct W<T>(T);
+struct WIShow;
+impl W<I> {
+    pub fn show(&self) -> WIShow {
+        WIShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T: Sized> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return I };
+    let _: WIShow = match W(id2(test(!n), I)) {
+        x @ W(I) => x.show(),
+    };
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw-id-right.rs
@@ -1,0 +1,37 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I;
+
+struct W<T>(T);
+struct WIShow;
+impl W<I> {
+    pub fn show(&self) -> WIShow {
+        WIShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T: Sized> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return I };
+    let _: WIShow = match W(id2(I, test(!n))) {
+        x @ W(I) => x.show(),
+    };
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw.old.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-onw.rs:29:21
+   |
+LL |         x @ W(I) => x.show(),
+   |                     ^^^^^^^^ expected `WIShow`, found `OnWShow`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-onw.rs
@@ -1,0 +1,34 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct I;
+
+struct W<T>(T);
+struct WIShow;
+impl W<I> {
+    pub fn show(&self) -> WIShow {
+        WIShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T: Sized> OnW for W<T> {}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return I };
+    let _: WIShow = match W(test(!n)) {
+        x @ W(I) => x.show(),
+    };
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.old.stderr
@@ -1,0 +1,36 @@
+error[E0599]: no method named `show` found for struct `W<impl Sized>` in the current scope
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.rs:24:24
+   |
+LL | struct W<T>(T);
+   | ----------- method `show` not found for this struct
+...
+LL |         x @ W(()) => x.show(),
+   |                        ^^^^ method not found in `W<impl Sized>`
+   |
+   = note: the method was found for
+           - `W<()>`
+
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.rs:21:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.rs:24:22
+   |
+LL |         x @ W(()) => x.show(),
+   |                      ^
+   = note: ...which requires evaluating trait selection obligation `W<test::{opaque#0}>: core::marker::Unpin`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.rs:21:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0391, E0599.
+For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly-id-left.rs
@@ -1,0 +1,28 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    #[allow(dead_code)]
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = match W(id2(test(!n), ())) {
+        x @ W(()) => x.show(),
+    };
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly-id-right.rs
@@ -1,0 +1,27 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    #[allow(dead_code)]
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = match W(id2((), test(!n))) {
+        x @ W(()) => x.show(),
+    };
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly.old.stderr
@@ -1,0 +1,36 @@
+error[E0599]: no method named `show` found for struct `W<impl Sized>` in the current scope
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly.rs:24:24
+   |
+LL | struct W<T>(T);
+   | ----------- method `show` not found for this struct
+...
+LL |         x @ W(()) => x.show(),
+   |                        ^^^^ method not found in `W<impl Sized>`
+   |
+   = note: the method was found for
+           - `W<()>`
+
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly.rs:21:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly.rs:24:22
+   |
+LL |         x @ W(()) => x.show(),
+   |                      ^
+   = note: ...which requires evaluating trait selection obligation `W<test::{opaque#0}>: core::marker::Unpin`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-match-at-binding-wrapped-wonly.rs:21:21
+   |
+LL | fn test(n: bool) -> impl Sized {
+   |                     ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0391, E0599.
+For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-at-binding-wrapped-wonly.rs
@@ -1,0 +1,28 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    #[allow(dead_code)]
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = match W(test(!n)) {
+        x @ W(()) => x.show(),
+    };
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-left.new.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `impl Sized` is non-empty
+  --> $DIR/reveal-hidden-via-match-exhaustiveness-empty-id-left.rs:15:11
+   |
+LL |     match id2(test(!n, e), panic!()) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Sized`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match id2(test(!n, e), panic!()) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-left.old.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `impl Sized` is non-empty
+  --> $DIR/reveal-hidden-via-match-exhaustiveness-empty-id-left.rs:15:11
+   |
+LL |     match id2(test(!n, e), panic!()) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Sized`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match id2(test(!n, e), panic!()) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-left.rs
@@ -1,0 +1,19 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: #116821
+
+enum E {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool, e: E) -> impl Sized {
+    let true = n else { return e };
+    match id2(test(!n, e), panic!()) {}
+    e
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-right.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-right.new.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `impl Sized` is non-empty
+  --> $DIR/reveal-hidden-via-match-exhaustiveness-empty-id-right.rs:15:11
+   |
+LL |     match id2(panic!(), test(!n, e)) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Sized`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match id2(panic!(), test(!n, e)) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-right.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-right.old.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `impl Sized` is non-empty
+  --> $DIR/reveal-hidden-via-match-exhaustiveness-empty-id-right.rs:15:11
+   |
+LL |     match id2(panic!(), test(!n, e)) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Sized`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match id2(panic!(), test(!n, e)) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty-id-right.rs
@@ -1,0 +1,19 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: #116821
+
+enum E {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool, e: E) -> impl Sized {
+    let true = n else { return e };
+    match id2(panic!(), test(!n, e)) {}
+    e
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty.new.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `impl Sized` is non-empty
+  --> $DIR/reveal-hidden-via-match-exhaustiveness-empty.rs:15:11
+   |
+LL |     match test(!n, e) {}
+   |           ^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Sized`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match test(!n, e) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty.old.stderr
@@ -1,0 +1,17 @@
+error[E0004]: non-exhaustive patterns: type `impl Sized` is non-empty
+  --> $DIR/reveal-hidden-via-match-exhaustiveness-empty.rs:15:11
+   |
+LL |     match test(!n, e) {}
+   |           ^^^^^^^^^^^
+   |
+   = note: the matched value is of type `impl Sized`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match test(!n, e) {
+LL +         _ => todo!(),
+LL +     }
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-empty.rs
@@ -1,0 +1,19 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: #116821
+
+enum E {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool, e: E) -> impl Sized {
+    let true = n else { return e };
+    match test(!n, e) {}
+    e
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-unit-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-unit-id-left.rs
@@ -1,0 +1,18 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    match id2(test(!n), ()) {
+        () => (),
+    };
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-unit-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-unit-id-right.rs
@@ -1,0 +1,18 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    match id2((), test(!n)) {
+        () => (),
+    };
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-unit.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-exhaustiveness-unit.rs
@@ -1,0 +1,18 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    match test(!n) {
+        () => (),
+    };
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-tuple-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-tuple-id-left.rs
@@ -1,0 +1,35 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I;
+struct IShow;
+impl I {
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return (I,) };
+    let _: IShow = match id2(test(!n), (I,)) {
+        (x,) => x.show(),
+    };
+    (I,)
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-tuple-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-tuple-id-right.rs
@@ -1,0 +1,35 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I;
+struct IShow;
+impl I {
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return (I,) };
+    let _: IShow = match id2((I,), test(!n)) {
+        (x,) => x.show(),
+    };
+    (I,)
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-tuple.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-match-tuple.rs
@@ -1,0 +1,35 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I;
+struct IShow;
+impl I {
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return (I,) };
+    let _: IShow = match test(!n) {
+        (x,) => x.show(),
+    };
+    (I,)
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-left.new.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:30:20
+   |
+LL |     let _: IShow = id2(test(!n), I).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^^^^^^ expected `IShow`, found `OnIShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-left.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:30:20
+   |
+LL |     let _: IShow = id2(test(!n), I).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^^^^^^ expected `IShow`, found `OnIShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-left.rs
@@ -1,0 +1,34 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl OnI {
+    let true = n else { return I };
+    let _: IShow = id2(test(!n), I).show();
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver-id-right.rs
@@ -1,0 +1,33 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct I;
+struct IShow;
+impl I {
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl OnI {
+    let true = n else { return I };
+    let _: IShow = id2(I, test(!n)).show();
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver.new.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver.new.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:26:20
+   |
+LL |     let _: IShow = test(!n).show();
+   |            -----   ^^^^^^^^^^^^^^^ expected `IShow`, found `OnIShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:26:20
+   |
+LL |     let _: IShow = test(!n).show();
+   |            -----   ^^^^^^^^^^^^^^^ expected `IShow`, found `OnIShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-unwrapped-receiver.rs
@@ -1,0 +1,30 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn test(n: bool) -> impl OnI {
+    let true = n else { return I };
+    let _: IShow = test(!n).show();
+    I
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-inner-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-inner-id-left.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-wrapped-receiver-inner-id-left.rs:30:20
+   |
+LL |     let _: WShow = W(id2(test(!n), ())).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `WShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-inner-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-inner-id-left.rs
@@ -1,0 +1,33 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = W(id2(test(!n), ())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-inner-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-inner-id-right.rs
@@ -1,0 +1,32 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = W(id2((), test(!n))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-outer-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-outer-id-left.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-wrapped-receiver-outer-id-left.rs:30:20
+   |
+LL |     let _: WShow = id2(W(test(!n)), W(())).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `WShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-outer-id-left.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-outer-id-left.rs
@@ -1,0 +1,33 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = id2(W(test(!n)), W(())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-outer-id-right.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver-outer-id-right.rs
@@ -1,0 +1,32 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = id2(W(()), W(test(!n))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver.old.stderr
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-wrapped-receiver.rs:26:20
+   |
+LL |     let _: WShow = W(test(!n)).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^ expected `WShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver.rs
+++ b/tests/ui/impl-trait/inference/in-defining-item/reveal-hidden-via-wrapped-receiver.rs
@@ -1,0 +1,29 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn test(n: bool) -> impl Sized {
+    let true = n else { return };
+    let _: WShow = W(test(!n)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-inner-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-inner-id-left.old.stderr
@@ -1,0 +1,23 @@
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-inner-id-left.rs:33:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-notsend-inner-id-left.rs:38:54
+   |
+LL |     let _: OnWShow = (&&W(id2(x, &() as *const ()))).show();
+   |                                                      ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<Test>: OnWSend`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-inner-id-left.rs:33:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-inner-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-inner-id-left.rs
@@ -1,0 +1,41 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test { &() as *const () }
+
+fn test(x: Test) {
+    let _: OnWShow = (&&W(id2(x, &() as *const ()))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-inner-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-inner-id-right.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test { &() as *const () }
+
+fn test(x: Test) {
+    let _: OnWShow = (&&W(id2(&() as *const (), x))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-outer-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-outer-id-left.old.stderr
@@ -1,0 +1,23 @@
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-outer-id-left.rs:33:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-notsend-outer-id-left.rs:38:57
+   |
+LL |     let _: OnWShow = id2(&&W(x), &&W(&() as *const ())).show();
+   |                                                         ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<Test>: OnWSend`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend-outer-id-left.rs:33:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-outer-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-outer-id-left.rs
@@ -1,0 +1,41 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test { &() as *const ()}
+
+fn test(x: Test) {
+    let _: OnWShow = id2(&&W(x), &&W(&() as *const ())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-outer-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend-outer-id-right.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test { &() as *const ()}
+
+fn test(x: Test) {
+    let _: OnWShow = id2(&&W(&() as *const ()), &&W(x)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend.new.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend.new.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-notsend.rs:37:22
+   |
+LL |     let _: OnWShow = (&&W(x)).show();
+   |            -------   ^^^^^^^^^^^^^^^ expected `OnWShow`, found `OnWSendShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend.old.stderr
@@ -1,0 +1,23 @@
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-notsend.rs:37:31
+   |
+LL |     let _: OnWShow = (&&W(x)).show();
+   |                               ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<Test>: OnWSend`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-notsend.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-notsend.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test { &() as *const () }
+
+fn test(x: Test) {
+    let _: OnWShow = (&&W(x)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-left.new.stderr
@@ -1,0 +1,63 @@
+error[E0391]: cycle detected when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires computing type of opaque `Test::{opaque#0}`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+note: ...which requires borrow-checking `test`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires promoting constants in MIR for `test`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires preparing `test` for borrow checking...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires unsafety-checking `test`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires building MIR for `test`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires resolving instance `<&W<Test> as OnWSend>::show`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:20:5
+   |
+LL |     fn show(&self) -> OnWSendShow {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires computing candidate for `<&W<Test> as OnWSend>`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:19:1
+   |
+LL | trait OnWSend {
+   | ^^^^^^^^^^^^^
+   = note: ...which again requires computing type of `Test::{opaque#0}`, completing the cycle
+note: cycle used when checking item types in top-level module
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:7:1
+   |
+LL | / #![feature(type_alias_impl_trait)]
+LL | |
+LL | | struct W<T>(T);
+LL | |
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-left.old.stderr
@@ -1,0 +1,32 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:37:26
+   |
+LL |     let _: OnWSendShow = (&&W(id2(x, ()))).show();
+   |            -----------   ^^^^^^^^^^^^^^^^^^^^^^^^ expected `OnWSendShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:37:44
+   |
+LL |     let _: OnWSendShow = (&&W(id2(x, ()))).show();
+   |                                            ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<Test>: OnWSend`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-inner-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0391.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-left.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: OnWSendShow = (&&W(id2(x, ()))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-inner-id-right.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: OnWSendShow = (&&W(id2((), x))).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-left.new.stderr
@@ -1,0 +1,63 @@
+error[E0391]: cycle detected when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires computing type of opaque `Test::{opaque#0}`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+note: ...which requires borrow-checking `test`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires promoting constants in MIR for `test`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires preparing `test` for borrow checking...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires unsafety-checking `test`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires building MIR for `test`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:36:1
+   |
+LL | fn test(x: Test) {
+   | ^^^^^^^^^^^^^^^^
+note: ...which requires resolving instance `<&W<Test> as OnWSend>::show`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:20:5
+   |
+LL |     fn show(&self) -> OnWSendShow {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires computing candidate for `<&W<Test> as OnWSend>`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:19:1
+   |
+LL | trait OnWSend {
+   | ^^^^^^^^^^^^^
+   = note: ...which again requires computing type of `Test::{opaque#0}`, completing the cycle
+note: cycle used when checking item types in top-level module
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:7:1
+   |
+LL | / #![feature(type_alias_impl_trait)]
+LL | |
+LL | | struct W<T>(T);
+LL | |
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-left.old.stderr
@@ -1,0 +1,32 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:37:26
+   |
+LL |     let _: OnWSendShow = id2(&&W(x), &&W(())).show();
+   |            -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `OnWSendShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:37:47
+   |
+LL |     let _: OnWSendShow = id2(&&W(x), &&W(())).show();
+   |                                               ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<Test>: OnWSend`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send-outer-id-left.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0391.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-left.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: OnWSendShow = id2(&&W(x), &&W(())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send-outer-id-right.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: OnWSendShow = id2(&&W(()), &&W(x)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send.new.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send.new.stderr
@@ -1,0 +1,12 @@
+error[E0283]: type annotations needed: cannot satisfy `&W<Test>: OnWSend`
+  --> $DIR/reveal-auto-trait-send.rs:37:35
+   |
+LL |     let _: OnWSendShow = (&&W(x)).show();
+   |                                   ^^^^
+   |
+   = note: cannot satisfy `&W<Test>: OnWSend`
+   = help: the trait `OnWSend` is implemented for `&W<Test>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send.old.stderr
@@ -1,0 +1,32 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-auto-trait-send.rs:37:26
+   |
+LL |     let _: OnWSendShow = (&&W(x)).show();
+   |            -----------   ^^^^^^^^^^^^^^^ expected `OnWSendShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-auto-trait-send.rs:37:35
+   |
+LL |     let _: OnWSendShow = (&&W(x)).show();
+   |                                   ^^^^
+   = note: ...which requires evaluating trait selection obligation `&'a W<Test>: OnWSend`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-auto-trait-send.rs:32:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0391.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-auto-trait-send.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+
+struct OnWSendShow;
+trait OnWSend {
+    fn show(&self) -> OnWSendShow {
+        OnWSendShow
+    }
+}
+
+impl<T> OnW for W<T> {}
+impl<T: Send> OnWSend for &W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: OnWSendShow = (&&W(x)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-left.new.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-left.new.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:37:20
+   |
+LL |     let _: IShow = id2(x, I).show();
+   |            -----   ^^^^^^^^^^^^^^^^ expected `IShow`, found `OnIShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-left.old.stderr
@@ -1,0 +1,37 @@
+error[E0599]: no method named `show` found for opaque type `Test` in the current scope
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:37:30
+   |
+LL |     let _: IShow = id2(x, I).show();
+   |                              ^^^^ method not found in `Test`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `OnI` defines an item `show`, perhaps you need to implement it
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:19:1
+   |
+LL | trait OnI {
+   | ^^^^^^^^^
+
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:30:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:37:20
+   |
+LL |     let _: IShow = id2(x, I).show();
+   |                    ^^^^^^^^^
+   = note: ...which requires evaluating trait selection obligation `Test: core::marker::Unpin`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-unwrapped-receiver-id-left.rs:30:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0391, E0599.
+For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-left.rs
@@ -1,0 +1,40 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {
+    I
+}
+
+fn test(x: Test) {
+    let _: IShow = id2(x, I).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver-id-right.rs
@@ -1,0 +1,39 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct I;
+struct IShow;
+impl I {
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {
+    I
+}
+
+fn test(x: Test) {
+    let _: IShow = id2(I, x).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver.new.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver.new.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:33:20
+   |
+LL |     let _: IShow = x.show();
+   |            -----   ^^^^^^^^ expected `IShow`, found `OnIShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver.old.stderr
@@ -1,0 +1,37 @@
+error[E0599]: no method named `show` found for opaque type `Test` in the current scope
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:33:22
+   |
+LL |     let _: IShow = x.show();
+   |                      ^^^^ method not found in `Test`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `OnI` defines an item `show`, perhaps you need to implement it
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:19:1
+   |
+LL | trait OnI {
+   | ^^^^^^^^^
+
+error[E0391]: cycle detected when computing type of opaque `Test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:26:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   |
+note: ...which requires type-checking `test`...
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:33:20
+   |
+LL |     let _: IShow = x.show();
+   |                    ^
+   = note: ...which requires evaluating trait selection obligation `Test: core::marker::Unpin`...
+   = note: ...which again requires computing type of opaque `Test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `Test::{opaque#0}`
+  --> $DIR/reveal-hidden-via-unwrapped-receiver.rs:26:13
+   |
+LL | type Test = impl Sized;
+   |             ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0391, E0599.
+For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-unwrapped-receiver.rs
@@ -1,0 +1,36 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct I;
+struct IShow;
+impl I {
+    #[allow(dead_code)]
+    pub fn show(&self) -> IShow {
+        IShow
+    }
+}
+
+struct OnIShow;
+trait OnI {
+    fn show(&self) -> OnIShow {
+        OnIShow
+    }
+}
+impl OnI for I {}
+
+type Test = impl Sized;
+
+fn define() -> Test {
+    I
+}
+
+fn test(x: Test) {
+    let _: IShow = x.show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-inner-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-inner-id-left.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-wrapped-receiver-inner-id-left.rs:35:20
+   |
+LL |     let _: WShow = W(id2(x, ())).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^^^ expected `WShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-inner-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-inner-id-left.rs
@@ -1,0 +1,38 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: WShow = W(id2(x, ())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-inner-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-inner-id-right.rs
@@ -1,0 +1,37 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: WShow = W(id2((), x)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-outer-id-left.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-outer-id-left.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-wrapped-receiver-outer-id-left.rs:35:20
+   |
+LL |     let _: WShow = id2(W(x), W(())).show();
+   |            -----   ^^^^^^^^^^^^^^^^^^^^^^^ expected `WShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-outer-id-left.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-outer-id-left.rs
@@ -1,0 +1,38 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: WShow = id2(W(x), W(())).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-outer-id-right.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver-outer-id-right.rs
@@ -1,0 +1,37 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+fn id2<T>(_: T, x: T) -> T {
+    x
+}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: WShow = id2(W(()), W(x)).show();
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver.old.stderr
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver.old.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/reveal-hidden-via-wrapped-receiver.rs:31:20
+   |
+LL |     let _: WShow = W(x).show();
+   |            -----   ^^^^^^^^^^^ expected `WShow`, found `OnWShow`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver.rs
+++ b/tests/ui/impl-trait/inference/may-define-without-must-define/reveal-hidden-via-wrapped-receiver.rs
@@ -1,0 +1,34 @@
+// edition:2021
+// revisions: new old
+// [new]compile-flags: -Ztrait-solver=next
+// [old]compile-flags: -Ztrait-solver=classic
+// [new]check-pass
+// [old]known-bug: unknown
+
+#![feature(type_alias_impl_trait)]
+
+struct W<T>(T);
+struct WShow;
+impl W<()> {
+    pub fn show(&self) -> WShow {
+        WShow
+    }
+}
+
+struct OnWShow;
+trait OnW {
+    fn show(&self) -> OnWShow {
+        OnWShow
+    }
+}
+impl<T> OnW for W<T> {}
+
+type Test = impl Sized;
+
+fn define() -> Test {}
+
+fn test(x: Test) {
+    let _: WShow = W(x).show();
+}
+
+fn main() {}


### PR DESCRIPTION
When considering an opaque type within a body that is permitted to define the hidden type for that opaque, we're expecting the new trait solver to sometimes produce different results.

Sometimes this is due to the fact that the new trait solver considers more cases to be defining, such as when defining the hidden type allows an impl for some wrapper type to be matched.

In other cases, this is due to lazy normalization, which e.g. allows the new trait solver to more consistently handle as a concrete type the return value of...

```rust
id2<T>(_: T, x: T ) -> T { x }
```

...when it is called with a value of the opaque type and a value of the corresponding hidden type.

However, the new trait solver is not yet done, and it does not consistently produce the results we expect that it will once complete.

As we work toward stabilizing type alias impl Trait (TAIT), we need to plan for what the behavior of the new trait solver will be. Similarly, since return position impl Trait (RPIT) is already stable but will see inference differences with the new trait solver, we need to begin to plan for that also.

To help enable this planning, let's add test cases that define what the correct inference behavior should be when handling opaue types. The goal of this commit is to prompt discussion and ensure there is a consensus on this behavior, then to document that behavior in these tests.

Where the correct behavior does not match the behavior of either the new or the old trait solver, we've chosen to mark that as a known bug.  For the new solver, we've done this since it is still a work in progress and is expected to eventually model the correct behavior. For the old solver, we've done this since the behavior is inconsistent and often surprising, and since we may need to add future-incompat lints or take other steps to prepare the ecosystem for the transition to the new solver.