### PR TITLE
Make exhaustiveness usable outside of rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,6 +4348,7 @@ dependencies = [
  "rustc_target",
  "smallvec",
  "tracing",
+ "typed-arena",
 ]
 
 [[package]]
@@ -5682,6 +5683,12 @@ checksum = "b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46"
 dependencies = [
  "rustc-hash",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -14,7 +14,6 @@
 )]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 
-#[cfg(feature = "nightly")]
 pub mod bit_set;
 #[cfg(feature = "nightly")]
 pub mod interval;

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::{self, Ty};
-use rustc_pattern_analysis::{cx::MatchCheckCtxt, errors::Uncovered};
+use rustc_pattern_analysis::{errors::Uncovered, rustc::RustcCtxt};
 use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 
@@ -454,7 +454,7 @@ pub enum UnusedUnsafeEnclosing {
 }
 
 pub(crate) struct NonExhaustivePatternsTypeNotEmpty<'p, 'tcx, 'm> {
-    pub cx: &'m MatchCheckCtxt<'p, 'tcx>,
+    pub cx: &'m RustcCtxt<'p, 'tcx>,
     pub expr_span: Span,
     pub span: Span,
     pub ty: Ty<'tcx>,

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -6,7 +6,7 @@ use rustc_errors::{
 };
 use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::{self, Ty};
-use rustc_pattern_analysis::{errors::Uncovered, rustc::RustcCtxt};
+use rustc_pattern_analysis::{errors::Uncovered, rustc::RustcMatchCheckCtxt};
 use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 
@@ -454,7 +454,7 @@ pub enum UnusedUnsafeEnclosing {
 }
 
 pub(crate) struct NonExhaustivePatternsTypeNotEmpty<'p, 'tcx, 'm> {
-    pub cx: &'m RustcCtxt<'p, 'tcx>,
+    pub cx: &'m RustcMatchCheckCtxt<'p, 'tcx>,
     pub expr_span: Span,
     pub span: Span,
     pub ty: Ty<'tcx>,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -874,7 +874,7 @@ fn pat_is_catchall(pat: &DeconstructedPat<'_, '_>) -> bool {
     use Constructor::*;
     match pat.ctor() {
         Wildcard => true,
-        Single => pat.iter_fields().all(|pat| pat_is_catchall(pat)),
+        Struct | Ref => pat.iter_fields().all(|pat| pat_is_catchall(pat)),
         _ => false,
     }
 }

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1,7 +1,7 @@
 use rustc_pattern_analysis::errors::Uncovered;
 use rustc_pattern_analysis::rustc::{
-    Constructor, DeconstructedPat, RustcCtxt as MatchCheckCtxt, Usefulness, UsefulnessReport,
-    WitnessPat,
+    Constructor, DeconstructedPat, RustcMatchCheckCtxt as MatchCheckCtxt, Usefulness,
+    UsefulnessReport, WitnessPat,
 };
 use rustc_pattern_analysis::{analyze_match, MatchArm};
 

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1,7 +1,8 @@
-use rustc_pattern_analysis::cx::{
-    Constructor, DeconstructedPat, MatchCheckCtxt, Usefulness, UsefulnessReport, WitnessPat,
-};
 use rustc_pattern_analysis::errors::Uncovered;
+use rustc_pattern_analysis::rustc::{
+    Constructor, DeconstructedPat, RustcCtxt as MatchCheckCtxt, Usefulness, UsefulnessReport,
+    WitnessPat,
+};
 use rustc_pattern_analysis::{analyze_match, MatchArm};
 
 use crate::errors::*;

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -856,21 +856,21 @@ fn report_arm_reachability<'p, 'tcx>(
     for (arm, is_useful) in report.arm_usefulness.iter() {
         match is_useful {
             Usefulness::Redundant => {
-                report_unreachable_pattern(*arm.pat.span(), arm.arm_data, catchall)
+                report_unreachable_pattern(*arm.pat.data(), arm.arm_data, catchall)
             }
-            Usefulness::Useful(redundant_spans) if redundant_spans.is_empty() => {}
+            Usefulness::Useful(redundant_subpats) if redundant_subpats.is_empty() => {}
             // The arm is reachable, but contains redundant subpatterns (from or-patterns).
-            Usefulness::Useful(redundant_spans) => {
-                let mut redundant_spans = redundant_spans.clone();
+            Usefulness::Useful(redundant_subpats) => {
+                let mut redundant_subpats = redundant_subpats.clone();
                 // Emit lints in the order in which they occur in the file.
-                redundant_spans.sort_unstable();
-                for span in redundant_spans {
-                    report_unreachable_pattern(span, arm.arm_data, None);
+                redundant_subpats.sort_unstable_by_key(|pat| pat.data());
+                for pat in redundant_subpats {
+                    report_unreachable_pattern(*pat.data(), arm.arm_data, None);
                 }
             }
         }
         if !arm.has_guard && catchall.is_none() && pat_is_catchall(arm.pat) {
-            catchall = Some(*arm.pat.span());
+            catchall = Some(*arm.pat.data());
         }
     }
 }

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -8,15 +8,28 @@ edition = "2021"
 rustc_apfloat = "0.2.0"
 rustc_arena = { path = "../rustc_arena" }
 rustc_data_structures = { path = "../rustc_data_structures" }
-rustc_errors = { path = "../rustc_errors" }
-rustc_fluent_macro = { path = "../rustc_fluent_macro" }
-rustc_hir = { path = "../rustc_hir" }
+rustc_errors = { path = "../rustc_errors", optional = true }
+rustc_fluent_macro = { path = "../rustc_fluent_macro", optional = true }
+rustc_hir = { path = "../rustc_hir", optional = true }
 rustc_index = { path = "../rustc_index" }
-rustc_macros = { path = "../rustc_macros" }
-rustc_middle = { path = "../rustc_middle" }
-rustc_session = { path = "../rustc_session" }
-rustc_span = { path = "../rustc_span" }
-rustc_target = { path = "../rustc_target" }
+rustc_macros = { path = "../rustc_macros", optional = true }
+rustc_middle = { path = "../rustc_middle", optional = true }
+rustc_session = { path = "../rustc_session", optional = true }
+rustc_span = { path = "../rustc_span", optional = true }
+rustc_target = { path = "../rustc_target", optional = true }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 # tidy-alphabetical-end
+
+[features]
+default = ["rustc"]
+rustc = [
+    "dep:rustc_errors",
+    "dep:rustc_fluent_macro",
+    "dep:rustc_hir",
+    "dep:rustc_macros",
+    "dep:rustc_middle",
+    "dep:rustc_session",
+    "dep:rustc_span",
+    "dep:rustc_target",
+]

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # tidy-alphabetical-start
 rustc_apfloat = "0.2.0"
 rustc_arena = { path = "../rustc_arena" }
-rustc_data_structures = { path = "../rustc_data_structures" }
+rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_errors = { path = "../rustc_errors", optional = true }
 rustc_fluent_macro = { path = "../rustc_fluent_macro", optional = true }
 rustc_hir = { path = "../rustc_hir", optional = true }
@@ -24,6 +24,7 @@ tracing = "0.1"
 [features]
 default = ["rustc"]
 rustc = [
+    "dep:rustc_data_structures",
     "dep:rustc_errors",
     "dep:rustc_fluent_macro",
     "dep:rustc_hir",

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -6,24 +6,28 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 rustc_apfloat = "0.2.0"
-rustc_arena = { path = "../rustc_arena" }
+rustc_arena = { path = "../rustc_arena", optional = true }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_errors = { path = "../rustc_errors", optional = true }
 rustc_fluent_macro = { path = "../rustc_fluent_macro", optional = true }
 rustc_hir = { path = "../rustc_hir", optional = true }
-rustc_index = { path = "../rustc_index" }
+rustc_index = { path = "../rustc_index", default-features = false }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_middle = { path = "../rustc_middle", optional = true }
 rustc_session = { path = "../rustc_session", optional = true }
 rustc_span = { path = "../rustc_span", optional = true }
 rustc_target = { path = "../rustc_target", optional = true }
-smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
+smallvec = { version = "1.8.1", features = ["union"] }
 tracing = "0.1"
+typed-arena = { version = "2.0.2", optional = true }
 # tidy-alphabetical-end
 
 [features]
 default = ["rustc"]
+# It's not possible to only enable the `typed_arena` dependency when the `rustc` feature is off, so
+# we use another feature instead. The crate won't compile if one of these isn't enabled.
 rustc = [
+    "dep:rustc_arena",
     "dep:rustc_data_structures",
     "dep:rustc_errors",
     "dep:rustc_fluent_macro",
@@ -33,4 +37,9 @@ rustc = [
     "dep:rustc_session",
     "dep:rustc_span",
     "dep:rustc_target",
+    "smallvec/may_dangle",
+    "rustc_index/nightly",
+]
+stable = [
+    "dep:typed-arena",
 ]

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -162,7 +162,7 @@ use self::Constructor::*;
 use self::MaybeInfiniteInt::*;
 use self::SliceKind::*;
 
-use crate::usefulness::PatCtxt;
+use crate::usefulness::PlaceCtxt;
 use crate::MatchCx;
 
 /// Whether we have seen a constructor in the column or not.
@@ -717,7 +717,7 @@ impl<Cx: MatchCx> Constructor<Cx> {
 
     /// The number of fields for this constructor. This must be kept in sync with
     /// `Fields::wildcards`.
-    pub(crate) fn arity(&self, pcx: &PatCtxt<'_, '_, Cx>) -> usize {
+    pub(crate) fn arity(&self, pcx: &PlaceCtxt<'_, '_, Cx>) -> usize {
         pcx.cx.ctor_arity(self, pcx.ty)
     }
 
@@ -726,7 +726,7 @@ impl<Cx: MatchCx> Constructor<Cx> {
     /// this checks for inclusion.
     // We inline because this has a single call site in `Matrix::specialize_constructor`.
     #[inline]
-    pub(crate) fn is_covered_by<'p>(&self, pcx: &PatCtxt<'_, 'p, Cx>, other: &Self) -> bool {
+    pub(crate) fn is_covered_by<'p>(&self, pcx: &PlaceCtxt<'_, 'p, Cx>, other: &Self) -> bool {
         match (self, other) {
             (Wildcard, _) => pcx
                 .cx
@@ -859,7 +859,7 @@ impl<Cx: MatchCx> ConstructorSet<Cx> {
     #[instrument(level = "debug", skip(self, pcx, ctors), ret)]
     pub(crate) fn split<'a>(
         &self,
-        pcx: &PatCtxt<'_, '_, Cx>,
+        pcx: &PlaceCtxt<'_, '_, Cx>,
         ctors: impl Iterator<Item = &'a Constructor<Cx>> + Clone,
     ) -> SplitConstructorSet<Cx>
     where
@@ -1008,7 +1008,7 @@ impl<Cx: MatchCx> ConstructorSet<Cx> {
         // In the absence of the `exhaustive_patterns` feature however, we don't count nested empty
         // types as empty. Only non-nested `!` or `enum Foo {}` are considered empty.
         if !pcx.cx.is_exhaustive_patterns_feature_on()
-            && !(pcx.is_top_level && matches!(self, Self::NoConstructors))
+            && !(pcx.is_scrutinee && matches!(self, Self::NoConstructors))
         {
             // Treat all missing constructors as nonempty.
             // This clears `missing_empty`.

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -40,7 +40,7 @@
 //! - That have no non-trivial intersection with any of the constructors in the column (i.e. they're
 //!     each either disjoint with or covered by any given column constructor).
 //!
-//! We compute this in two steps: first [`MatchCx::ctors_for_ty`] determines the
+//! We compute this in two steps: first [`TypeCx::ctors_for_ty`] determines the
 //! set of all possible constructors for the type. Then [`ConstructorSet::split`] looks at the
 //! column of constructors and splits the set into groups accordingly. The precise invariants of
 //! [`ConstructorSet::split`] is described in [`SplitConstructorSet`].
@@ -136,7 +136,7 @@
 //! the algorithm can't distinguish them from a nonempty constructor. The only known case where this
 //! could happen is the `[..]` pattern on `[!; N]` with `N > 0` so we must take care to not emit it.
 //!
-//! This is all handled by [`MatchCx::ctors_for_ty`] and
+//! This is all handled by [`TypeCx::ctors_for_ty`] and
 //! [`ConstructorSet::split`]. The invariants of [`SplitConstructorSet`] are also of interest.
 //!
 //!
@@ -163,7 +163,7 @@ use self::MaybeInfiniteInt::*;
 use self::SliceKind::*;
 
 use crate::usefulness::PlaceCtxt;
-use crate::MatchCx;
+use crate::TypeCx;
 
 /// Whether we have seen a constructor in the column or not.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -643,7 +643,7 @@ impl OpaqueId {
 /// constructor. `Constructor::apply` reconstructs the pattern from a pair of `Constructor` and
 /// `Fields`.
 #[derive(Clone, Debug, PartialEq)]
-pub enum Constructor<Cx: MatchCx> {
+pub enum Constructor<Cx: TypeCx> {
     /// Tuples and structs.
     Struct,
     /// Enum variants.
@@ -685,7 +685,7 @@ pub enum Constructor<Cx: MatchCx> {
     Missing,
 }
 
-impl<Cx: MatchCx> Constructor<Cx> {
+impl<Cx: TypeCx> Constructor<Cx> {
     pub(crate) fn is_non_exhaustive(&self) -> bool {
         matches!(self, NonExhaustive)
     }
@@ -798,7 +798,7 @@ pub enum VariantVisibility {
 /// In terms of division of responsibility, [`ConstructorSet::split`] handles all of the
 /// `exhaustive_patterns` feature.
 #[derive(Debug)]
-pub enum ConstructorSet<Cx: MatchCx> {
+pub enum ConstructorSet<Cx: TypeCx> {
     /// The type is a tuple or struct. `empty` tracks whether the type is empty.
     Struct { empty: bool },
     /// This type has the following list of constructors. If `variants` is empty and
@@ -846,13 +846,13 @@ pub enum ConstructorSet<Cx: MatchCx> {
 /// of the `ConstructorSet` for the type, yet if we forgot to include them in `present` we would be
 /// ignoring any row with `Opaque`s in the algorithm. Hence the importance of point 4.
 #[derive(Debug)]
-pub(crate) struct SplitConstructorSet<Cx: MatchCx> {
+pub(crate) struct SplitConstructorSet<Cx: TypeCx> {
     pub(crate) present: SmallVec<[Constructor<Cx>; 1]>,
     pub(crate) missing: Vec<Constructor<Cx>>,
     pub(crate) missing_empty: Vec<Constructor<Cx>>,
 }
 
-impl<Cx: MatchCx> ConstructorSet<Cx> {
+impl<Cx: TypeCx> ConstructorSet<Cx> {
     /// This analyzes a column of constructors to 1/ determine which constructors of the type (if
     /// any) are missing; 2/ split constructors to handle non-trivial intersections e.g. on ranges
     /// or slices. This can get subtle; see [`SplitConstructorSet`] for details of this operation

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -266,8 +266,7 @@ pub struct IntRange {
 
 impl IntRange {
     /// Best effort; will not know that e.g. `255u8..` is a singleton.
-    #[cfg_attr(not(feature = "rustc"), allow(dead_code))]
-    pub(crate) fn is_singleton(&self) -> bool {
+    pub fn is_singleton(&self) -> bool {
         // Since `lo` and `hi` can't be the same `Infinity` and `plus_one` never changes from finite
         // to infinite, this correctly only detects ranges that contain exacly one `Finite(x)`.
         self.lo.plus_one() == self.hi

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -266,6 +266,7 @@ pub struct IntRange {
 
 impl IntRange {
     /// Best effort; will not know that e.g. `255u8..` is a singleton.
+    #[cfg_attr(not(feature = "rustc"), allow(dead_code))]
     pub(crate) fn is_singleton(&self) -> bool {
         // Since `lo` and `hi` can't be the same `Infinity` and `plus_one` never changes from finite
         // to infinite, this correctly only detects ranges that contain exacly one `Finite(x)`.

--- a/compiler/rustc_pattern_analysis/src/cx.rs
+++ b/compiler/rustc_pattern_analysis/src/cx.rs
@@ -49,8 +49,12 @@ pub struct MatchCheckCtxt<'p, 'tcx> {
 }
 
 impl<'p, 'tcx> MatchCheckCtxt<'p, 'tcx> {
-    pub(super) fn is_uninhabited(&self, ty: Ty<'tcx>) -> bool {
+    pub(crate) fn is_uninhabited(&self, ty: Ty<'tcx>) -> bool {
         !ty.is_inhabited_from(self.tcx, self.module, self.param_env)
+    }
+
+    pub(crate) fn is_opaque(ty: Ty<'tcx>) -> bool {
+        matches!(ty.kind(), ty::Alias(ty::Opaque, ..))
     }
 
     /// Returns whether the given type is an enum from another crate declared `#[non_exhaustive]`.

--- a/compiler/rustc_pattern_analysis/src/errors.rs
+++ b/compiler/rustc_pattern_analysis/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_middle::thir::Pat;
 use rustc_middle::ty::Ty;
 use rustc_span::Span;
 
-use crate::cx::{MatchCheckCtxt, WitnessPat};
+use crate::rustc::{RustcCtxt, WitnessPat};
 
 #[derive(Subdiagnostic)]
 #[label(pattern_analysis_uncovered)]
@@ -21,7 +21,7 @@ pub struct Uncovered<'tcx> {
 impl<'tcx> Uncovered<'tcx> {
     pub fn new<'p>(
         span: Span,
-        cx: &MatchCheckCtxt<'p, 'tcx>,
+        cx: &RustcCtxt<'p, 'tcx>,
         witnesses: Vec<WitnessPat<'p, 'tcx>>,
     ) -> Self {
         let witness_1 = cx.hoist_witness_pat(witnesses.get(0).unwrap());

--- a/compiler/rustc_pattern_analysis/src/errors.rs
+++ b/compiler/rustc_pattern_analysis/src/errors.rs
@@ -1,10 +1,10 @@
-use crate::{cx::MatchCheckCtxt, pat::WitnessPat};
-
 use rustc_errors::{AddToDiagnostic, Diagnostic, SubdiagnosticMessage};
 use rustc_macros::{LintDiagnostic, Subdiagnostic};
 use rustc_middle::thir::Pat;
 use rustc_middle::ty::Ty;
 use rustc_span::Span;
+
+use crate::cx::{MatchCheckCtxt, WitnessPat};
 
 #[derive(Subdiagnostic)]
 #[label(pattern_analysis_uncovered)]
@@ -22,7 +22,7 @@ impl<'tcx> Uncovered<'tcx> {
     pub fn new<'p>(
         span: Span,
         cx: &MatchCheckCtxt<'p, 'tcx>,
-        witnesses: Vec<WitnessPat<'tcx>>,
+        witnesses: Vec<WitnessPat<'p, 'tcx>>,
     ) -> Self {
         let witness_1 = cx.hoist_witness_pat(witnesses.get(0).unwrap());
         Self {

--- a/compiler/rustc_pattern_analysis/src/errors.rs
+++ b/compiler/rustc_pattern_analysis/src/errors.rs
@@ -4,7 +4,7 @@ use rustc_middle::thir::Pat;
 use rustc_middle::ty::Ty;
 use rustc_span::Span;
 
-use crate::rustc::{RustcCtxt, WitnessPat};
+use crate::rustc::{RustcMatchCheckCtxt, WitnessPat};
 
 #[derive(Subdiagnostic)]
 #[label(pattern_analysis_uncovered)]
@@ -21,7 +21,7 @@ pub struct Uncovered<'tcx> {
 impl<'tcx> Uncovered<'tcx> {
     pub fn new<'p>(
         span: Span,
-        cx: &RustcCtxt<'p, 'tcx>,
+        cx: &RustcMatchCheckCtxt<'p, 'tcx>,
         witnesses: Vec<WitnessPat<'p, 'tcx>>,
     ) -> Self {
         let witness_1 = cx.hoist_witness_pat(witnesses.get(0).unwrap());

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -14,36 +14,71 @@ extern crate rustc_middle;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
+use std::fmt;
+
+use constructor::{Constructor, ConstructorSet};
 use lints::PatternColumn;
 use rustc_hir::HirId;
+use rustc_index::Idx;
 use rustc_middle::ty::Ty;
-use usefulness::{compute_match_usefulness, UsefulnessReport};
+use usefulness::{compute_match_usefulness, UsefulnessReport, ValidityConstraint};
 
 use crate::cx::MatchCheckCtxt;
 use crate::lints::{lint_nonexhaustive_missing_variants, lint_overlapping_range_endpoints};
 use crate::pat::DeconstructedPat;
 
+pub trait MatchCx: Sized + Clone + fmt::Debug {
+    type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
+    type Span: Clone + Default;
+    type VariantIdx: Clone + Idx;
+    type StrLit: Clone + PartialEq + fmt::Debug;
+
+    fn is_opaque_ty(ty: Self::Ty) -> bool;
+    fn is_exhaustive_patterns_feature_on(&self) -> bool;
+
+    /// The number of fields for this constructor.
+    fn ctor_arity(&self, ctor: &Constructor<Self>, ty: Self::Ty) -> usize;
+
+    /// The types of the fields for this constructor. The result must have a length of
+    /// `ctor_arity()`.
+    fn ctor_sub_tys(&self, ctor: &Constructor<Self>, ty: Self::Ty) -> &[Self::Ty];
+
+    /// The set of all the constructors for `ty`.
+    ///
+    /// This must follow the invariants of `ConstructorSet`
+    fn ctors_for_ty(&self, ty: Self::Ty) -> ConstructorSet<Self>;
+
+    /// Best-effort `Debug` implementation.
+    fn debug_pat(f: &mut fmt::Formatter<'_>, pat: &DeconstructedPat<'_, Self>) -> fmt::Result;
+
+    /// Raise a bug.
+    fn bug(&self, fmt: fmt::Arguments<'_>) -> !;
+}
+
 /// The arm of a match expression.
-#[derive(Clone, Copy, Debug)]
-pub struct MatchArm<'p, 'tcx> {
+#[derive(Clone, Debug)]
+pub struct MatchArm<'p, Cx: MatchCx> {
     /// The pattern must have been lowered through `check_match::MatchVisitor::lower_pattern`.
-    pub pat: &'p DeconstructedPat<'p, 'tcx>,
+    pub pat: &'p DeconstructedPat<'p, Cx>,
     pub hir_id: HirId,
     pub has_guard: bool,
 }
+
+impl<'p, Cx: MatchCx> Copy for MatchArm<'p, Cx> {}
 
 /// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
 /// useful, and runs some lints.
 pub fn analyze_match<'p, 'tcx>(
     cx: &MatchCheckCtxt<'p, 'tcx>,
-    arms: &[MatchArm<'p, 'tcx>],
+    arms: &[MatchArm<'p, MatchCheckCtxt<'p, 'tcx>>],
     scrut_ty: Ty<'tcx>,
-) -> UsefulnessReport<'p, 'tcx> {
+) -> UsefulnessReport<'p, MatchCheckCtxt<'p, 'tcx>> {
     // Arena to store the extra wildcards we construct during analysis.
     let wildcard_arena = cx.pattern_arena;
     let pat_column = PatternColumn::new(arms);
 
-    let report = compute_match_usefulness(cx, arms, scrut_ty, wildcard_arena);
+    let scrut_validity = ValidityConstraint::from_bool(cx.known_valid_scrutinee);
+    let report = compute_match_usefulness(cx, arms, scrut_ty, scrut_validity, wildcard_arena);
 
     // Lint on ranges that overlap on their endpoints, which is likely a mistake.
     lint_overlapping_range_endpoints(cx, &pat_column, wildcard_arena);

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -32,7 +32,7 @@ use crate::lints::{
 };
 use crate::pat::DeconstructedPat;
 #[cfg(feature = "rustc")]
-use crate::rustc::RustcCtxt;
+use crate::rustc::RustcMatchCheckCtxt;
 #[cfg(feature = "rustc")]
 use crate::usefulness::{compute_match_usefulness, ValidityConstraint};
 
@@ -90,7 +90,7 @@ pub use rustc_data_structures::captures::Captures;
 /// useful, and runs some lints.
 #[cfg(feature = "rustc")]
 pub fn analyze_match<'p, 'tcx>(
-    cx: &RustcCtxt<'p, 'tcx>,
+    cx: &RustcMatchCheckCtxt<'p, 'tcx>,
     arms: &[rustc::MatchArm<'p, 'tcx>],
     scrut_ty: Ty<'tcx>,
 ) -> rustc::UsefulnessReport<'p, 'tcx> {

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -49,16 +49,16 @@ impl<'a, T: ?Sized> Captures<'a> for T {}
 /// Context that provides type information about constructors.
 ///
 /// Most of the crate is parameterized on a type that implements this trait.
-pub trait MatchCx: Sized + Clone + fmt::Debug {
+pub trait TypeCx: Sized + Clone + fmt::Debug {
     /// The type of a pattern.
     type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
     /// The index of an enum variant.
     type VariantIdx: Clone + Idx;
     /// A string literal
     type StrLit: Clone + PartialEq + fmt::Debug;
-    /// Extra data to store on a match arm.
+    /// Extra data to store in a match arm.
     type ArmData: Copy + Clone + fmt::Debug;
-    /// Extra data to store on a pattern. `Default` needed when we create fictitious wildcard
+    /// Extra data to store in a pattern. `Default` needed when we create fictitious wildcard
     /// patterns during analysis.
     type PatData: Clone + Default;
 
@@ -86,24 +86,24 @@ pub trait MatchCx: Sized + Clone + fmt::Debug {
 
 /// Context that provides information global to a match.
 #[derive(Clone)]
-pub struct MatchCtxt<'a, 'p, Cx: MatchCx> {
+pub struct MatchCtxt<'a, 'p, Cx: TypeCx> {
     /// The context for type information.
     pub tycx: &'a Cx,
     /// An arena to store the wildcards we produce during analysis.
     pub wildcard_arena: &'a TypedArena<DeconstructedPat<'p, Cx>>,
 }
 
-impl<'a, 'p, Cx: MatchCx> Copy for MatchCtxt<'a, 'p, Cx> {}
+impl<'a, 'p, Cx: TypeCx> Copy for MatchCtxt<'a, 'p, Cx> {}
 
 /// The arm of a match expression.
 #[derive(Clone, Debug)]
-pub struct MatchArm<'p, Cx: MatchCx> {
+pub struct MatchArm<'p, Cx: TypeCx> {
     pub pat: &'p DeconstructedPat<'p, Cx>,
     pub has_guard: bool,
     pub arm_data: Cx::ArmData,
 }
 
-impl<'p, Cx: MatchCx> Copy for MatchArm<'p, Cx> {}
+impl<'p, Cx: TypeCx> Copy for MatchArm<'p, Cx> {}
 
 /// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
 /// useful, and runs some lints.

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -79,6 +79,13 @@ pub struct MatchArm<'p, Cx: MatchCx> {
 
 impl<'p, Cx: MatchCx> Copy for MatchArm<'p, Cx> {}
 
+#[cfg(not(feature = "rustc"))]
+pub trait Captures<'a> {}
+#[cfg(not(feature = "rustc"))]
+impl<'a, T: ?Sized> Captures<'a> for T {}
+#[cfg(feature = "rustc")]
+pub use rustc_data_structures::captures::Captures;
+
 /// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
 /// useful, and runs some lints.
 #[cfg(feature = "rustc")]

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -30,8 +30,12 @@ use crate::rustc::RustcCtxt;
 pub trait MatchCx: Sized + Clone + fmt::Debug {
     type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
     type Span: Clone + Default;
+    /// The index of an enum variant.
     type VariantIdx: Clone + Idx;
+    /// A string literal
     type StrLit: Clone + PartialEq + fmt::Debug;
+    /// Extra data to store on a match arm.
+    type ArmData: Copy + Clone + fmt::Debug;
 
     fn is_opaque_ty(ty: Self::Ty) -> bool;
     fn is_exhaustive_patterns_feature_on(&self) -> bool;
@@ -60,8 +64,8 @@ pub trait MatchCx: Sized + Clone + fmt::Debug {
 pub struct MatchArm<'p, Cx: MatchCx> {
     /// The pattern must have been lowered through `check_match::MatchVisitor::lower_pattern`.
     pub pat: &'p DeconstructedPat<'p, Cx>,
-    pub hir_id: HirId,
     pub has_guard: bool,
+    pub arm_data: Cx::ArmData,
 }
 
 impl<'p, Cx: MatchCx> Copy for MatchArm<'p, Cx> {}

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -37,14 +37,17 @@ use crate::rustc::RustcMatchCheckCtxt;
 use crate::usefulness::{compute_match_usefulness, ValidityConstraint};
 
 pub trait MatchCx: Sized + Clone + fmt::Debug {
+    /// The type of a pattern.
     type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
-    type Span: Clone + Default;
     /// The index of an enum variant.
     type VariantIdx: Clone + Idx;
     /// A string literal
     type StrLit: Clone + PartialEq + fmt::Debug;
     /// Extra data to store on a match arm.
     type ArmData: Copy + Clone + fmt::Debug;
+    /// Extra data to store on a pattern. `Default` needed when we create fictitious wildcard
+    /// patterns during analysis.
+    type PatData: Clone + Default;
 
     fn is_opaque_ty(ty: Self::Ty) -> bool;
     fn is_exhaustive_patterns_feature_on(&self) -> bool;

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -1,31 +1,40 @@
 //! Analysis of patterns, notably match exhaustiveness checking.
 
 pub mod constructor;
+#[cfg(feature = "rustc")]
 pub mod errors;
+#[cfg(feature = "rustc")]
 pub(crate) mod lints;
 pub mod pat;
+#[cfg(feature = "rustc")]
 pub mod rustc;
 pub mod usefulness;
 
 #[macro_use]
 extern crate tracing;
+#[cfg(feature = "rustc")]
 #[macro_use]
 extern crate rustc_middle;
 
+#[cfg(feature = "rustc")]
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }
 
 use std::fmt;
 
-use constructor::{Constructor, ConstructorSet};
-use lints::PatternColumn;
-use rustc_hir::HirId;
 use rustc_index::Idx;
+#[cfg(feature = "rustc")]
 use rustc_middle::ty::Ty;
-use usefulness::{compute_match_usefulness, ValidityConstraint};
 
-use crate::lints::{lint_nonexhaustive_missing_variants, lint_overlapping_range_endpoints};
+use crate::constructor::{Constructor, ConstructorSet};
+#[cfg(feature = "rustc")]
+use crate::lints::{
+    lint_nonexhaustive_missing_variants, lint_overlapping_range_endpoints, PatternColumn,
+};
 use crate::pat::DeconstructedPat;
+#[cfg(feature = "rustc")]
 use crate::rustc::RustcCtxt;
+#[cfg(feature = "rustc")]
+use crate::usefulness::{compute_match_usefulness, ValidityConstraint};
 
 pub trait MatchCx: Sized + Clone + fmt::Debug {
     type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
@@ -72,6 +81,7 @@ impl<'p, Cx: MatchCx> Copy for MatchArm<'p, Cx> {}
 
 /// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
 /// useful, and runs some lints.
+#[cfg(feature = "rustc")]
 pub fn analyze_match<'p, 'tcx>(
     cx: &RustcCtxt<'p, 'tcx>,
     arms: &[rustc::MatchArm<'p, 'tcx>],

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -79,12 +79,8 @@ pub struct MatchArm<'p, Cx: MatchCx> {
 
 impl<'p, Cx: MatchCx> Copy for MatchArm<'p, Cx> {}
 
-#[cfg(not(feature = "rustc"))]
 pub trait Captures<'a> {}
-#[cfg(not(feature = "rustc"))]
 impl<'a, T: ?Sized> Captures<'a> for T {}
-#[cfg(feature = "rustc")]
-pub use rustc_data_structures::captures::Captures;
 
 /// The entrypoint for this crate. Computes whether a match is exhaustive and which of its arms are
 /// useful, and runs some lints.

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -205,7 +205,7 @@ pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
         // usage of the lint.
         for arm in arms {
             let (lint_level, lint_level_source) =
-                cx.tcx.lint_level_at_node(NON_EXHAUSTIVE_OMITTED_PATTERNS, arm.hir_id);
+                cx.tcx.lint_level_at_node(NON_EXHAUSTIVE_OMITTED_PATTERNS, arm.arm_data);
             if !matches!(lint_level, rustc_session::lint::Level::Allow) {
                 let decorator = NonExhaustiveOmittedPatternLintOnArm {
                     lint_span: lint_level_source.span(),

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -82,14 +82,11 @@ impl<'a, 'p, 'tcx> PatternColumn<'a, 'p, 'tcx> {
     /// This returns one column per field of the constructor. They usually all have the same length
     /// (the number of patterns in `self` that matched `ctor`), except that we expand or-patterns
     /// which may change the lengths.
-    fn specialize<'b>(
+    fn specialize(
         &self,
-        pcx: &'b PatCtxt<'_, 'p, 'tcx>,
+        pcx: &PatCtxt<'a, 'p, 'tcx>,
         ctor: &Constructor<'p, 'tcx>,
-    ) -> Vec<PatternColumn<'b, 'p, 'tcx>>
-    where
-        'a: 'b,
-    {
+    ) -> Vec<PatternColumn<'a, 'p, 'tcx>> {
         let arity = ctor.arity(pcx);
         if arity == 0 {
             return Vec::new();

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -213,7 +213,7 @@ pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
                 };
 
                 use rustc_errors::DecorateLint;
-                let mut err = cx.tcx.sess.struct_span_warn(*arm.pat.span(), "");
+                let mut err = cx.tcx.sess.struct_span_warn(*arm.pat.data(), "");
                 err.set_primary_message(decorator.msg());
                 decorator.decorate_lint(&mut err);
                 err.emit();
@@ -263,7 +263,7 @@ pub(crate) fn lint_overlapping_range_endpoints<'a, 'p, 'tcx>(
                 let mut suffixes: SmallVec<[_; 1]> = Default::default();
                 // Iterate on patterns that contained `overlap`.
                 for pat in column.iter() {
-                    let this_span = *pat.span();
+                    let this_span = *pat.data();
                     let Constructor::IntRange(this_range) = pat.ctor() else { continue };
                     if this_range.is_singleton() {
                         // Don't lint when one of the ranges is a singleton.

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -53,12 +53,11 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
         }
         // If the type is opaque and it is revealed anywhere in the column, we take the revealed
         // version. Otherwise we could encounter constructors for the revealed type and crash.
-        let is_opaque = |ty: Ty<'tcx>| matches!(ty.kind(), ty::Alias(ty::Opaque, ..));
         let first_ty = self.patterns[0].ty();
-        if is_opaque(first_ty) {
+        if MatchCheckCtxt::is_opaque(first_ty) {
             for pat in &self.patterns {
                 let ty = pat.ty();
-                if !is_opaque(ty) {
+                if !MatchCheckCtxt::is_opaque(ty) {
                     return Some(ty);
                 }
             }

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -15,7 +15,7 @@ use crate::rustc::{
     Constructor, DeconstructedPat, MatchArm, MatchCtxt, PlaceCtxt, RustcMatchCheckCtxt,
     SplitConstructorSet, WitnessPat,
 };
-use crate::MatchCx;
+use crate::TypeCx;
 
 /// A column of patterns in the matrix, where a column is the intuitive notion of "subpatterns that
 /// inspect the same subvalue/place".

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -13,7 +13,7 @@ use crate::errors::{
     OverlappingRangeEndpoints, Uncovered,
 };
 use crate::rustc::{
-    Constructor, DeconstructedPat, MatchArm, PatCtxt, RustcMatchCheckCtxt, SplitConstructorSet,
+    Constructor, DeconstructedPat, MatchArm, PlaceCtxt, RustcMatchCheckCtxt, SplitConstructorSet,
     WitnessPat,
 };
 use crate::MatchCx;
@@ -68,7 +68,7 @@ impl<'a, 'p, 'tcx> PatternColumn<'a, 'p, 'tcx> {
     }
 
     /// Do constructor splitting on the constructors of the column.
-    fn analyze_ctors(&self, pcx: &PatCtxt<'_, 'p, 'tcx>) -> SplitConstructorSet<'p, 'tcx> {
+    fn analyze_ctors(&self, pcx: &PlaceCtxt<'_, 'p, 'tcx>) -> SplitConstructorSet<'p, 'tcx> {
         let column_ctors = self.patterns.iter().map(|p| p.ctor());
         pcx.cx.ctors_for_ty(pcx.ty).split(pcx, column_ctors)
     }
@@ -84,7 +84,7 @@ impl<'a, 'p, 'tcx> PatternColumn<'a, 'p, 'tcx> {
     /// which may change the lengths.
     fn specialize(
         &self,
-        pcx: &PatCtxt<'a, 'p, 'tcx>,
+        pcx: &PlaceCtxt<'a, 'p, 'tcx>,
         ctor: &Constructor<'p, 'tcx>,
     ) -> Vec<PatternColumn<'a, 'p, 'tcx>> {
         let arity = ctor.arity(pcx);
@@ -130,7 +130,7 @@ fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
     let Some(ty) = column.head_ty() else {
         return Vec::new();
     };
-    let pcx = &PatCtxt::new_dummy(cx, ty, wildcard_arena);
+    let pcx = &PlaceCtxt::new_dummy(cx, ty, wildcard_arena);
 
     let set = column.analyze_ctors(pcx);
     if set.present.is_empty() {
@@ -232,7 +232,7 @@ pub(crate) fn lint_overlapping_range_endpoints<'a, 'p, 'tcx>(
     let Some(ty) = column.head_ty() else {
         return;
     };
-    let pcx = &PatCtxt::new_dummy(cx, ty, wildcard_arena);
+    let pcx = &PlaceCtxt::new_dummy(cx, ty, wildcard_arena);
 
     let set = column.analyze_ctors(pcx);
 

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -5,13 +5,11 @@ use std::fmt;
 
 use smallvec::{smallvec, SmallVec};
 
-use rustc_data_structures::captures::Captures;
-
-use self::Constructor::*;
-
 use crate::constructor::{Constructor, Slice, SliceKind};
 use crate::usefulness::PatCtxt;
-use crate::MatchCx;
+use crate::{Captures, MatchCx};
+
+use self::Constructor::*;
 
 /// Values and patterns can be represented as a constructor applied to some fields. This represents
 /// a pattern in this form.

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -7,7 +7,7 @@ use smallvec::{smallvec, SmallVec};
 
 use crate::constructor::{Constructor, Slice, SliceKind};
 use crate::usefulness::PlaceCtxt;
-use crate::{Captures, MatchCx};
+use crate::{Captures, TypeCx};
 
 use self::Constructor::*;
 
@@ -22,7 +22,7 @@ use self::Constructor::*;
 /// This happens if a private or `non_exhaustive` field is uninhabited, because the code mustn't
 /// observe that it is uninhabited. In that case that field is not included in `fields`. Care must
 /// be taken when converting to/from `thir::Pat`.
-pub struct DeconstructedPat<'p, Cx: MatchCx> {
+pub struct DeconstructedPat<'p, Cx: TypeCx> {
     ctor: Constructor<Cx>,
     fields: &'p [DeconstructedPat<'p, Cx>],
     ty: Cx::Ty,
@@ -31,7 +31,7 @@ pub struct DeconstructedPat<'p, Cx: MatchCx> {
     useful: Cell<bool>,
 }
 
-impl<'p, Cx: MatchCx> DeconstructedPat<'p, Cx> {
+impl<'p, Cx: TypeCx> DeconstructedPat<'p, Cx> {
     pub fn wildcard(ty: Cx::Ty, data: Cx::PatData) -> Self {
         Self::new(Wildcard, &[], ty, data)
     }
@@ -152,7 +152,7 @@ impl<'p, Cx: MatchCx> DeconstructedPat<'p, Cx> {
 
 /// This is mostly copied from the `Pat` impl. This is best effort and not good enough for a
 /// `Display` impl.
-impl<'p, Cx: MatchCx> fmt::Debug for DeconstructedPat<'p, Cx> {
+impl<'p, Cx: TypeCx> fmt::Debug for DeconstructedPat<'p, Cx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Cx::debug_pat(f, self)
     }
@@ -161,13 +161,13 @@ impl<'p, Cx: MatchCx> fmt::Debug for DeconstructedPat<'p, Cx> {
 /// Same idea as `DeconstructedPat`, except this is a fictitious pattern built up for diagnostics
 /// purposes. As such they don't use interning and can be cloned.
 #[derive(Debug, Clone)]
-pub struct WitnessPat<Cx: MatchCx> {
+pub struct WitnessPat<Cx: TypeCx> {
     ctor: Constructor<Cx>,
     pub(crate) fields: Vec<WitnessPat<Cx>>,
     ty: Cx::Ty,
 }
 
-impl<Cx: MatchCx> WitnessPat<Cx> {
+impl<Cx: TypeCx> WitnessPat<Cx> {
     pub(crate) fn new(ctor: Constructor<Cx>, fields: Vec<Self>, ty: Cx::Ty) -> Self {
         Self { ctor, fields, ty }
     }

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -81,10 +81,10 @@ impl<'p, Cx: MatchCx> DeconstructedPat<'p, Cx> {
         other_ctor: &Constructor<Cx>,
     ) -> SmallVec<[&'a DeconstructedPat<'p, Cx>; 2]> {
         let wildcard_sub_tys = || {
-            let tys = pcx.cx.ctor_sub_tys(other_ctor, pcx.ty);
+            let tys = pcx.ctor_sub_tys(other_ctor);
             tys.iter()
                 .map(|ty| DeconstructedPat::wildcard(*ty, Cx::PatData::default()))
-                .map(|pat| pcx.wildcard_arena.alloc(pat) as &_)
+                .map(|pat| pcx.mcx.wildcard_arena.alloc(pat) as &_)
                 .collect()
         };
         match (&self.ctor, other_ctor) {
@@ -179,7 +179,7 @@ impl<Cx: MatchCx> WitnessPat<Cx> {
     /// For example, if `ctor` is a `Constructor::Variant` for `Option::Some`, we get the pattern
     /// `Some(_)`.
     pub(crate) fn wild_from_ctor(pcx: &PlaceCtxt<'_, '_, Cx>, ctor: Constructor<Cx>) -> Self {
-        let field_tys = pcx.cx.ctor_sub_tys(&ctor, pcx.ty);
+        let field_tys = pcx.ctor_sub_tys(&ctor);
         let fields = field_tys.iter().map(|ty| Self::wildcard(*ty)).collect();
         Self::new(ctor, fields, pcx.ty)
     }

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use smallvec::{smallvec, SmallVec};
 
 use crate::constructor::{Constructor, Slice, SliceKind};
-use crate::usefulness::PatCtxt;
+use crate::usefulness::PlaceCtxt;
 use crate::{Captures, MatchCx};
 
 use self::Constructor::*;
@@ -77,7 +77,7 @@ impl<'p, Cx: MatchCx> DeconstructedPat<'p, Cx> {
     /// `other_ctor` can be different from `self.ctor`, but must be covered by it.
     pub(crate) fn specialize<'a>(
         &self,
-        pcx: &PatCtxt<'a, 'p, Cx>,
+        pcx: &PlaceCtxt<'a, 'p, Cx>,
         other_ctor: &Constructor<Cx>,
     ) -> SmallVec<[&'a DeconstructedPat<'p, Cx>; 2]> {
         let wildcard_sub_tys = || {
@@ -178,7 +178,7 @@ impl<Cx: MatchCx> WitnessPat<Cx> {
     /// Construct a pattern that matches everything that starts with this constructor.
     /// For example, if `ctor` is a `Constructor::Variant` for `Option::Some`, we get the pattern
     /// `Some(_)`.
-    pub(crate) fn wild_from_ctor(pcx: &PatCtxt<'_, '_, Cx>, ctor: Constructor<Cx>) -> Self {
+    pub(crate) fn wild_from_ctor(pcx: &PlaceCtxt<'_, '_, Cx>, ctor: Constructor<Cx>) -> Self {
         let field_tys = pcx.cx.ctor_sub_tys(&ctor, pcx.ty);
         let fields = field_tys.iter().map(|ty| Self::wildcard(*ty)).collect();
         Self::new(ctor, fields, pcx.ty)

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -35,7 +35,7 @@ pub(crate) type PatCtxt<'a, 'p, 'tcx> =
     crate::usefulness::PatCtxt<'a, 'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub(crate) type SplitConstructorSet<'p, 'tcx> =
     crate::constructor::SplitConstructorSet<RustcMatchCheckCtxt<'p, 'tcx>>;
-pub type Usefulness = crate::usefulness::Usefulness<Span>;
+pub type Usefulness<'p, 'tcx> = crate::usefulness::Usefulness<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub type UsefulnessReport<'p, 'tcx> =
     crate::usefulness::UsefulnessReport<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub type WitnessPat<'p, 'tcx> = crate::pat::WitnessPat<RustcMatchCheckCtxt<'p, 'tcx>>;
@@ -864,10 +864,10 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
 
 impl<'p, 'tcx> MatchCx for RustcMatchCheckCtxt<'p, 'tcx> {
     type Ty = Ty<'tcx>;
-    type Span = Span;
     type VariantIdx = VariantIdx;
     type StrLit = Const<'tcx>;
     type ArmData = HirId;
+    type PatData = Span;
 
     fn is_exhaustive_patterns_feature_on(&self) -> bool {
         self.tcx.features().exhaustive_patterns

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -31,6 +31,7 @@ pub type ConstructorSet<'p, 'tcx> =
 pub type DeconstructedPat<'p, 'tcx> =
     crate::pat::DeconstructedPat<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub type MatchArm<'p, 'tcx> = crate::MatchArm<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
+pub type MatchCtxt<'a, 'p, 'tcx> = crate::MatchCtxt<'a, 'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub(crate) type PlaceCtxt<'a, 'p, 'tcx> =
     crate::usefulness::PlaceCtxt<'a, 'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub(crate) type SplitConstructorSet<'p, 'tcx> =

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -20,7 +20,7 @@ use smallvec::SmallVec;
 use crate::constructor::{
     IntRange, MaybeInfiniteInt, OpaqueId, RangeEnd, Slice, SliceKind, VariantVisibility,
 };
-use crate::MatchCx;
+use crate::TypeCx;
 
 use crate::constructor::Constructor::*;
 
@@ -863,7 +863,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
     }
 }
 
-impl<'p, 'tcx> MatchCx for RustcMatchCheckCtxt<'p, 'tcx> {
+impl<'p, 'tcx> TypeCx for RustcMatchCheckCtxt<'p, 'tcx> {
     type Ty = Ty<'tcx>;
     type VariantIdx = VariantIdx;
     type StrLit = Const<'tcx>;

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -25,19 +25,23 @@ use crate::MatchCx;
 use crate::constructor::Constructor::*;
 
 // Re-export rustc-specific versions of all these types.
-pub type Constructor<'p, 'tcx> = crate::constructor::Constructor<RustcCtxt<'p, 'tcx>>;
-pub type ConstructorSet<'p, 'tcx> = crate::constructor::ConstructorSet<RustcCtxt<'p, 'tcx>>;
-pub type DeconstructedPat<'p, 'tcx> = crate::pat::DeconstructedPat<'p, RustcCtxt<'p, 'tcx>>;
-pub type MatchArm<'p, 'tcx> = crate::MatchArm<'p, RustcCtxt<'p, 'tcx>>;
-pub(crate) type PatCtxt<'a, 'p, 'tcx> = crate::usefulness::PatCtxt<'a, 'p, RustcCtxt<'p, 'tcx>>;
+pub type Constructor<'p, 'tcx> = crate::constructor::Constructor<RustcMatchCheckCtxt<'p, 'tcx>>;
+pub type ConstructorSet<'p, 'tcx> =
+    crate::constructor::ConstructorSet<RustcMatchCheckCtxt<'p, 'tcx>>;
+pub type DeconstructedPat<'p, 'tcx> =
+    crate::pat::DeconstructedPat<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
+pub type MatchArm<'p, 'tcx> = crate::MatchArm<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
+pub(crate) type PatCtxt<'a, 'p, 'tcx> =
+    crate::usefulness::PatCtxt<'a, 'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub(crate) type SplitConstructorSet<'p, 'tcx> =
-    crate::constructor::SplitConstructorSet<RustcCtxt<'p, 'tcx>>;
+    crate::constructor::SplitConstructorSet<RustcMatchCheckCtxt<'p, 'tcx>>;
 pub type Usefulness = crate::usefulness::Usefulness<Span>;
-pub type UsefulnessReport<'p, 'tcx> = crate::usefulness::UsefulnessReport<'p, RustcCtxt<'p, 'tcx>>;
-pub type WitnessPat<'p, 'tcx> = crate::pat::WitnessPat<RustcCtxt<'p, 'tcx>>;
+pub type UsefulnessReport<'p, 'tcx> =
+    crate::usefulness::UsefulnessReport<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
+pub type WitnessPat<'p, 'tcx> = crate::pat::WitnessPat<RustcMatchCheckCtxt<'p, 'tcx>>;
 
 #[derive(Clone)]
-pub struct RustcCtxt<'p, 'tcx> {
+pub struct RustcMatchCheckCtxt<'p, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     /// The module in which the match occurs. This is necessary for
     /// checking inhabited-ness of types because whether a type is (visibly)
@@ -61,13 +65,13 @@ pub struct RustcCtxt<'p, 'tcx> {
     pub known_valid_scrutinee: bool,
 }
 
-impl<'p, 'tcx> fmt::Debug for RustcCtxt<'p, 'tcx> {
+impl<'p, 'tcx> fmt::Debug for RustcMatchCheckCtxt<'p, 'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RustcCtxt").finish()
+        f.debug_struct("RustcMatchCheckCtxt").finish()
     }
 }
 
-impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
+impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
     pub(crate) fn is_uninhabited(&self, ty: Ty<'tcx>) -> bool {
         !ty.is_inhabited_from(self.tcx, self.module, self.param_env)
     }
@@ -152,7 +156,8 @@ impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
                         // patterns. If we're here we can assume this is a box pattern.
                         cx.dropless_arena.alloc_from_iter(once(args.type_at(0)))
                     } else {
-                        let variant = &adt.variant(RustcCtxt::variant_index_for_adt(&ctor, *adt));
+                        let variant =
+                            &adt.variant(RustcMatchCheckCtxt::variant_index_for_adt(&ctor, *adt));
                         let tys = cx.list_variant_nonhidden_fields(ty, variant).map(|(_, ty)| ty);
                         cx.dropless_arena.alloc_from_iter(tys)
                     }
@@ -197,7 +202,8 @@ impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
                         // patterns. If we're here we can assume this is a box pattern.
                         1
                     } else {
-                        let variant = &adt.variant(RustcCtxt::variant_index_for_adt(&ctor, *adt));
+                        let variant =
+                            &adt.variant(RustcMatchCheckCtxt::variant_index_for_adt(&ctor, *adt));
                         self.list_variant_nonhidden_fields(ty, variant).count()
                     }
                 }
@@ -428,7 +434,8 @@ impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
                             PatKind::Variant { variant_index, .. } => Variant(variant_index),
                             _ => bug!(),
                         };
-                        let variant = &adt.variant(RustcCtxt::variant_index_for_adt(&ctor, *adt));
+                        let variant =
+                            &adt.variant(RustcMatchCheckCtxt::variant_index_for_adt(&ctor, *adt));
                         // For each field in the variant, we store the relevant index into `self.fields` if any.
                         let mut field_id_to_id: Vec<Option<usize>> =
                             (0..variant.fields.len()).map(|_| None).collect();
@@ -687,7 +694,8 @@ impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
                     PatKind::Deref { subpattern: subpatterns.next().unwrap() }
                 }
                 ty::Adt(adt_def, args) => {
-                    let variant_index = RustcCtxt::variant_index_for_adt(&pat.ctor(), *adt_def);
+                    let variant_index =
+                        RustcMatchCheckCtxt::variant_index_for_adt(&pat.ctor(), *adt_def);
                     let variant = &adt_def.variant(variant_index);
                     let subpatterns = cx
                         .list_variant_nonhidden_fields(pat.ty(), variant)
@@ -782,13 +790,14 @@ impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
                     write!(f, "box {subpattern:?}")
                 }
                 ty::Adt(..) | ty::Tuple(..) => {
-                    let variant = match pat.ty().kind() {
-                        ty::Adt(adt, _) => {
-                            Some(adt.variant(RustcCtxt::variant_index_for_adt(pat.ctor(), *adt)))
-                        }
-                        ty::Tuple(_) => None,
-                        _ => unreachable!(),
-                    };
+                    let variant =
+                        match pat.ty().kind() {
+                            ty::Adt(adt, _) => Some(adt.variant(
+                                RustcMatchCheckCtxt::variant_index_for_adt(pat.ctor(), *adt),
+                            )),
+                            ty::Tuple(_) => None,
+                            _ => unreachable!(),
+                        };
 
                     if let Some(variant) = variant {
                         write!(f, "{}", variant.name)?;
@@ -853,7 +862,7 @@ impl<'p, 'tcx> RustcCtxt<'p, 'tcx> {
     }
 }
 
-impl<'p, 'tcx> MatchCx for RustcCtxt<'p, 'tcx> {
+impl<'p, 'tcx> MatchCx for RustcMatchCheckCtxt<'p, 'tcx> {
     type Ty = Ty<'tcx>;
     type Span = Span;
     type VariantIdx = VariantIdx;

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -31,8 +31,8 @@ pub type ConstructorSet<'p, 'tcx> =
 pub type DeconstructedPat<'p, 'tcx> =
     crate::pat::DeconstructedPat<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub type MatchArm<'p, 'tcx> = crate::MatchArm<'p, RustcMatchCheckCtxt<'p, 'tcx>>;
-pub(crate) type PatCtxt<'a, 'p, 'tcx> =
-    crate::usefulness::PatCtxt<'a, 'p, RustcMatchCheckCtxt<'p, 'tcx>>;
+pub(crate) type PlaceCtxt<'a, 'p, 'tcx> =
+    crate::usefulness::PlaceCtxt<'a, 'p, RustcMatchCheckCtxt<'p, 'tcx>>;
 pub(crate) type SplitConstructorSet<'p, 'tcx> =
     crate::constructor::SplitConstructorSet<RustcMatchCheckCtxt<'p, 'tcx>>;
 pub type Usefulness<'p, 'tcx> = crate::usefulness::Usefulness<'p, RustcMatchCheckCtxt<'p, 'tcx>>;

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -556,7 +556,7 @@ use smallvec::{smallvec, SmallVec};
 use std::fmt;
 
 use rustc_data_structures::{captures::Captures, stack::ensure_sufficient_stack};
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::Ty;
 use rustc_span::{Span, DUMMY_SP};
 
 use crate::constructor::{Constructor, ConstructorSet};
@@ -856,11 +856,10 @@ impl<'p, 'tcx> Matrix<'p, 'tcx> {
         let mut ty = self.wildcard_row.head().ty();
         // If the type is opaque and it is revealed anywhere in the column, we take the revealed
         // version. Otherwise we could encounter constructors for the revealed type and crash.
-        let is_opaque = |ty: Ty<'tcx>| matches!(ty.kind(), ty::Alias(ty::Opaque, ..));
-        if is_opaque(ty) {
+        if MatchCheckCtxt::is_opaque(ty) {
             for pat in self.heads() {
                 let pat_ty = pat.ty();
-                if !is_opaque(pat_ty) {
+                if !MatchCheckCtxt::is_opaque(pat_ty) {
                     ty = pat_ty;
                     break;
                 }

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -555,7 +555,12 @@
 use smallvec::{smallvec, SmallVec};
 use std::fmt;
 
+// It's not possible to only enable the `typed_arena` dependency when the `rustc` feature is off, so
+// we use another feature instead. The crate won't compile if one of these isn't enabled.
+#[cfg(feature = "rustc")]
 use rustc_arena::TypedArena;
+#[cfg(feature = "stable")]
+use typed_arena::Arena as TypedArena;
 
 use crate::constructor::{Constructor, ConstructorSet};
 use crate::pat::{DeconstructedPat, WitnessPat};

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -556,13 +556,19 @@ use smallvec::{smallvec, SmallVec};
 use std::fmt;
 
 use rustc_arena::TypedArena;
-use rustc_data_structures::{captures::Captures, stack::ensure_sufficient_stack};
 
 use crate::constructor::{Constructor, ConstructorSet};
 use crate::pat::{DeconstructedPat, WitnessPat};
-use crate::{MatchArm, MatchCx};
+use crate::{Captures, MatchArm, MatchCx};
 
 use self::ValidityConstraint::*;
+
+#[cfg(feature = "rustc")]
+use rustc_data_structures::stack::ensure_sufficient_stack;
+#[cfg(not(feature = "rustc"))]
+pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
+    f()
+}
 
 #[derive(Clone)]
 pub(crate) struct PatCtxt<'a, 'p, Cx: MatchCx> {

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -578,6 +578,7 @@ pub(crate) struct PatCtxt<'a, 'p, Cx: MatchCx> {
 
 impl<'a, 'p, Cx: MatchCx> PatCtxt<'a, 'p, Cx> {
     /// A `PatCtxt` when code other than `is_useful` needs one.
+    #[cfg_attr(not(feature = "rustc"), allow(dead_code))]
     pub(crate) fn new_dummy(
         cx: &'a Cx,
         ty: Cx::Ty,
@@ -601,7 +602,7 @@ impl<'a, 'p, Cx: MatchCx> fmt::Debug for PatCtxt<'a, 'p, Cx> {
 /// - in the matrix, track whether a given place (aka column) is known to contain a valid value or
 ///     not.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum ValidityConstraint {
+pub enum ValidityConstraint {
     ValidOnly,
     MaybeInvalid,
     /// Option for backwards compatibility: the place is not known to be valid but we allow omitting
@@ -610,7 +611,7 @@ pub(crate) enum ValidityConstraint {
 }
 
 impl ValidityConstraint {
-    pub(crate) fn from_bool(is_valid_only: bool) -> Self {
+    pub fn from_bool(is_valid_only: bool) -> Self {
         if is_valid_only { ValidOnly } else { MaybeInvalid }
     }
 
@@ -1296,7 +1297,7 @@ pub struct UsefulnessReport<'p, Cx: MatchCx> {
 
 /// Computes whether a match is exhaustive and which of its arms are useful.
 #[instrument(skip(cx, arms, wildcard_arena), level = "debug")]
-pub(crate) fn compute_match_usefulness<'p, Cx: MatchCx>(
+pub fn compute_match_usefulness<'p, Cx: MatchCx>(
     cx: &Cx,
     arms: &[MatchArm<'p, Cx>],
     scrut_ty: Cx::Ty,

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -357,6 +357,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "tracing-tree",
     "twox-hash",
     "type-map",
+    "typed-arena",
     "typenum",
     "unic-langid",
     "unic-langid-impl",


### PR DESCRIPTION
With this PR, `rustc_pattern_analysis` compiles on stable (with the `stable` feature)! `rust-analyzer` will be able to use it to provide match-related diagnostics and refactors.

Two questions:
- Should I name the feature `nightly` instead of `rustc` for consistency with other crates? `rustc` makes more sense imo.
- `typed-arena` is an optional dependency but tidy made me add it to the allow-list anyway. Can I avoid that somehow?

r? @compiler-errors 