### PR TITLE
llvm-wrapper: adapt for LLVM API change

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -37,7 +37,9 @@
 #include "llvm/Transforms/Utils/FunctionImportUtils.h"
 #include "llvm/LTO/LTO.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
-
+#if LLVM_VERSION_GE(18, 0)
+#include "llvm/TargetParser/Host.h"
+#endif
 #include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 #include "llvm/Support/TimeProfiler.h"


### PR DESCRIPTION
LLVM commit https://github.com/llvm/llvm-project/commit/f09cf34d00625e57dea5317a3ac0412c07292148 (old) moved some functions to a different header. It looks we were getting it transitively in PassWrapper, and something in LLVM recently removed it from the set of transitively available headers, so include it directly:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/24416#018c5de6-b9c9-4b22-9473-6070d99dcfa7/233-537

r? @nikic 