### PR TITLE
DO NOT REVIEW. DO NOT MERGE. Prove that `rustc_expected_cgu_reuse` tests are broken

### DIFF
--- a/tests/incremental/thinlto/cgu_invalidated_via_import.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_via_import.rs
@@ -14,14 +14,14 @@
                             kind="no")]
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-foo",
                             cfg="cfail3",
-                            kind="post-lto")]
+                            kind="no")]
 
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-bar",
                             cfg="cfail2",
-                            kind="pre-lto")]
+                            kind="no")]
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-bar",
                             cfg="cfail3",
-                            kind="post-lto")]
+                            kind="no")]
 
 mod foo {
 

--- a/tests/incremental/thinlto/cgu_keeps_identical_fn.rs
+++ b/tests/incremental/thinlto/cgu_keeps_identical_fn.rs
@@ -13,17 +13,17 @@
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-foo",
     cfg = "cfail3",
-    kind = "post-lto"
+    kind = "no"
 )]
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-bar",
     cfg = "cfail2",
-    kind = "post-lto"
+    kind = "no"
 )]
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-bar",
     cfg = "cfail3",
-    kind = "post-lto"
+    kind = "no"
 )]
 
 mod foo {

--- a/tests/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
+++ b/tests/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
@@ -13,21 +13,21 @@
                             kind="no")]
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-foo",
                             cfg="cfail3",
-                            kind="post-lto")]
+                            kind="no")]
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-bar",
                             cfg="cfail2",
-                            kind="pre-lto")]
+                            kind="no")]
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-bar",
                             cfg="cfail3",
-                            kind="post-lto")]
+                            kind="no")]
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-baz",
                             cfg="cfail2",
-                            kind="post-lto")]
+                            kind="no")]
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-baz",
                             cfg="cfail3",
-                            kind="post-lto")]
+                            kind="no")]
 mod foo {
 
     #[cfg(cfail1)]


### PR DESCRIPTION
I will file a bug report about `rustc_expected_cgu_reuse` being broken.

I will refer to this CI run as proof in the soon-to-be-reported issue that it is broken. I have changed expected outcome, so CI should definitely not pass, but it will.

I also have a fix but I want to do things in the right order to make code review easier.