### PR TITLE
force current stage when `--stage` is expilicitly used

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -977,7 +977,7 @@ impl<'a> Builder<'a> {
 
     /// Similar to `compiler`, except handles the full-bootstrap option to
     /// silently use the stage1 compiler instead of a stage2 compiler if one is
-    /// requested.
+    /// requested. This behaviour is ignored if `--stage` is explicitly set.
     ///
     /// Note that this does *not* have the side effect of creating
     /// `compiler(stage, host)`, unlike `compiler` above which does have such
@@ -992,7 +992,9 @@ impl<'a> Builder<'a> {
         host: TargetSelection,
         target: TargetSelection,
     ) -> Compiler {
-        if self.build.force_use_stage2(stage) {
+        if self.config.explicit_stage {
+            self.compiler(stage, host)
+        } else if self.build.force_use_stage2(stage) {
             self.compiler(2, self.config.build)
         } else if self.build.force_use_stage1(stage, target) {
             self.compiler(1, self.config.build)

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -184,6 +184,8 @@ pub struct Config {
 
     pub on_fail: Option<String>,
     pub stage: u32,
+    /// Indicates whether `--stage` was explicitly used or not.
+    pub explicit_stage: bool,
     pub keep_stage: Vec<u32>,
     pub keep_stage_std: Vec<u32>,
     pub src: PathBuf,
@@ -1216,6 +1218,7 @@ impl Config {
         config.incremental = flags.incremental;
         config.dry_run = if flags.dry_run { DryRun::UserSelected } else { DryRun::Disabled };
         config.dump_bootstrap_shims = flags.dump_bootstrap_shims;
+        config.explicit_stage = flags.stage.is_some();
         config.keep_stage = flags.keep_stage;
         config.keep_stage_std = flags.keep_stage_std;
         config.color = flags.color;


### PR DESCRIPTION
Allows users to build std with stage2 compiler without using `full-bootstrap`.

Fixes #118233
Fixes #118918