### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -208,6 +208,24 @@ where
         if layout.abi.is_uninhabited() {
             // `read_discriminant` should have excluded uninhabited variants... but ConstProp calls
             // us on dead code.
+            // In the future we might want to allow this to permit code like this:
+            // (this is a Rust/MIR pseudocode mix)
+            // ```
+            // enum Option2 {
+            //   Some(i32, !),
+            //   None,
+            // }
+            //
+            // fn panic() -> ! { panic!() }
+            //
+            // let x: Option2;
+            // x.Some.0 = 42;
+            // x.Some.1 = panic();
+            // SetDiscriminant(x, Some);
+            // ```
+            // However, for now we don't generate such MIR, and this check here *has* found real
+            // bugs (see https://github.com/rust-lang/rust/issues/115145), so we will keep rejecting
+            // it.
             throw_inval!(ConstPropNonsense)
         }
         // This cannot be `transmute` as variants *can* have a smaller size than the entire enum.

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -212,11 +212,17 @@ where
     let cgu_name_cache = &mut FxHashMap::default();
 
     for mono_item in mono_items {
-        // Handle only root items directly here. Inlined items are handled at
-        // the bottom of the loop based on reachability.
+        // Handle only root (GloballyShared) items directly here. Inlined (LocalCopy) items
+        // are handled at the bottom of the loop based on reachability, with one exception.
+        // The #[lang = "start"] item is the program entrypoint, so there are no calls to it in MIR.
+        // So even if its mode is LocalCopy, we need to treat it like a root.
         match mono_item.instantiation_mode(cx.tcx) {
             InstantiationMode::GloballyShared { .. } => {}
-            InstantiationMode::LocalCopy => continue,
+            InstantiationMode::LocalCopy => {
+                if Some(mono_item.def_id()) != cx.tcx.lang_items().start_fn() {
+                    continue;
+                }
+            }
         }
 
         let characteristic_def_id = characteristic_def_id_of_mono_item(cx.tcx, mono_item);

--- a/compiler/rustc_trait_selection/src/solve/project_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/project_goals.rs
@@ -8,16 +8,28 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         &mut self,
         goal: Goal<'tcx, ProjectionPredicate<'tcx>>,
     ) -> QueryResult<'tcx> {
-        match goal.predicate.term.unpack() {
-            ty::TermKind::Ty(term) => {
-                let alias = goal.predicate.projection_ty.to_ty(self.tcx());
-                self.eq(goal.param_env, alias, term)?;
-                self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-            }
-            // FIXME(associated_const_equality): actually do something here.
-            ty::TermKind::Const(_) => {
-                self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-            }
-        }
+        let tcx = self.tcx();
+        let projection_term = match goal.predicate.term.unpack() {
+            ty::TermKind::Ty(_) => goal.predicate.projection_ty.to_ty(tcx).into(),
+            ty::TermKind::Const(_) => ty::Const::new_unevaluated(
+                tcx,
+                ty::UnevaluatedConst::new(
+                    goal.predicate.projection_ty.def_id,
+                    goal.predicate.projection_ty.args,
+                ),
+                tcx.type_of(goal.predicate.projection_ty.def_id)
+                    .instantiate(tcx, goal.predicate.projection_ty.args),
+            )
+            .into(),
+        };
+        self.add_goal(goal.with(
+            tcx,
+            ty::PredicateKind::AliasRelate(
+                projection_term,
+                goal.predicate.term,
+                ty::AliasRelationDirection::Equate,
+            ),
+        ));
+        self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
     }
 }

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -155,7 +155,6 @@ fn lang_start_internal(
 }
 
 #[cfg(not(test))]
-#[inline(never)]
 #[lang = "start"]
 fn lang_start<T: crate::process::Termination + 'static>(
     main: fn() -> T,

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -488,7 +488,7 @@ pub(crate) fn build_index<'tcx>(
 
     // Collect the index into a string
     format!(
-        r#""{}":{}"#,
+        r#"["{}",{}]"#,
         krate.name(tcx),
         serde_json::to_string(&CrateData {
             doc: crate_doc,

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -167,23 +167,24 @@ pub(super) fn write_shared(
         let mut krates = Vec::new();
 
         if path.exists() {
-            let prefix = format!("\"{krate}\"");
+            let prefix = format!("[\"{krate}\"");
             for line in BufReader::new(File::open(path)?).lines() {
                 let line = line?;
-                if !line.starts_with('"') {
+                if !line.starts_with("[\"") {
                     continue;
                 }
                 if line.starts_with(&prefix) {
                     continue;
                 }
-                if line.ends_with(",\\") {
+                if line.ends_with("],\\") {
                     ret.push(line[..line.len() - 2].to_string());
                 } else {
                     // Ends with "\\" (it's the case for the last added crate line)
                     ret.push(line[..line.len() - 1].to_string());
                 }
                 krates.push(
-                    line.split('"')
+                    line[1..] // We skip the `[` parent at the beginning of the line.
+                        .split('"')
                         .find(|s| !s.is_empty())
                         .map(|s| s.to_owned())
                         .unwrap_or_else(String::new),
@@ -285,7 +286,7 @@ pub(super) fn write_shared(
             let (mut all_sources, _krates) =
                 try_err!(collect_json(&dst, krate.name(cx.tcx()).as_str()), &dst);
             all_sources.push(format!(
-                r#""{}":{}"#,
+                r#"["{}",{}]"#,
                 &krate.name(cx.tcx()),
                 hierarchy
                     .to_json_string()
@@ -296,9 +297,9 @@ pub(super) fn write_shared(
                     .replace("\\\"", "\\\\\"")
             ));
             all_sources.sort();
-            let mut v = String::from("var srcIndex = JSON.parse('{\\\n");
+            let mut v = String::from("const srcIndex = new Map(JSON.parse('[\\\n");
             v.push_str(&all_sources.join(",\\\n"));
-            v.push_str("\\\n}');\ncreateSrcSidebar();\n");
+            v.push_str("\\\n]'));\ncreateSrcSidebar();\n");
             Ok(v.into_bytes())
         };
         write_invocation_specific("src-files.js", &make_sources)?;
@@ -316,11 +317,11 @@ pub(super) fn write_shared(
     // with rustdoc running in parallel.
     all_indexes.sort();
     write_invocation_specific("search-index.js", &|| {
-        let mut v = String::from("var searchIndex = JSON.parse('{\\\n");
+        let mut v = String::from("const searchIndex = new Map(JSON.parse('[\\\n");
         v.push_str(&all_indexes.join(",\\\n"));
         v.push_str(
             r#"\
-}');
+]'));
 if (typeof window !== 'undefined' && window.initSearch) {window.initSearch(searchIndex)};
 if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
 "#,

--- a/src/librustdoc/html/static/js/src-script.js
+++ b/src/librustdoc/html/static/js/src-script.js
@@ -118,10 +118,10 @@ function createSrcSidebar() {
     title.className = "title";
     title.innerText = "Files";
     sidebar.appendChild(title);
-    Object.keys(srcIndex).forEach(key => {
-        srcIndex[key][NAME_OFFSET] = key;
-        hasFoundFile = createDirEntry(srcIndex[key], sidebar, "", hasFoundFile);
-    });
+    for (const [key, source] of srcIndex) {
+        source[NAME_OFFSET] = key;
+        hasFoundFile = createDirEntry(source, sidebar, "", hasFoundFile);
+    }
 
     container.appendChild(sidebar);
     // Focus on the current file in the source files sidebar.

--- a/tests/ui/traits/new-solver/closure-signature-inference-2.rs
+++ b/tests/ui/traits/new-solver/closure-signature-inference-2.rs
@@ -1,0 +1,21 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+fn map<T: Default, U, F: FnOnce(T) -> U>(f: F) {
+    f(T::default());
+}
+
+fn main() {
+    map::<i32, _ /* ?U */, _ /* ?F */>(|x| x.to_string());
+    // PREVIOUSLY when confirming the `map` call, we register:
+    //
+    // (1.) ?F: FnOnce<(i32,)>
+    // (2.) <?F as FnOnce<(i32,)>>::Output projects-to ?U
+    //
+    // While (1.) is ambiguous, (2.) immediately gets processed
+    // and we infer `?U := <?F as FnOnce<(i32,)>>::Output`.
+    //
+    // Thus, the only pending obligation that remains is (1.).
+    // Since it is a trait obligation, we don't use it to deduce
+    // the closure signature, and we fail!
+}

--- a/tests/ui/traits/new-solver/closure-signature-inference.rs
+++ b/tests/ui/traits/new-solver/closure-signature-inference.rs
@@ -1,0 +1,15 @@
+// compile-flags: -Ztrait-solver=next
+// check-pass
+
+struct A;
+impl A {
+    fn hi(self) {}
+}
+
+fn hello() -> Result<(A,), ()> {
+    Err(())
+}
+
+fn main() {
+    let x = hello().map(|(x,)| x.hi());
+}

--- a/tests/ui/traits/new-solver/generalize/generalize-proj-new-universe-index-2.stderr
+++ b/tests/ui/traits/new-solver/generalize/generalize-proj-new-universe-index-2.stderr
@@ -1,8 +1,18 @@
-error[E0284]: type annotations needed: cannot satisfy `<<Rigid as IdHigherRankedBound>::Assoc as WithAssoc<<Wrapper<Leaf> as Id>::Assoc>>::Assoc normalizes-to <<Leaf as WithAssoc<_>>::Assoc as Id>::Assoc`
+error[E0284]: type annotations needed
   --> $DIR/generalize-proj-new-universe-index-2.rs:74:5
    |
 LL |     bound::<<Rigid as IdHigherRankedBound>::Assoc, <Wrapper<Leaf> as Id>::Assoc, _>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `<<Rigid as IdHigherRankedBound>::Assoc as WithAssoc<<Wrapper<Leaf> as Id>::Assoc>>::Assoc normalizes-to <<Leaf as WithAssoc<_>>::Assoc as Id>::Assoc`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `V` declared on the function `bound`
+   |
+   = note: cannot satisfy `<<Rigid as IdHigherRankedBound>::Assoc as WithAssoc<<Wrapper<Leaf> as Id>::Assoc>>::Assoc == _`
+note: required by a bound in `bound`
+  --> $DIR/generalize-proj-new-universe-index-2.rs:69:21
+   |
+LL | fn bound<T: ?Sized, U: ?Sized, V: ?Sized>()
+   |    ----- required by a bound in this function
+LL | where
+LL |     T: WithAssoc<U, Assoc = V>,
+   |                     ^^^^^^^^^ required by this bound in `bound`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - #118770 (Fix cases where std accidentally relied on inline(never))
 - #118910 ([rustdoc] Use Map instead of Object for source files and search index)
 - #118914 (Unconditionally register alias-relate in projection goal)
 - #118935 (interpret: extend comment on the inhabitedness check in downcast)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118770,118910,118914,118935)
<!-- homu-ignore:end -->