### PR TITLE
fix: correct the args for `disambiguate the associated function` diagnostic

### DIFF
--- a/tests/ui/methods/disambiguate-associated-function-first-arg.rs
+++ b/tests/ui/methods/disambiguate-associated-function-first-arg.rs
@@ -26,3 +26,24 @@ trait O {
 impl O for A {
     fn new(_a: A, _b: i32) {}
 }
+
+struct S;
+
+trait TraitA {
+    fn f(self);
+}
+trait TraitB {
+    fn f(self);
+}
+
+impl<T> TraitA for T {
+    fn f(self) {}
+}
+impl<T> TraitB for T {
+    fn f(self) {}
+}
+
+fn test() {
+    S.f();
+   //~^ multiple applicable items in scope
+}

--- a/tests/ui/methods/disambiguate-associated-function-first-arg.rs
+++ b/tests/ui/methods/disambiguate-associated-function-first-arg.rs
@@ -1,0 +1,28 @@
+struct A {}
+
+fn main() {
+    let _a = A {};
+    _a.new(1);
+    //~^ ERROR no method named `new` found for struct `A` in the current scope
+}
+
+trait M {
+    fn new(_a: i32);
+}
+impl M for A {
+    fn new(_a: i32) {}
+}
+
+trait N {
+    fn new(_a: Self, _b: i32);
+}
+impl N for A {
+    fn new(_a: Self, _b: i32) {}
+}
+
+trait O {
+    fn new(_a: Self, _b: i32);
+}
+impl O for A {
+    fn new(_a: A, _b: i32) {}
+}

--- a/tests/ui/methods/disambiguate-associated-function-first-arg.stderr
+++ b/tests/ui/methods/disambiguate-associated-function-first-arg.stderr
@@ -1,0 +1,41 @@
+error[E0599]: no method named `new` found for struct `A` in the current scope
+  --> $DIR/disambiguate-associated-function-first-arg.rs:5:8
+   |
+LL | struct A {}
+   | -------- method `new` not found for this struct
+...
+LL |     _a.new(1);
+   |        ^^^ this is an associated function, not a method
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: candidate #1 is defined in the trait `M`
+  --> $DIR/disambiguate-associated-function-first-arg.rs:10:5
+   |
+LL |     fn new(_a: i32);
+   |     ^^^^^^^^^^^^^^^^
+note: candidate #2 is defined in the trait `N`
+  --> $DIR/disambiguate-associated-function-first-arg.rs:17:5
+   |
+LL |     fn new(_a: Self, _b: i32);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: candidate #3 is defined in the trait `O`
+  --> $DIR/disambiguate-associated-function-first-arg.rs:24:5
+   |
+LL |     fn new(_a: Self, _b: i32);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: disambiguate the associated function for candidate #1
+   |
+LL |     <A as M>::new(1);
+   |     ~~~~~~~~~~~~~~~~
+help: disambiguate the associated function for candidate #2
+   |
+LL |     <A as N>::new(_a, 1);
+   |     ~~~~~~~~~~~~~~~~~~~~
+help: disambiguate the associated function for candidate #3
+   |
+LL |     <A as O>::new(_a, 1);
+   |     ~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/methods/disambiguate-associated-function-first-arg.stderr
+++ b/tests/ui/methods/disambiguate-associated-function-first-arg.stderr
@@ -36,6 +36,32 @@ help: disambiguate the associated function for candidate #3
 LL |     <A as O>::new(_a, 1);
    |     ~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 1 previous error
+error[E0034]: multiple applicable items in scope
+  --> $DIR/disambiguate-associated-function-first-arg.rs:47:7
+   |
+LL |     S.f();
+   |       ^ multiple `f` found
+   |
+note: candidate #1 is defined in an impl of the trait `TraitA` for the type `T`
+  --> $DIR/disambiguate-associated-function-first-arg.rs:40:5
+   |
+LL |     fn f(self) {}
+   |     ^^^^^^^^^^
+note: candidate #2 is defined in an impl of the trait `TraitB` for the type `T`
+  --> $DIR/disambiguate-associated-function-first-arg.rs:43:5
+   |
+LL |     fn f(self) {}
+   |     ^^^^^^^^^^
+help: disambiguate the method for candidate #1
+   |
+LL |     TraitA::f(S);
+   |     ~~~~~~~~~~~~
+help: disambiguate the method for candidate #2
+   |
+LL |     TraitB::f(S);
+   |     ~~~~~~~~~~~~
 
-For more information about this error, try `rustc --explain E0599`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0034, E0599.
+For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/methods/method-ambiguity-no-rcvr.stderr
+++ b/tests/ui/methods/method-ambiguity-no-rcvr.stderr
@@ -20,12 +20,12 @@ LL |     fn foo() {}
    |     ^^^^^^^^
 help: disambiguate the associated function for candidate #1
    |
-LL |     <Qux as Foo>::foo(Qux);
-   |     ~~~~~~~~~~~~~~~~~~~~~~
+LL |     <Qux as Foo>::foo();
+   |     ~~~~~~~~~~~~~~~~~~~
 help: disambiguate the associated function for candidate #2
    |
-LL |     <Qux as FooBar>::foo(Qux);
-   |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     <Qux as FooBar>::foo();
+   |     ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This is somehow silimar to https://github.com/rust-lang/rust/pull/118502, we shouldn't take receiver as first arg all the cases.

close https://github.com/rust-lang/rust/issues/118819