### PR TITLE
Unbreak non-unix non-windows bootstrap

### DIFF
--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -5,7 +5,6 @@
 //! parent directory, and otherwise documentation can be found throughout the `build`
 //! directory in each respective module.
 
-#[cfg(all(any(unix, windows), not(target_os = "solaris")))]
 use std::io::Write;
 #[cfg(all(any(unix, windows), not(target_os = "solaris")))]
 use std::process;


### PR DESCRIPTION
Fixes #118862.

#118647 added a new use of std::io::Write that is not conditional on any cfg.

https://github.com/rust-lang/rust/blob/028b6d152e904bbc02dc3cd67e4cbdffcbd039e1/src/bootstrap/src/bin/main.rs#L134

```console
error[E0599]: no method named `write_all` found for struct `File` in the current scope
   --> src/bin/main.rs:134:21
    |
134 |             t!(file.write_all(lines.join("\n").as_bytes()));
    |                     ^^^^^^^^^ method not found in `File`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
8   + use std::io::Write;
    |
```