### PR TITLE
coverage: Regression test for `assert!(!false)`

### DIFF
--- a/tests/coverage/assert_not.cov-map
+++ b/tests/coverage/assert_not.cov-map
@@ -1,0 +1,16 @@
+Function name: assert_not::main
+Raw bytes (33): 0x[01, 01, 02, 05, 00, 0d, 00, 05, 01, 06, 01, 01, 12, 05, 02, 05, 00, 14, 02, 01, 05, 00, 14, 0d, 01, 05, 00, 16, 06, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 2
+- expression 0 operands: lhs = Counter(1), rhs = Zero
+- expression 1 operands: lhs = Counter(3), rhs = Zero
+Number of file 0 mappings: 5
+- Code(Counter(0)) at (prev + 6, 1) to (start + 1, 18)
+- Code(Counter(1)) at (prev + 2, 5) to (start + 0, 20)
+- Code(Expression(0, Sub)) at (prev + 1, 5) to (start + 0, 20)
+    = (c1 - Zero)
+- Code(Counter(3)) at (prev + 1, 5) to (start + 0, 22)
+- Code(Expression(1, Sub)) at (prev + 1, 1) to (start + 0, 2)
+    = (c3 - Zero)
+

--- a/tests/coverage/assert_not.coverage
+++ b/tests/coverage/assert_not.coverage
@@ -1,0 +1,12 @@
+   LL|       |// edition: 2021
+   LL|       |
+   LL|       |// Regression test for <https://github.com/rust-lang/rust/issues/118904>.
+   LL|       |// `assert!(true)` and `assert!(!false)` should have similar coverage spans.
+   LL|       |
+   LL|      1|fn main() {
+   LL|      1|    assert!(true);
+   LL|      1|    assert!(!false);
+   LL|      1|    assert!(!!true);
+   LL|      1|    assert!(!!!false);
+   LL|      1|}
+

--- a/tests/coverage/assert_not.rs
+++ b/tests/coverage/assert_not.rs
@@ -1,0 +1,11 @@
+// edition: 2021
+
+// Regression test for <https://github.com/rust-lang/rust/issues/118904>.
+// `assert!(true)` and `assert!(!false)` should have similar coverage spans.
+
+fn main() {
+    assert!(true);
+    assert!(!false);
+    assert!(!!true);
+    assert!(!!!false);
+}


### PR DESCRIPTION
This verifies that #118904 has already been fixed by #118198.

---

@rustbot label +A-code-coverage