### PR TITLE
Remove extra check cfg handled by libc directly

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -83,8 +83,6 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Std), "no_global_oom_handling", None),
     (Some(Mode::Std), "no_rc", None),
     (Some(Mode::Std), "no_sync", None),
-    (Some(Mode::Std), "freebsd12", None),
-    (Some(Mode::Std), "freebsd13", None),
     (Some(Mode::Std), "backtrace_in_libstd", None),
     /* Extra values not defined in the built-in targets yet, but used in std */
     (Some(Mode::Std), "target_env", Some(&["libnx"])),


### PR DESCRIPTION
The `libc` crate has handle for quite some time now [check-cfg in it's own build script](https://github.com/rust-lang/libc/blob/497ac428bc010b5db9682ecf94cd567b31d53e5c/build.rs#L6-L32).

We therefor no longer need to manually define them.