### PR TITLE
WIP: optimize process spawning on Linux

### DIFF
--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -93,13 +93,13 @@ pub struct Command {
     /// `args`, followed by a `null`. Be careful when modifying `program` or
     /// `args` to properly update this as well.
     argv: Argv,
-    env: CommandEnv,
+    pub env: CommandEnv,
 
     program_kind: ProgramKind,
     cwd: Option<CString>,
     uid: Option<uid_t>,
     gid: Option<gid_t>,
-    saw_nul: bool,
+    pub saw_nul: bool,
     closures: Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>>,
     groups: Option<Box<[gid_t]>>,
     stdin: Option<Stdio>,
@@ -402,7 +402,7 @@ fn os2c(s: &OsStr, saw_nul: &mut bool) -> CString {
 
 // Helper type to manage ownership of the strings within a C-style array.
 pub struct CStringArray {
-    items: Vec<CString>,
+    pub items: Vec<CString>,
     ptrs: Vec<*const c_char>,
 }
 
@@ -426,7 +426,10 @@ impl CStringArray {
     }
 }
 
-fn construct_envp(env: BTreeMap<OsString, OsString>, saw_nul: &mut bool) -> CStringArray {
+pub(crate) fn construct_envp(
+    env: BTreeMap<OsString, OsString>,
+    saw_nul: &mut bool,
+) -> CStringArray {
     let mut result = CStringArray::with_capacity(env.len());
     for (mut k, v) in env {
         // Reserve additional space for '=' and null terminator

--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -12,9 +12,9 @@ use crate::sys::process::{EnvKey, ExitStatus, Process, StdioPipes};
 // Stores a set of changes to an environment
 #[derive(Clone)]
 pub struct CommandEnv {
-    clear: bool,
+    pub clear: bool,
     saw_path: bool,
-    vars: BTreeMap<EnvKey, Option<OsString>>,
+    pub vars: BTreeMap<EnvKey, Option<OsString>>,
 }
 
 impl Default for CommandEnv {


### PR DESCRIPTION
This PR optimizes process spawning on Linux by avoiding allocations and sorting when copying environment variables. The code is quite WIP, as I'm not sure where should I put this optimized code (`process_unix`, `process_common`?).

I wasn't able to get large speedups by just removing the `BTreeMap`, so I went all the way and tried to remove as many allocations as possible. I created a simple benchmark [here](https://github.com/Kobzol/rust-cmd-spawn-bench) that spawns 8k processes, each with ~200 environment variables. Locally, on my Linux `5.15.0` and glibc `2.35`, the benchmark goes from `~1.4s` to `~1s` after the changes. This is of course a massive stress test for command spawning, for most situations, the perf. improvements will be negligible.

One behaviour change of this PR is that the environment variables are no longer sorted before being passed to the spawned command, but I don't think that it's very important on Linux.

The motivation for this PR is that process spawning on Linux can be quite slow if there are a lot of environment variables, you don't use `Command::env_clear()` and you set some environment variables. In that case, all existing environment variables will be copied (several times), which can be a bottleneck if there are a lot of variables. This has occured to me in [HyperQueue](https://github.com/It4innovations/hyperqueue), which spawns a lot of processes, and this turned out to be a bottleneck in some cases. Some discussion of this problem has happened [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Slow.20command.20spawning).