### PR TITLE
rustdoc-search: fix a race condition in search index loading

### DIFF
--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -297,7 +297,10 @@ pub(super) fn write_shared(
                     .replace("\\\"", "\\\\\"")
             ));
             all_sources.sort();
-            let mut v = String::from("const srcIndex = new Map(JSON.parse('[\\\n");
+            // This needs to be `var`, not `const`.
+            // This variable needs declared in the current global scope so that if
+            // src-script.js loads first, it can pick it up.
+            let mut v = String::from("var srcIndex = new Map(JSON.parse('[\\\n");
             v.push_str(&all_sources.join(",\\\n"));
             v.push_str("\\\n]'));\ncreateSrcSidebar();\n");
             Ok(v.into_bytes())
@@ -317,7 +320,10 @@ pub(super) fn write_shared(
     // with rustdoc running in parallel.
     all_indexes.sort();
     write_invocation_specific("search-index.js", &|| {
-        let mut v = String::from("const searchIndex = new Map(JSON.parse('[\\\n");
+        // This needs to be `var`, not `const`.
+        // This variable needs declared in the current global scope so that if
+        // search.js loads first, it can pick it up.
+        let mut v = String::from("var searchIndex = new Map(JSON.parse('[\\\n");
         v.push_str(&all_indexes.join(",\\\n"));
         v.push_str(
             r#"\


### PR DESCRIPTION
`var` declare it in the global scope, and `const` does not. It needs to be declared in global scope.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const

> const declarations do not create properties on [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) when declared at the top level of a script.

Fixes a regression introduced by https://github.com/rust-lang/rust/pull/118910