### PR TITLE
temporarily revert "ice on ambguity in mir typeck"

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -157,18 +157,10 @@ where
         }
 
         let mut region_constraints = QueryRegionConstraints::default();
-        let (output, error_info, mut obligations) =
-            Q::fully_perform_into(self, infcx, &mut region_constraints)
-                .map_err(|_| {
-                    infcx.tcx.sess.span_delayed_bug(span, format!("error performing {self:?}"))
-                })
-                .and_then(|(output, error_info, obligations, certainty)| match certainty {
-                    Certainty::Proven => Ok((output, error_info, obligations)),
-                    Certainty::Ambiguous => Err(infcx
-                        .tcx
-                        .sess
-                        .span_delayed_bug(span, format!("ambiguity performing {self:?}"))),
-                })?;
+        let (output, error_info, mut obligations, _) =
+            Q::fully_perform_into(self, infcx, &mut region_constraints).map_err(|_| {
+                infcx.tcx.sess.span_delayed_bug(span, format!("error performing {self:?}"))
+            })?;
 
         // Typically, instantiating NLL query results does not
         // create obligations. However, in some cases there

--- a/tests/ui/wf/unnormalized-projection-guides-inference.rs
+++ b/tests/ui/wf/unnormalized-projection-guides-inference.rs
@@ -1,0 +1,24 @@
+// The WF requirements of the *unnormalized* form of type annotations
+// can guide inference.
+// check-pass
+
+pub trait EqualTo {
+    type Ty;
+}
+impl<X> EqualTo for X {
+    type Ty = X;
+}
+
+trait MyTrait<U: EqualTo<Ty = Self>> {
+    type Out;
+}
+impl<T, U: EqualTo<Ty = T>> MyTrait<U> for T {
+    type Out = ();
+}
+
+fn main() {
+    let _: <_ as MyTrait<u8>>::Out;
+    // We shoud be able to infer a value for the inference variable above.
+    // The WF of the unnormalized projection requires `u8: EqualTo<Ty = _>`,
+    // which is sufficient to guide inference.
+}


### PR DESCRIPTION
Reverts #116530 as a temporary measure to fix #117577. That issue should be ultimately fixed by checking WF of type annotations prior to normalization, which is implemented in #104098 but this PR is intended to be backported to beta.

r? @compiler-errors (the reviewer of the reverted PR)