### PR TITLE
recurse into refs when comparing tys for diagnostics

### DIFF
--- a/tests/ui/associated-consts/associated-const-impl-wrong-lifetime.stderr
+++ b/tests/ui/associated-consts/associated-const-impl-wrong-lifetime.stderr
@@ -4,8 +4,8 @@ error[E0308]: const not compatible with trait
 LL |     const NAME: &'a str = "unit";
    |     ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected reference `&'static str`
-              found reference `&'a str`
+   = note: expected reference `&'static _`
+              found reference `&'a _`
 note: the lifetime `'a` as defined here...
   --> $DIR/associated-const-impl-wrong-lifetime.rs:6:6
    |

--- a/tests/ui/associated-types/dont-suggest-cyclic-constraint.stderr
+++ b/tests/ui/associated-types/dont-suggest-cyclic-constraint.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     debug_assert_eq!(iter.next(), Some(value));
    |                                   ^^^^^^^^^^^ expected `Option<<I as Iterator>::Item>`, found `Option<&<I as Iterator>::Item>`
    |
-   = note: expected enum `Option<<I as Iterator>::Item>`
-              found enum `Option<&<I as Iterator>::Item>`
+   = note: expected enum `Option<_>`
+              found enum `Option<&_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/in-trait/async-example-desugared-boxed-in-trait.stderr
+++ b/tests/ui/async-await/in-trait/async-example-desugared-boxed-in-trait.stderr
@@ -9,8 +9,8 @@ note: type in trait
    |
 LL |     fn foo(&self) -> Pin<Box<dyn Future<Output = i32> + '_>>;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected signature `fn(&i32) -> Pin<Box<dyn Future<Output = i32>>>`
-              found signature `fn(&i32) -> impl Future<Output = i32>`
+   = note: expected signature `fn(&_) -> Pin<Box<dyn Future<Output = i32>>>`
+              found signature `fn(&_) -> impl Future<Output = i32>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/tests/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -22,8 +22,8 @@ error[E0308]: method not compatible with trait
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected signature `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
-              found signature `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
+   = note: expected signature `fn(&'a _, Inv<'c>, Inv<'c>, Inv<'_>)`
+              found signature `fn(&'a _, Inv<'_>, Inv<'c>, Inv<'_>)`
 note: the lifetime `'c` as defined here...
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
@@ -41,8 +41,8 @@ error[E0308]: method not compatible with trait
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected signature `fn(&'a isize, Inv<'c>, Inv<'c>, Inv<'_>)`
-              found signature `fn(&'a isize, Inv<'_>, Inv<'c>, Inv<'_>)`
+   = note: expected signature `fn(&'a _, Inv<'c>, Inv<'c>, Inv<'_>)`
+              found signature `fn(&'a _, Inv<'_>, Inv<'c>, Inv<'_>)`
 note: the lifetime `'c` as defined here...
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |

--- a/tests/ui/box/issue-82446.stderr
+++ b/tests/ui/box/issue-82446.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |         val
    |         ^^^ expected `Box<dyn MyTrait>`, found `&Box<dyn MyTrait>`
    |
-   = note: expected struct `Box<(dyn MyTrait + 'static)>`
-           found reference `&Box<(dyn MyTrait + 'static)>`
+   = note: expected struct `Box<_>`
+           found reference `&Box<_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/tests/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -25,8 +25,8 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
    |                                                 ^ one type is more general than the other
    |
-   = note: expected fn pointer `fn(&u32)`
-              found fn pointer `for<'a> fn(&'a u32)`
+   = note: expected fn pointer `fn(&_)`
+              found fn pointer `for<'a> fn(&'a _)`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:39:50
@@ -34,8 +34,8 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
    |                                                  ^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a> fn(&'a u32)`
-              found fn pointer `fn(&u32)`
+   = note: expected fn pointer `for<'a> fn(&'a _)`
+              found fn pointer `fn(&_)`
 
 error[E0308]: mismatched types
   --> $DIR/expect-fn-supply-fn.rs:48:50
@@ -43,8 +43,8 @@ error[E0308]: mismatched types
 LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
    |                                                  ^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a> fn(&'a u32)`
-              found fn pointer `fn(&u32)`
+   = note: expected fn pointer `for<'a> fn(&'a _)`
+              found fn pointer `fn(&_)`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/closures/multiple-fn-bounds.stderr
+++ b/tests/ui/closures/multiple-fn-bounds.stderr
@@ -6,8 +6,8 @@ LL |     foo(move |x| v);
    |     |
    |     expected due to this
    |
-   = note: expected closure signature `fn(char) -> _`
-              found closure signature `for<'a> fn(&'a char) -> _`
+   = note: expected closure signature `fn(_) -> _`
+              found closure signature `for<'a> fn(&'a _) -> _`
 note: closure inferred to have a different signature due to this bound
   --> $DIR/multiple-fn-bounds.rs:1:11
    |

--- a/tests/ui/fn/fn-pointer-mismatch.rs
+++ b/tests/ui/fn/fn-pointer-mismatch.rs
@@ -35,20 +35,20 @@ fn main() {
     // suggest removing reference
     let c: fn(u32) -> u32 = &foo;
     //~^ ERROR mismatched types
-    //~| expected fn pointer `fn(u32) -> u32`
-    //~| found reference `&fn(u32) -> u32 {foo}`
+    //~| expected fn pointer `fn(_) -> _`
+    //~| found reference `&fn(_) -> _ {foo}`
 
     // suggest using reference
     let d: &fn(u32) -> u32 = foo;
     //~^ ERROR mismatched types
-    //~| expected reference `&fn(u32) -> u32`
-    //~| found fn item `fn(u32) -> u32 {foo}`
+    //~| expected reference `&fn(_) -> _`
+    //~| found fn item `fn(_) -> _ {foo}`
 
     // suggest casting with reference
     let e: &fn(u32) -> u32 = &foo;
     //~^ ERROR mismatched types
-    //~| expected reference `&fn(u32) -> u32`
-    //~| found reference `&fn(u32) -> u32 {foo}`
+    //~| expected reference `&fn(_) -> _`
+    //~| found reference `&fn(_) -> _ {foo}`
 
     // OK
     let mut z: fn(u32) -> u32 = foo as fn(u32) -> u32;

--- a/tests/ui/fn/fn-pointer-mismatch.stderr
+++ b/tests/ui/fn/fn-pointer-mismatch.stderr
@@ -6,8 +6,8 @@ LL |     let g = if n % 2 == 0 { &foo } else { &bar };
    |                             |
    |                             expected because of this
    |
-   = note: expected reference `&fn(u32) -> u32 {foo}`
-              found reference `&fn(u32) -> u32 {bar}`
+   = note: expected reference `&fn(_) -> _ {foo}`
+              found reference `&fn(_) -> _ {bar}`
    = note: different fn items have unique types, even if their signatures are the same
    = help: consider casting both fn items to fn pointers using `as fn(u32) -> u32`
 
@@ -47,8 +47,8 @@ LL |     let c: fn(u32) -> u32 = &foo;
    |            |
    |            expected due to this
    |
-   = note: expected fn pointer `fn(u32) -> u32`
-               found reference `&fn(u32) -> u32 {foo}`
+   = note: expected fn pointer `fn(_) -> _`
+               found reference `&fn(_) -> _ {foo}`
 help: consider removing the reference
    |
 LL |     let c: fn(u32) -> u32 = foo;
@@ -62,8 +62,8 @@ LL |     let d: &fn(u32) -> u32 = foo;
    |            |
    |            expected due to this
    |
-   = note: expected reference `&fn(u32) -> u32`
-                found fn item `fn(u32) -> u32 {foo}`
+   = note: expected reference `&fn(_) -> _`
+                found fn item `fn(_) -> _ {foo}`
 help: consider using a reference
    |
 LL |     let d: &fn(u32) -> u32 = &foo;
@@ -77,8 +77,8 @@ LL |     let e: &fn(u32) -> u32 = &foo;
    |            |
    |            expected due to this
    |
-   = note: expected reference `&fn(u32) -> u32`
-              found reference `&fn(u32) -> u32 {foo}`
+   = note: expected reference `&fn(_) -> _`
+              found reference `&fn(_) -> _ {foo}`
    = note: fn items are distinct from fn pointers
 help: consider casting to a fn pointer
    |

--- a/tests/ui/generic-associated-types/issue-88360.stderr
+++ b/tests/ui/generic-associated-types/issue-88360.stderr
@@ -9,8 +9,8 @@ LL |     fn copy(&self) -> Self::Gat<'_> where T: Copy {
 LL |         *self.test()
    |         ^^^^^^^^^^^^ expected `&T`, found type parameter `T`
    |
-   = note:   expected reference `&T`
-           found type parameter `T`
+   = note:   expected reference `&_`
+           found type parameter `_`
 help: consider removing deref here
    |
 LL -         *self.test()

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.stderr
@@ -8,8 +8,8 @@ LL | / check! { bound_a_b_ret_a_vs_bound_a_ret_a: (for<'a,'b> fn(&'a u32, &'b u3
 LL | | for<'a>    fn(&'a u32, &'a u32) -> &'a u32) }
    | |_____________________________________________- in this macro invocation
    |
-   = note: expected enum `Option<for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32>`
-              found enum `Option<for<'a> fn(&'a u32, &'a u32) -> &'a u32>`
+   = note: expected enum `Option<for<'a, 'b> fn(&'a _, &'b _) -> &'a _>`
+              found enum `Option<for<'a> fn(&'a _, &'a _) -> &'a _>`
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_vs_free_x.stderr
+++ b/tests/ui/higher-ranked/subtype/hr-subtype.bound_a_vs_free_x.stderr
@@ -8,8 +8,8 @@ LL | / check! { bound_a_vs_free_x: (for<'a> fn(&'a u32),
 LL | | fn(&'x u32)) }
    | |______________- in this macro invocation
    |
-   = note: expected enum `Option<for<'a> fn(&'a u32)>`
-              found enum `Option<fn(&u32)>`
+   = note: expected enum `Option<for<'a> fn(&'a _)>`
+              found enum `Option<fn(&_)>`
    = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-exists-forall-fn.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-exists-forall-fn.stderr
@@ -6,8 +6,8 @@ LL |     let _: for<'b> fn(&'b u32) = foo();
    |            |
    |            expected due to this
    |
-   = note: expected fn pointer `for<'b> fn(&'b u32)`
-              found fn pointer `fn(&u32)`
+   = note: expected fn pointer `for<'b> fn(&'b _)`
+              found fn pointer `fn(&_)`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/specialization-broken.stderr
+++ b/tests/ui/impl-trait/in-trait/specialization-broken.stderr
@@ -15,8 +15,8 @@ note: type in trait
    |
 LL |     fn bar(&self) -> impl Sized;
    |                      ^^^^^^^^^^
-   = note: expected signature `fn(&U) -> impl Sized`
-              found signature `fn(&U) -> U`
+   = note: expected signature `fn(&_) -> impl Sized`
+              found signature `fn(&_) -> U`
 
 error: method with return-position `impl Trait` in trait cannot be specialized
   --> $DIR/specialization-broken.rs:15:5

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -18,8 +18,8 @@ LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    |                              expected `a::Bar`, found opaque type
    |                              help: change the parameter type to match the trait: `&(a::Bar, i32)`
    |
-   = note: expected signature `fn(&a::Bar, &(a::Bar, i32)) -> _`
-              found signature `fn(&a::Bar, &(a::Foo, i32)) -> _`
+   = note: expected signature `fn(&a::Bar, &(a::Bar, _)) -> _`
+              found signature `fn(&a::Bar, &(a::Foo, _)) -> _`
 
 error: unconstrained opaque type
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:18:16
@@ -41,8 +41,8 @@ LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    |                              expected opaque type, found `b::Bar`
    |                              help: change the parameter type to match the trait: `&(b::Foo, i32)`
    |
-   = note: expected signature `fn(&b::Bar, &(b::Foo, i32)) -> _`
-              found signature `fn(&b::Bar, &(b::Bar, i32)) -> _`
+   = note: expected signature `fn(&b::Bar, &(b::Foo, _)) -> _`
+              found signature `fn(&b::Bar, &(b::Bar, _)) -> _`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:24:12
    |

--- a/tests/ui/implied-bounds/issue-100690.stderr
+++ b/tests/ui/implied-bounds/issue-100690.stderr
@@ -6,8 +6,8 @@ LL |         real_dispatch(f)
    |         |
    |         required by a bound introduced by this call
    |
-   = note: expected a closure with arguments `(&mut UIView<'a, T>,)`
-              found a closure with arguments `(&mut UIView<'_, T>,)`
+   = note: expected a closure with arguments `(&mut UIView<'a, _>,)`
+              found a closure with arguments `(&mut UIView<'_, _>,)`
 note: required by a bound in `real_dispatch`
   --> $DIR/issue-100690.rs:9:8
    |

--- a/tests/ui/issues/issue-17905-2.stderr
+++ b/tests/ui/issues/issue-17905-2.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched `self` parameter type
 LL |     fn say(self: &Pair<&str, isize>) {
    |                  ^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected struct `Pair<&str, _>`
-              found struct `Pair<&str, _>`
+   = note: expected struct `Pair<&_, _>`
+              found struct `Pair<&_, _>`
 note: the anonymous lifetime defined here...
   --> $DIR/issue-17905-2.rs:8:24
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched `self` parameter type
 LL |     fn say(self: &Pair<&str, isize>) {
    |                  ^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected struct `Pair<&str, _>`
-              found struct `Pair<&str, _>`
+   = note: expected struct `Pair<&_, _>`
+              found struct `Pair<&_, _>`
 note: the anonymous lifetime as defined here...
   --> $DIR/issue-17905-2.rs:5:5
    |

--- a/tests/ui/issues/issue-20225.stderr
+++ b/tests/ui/issues/issue-20225.stderr
@@ -9,8 +9,8 @@ LL |   extern "rust-call" fn call(&self, (_,): (T,)) {}
    |                                           expected `&'a T`, found type parameter `T`
    |                                           help: change the parameter type to match the trait: `(&'a T,)`
    |
-   = note: expected signature `extern "rust-call" fn(&Foo, (&'a T,))`
-              found signature `extern "rust-call" fn(&Foo, (T,))`
+   = note: expected signature `extern "rust-call" fn(&Foo, (&'a _,))`
+              found signature `extern "rust-call" fn(&Foo, (_,))`
 
 error[E0053]: method `call_mut` has an incompatible type for trait
   --> $DIR/issue-20225.rs:11:51
@@ -23,8 +23,8 @@ LL |   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
    |                                                   expected `&'a T`, found type parameter `T`
    |                                                   help: change the parameter type to match the trait: `(&'a T,)`
    |
-   = note: expected signature `extern "rust-call" fn(&mut Foo, (&'a T,))`
-              found signature `extern "rust-call" fn(&mut Foo, (T,))`
+   = note: expected signature `extern "rust-call" fn(&mut Foo, (&'a _,))`
+              found signature `extern "rust-call" fn(&mut Foo, (_,))`
 
 error[E0053]: method `call_once` has an incompatible type for trait
   --> $DIR/issue-20225.rs:18:47
@@ -38,8 +38,8 @@ LL |   extern "rust-call" fn call_once(self, (_,): (T,)) {}
    |                                               expected `&'a T`, found type parameter `T`
    |                                               help: change the parameter type to match the trait: `(&'a T,)`
    |
-   = note: expected signature `extern "rust-call" fn(Foo, (&'a T,))`
-              found signature `extern "rust-call" fn(Foo, (T,))`
+   = note: expected signature `extern "rust-call" fn(Foo, (&'a _,))`
+              found signature `extern "rust-call" fn(Foo, (_,))`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-24322.stderr
+++ b/tests/ui/issues/issue-24322.stderr
@@ -6,8 +6,8 @@ LL |     let x: &fn(&B) -> u32 = &B::func;
    |            |
    |            expected due to this
    |
-   = note: expected reference `&for<'a> fn(&'a B) -> u32`
-              found reference `&for<'a> fn(&'a B) -> u32 {B::func}`
+   = note: expected reference `&for<'a> fn(&'a B) -> _`
+              found reference `&for<'a> fn(&'a B) -> _ {B::func}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-37884.stderr
+++ b/tests/ui/issues/issue-37884.stderr
@@ -4,8 +4,8 @@ error[E0308]: method not compatible with trait
 LL |     fn next(&'a mut self) -> Option<Self::Item>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected signature `fn(&mut RepeatMut<'a, T>) -> Option<_>`
-              found signature `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
+   = note: expected signature `fn(&mut RepeatMut<'_, _>) -> Option<_>`
+              found signature `fn(&'a mut RepeatMut<'_, _>) -> Option<_>`
 note: the anonymous lifetime as defined here...
   --> $DIR/issue-37884.rs:6:5
    |

--- a/tests/ui/let-else/let-else-binding-explicit-mut-annotated.stderr
+++ b/tests/ui/let-else/let-else-binding-explicit-mut-annotated.stderr
@@ -6,8 +6,8 @@ LL |     let Some(n): &mut Option<i32> = &&Some(5i32) else { return };
    |                  |
    |                  expected due to this
    |
-   = note: expected mutable reference `&mut Option<i32>`
-                      found reference `&&Option<i32>`
+   = note: expected mutable reference `&mut Option<_>`
+                      found reference `&&Option<_>`
 
 error[E0308]: mismatched types
   --> $DIR/let-else-binding-explicit-mut-annotated.rs:13:37
@@ -17,8 +17,8 @@ LL |     let Some(n): &mut Option<i32> = &&mut Some(5i32) else { return };
    |                  |
    |                  expected due to this
    |
-   = note: expected mutable reference `&mut Option<i32>`
-                      found reference `&&mut Option<i32>`
+   = note: expected mutable reference `&mut Option<_>`
+                      found reference `&&mut Option<_>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lifetimes/issue-79187-2.stderr
+++ b/tests/ui/lifetimes/issue-79187-2.stderr
@@ -54,8 +54,8 @@ error[E0308]: mismatched types
 LL |     take_foo(|a: &i32| a);
    |     ^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected reference `&i32`
-              found reference `&i32`
+   = note: expected reference `&_`
+              found reference `&_`
 note: the lifetime requirement is introduced here
   --> $DIR/issue-79187-2.rs:5:21
    |
@@ -68,8 +68,8 @@ error[E0308]: mismatched types
 LL |     take_foo(|a: &i32| -> &i32 { a });
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected reference `&i32`
-              found reference `&i32`
+   = note: expected reference `&_`
+              found reference `&_`
 note: the lifetime requirement is introduced here
   --> $DIR/issue-79187-2.rs:5:21
    |

--- a/tests/ui/lub-glb/old-lub-glb-hr-noteq1.leak.stderr
+++ b/tests/ui/lub-glb/old-lub-glb-hr-noteq1.leak.stderr
@@ -12,8 +12,8 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
-              found fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+   = note: expected fn pointer `for<'a, 'b> fn(&'a _, &'b _) -> &'a _`
+              found fn pointer `for<'a> fn(&'a _, &'a _) -> &'a _`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lub-glb/old-lub-glb-hr-noteq1.noleak.stderr
+++ b/tests/ui/lub-glb/old-lub-glb-hr-noteq1.noleak.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |         _ => y,
    |              ^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
-              found fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+   = note: expected fn pointer `for<'a, 'b> fn(&'a _, &'b _) -> &'a _`
+              found fn pointer `for<'a> fn(&'a _, &'a _) -> &'a _`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lub-glb/old-lub-glb-hr-noteq2.leak.stderr
+++ b/tests/ui/lub-glb/old-lub-glb-hr-noteq2.leak.stderr
@@ -11,8 +11,8 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
-              found fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+   = note: expected fn pointer `for<'a> fn(&'a _, &'a _) -> &'a _`
+              found fn pointer `for<'a, 'b> fn(&'a _, &'b _) -> &'a _`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mir/field-projection-mutating-context.stderr
+++ b/tests/ui/mir/field-projection-mutating-context.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let Foo(ref mut y): Foo<fn(&'static str)> = x;
    |             ^^^^^^^^^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a> fn(&'a str)`
-              found fn pointer `fn(&str)`
+   = note: expected fn pointer `for<'a> fn(&'a _)`
+              found fn pointer `fn(&_)`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -6,8 +6,8 @@ LL |     a.iter().map(|_: (u32, u32)| 45);
    |              |
    |              expected due to this
    |
-   = note: expected closure signature `fn(&(u32, u32)) -> _`
-              found closure signature `fn((u32, u32)) -> _`
+   = note: expected closure signature `fn(&(_, _)) -> _`
+              found closure signature `fn((_, _)) -> _`
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 help: consider adjusting the signature so it borrows its argument

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -6,8 +6,8 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |                                |
    |                                expected due to this
    |
-   = note: expected closure signature `for<'a> fn(&'a &str) -> _`
-              found closure signature `for<'a> fn(&'a str) -> _`
+   = note: expected closure signature `for<'a> fn(&'a &_) -> _`
+              found closure signature `for<'a> fn(&'a _) -> _`
 note: required by a bound in `filter`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 help: consider adjusting the signature so it borrows its argument

--- a/tests/ui/mismatched_types/normalize-fn-sig.stderr
+++ b/tests/ui/mismatched_types/normalize-fn-sig.stderr
@@ -6,8 +6,8 @@ LL |     needs_i32_ref_fn(foo::<()>);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected fn pointer `fn(&'static i32, i32)`
-                 found fn item `fn(i32, &'static i32) {foo::<()>}`
+   = note: expected fn pointer `fn(&'static _, _)`
+                 found fn item `fn(_, &'static _) {foo::<()>}`
 note: function defined here
   --> $DIR/normalize-fn-sig.rs:11:4
    |

--- a/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.stderr
+++ b/tests/ui/moves/assignment-of-clone-call-on-ref-due-to-missing-bound.stderr
@@ -6,8 +6,8 @@ LL |             let mut x: HashSet<Day> = v.clone();
    |                        |
    |                        expected due to this
    |
-   = note: expected struct `HashSet<Day>`
-           found reference `&HashSet<Day>`
+   = note: expected struct `HashSet<_>`
+           found reference `&HashSet<_>`
 note: `HashSet<Day>` does not implement `Clone`, so `&HashSet<Day>` was cloned instead
   --> $DIR/assignment-of-clone-call-on-ref-due-to-missing-bound.rs:18:39
    |

--- a/tests/ui/nll/relate_tys/hr-fn-aaa-as-aba.stderr
+++ b/tests/ui/nll/relate_tys/hr-fn-aaa-as-aba.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let a: for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32 = make_it();
    |                                                          ^^^^^^^^^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32`
-              found fn pointer `for<'a> fn(&'a u32, &'a u32) -> &'a u32`
+   = note: expected fn pointer `for<'a, 'b> fn(&'a _, &'b _) -> &'a _`
+              found fn pointer `for<'a> fn(&'a _, &'a _) -> &'a _`
 
 error[E0308]: mismatched types
   --> $DIR/hr-fn-aaa-as-aba.rs:20:12
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     let _: for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32 = make_it();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32`
-              found fn pointer `for<'a> fn(&'a u32, &'a u32) -> &'a u32`
+   = note: expected fn pointer `for<'a, 'b> fn(&'a _, &'b _) -> &'a _`
+              found fn pointer `for<'a> fn(&'a _, &'a _) -> &'a _`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/relate_tys/universe-violation.stderr
+++ b/tests/ui/nll/relate_tys/universe-violation.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let b: fn(&u32) -> &u32 = a;
    |                               ^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'a> fn(&'a u32) -> &'a u32`
-              found fn pointer `fn(&u32) -> &u32`
+   = note: expected fn pointer `for<'a> fn(&'a _) -> &'a _`
+              found fn pointer `fn(&_) -> &_`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/trait-associated-constant.stderr
+++ b/tests/ui/nll/trait-associated-constant.stderr
@@ -4,8 +4,8 @@ error[E0308]: const not compatible with trait
 LL |     const AC: Option<&'c str> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected enum `Option<&'b str>`
-              found enum `Option<&'c str>`
+   = note: expected enum `Option<&'b _>`
+              found enum `Option<&'c _>`
 note: the lifetime `'c` as defined here...
   --> $DIR/trait-associated-constant.rs:20:18
    |

--- a/tests/ui/or-patterns/inconsistent-modes.stderr
+++ b/tests/ui/or-patterns/inconsistent-modes.stderr
@@ -57,8 +57,8 @@ LL |     let (Ok(ref a) | Err(ref mut a)): Result<&u8, &mut u8> = Ok(&0);
    |             |            types differ in mutability
    |             first introduced with type `&&u8` here
    |
-   = note:      expected reference `&&u8`
-           found mutable reference `&mut &mut u8`
+   = note:      expected reference `&&_`
+           found mutable reference `&mut &mut _`
    = note: a binding must have the same type in all alternatives
 
 error[E0308]: mismatched types

--- a/tests/ui/range/issue-73553-misinterp-range-literal.stderr
+++ b/tests/ui/range/issue-73553-misinterp-range-literal.stderr
@@ -6,8 +6,8 @@ LL |     demo(tell(1)..tell(10));
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&std::ops::Range<usize>`
-                 found struct `std::ops::Range<usize>`
+   = note: expected reference `&std::ops::Range<_>`
+                 found struct `std::ops::Range<_>`
 note: function defined here
   --> $DIR/issue-73553-misinterp-range-literal.rs:3:4
    |

--- a/tests/ui/regions/issue-101280.stderr
+++ b/tests/ui/regions/issue-101280.stderr
@@ -6,8 +6,8 @@ LL | fn f<'r>(f: fn(Cell<(&'r i32, &i32)>)) -> Ty {
 LL |     f
    |     ^ one type is more general than the other
    |
-   = note: expected fn pointer `for<'r> fn(Cell<(&'r i32, &'r i32)>)`
-              found fn pointer `for<'a> fn(Cell<(&'r i32, &'a i32)>)`
+   = note: expected fn pointer `for<'r> fn(Cell<(&'r _, &'r _)>)`
+              found fn pointer `for<'a> fn(Cell<(&'r _, &'a _)>)`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -6,8 +6,8 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    |            |
    |            expected due to this
    |
-   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b isize, &'c mut &'d isize)`
-                 found fn item `for<'a, 'b> fn(&'a mut &isize, &'b mut &isize) {a::<'_, '_>}`
+   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
+                 found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -6,8 +6,8 @@ LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
    |            |
    |            expected due to this
    |
-   = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b isize, &'c mut &'d isize, &'e mut &'f isize)`
-                 found fn item `for<'a, 'b, 'c> fn(&'a mut &isize, &'b mut &isize, &'c mut &isize) {a::<'_, '_, '_>}`
+   = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b _, &'c mut &'d _, &'e mut &'f _)`
+                 found fn item `for<'a, 'b, 'c> fn(&'a mut &_, &'b mut &_, &'c mut &_) {a::<'_, '_, '_>}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -6,8 +6,8 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    |            |
    |            expected due to this
    |
-   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b isize, &'c mut &'d isize)`
-                 found fn item `for<'a, 'b> fn(&'a mut &isize, &'b mut &isize) {a::<'_, '_>}`
+   = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
+                 found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-inconsistent-binding-mode.stderr
+++ b/tests/ui/resolve/resolve-inconsistent-binding-mode.stderr
@@ -62,8 +62,8 @@ LL |         Opts::A(ref mut i) | Opts::B(ref i) => {}
    |                 |
    |                 first introduced with type `&mut isize` here
    |
-   = note: expected mutable reference `&mut isize`
-                      found reference `&isize`
+   = note: expected mutable reference `&mut _`
+                      found reference `&_`
    = note: in the same arm, a binding must have the same type in all alternatives
 
 error: aborting due to 6 previous errors

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/lit.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/lit.stderr
@@ -6,8 +6,8 @@ LL |     match &s {
 LL |             "abc" => true,
    |             ^^^^^ expected `&&str`, found `&str`
    |
-   = note: expected reference `&&str`
-              found reference `&'static str`
+   = note: expected reference `&&_`
+              found reference `&'static _`
 
 error[E0308]: mismatched types
   --> $DIR/lit.rs:16:9

--- a/tests/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.stderr
+++ b/tests/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     fn y(&self, y: f64) -> Self { P{y, .. self.clone() } }
    |                                           ^^^^^^^^^^^^ expected `P<T>`, found `&P<T>`
    |
-   = note: expected struct `P<T>`
-           found reference `&P<T>`
+   = note: expected struct `P<_>`
+           found reference `&P<_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-reference-to-fn-1.stderr
+++ b/tests/ui/static/static-reference-to-fn-1.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |         func: &foo,
    |               ^^^^ expected `&fn() -> Option<isize>`, found `&fn() -> Option<isize> {foo}`
    |
-   = note: expected reference `&fn() -> Option<isize>`
-              found reference `&fn() -> Option<isize> {foo}`
+   = note: expected reference `&fn() -> Option<_>`
+              found reference `&fn() -> Option<_> {foo}`
    = note: fn items are distinct from fn pointers
 help: consider casting to a fn pointer
    |

--- a/tests/ui/suggestions/as-ref.stderr
+++ b/tests/ui/suggestions/as-ref.stderr
@@ -78,8 +78,8 @@ LL |     let y: Option<&usize> = x;
    |            |
    |            expected due to this
    |
-   = note:   expected enum `Option<&usize>`
-           found reference `&Option<usize>`
+   = note:   expected enum `Option<&_>`
+           found reference `&Option<_>`
 help: try using `.as_ref()` to convert `&Option<usize>` to `Option<&usize>`
    |
 LL |     let y: Option<&usize> = x.as_ref();
@@ -93,8 +93,8 @@ LL |     let y: Result<&usize, &usize> = x;
    |            |
    |            expected due to this
    |
-   = note:   expected enum `Result<&usize, &usize>`
-           found reference `&Result<usize, usize>`
+   = note:   expected enum `Result<&_, &_>`
+           found reference `&Result<_, _>`
 help: try using `.as_ref()` to convert `&Result<usize, usize>` to `Result<&usize, &usize>`
    |
 LL |     let y: Result<&usize, &usize> = x.as_ref();
@@ -108,8 +108,8 @@ LL |     let y: Result<&usize, usize> = x;
    |            |
    |            expected due to this
    |
-   = note:   expected enum `Result<&usize, usize>`
-           found reference `&Result<usize, usize>`
+   = note:   expected enum `Result<&_, _>`
+           found reference `&Result<_, _>`
 
 error[E0308]: mismatched types
   --> $DIR/as-ref.rs:22:42

--- a/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
+++ b/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
@@ -8,8 +8,8 @@ LL | fn wat<T>(t: &T) -> T {
 LL |     t.clone()
    |     ^^^^^^^^^ expected type parameter `T`, found `&T`
    |
-   = note: expected type parameter `T`
-                   found reference `&T`
+   = note: expected type parameter `_`
+                   found reference `&_`
 note: `T` does not implement `Clone`, so `&T` was cloned instead
   --> $DIR/clone-on-unconstrained-borrowed-type-param.rs:3:5
    |

--- a/tests/ui/suggestions/method-access-to-range-literal-typo.stderr
+++ b/tests/ui/suggestions/method-access-to-range-literal-typo.stderr
@@ -18,8 +18,8 @@ LL |     fn method(&self) -> Option<&Vec<u8>> {
 LL |         self.option..as_ref().map(|x| x)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<&Vec<u8>>`, found `Range<Option<Vec<u8>>>`
    |
-   = note: expected enum `Option<&Vec<u8>>`
-            found struct `std::ops::Range<Option<Vec<u8>>>`
+   = note: expected enum `Option<&Vec<_>>`
+            found struct `std::ops::Range<Option<Vec<_>>>`
 help: you likely meant to write a method call instead of a range
    |
 LL -         self.option..as_ref().map(|x| x)

--- a/tests/ui/suggestions/mut-ref-reassignment.stderr
+++ b/tests/ui/suggestions/mut-ref-reassignment.stderr
@@ -32,8 +32,8 @@ LL | fn suggestion2(opt: &mut Option<String>) {
 LL |     opt = Some(String::new())
    |           ^^^^^^^^^^^^^^^^^^^ expected `&mut Option<String>`, found `Option<String>`
    |
-   = note: expected mutable reference `&mut Option<String>`
-                           found enum `Option<String>`
+   = note: expected mutable reference `&mut Option<_>`
+                           found enum `Option<_>`
 help: consider dereferencing here to assign to the mutably borrowed value
    |
 LL |     *opt = Some(String::new())

--- a/tests/ui/traits/impl-method-mismatch.stderr
+++ b/tests/ui/traits/impl-method-mismatch.stderr
@@ -9,8 +9,8 @@ note: type in trait
    |
 LL |     fn jumbo(&self, x: &usize) -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected signature `fn(&usize, &usize) -> usize`
-              found signature `unsafe fn(&usize, &usize)`
+   = note: expected signature `fn(&_, &_) -> usize`
+              found signature `unsafe fn(&_, &_)`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/wrong-mul-method-signature.stderr
+++ b/tests/ui/traits/wrong-mul-method-signature.stderr
@@ -7,8 +7,8 @@ LL |     fn mul(self, s: &f64) -> Vec1 {
    |                     expected `f64`, found `&f64`
    |                     help: change the parameter type to match the trait: `f64`
    |
-   = note: expected signature `fn(Vec1, f64) -> Vec1`
-              found signature `fn(Vec1, &f64) -> Vec1`
+   = note: expected signature `fn(Vec1, _) -> Vec1`
+              found signature `fn(Vec1, &_) -> Vec1`
 
 error[E0053]: method `mul` has an incompatible type for trait
   --> $DIR/wrong-mul-method-signature.rs:33:21

--- a/tests/ui/type/type-check/point-at-inference-2.stderr
+++ b/tests/ui/type/type-check/point-at-inference-2.stderr
@@ -25,8 +25,8 @@ LL |     bar(v);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected struct `Vec<i32>`
-              found struct `Vec<&i32>`
+   = note: expected struct `Vec<_>`
+              found struct `Vec<&_>`
 note: function defined here
   --> $DIR/point-at-inference-2.rs:1:4
    |
@@ -43,8 +43,8 @@ LL |     bar(v);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected struct `Vec<i32>`
-              found struct `Vec<&i32>`
+   = note: expected struct `Vec<_>`
+              found struct `Vec<&_>`
 note: function defined here
   --> $DIR/point-at-inference-2.rs:1:4
    |

--- a/tests/ui/type/type-mismatch.stderr
+++ b/tests/ui/type/type-mismatch.stderr
@@ -382,8 +382,8 @@ LL |     want::<&Foo<foo>>(f);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&Foo<foo>`
-                 found struct `Foo<foo>`
+   = note: expected reference `&Foo<_>`
+                 found struct `Foo<_>`
 note: function defined here
   --> $DIR/type-mismatch.rs:14:4
    |
@@ -402,8 +402,8 @@ LL |     want::<&Foo<foo, B>>(f);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&Foo<foo, B>`
-                 found struct `Foo<foo>`
+   = note: expected reference `&Foo<_, B>`
+                 found struct `Foo<_, A>`
 note: function defined here
   --> $DIR/type-mismatch.rs:14:4
    |
@@ -546,8 +546,8 @@ LL |     want::<&Foo<foo>>(f);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&Foo<foo>`
-                 found struct `Foo<foo, B>`
+   = note: expected reference `&Foo<_, A>`
+                 found struct `Foo<_, B>`
 note: function defined here
   --> $DIR/type-mismatch.rs:14:4
    |
@@ -562,8 +562,8 @@ LL |     want::<&Foo<foo, B>>(f);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&Foo<foo, B>`
-                 found struct `Foo<foo, B>`
+   = note: expected reference `&Foo<_, _>`
+                 found struct `Foo<_, _>`
 note: function defined here
   --> $DIR/type-mismatch.rs:14:4
    |
@@ -726,8 +726,8 @@ LL |     want::<&Foo<foo>>(f);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&Foo<foo>`
-                 found struct `Foo<foo, B, A>`
+   = note: expected reference `&Foo<_, A, B>`
+                 found struct `Foo<_, B, A>`
 note: function defined here
   --> $DIR/type-mismatch.rs:14:4
    |
@@ -742,8 +742,8 @@ LL |     want::<&Foo<foo, B>>(f);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&Foo<foo, B>`
-                 found struct `Foo<foo, B, A>`
+   = note: expected reference `&Foo<_, _, B>`
+                 found struct `Foo<_, _, A>`
 note: function defined here
   --> $DIR/type-mismatch.rs:14:4
    |

--- a/tests/ui/typeck/bad-index-due-to-nested.stderr
+++ b/tests/ui/typeck/bad-index-due-to-nested.stderr
@@ -44,8 +44,8 @@ LL | fn index<'a, K, V>(map: &'a HashMap<K, V>, k: K) -> &'a V {
 LL |     map[k]
    |         ^ expected `&K`, found type parameter `K`
    |
-   = note:   expected reference `&K`
-           found type parameter `K`
+   = note:   expected reference `&_`
+           found type parameter `_`
 help: consider borrowing here
    |
 LL |     map[&k]
@@ -59,8 +59,8 @@ LL | fn index<'a, K, V>(map: &'a HashMap<K, V>, k: K) -> &'a V {
 LL |     map[k]
    |     ^^^^^^ expected `&V`, found type parameter `V`
    |
-   = note:   expected reference `&'a V`
-           found type parameter `V`
+   = note:   expected reference `&'a _`
+           found type parameter `_`
 help: consider borrowing here
    |
 LL |     &map[k]

--- a/tests/ui/typeck/mismatched-map-under-self.stderr
+++ b/tests/ui/typeck/mismatched-map-under-self.stderr
@@ -12,8 +12,8 @@ note: type in trait
    |
 LL |     fn values(&self) -> Self::Values;
    |               ^^^^^
-   = note: expected signature `fn(&Option<T>)`
-              found signature `fn(Option<T>)`
+   = note: expected signature `fn(&Option<_>)`
+              found signature `fn(Option<_>)`
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/mismatched-map-under-self.rs:12:18

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -39,12 +39,12 @@ impl<'a, T> SomeTrait for &'a Bar<T> {
     //~| ERROR has an incompatible type for trait
     fn dummy3(self: &&Bar<T>) {}
     //~^ ERROR mismatched `self` parameter type
-    //~| expected reference `&'a Bar<T>`
-    //~| found reference `&Bar<T>`
+    //~| expected reference `&'a Bar<_>`
+    //~| found reference `&Bar<_>`
     //~| lifetime mismatch
     //~| ERROR mismatched `self` parameter type
-    //~| expected reference `&'a Bar<T>`
-    //~| found reference `&Bar<T>`
+    //~| expected reference `&'a Bar<_>`
+    //~| found reference `&Bar<_>`
     //~| lifetime mismatch
 }
 

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -31,8 +31,8 @@ error[E0308]: mismatched `self` parameter type
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^ lifetime mismatch
    |
-   = note: expected reference `&'a Bar<T>`
-              found reference `&Bar<T>`
+   = note: expected reference `&'a Bar<_>`
+              found reference `&Bar<_>`
 note: the anonymous lifetime defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:37:21
    |
@@ -50,8 +50,8 @@ error[E0308]: mismatched `self` parameter type
 LL |     fn dummy2(self: &Bar<T>) {}
    |                     ^^^^^^^ lifetime mismatch
    |
-   = note: expected reference `&'a Bar<T>`
-              found reference `&Bar<T>`
+   = note: expected reference `&'a Bar<_>`
+              found reference `&Bar<_>`
 note: the lifetime `'a` as defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
@@ -69,8 +69,8 @@ error[E0308]: mismatched `self` parameter type
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                     ^^^^^^^^ lifetime mismatch
    |
-   = note: expected reference `&'a Bar<T>`
-              found reference `&Bar<T>`
+   = note: expected reference `&'a Bar<_>`
+              found reference `&Bar<_>`
 note: the anonymous lifetime defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:40:22
    |
@@ -88,8 +88,8 @@ error[E0308]: mismatched `self` parameter type
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                     ^^^^^^^^ lifetime mismatch
    |
-   = note: expected reference `&'a Bar<T>`
-              found reference `&Bar<T>`
+   = note: expected reference `&'a Bar<_>`
+              found reference `&Bar<_>`
 note: the lifetime `'a` as defined here...
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
@@ -115,8 +115,8 @@ note: type in trait
    |
 LL |     fn dummy2(&self);
    |               ^^^^^
-   = note: expected signature `fn(&&'a Bar<T>)`
-              found signature `fn(&Bar<T>)`
+   = note: expected signature `fn(&&'a Bar<_>)`
+              found signature `fn(&Bar<_>)`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/unsafe/unsafe-trait-impl.rs
+++ b/tests/ui/unsafe/unsafe-trait-impl.rs
@@ -7,8 +7,8 @@ trait Foo {
 impl Foo for u32 {
     fn len(&self) -> u32 { *self }
     //~^ ERROR method `len` has an incompatible type for trait
-    //~| expected signature `unsafe fn(&u32) -> _`
-    //~| found signature `fn(&u32) -> _`
+    //~| expected signature `unsafe fn(&_) -> _`
+    //~| found signature `fn(&_) -> _`
 }
 
 fn main() { }

--- a/tests/ui/unsafe/unsafe-trait-impl.stderr
+++ b/tests/ui/unsafe/unsafe-trait-impl.stderr
@@ -9,8 +9,8 @@ note: type in trait
    |
 LL |     unsafe fn len(&self) -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected signature `unsafe fn(&u32) -> _`
-              found signature `fn(&u32) -> _`
+   = note: expected signature `unsafe fn(&_) -> _`
+              found signature `fn(&_) -> _`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
before: 
![image](https://github.com/rust-lang/rust/assets/23638587/bf6abd62-c7f3-4c09-a47e-31b6e129de19)

after:
![image](https://github.com/rust-lang/rust/assets/23638587/b704d728-ddba-4204-aebe-c07dcbbcb55c)

this diff from the test suite is also quite nice imo:
```diff
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     debug_assert_eq!(iter.next(), Some(value));
    |                                   ^^^^^^^^^^^ expected `Option<<I as Iterator>::Item>`, found `Option<&<I as Iterator>::Item>`
    |
-   = note: expected enum `Option<<I as Iterator>::Item>`
-              found enum `Option<&<I as Iterator>::Item>`
+   = note: expected enum `Option<_>`
+              found enum `Option<&_>`
```