### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -600,6 +600,16 @@ change-id = 117813
 # desired in distributions, for example.
 #rpath = true
 
+# Indicates whether symbols should be stripped using `-Cstrip=symbols`.
+#strip = false
+
+# Indicates whether stack protectors should be used
+# via the unstable option `-Zstack-protector`.
+#
+# Valid options are : `none`(default),`basic`,`strong`, or `all`.
+# `strong` and `basic` options may be buggy and are not recommended, see rust-lang/rust#114903.
+#stack-protector = "none"
+
 # Prints each test name as it is executed, to help debug issues in the test harness itself.
 #verbose-tests = false
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1667,6 +1667,12 @@ impl<'a> Builder<'a> {
             }
         }
 
+        cargo.env(profile_var("STRIP"), self.config.rust_strip.to_string());
+
+        if let Some(stack_protector) = &self.config.rust_stack_protector {
+            rustflags.arg(&format!("-Zstack-protector={stack_protector}"));
+        }
+
         if let Some(host_linker) = self.linker(compiler.host) {
             hostflags.arg(format!("-Clinker={}", host_linker.display()));
         }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -222,6 +222,8 @@ pub struct Config {
     pub rust_debuginfo_level_tests: DebuginfoLevel,
     pub rust_split_debuginfo: SplitDebuginfo,
     pub rust_rpath: bool,
+    pub rust_strip: bool,
+    pub rust_stack_protector: Option<String>,
     pub rustc_parallel: bool,
     pub rustc_default_linker: Option<String>,
     pub rust_optimize_tests: bool,
@@ -1001,6 +1003,8 @@ define_config! {
         description: Option<String> = "description",
         musl_root: Option<String> = "musl-root",
         rpath: Option<bool> = "rpath",
+        strip: Option<bool> = "strip",
+        stack_protector: Option<String> = "stack-protector",
         verbose_tests: Option<bool> = "verbose-tests",
         optimize_tests: Option<bool> = "optimize-tests",
         codegen_tests: Option<bool> = "codegen-tests",
@@ -1069,6 +1073,7 @@ impl Config {
         config.docs = true;
         config.docs_minification = true;
         config.rust_rpath = true;
+        config.rust_strip = false;
         config.channel = "dev".to_string();
         config.codegen_tests = true;
         config.rust_dist_src = true;
@@ -1422,6 +1427,8 @@ impl Config {
             set(&mut config.rust_optimize_tests, rust.optimize_tests);
             set(&mut config.codegen_tests, rust.codegen_tests);
             set(&mut config.rust_rpath, rust.rpath);
+            set(&mut config.rust_strip, rust.strip);
+            config.rust_stack_protector = rust.stack_protector;
             set(&mut config.jemalloc, rust.jemalloc);
             set(&mut config.test_compare_mode, rust.test_compare_mode);
             set(&mut config.backtrace, rust.backtrace);

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -83,8 +83,6 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
     (Some(Mode::Std), "no_global_oom_handling", None),
     (Some(Mode::Std), "no_rc", None),
     (Some(Mode::Std), "no_sync", None),
-    (Some(Mode::Std), "freebsd12", None),
-    (Some(Mode::Std), "freebsd13", None),
     (Some(Mode::Std), "backtrace_in_libstd", None),
     /* Extra values not defined in the built-in targets yet, but used in std */
     (Some(Mode::Std), "target_env", Some(&["libnx"])),

--- a/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.fixed
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.fixed
@@ -7,10 +7,24 @@ impl A {
     fn test(_a: Self, _b: i32) {}
 }
 
+struct B<T> {
+    _b: T
+}
+impl<T> B<T> {
+    fn hello(_a: i32) {}
+    fn test(_a: Self, _b: i32) {}
+}
+
 fn main() {
     let _a = A {};
     A::hello(1);
     //~^ ERROR no method named `hello` found
     A::test(_a, 1);
+    //~^ ERROR no method named `test` found
+
+    let _b = B {_b: ""};
+    B::<&str>::hello(1);
+    //~^ ERROR no method named `hello` found
+    B::<&str>::test(_b, 1);
     //~^ ERROR no method named `test` found
 }

--- a/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.rs
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.rs
@@ -7,10 +7,24 @@ impl A {
     fn test(_a: Self, _b: i32) {}
 }
 
+struct B<T> {
+    _b: T
+}
+impl<T> B<T> {
+    fn hello(_a: i32) {}
+    fn test(_a: Self, _b: i32) {}
+}
+
 fn main() {
     let _a = A {};
     _a.hello(1);
     //~^ ERROR no method named `hello` found
     _a.test(1);
+    //~^ ERROR no method named `test` found
+
+    let _b = B {_b: ""};
+    _b.hello(1);
+    //~^ ERROR no method named `hello` found
+    _b.test(1);
     //~^ ERROR no method named `test` found
 }

--- a/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.stderr
+++ b/tests/ui/suggestions/suggest-assoc-fn-call-without-receiver.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `hello` found for struct `A` in the current scope
-  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:12:8
+  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:20:8
    |
 LL | struct A {}
    | -------- method `hello` not found for this struct
@@ -18,7 +18,7 @@ LL |     fn hello(_a: i32) {}
    |     ^^^^^^^^^^^^^^^^^
 
 error[E0599]: no method named `test` found for struct `A` in the current scope
-  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:14:8
+  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:22:8
    |
 LL | struct A {}
    | -------- method `test` not found for this struct
@@ -36,6 +36,44 @@ note: the candidate is defined in an impl for the type `A`
 LL |     fn test(_a: Self, _b: i32) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0599]: no method named `hello` found for struct `B<&str>` in the current scope
+  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:26:8
+   |
+LL | struct B<T> {
+   | ----------- method `hello` not found for this struct
+...
+LL |     _b.hello(1);
+   |     ---^^^^^---
+   |     |  |
+   |     |  this is an associated function, not a method
+   |     help: use associated function syntax instead: `B::<&str>::hello(1)`
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in an impl for the type `B<T>`
+  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:14:5
+   |
+LL |     fn hello(_a: i32) {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error[E0599]: no method named `test` found for struct `B<&str>` in the current scope
+  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:28:8
+   |
+LL | struct B<T> {
+   | ----------- method `test` not found for this struct
+...
+LL |     _b.test(1);
+   |     ---^^^^---
+   |     |  |
+   |     |  this is an associated function, not a method
+   |     help: use associated function syntax instead: `B::<&str>::test(_b, 1)`
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in an impl for the type `B<T>`
+  --> $DIR/suggest-assoc-fn-call-without-receiver.rs:15:5
+   |
+LL |     fn test(_a: Self, _b: i32) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/traits/new-solver/cycles/coinduction/fixpoint-exponential-growth.rs
+++ b/tests/ui/traits/new-solver/cycles/coinduction/fixpoint-exponential-growth.rs
@@ -3,8 +3,12 @@
 // Proving `W<?0>: Trait` instantiates `?0` with `(W<?1>, W<?2>)` and then
 // proves `W<?1>: Trait` and `W<?2>: Trait`, resulting in a coinductive cycle.
 //
-// Proving coinductive cycles runs until we reach a fixpoint. This fixpoint is
-// never reached here and each step doubles the amount of nested obligations.
+// Proving coinductive cycles runs until we reach a fixpoint. However, after
+// computing `try_evaluate_added_goals` in the second fixpoint iteration, the
+// self type already has a depth equal to the number of steps. This results
+// in enormous constraints, causing the canonicalizer to hang without ever
+// reaching the recursion limit. We currently avoid that by erasing the constraints
+// from overflow.
 //
 // This previously caused a hang in the trait solver, see
 // https://github.com/rust-lang/trait-system-refactor-initiative/issues/13.

--- a/tests/ui/traits/new-solver/cycles/coinduction/fixpoint-exponential-growth.stderr
+++ b/tests/ui/traits/new-solver/cycles/coinduction/fixpoint-exponential-growth.stderr
@@ -1,12 +1,12 @@
 error[E0275]: overflow evaluating the requirement `W<_>: Trait`
-  --> $DIR/fixpoint-exponential-growth.rs:29:13
+  --> $DIR/fixpoint-exponential-growth.rs:33:13
    |
 LL |     impls::<W<_>>();
    |             ^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`fixpoint_exponential_growth`)
 note: required by a bound in `impls`
-  --> $DIR/fixpoint-exponential-growth.rs:26:13
+  --> $DIR/fixpoint-exponential-growth.rs:30:13
    |
 LL | fn impls<T: Trait>() {}
    |             ^^^^^ required by this bound in `impls`

--- a/tests/ui/traits/new-solver/cycles/inductive-fixpoint-hang.rs
+++ b/tests/ui/traits/new-solver/cycles/inductive-fixpoint-hang.rs
@@ -1,0 +1,33 @@
+// compile-flags: -Ztrait-solver=next
+
+// This currently hangs if we do not erase constraints from
+// overflow.
+//
+// We set the provisional result of `W<?0>` to `?0 := W<_>`.
+// The next iteration does not simply result in a `?0 := W<W<_>` constraint as
+// one might expect, but instead each time we evaluate the nested `W<T>` goal we
+// apply the previously returned constraints: the first fixpoint iteration goes
+// as follows: `W<?1>: Trait` constrains `?1` to `W<?2>`, we then evaluate
+// `W<W<?2>>: Trait` the next time we try to prove the nested goal. This results
+// inn `W<W<W<?3>>>` and so on. This goes on until we reach overflow in
+// `try_evaluate_added_goals`.  This means the provisional result after the
+// second fixpoint iteration is already `W<W<W<...>>>` with a size proportional
+// to the number of steps in `try_evaluate_added_goals`. The size then continues
+// to grow. The exponential blowup from having 2 nested goals per impl causes
+// the solver to hang without hitting the recursion limit.
+trait Trait {}
+
+struct W<T: ?Sized>(*const T);
+
+impl<T: ?Sized> Trait for W<W<T>>
+where
+    W<T>: Trait,
+    W<T>: Trait,
+{}
+
+fn impls_trait<T: Trait>() {}
+
+fn main() {
+    impls_trait::<W<_>>();
+    //~^ ERROR overflow evaluating the requirement
+}

--- a/tests/ui/traits/new-solver/cycles/inductive-fixpoint-hang.stderr
+++ b/tests/ui/traits/new-solver/cycles/inductive-fixpoint-hang.stderr
@@ -1,0 +1,16 @@
+error[E0275]: overflow evaluating the requirement `W<_>: Trait`
+  --> $DIR/inductive-fixpoint-hang.rs:31:19
+   |
+LL |     impls_trait::<W<_>>();
+   |                   ^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inductive_fixpoint_hang`)
+note: required by a bound in `impls_trait`
+  --> $DIR/inductive-fixpoint-hang.rs:28:19
+   |
+LL | fn impls_trait<T: Trait>() {}
+   |                   ^^^^^ required by this bound in `impls_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Successful merges:

 - #117966 (add safe compilation options)
 - #118747 (Remove extra check cfg handled by libc directly)
 - #118774 (add test for inductive cycle hangs)
 - #118775 (chore: add test case for type with generic)
 - #118782 (use `&` instead of start-process in x.ps1)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117966,118747,118774,118775,118782)
<!-- homu-ignore:end -->