### PR TITLE
Use the `Waker::noop` API in tests

### DIFF
--- a/tests/ui/async-await/in-trait/async-default-fn-overridden.rs
+++ b/tests/ui/async-await/in-trait/async-default-fn-overridden.rs
@@ -1,6 +1,7 @@
 // run-pass
 // edition:2021
 
+#![feature(noop_waker)]
 
 use std::future::Future;
 
@@ -32,33 +33,18 @@ async fn async_main() {
 // ------------------------------------------------------------------------- //
 // Implementation Details Below...
 
-use std::pin::Pin;
+use std::pin::pin;
 use std::task::*;
 
-pub fn noop_waker() -> Waker {
-    let raw = RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE);
-
-    // SAFETY: the contracts for RawWaker and RawWakerVTable are upheld
-    unsafe { Waker::from_raw(raw) }
-}
-
-const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
-
-unsafe fn noop_clone(_p: *const ()) -> RawWaker {
-    RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)
-}
-
-unsafe fn noop(_p: *const ()) {}
-
 fn main() {
-    let mut fut = async_main();
+    let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = noop_waker();
+    let waker = Waker::noop();
     let ctx = &mut Context::from_waker(&waker);
 
     loop {
-        match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {
+        match fut.as_mut().poll(ctx) {
             Poll::Pending => {}
             Poll::Ready(()) => break,
         }

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
@@ -2,6 +2,7 @@
 // known-bug: #108309
 
 #![feature(min_specialization)]
+#![feature(noop_waker)]
 
 struct MyStruct;
 
@@ -35,34 +36,18 @@ async fn indirection<T>(x: T) -> &'static str {
 // ------------------------------------------------------------------------- //
 // Implementation Details Below...
 
-use std::future::Future;
-use std::pin::Pin;
+use std::pin::{pin, Pin};
 use std::task::*;
 
-pub fn noop_waker() -> Waker {
-    let raw = RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE);
-
-    // SAFETY: the contracts for RawWaker and RawWakerVTable are upheld
-    unsafe { Waker::from_raw(raw) }
-}
-
-const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
-
-unsafe fn noop_clone(_p: *const ()) -> RawWaker {
-    RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)
-}
-
-unsafe fn noop(_p: *const ()) {}
-
 fn main() {
-    let mut fut = async_main();
+    let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = noop_waker();
+    let waker = Waker::noop();
     let ctx = &mut Context::from_waker(&waker);
 
     loop {
-        match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {
+        match fut.as_mut().poll(ctx) {
             Poll::Pending => {}
             Poll::Ready(()) => break,
         }

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
@@ -1,11 +1,11 @@
 error[E0053]: method `foo` has an incompatible type for trait
-  --> $DIR/dont-project-to-specializable-projection.rs:13:5
+  --> $DIR/dont-project-to-specializable-projection.rs:14:5
    |
 LL |     default async fn foo(_: T) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found future
    |
 note: type in trait
-  --> $DIR/dont-project-to-specializable-projection.rs:9:5
+  --> $DIR/dont-project-to-specializable-projection.rs:10:5
    |
 LL |     async fn foo(_: T) -> &'static str;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,13 +13,29 @@ LL |     async fn foo(_: T) -> &'static str;
               found signature `fn(_) -> impl Future<Output = &'static str>`
 
 error: async associated function in trait cannot be specialized
-  --> $DIR/dont-project-to-specializable-projection.rs:13:5
+  --> $DIR/dont-project-to-specializable-projection.rs:14:5
    |
 LL |     default async fn foo(_: T) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: specialization behaves in inconsistent and surprising ways with async functions in traits, and for now is disallowed
 
-error: aborting due to 2 previous errors
+error[E0599]: no method named `poll` found for struct `Pin<&mut impl Future<Output = ()>>` in the current scope
+  --> $DIR/dont-project-to-specializable-projection.rs:50:28
+   |
+LL |         match fut.as_mut().poll(ctx) {
+   |                            ^^^^ method not found in `Pin<&mut impl Future<Output = ()>>`
+  --> $SRC_DIR/core/src/future/future.rs:LL:COL
+   |
+   = note: the method is available for `Pin<&mut impl Future<Output = ()>>` here
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL + use std::future::Future;
+   |
 
-For more information about this error, try `rustc --explain E0053`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0053, E0599.
+For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/coroutine/async_gen_fn_iter.rs
+++ b/tests/ui/coroutine/async_gen_fn_iter.rs
@@ -3,6 +3,7 @@
 // run-pass
 
 #![feature(gen_blocks, async_iterator)]
+#![feature(noop_waker)]
 
 // make sure that a ridiculously simple async gen fn works as an iterator.
 
@@ -42,7 +43,7 @@ async fn async_main() {
 // ------------------------------------------------------------------------- //
 // Implementation Details Below...
 
-use std::pin::Pin;
+use std::pin::{Pin, pin};
 use std::task::*;
 use std::async_iter::AsyncIterator;
 use std::future::Future;
@@ -69,30 +70,15 @@ impl<'s, S: AsyncIterator> Future for Next<'s, S> where S: Unpin {
     }
 }
 
-pub fn noop_waker() -> Waker {
-    let raw = RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE);
-
-    // SAFETY: the contracts for RawWaker and RawWakerVTable are upheld
-    unsafe { Waker::from_raw(raw) }
-}
-
-const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
-
-unsafe fn noop_clone(_p: *const ()) -> RawWaker {
-    RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)
-}
-
-unsafe fn noop(_p: *const ()) {}
-
 fn main() {
-    let mut fut = async_main();
+    let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = noop_waker();
+    let waker = Waker::noop();
     let ctx = &mut Context::from_waker(&waker);
 
     loop {
-        match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {
+        match fut.as_mut().poll(ctx) {
             Poll::Pending => {}
             Poll::Ready(()) => break,
         }

--- a/tests/ui/dyn-star/dispatch-on-pin-mut.rs
+++ b/tests/ui/dyn-star/dispatch-on-pin-mut.rs
@@ -4,6 +4,7 @@
 
 #![feature(dyn_star)]
 //~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+#![feature(noop_waker)]
 
 use std::future::Future;
 
@@ -18,33 +19,18 @@ async fn async_main() {
 // ------------------------------------------------------------------------- //
 // Implementation Details Below...
 
-use std::pin::Pin;
 use std::task::*;
-
-pub fn noop_waker() -> Waker {
-    let raw = RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE);
-
-    // SAFETY: the contracts for RawWaker and RawWakerVTable are upheld
-    unsafe { Waker::from_raw(raw) }
-}
-
-const NOOP_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(noop_clone, noop, noop, noop);
-
-unsafe fn noop_clone(_p: *const ()) -> RawWaker {
-    RawWaker::new(std::ptr::null(), &NOOP_WAKER_VTABLE)
-}
-
-unsafe fn noop(_p: *const ()) {}
+use std::pin::pin;
 
 fn main() {
-    let mut fut = async_main();
+    let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = noop_waker();
+    let waker = Waker::noop();
     let ctx = &mut Context::from_waker(&waker);
 
     loop {
-        match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {
+        match fut.as_mut().poll(ctx) {
             Poll::Pending => {}
             Poll::Ready(()) => break,
         }


### PR DESCRIPTION
Avoids the need to duplicate this code over and over again

r? eholk