### PR TITLE
Use immediate_backend_type when reading from a const alloc

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -155,7 +155,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             Abi::Scalar(s @ abi::Scalar::Initialized { .. }) => {
                 let size = s.size(bx);
                 assert_eq!(size, layout.size, "abi::Scalar size does not match layout size");
-                let val = read_scalar(offset, size, s, bx.backend_type(layout));
+                let val = read_scalar(offset, size, s, bx.immediate_backend_type(layout));
                 OperandRef { val: OperandValue::Immediate(val), layout }
             }
             Abi::ScalarPair(

--- a/tests/ui/codegen/const-bool-bitcast.rs
+++ b/tests/ui/codegen/const-bool-bitcast.rs
@@ -1,0 +1,15 @@
+// This is a regression test for https://github.com/rust-lang/rust/issues/118047
+// build-pass
+// compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+DataflowConstProp
+
+#![crate_type = "lib"]
+
+pub struct State {
+    inner: bool
+}
+
+pub fn make() -> State {
+    State {
+        inner: true
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/118047

r? @nikic 