### PR TITLE
UnsafeCell::raw_get: use raw pointer self type

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -2159,7 +2159,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let m = MaybeUninit::<UnsafeCell<i32>>::uninit();
-    /// unsafe { UnsafeCell::raw_get(m.as_ptr()).write(5); }
+    /// unsafe { m.as_ptr().raw_get().write(5); }
     /// // avoid below which references to uninitialized data
     /// // unsafe { UnsafeCell::get(&*m.as_ptr()).write(5); }
     /// let uc = unsafe { m.assume_init() };
@@ -2170,11 +2170,11 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[stable(feature = "unsafe_cell_raw_get", since = "1.56.0")]
     #[rustc_const_stable(feature = "unsafe_cell_raw_get", since = "1.56.0")]
     #[rustc_diagnostic_item = "unsafe_cell_raw_get"]
-    pub const fn raw_get(this: *const Self) -> *mut T {
+    pub const fn raw_get(self: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
         // #[repr(transparent)]. This exploits std's special status, there is
         // no guarantee for user code that this will work in future versions of the compiler!
-        this as *const T as *mut T
+        self as *const T as *mut T
     }
 }
 
@@ -2270,11 +2270,11 @@ impl<T: ?Sized> SyncUnsafeCell<T> {
     ///
     /// See [`UnsafeCell::get`] for details.
     #[inline]
-    pub const fn raw_get(this: *const Self) -> *mut T {
+    pub const fn raw_get(self: *const Self) -> *mut T {
         // We can just cast the pointer from `SyncUnsafeCell<T>` to `T` because
         // of #[repr(transparent)] on both SyncUnsafeCell and UnsafeCell.
         // See UnsafeCell::raw_get.
-        this as *const T as *mut T
+        self as *const T as *mut T
     }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -202,6 +202,7 @@
 #![feature(adt_const_params)]
 #![feature(allow_internal_unsafe)]
 #![feature(allow_internal_unstable)]
+#![feature(arbitrary_self_types)]
 #![feature(asm_const)]
 #![feature(associated_type_bounds)]
 #![feature(auto_traits)]


### PR DESCRIPTION
[Back in the day](https://github.com/rust-lang/rust/pull/66248#discussion_r344463751) we made this an associated function to avoid relying on raw-ptr self types. I'd like to know if that is still a concern -- I hope we can stabilize https://github.com/rust-lang/rust/issues/74265 and https://github.com/rust-lang/rust/issues/71146 soon, and while strangely those do not require the `arbitrary_self_types` feature, I would think that for the compiler and type system those are very similar cases. So I'd like to see if we are comfortable having stable methods with raw pointer self types. I expect this will need t-lang FCP (and t-libs-api), and also t-types involvement.

So @rust-lang/types, what are your thoughts here? This has to pass by you before we send it to the top-level teams; I don't know if we should make one big FCP for all 3 teams or how else t-types should best be involved here.