### PR TITLE
Revert using MCP510 in bootstrap

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -15,7 +15,8 @@ use std::sync::OnceLock;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use crate::core::builder::Builder;
-use crate::core::config::{Config, LldMode, TargetSelection};
+use crate::core::config::{Config, TargetSelection};
+use crate::LldMode;
 
 pub use crate::utils::dylib::{dylib_path, dylib_path_var};
 
@@ -513,16 +514,7 @@ pub fn linker_flags(
 ) -> Vec<String> {
     let mut args = vec![];
     if !builder.is_lld_direct_linker(target) && builder.config.lld_mode.is_used() {
-        match builder.config.lld_mode {
-            LldMode::External => {
-                args.push("-Clinker-flavor=gnu-lld-cc".to_string());
-            }
-            LldMode::SelfContained => {
-                args.push("-Clinker-flavor=gnu-lld-cc".to_string());
-                args.push("-Clink-self-contained=+linker".to_string());
-            }
-            LldMode::Unused => {}
-        }
+        args.push(String::from("-Clink-arg=-fuse-ld=lld"));
 
         if matches!(lld_threads, LldThreads::No) {
             args.push(format!(


### PR DESCRIPTION
This reverts commit 40c3d351ada5d991f7474ecc4bc6c9b976c656cb. The commit started dogfooding MCP510 to enable `lld` when building the compiler , but it broke tests, because we don't pass `-Zunstable-options` on enough places. This PR hotfixes that, and temporarily makes the "self-contained" option.. not very self-contained. I'll send a proper fix later, but I want to unblock rustc developres that use `lld` locally.

r? @nnethercote (who discovered the problem)