### PR TITLE
Add an `is_effect` flag to `GenericArgKind`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -607,7 +607,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                     search_stack.push((ty, hir_ty));
                 }
 
-                (GenericArgKind::Const(_ct), hir::GenericArg::Const(_hir_ct)) => {
+                (GenericArgKind::Const(_ct, _), hir::GenericArg::Const(_hir_ct)) => {
                     // Lifetimes cannot be found in consts, so we don't need
                     // to search anything here.
                 }
@@ -615,7 +615,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
                 (
                     GenericArgKind::Lifetime(_)
                     | GenericArgKind::Type(_)
-                    | GenericArgKind::Const(_),
+                    | GenericArgKind::Const(_, _),
                     _,
                 ) => {
                     // HIR lowering sometimes doesn't catch this in erroneous

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -392,7 +392,7 @@ fn check_opaque_type_parameter_valid(
             // see that issue for more. We will also have to ignore unused lifetime
             // params for RPIT, but that's comparatively trivial ✨
             GenericArgKind::Lifetime(_) => continue,
-            GenericArgKind::Const(ct) => matches!(ct.kind(), ty::ConstKind::Param(_)),
+            GenericArgKind::Const(ct, _) => matches!(ct.kind(), ty::ConstKind::Param(_)),
         };
 
         if arg_is_param {

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -162,7 +162,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
                 .type_must_outlive(origin, t1, r2, constraint_category);
             }
 
-            GenericArgKind::Const(_) => unreachable!(),
+            GenericArgKind::Const(_, _) => unreachable!(),
         }
     }
 

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -644,7 +644,7 @@ fn push_generic_params_internal<'tcx>(
             GenericArgKind::Type(type_parameter) => {
                 push_debuginfo_type_name(tcx, type_parameter, true, output, visited);
             }
-            GenericArgKind::Const(ct) => {
+            GenericArgKind::Const(ct, false) => {
                 push_const_param(tcx, ct, output);
             }
             other => bug!("Unexpected non-erasable generic: {:?}", other),

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -172,7 +172,9 @@ impl Qualif for NeedsNonConstDrop {
                 destruct_def_id,
                 [
                     ty::GenericArg::from(ty),
-                    ty::GenericArg::from(cx.tcx.expected_const_effect_param_for_body(cx.def_id())),
+                    ty::GenericArg::effect_const_arg(
+                        cx.tcx.expected_const_effect_param_for_body(cx.def_id()),
+                    ),
                 ],
             ),
         );

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -361,7 +361,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                             )
                             .into()
                         }
-                        ty::GenericParamDefKind::Const { .. } => {
+                        ty::GenericParamDefKind::Const { is_host_effect, .. } => {
                             if !emitted_bad_param_err {
                                 tcx.sess.emit_err(
                                     crate::errors::ReturnTypeNotationIllegalParam::Const {
@@ -375,13 +375,16 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                                 .type_of(param.def_id)
                                 .no_bound_vars()
                                 .expect("ct params cannot have early bound vars");
-                            ty::Const::new_bound(
-                                tcx,
-                                ty::INNERMOST,
-                                ty::BoundVar::from_usize(num_bound_vars),
-                                ty,
+                            // FIXME(fee1-dead) this seems like something that's very commonly written
+                            ty::GenericArg::new_const(
+                                ty::Const::new_bound(
+                                    tcx,
+                                    ty::INNERMOST,
+                                    ty::BoundVar::from_usize(num_bound_vars),
+                                    ty,
+                                ),
+                                is_host_effect,
                             )
-                            .into()
                         }
                     };
                     num_bound_vars += 1;

--- a/compiler/rustc_hir_analysis/src/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/bounds.rs
@@ -56,7 +56,11 @@ impl<'tcx> Bounds<'tcx> {
             let trait_ref = trait_ref.map_bound(|mut trait_ref| {
                 trait_ref.args =
                     tcx.mk_args_from_iter(trait_ref.args.iter().enumerate().map(|(n, arg)| {
-                        if host_index == n { tcx.consts.true_.into() } else { arg }
+                        if host_index == n {
+                            ty::GenericArg::effect_const_arg(tcx.consts.true_)
+                        } else {
+                            arg
+                        }
                     }));
                 trait_ref
             });

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -2357,18 +2357,20 @@ fn param_env_with_gat_bounds<'tcx>(
                     )
                     .into()
                 }
-                GenericParamDefKind::Const { .. } => {
+                GenericParamDefKind::Const { is_host_effect, .. } => {
                     let bound_var = ty::BoundVariableKind::Const;
                     bound_vars.push(bound_var);
-                    ty::Const::new_bound(
-                        tcx,
-                        ty::INNERMOST,
-                        ty::BoundVar::from_usize(bound_vars.len() - 1),
-                        tcx.type_of(param.def_id)
-                            .no_bound_vars()
-                            .expect("const parameter types cannot be generic"),
+                    ty::GenericArg::new_const(
+                        ty::Const::new_bound(
+                            tcx,
+                            ty::INNERMOST,
+                            ty::BoundVar::from_usize(bound_vars.len() - 1),
+                            tcx.type_of(param.def_id)
+                                .no_bound_vars()
+                                .expect("const parameter types cannot be generic"),
+                        ),
+                        is_host_effect,
                     )
-                    .into()
                 }
             });
         // When checking something like

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1328,7 +1328,7 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                     }
                 }
             }
-            GenericParamDefKind::Const { .. } => {
+            GenericParamDefKind::Const { is_host_effect, .. } => {
                 if is_our_default(param) {
                     // FIXME(const_generics_defaults): This
                     // is incorrect when dealing with unused args, for example
@@ -1339,7 +1339,7 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                         wfcx.register_wf_obligation(
                             tcx.def_span(param.def_id),
                             None,
-                            default_ct.into(),
+                            ty::GenericArg::new_const(default_ct, is_host_effect),
                         );
                     }
                 }
@@ -1377,14 +1377,14 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
 
                 tcx.mk_param_from_def(param)
             }
-            GenericParamDefKind::Const { .. } => {
+            GenericParamDefKind::Const { is_host_effect, .. } => {
                 // If the param has a default, ...
                 if is_our_default(param) {
                     let default_ct = tcx.const_param_default(param.def_id).instantiate_identity();
                     // ... and it's not a dependent default, ...
                     if !default_ct.has_param() {
                         // ... then substitute it with the default.
-                        return default_ct.into();
+                        return ty::GenericArg::new_const(default_ct, is_host_effect);
                     }
                 }
 

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -47,7 +47,7 @@ pub(super) fn predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericPredic
                     def_id,
                     ty::GenericArgs::for_item(tcx, def_id, |param, _| {
                         if param.is_host_effect() {
-                            tcx.consts.true_.into()
+                            ty::GenericArg::effect_const_arg(tcx.consts.true_)
                         } else {
                             tcx.mk_param_from_def(param)
                         }

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -100,7 +100,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
 
             // No predicates from lifetimes or constants, except potentially
             // constants' types, but `walk` will get to them as well.
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_, _) => continue,
         };
 
         match *ty.kind() {

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -115,7 +115,7 @@ fn inferred_outlives_crate(tcx: TyCtxt<'_>, (): ()) -> CratePredicatesMap<'_> {
                                 .to_predicate(tcx),
                                 span,
                             )),
-                            GenericArgKind::Const(_) => {
+                            GenericArgKind::Const(_, _) => {
                                 // Generic consts don't impose any constraints.
                                 None
                             }

--- a/compiler/rustc_hir_analysis/src/outlives/utils.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/utils.rs
@@ -138,7 +138,7 @@ pub(crate) fn insert_outlives_predicate<'tcx>(
             required_predicates.entry(ty::OutlivesPredicate(kind, outlived_region)).or_insert(span);
         }
 
-        GenericArgKind::Const(_) => {
+        GenericArgKind::Const(_, _) => {
             // Generic consts don't impose any constraints.
         }
     }

--- a/compiler/rustc_hir_analysis/src/variance/constraints.rs
+++ b/compiler/rustc_hir_analysis/src/variance/constraints.rs
@@ -205,7 +205,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                     self.add_constraints_from_region(current, lt, variance_i)
                 }
                 GenericArgKind::Type(ty) => self.add_constraints_from_ty(current, ty, variance_i),
-                GenericArgKind::Const(val) => {
+                GenericArgKind::Const(val, _) => {
                     self.add_constraints_from_const(current, val, variance_i)
                 }
             }
@@ -364,7 +364,7 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                     self.add_constraints_from_region(current, lt, variance_i)
                 }
                 GenericArgKind::Type(ty) => self.add_constraints_from_ty(current, ty, variance_i),
-                GenericArgKind::Const(val) => {
+                GenericArgKind::Const(val, _) => {
                     self.add_constraints_from_const(current, val, variance)
                 }
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -39,8 +39,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     (pred.trait_ref.args.to_vec(), Some(pred.self_ty().into()))
                 }
                 ty::ClauseKind::Projection(pred) => (pred.projection_ty.args.to_vec(), None),
-                ty::ClauseKind::ConstArgHasType(arg, ty) => (vec![ty.into(), arg.into()], None),
-                ty::ClauseKind::ConstEvaluatable(e) => (vec![e.into()], None),
+                ty::ClauseKind::ConstArgHasType(arg, ty) => {
+                    (vec![ty.into(), ty::GenericArg::normal_const_arg(arg)], None)
+                }
+                ty::ClauseKind::ConstEvaluatable(e) => {
+                    (vec![ty::GenericArg::normal_const_arg(e)], None)
+                }
                 _ => return false,
             };
 
@@ -52,7 +56,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         && matches(ty::ParamTerm::Ty(param_ty))
                     {
                         Some(arg)
-                    } else if let ty::GenericArgKind::Const(ct) = arg.unpack()
+                    } else if let ty::GenericArgKind::Const(ct, _) = arg.unpack()
                         && let ty::ConstKind::Param(param_ct) = ct.kind()
                         && matches(ty::ParamTerm::Const(param_ct))
                     {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1562,15 +1562,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     kind: TypeVariableOriginKind::MiscVariable,
                                 })
                                 .into(),
-                            GenericArgKind::Const(arg) => self
-                                .next_const_var(
+                            GenericArgKind::Const(arg, is_effect) => ty::GenericArg::new_const(
+                                self.next_const_var(
                                     arg.ty(),
                                     ConstVariableOrigin {
                                         span: rustc_span::DUMMY_SP,
                                         kind: ConstVariableOriginKind::MiscVariable,
                                     },
-                                )
-                                .into(),
+                                ),
+                                is_effect,
+                            ),
                         }
                     } else {
                         arg

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -814,7 +814,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Resolver<'cx, 'tcx> {
             Ok(ct) => self.fcx.tcx.erase_regions(ct),
             Err(_) => {
                 debug!("Resolver::fold_const: input const `{:?}` not fully resolvable", ct);
-                let e = self.report_error(ct);
+                let e = self.report_error(ty::GenericArg::normal_const_arg(ct));
                 self.replaced_with_error = Some(e);
                 ty::Const::new_error(self.fcx.tcx, e, ct.ty())
             }

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -414,13 +414,13 @@ impl<'tcx> ToTrace<'tcx> for ty::GenericArg<'tcx> {
             values: match (a.unpack(), b.unpack()) {
                 (Lifetime(a), Lifetime(b)) => Regions(ExpectedFound::new(a_is_expected, a, b)),
                 (Type(a), Type(b)) => Terms(ExpectedFound::new(a_is_expected, a.into(), b.into())),
-                (Const(a), Const(b)) => {
+                (Const(a, _), Const(b, _)) => {
                     Terms(ExpectedFound::new(a_is_expected, a.into(), b.into()))
                 }
 
-                (Lifetime(_), Type(_) | Const(_))
-                | (Type(_), Lifetime(_) | Const(_))
-                | (Const(_), Lifetime(_) | Type(_)) => {
+                (Lifetime(_), Type(_) | Const(_, _))
+                | (Type(_), Lifetime(_) | Const(_, _))
+                | (Const(_, _), Lifetime(_) | Type(_)) => {
                     bug!("relating different kinds: {a:?} {b:?}")
                 }
             },

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -807,7 +807,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         if bound_to != const_var {
             self.fold_const(bound_to)
         } else {
-            let var = self.canonical_var(info, const_var.into());
+            let var = self.canonical_var(info, ty::GenericArg::normal_const_arg(const_var));
             ty::Const::new_bound(self.tcx, self.binder_index, var, self.fold_ty(const_var.ty()))
         }
     }

--- a/compiler/rustc_infer/src/infer/canonical/mod.rs
+++ b/compiler/rustc_infer/src/infer/canonical/mod.rs
@@ -144,22 +144,29 @@ impl<'tcx> InferCtxt<'tcx> {
                 ty::Region::new_placeholder(self.tcx, placeholder_mapped).into()
             }
 
-            CanonicalVarKind::Const(ui, ty) => self
-                .next_const_var_in_universe(
+            CanonicalVarKind::Const(ui, ty) => {
+                ty::GenericArg::normal_const_arg(self.next_const_var_in_universe(
                     ty,
                     ConstVariableOrigin { kind: ConstVariableOriginKind::MiscVariable, span },
                     universe_map(ui),
-                )
-                .into(),
+                ))
+            }
             CanonicalVarKind::Effect => {
                 let vid = self.inner.borrow_mut().effect_unification_table().new_key(None).vid;
-                ty::Const::new_infer(self.tcx, ty::InferConst::EffectVar(vid), self.tcx.types.bool)
-                    .into()
+                ty::GenericArg::effect_const_arg(ty::Const::new_infer(
+                    self.tcx,
+                    ty::InferConst::EffectVar(vid),
+                    self.tcx.types.bool,
+                ))
             }
             CanonicalVarKind::PlaceholderConst(ty::PlaceholderConst { universe, bound }, ty) => {
                 let universe_mapped = universe_map(universe);
                 let placeholder_mapped = ty::PlaceholderConst { universe: universe_mapped, bound };
-                ty::Const::new_placeholder(self.tcx, placeholder_mapped, ty).into()
+                ty::GenericArg::normal_const_arg(ty::Const::new_placeholder(
+                    self.tcx,
+                    placeholder_mapped,
+                    ty,
+                ))
             }
         }
     }

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -301,7 +301,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     .relate(v1, v2)?;
                 }
 
-                (GenericArgKind::Const(v1), GenericArgKind::Const(v2)) => {
+                (GenericArgKind::Const(v1, _), GenericArgKind::Const(v2, _)) => {
                     TypeRelating::new(
                         self,
                         QueryTypeRelatingDelegate {
@@ -468,7 +468,7 @@ impl<'tcx> InferCtxt<'tcx> {
                         opt_values[br.var] = Some(*original_value);
                     }
                 }
-                GenericArgKind::Const(result_value) => {
+                GenericArgKind::Const(result_value, _) => {
                     if let ty::ConstKind::Bound(debruijn, b) = result_value.kind() {
                         // ...in which case we would set `canonical_vars[0]` to `Some(const X)`.
 
@@ -635,7 +635,7 @@ impl<'tcx> InferCtxt<'tcx> {
                                 .into_obligations(),
                         );
                     }
-                    (GenericArgKind::Const(v1), GenericArgKind::Const(v2)) => {
+                    (GenericArgKind::Const(v1, _), GenericArgKind::Const(v2, _)) => {
                         let ok = self.at(cause, param_env).eq(DefineOpaqueTypes::Yes, v1, v2)?;
                         obligations.extend(ok.into_obligations());
                     }

--- a/compiler/rustc_infer/src/infer/canonical/substitute.rs
+++ b/compiler/rustc_infer/src/infer/canonical/substitute.rs
@@ -83,7 +83,7 @@ where
                 r => bug!("{:?} is a type but value is {:?}", bound_ty, r),
             },
             consts: &mut |bound_ct: ty::BoundVar, _| match var_values[bound_ct].unpack() {
-                GenericArgKind::Const(ct) => ct,
+                GenericArgKind::Const(ct, _) => ct,
                 c => bug!("{:?} is a const but value is {:?}", bound_ct, c),
             },
         };

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -356,7 +356,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 .filter(|(i, _)| variances[*i] == ty::Variance::Invariant)
                 .filter_map(|(_, arg)| match arg.unpack() {
                     GenericArgKind::Lifetime(r) => Some(r),
-                    GenericArgKind::Type(_) | GenericArgKind::Const(_) => None,
+                    GenericArgKind::Type(_) | GenericArgKind::Const(_, _) => None,
                 })
                 .chain(std::iter::once(self.tcx.lifetimes.re_static))
                 .collect(),

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -86,7 +86,7 @@ fn compute_components<'tcx>(
                             compute_components(tcx, ty, out, visited);
                         }
                         GenericArgKind::Lifetime(_) => {}
-                        GenericArgKind::Const(_) => {
+                        GenericArgKind::Const(_, _) => {
                             compute_components_recursive(tcx, child, out, visited);
                         }
                     }
@@ -222,7 +222,7 @@ pub(super) fn compute_alias_components_recursive<'tcx>(
                     out.push(Component::Region(lt));
                 }
             }
-            GenericArgKind::Const(_) => {
+            GenericArgKind::Const(_, _) => {
                 compute_components_recursive(tcx, child, out, visited);
             }
         }
@@ -250,7 +250,7 @@ fn compute_components_recursive<'tcx>(
                     out.push(Component::Region(lt));
                 }
             }
-            GenericArgKind::Const(_) => {
+            GenericArgKind::Const(_, _) => {
                 compute_components_recursive(tcx, child, out, visited);
             }
         }

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -444,7 +444,7 @@ where
                 GenericArgKind::Type(ty) => {
                     self.type_must_outlive(origin.clone(), ty, region, constraint);
                 }
-                GenericArgKind::Const(_) => {
+                GenericArgKind::Const(_, _) => {
                     // Const parameters don't impose constraints.
                 }
             }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -158,6 +158,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     ) -> Self::Const {
         Const::new_bound(self, debruijn, var, ty)
     }
+
+    fn mk_const_arg(self, ct: Self::Const, is_effect: bool) -> Self::GenericArg {
+        GenericArg::new_const(ct, is_effect)
+    }
 }
 
 type InternedSet<'tcx, T> = ShardedHashMap<InternedInSet<'tcx, T>, ()>;

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1826,14 +1826,16 @@ impl<'tcx> TyCtxt<'tcx> {
                 ty::Region::new_early_param(self, param.to_early_bound_region_data()).into()
             }
             GenericParamDefKind::Type { .. } => Ty::new_param(self, param.index, param.name).into(),
-            GenericParamDefKind::Const { .. } => ty::Const::new_param(
-                self,
-                ParamConst { index: param.index, name: param.name },
-                self.type_of(param.def_id)
-                    .no_bound_vars()
-                    .expect("const parameter types cannot be generic"),
-            )
-            .into(),
+            GenericParamDefKind::Const { is_host_effect, .. } => GenericArg::new_const(
+                ty::Const::new_param(
+                    self,
+                    ParamConst { index: param.index, name: param.name },
+                    self.type_of(param.def_id)
+                        .no_bound_vars()
+                        .expect("const parameter types cannot be generic"),
+                ),
+                is_host_effect,
+            ),
         }
     }
 

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -201,9 +201,10 @@ impl DeepRejectCtxt {
                 (GenericArgKind::Type(obl), GenericArgKind::Type(imp)) => {
                     self.types_may_unify(obl, imp)
                 }
-                (GenericArgKind::Const(obl), GenericArgKind::Const(imp)) => {
-                    self.consts_may_unify(obl, imp)
-                }
+                (
+                    GenericArgKind::Const(obl, is_effect_a),
+                    GenericArgKind::Const(imp, is_effect_b),
+                ) if is_effect_a == is_effect_b => self.consts_may_unify(obl, imp),
                 _ => bug!("kind mismatch: {obl} {imp}"),
             }
         })

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -375,7 +375,7 @@ impl FlagComputation {
             match kind.unpack() {
                 GenericArgKind::Type(ty) => self.add_ty(ty),
                 GenericArgKind::Lifetime(lt) => self.add_region(lt),
-                GenericArgKind::Const(ct) => self.add_const(ct),
+                GenericArgKind::Const(ct, _) => self.add_const(ct),
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/generic_args.rs
+++ b/compiler/rustc_middle/src/ty/generic_args.rs
@@ -113,6 +113,15 @@ impl<'tcx> From<Ty<'tcx>> for GenericArg<'tcx> {
     }
 }
 
+impl<'tcx> From<ty::Term<'tcx>> for GenericArg<'tcx> {
+    fn from(value: ty::Term<'tcx>) -> Self {
+        match value.unpack() {
+            ty::TermKind::Ty(t) => t.into(),
+            ty::TermKind::Const(c) => Self::new_const(c, false),
+        }
+    }
+}
+
 impl<'tcx> GenericArg<'tcx> {
     #[inline]
     pub fn unpack(self) -> GenericArgKind<'tcx> {

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -346,7 +346,9 @@ impl<'tcx> Instance<'tcx> {
     pub fn mono(tcx: TyCtxt<'tcx>, def_id: DefId) -> Instance<'tcx> {
         let args = GenericArgs::for_item(tcx, def_id, |param, _| match param.kind {
             ty::GenericParamDefKind::Lifetime => tcx.lifetimes.re_erased.into(),
-            ty::GenericParamDefKind::Const { is_host_effect: true, .. } => tcx.consts.true_.into(),
+            ty::GenericParamDefKind::Const { is_host_effect: true, .. } => {
+                ty::GenericArg::effect_const_arg(tcx.consts.true_)
+            }
             ty::GenericParamDefKind::Type { .. } => {
                 bug!("Instance::mono: {:?} has type parameters", def_id)
             }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -934,13 +934,6 @@ impl<'tcx> Term<'tcx> {
         if let TermKind::Const(c) = self.unpack() { Some(c) } else { None }
     }
 
-    pub fn into_arg(self) -> GenericArg<'tcx> {
-        match self.unpack() {
-            TermKind::Ty(ty) => ty.into(),
-            TermKind::Const(c) => c.into(),
-        }
-    }
-
     /// This function returns the inner `AliasTy` for a `ty::Alias` or `ConstKind::Unevaluated`.
     pub fn to_alias_ty(&self, tcx: TyCtxt<'tcx>) -> Option<AliasTy<'tcx>> {
         match self.unpack() {

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -201,7 +201,8 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for NormalizeAfterErasingRegionsFolder<'tcx>
     }
 
     fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        self.normalize_generic_arg_after_erasing_regions(c.into()).expect_const()
+        self.normalize_generic_arg_after_erasing_regions(ty::GenericArg::normal_const_arg(c))
+            .expect_const()
     }
 }
 
@@ -242,7 +243,9 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for TryNormalizeAfterErasingRegionsF
     }
 
     fn try_fold_const(&mut self, c: ty::Const<'tcx>) -> Result<ty::Const<'tcx>, Self::Error> {
-        match self.try_normalize_generic_arg_after_erasing_regions(c.into()) {
+        match self
+            .try_normalize_generic_arg_after_erasing_regions(ty::GenericArg::normal_const_arg(c))
+        {
             Ok(t) => Ok(t.expect_const()),
             Err(_) => Err(NormalizationError::Const(c)),
         }

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -200,10 +200,10 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
         match ct.kind() {
             ty::ConstKind::Param(..) => {
                 // Look it up in the substitution list.
-                match self.map.get(&ct.into()).map(|k| k.unpack()) {
+                match self.map.get(&GenericArg::normal_const_arg(ct)).map(|k| k.unpack()) {
                     // Found it in the substitution list, replace with the parameter from the
                     // opaque type.
-                    Some(GenericArgKind::Const(c1)) => c1,
+                    Some(GenericArgKind::Const(c1, _)) => c1,
                     Some(u) => panic!("const mapped to unexpected kind: {u:?}"),
                     None => {
                         let guar = self

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -774,8 +774,11 @@ impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
             (GenericArgKind::Type(a_ty), GenericArgKind::Type(b_ty)) => {
                 Ok(relation.relate(a_ty, b_ty)?.into())
             }
-            (GenericArgKind::Const(a_ct), GenericArgKind::Const(b_ct)) => {
-                Ok(relation.relate(a_ct, b_ct)?.into())
+            (
+                GenericArgKind::Const(a_ct, is_effect_a),
+                GenericArgKind::Const(b_ct, is_effect_b),
+            ) if is_effect_a == is_effect_b => {
+                Ok(GenericArg::new_const(relation.relate(a_ct, b_ct)?, is_effect_a))
             }
             (GenericArgKind::Lifetime(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
@@ -783,7 +786,7 @@ impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
             (GenericArgKind::Type(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
-            (GenericArgKind::Const(unpacked), x) => {
+            (GenericArgKind::Const(unpacked, _), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
         }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -316,7 +316,7 @@ impl<'tcx> fmt::Debug for GenericArg<'tcx> {
         match self.unpack() {
             GenericArgKind::Lifetime(lt) => lt.fmt(f),
             GenericArgKind::Type(ty) => ty.fmt(f),
-            GenericArgKind::Const(ct) => ct.fmt(f),
+            GenericArgKind::Const(ct, _) => ct.fmt(f),
         }
     }
 }
@@ -327,7 +327,9 @@ impl<'tcx> DebugWithInfcx<TyCtxt<'tcx>> for GenericArg<'tcx> {
     ) -> core::fmt::Result {
         match this.data.unpack() {
             GenericArgKind::Lifetime(lt) => write!(f, "{:?}", &this.wrap(lt)),
-            GenericArgKind::Const(ct) => write!(f, "{:?}", &this.wrap(ct)),
+            GenericArgKind::Const(ct, is_effect) => {
+                write!(f, "{:?}{}", &this.wrap(ct), if is_effect { " (effect arg)" } else { "" })
+            }
             GenericArgKind::Type(ty) => write!(f, "{:?}", &this.wrap(ty)),
         }
     }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -647,7 +647,7 @@ impl<'tcx> IsIdentity for CanonicalUserType<'tcx> {
                             _ => false,
                         },
 
-                        GenericArgKind::Const(ct) => match ct.kind() {
+                        GenericArgKind::Const(ct, _) => match ct.kind() {
                             ty::ConstKind::Bound(debruijn, b) => {
                                 // We only allow a `ty::INNERMOST` index in substitutions.
                                 assert_eq!(debruijn, ty::INNERMOST);

--- a/compiler/rustc_next_trait_solver/src/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonicalizer.rs
@@ -409,9 +409,9 @@ impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I>
         };
 
         let var = ty::BoundVar::from(
-            self.variables.iter().position(|&v| v == c.into()).unwrap_or_else(|| {
+            self.variables.iter().position(|&v| v.as_const() == Some(c)).unwrap_or_else(|| {
                 let var = self.variables.len();
-                self.variables.push(c.into());
+                self.variables.push(ty::GenericArg::new_const(c, kind == CanonicalVarKind::Effect));
                 self.primitive_var_infos.push(CanonicalVarInfo { kind });
                 var
             }),

--- a/compiler/rustc_next_trait_solver/src/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonicalizer.rs
@@ -409,12 +409,16 @@ impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I>
         };
 
         let var = ty::BoundVar::from(
-            self.variables.iter().position(|&v| v.as_const() == Some(c)).unwrap_or_else(|| {
-                let var = self.variables.len();
-                self.variables.push(ty::GenericArg::new_const(c, kind == CanonicalVarKind::Effect));
-                self.primitive_var_infos.push(CanonicalVarInfo { kind });
-                var
-            }),
+            self.variables
+                .iter()
+                .position(|&v| self.interner().mk_const_arg(c, false) == v)
+                .unwrap_or_else(|| {
+                    let var = self.variables.len();
+                    self.variables
+                        .push(self.interner().mk_const_arg(c, kind == CanonicalVarKind::Effect));
+                    self.primitive_var_infos.push(CanonicalVarInfo { kind });
+                    var
+                }),
         );
 
         self.interner().mk_bound_const(self.binder_index, var, c.ty())

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -47,7 +47,9 @@ impl<'tcx> RustcInternal<'tcx> for GenericArgKind {
         match self {
             GenericArgKind::Lifetime(reg) => reg.internal(tables).into(),
             GenericArgKind::Type(ty) => ty.internal(tables).into(),
-            GenericArgKind::Const(cnst) => ty_const(cnst, tables).into(),
+            GenericArgKind::Const(cnst) => {
+                rustc_ty::GenericArg::normal_const_arg(ty_const(cnst, tables))
+            }
         }
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -163,7 +163,7 @@ impl<'tcx> Stable<'tcx> for ty::GenericArgKind<'tcx> {
         match self {
             ty::GenericArgKind::Lifetime(region) => GenericArgKind::Lifetime(region.stable(tables)),
             ty::GenericArgKind::Type(ty) => GenericArgKind::Type(ty.stable(tables)),
-            ty::GenericArgKind::Const(cnst) => GenericArgKind::Const(cnst.stable(tables)),
+            ty::GenericArgKind::Const(cnst, _) => GenericArgKind::Const(cnst.stable(tables)),
         }
     }
 }

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -319,7 +319,7 @@ fn encode_args<'tcx>(
                 GenericArgKind::Type(ty) => {
                     s.push_str(&encode_ty(tcx, ty, dict, options));
                 }
-                GenericArgKind::Const(c) => {
+                GenericArgKind::Const(c, _) => {
                     s.push_str(&encode_const(tcx, c, dict, options));
                 }
             }

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -808,6 +808,8 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
         });
         let args = args.iter().cloned().filter(|arg| match arg.unpack() {
             GenericArgKind::Lifetime(_) => print_regions,
+            // don't print effect parameters
+            GenericArgKind::Const(_, true) => false,
             _ => true,
         });
 
@@ -825,7 +827,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
                 GenericArgKind::Type(ty) => {
                     ty.print(self)?;
                 }
-                GenericArgKind::Const(c) => {
+                GenericArgKind::Const(c, _) => {
                     self.push("K");
                     c.print(self)?;
                 }

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/canonical.rs
@@ -265,7 +265,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
                         opt_values[br.var] = Some(*original_value);
                     }
                 }
-                GenericArgKind::Const(c) => {
+                GenericArgKind::Const(c, _) => {
                     if let ty::ConstKind::Bound(debruijn, b) = c.kind() {
                         assert_eq!(debruijn, ty::INNERMOST);
                         opt_values[b] = Some(*original_value);
@@ -340,7 +340,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
             match lhs.unpack() {
                 GenericArgKind::Lifetime(lhs) => self.register_region_outlives(lhs, rhs),
                 GenericArgKind::Type(lhs) => self.register_ty_outlives(lhs, rhs),
-                GenericArgKind::Const(_) => bug!("const outlives: {lhs:?}: {rhs:?}"),
+                GenericArgKind::Const(_, _) => bug!("const outlives: {lhs:?}: {rhs:?}"),
             }
         }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2611,7 +2611,11 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     .projection_ty
                     .args
                     .iter()
-                    .chain(Some(data.term.into_arg()))
+                    .chain(Some(match data.term.unpack() {
+                        ty::TermKind::Ty(ty) => ty.into(),
+                        // FIXME(effects) is this correct
+                        ty::TermKind::Const(ct) => ty::GenericArg::normal_const_arg(ct),
+                    }))
                     .find(|g| g.has_non_region_infer());
                 if let Some(subst) = subst {
                     let mut err = self.emit_inference_failure_err(

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -184,7 +184,7 @@ pub fn compute_implied_outlives_bounds_inner<'tcx>(
                 push_outlives_components(tcx, ty_a, &mut components);
                 implied_bounds.extend(implied_bounds_from_components(r_b, components))
             }
-            ty::GenericArgKind::Const(_) => unreachable!(),
+            ty::GenericArgKind::Const(_, _) => unreachable!(),
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -304,7 +304,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 ty::GenericArg::from(to_ty),
                                 ty::GenericArg::from(from_ty),
                                 ty::GenericArg::from(scope),
-                                ty::GenericArg::from(assume_const),
+                                ty::GenericArg::normal_const_arg(assume_const),
                             ],
                         );
                         Obligation::with_depth(
@@ -608,18 +608,20 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                             )
                             .into()
                         }
-                        GenericParamDefKind::Const { .. } => {
+                        GenericParamDefKind::Const { is_host_effect, .. } => {
                             let bound_var = ty::BoundVariableKind::Const;
                             bound_vars.push(bound_var);
-                            ty::Const::new_bound(
-                                tcx,
-                                ty::INNERMOST,
-                                ty::BoundVar::from_usize(bound_vars.len() - 1),
-                                tcx.type_of(param.def_id)
-                                    .no_bound_vars()
-                                    .expect("const parameter types cannot be generic"),
+                            ty::GenericArg::new_const(
+                                ty::Const::new_bound(
+                                    tcx,
+                                    ty::INNERMOST,
+                                    ty::BoundVar::from_usize(bound_vars.len() - 1),
+                                    tcx.type_of(param.def_id)
+                                        .no_bound_vars()
+                                        .expect("const parameter types cannot be generic"),
+                                ),
+                                is_host_effect,
                             )
-                            .into()
                         }
                     });
                     let bound_vars = tcx.mk_bound_variable_kinds(&bound_vars);

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -1213,8 +1213,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         else {
             bug!()
         };
-        let host_effect_param: ty::GenericArg<'tcx> =
-            obligation.predicate.skip_binder().trait_ref.args.const_at(host_effect_index).into();
+        let host_effect_param = ty::GenericArg::effect_const_arg(
+            obligation.predicate.skip_binder().trait_ref.args.const_at(host_effect_index),
+        );
 
         let drop_trait = self.tcx().require_lang_item(LangItem::Drop, None);
 

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -354,10 +354,13 @@ pub fn check_args_compatible<'tcx>(
         }
 
         for (param, arg) in std::iter::zip(&generics.params, own_args) {
-            match (&param.kind, arg.unpack()) {
+            match (param.kind, arg.unpack()) {
                 (ty::GenericParamDefKind::Type { .. }, ty::GenericArgKind::Type(_))
-                | (ty::GenericParamDefKind::Lifetime, ty::GenericArgKind::Lifetime(_))
-                | (ty::GenericParamDefKind::Const { .. }, ty::GenericArgKind::Const(_)) => {}
+                | (ty::GenericParamDefKind::Lifetime, ty::GenericArgKind::Lifetime(_)) => {}
+                (
+                    ty::GenericParamDefKind::Const { is_host_effect, .. },
+                    ty::GenericArgKind::Const(_, is_effect),
+                ) if is_host_effect == is_effect => {}
                 _ => return false,
             }
         }

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -320,7 +320,7 @@ fn unsizing_params_for_adt<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> BitSet<u32
         // We can't unsize a lifetime
         ty::GenericArgKind::Lifetime(_) => None,
 
-        ty::GenericArgKind::Const(ct) => match ct.kind() {
+        ty::GenericArgKind::Const(ct, _) => match ct.kind() {
             ty::ConstKind::Param(p) => Some(p.index),
             _ => None,
         },

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -47,7 +47,6 @@ pub trait Interner: Sized {
         + DebugWithInfcx<Self>
         + Hash
         + Ord
-        + Into<Self::GenericArg>
         + IntoKind<Kind = ConstKind<Self>>
         + ConstTy<Self>;
     type AliasConst: Copy + DebugWithInfcx<Self> + Hash + Ord;
@@ -89,6 +88,8 @@ pub trait Interner: Sized {
     fn mk_bound_ty(self, debruijn: DebruijnIndex, var: BoundVar) -> Self::Ty;
     fn mk_bound_region(self, debruijn: DebruijnIndex, var: BoundVar) -> Self::Region;
     fn mk_bound_const(self, debruijn: DebruijnIndex, var: BoundVar, ty: Self::Ty) -> Self::Const;
+
+    fn mk_const_arg(self, ct: Self::Const, is_effect: bool) -> Self::GenericArg;
 }
 
 /// Common capabilities of placeholder kinds

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -123,9 +123,13 @@ pub(crate) fn ty_args_to_args<'tcx>(
                 }),
             )))
         }
-        GenericArgKind::Const(ct) => {
+        GenericArgKind::Const(ct, is_effect) => {
             if let ty::GenericParamDefKind::Const { is_host_effect: true, .. } = params[index].kind
             {
+                return None;
+            }
+
+            if is_effect {
                 return None;
             }
 

--- a/src/tools/clippy/clippy_lints/src/derive.rs
+++ b/src/tools/clippy/clippy_lints/src/derive.rs
@@ -349,7 +349,7 @@ fn check_copy_clone<'tcx>(cx: &LateContext<'tcx>, item: &Item<'_>, trait_ref: &h
     if ty_adt.repr().packed()
         && ty_subs
             .iter()
-            .any(|arg| matches!(arg.unpack(), GenericArgKind::Type(_) | GenericArgKind::Const(_)))
+            .any(|arg| matches!(arg.unpack(), GenericArgKind::Type(_) | GenericArgKind::Const(..)))
     {
         return;
     }

--- a/src/tools/clippy/clippy_lints/src/eta_reduction.rs
+++ b/src/tools/clippy/clippy_lints/src/eta_reduction.rs
@@ -267,7 +267,7 @@ fn has_late_bound_to_non_late_bound_regions(from_sig: FnSig<'_>, to_sig: FnSig<'
                         return true;
                     }
                 },
-                (GenericArgKind::Const(_), GenericArgKind::Const(_)) => (),
+                (GenericArgKind::Const(..), GenericArgKind::Const(..)) => (),
                 _ => return true,
             }
         }

--- a/src/tools/clippy/clippy_lints/src/let_underscore.rs
+++ b/src/tools/clippy/clippy_lints/src/let_underscore.rs
@@ -146,7 +146,7 @@ impl<'tcx> LateLintPass<'tcx> for LetUnderscore {
             let init_ty = cx.typeck_results().expr_ty(init);
             let contains_sync_guard = init_ty.walk().any(|inner| match inner.unpack() {
                 GenericArgKind::Type(inner_ty) => SYNC_GUARD_PATHS.iter().any(|path| match_type(cx, inner_ty, path)),
-                GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+                GenericArgKind::Lifetime(_) | GenericArgKind::Const(..) => false,
             });
             if contains_sync_guard {
                 span_lint_and_help(

--- a/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
+++ b/src/tools/clippy/clippy_lints/src/non_send_fields_in_send_ty.rs
@@ -213,7 +213,7 @@ fn ty_allowed_with_raw_pointer_heuristic<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'t
                 args.iter().all(|generic_arg| match generic_arg.unpack() {
                     GenericArgKind::Type(ty) => ty_allowed_with_raw_pointer_heuristic(cx, ty, send_trait),
                     // Lifetimes and const generics are not solid part of ADT and ignored
-                    GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => true,
+                    GenericArgKind::Lifetime(_) | GenericArgKind::Const(..) => true,
                 })
             } else {
                 false

--- a/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
+++ b/src/tools/clippy/clippy_lints/src/only_used_in_recursion.rs
@@ -388,7 +388,7 @@ fn has_matching_args(kind: FnKind, args: GenericArgsRef<'_>) -> bool {
         FnKind::TraitFn => args.iter().enumerate().all(|(idx, subst)| match subst.unpack() {
             GenericArgKind::Lifetime(_) => true,
             GenericArgKind::Type(ty) => matches!(*ty.kind(), ty::Param(ty) if ty.index as usize == idx),
-            GenericArgKind::Const(c) => matches!(c.kind(), ConstKind::Param(c) if c.index as usize == idx),
+            GenericArgKind::Const(c, _) => matches!(c.kind(), ConstKind::Param(c) if c.index as usize == idx),
         }),
         #[allow(trivial_casts)]
         FnKind::ImplTraitFn(expected_args) => args as *const _ as usize == expected_args,

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -55,7 +55,7 @@ fn check_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, span: Span) -> McfResult {
 
             // No constraints on lifetimes or constants, except potentially
             // constants' types, but `walk` will get to them as well.
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => continue,
+            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_, _) => continue,
         };
 
         match ty.kind() {

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -65,7 +65,7 @@ pub fn can_partially_move_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool
 pub fn contains_adt_constructor<'tcx>(ty: Ty<'tcx>, adt: AdtDef<'tcx>) -> bool {
     ty.walk().any(|inner| match inner.unpack() {
         GenericArgKind::Type(inner_ty) => inner_ty.ty_adt_def() == Some(adt),
-        GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+        GenericArgKind::Lifetime(_) | GenericArgKind::Const(_, _) => false,
     })
 }
 
@@ -127,7 +127,7 @@ pub fn contains_ty_adt_constructor_opaque<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'
 
                 false
             },
-            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
+            GenericArgKind::Lifetime(_) | GenericArgKind::Const(_, _) => false,
         })
     }
 
@@ -562,7 +562,7 @@ pub fn same_type_and_consts<'tcx>(a: Ty<'tcx>, b: Ty<'tcx>) -> bool {
                 .iter()
                 .zip(args_b.iter())
                 .all(|(arg_a, arg_b)| match (arg_a.unpack(), arg_b.unpack()) {
-                    (GenericArgKind::Const(inner_a), GenericArgKind::Const(inner_b)) => inner_a == inner_b,
+                    (GenericArgKind::Const(inner_a, _), GenericArgKind::Const(inner_b, _)) => inner_a == inner_b,
                     (GenericArgKind::Type(type_a), GenericArgKind::Type(type_b)) => {
                         same_type_and_consts(type_a, type_b)
                     },
@@ -1080,7 +1080,7 @@ fn assert_generic_args_match<'tcx>(tcx: TyCtxt<'tcx>, did: DefId, args: &[Generi
             .find(|(_, (param, arg))| match (param, arg) {
                 (GenericParamDefKind::Lifetime, GenericArgKind::Lifetime(_))
                 | (GenericParamDefKind::Type { .. }, GenericArgKind::Type(_))
-                | (GenericParamDefKind::Const { .. }, GenericArgKind::Const(_)) => false,
+                | (GenericParamDefKind::Const { .. }, GenericArgKind::Const(_, _)) => false,
                 (
                     GenericParamDefKind::Lifetime
                     | GenericParamDefKind::Type { .. }

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
@@ -21,7 +21,6 @@ const fn equals_self<T: ~const Foo>(t: &T) -> bool {
 // it not using the impl.
 
 pub const EQ: bool = equals_self(&S);
-//~^ ERROR
-// FIXME(effects) the diagnostics here isn't ideal, we shouldn't get `<false>`
+//~^ ERROR: the trait bound `S: ~const Foo` is not satisfied
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `S: ~const Foo<false>` is not satisfied
+error[E0277]: the trait bound `S: ~const Foo` is not satisfied
   --> $DIR/call-generic-method-nonconst.rs:23:34
    |
 LL | pub const EQ: bool = equals_self(&S);
-   |                      ----------- ^^ the trait `Foo<false>` is not implemented for `S`
+   |                      ----------- ^^ the trait `Foo` is not implemented for `S`
    |                      |
    |                      required by a bound introduced by this call
    |


### PR DESCRIPTION
Which should help us prevent printing `<false>` (effects desugaring) in diagnostics.

r? @compiler-errors 
cc @oli-obk 