### PR TITLE
speed up `x install` by skipping archiving and compression

### DIFF
--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -131,4 +131,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "The \"codegen\"/\"llvm\" profile has been removed and replaced with \"compiler\", use it instead for the same behavior.",
     },
+    ChangeInfo {
+        change_id: 118724,
+        severity: ChangeSeverity::Info,
+        summary: "`x install` now skips providing tarball sources (under 'build/dist' path) to speed up the installation process.",
+    },
 ];

--- a/src/tools/rust-installer/src/main.rs
+++ b/src/tools/rust-installer/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::{self, Parser};
+use clap::Parser;
 
 #[derive(Parser)]
 struct CommandLine {

--- a/src/tools/rust-installer/src/tarballer.rs
+++ b/src/tools/rust-installer/src/tarballer.rs
@@ -38,6 +38,10 @@ actor! {
 impl Tarballer {
     /// Generates the actual tarballs
     pub fn run(self) -> Result<()> {
+        if let CompressionProfile::NoOp = self.compression_profile {
+            return Ok(());
+        }
+
         let tarball_name = self.output.clone() + ".tar";
         let encoder = CombinedEncoder::new(
             self.compression_formats


### PR DESCRIPTION
Performing archiving and compression on `x install` is nothing more than a waste of time and resources. Additionally, for systems like gentoo(which uses `x install`) this should be highly beneficial.

[benchmark report](https://github.com/rust-lang/rust/pull/118724#issuecomment-1848964908)

Resolves #109308

r? Mark-Simulacrum (I think you want to review this, feel free to change it if otherwise.)