### PR TITLE
Do not parenthesize exterior struct lit inside match guards

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1166,8 +1166,11 @@ impl<'a> State<'a> {
                 | ast::ExprKind::Closure(..)
                 | ast::ExprKind::Ret(..)
                 | ast::ExprKind::Yeet(..) => true,
-                _ => parser::contains_exterior_struct_lit(expr),
-            } || parser::needs_par_as_let_scrutinee(expr.precedence().order()),
+                _ => {
+                    parser::contains_exterior_struct_lit(expr)
+                        || parser::needs_par_as_let_scrutinee(expr.precedence().order())
+                }
+            },
         );
     }
 

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1161,8 +1161,13 @@ impl<'a> State<'a> {
         self.word_space("=");
         self.print_expr_cond_paren(
             expr,
-            Self::cond_needs_par(expr)
-                || parser::needs_par_as_let_scrutinee(expr.precedence().order()),
+            match expr.kind {
+                ast::ExprKind::Break(..)
+                | ast::ExprKind::Closure(..)
+                | ast::ExprKind::Ret(..)
+                | ast::ExprKind::Yeet(..) => true,
+                _ => parser::contains_exterior_struct_lit(expr),
+            } || parser::needs_par_as_let_scrutinee(expr.precedence().order()),
         );
     }
 

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1159,8 +1159,11 @@ impl<'a> State<'a> {
         self.print_pat(pat);
         self.space();
         self.word_space("=");
-        let npals = || parser::needs_par_as_let_scrutinee(expr.precedence().order());
-        self.print_expr_cond_paren(expr, Self::cond_needs_par(expr) || npals())
+        self.print_expr_cond_paren(
+            expr,
+            Self::cond_needs_par(expr)
+                || parser::needs_par_as_let_scrutinee(expr.precedence().order()),
+        );
     }
 
     fn print_mac(&mut self, m: &ast::MacCall) {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1161,16 +1161,8 @@ impl<'a> State<'a> {
         self.word_space("=");
         self.print_expr_cond_paren(
             expr,
-            match expr.kind {
-                ast::ExprKind::Break(..)
-                | ast::ExprKind::Closure(..)
-                | ast::ExprKind::Ret(..)
-                | ast::ExprKind::Yeet(..) => true,
-                _ => {
-                    parser::contains_exterior_struct_lit(expr)
-                        || parser::needs_par_as_let_scrutinee(expr.precedence().order())
-                }
-            },
+            parser::contains_exterior_struct_lit(expr)
+                || parser::needs_par_as_let_scrutinee(expr.precedence().order()),
         );
     }
 

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1162,7 +1162,7 @@ impl<'a> State<'a> {
     /// For example each of the following would mean the wrong thing without
     /// parentheses.
     ///
-    /// ```ignore
+    /// ```ignore (illustrative)
     /// if let _ = (Struct {}) {}
     ///
     /// if let _ = (true && false) {}
@@ -1173,7 +1173,7 @@ impl<'a> State<'a> {
     /// the match guard expression. Parsing of the expression is not terminated
     /// by `{` in that position.
     ///
-    /// ```ignore
+    /// ```ignore (illustrative)
     /// match () {
     ///     () if let _ = Struct {} => {}
     ///     () if let _ = (true && false) => {}

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -69,7 +69,7 @@ impl<'a> State<'a> {
     ///
     /// These cases need parens due to the parse error observed in #26461: `if return {}`
     /// parses as the erroneous construct `if (return {})`, not `if (return) {}`.
-    pub(super) fn cond_needs_par(expr: &ast::Expr) -> bool {
+    fn cond_needs_par(expr: &ast::Expr) -> bool {
         match expr.kind {
             ast::ExprKind::Break(..)
             | ast::ExprKind::Closure(..)

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -1,4 +1,5 @@
 use crate::pp::Breaks::Inconsistent;
+use crate::pprust::state::expr::FixupContext;
 use crate::pprust::state::{AnnNode, PrintState, State, INDENT_UNIT};
 
 use ast::StaticItem;
@@ -97,7 +98,7 @@ impl<'a> State<'a> {
         self.end(); // end the head-ibox
         if let Some(body) = body {
             self.word_space("=");
-            self.print_expr(body);
+            self.print_expr(body, FixupContext::default());
         }
         self.print_where_clause(&generics.where_clause);
         self.word(";");
@@ -514,7 +515,7 @@ impl<'a> State<'a> {
         if let Some(d) = &v.disr_expr {
             self.space();
             self.word_space("=");
-            self.print_expr(&d.value)
+            self.print_expr(&d.value, FixupContext::default())
         }
     }
 

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -10,6 +10,8 @@
 #![feature(coroutines)]
 #![feature(decl_macro)]
 #![feature(explicit_tail_calls)]
+#![feature(if_let_guard)]
+#![feature(let_chains)]
 #![feature(more_qualified_paths)]
 #![feature(never_patterns)]
 #![feature(raw_ref_op)]
@@ -47,7 +49,7 @@ macro_rules! c1 {
 // easy to find the cases where the two pretty-printing approaches give
 // different results.
 macro_rules! c2 {
-    ($frag:ident, [$($tt:tt)*], $s1:literal, $s2:literal) => {
+    ($frag:ident, [$($tt:tt)*], $s1:literal, $s2:literal $(,)?) => {
         assert_ne!($s1, $s2, "should use `c1!` instead");
         assert_eq!($frag!($($tt)*), $s1);
         assert_eq!(stringify!($($tt)*), $s2);
@@ -136,6 +138,23 @@ fn test_expr() {
 
     // ExprKind::Let
     c1!(expr, [ if let Some(a) = b { c } else { d } ], "if let Some(a) = b { c } else { d }");
+    c1!(expr, [ if let _ = true && false {} ], "if let _ = true && false {}");
+    c1!(expr, [ if let _ = (true && false) {} ], "if let _ = (true && false) {}");
+    macro_rules! c2_if_let {
+        ($expr:expr, $expr_expected:expr, $tokens_expected:expr $(,)?) => {
+            c2!(expr, [ if let _ = $expr {} ], $expr_expected, $tokens_expected);
+        };
+    }
+    c2_if_let!(
+        true && false,
+        "if let _ = (true && false) {}",
+        "if let _ = true && false {}",
+    );
+    c2!(expr,
+        [ match () { _ if let _ = Struct {} => {} } ],
+        "match () { _ if let _ = (Struct {}) => {} }", // FIXME: do not parenthesize
+        "match() { _ if let _ = Struct {} => {} }",
+    );
 
     // ExprKind::If
     c1!(expr, [ if true {} ], "if true {}");

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -152,7 +152,7 @@ fn test_expr() {
     );
     c2!(expr,
         [ match () { _ if let _ = Struct {} => {} } ],
-        "match () { _ if let _ = (Struct {}) => {} }", // FIXME: do not parenthesize
+        "match () { _ if let _ = Struct {} => {} }",
         "match() { _ if let _ = Struct {} => {} }",
     );
 


### PR DESCRIPTION
Before this PR, the AST pretty-printer injects parentheses around expressions any time parens _could_ be needed depending on what else is in the code that surrounds that expression. But the pretty-printer did not pass around enough context to understand whether parentheses really _are_ needed on any particular expression. As a consequence, there are false positives where unneeded parentheses are being inserted.

Example:

```rust
#![feature(if_let_guard)]

macro_rules! pp {
    ($e:expr) => {
        stringify!($e)
    };
}

fn main() {
    println!("{}", pp!(match () { () if let _ = Struct {} => {} }));
}
```

**Before:**

```console
match () { () if let _ = (Struct {}) => {} }
```

**After:**

```console
match () { () if let _ = Struct {} => {} }
```

This PR introduces a bit of state that is passed across various expression printing methods to help understand accurately whether particular situations require parentheses injected by the pretty printer, and it fixes one such false positive involving match guards as shown above.

There are other parenthesization false positive cases not fixed by this PR. I intend to address these in follow-up PRs. For example here is one: the expression `{ let _ = match x {} + 1; }` is pretty-printed as `{ let _ = (match x {}) + 1; }` despite there being no reason for parentheses to appear there.