### PR TITLE
Seal `MetadataExt` on all platforms

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -111,6 +111,10 @@ pub struct File {
 #[derive(Clone)]
 pub struct Metadata(fs_imp::FileAttr);
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for Metadata {}
+
 /// Iterator over the entries in a directory.
 ///
 /// This iterator is returned from the [`read_dir`] function of this module and

--- a/library/std/src/os/aix/fs.rs
+++ b/library/std/src/os/aix/fs.rs
@@ -5,13 +5,14 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 /// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the device ID on which this file resides.
     ///
     /// # Examples

--- a/library/std/src/os/android/fs.rs
+++ b/library/std/src/os/android/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::android::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/dragonfly/fs.rs
+++ b/library/std/src/os/dragonfly/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::dragonfly::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/emscripten/fs.rs
+++ b/library/std/src/os/emscripten/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::emscripten::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/espidf/fs.rs
+++ b/library/std/src/os/espidf/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::espidf::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext", since = "1.1.0")]
     #[deprecated(
         since = "1.8.0",

--- a/library/std/src/os/freebsd/fs.rs
+++ b/library/std/src/os/freebsd/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::freebsd::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/fuchsia/fs.rs
+++ b/library/std/src/os/fuchsia/fs.rs
@@ -1,13 +1,14 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 /// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/os/haiku/fs.rs
+++ b/library/std/src/os/haiku/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::haiku::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/horizon/fs.rs
+++ b/library/std/src/os/horizon/fs.rs
@@ -1,13 +1,14 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 /// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/os/hurd/fs.rs
+++ b/library/std/src/os/hurd/fs.rs
@@ -5,13 +5,14 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 /// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the device ID on which this file resides.
     ///
     /// # Examples

--- a/library/std/src/os/illumos/fs.rs
+++ b/library/std/src/os/illumos/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::illumos::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/ios/fs.rs
+++ b/library/std/src/os/ios/fs.rs
@@ -12,7 +12,7 @@ use super::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/l4re/fs.rs
+++ b/library/std/src/os/l4re/fs.rs
@@ -5,6 +5,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -14,7 +15,7 @@ use crate::os::l4re::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/linux/fs.rs
+++ b/library/std/src/os/linux/fs.rs
@@ -5,6 +5,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -14,7 +15,7 @@ use crate::os::linux::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/macos/fs.rs
+++ b/library/std/src/os/macos/fs.rs
@@ -12,7 +12,7 @@ use crate::os::macos::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/netbsd/fs.rs
+++ b/library/std/src/os/netbsd/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::netbsd::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/nto/fs.rs
+++ b/library/std/src/os/nto/fs.rs
@@ -1,10 +1,11 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/os/openbsd/fs.rs
+++ b/library/std/src/os/openbsd/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::openbsd::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/redox/fs.rs
+++ b/library/std/src/os/redox/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::redox::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/solaris/fs.rs
+++ b/library/std/src/os/solaris/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::solaris::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -429,7 +429,7 @@ impl OpenOptionsExt for OpenOptions {
 
 /// Unix-specific extensions to [`fs::Metadata`].
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the ID of the device containing the file.
     ///
     /// # Examples

--- a/library/std/src/os/vita/fs.rs
+++ b/library/std/src/os/vita/fs.rs
@@ -1,13 +1,14 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 /// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/os/vxworks/fs.rs
+++ b/library/std/src/os/vxworks/fs.rs
@@ -1,12 +1,12 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
-
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -9,6 +9,7 @@ use crate::ffi::OsStr;
 use crate::fs::{self, File, Metadata, OpenOptions};
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
+use crate::sealed::Sealed;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 // Used for `File::read` on intra-doc links
 #[allow(unused_imports)]
@@ -410,7 +411,7 @@ impl OpenOptionsExt for OpenOptions {
 }
 
 /// WASI-specific extensions to [`fs::Metadata`].
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the `st_dev` field of the internal `filestat_t`
     fn dev(&self) -> u64;
     /// Returns the `st_ino` field of the internal `filestat_t`

--- a/library/std/src/os/watchos/fs.rs
+++ b/library/std/src/os/watchos/fs.rs
@@ -12,7 +12,7 @@ use crate::os::watchos::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -301,7 +301,7 @@ impl OpenOptionsExt for OpenOptions {
 /// [`BY_HANDLE_FILE_INFORMATION`]:
 ///     https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the value of the `dwFileAttributes` field of this metadata.
     ///
     /// This field contains the file system attribute information for a file


### PR DESCRIPTION
The Windows flavour of [`MetadataExt`](https://doc.rust-lang.org/std/os/windows/fs/trait.MetadataExt.html) is currently unimplementable on stable because of unstable methods. Therefore anyone making a cross-platform library that implements `MetadataExt` will fail on Windows. So let's see if we can seal it for all platforms.

[Last time this was tried](https://github.com/rust-lang/rust/pull/81213#issuecomment-767651811), sealing `MetadataExt` only caused a problem for one old version of one crate.