### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/stable_mir/src/mir/pretty.rs
+++ b/compiler/stable_mir/src/mir/pretty.rs
@@ -58,18 +58,31 @@ pub fn pretty_statement(statement: &StatementKind) -> String {
             pretty.push_str(format!("        _{} = ", place.local).as_str());
             pretty.push_str(format!("{}", &pretty_rvalue(rval)).as_str());
         }
-        StatementKind::FakeRead(_, _) => todo!(),
-        StatementKind::SetDiscriminant { .. } => todo!(),
-        StatementKind::Deinit(_) => todo!(),
-        StatementKind::StorageLive(_) => todo!(),
-        StatementKind::StorageDead(_) => todo!(),
-        StatementKind::Retag(_, _) => todo!(),
-        StatementKind::PlaceMention(_) => todo!(),
-        StatementKind::AscribeUserType { .. } => todo!(),
-        StatementKind::Coverage(_) => todo!(),
-        StatementKind::Intrinsic(_) => todo!(),
-        StatementKind::ConstEvalCounter => (),
-        StatementKind::Nop => (),
+        // FIXME: Add rest of the statements
+        StatementKind::FakeRead(_, _) => return format!("StatementKind::FakeRead:Unimplemented"),
+        StatementKind::SetDiscriminant { .. } => {
+            return format!("StatementKind::SetDiscriminant:Unimplemented");
+        }
+        StatementKind::Deinit(_) => return format!("StatementKind::Deinit:Unimplemented"),
+        StatementKind::StorageLive(_) => {
+            return format!("StatementKind::StorageLive:Unimplemented");
+        }
+        StatementKind::StorageDead(_) => {
+            return format!("StatementKind::StorageDead:Unimplemented");
+        }
+        StatementKind::Retag(_, _) => return format!("StatementKind::Retag:Unimplemented"),
+        StatementKind::PlaceMention(_) => {
+            return format!("StatementKind::PlaceMention:Unimplemented");
+        }
+        StatementKind::AscribeUserType { .. } => {
+            return format!("StatementKind::AscribeUserType:Unimplemented");
+        }
+        StatementKind::Coverage(_) => return format!("StatementKind::Coverage:Unimplemented"),
+        StatementKind::Intrinsic(_) => return format!("StatementKind::Intrinsic:Unimplemented"),
+        StatementKind::ConstEvalCounter => {
+            return format!("StatementKind::ConstEvalCounter:Unimplemented");
+        }
+        StatementKind::Nop => return format!("StatementKind::Nop:Unimplemented"),
     }
     pretty
 }
@@ -355,7 +368,7 @@ pub fn pretty_rvalue(rval: &Rvalue) -> String {
             pretty.push_str(" ");
             pretty.push_str(&pretty_ty(cnst.ty().kind()));
         }
-        Rvalue::ShallowInitBox(_, _) => todo!(),
+        Rvalue::ShallowInitBox(_, _) => (),
         Rvalue::ThreadLocalRef(item) => {
             pretty.push_str("thread_local_ref");
             pretty.push_str(format!("{:#?}", item).as_str());

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -143,7 +143,7 @@ fn check_version(config: &Config) -> Option<String> {
                 "update `config.toml` to use `change-id = {latest_change_id}` instead"
             ));
 
-            if io::stdout().is_terminal() {
+            if io::stdout().is_terminal() && !config.dry_run() {
                 t!(fs::write(warned_id_path, latest_change_id.to_string()));
             }
         }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1741,7 +1741,7 @@ impl Config {
         config
     }
 
-    pub(crate) fn dry_run(&self) -> bool {
+    pub fn dry_run(&self) -> bool {
         match self.dry_run {
             DryRun::Disabled => false,
             DryRun::SelfCheck | DryRun::UserSelected => true,

--- a/src/tools/miri/tests/pass/packed-struct-dyn-trait.rs
+++ b/src/tools/miri/tests/pass/packed-struct-dyn-trait.rs
@@ -1,0 +1,21 @@
+// run-pass
+use std::ptr::addr_of;
+
+// When the unsized tail is a `dyn Trait`, its alignments is only dynamically known. This means the
+// packed(2) needs to be applied at runtime: the actual alignment of the field is `min(2,
+// usual_alignment)`. Here we check that we do this right by comparing size, alignment, and field
+// offset before and after unsizing.
+fn main() {
+    #[repr(C, packed(2))]
+    struct Packed<T: ?Sized>(u8, core::mem::ManuallyDrop<T>);
+
+    let p = Packed(0, core::mem::ManuallyDrop::new(1));
+    let p: &Packed<usize> = &p;
+    let sized = (core::mem::size_of_val(p), core::mem::align_of_val(p));
+    let sized_offset = unsafe { addr_of!(p.1).cast::<u8>().offset_from(addr_of!(p.0)) };
+    let p: &Packed<dyn Send> = p;
+    let un_sized = (core::mem::size_of_val(p), core::mem::align_of_val(p));
+    let un_sized_offset = unsafe { addr_of!(p.1).cast::<u8>().offset_from(addr_of!(p.0)) };
+    assert_eq!(sized, un_sized);
+    assert_eq!(sized_offset, un_sized_offset);
+}

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1852;
-const ROOT_ENTRY_LIMIT: usize = 866;
+const ROOT_ENTRY_LIMIT: usize = 867;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/packed/dyn-trait.rs
+++ b/tests/ui/packed/dyn-trait.rs
@@ -1,0 +1,21 @@
+// run-pass
+use std::ptr::addr_of;
+
+// When the unsized tail is a `dyn Trait`, its alignments is only dynamically known. This means the
+// packed(2) needs to be applied at runtime: the actual alignment of the field is `min(2,
+// usual_alignment)`. Here we check that we do this right by comparing size, alignment, and field
+// offset before and after unsizing.
+fn main() {
+    #[repr(C, packed(2))]
+    struct Packed<T: ?Sized>(u8, core::mem::ManuallyDrop<T>);
+
+    let p = Packed(0, core::mem::ManuallyDrop::new(1));
+    let p: &Packed<usize> = &p;
+    let sized = (core::mem::size_of_val(p), core::mem::align_of_val(p));
+    let sized_offset = unsafe { addr_of!(p.1).cast::<u8>().offset_from(addr_of!(p.0)) };
+    let p: &Packed<dyn Send> = p;
+    let un_sized = (core::mem::size_of_val(p), core::mem::align_of_val(p));
+    let un_sized_offset = unsafe { addr_of!(p.1).cast::<u8>().offset_from(addr_of!(p.0)) };
+    assert_eq!(sized, un_sized);
+    assert_eq!(sized_offset, un_sized_offset);
+}

--- a/tests/ui/stable-mir-print/basic_function.rs
+++ b/tests/ui/stable-mir-print/basic_function.rs
@@ -1,0 +1,14 @@
+// compile-flags: -Z unpretty=stable-mir -Z mir-opt-level=3
+// check-pass
+
+fn foo(i:i32) -> i32 {
+    i + 1
+}
+
+fn bar(vec: &mut Vec<i32>) -> Vec<i32> {
+    let mut new_vec = vec.clone();
+    new_vec.push(1);
+    new_vec
+}
+
+fn main(){}

--- a/tests/ui/stable-mir-print/basic_function.stdout
+++ b/tests/ui/stable-mir-print/basic_function.stdout
@@ -1,0 +1,234 @@
+// WARNING: This is highly experimental output it's intended for stable-mir developers only.
+// If you find a bug or want to improve the output open a issue at https://github.com/rust-lang/project-stable-mir.
+fn foo(_0: i32) -> i32 {
+    let mut _0: (i32, bool);
+}
+    bb0: {
+        _2 = 1 Add const 1_i32
+        assert(!move _2 bool),"attempt to compute `{} + {}`, which would overflow", 1, const 1_i32) -> [success: bb1, unwind continue]
+    }
+    bb1: {
+        _0 = move _2
+        return
+    }
+fn bar(_0: &mut Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+}) -> Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+} {
+    let mut _0: Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+};
+    let mut _1: &Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+};
+    let _2: ();
+    let mut _3: &mut Ty {
+    id: 10,
+    kind: RigidTy(
+        Adt(
+            AdtDef(
+                DefId {
+                    id: 3,
+                    name: "std::vec::Vec",
+                },
+            ),
+            GenericArgs(
+                [
+                    Type(
+                        Ty {
+                            id: 11,
+                            kind: Param(
+                                ParamTy {
+                                    index: 0,
+                                    name: "T",
+                                },
+                            ),
+                        },
+                    ),
+                    Type(
+                        Ty {
+                            id: 12,
+                            kind: Param(
+                                ParamTy {
+                                    index: 1,
+                                    name: "A",
+                                },
+                            ),
+                        },
+                    ),
+                ],
+            ),
+        ),
+    ),
+};
+}
+    bb0: {
+        _3 = refShared1
+        _2 = const <Vec<i32> as Clone>::clone(move _3) -> [return: bb1, unwind continue]
+    }
+    bb1: {
+        _5 = refMut {
+    kind: TwoPhaseBorrow,
+}2
+        _4 = const Vec::<i32>::push(move _5, const 1_i32) -> [return: bb2, unwind: bb3]
+    }
+    bb2: {
+        _0 = move _2
+        return
+    }
+    bb3: {
+        drop(_2) -> [return: bb4, unwind terminate]
+    }
+    bb4: {
+        resume
+    }
+fn main() -> () {
+}
+    bb0: {
+        return
+    }


### PR DESCRIPTION
Successful merges:

 - #118375 (Add -Zunpretty=stable-mir output test)
 - #118538 (fix dynamic size/align computation logic for packed types with dyn trait tail)
 - #118789 (fix --dry-run when the change-id warning is printed)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118375,118538,118789)
<!-- homu-ignore:end -->