### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1568,7 +1568,7 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
 
         // Alignment of T, must be a constant integer value:
         let alignment_ty = bx.type_i32();
-        let alignment = bx.const_i32(bx.align_of(values_ty).bytes() as i32);
+        let alignment = bx.const_i32(bx.align_of(values_elem).bytes() as i32);
 
         // Truncate the mask vector to a vector of i1s:
         let (mask, mask_ty) = {

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -21,7 +21,7 @@ pub trait ValueVisitor<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>>: Sized {
     /// `read_discriminant` can be hooked for better error messages.
     #[inline(always)]
     fn read_discriminant(&mut self, v: &Self::V) -> InterpResult<'tcx, VariantIdx> {
-        Ok(self.ecx().read_discriminant(&v.to_op(self.ecx())?)?)
+        self.ecx().read_discriminant(&v.to_op(self.ecx())?)
     }
 
     /// This function provides the chance to reorder the order in which fields are visited for

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -587,10 +587,8 @@ fn show_md_content_with_pager(content: &str, color: ColorConfig) {
     let mut print_formatted = if pager_name == "less" {
         cmd.arg("-r");
         true
-    } else if ["bat", "catbat", "delta"].iter().any(|v| *v == pager_name) {
-        true
     } else {
-        false
+        ["bat", "catbat", "delta"].iter().any(|v| *v == pager_name)
     };
 
     if color == ColorConfig::Never {

--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -34,17 +34,14 @@ fn associated_type_bounds<'tcx>(
     let trait_def_id = tcx.local_parent(assoc_item_def_id);
     let trait_predicates = tcx.trait_explicit_predicates_and_bounds(trait_def_id);
 
-    let bounds_from_parent = trait_predicates
-        .predicates
-        .iter()
-        .copied()
-        .filter(|(pred, _)| match pred.kind().skip_binder() {
+    let bounds_from_parent = trait_predicates.predicates.iter().copied().filter(|(pred, _)| {
+        match pred.kind().skip_binder() {
             ty::ClauseKind::Trait(tr) => tr.self_ty() == item_ty,
             ty::ClauseKind::Projection(proj) => proj.projection_ty.self_ty() == item_ty,
             ty::ClauseKind::TypeOutlives(outlives) => outlives.0 == item_ty,
             _ => false,
-        })
-        .map(|(clause, span)| (clause, span));
+        }
+    });
 
     let all_bounds = tcx.arena.alloc_from_iter(bounds.clauses().chain(bounds_from_parent));
     debug!(

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1701,7 +1701,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
             && !ty.is_never()
         {
             let indentation = if let None = block.expr
-                && let [.., last] = &block.stmts[..]
+                && let [.., last] = &block.stmts
             {
                 tcx.sess.source_map().indentation_before(last.span).unwrap_or_else(String::new)
             } else if let Some(expr) = block.expr {
@@ -1710,7 +1710,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 String::new()
             };
             if let None = block.expr
-                && let [.., last] = &block.stmts[..]
+                && let [.., last] = &block.stmts
             {
                 err.span_suggestion_verbose(
                     last.span.shrink_to_hi(),
@@ -1750,7 +1750,7 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                 }
             }
             if let None = block.expr
-                && let [.., last] = &block.stmts[..]
+                && let [.., last] = &block.stmts
             {
                 sugg.push((last.span.shrink_to_hi(), format!("\n{indentation}None")));
             } else if let Some(expr) = block.expr {

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -862,7 +862,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             mutability,
                         ),
                     ),
-                    match &args[..] {
+                    match &args {
                         [] => (base.span.shrink_to_hi().with_hi(deref.span.hi()), ")".to_string()),
                         [first, ..] => (base.span.between(first.span), ", ".to_string()),
                     },

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -315,11 +315,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let final_tupled_upvars_type = Ty::new_tup(self.tcx, &final_upvar_tys);
         self.demand_suptype(span, args.tupled_upvars_ty(), final_tupled_upvars_type);
 
-        let fake_reads = delegate
-            .fake_reads
-            .into_iter()
-            .map(|(place, cause, hir_id)| (place, cause, hir_id))
-            .collect();
+        let fake_reads = delegate.fake_reads;
+
         self.typeck_results.borrow_mut().closure_fake_reads.insert(closure_def_id, fake_reads);
 
         if self.tcx.sess.opts.unstable_opts.profile_closures {

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2452,7 +2452,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
             if !suggs.is_empty() {
                 err.multipart_suggestion_verbose(
-                    format!("{msg}"),
+                    msg,
                     suggs,
                     Applicability::MaybeIncorrect, // Issue #41966
                 );

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -174,7 +174,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         span: Span,
     ) -> Result<PatKind<'tcx>, ErrorGuaranteed> {
         if lo_expr.is_none() && hi_expr.is_none() {
-            let msg = format!("found twice-open range pattern (`..`) outside of error recovery");
+            let msg = "found twice-open range pattern (`..`) outside of error recovery";
             return Err(self.tcx.sess.span_delayed_bug(span, msg));
         }
 

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -649,7 +649,7 @@ impl OpportunitySet {
 
             // `succ` must be a successor of `current`. If it is not, this means this TO is not
             // satisfiable and a previous TO erased this edge, so we bail out.
-            if basic_blocks[current].terminator().successors().find(|s| *s == succ).is_none() {
+            if !basic_blocks[current].terminator().successors().any(|s| s == succ) {
                 debug!("impossible");
                 return;
             }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1440,21 +1440,23 @@ impl<'a> Parser<'a> {
             } else if this.eat_keyword(kw::Underscore) {
                 Ok(this.mk_expr(this.prev_token.span, ExprKind::Underscore))
             } else if this.token.uninterpolated_span().at_least_rust_2018() {
-                // `Span:.at_least_rust_2018()` is somewhat expensive; don't get it repeatedly.
-                if this.check_keyword(kw::Async) {
+                // `Span::at_least_rust_2018()` is somewhat expensive; don't get it repeatedly.
+                if this.token.uninterpolated_span().at_least_rust_2024()
+                    // check for `gen {}` and `gen move {}`
+                    // or `async gen {}` and `async gen move {}`
+                    && (this.is_gen_block(kw::Gen, 0)
+                        || (this.check_keyword(kw::Async) && this.is_gen_block(kw::Gen, 1)))
+                {
+                    // FIXME: (async) gen closures aren't yet parsed.
+                    this.parse_gen_block()
+                } else if this.check_keyword(kw::Async) {
                     // FIXME(gen_blocks): Parse `gen async` and suggest swap
                     if this.is_gen_block(kw::Async, 0) {
                         // Check for `async {` and `async move {`,
-                        // or `async gen {` and `async gen move {`.
                         this.parse_gen_block()
                     } else {
                         this.parse_expr_closure()
                     }
-                } else if this.token.uninterpolated_span().at_least_rust_2024()
-                    && (this.is_gen_block(kw::Gen, 0)
-                        || (this.check_keyword(kw::Async) && this.is_gen_block(kw::Gen, 1)))
-                {
-                    this.parse_gen_block()
                 } else if this.eat_keyword_noexpect(kw::Await) {
                     this.recover_incorrect_await_syntax(lo, this.prev_token.span)
                 } else {
@@ -3219,9 +3221,16 @@ impl<'a> Parser<'a> {
             if self.eat_keyword(kw::Gen) { GenBlockKind::AsyncGen } else { GenBlockKind::Async }
         } else {
             assert!(self.eat_keyword(kw::Gen));
-            self.sess.gated_spans.gate(sym::gen_blocks, lo.to(self.token.span));
             GenBlockKind::Gen
         };
+        match kind {
+            GenBlockKind::Async => {
+                // `async` blocks are stable
+            }
+            GenBlockKind::Gen | GenBlockKind::AsyncGen => {
+                self.sess.gated_spans.gate(sym::gen_blocks, lo.to(self.prev_token.span));
+            }
+        }
         let capture_clause = self.parse_capture_clause()?;
         let (attrs, body) = self.parse_inner_attrs_and_block()?;
         let kind = ExprKind::Gen(capture_clause, body, kind);

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -979,7 +979,7 @@ impl ConstructorSet {
             && !(pcx.is_top_level && matches!(self, Self::NoConstructors))
         {
             // Treat all missing constructors as nonempty.
-            missing.extend(missing_empty.drain(..));
+            missing.append(&mut missing_empty);
         }
 
         SplitConstructorSet { present, missing, missing_empty }

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -979,6 +979,7 @@ impl ConstructorSet {
             && !(pcx.is_top_level && matches!(self, Self::NoConstructors))
         {
             // Treat all missing constructors as nonempty.
+            // This clears `missing_empty`.
             missing.append(&mut missing_empty);
         }
 

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -70,7 +70,7 @@ const DEP_NODE_PAD: usize = DEP_NODE_SIZE - 1;
 const DEP_NODE_WIDTH_BITS: usize = DEP_NODE_SIZE / 2;
 
 /// Data for use when recompiling the **current crate**.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SerializedDepGraph {
     /// The set of all DepNodes in the graph
     nodes: IndexVec<SerializedDepNodeIndex, DepNode>,
@@ -87,18 +87,6 @@ pub struct SerializedDepGraph {
     /// Stores a map from fingerprints to nodes per dep node kind.
     /// This is the reciprocal of `nodes`.
     index: Vec<UnhashMap<PackedFingerprint, SerializedDepNodeIndex>>,
-}
-
-impl Default for SerializedDepGraph {
-    fn default() -> Self {
-        SerializedDepGraph {
-            nodes: Default::default(),
-            fingerprints: Default::default(),
-            edge_list_indices: Default::default(),
-            edge_list_data: Default::default(),
-            index: Default::default(),
-        }
-    }
 }
 
 impl SerializedDepGraph {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1063,12 +1063,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                             initial_binding.res()
                         });
                         let res = binding.res();
-                        let has_ambiguity_error = this
-                            .ambiguity_errors
-                            .iter()
-                            .filter(|error| !error.warning)
-                            .next()
-                            .is_some();
+                        let has_ambiguity_error =
+                            this.ambiguity_errors.iter().any(|error| !error.warning);
                         if res == Res::Err || has_ambiguity_error {
                             this.tcx
                                 .sess

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2178,7 +2178,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                 let (span, text) = match path.segments.first() {
                     Some(seg) if let Some(name) = seg.ident.as_str().strip_prefix("let") => {
                         // a special case for #117894
-                        let name = name.strip_prefix("_").unwrap_or(name);
+                        let name = name.strip_prefix('_').unwrap_or(name);
                         (ident_span, format!("let {name}"))
                     }
                     _ => (ident_span.shrink_to_lo(), "let ".to_string()),

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1829,13 +1829,12 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             )
             .iter()
             .filter_map(|candidate| candidate.did)
-            .filter(|did| {
+            .find(|did| {
                 self.r
                     .tcx
                     .get_attrs(*did, sym::rustc_diagnostic_item)
                     .any(|attr| attr.value_str() == Some(sym::Default))
-            })
-            .next();
+            });
         let Some(default_trait) = default_trait else {
             return;
         };
@@ -1880,11 +1879,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
         };
 
         fields.is_some_and(|fields| {
-            fields
-                .iter()
-                .filter(|vis| !self.r.is_accessible_from(**vis, self.parent_scope.module))
-                .next()
-                .is_some()
+            fields.iter().any(|vis| !self.r.is_accessible_from(*vis, self.parent_scope.module))
         })
     }
 

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -157,7 +157,7 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
                 (name == crate_name).then(|| smir_crate(tables.tcx, *crate_num))
             })
             .into_iter()
-            .filter_map(|c| c)
+            .flatten()
             .collect();
         crates
     }

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -707,7 +707,7 @@ impl<'tcx> Stable<'tcx> for rustc_middle::mir::Const<'tcx> {
                 let id = tables.intern_const(*self);
                 Const::new(kind, ty, id)
             }
-            mir::Const::Val(val, ty) if matches!(val, mir::ConstValue::ZeroSized) => {
+            mir::Const::Val(mir::ConstValue::ZeroSized, ty) => {
                 let ty = ty.stable(tables);
                 let id = tables.intern_const(*self);
                 Const::new(ConstantKind::ZeroSized, ty, id)

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -364,7 +364,7 @@ fn encode_ty_name(tcx: TyCtxt<'_>, def_id: DefId) -> String {
     //     _ZTSFvu27NvNtC1234_5crate6Trait13fooIu22NtC1234_5crate7Struct1Iu3i32ES_EE
     //
     // The reason for not using v0's extended form of paths is to use a consistent and simpler
-    // encoding, as the reasoning for using it isn't relevand for type metadata identifiers (i.e.,
+    // encoding, as the reasoning for using it isn't relevant for type metadata identifiers (i.e.,
     // keep symbol names close to how methods are represented in error messages). See
     // https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html#methods.
     let mut s = String::new();

--- a/compiler/rustc_trait_selection/src/infer.rs
+++ b/compiler/rustc_trait_selection/src/infer.rs
@@ -101,11 +101,10 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
                         self.tcx.impl_trait_ref(impl_def_id).map(|r| (impl_def_id, r))
                     })
                     .map(|(impl_def_id, imp)| (impl_def_id, imp.skip_binder()))
-                    .filter(|(_, imp)| match imp.self_ty().peel_refs().kind() {
+                    .find(|(_, imp)| match imp.self_ty().peel_refs().kind() {
                         ty::Adt(i_def, _) if i_def.did() == def.did() => true,
                         _ => false,
                     })
-                    .next()
             {
                 let mut fulfill_cx = FulfillmentCtxt::new(self);
                 // We get all obligations from the impl to talk about specific

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2167,7 +2167,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             })
             .collect();
         err.multipart_suggestion(
-            format!("consider wrapping the function in a closure"),
+            "consider wrapping the function in a closure",
             vec![
                 (arg.span.shrink_to_lo(), format!("|{}| ", closure_names.join(", "))),
                 (arg.span.shrink_to_hi(), format!("({})", call_names.join(", "))),

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -1069,7 +1069,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             if !self.tcx.is_diagnostic_item(sym::Result, def.did()) {
                 return None;
             }
-            Some(arg.as_type()?)
+            arg.as_type()
         };
 
         let mut suggested = false;

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -15,7 +15,7 @@ trait DisplayInt:
     fn zero() -> Self;
     fn from_u8(u: u8) -> Self;
     fn to_u8(&self) -> u8;
-    fn to_u16(&self) -> u16;
+    #[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
     fn to_u32(&self) -> u32;
     fn to_u64(&self) -> u64;
     fn to_u128(&self) -> u128;
@@ -27,7 +27,7 @@ macro_rules! impl_int {
           fn zero() -> Self { 0 }
           fn from_u8(u: u8) -> Self { u as Self }
           fn to_u8(&self) -> u8 { *self as u8 }
-          fn to_u16(&self) -> u16 { *self as u16 }
+          #[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
           fn to_u32(&self) -> u32 { *self as u32 }
           fn to_u64(&self) -> u64 { *self as u64 }
           fn to_u128(&self) -> u128 { *self as u128 }
@@ -40,7 +40,7 @@ macro_rules! impl_uint {
           fn zero() -> Self { 0 }
           fn from_u8(u: u8) -> Self { u as Self }
           fn to_u8(&self) -> u8 { *self as u8 }
-          fn to_u16(&self) -> u16 { *self as u16 }
+          #[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
           fn to_u32(&self) -> u32 { *self as u32 }
           fn to_u64(&self) -> u64 { *self as u64 }
           fn to_u128(&self) -> u128 { *self as u128 }

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -48,7 +48,7 @@ impl RawWaker {
     /// Get the `data` pointer used to create this `RawWaker`.
     #[inline]
     #[must_use]
-    #[unstable(feature = "waker_getters", issue = "87021")]
+    #[unstable(feature = "waker_getters", issue = "96992")]
     pub fn data(&self) -> *const () {
         self.data
     }
@@ -56,7 +56,7 @@ impl RawWaker {
     /// Get the `vtable` pointer used to create this `RawWaker`.
     #[inline]
     #[must_use]
-    #[unstable(feature = "waker_getters", issue = "87021")]
+    #[unstable(feature = "waker_getters", issue = "96992")]
     pub fn vtable(&self) -> &'static RawWakerVTable {
         self.vtable
     }
@@ -371,7 +371,7 @@ impl Waker {
     /// Get a reference to the underlying [`RawWaker`].
     #[inline]
     #[must_use]
-    #[unstable(feature = "waker_getters", issue = "87021")]
+    #[unstable(feature = "waker_getters", issue = "96992")]
     pub fn as_raw(&self) -> &RawWaker {
         &self.waker
     }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2245,8 +2245,8 @@ impl GenericArgs {
     }
     pub(crate) fn bindings<'a>(&'a self) -> Box<dyn Iterator<Item = TypeBinding> + 'a> {
         match self {
-            &GenericArgs::AngleBracketed { ref bindings, .. } => Box::new(bindings.iter().cloned()),
-            &GenericArgs::Parenthesized { ref output, .. } => Box::new(
+            GenericArgs::AngleBracketed { bindings, .. } => Box::new(bindings.iter().cloned()),
+            GenericArgs::Parenthesized { output, .. } => Box::new(
                 output
                     .as_ref()
                     .map(|ty| TypeBinding {
@@ -2270,8 +2270,8 @@ impl<'a> IntoIterator for &'a GenericArgs {
     type Item = GenericArg;
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            &GenericArgs::AngleBracketed { ref args, .. } => Box::new(args.iter().cloned()),
-            &GenericArgs::Parenthesized { ref inputs, .. } => {
+            GenericArgs::AngleBracketed { args, .. } => Box::new(args.iter().cloned()),
+            GenericArgs::Parenthesized { inputs, .. } => {
                 Box::new(inputs.iter().cloned().map(GenericArg::Type))
             }
         }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1285,6 +1285,16 @@ impl LangString {
                         data.edition = x[7..].parse::<Edition>().ok();
                     }
                     LangStringToken::LangToken(x)
+                        if x.starts_with("rust") && x[4..].parse::<Edition>().is_ok() =>
+                    {
+                        if let Some(extra) = extra {
+                            extra.error_invalid_codeblock_attr(format!(
+                                "unknown attribute `{x}`. Did you mean `edition{}`?",
+                                &x[4..]
+                            ));
+                        }
+                    }
+                    LangStringToken::LangToken(x)
                         if allow_error_code_check && x.starts_with('E') && x.len() == 5 =>
                     {
                         if x[1..].parse::<u32>().is_ok() {

--- a/src/librustdoc/html/render/type_layout.rs
+++ b/src/librustdoc/html/render/type_layout.rs
@@ -79,6 +79,7 @@ pub(crate) fn document_type_layout<'a, 'cx: 'a>(
             TypeLayoutSize { is_unsized, is_uninhabited, size }
         });
 
-        Ok(TypeLayout { variants, type_layout_size }.render_into(f).unwrap())
+        TypeLayout { variants, type_layout_size }.render_into(f).unwrap();
+        Ok(())
     })
 }

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2102,8 +2102,6 @@ function initSearch(rawSearchIndex) {
         }
 
         function innerRunQuery() {
-            let elem, i, nSearchWords, in_returned, row;
-
             let queryLen = 0;
             for (const elem of parsedQuery.elems) {
                 queryLen += elem.name.length;
@@ -2225,8 +2223,8 @@ function initSearch(rawSearchIndex) {
 
             if (parsedQuery.foundElems === 1) {
                 if (parsedQuery.elems.length === 1) {
-                    elem = parsedQuery.elems[0];
-                    for (i = 0, nSearchWords = searchWords.length; i < nSearchWords; ++i) {
+                    const elem = parsedQuery.elems[0];
+                    for (let i = 0, nSearchWords = searchWords.length; i < nSearchWords; ++i) {
                         // It means we want to check for this element everywhere (in names, args and
                         // returned).
                         handleSingleArg(
@@ -2241,10 +2239,9 @@ function initSearch(rawSearchIndex) {
                     }
                 } else if (parsedQuery.returned.length === 1) {
                     // We received one returned argument to check, so looking into returned values.
-                    elem = parsedQuery.returned[0];
-                    for (i = 0, nSearchWords = searchWords.length; i < nSearchWords; ++i) {
-                        row = searchIndex[i];
-                        in_returned = row.type && unifyFunctionTypes(
+                    for (let i = 0, nSearchWords = searchWords.length; i < nSearchWords; ++i) {
+                        const row = searchIndex[i];
+                        const in_returned = row.type && unifyFunctionTypes(
                             row.type.output,
                             parsedQuery.returned,
                             row.type.where_clause
@@ -2262,7 +2259,7 @@ function initSearch(rawSearchIndex) {
                     }
                 }
             } else if (parsedQuery.foundElems > 0) {
-                for (i = 0, nSearchWords = searchWords.length; i < nSearchWords; ++i) {
+                for (let i = 0, nSearchWords = searchWords.length; i < nSearchWords; ++i) {
                     handleArgs(searchIndex[i], i, results_others);
                 }
             }
@@ -2418,7 +2415,6 @@ function initSearch(rawSearchIndex) {
         const extraClass = display ? " active" : "";
 
         const output = document.createElement("div");
-        let length = 0;
         if (array.length > 0) {
             output.className = "search-results " + extraClass;
 
@@ -2427,8 +2423,6 @@ function initSearch(rawSearchIndex) {
                 const type = itemTypes[item.ty];
                 const longType = longItemTypes[item.ty];
                 const typeName = longType.length !== 0 ? `${longType}` : "?";
-
-                length += 1;
 
                 const link = document.createElement("a");
                 link.className = "result-" + type;
@@ -2477,7 +2471,7 @@ ${item.displayPath}<span class="${type}">${name}</span>\
                 "href=\"https://docs.rs\">Docs.rs</a> for documentation of crates released on" +
                 " <a href=\"https://crates.io/\">crates.io</a>.</li></ul>";
         }
-        return [output, length];
+        return [output, array.length];
     }
 
     function makeTabHeader(tabNb, text, nbElems) {

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
@@ -21,7 +21,7 @@ extern "platform-intrinsic" {
 #[no_mangle]
 pub unsafe fn load_f32x2(mask: Vec2<i32>, pointer: *const f32,
                          values: Vec2<f32>) -> Vec2<f32> {
-    // CHECK: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 {{.*}}, <2 x i1> {{.*}}, <2 x float> {{.*}})
+    // CHECK: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 4, <2 x i1> {{.*}}, <2 x float> {{.*}})
     simd_masked_load(mask, pointer, values)
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
@@ -20,7 +20,7 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @store_f32x2
 #[no_mangle]
 pub unsafe fn store_f32x2(mask: Vec2<i32>, pointer: *mut f32, values: Vec2<f32>) {
-    // CHECK: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr {{.*}}, i32 {{.*}}, <2 x i1> {{.*}})
+    // CHECK: call void @llvm.masked.store.v2f32.p0(<2 x float> {{.*}}, ptr {{.*}}, i32 4, <2 x i1> {{.*}})
     simd_masked_store(mask, pointer, values)
 }
 

--- a/tests/rustdoc-ui/doctest/check-attr-test.stderr
+++ b/tests/rustdoc-ui/doctest/check-attr-test.stderr
@@ -1,4 +1,4 @@
-error: unknown attribute `compile-fail`. Did you mean `compile_fail`?
+error: unknown attribute `compile-fail`
  --> $DIR/check-attr-test.rs:5:1
   |
 5 | / /// foo
@@ -8,6 +8,7 @@ error: unknown attribute `compile-fail`. Did you mean `compile_fail`?
 9 | | /// ```
   | |_______^
   |
+  = help: there is an attribute with a similar name: `compile_fail`
   = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 note: the lint level is defined here
  --> $DIR/check-attr-test.rs:3:9
@@ -15,7 +16,7 @@ note: the lint level is defined here
 3 | #![deny(rustdoc::invalid_codeblock_attributes)]
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unknown attribute `compilefail`. Did you mean `compile_fail`?
+error: unknown attribute `compilefail`
  --> $DIR/check-attr-test.rs:5:1
   |
 5 | / /// foo
@@ -25,9 +26,10 @@ error: unknown attribute `compilefail`. Did you mean `compile_fail`?
 9 | | /// ```
   | |_______^
   |
+  = help: there is an attribute with a similar name: `compile_fail`
   = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 
-error: unknown attribute `comPile_fail`. Did you mean `compile_fail`?
+error: unknown attribute `comPile_fail`
  --> $DIR/check-attr-test.rs:5:1
   |
 5 | / /// foo
@@ -37,9 +39,10 @@ error: unknown attribute `comPile_fail`. Did you mean `compile_fail`?
 9 | | /// ```
   | |_______^
   |
+  = help: there is an attribute with a similar name: `compile_fail`
   = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 
-error: unknown attribute `should-panic`. Did you mean `should_panic`?
+error: unknown attribute `should-panic`
   --> $DIR/check-attr-test.rs:12:1
    |
 12 | / /// bar
@@ -49,9 +52,10 @@ error: unknown attribute `should-panic`. Did you mean `should_panic`?
 16 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `should_panic`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
 
-error: unknown attribute `shouldpanic`. Did you mean `should_panic`?
+error: unknown attribute `shouldpanic`
   --> $DIR/check-attr-test.rs:12:1
    |
 12 | / /// bar
@@ -61,9 +65,10 @@ error: unknown attribute `shouldpanic`. Did you mean `should_panic`?
 16 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `should_panic`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
 
-error: unknown attribute `shOuld_panic`. Did you mean `should_panic`?
+error: unknown attribute `shOuld_panic`
   --> $DIR/check-attr-test.rs:12:1
    |
 12 | / /// bar
@@ -73,9 +78,10 @@ error: unknown attribute `shOuld_panic`. Did you mean `should_panic`?
 16 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `should_panic`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
 
-error: unknown attribute `no-run`. Did you mean `no_run`?
+error: unknown attribute `no-run`
   --> $DIR/check-attr-test.rs:19:1
    |
 19 | / /// foobar
@@ -85,9 +91,10 @@ error: unknown attribute `no-run`. Did you mean `no_run`?
 23 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `no_run`
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `norun`. Did you mean `no_run`?
+error: unknown attribute `norun`
   --> $DIR/check-attr-test.rs:19:1
    |
 19 | / /// foobar
@@ -97,9 +104,10 @@ error: unknown attribute `norun`. Did you mean `no_run`?
 23 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `no_run`
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `nO_run`. Did you mean `no_run`?
+error: unknown attribute `nO_run`
   --> $DIR/check-attr-test.rs:19:1
    |
 19 | / /// foobar
@@ -109,9 +117,10 @@ error: unknown attribute `nO_run`. Did you mean `no_run`?
 23 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `no_run`
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `test-harness`. Did you mean `test_harness`?
+error: unknown attribute `test-harness`
   --> $DIR/check-attr-test.rs:26:1
    |
 26 | / /// b
@@ -121,9 +130,10 @@ error: unknown attribute `test-harness`. Did you mean `test_harness`?
 30 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: unknown attribute `testharness`. Did you mean `test_harness`?
+error: unknown attribute `testharness`
   --> $DIR/check-attr-test.rs:26:1
    |
 26 | / /// b
@@ -133,9 +143,10 @@ error: unknown attribute `testharness`. Did you mean `test_harness`?
 30 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: unknown attribute `tesT_harness`. Did you mean `test_harness`?
+error: unknown attribute `tesT_harness`
   --> $DIR/check-attr-test.rs:26:1
    |
 26 | / /// b
@@ -145,6 +156,7 @@ error: unknown attribute `tesT_harness`. Did you mean `test_harness`?
 30 | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
 error: aborting due to 12 previous errors

--- a/tests/rustdoc-ui/lints/check-attr.rs
+++ b/tests/rustdoc-ui/lints/check-attr.rs
@@ -39,3 +39,11 @@ pub fn foobar() {}
 /// boo
 /// ```
 pub fn b() {}
+
+/// b
+//~^ ERROR
+///
+/// ```rust2018
+/// boo
+/// ```
+pub fn c() {}

--- a/tests/rustdoc-ui/lints/check-attr.rs
+++ b/tests/rustdoc-ui/lints/check-attr.rs
@@ -47,3 +47,12 @@ pub fn b() {}
 /// boo
 /// ```
 pub fn c() {}
+
+/// b
+//~^ ERROR
+//~| ERROR
+///
+/// ```rust2018 shouldpanic
+/// boo
+/// ```
+pub fn d() {}

--- a/tests/rustdoc-ui/lints/check-attr.stderr
+++ b/tests/rustdoc-ui/lints/check-attr.stderr
@@ -196,5 +196,34 @@ LL | | /// ```
    |
    = help: there is an attribute with a similar name: `edition2018`
 
-error: aborting due to 13 previous errors
+error: unknown attribute `rust2018`
+  --> $DIR/check-attr.rs:51:1
+   |
+LL | / /// b
+LL | |
+LL | |
+LL | | ///
+LL | | /// ```rust2018 shouldpanic
+LL | | /// boo
+LL | | /// ```
+   | |_______^
+   |
+   = help: there is an attribute with a similar name: `edition2018`
+
+error: unknown attribute `shouldpanic`
+  --> $DIR/check-attr.rs:51:1
+   |
+LL | / /// b
+LL | |
+LL | |
+LL | | ///
+LL | | /// ```rust2018 shouldpanic
+LL | | /// boo
+LL | | /// ```
+   | |_______^
+   |
+   = help: there is an attribute with a similar name: `should_panic`
+   = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
+
+error: aborting due to 15 previous errors
 

--- a/tests/rustdoc-ui/lints/check-attr.stderr
+++ b/tests/rustdoc-ui/lints/check-attr.stderr
@@ -1,4 +1,4 @@
-error: unknown attribute `compile-fail`. Did you mean `compile_fail`?
+error: unknown attribute `compile-fail`
   --> $DIR/check-attr.rs:3:1
    |
 LL | / /// foo
@@ -10,6 +10,7 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `compile_fail`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 note: the lint level is defined here
   --> $DIR/check-attr.rs:1:9
@@ -17,7 +18,7 @@ note: the lint level is defined here
 LL | #![deny(rustdoc::invalid_codeblock_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unknown attribute `compilefail`. Did you mean `compile_fail`?
+error: unknown attribute `compilefail`
   --> $DIR/check-attr.rs:3:1
    |
 LL | / /// foo
@@ -29,9 +30,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `compile_fail`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 
-error: unknown attribute `comPile_fail`. Did you mean `compile_fail`?
+error: unknown attribute `comPile_fail`
   --> $DIR/check-attr.rs:3:1
    |
 LL | / /// foo
@@ -43,9 +45,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `compile_fail`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it compiles successfully
 
-error: unknown attribute `should-panic`. Did you mean `should_panic`?
+error: unknown attribute `should-panic`
   --> $DIR/check-attr.rs:13:1
    |
 LL | / /// bar
@@ -57,9 +60,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `should_panic`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
 
-error: unknown attribute `shouldpanic`. Did you mean `should_panic`?
+error: unknown attribute `shouldpanic`
   --> $DIR/check-attr.rs:13:1
    |
 LL | / /// bar
@@ -71,9 +75,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `should_panic`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
 
-error: unknown attribute `sHould_panic`. Did you mean `should_panic`?
+error: unknown attribute `sHould_panic`
   --> $DIR/check-attr.rs:13:1
    |
 LL | / /// bar
@@ -85,9 +90,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `should_panic`
    = help: the code block will either not be tested if not marked as a rust one or won't fail if it doesn't panic when running
 
-error: unknown attribute `no-run`. Did you mean `no_run`?
+error: unknown attribute `no-run`
   --> $DIR/check-attr.rs:23:1
    |
 LL | / /// foobar
@@ -99,9 +105,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `no_run`
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `norun`. Did you mean `no_run`?
+error: unknown attribute `norun`
   --> $DIR/check-attr.rs:23:1
    |
 LL | / /// foobar
@@ -113,9 +120,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `no_run`
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `no_Run`. Did you mean `no_run`?
+error: unknown attribute `no_Run`
   --> $DIR/check-attr.rs:23:1
    |
 LL | / /// foobar
@@ -127,9 +135,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `no_run`
    = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
 
-error: unknown attribute `test-harness`. Did you mean `test_harness`?
+error: unknown attribute `test-harness`
   --> $DIR/check-attr.rs:33:1
    |
 LL | / /// b
@@ -141,9 +150,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: unknown attribute `testharness`. Did you mean `test_harness`?
+error: unknown attribute `testharness`
   --> $DIR/check-attr.rs:33:1
    |
 LL | / /// b
@@ -155,9 +165,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: unknown attribute `teSt_harness`. Did you mean `test_harness`?
+error: unknown attribute `teSt_harness`
   --> $DIR/check-attr.rs:33:1
    |
 LL | / /// b
@@ -169,9 +180,10 @@ LL | | /// boo
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: unknown attribute `rust2018`. Did you mean `edition2018`?
+error: unknown attribute `rust2018`
   --> $DIR/check-attr.rs:43:1
    |
 LL | / /// b
@@ -181,6 +193,8 @@ LL | | /// ```rust2018
 LL | | /// boo
 LL | | /// ```
    | |_______^
+   |
+   = help: there is an attribute with a similar name: `edition2018`
 
 error: aborting due to 13 previous errors
 

--- a/tests/rustdoc-ui/lints/check-attr.stderr
+++ b/tests/rustdoc-ui/lints/check-attr.stderr
@@ -171,5 +171,16 @@ LL | | /// ```
    |
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
-error: aborting due to 12 previous errors
+error: unknown attribute `rust2018`. Did you mean `edition2018`?
+  --> $DIR/check-attr.rs:43:1
+   |
+LL | / /// b
+LL | |
+LL | | ///
+LL | | /// ```rust2018
+LL | | /// boo
+LL | | /// ```
+   | |_______^
+
+error: aborting due to 13 previous errors
 

--- a/tests/rustdoc-ui/lints/check-fail.stderr
+++ b/tests/rustdoc-ui/lints/check-fail.stderr
@@ -22,7 +22,7 @@ note: the lint level is defined here
 LL | #![deny(rustdoc::missing_doc_code_examples)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unknown attribute `testharness`. Did you mean `test_harness`?
+error: unknown attribute `testharness`
   --> $DIR/check-fail.rs:8:1
    |
 LL | / //! ```rust,testharness
@@ -31,6 +31,7 @@ LL | | //! let x = 12;
 LL | | //! ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 note: the lint level is defined here
   --> $DIR/check-fail.rs:6:9
@@ -39,7 +40,7 @@ LL | #![deny(rustdoc::all)]
    |         ^^^^^^^^^^^^
    = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc::all)]`
 
-error: unknown attribute `testharness`. Did you mean `test_harness`?
+error: unknown attribute `testharness`
   --> $DIR/check-fail.rs:17:1
    |
 LL | / /// hello
@@ -50,6 +51,7 @@ LL | | /// let x = 12;
 LL | | /// ```
    | |_______^
    |
+   = help: there is an attribute with a similar name: `test_harness`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
 error: aborting due to 4 previous errors

--- a/tests/ui/coroutine/async-gen-deduce-yield.rs
+++ b/tests/ui/coroutine/async-gen-deduce-yield.rs
@@ -1,0 +1,14 @@
+// compile-flags: --edition 2024 -Zunstable-options
+// check-pass
+
+#![feature(async_iterator, gen_blocks)]
+
+use std::async_iter::AsyncIterator;
+
+fn deduce() -> impl AsyncIterator<Item = ()> {
+    async gen {
+        yield Default::default();
+    }
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-gen_blocks.e2024.stderr
+++ b/tests/ui/feature-gates/feature-gate-gen_blocks.e2024.stderr
@@ -2,16 +2,34 @@ error[E0658]: gen blocks are experimental
   --> $DIR/feature-gate-gen_blocks.rs:5:5
    |
 LL |     gen {};
-   |     ^^^^^
+   |     ^^^
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
 
 error[E0658]: gen blocks are experimental
-  --> $DIR/feature-gate-gen_blocks.rs:13:5
+  --> $DIR/feature-gate-gen_blocks.rs:12:5
+   |
+LL |     async gen {};
+   |     ^^^^^^^^^
+   |
+   = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
+   = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+
+error[E0658]: gen blocks are experimental
+  --> $DIR/feature-gate-gen_blocks.rs:22:5
    |
 LL |     gen {};
-   |     ^^^^^
+   |     ^^^
+   |
+   = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
+   = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+
+error[E0658]: gen blocks are experimental
+  --> $DIR/feature-gate-gen_blocks.rs:25:5
+   |
+LL |     async gen {};
+   |     ^^^^^^^^^
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
@@ -22,7 +40,13 @@ error[E0282]: type annotations needed
 LL |     gen {};
    |         ^^ cannot infer type
 
-error: aborting due to 3 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/feature-gate-gen_blocks.rs:12:15
+   |
+LL |     async gen {};
+   |               ^^ cannot infer type
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0282, E0658.
 For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/feature-gates/feature-gate-gen_blocks.none.stderr
+++ b/tests/ui/feature-gates/feature-gate-gen_blocks.none.stderr
@@ -1,9 +1,21 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `gen`
+  --> $DIR/feature-gate-gen_blocks.rs:12:11
+   |
+LL |     async gen {};
+   |           ^^^ expected one of 8 possible tokens
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `gen`
+  --> $DIR/feature-gate-gen_blocks.rs:25:11
+   |
+LL |     async gen {};
+   |           ^^^ expected one of 8 possible tokens
+
 error[E0422]: cannot find struct, variant or union type `gen` in this scope
   --> $DIR/feature-gate-gen_blocks.rs:5:5
    |
 LL |     gen {};
    |     ^^^ not found in this scope
 
-error: aborting due to 1 previous error
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0422`.

--- a/tests/ui/feature-gates/feature-gate-gen_blocks.rs
+++ b/tests/ui/feature-gates/feature-gate-gen_blocks.rs
@@ -1,15 +1,28 @@
 // revisions: e2024 none
 //[e2024] compile-flags: --edition 2024 -Zunstable-options
 
-fn main() {
+fn test_gen() {
     gen {};
     //[none]~^ ERROR: cannot find struct, variant or union type `gen`
     //[e2024]~^^ ERROR: gen blocks are experimental
     //[e2024]~| ERROR: type annotations needed
 }
 
+fn test_async_gen() {
+    async gen {};
+    //[none]~^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `gen`
+    //[e2024]~^^ ERROR: gen blocks are experimental
+    //[e2024]~| ERROR: type annotations needed
+}
+
+fn main() {}
+
 #[cfg(FALSE)]
 fn foo() {
     gen {};
     //[e2024]~^ ERROR: gen blocks are experimental
+
+    async gen {};
+    //[e2024]~^ ERROR: gen blocks are experimental
+    //[none]~^^ ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `gen`
 }


### PR DESCRIPTION
Successful merges:

 - #118858 (Remove dead codes in core)
 - #118864 (Fix alignment passed down to LLVM for simd_masked_load)
 - #118872 (Add rustX check to codeblock attributes lint)
 - #118873 (fix `waker_getters` tracking issue number)
 - #118884 (NFC: simplify merging of two vecs)
 - #118885 (clippy::complexity fixes)
 - #118886 (Clean up variables in `search.js`)
 - #118887 (Typo)
 - #118889 (more clippy::complexity fixes)
 - #118891 (Actually parse async gen blocks correctly)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118858,118864,118872,118873,118884,118885,118886,118887,118889,118891)
<!-- homu-ignore:end -->