### PR TITLE
Extend tidy alphabetical checking to `tests/`.

### DIFF
--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -132,6 +132,7 @@ fn main() {
         check!(edition, &library_path);
 
         check!(alphabetical, &src_path);
+        check!(alphabetical, &tests_path);
         check!(alphabetical, &compiler_path);
         check!(alphabetical, &library_path);
 


### PR DESCRIPTION
This is desired for #118702.

r? @Nilstrieb