### PR TITLE
fix(tests): remove check for `echo`

### DIFF
--- a/tests/run-make-fulldeps/hotplug_codegen_backend/Makefile
+++ b/tests/run-make-fulldeps/hotplug_codegen_backend/Makefile
@@ -7,7 +7,6 @@ include ../../run-make/tools.mk
 # -Zbinary-dep-depinfo is used.
 
 all:
-	/bin/echo || exit 0 # This test requires /bin/echo to exist
 	$(RUSTC) the_backend.rs --crate-name the_backend --crate-type dylib \
 		-o $(TMPDIR)/the_backend.dylib
 


### PR DESCRIPTION
fixes: #56222

Removes check for `echo` as it doesn't seem to be used anywhere.