### PR TITLE
rustc_codegen_ssa: Remove trailing spaces in Display impl for CguReuse

### DIFF
--- a/compiler/rustc_codegen_ssa/src/assert_module_sources.rs
+++ b/compiler/rustc_codegen_ssa/src/assert_module_sources.rs
@@ -199,8 +199,8 @@ impl fmt::Display for CguReuse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             CguReuse::No => write!(f, "No"),
-            CguReuse::PreLto => write!(f, "PreLto "),
-            CguReuse::PostLto => write!(f, "PostLto "),
+            CguReuse::PreLto => write!(f, "PreLto"),
+            CguReuse::PostLto => write!(f, "PostLto"),
         }
     }
 }


### PR DESCRIPTION
Otherwise errors will look like this:

    error: CGU-reuse for `cgu_invalidated_via_import-bar` is `PreLto ` but should be `PostLto `

### Background

I noticed that error messages looked wonky while investigating if
https://github.com/rust-lang/rust/blob/529047cfc3f4f7b3ea5aaac054408f368d153727/compiler/rustc_codegen_ssa/src/assert_module_sources.rs#L281-L287
should not be wrapped by `sess.emit_err(...)`. Right now it looks like the error is accidentally ignored. It looks like https://github.com/rust-lang/rust/pull/100753/commits/706452eba74026c51e8d0fa30aee2497c69eafc0 might have accidentally started ignoring it (by removing the `diag.span_err()` call). I am still investigating, but regardless of the outcome we should fix the trailing whitespace.
