### PR TITLE
Edit target doc template to remove email

### DIFF
--- a/src/doc/rustc/src/platform-support/TEMPLATE.md
+++ b/src/doc/rustc/src/platform-support/TEMPLATE.md
@@ -6,7 +6,7 @@ One-sentence description of the target (e.g. CPU, OS)
 
 ## Target maintainers
 
-- Some Person, `email@example.org`, https://github.com/...
+- Some Person, https://github.com/...
 
 ## Requirements
 


### PR DESCRIPTION
We don't really want to communicate with target maintainers via email. GitHub is where everything happens, people should have a GitHub account that can be pinged on issues.

This doesn't necessarily have to be a strict rule, but edit the template to suggest this. The previous template made it look like we care about having an email address, which we do not.

r? @davidtwco 