### PR TITLE
Check normalized call signature for WF in mir typeck

### DIFF
--- a/tests/ui/nll/check-normalized-sig-for-wf.rs
+++ b/tests/ui/nll/check-normalized-sig-for-wf.rs
@@ -1,0 +1,27 @@
+// <https://github.com/rust-lang/rust/issues/114936>
+fn whoops(
+    s: String,
+    f: impl for<'s> FnOnce(&'s str) -> (&'static str, [&'static &'s (); 0]),
+) -> &'static str
+{
+    f(&s).0
+    //~^ ERROR `s` does not live long enough
+}
+
+// <https://github.com/rust-lang/rust/issues/118876>
+fn extend<T>(input: &T) -> &'static T {
+    struct Bounded<'a, 'b: 'static, T>(&'a T, [&'b (); 0]);
+    let n: Box<dyn FnOnce(&T) -> Bounded<'static, '_, T>> = Box::new(|x| Bounded(x, []));
+    n(input).0
+    //~^ ERROR borrowed data escapes outside of function
+}
+
+// <https://github.com/rust-lang/rust/issues/118876>
+fn extend_mut<'a, T>(input: &'a mut T) -> &'static mut T {
+    struct Bounded<'a, 'b: 'static, T>(&'a mut T, [&'b (); 0]);
+    let mut n: Box<dyn FnMut(&mut T) -> Bounded<'static, '_, T>> = Box::new(|x| Bounded(x, []));
+    n(input).0
+    //~^ ERROR borrowed data escapes outside of function
+}
+
+fn main() {}

--- a/tests/ui/nll/check-normalized-sig-for-wf.stderr
+++ b/tests/ui/nll/check-normalized-sig-for-wf.stderr
@@ -1,0 +1,47 @@
+error[E0597]: `s` does not live long enough
+  --> $DIR/check-normalized-sig-for-wf.rs:7:7
+   |
+LL |     s: String,
+   |     - binding `s` declared here
+...
+LL |     f(&s).0
+   |     --^^-
+   |     | |
+   |     | borrowed value does not live long enough
+   |     argument requires that `s` is borrowed for `'static`
+LL |
+LL | }
+   | - `s` dropped here while still borrowed
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/check-normalized-sig-for-wf.rs:15:5
+   |
+LL | fn extend<T>(input: &T) -> &'static T {
+   |              -----  - let's call the lifetime of this reference `'1`
+   |              |
+   |              `input` is a reference that is only valid in the function body
+...
+LL |     n(input).0
+   |     ^^^^^^^^
+   |     |
+   |     `input` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/check-normalized-sig-for-wf.rs:23:5
+   |
+LL | fn extend_mut<'a, T>(input: &'a mut T) -> &'static mut T {
+   |               --     ----- `input` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+...
+LL |     n(input).0
+   |     ^^^^^^^^
+   |     |
+   |     `input` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0521, E0597.
+For more information about an error, try `rustc --explain E0521`.


### PR DESCRIPTION
Unfortunately we don't check that the built-in implementations for `Fn*` traits are actually well-formed in the same way that we do for user-provided impls.

Essentially, when checking a call terminator, we end up with a signature that references an unnormalized `<[closure] as FnOnce<...>>::Output` in its output. That output type, due to the built-in impl, doesn't follow the expected rule that `WF(ty)` implies `WF(normalized(ty))`. We fix this by also checking the normalized signature here. 

**See** boxy's detailed and useful explanation comment which explains this in more detail: https://github.com/rust-lang/rust/issues/114936#issuecomment-1710388741

Fixes #114936
Fixes #118876

r? types
cc @BoxyUwU @lcnr