### PR TITLE
[rustdoc] Use Map instead of Object for source files and search index

### DIFF
--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -488,7 +488,7 @@ pub(crate) fn build_index<'tcx>(
 
     // Collect the index into a string
     format!(
-        r#""{}":{}"#,
+        r#"["{}",{}]"#,
         krate.name(tcx),
         serde_json::to_string(&CrateData {
             doc: crate_doc,

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -167,23 +167,24 @@ pub(super) fn write_shared(
         let mut krates = Vec::new();
 
         if path.exists() {
-            let prefix = format!("\"{krate}\"");
+            let prefix = format!("[\"{krate}\"");
             for line in BufReader::new(File::open(path)?).lines() {
                 let line = line?;
-                if !line.starts_with('"') {
+                if !line.starts_with("[\"") {
                     continue;
                 }
                 if line.starts_with(&prefix) {
                     continue;
                 }
-                if line.ends_with(",\\") {
+                if line.ends_with("],\\") {
                     ret.push(line[..line.len() - 2].to_string());
                 } else {
                     // Ends with "\\" (it's the case for the last added crate line)
                     ret.push(line[..line.len() - 1].to_string());
                 }
                 krates.push(
-                    line.split('"')
+                    line[1..] // We skip the `[` parent at the beginning of the line.
+                        .split('"')
                         .find(|s| !s.is_empty())
                         .map(|s| s.to_owned())
                         .unwrap_or_else(String::new),
@@ -285,7 +286,7 @@ pub(super) fn write_shared(
             let (mut all_sources, _krates) =
                 try_err!(collect_json(&dst, krate.name(cx.tcx()).as_str()), &dst);
             all_sources.push(format!(
-                r#""{}":{}"#,
+                r#"["{}",{}]"#,
                 &krate.name(cx.tcx()),
                 hierarchy
                     .to_json_string()
@@ -296,9 +297,9 @@ pub(super) fn write_shared(
                     .replace("\\\"", "\\\\\"")
             ));
             all_sources.sort();
-            let mut v = String::from("var srcIndex = JSON.parse('{\\\n");
+            let mut v = String::from("const srcIndex = new Map(JSON.parse('[\\\n");
             v.push_str(&all_sources.join(",\\\n"));
-            v.push_str("\\\n}');\ncreateSrcSidebar();\n");
+            v.push_str("\\\n]'));\ncreateSrcSidebar();\n");
             Ok(v.into_bytes())
         };
         write_invocation_specific("src-files.js", &make_sources)?;
@@ -316,11 +317,11 @@ pub(super) fn write_shared(
     // with rustdoc running in parallel.
     all_indexes.sort();
     write_invocation_specific("search-index.js", &|| {
-        let mut v = String::from("var searchIndex = JSON.parse('{\\\n");
+        let mut v = String::from("const searchIndex = new Map(JSON.parse('[\\\n");
         v.push_str(&all_indexes.join(",\\\n"));
         v.push_str(
             r#"\
-}');
+]'));
 if (typeof window !== 'undefined' && window.initSearch) {window.initSearch(searchIndex)};
 if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
 "#,

--- a/src/librustdoc/html/static/js/src-script.js
+++ b/src/librustdoc/html/static/js/src-script.js
@@ -118,10 +118,10 @@ function createSrcSidebar() {
     title.className = "title";
     title.innerText = "Files";
     sidebar.appendChild(title);
-    Object.keys(srcIndex).forEach(key => {
-        srcIndex[key][NAME_OFFSET] = key;
-        hasFoundFile = createDirEntry(srcIndex[key], sidebar, "", hasFoundFile);
-    });
+    for (const [key, source] of srcIndex) {
+        source[NAME_OFFSET] = key;
+        hasFoundFile = createDirEntry(source, sidebar, "", hasFoundFile);
+    }
 
     container.appendChild(sidebar);
     // Focus on the current file in the source files sidebar.


### PR DESCRIPTION
It's cleaner and is also easier to manipulate `Map` rather than `Object` types.

r? @notriddle 