### PR TITLE
fix: Overlapping spans in delimited meta-vars

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -236,6 +236,13 @@ fn expand_macro<'cx>(
                             target_sp.open = source_sp.open.with_ctxt(ctxt);
                             target_sp.close = source_sp.close.with_ctxt(ctxt);
                         }
+                        (
+                            TokenTree::Delimited(target_sp, ..),
+                            mbe::TokenTree::MetaVar(source_sp, ..),
+                        ) => {
+                            target_sp.open = source_sp.with_ctxt(ctxt);
+                            target_sp.close = source_sp.with_ctxt(ctxt).shrink_to_hi();
+                        }
                         _ => {
                             let sp = rhs_tt.span().with_ctxt(ctxt);
                             tt.set_span(sp);

--- a/tests/ui/macros/issue-118786.rs
+++ b/tests/ui/macros/issue-118786.rs
@@ -1,0 +1,16 @@
+// compile-flags: --crate-type lib -O -C debug-assertions=yes
+
+// Regression test for issue 118786
+
+macro_rules! make_macro {
+    ($macro_name:tt) => {
+        macro_rules! $macro_name {
+        //~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+        //~| ERROR macro expansion ignores token `{` and any following
+        //~| ERROR cannot find macro `macro_rules` in this scope
+            () => {}
+        }
+    }
+}
+
+make_macro!((meow));

--- a/tests/ui/macros/issue-118786.stderr
+++ b/tests/ui/macros/issue-118786.stderr
@@ -1,0 +1,47 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-118786.rs:7:22
+   |
+LL |         macro_rules! $macro_name {
+   |                      ^^^^^^^^^^^
+   |
+help: change the delimiters to curly braces
+   |
+LL |         macro_rules! {} {
+   |                      ~          +
+help: add a semicolon
+   |
+LL |         macro_rules! $macro_name; {
+   |                                 +
+
+error: macro expansion ignores token `{` and any following
+  --> $DIR/issue-118786.rs:7:34
+   |
+LL |         macro_rules! $macro_name {
+   |                                  ^
+...
+LL | make_macro!((meow));
+   | ------------------- caused by the macro expansion here
+   |
+   = note: the usage of `make_macro!` is likely invalid in item context
+
+error: cannot find macro `macro_rules` in this scope
+  --> $DIR/issue-118786.rs:7:9
+   |
+LL |         macro_rules! $macro_name {
+   |         ^^^^^^^^^^^
+...
+LL | make_macro!((meow));
+   | ------------------- in this macro invocation
+   |
+note: maybe you have forgotten to define a name for this `macro_rules!`
+  --> $DIR/issue-118786.rs:7:9
+   |
+LL |         macro_rules! $macro_name {
+   |         ^^^^^^^^^^^
+...
+LL | make_macro!((meow));
+   | ------------------- in this macro invocation
+   = note: this error originates in the macro `make_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Closes #118786 

Delimited meta-vars inside of MBE's spans were set to have the same opening and closing position resulting in an ICE when debug assertions were enabled and an error was present in the templated code. 

This ensures that the spans do not overlap, whilst still having the spans point at the usage of the meta-var inside the macro definition.

It includes a regression test.

🖤 