### PR TITLE
A regression test for #115145

### DIFF
--- a/src/tools/miri/tests/pass/uninhabited-coroutine-variant.rs
+++ b/src/tools/miri/tests/pass/uninhabited-coroutine-variant.rs
@@ -1,0 +1,25 @@
+#![feature(noop_waker)]
+use std::future::Future;
+
+enum Runtime {}
+
+async fn run(_: Runtime) {}
+
+async fn apply_timeout() {
+    let c = async {};
+    match None::<Runtime> {
+        None => {
+            c.await;
+        },
+        Some(r) => {
+            run(r).await;
+        }
+    }
+}
+
+fn main() {
+    let waker = std::task::Waker::noop();
+    let mut ctx = std::task::Context::from_waker(&waker);
+    let fut = std::pin::pin!(apply_timeout());
+    let _ = fut.poll(&mut ctx);
+}


### PR DESCRIPTION
The example here (reduced from the crate deadpool) used to ICE Miri until the fix in https://github.com/rust-lang/rust/pull/118871

r? @RalfJung