### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -155,7 +155,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             Abi::Scalar(s @ abi::Scalar::Initialized { .. }) => {
                 let size = s.size(bx);
                 assert_eq!(size, layout.size, "abi::Scalar size does not match layout size");
-                let val = read_scalar(offset, size, s, bx.backend_type(layout));
+                let val = read_scalar(offset, size, s, bx.immediate_backend_type(layout));
                 OperandRef { val: OperandValue::Immediate(val), layout }
             }
             Abi::ScalarPair(

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,7 +30,7 @@
 #
 # If `change-id` does not match the version that is currently running,
 # `x.py` will prompt you to update it and check the related PR for more details.
-change-id = 117813
+change-id = 118703
 
 # =============================================================================
 # Tweaking how LLVM is compiled

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -857,7 +857,6 @@ define_config! {
 define_config! {
     struct Dist {
         sign_folder: Option<String> = "sign-folder",
-        gpg_password_file: Option<String> = "gpg-password-file",
         upload_addr: Option<String> = "upload-addr",
         src_tarball: Option<bool> = "src-tarball",
         missing_tools: Option<bool> = "missing-tools",
@@ -995,7 +994,6 @@ define_config! {
         debuginfo_level_tools: Option<DebuginfoLevel> = "debuginfo-level-tools",
         debuginfo_level_tests: Option<DebuginfoLevel> = "debuginfo-level-tests",
         split_debuginfo: Option<String> = "split-debuginfo",
-        run_dsymutil: Option<bool> = "run-dsymutil",
         backtrace: Option<bool> = "backtrace",
         incremental: Option<bool> = "incremental",
         parallel_compiler: Option<bool> = "parallel-compiler",
@@ -1447,7 +1445,6 @@ impl Config {
                 debuginfo_level_tools: debuginfo_level_tools_toml,
                 debuginfo_level_tests: debuginfo_level_tests_toml,
                 split_debuginfo,
-                run_dsymutil: _,
                 backtrace,
                 incremental,
                 parallel_compiler,
@@ -1769,7 +1766,6 @@ impl Config {
         if let Some(dist) = toml.dist {
             let Dist {
                 sign_folder,
-                gpg_password_file: _,
                 upload_addr,
                 src_tarball,
                 missing_tools,

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -86,4 +86,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Use of the `if-available` value for `download-ci-llvm` is deprecated; prefer using the new `if-unchanged` value.",
     },
+    ChangeInfo {
+        change_id: 118703,
+        severity: ChangeSeverity::Info,
+        summary: "Removed rust.run_dsymutil and dist.gpg_password_file config options, as they were unused.",
+    },
 ];

--- a/tests/ui/codegen/const-bool-bitcast.rs
+++ b/tests/ui/codegen/const-bool-bitcast.rs
@@ -1,0 +1,15 @@
+// This is a regression test for https://github.com/rust-lang/rust/issues/118047
+// build-pass
+// compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+DataflowConstProp
+
+#![crate_type = "lib"]
+
+pub struct State {
+    inner: bool
+}
+
+pub fn make() -> State {
+    State {
+        inner: true
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #118703 (Remove unused bootstrap config option)
 - #118791 (Use immediate_backend_type when reading from a const alloc)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118703,118791)
<!-- homu-ignore:end -->