### PR TITLE
Update to LLVM 17.0.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/17.0-2023-09-19
+	branch = rustc/17.0-2023-12-14
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1791,8 +1791,7 @@ impl Config {
                 config.llvm_link_shared.set(Some(true));
             }
         } else {
-            config.llvm_from_ci = config.channel == "dev"
-                && crate::core::build_steps::llvm::is_ci_llvm_available(&config, false);
+            config.llvm_from_ci = config.parse_download_ci_llvm(None, false);
         }
 
         if let Some(t) = toml.target {
@@ -2337,29 +2336,30 @@ impl Config {
         download_ci_llvm: Option<StringOrBool>,
         asserts: bool,
     ) -> bool {
+        let if_unchanged = || {
+            // Git is needed to track modifications here, but tarball source is not available.
+            // If not modified here or built through tarball source, we maintain consistency
+            // with '"if available"'.
+            if !self.rust_info.is_from_tarball()
+                && self
+                    .last_modified_commit(&["src/llvm-project"], "download-ci-llvm", true)
+                    .is_none()
+            {
+                // there are some untracked changes in the the given paths.
+                false
+            } else {
+                llvm::is_ci_llvm_available(&self, asserts)
+            }
+        };
         match download_ci_llvm {
-            None => self.channel == "dev" && llvm::is_ci_llvm_available(&self, asserts),
+            None => self.channel == "dev" && if_unchanged(),
             Some(StringOrBool::Bool(b)) => b,
             // FIXME: "if-available" is deprecated. Remove this block later (around mid 2024)
             // to not break builds between the recent-to-old checkouts.
             Some(StringOrBool::String(s)) if s == "if-available" => {
                 llvm::is_ci_llvm_available(&self, asserts)
             }
-            Some(StringOrBool::String(s)) if s == "if-unchanged" => {
-                // Git is needed to track modifications here, but tarball source is not available.
-                // If not modified here or built through tarball source, we maintain consistency
-                // with '"if available"'.
-                if !self.rust_info.is_from_tarball()
-                    && self
-                        .last_modified_commit(&["src/llvm-project"], "download-ci-llvm", true)
-                        .is_none()
-                {
-                    // there are some untracked changes in the the given paths.
-                    false
-                } else {
-                    llvm::is_ci_llvm_available(&self, asserts)
-                }
-            }
+            Some(StringOrBool::String(s)) if s == "if-unchanged" => if_unchanged(),
             Some(StringOrBool::String(other)) => {
                 panic!("unrecognized option for download-ci-llvm: {:?}", other)
             }

--- a/src/bootstrap/src/tests/config.rs
+++ b/src/bootstrap/src/tests/config.rs
@@ -31,10 +31,10 @@ fn download_ci_llvm() {
     assert_eq!(parse_llvm(""), if_unchanged);
     assert_eq!(parse_llvm("rust.channel = \"dev\""), if_unchanged);
     assert!(!parse_llvm("rust.channel = \"stable\""));
-    assert!(parse_llvm("build.build = \"x86_64-unknown-linux-gnu\""));
-    assert!(parse_llvm(
+    assert_eq!(parse_llvm("build.build = \"x86_64-unknown-linux-gnu\""), if_unchanged);
+    assert_eq!(parse_llvm(
         "llvm.assertions = true \r\n build.build = \"x86_64-unknown-linux-gnu\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
-    ));
+    ), if_unchanged);
     assert!(!parse_llvm(
         "llvm.assertions = true \r\n build.build = \"aarch64-apple-darwin\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
     ));


### PR DESCRIPTION
This is a rebase on the final LLVM 17 release.

Includes the RISCV fix requested in https://github.com/rust-lang/llvm-project/pull/157 (and I think this is also the only change in this release that is relevant to rustc).

r? @cuviper 

Fixes #117902