### PR TITLE
Remove weird handling of ## in code examples

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1095,7 +1095,7 @@ mod move_keyword {}
 /// ```rust,compile_fail,E0502
 /// let mut v = vec![0, 1];
 /// let mut_ref_v = &mut v;
-/// ##[allow(unused)]
+/// #[allow(unused)]
 /// let ref_v = &v;
 /// mut_ref_v.push(2);
 /// ```

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -168,9 +168,7 @@ impl<'a> Line<'a> {
 // then reallocate to remove it; which would make us return a String.
 fn map_line(s: &str) -> Line<'_> {
     let trimmed = s.trim();
-    if trimmed.starts_with("##") {
-        Line::Shown(Cow::Owned(s.replacen("##", "#", 1)))
-    } else if let Some(stripped) = trimmed.strip_prefix("# ") {
+    if let Some(stripped) = trimmed.strip_prefix("# ") {
         // # text
         Line::Hidden(stripped)
     } else if trimmed == "#" {

--- a/tests/rustdoc/issue-41783.codeblock.html
+++ b/tests/rustdoc/issue-41783.codeblock.html
@@ -1,5 +1,5 @@
-<code># single
-## double
-### triple
-<span class="attr">#[outer]
-#![inner]</span></code>
+<code>## single
+### double
+#### triple
+#<span class="attr">#[outer]
+</span>#<span class="attr">#![inner]</span></code>

--- a/tests/rustdoc/issue-41783.rs
+++ b/tests/rustdoc/issue-41783.rs
@@ -4,7 +4,7 @@
 // @hasraw - '<span class="attr">#[outer]'
 // @!hasraw - '<span class="attr">#[outer]</span>'
 // @hasraw - '#![inner]</span>'
-// @!hasraw - '<span class="attr">#![inner]</span>'
+// @hasraw - '#<span class="attr">#![inner]</span>'
 // @snapshot 'codeblock' - '//*[@class="toggle top-doc"]/*[@class="docblock"]//pre/code'
 
 /// ```no_run


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/pull/118711, the handling of `##` in code blocks in code examples is very surprising. Let's see if crates are using it with a crater run.

# description

Currently, if you have two `#` characters following each other, the first one will be stripped. So this code:

```rust
/// ```
/// ## something
/// ```
```

is rendered as:

```
# something
```

This PR removes this behaviour and won't strip the first `#` item so the previous code will be rendered:

```
## something
```

# Motivation

It looks more like a bug rather than a feature as it is a very unexpected behaviour. This PR intends to remove it. As seen in the crater run below, it seems no published crate relies on it either.

r? @notriddle 