### PR TITLE
Make most `rustc_type_ir` kinds `Copy` by default

### DIFF
--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -92,10 +92,6 @@ macro_rules! arena_types {
             [] name_set: rustc_data_structures::unord::UnordSet<rustc_span::symbol::Symbol>,
             [] ordered_name_set: rustc_data_structures::fx::FxIndexSet<rustc_span::symbol::Symbol>,
 
-            // Interned types
-            [] tys: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::TyKind<'tcx>>,
-            [] consts: rustc_type_ir::WithCachedTypeInfo<rustc_middle::ty::ConstData<'tcx>>,
-
             // Note that this deliberately duplicates items in the `rustc_hir::arena`,
             // since we need to allocate this type on both the `rustc_hir` arena
             // (during lowering) and the `librustc_middle` arena (for decoding MIR)

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -41,7 +41,8 @@ impl<'tcx> ConstTy<TyCtxt<'tcx>> for Const<'tcx> {
 }
 
 /// Typed constant value.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, HashStable, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(HashStable, TyEncodable, TyDecodable)]
 pub struct ConstData<'tcx> {
     pub ty: Ty<'tcx>,
     pub kind: ConstKind<'tcx>,

--- a/compiler/rustc_type_ir/src/canonical.rs
+++ b/compiler/rustc_type_ir/src/canonical.rs
@@ -119,12 +119,7 @@ where
 /// a copy of the canonical value in some other inference context,
 /// with fresh inference variables replacing the canonical values.
 #[derive(derivative::Derivative)]
-#[derivative(
-    Clone(bound = ""),
-    Hash(bound = ""),
-    Copy(bound = "CanonicalVarKind<I>: Copy"),
-    Debug(bound = "")
-)]
+#[derivative(Clone(bound = ""), Copy(bound = ""), Hash(bound = ""), Debug(bound = ""))]
 #[cfg_attr(feature = "nightly", derive(TyDecodable, TyEncodable, HashStable_NoContext))]
 pub struct CanonicalVarInfo<I: Interner> {
     pub kind: CanonicalVarKind<I>,
@@ -207,7 +202,7 @@ impl<I: Interner> CanonicalVarInfo<I> {
 /// in the type-theory sense of the term -- i.e., a "meta" type system
 /// that analyzes type-like values.
 #[derive(derivative::Derivative)]
-#[derivative(Clone(bound = ""), Hash(bound = ""), Debug(bound = ""))]
+#[derivative(Clone(bound = ""), Copy(bound = ""), Hash(bound = ""), Debug(bound = ""))]
 #[cfg_attr(feature = "nightly", derive(TyDecodable, TyEncodable, HashStable_NoContext))]
 pub enum CanonicalVarKind<I: Interner> {
     /// Some kind of type inference variable.
@@ -232,15 +227,6 @@ pub enum CanonicalVarKind<I: Interner> {
 
     /// A "placeholder" that represents "any const".
     PlaceholderConst(I::PlaceholderConst, I::Ty),
-}
-
-impl<I: Interner> Copy for CanonicalVarKind<I>
-where
-    I::PlaceholderTy: Copy,
-    I::PlaceholderRegion: Copy,
-    I::PlaceholderConst: Copy,
-    I::Ty: Copy,
-{
 }
 
 impl<I: Interner> PartialEq for CanonicalVarKind<I> {

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -10,6 +10,7 @@ use self::ConstKind::*;
 #[derive(derivative::Derivative)]
 #[derivative(
     Clone(bound = ""),
+    Copy(bound = ""),
     PartialOrd(bound = ""),
     PartialOrd = "feature_allow_slow_enum",
     Ord(bound = ""),

--- a/compiler/rustc_type_ir/src/predicate_kind.rs
+++ b/compiler/rustc_type_ir/src/predicate_kind.rs
@@ -8,7 +8,7 @@ use crate::Interner;
 /// A clause is something that can appear in where bounds or be inferred
 /// by implied bounds.
 #[derive(derivative::Derivative)]
-#[derivative(Clone(bound = ""), Hash(bound = ""))]
+#[derivative(Clone(bound = ""), Copy(bound = ""), Hash(bound = ""))]
 #[cfg_attr(feature = "nightly", derive(TyEncodable, TyDecodable, HashStable_NoContext))]
 pub enum ClauseKind<I: Interner> {
     /// Corresponds to `where Foo: Bar<A, B, C>`. `Foo` here would be
@@ -35,18 +35,6 @@ pub enum ClauseKind<I: Interner> {
 
     /// Constant initializer must evaluate successfully.
     ConstEvaluatable(I::Const),
-}
-
-impl<I: Interner> Copy for ClauseKind<I>
-where
-    I::Ty: Copy,
-    I::Const: Copy,
-    I::GenericArg: Copy,
-    I::TraitPredicate: Copy,
-    I::ProjectionPredicate: Copy,
-    I::TypeOutlivesPredicate: Copy,
-    I::RegionOutlivesPredicate: Copy,
-{
 }
 
 impl<I: Interner> PartialEq for ClauseKind<I> {
@@ -120,7 +108,13 @@ where
 }
 
 #[derive(derivative::Derivative)]
-#[derivative(Clone(bound = ""), Hash(bound = ""), PartialEq(bound = ""), Eq(bound = ""))]
+#[derivative(
+    Clone(bound = ""),
+    Copy(bound = ""),
+    Hash(bound = ""),
+    PartialEq(bound = ""),
+    Eq(bound = "")
+)]
 #[cfg_attr(feature = "nightly", derive(TyEncodable, TyDecodable, HashStable_NoContext))]
 pub enum PredicateKind<I: Interner> {
     /// Prove a clause
@@ -167,19 +161,6 @@ pub enum PredicateKind<I: Interner> {
     ///
     /// Only used for new solver
     AliasRelate(I::Term, I::Term, AliasRelationDirection),
-}
-
-impl<I: Interner> Copy for PredicateKind<I>
-where
-    I::DefId: Copy,
-    I::Const: Copy,
-    I::GenericArgs: Copy,
-    I::Term: Copy,
-    I::CoercePredicate: Copy,
-    I::SubtypePredicate: Copy,
-    I::NormalizesTo: Copy,
-    ClauseKind<I>: Copy,
-{
 }
 
 impl<I: Interner> TypeFoldable<I> for PredicateKind<I>

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -115,6 +115,7 @@ use self::RegionKind::*;
 #[derive(derivative::Derivative)]
 #[derivative(
     Clone(bound = ""),
+    Copy(bound = ""),
     PartialOrd(bound = ""),
     PartialOrd = "feature_allow_slow_enum",
     Ord(bound = ""),
@@ -187,18 +188,6 @@ const fn regionkind_discriminant<I: Interner>(value: &RegionKind<I>) -> usize {
         ReErased => 6,
         ReError(_) => 7,
     }
-}
-
-// This is manually implemented because a derive would require `I: Copy`
-impl<I: Interner> Copy for RegionKind<I>
-where
-    I::EarlyParamRegion: Copy,
-    I::BoundRegion: Copy,
-    I::LateParamRegion: Copy,
-    I::InferRegion: Copy,
-    I::PlaceholderRegion: Copy,
-    I::ErrorGuaranteed: Copy,
-{
 }
 
 // This is manually implemented because a derive would require `I: PartialEq`

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -111,6 +111,7 @@ pub enum AliasKind {
 #[derive(derivative::Derivative)]
 #[derivative(
     Clone(bound = ""),
+    Copy(bound = ""),
     PartialOrd(bound = ""),
     PartialOrd = "feature_allow_slow_enum",
     Ord(bound = ""),


### PR DESCRIPTION
1. There's no reason why `TyKind` and `ConstKind`/`ConstData` can't be `Copy`. This allows us to avoid needing a typed arena for the two types.
2. Simplify some impls into derives.