### PR TITLE
Fix ICE from zero-length span when suggesting to remove trailing semi-colon from final statement in block

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -3163,8 +3163,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         };
         if self.can_eq(self.param_env, expected_ty, ty) {
+            let span = stmt
+                .span
+                .from_expansion()
+                .then(|| {
+                    let mac_call = rustc_span::source_map::original_sp(stmt.span, block.span);
+                    self.tcx.sess.source_map().mac_call_stmt_semi_span(mac_call)
+                })
+                .flatten()
+                .unwrap_or_else(|| stmt.span.with_lo(tail_expr.span.hi()));
             err.span_suggestion_short(
-                stmt.span.with_lo(tail_expr.span.hi()),
+                span,
                 "remove this semicolon",
                 "",
                 Applicability::MachineApplicable,

--- a/tests/ui/typeck/issue-114251.rs
+++ b/tests/ui/typeck/issue-114251.rs
@@ -1,0 +1,17 @@
+// compile-flags: -C debug-assertions
+
+macro_rules! feedu8 {
+    () => {
+        0u8
+    }
+}
+
+fn main() {
+    let kitty = {
+        feedu8!();
+        //~^ HELP: remove this semicolon
+    };
+
+    let cat: u8 = kitty;
+    //~^ ERROR: mismatched types
+}

--- a/tests/ui/typeck/issue-114251.stderr
+++ b/tests/ui/typeck/issue-114251.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-114251.rs:15:19
+   |
+LL |         feedu8!();
+   |                  - help: remove this semicolon
+...
+LL |     let cat: u8 = kitty;
+   |              --   ^^^^^ expected `u8`, found `()`
+   |              |
+   |              expected due to this
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This fixes #114251 

The span for the suggestion of removing the semi-colon from the final statement in a block was constructed with zero-length, resulting in an ICE when debug-assersions were enabled.

This PR fixes that by ensuring that the span covers the semi-colon and isn't just zero-length.

It includes a regression test.

🖤 