### PR TITLE
Erase late bound regions from `Instance::fn_sig()` and add a few more details to StableMIR APIs

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -13,8 +13,8 @@ use stable_mir::mir::mono::{InstanceDef, StaticDef};
 use stable_mir::mir::Body;
 use stable_mir::target::{MachineInfo, MachineSize};
 use stable_mir::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, GenericArgs,
-    LineInfo, PolyFnSig, RigidTy, Span, Ty, TyKind, VariantDef,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, FnSig,
+    GenericArgs, LineInfo, PolyFnSig, RigidTy, Span, Ty, TyKind, VariantDef,
 };
 use stable_mir::{Crate, CrateItem, DefId, Error, Filename, ItemKind, Symbol};
 use std::cell::RefCell;
@@ -324,7 +324,16 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
     fn instance_ty(&self, def: InstanceDef) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
         let instance = tables.instances[def];
-        instance.ty(tables.tcx, ParamEnv::empty()).stable(&mut *tables)
+        instance.ty(tables.tcx, ParamEnv::reveal_all()).stable(&mut *tables)
+    }
+
+    fn instance_sig(&self, def: InstanceDef) -> FnSig {
+        let mut tables = self.0.borrow_mut();
+        let instance = tables.instances[def];
+        let ty = instance.ty(tables.tcx, ParamEnv::reveal_all());
+        let sig = if ty.is_fn() { ty.fn_sig(tables.tcx) } else { instance.args.as_closure().sig() };
+        // Erase late bound regions.
+        tables.tcx.instantiate_bound_regions_with_erased(sig).stable(&mut *tables)
     }
 
     fn instance_def_id(&self, def: InstanceDef) -> stable_mir::DefId {

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -36,6 +36,7 @@ impl<'tcx> Stable<'tcx> for mir::Body<'tcx> {
                 .collect(),
             self.arg_count,
             self.var_debug_info.iter().map(|info| info.stable(tables)).collect(),
+            self.spread_arg.stable(tables),
         )
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
@@ -57,7 +57,9 @@ impl<'tcx> Stable<'tcx> for rustc_hir::CoroutineKind {
                 stable_mir::mir::CoroutineKind::Gen(source.stable(tables))
             }
             CoroutineKind::Coroutine => stable_mir::mir::CoroutineKind::Coroutine,
-            CoroutineKind::AsyncGen(_) => todo!(),
+            CoroutineKind::AsyncGen(source) => {
+                stable_mir::mir::CoroutineKind::AsyncGen(source.stable(tables))
+            }
         }
     }
 }

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -10,9 +10,9 @@ use crate::mir::mono::{Instance, InstanceDef, StaticDef};
 use crate::mir::Body;
 use crate::target::MachineInfo;
 use crate::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, FnSig,
-    GenericArgs, GenericPredicates, Generics, ImplDef, ImplTrait, LineInfo, PolyFnSig, RigidTy,
-    Span, TraitDecl, TraitDef, Ty, TyKind, VariantDef,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, GenericArgs,
+    GenericPredicates, Generics, ImplDef, ImplTrait, LineInfo, PolyFnSig, RigidTy, Span, TraitDecl,
+    TraitDef, Ty, TyKind, VariantDef,
 };
 use crate::{
     mir, Crate, CrateItem, CrateItems, DefId, Error, Filename, ImplTraitDecls, ItemKind, Symbol,
@@ -120,9 +120,6 @@ pub trait Context {
 
     /// Get the instance type with generic substitutions applied and lifetimes erased.
     fn instance_ty(&self, instance: InstanceDef) -> Ty;
-
-    /// Get the instance signature with .
-    fn instance_sig(&self, def: InstanceDef) -> FnSig;
 
     /// Get the instance.
     fn instance_def_id(&self, instance: InstanceDef) -> DefId;

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -10,9 +10,9 @@ use crate::mir::mono::{Instance, InstanceDef, StaticDef};
 use crate::mir::Body;
 use crate::target::MachineInfo;
 use crate::ty::{
-    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, GenericArgs,
-    GenericPredicates, Generics, ImplDef, ImplTrait, LineInfo, PolyFnSig, RigidTy, Span, TraitDecl,
-    TraitDef, Ty, TyKind, VariantDef,
+    AdtDef, AdtKind, Allocation, ClosureDef, ClosureKind, Const, FieldDef, FnDef, FnSig,
+    GenericArgs, GenericPredicates, Generics, ImplDef, ImplTrait, LineInfo, PolyFnSig, RigidTy,
+    Span, TraitDecl, TraitDef, Ty, TyKind, VariantDef,
 };
 use crate::{
     mir, Crate, CrateItem, CrateItems, DefId, Error, Filename, ImplTraitDecls, ItemKind, Symbol,
@@ -120,6 +120,9 @@ pub trait Context {
 
     /// Get the instance type with generic substitutions applied and lifetimes erased.
     fn instance_ty(&self, instance: InstanceDef) -> Ty;
+
+    /// Get the instance signature with .
+    fn instance_sig(&self, def: InstanceDef) -> FnSig;
 
     /// Get the instance.
     fn instance_def_id(&self, instance: InstanceDef) -> DefId;

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -4,6 +4,7 @@ use crate::ty::{
     VariantIdx,
 };
 use crate::{Error, Opaque, Span, Symbol};
+use std::borrow::Cow;
 use std::io;
 /// The SMIR representation of a single function.
 #[derive(Clone, Debug)]
@@ -264,51 +265,63 @@ pub enum AssertMessage {
 }
 
 impl AssertMessage {
-    pub fn description(&self) -> Result<&'static str, Error> {
+    pub fn description(&self) -> Result<Cow<'static, str>, Error> {
         match self {
-            AssertMessage::Overflow(BinOp::Add, _, _) => Ok("attempt to add with overflow"),
-            AssertMessage::Overflow(BinOp::Sub, _, _) => Ok("attempt to subtract with overflow"),
-            AssertMessage::Overflow(BinOp::Mul, _, _) => Ok("attempt to multiply with overflow"),
-            AssertMessage::Overflow(BinOp::Div, _, _) => Ok("attempt to divide with overflow"),
-            AssertMessage::Overflow(BinOp::Rem, _, _) => {
-                Ok("attempt to calculate the remainder with overflow")
+            AssertMessage::Overflow(BinOp::Add, _, _) => Ok("attempt to add with overflow".into()),
+            AssertMessage::Overflow(BinOp::Sub, _, _) => {
+                Ok("attempt to subtract with overflow".into())
             }
-            AssertMessage::OverflowNeg(_) => Ok("attempt to negate with overflow"),
-            AssertMessage::Overflow(BinOp::Shr, _, _) => Ok("attempt to shift right with overflow"),
-            AssertMessage::Overflow(BinOp::Shl, _, _) => Ok("attempt to shift left with overflow"),
+            AssertMessage::Overflow(BinOp::Mul, _, _) => {
+                Ok("attempt to multiply with overflow".into())
+            }
+            AssertMessage::Overflow(BinOp::Div, _, _) => {
+                Ok("attempt to divide with overflow".into())
+            }
+            AssertMessage::Overflow(BinOp::Rem, _, _) => {
+                Ok("attempt to calculate the remainder with overflow".into())
+            }
+            AssertMessage::OverflowNeg(_) => Ok("attempt to negate with overflow".into()),
+            AssertMessage::Overflow(BinOp::Shr, _, _) => {
+                Ok("attempt to shift right with overflow".into())
+            }
+            AssertMessage::Overflow(BinOp::Shl, _, _) => {
+                Ok("attempt to shift left with overflow".into())
+            }
             AssertMessage::Overflow(op, _, _) => Err(error!("`{:?}` cannot overflow", op)),
-            AssertMessage::DivisionByZero(_) => Ok("attempt to divide by zero"),
+            AssertMessage::DivisionByZero(_) => Ok("attempt to divide by zero".into()),
             AssertMessage::RemainderByZero(_) => {
-                Ok("attempt to calculate the remainder with a divisor of zero")
+                Ok("attempt to calculate the remainder with a divisor of zero".into())
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::Coroutine) => {
-                Ok("coroutine resumed after completion")
+                Ok("coroutine resumed after completion".into())
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::Async(_)) => {
-                Ok("`async fn` resumed after completion")
+                Ok("`async fn` resumed after completion".into())
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::Gen(_)) => {
-                Ok("`async gen fn` resumed after completion")
+                Ok("`async gen fn` resumed after completion".into())
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::AsyncGen(_)) => {
-                Ok("`gen fn` should just keep returning `AssertMessage::None` after completion")
+                Ok("`gen fn` should just keep returning `AssertMessage::None` after completion"
+                    .into())
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::Coroutine) => {
-                Ok("coroutine resumed after panicking")
+                Ok("coroutine resumed after panicking".into())
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::Async(_)) => {
-                Ok("`async fn` resumed after panicking")
+                Ok("`async fn` resumed after panicking".into())
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::Gen(_)) => {
-                Ok("`async gen fn` resumed after panicking")
+                Ok("`async gen fn` resumed after panicking".into())
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::AsyncGen(_)) => {
-                Ok("`gen fn` should just keep returning `AssertMessage::None` after panicking")
+                Ok("`gen fn` should just keep returning `AssertMessage::None` after panicking"
+                    .into())
             }
 
-            AssertMessage::BoundsCheck { .. } => Ok("index out of bounds"),
+            AssertMessage::BoundsCheck { .. } => Ok("index out of bounds".into()),
             AssertMessage::MisalignedPointerDereference { .. } => {
-                Ok("misaligned pointer dereference")
+                Ok("misaligned pointer dereference".into())
             }
         }
     }

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -4,7 +4,6 @@ use crate::ty::{
     VariantIdx,
 };
 use crate::{Error, Opaque, Span, Symbol};
-use std::borrow::Cow;
 use std::io;
 /// The SMIR representation of a single function.
 #[derive(Clone, Debug)]
@@ -265,63 +264,51 @@ pub enum AssertMessage {
 }
 
 impl AssertMessage {
-    pub fn description(&self) -> Result<Cow<'static, str>, Error> {
+    pub fn description(&self) -> Result<&'static str, Error> {
         match self {
-            AssertMessage::Overflow(BinOp::Add, _, _) => Ok("attempt to add with overflow".into()),
-            AssertMessage::Overflow(BinOp::Sub, _, _) => {
-                Ok("attempt to subtract with overflow".into())
-            }
-            AssertMessage::Overflow(BinOp::Mul, _, _) => {
-                Ok("attempt to multiply with overflow".into())
-            }
-            AssertMessage::Overflow(BinOp::Div, _, _) => {
-                Ok("attempt to divide with overflow".into())
-            }
+            AssertMessage::Overflow(BinOp::Add, _, _) => Ok("attempt to add with overflow"),
+            AssertMessage::Overflow(BinOp::Sub, _, _) => Ok("attempt to subtract with overflow"),
+            AssertMessage::Overflow(BinOp::Mul, _, _) => Ok("attempt to multiply with overflow"),
+            AssertMessage::Overflow(BinOp::Div, _, _) => Ok("attempt to divide with overflow"),
             AssertMessage::Overflow(BinOp::Rem, _, _) => {
-                Ok("attempt to calculate the remainder with overflow".into())
+                Ok("attempt to calculate the remainder with overflow")
             }
-            AssertMessage::OverflowNeg(_) => Ok("attempt to negate with overflow".into()),
-            AssertMessage::Overflow(BinOp::Shr, _, _) => {
-                Ok("attempt to shift right with overflow".into())
-            }
-            AssertMessage::Overflow(BinOp::Shl, _, _) => {
-                Ok("attempt to shift left with overflow".into())
-            }
+            AssertMessage::OverflowNeg(_) => Ok("attempt to negate with overflow"),
+            AssertMessage::Overflow(BinOp::Shr, _, _) => Ok("attempt to shift right with overflow"),
+            AssertMessage::Overflow(BinOp::Shl, _, _) => Ok("attempt to shift left with overflow"),
             AssertMessage::Overflow(op, _, _) => Err(error!("`{:?}` cannot overflow", op)),
-            AssertMessage::DivisionByZero(_) => Ok("attempt to divide by zero".into()),
+            AssertMessage::DivisionByZero(_) => Ok("attempt to divide by zero"),
             AssertMessage::RemainderByZero(_) => {
-                Ok("attempt to calculate the remainder with a divisor of zero".into())
+                Ok("attempt to calculate the remainder with a divisor of zero")
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::Coroutine) => {
-                Ok("coroutine resumed after completion".into())
+                Ok("coroutine resumed after completion")
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::Async(_)) => {
-                Ok("`async fn` resumed after completion".into())
+                Ok("`async fn` resumed after completion")
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::Gen(_)) => {
-                Ok("`async gen fn` resumed after completion".into())
+                Ok("`async gen fn` resumed after completion")
             }
             AssertMessage::ResumedAfterReturn(CoroutineKind::AsyncGen(_)) => {
-                Ok("`gen fn` should just keep returning `AssertMessage::None` after completion"
-                    .into())
+                Ok("`gen fn` should just keep returning `AssertMessage::None` after completion")
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::Coroutine) => {
-                Ok("coroutine resumed after panicking".into())
+                Ok("coroutine resumed after panicking")
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::Async(_)) => {
-                Ok("`async fn` resumed after panicking".into())
+                Ok("`async fn` resumed after panicking")
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::Gen(_)) => {
-                Ok("`async gen fn` resumed after panicking".into())
+                Ok("`async gen fn` resumed after panicking")
             }
             AssertMessage::ResumedAfterPanic(CoroutineKind::AsyncGen(_)) => {
-                Ok("`gen fn` should just keep returning `AssertMessage::None` after panicking"
-                    .into())
+                Ok("`gen fn` should just keep returning `AssertMessage::None` after panicking")
             }
 
-            AssertMessage::BoundsCheck { .. } => Ok("index out of bounds".into()),
+            AssertMessage::BoundsCheck { .. } => Ok("index out of bounds"),
             AssertMessage::MisalignedPointerDereference { .. } => {
-                Ok("misaligned pointer dereference".into())
+                Ok("misaligned pointer dereference")
             }
         }
     }

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -117,7 +117,7 @@ impl Instance {
 
     /// Get this function signature with all types already instantiated.
     pub fn fn_sig(&self) -> FnSig {
-        self.ty().kind().fn_sig().unwrap().skip_binder()
+        with(|cx| cx.instance_sig(self.def))
     }
 
     /// Check whether this instance is an empty shim.

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -1,6 +1,6 @@
 use crate::crate_def::CrateDef;
 use crate::mir::Body;
-use crate::ty::{Allocation, ClosureDef, ClosureKind, FnDef, FnSig, GenericArgs, IndexedVal, Ty};
+use crate::ty::{Allocation, ClosureDef, ClosureKind, FnDef, GenericArgs, IndexedVal, Ty};
 use crate::{with, CrateItem, DefId, Error, ItemKind, Opaque, Symbol};
 use std::fmt::{Debug, Formatter};
 
@@ -113,11 +113,6 @@ impl Instance {
                 crate::Error::new(format!("Failed to resolve `{def:?}` with `{args:?}`"))
             })
         })
-    }
-
-    /// Get this function signature with all types already instantiated.
-    pub fn fn_sig(&self) -> FnSig {
-        with(|cx| cx.instance_sig(self.def))
     }
 
     /// Check whether this instance is an empty shim.

--- a/compiler/stable_mir/src/mir/pretty.rs
+++ b/compiler/stable_mir/src/mir/pretty.rs
@@ -243,6 +243,7 @@ pub fn pretty_assert_message(msg: &AssertMessage) -> String {
             );
             pretty
         }
+        AssertMessage::Overflow(op, _, _) => unreachable!("`{:?}` cannot overflow", op),
         AssertMessage::OverflowNeg(op) => {
             let pretty_op = pretty_operand(op);
             pretty.push_str(
@@ -262,17 +263,15 @@ pub fn pretty_assert_message(msg: &AssertMessage) -> String {
             );
             pretty
         }
-        AssertMessage::ResumedAfterReturn(_) => {
-            format!("attempt to resume a generator after completion")
-        }
-        AssertMessage::ResumedAfterPanic(_) => format!("attempt to resume a panicked generator"),
         AssertMessage::MisalignedPointerDereference { required, found } => {
             let pretty_required = pretty_operand(required);
             let pretty_found = pretty_operand(found);
             pretty.push_str(format!("\"misaligned pointer dereference: address must be a multiple of {{}} but is {{}}\",{pretty_required}, {pretty_found}").as_str());
             pretty
         }
-        _ => todo!(),
+        AssertMessage::ResumedAfterReturn(_) | AssertMessage::ResumedAfterPanic(_) => {
+            msg.description().unwrap().to_string()
+        }
     }
 }
 

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -133,7 +133,7 @@ pub trait MirVisitor {
     }
 
     fn super_body(&mut self, body: &Body) {
-        let Body { blocks, locals: _, arg_count, var_debug_info } = body;
+        let Body { blocks, locals: _, arg_count, var_debug_info, spread_arg: _ } = body;
 
         for bb in blocks {
             self.visit_basic_block(bb);

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -6,7 +6,6 @@ use super::{
 use crate::crate_def::CrateDef;
 use crate::mir::alloc::{read_target_int, read_target_uint, AllocId};
 use crate::target::MachineInfo;
-use crate::ty::UintTy::U8;
 use crate::{Filename, Opaque};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
@@ -77,9 +76,14 @@ impl Ty {
         Ty::from_rigid_kind(RigidTy::Bool)
     }
 
-    /// Create a type representing `u8`.
-    pub fn u8_ty() -> Ty {
-        Ty::from_rigid_kind(RigidTy::Uint(U8))
+    /// Create a type representing a signed integer.
+    pub fn signed_ty(inner: IntTy) -> Ty {
+        Ty::from_rigid_kind(RigidTy::Int(inner))
+    }
+
+    /// Create a type representing an unsigned integer.
+    pub fn unsigned_ty(inner: UintTy) -> Ty {
+        Ty::from_rigid_kind(RigidTy::Uint(inner))
     }
 }
 

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::crate_def::CrateDef;
 use crate::mir::alloc::{read_target_int, read_target_uint, AllocId};
 use crate::target::MachineInfo;
+use crate::ty::UintTy::U8;
 use crate::{Filename, Opaque};
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
@@ -22,9 +23,7 @@ impl Debug for Ty {
 /// Constructors for `Ty`.
 impl Ty {
     /// Create a new type from a given kind.
-    ///
-    /// Note that not all types may be supported at this point.
-    fn from_rigid_kind(kind: RigidTy) -> Ty {
+    pub fn from_rigid_kind(kind: RigidTy) -> Ty {
         with(|cx| cx.new_rigid_ty(kind))
     }
 
@@ -76,6 +75,11 @@ impl Ty {
     /// Create a type representing `bool`.
     pub fn bool_ty() -> Ty {
         Ty::from_rigid_kind(RigidTy::Bool)
+    }
+
+    /// Create a type representing `u8`.
+    pub fn u8_ty() -> Ty {
+        Ty::from_rigid_kind(RigidTy::Uint(U8))
     }
 }
 

--- a/tests/ui-fulldeps/stable-mir/check_defs.rs
+++ b/tests/ui-fulldeps/stable-mir/check_defs.rs
@@ -69,7 +69,7 @@ fn extract_elem_ty(ty: Ty) -> Ty {
 
 /// Check signature and type of `Vec::<u8>::new` and its generic version.
 fn test_vec_new(instance: mir::mono::Instance) {
-    let sig = instance.fn_sig();
+    let sig = instance.ty().kind().fn_sig().unwrap().skip_binder();
     assert_matches!(sig.inputs(), &[]);
     let elem_ty = extract_elem_ty(sig.output());
     assert_matches!(elem_ty.kind(), TyKind::RigidTy(RigidTy::Uint(UintTy::U8)));


### PR DESCRIPTION
The Instance `fn_sig()` still included a late bound regions which needed a new compiler function in order to be erased. I've also bundled the following small fixes in this PR, let me know if you want me to isolate any of them.

  - Add missing `CoroutineKind::AsyncGen`.
  - Add optional spread argument to function body which is needed to properly analyze compiler shims.
  - Add a utility method to iterate over all locals together with their declaration.
  - Add a method to get the description of `AssertMessage`*.

* For the last one, we could consider eventually calling the internal `AssertKind::description()` to avoid code duplication. However, we still don't have ways to convert `AssertMessage`, `Operand`, `Place` and others, in order to use that. The other downside of using the internal method is that it will panic for some of the variants.

r ? @ouz-a 