### PR TITLE
Simplify source pages sidebar handling

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1540,6 +1540,30 @@ a.tooltip:hover::after {
 	align-items: stretch;
 	z-index: 10;
 }
+#src-sidebar-toggle > button {
+	font-size: inherit;
+	font-weight: bold;
+	background: none;
+	color: inherit;
+	text-align: center;
+	border: none;
+	outline: none;
+	flex: 1 1;
+	/* iOS button gradient: https://stackoverflow.com/q/5438567 */
+	-webkit-appearance: none;
+	opacity: 1;
+	display: block;
+}
+#src-sidebar-toggle > button.collapse {
+	display: none;
+}
+.src-sidebar-expanded #src-sidebar-toggle > button.expand {
+	display: none;
+}
+.src-sidebar-expanded #src-sidebar-toggle > button.collapse {
+	display: block;
+}
+
 #src-sidebar {
 	width: 100%;
 	overflow: auto;
@@ -1557,20 +1581,6 @@ a.tooltip:hover::after {
 #src-sidebar div.files > a.selected {
 	background-color: var(--src-sidebar-background-selected);
 }
-#src-sidebar-toggle > button {
-	font-size: inherit;
-	font-weight: bold;
-	background: none;
-	color: inherit;
-	text-align: center;
-	border: none;
-	outline: none;
-	flex: 1 1;
-	/* iOS button gradient: https://stackoverflow.com/q/5438567 */
-	-webkit-appearance: none;
-	opacity: 1;
-}
-
 #settings-menu, #help-button {
 	margin-left: 4px;
 	display: flex;

--- a/src/librustdoc/html/static/js/src-script.js
+++ b/src/librustdoc/html/static/js/src-script.js
@@ -71,48 +71,34 @@ function createDirEntry(elem, parent, fullPath, hasFoundFile) {
     return hasFoundFile;
 }
 
-let toggleLabel;
-
-function getToggleLabel() {
-    toggleLabel = toggleLabel || document.querySelector("#src-sidebar-toggle button");
-    return toggleLabel;
-}
-
 window.rustdocCloseSourceSidebar = () => {
     removeClass(document.documentElement, "src-sidebar-expanded");
-    getToggleLabel().innerText = ">";
     updateLocalStorage("source-sidebar-show", "false");
 };
 
 window.rustdocShowSourceSidebar = () => {
     addClass(document.documentElement, "src-sidebar-expanded");
-    getToggleLabel().innerText = "<";
     updateLocalStorage("source-sidebar-show", "true");
 };
 
-function toggleSidebar() {
-    const child = this.parentNode.children[0];
-    if (child.innerText === ">") {
-        window.rustdocShowSourceSidebar();
-    } else {
-        window.rustdocCloseSourceSidebar();
-    }
+function createButton(className, text, onclick) {
+    const button = document.createElement("button");
+    button.className = className;
+    button.innerText = text;
+    button.onclick = onclick;
+    return button;
 }
 
 function createSidebarToggle() {
     const sidebarToggle = document.createElement("div");
     sidebarToggle.id = "src-sidebar-toggle";
 
-    const inner = document.createElement("button");
+    sidebarToggle.appendChild(createButton("expand", ">", window.rustdocShowSourceSidebar));
+    sidebarToggle.appendChild(createButton("collapse", "<", window.rustdocCloseSourceSidebar));
 
     if (getCurrentValue("source-sidebar-show") === "true") {
-        inner.innerText = "<";
-    } else {
-        inner.innerText = ">";
+        window.rustdocShowSourceSidebar();
     }
-    inner.onclick = toggleSidebar;
-
-    sidebarToggle.appendChild(inner);
     return sidebarToggle;
 }
 

--- a/tests/rustdoc-gui/sidebar-source-code-display.goml
+++ b/tests/rustdoc-gui/sidebar-source-code-display.goml
@@ -47,14 +47,14 @@ define-function: (
         // Without hover or focus.
         assert-css: ("#src-sidebar-toggle > button", {"background-color": |background_toggle|})
         // With focus.
-        focus: "#src-sidebar-toggle > button"
+        focus: "#src-sidebar-toggle > button.collapse"
         assert-css: (
             "#src-sidebar-toggle > button:focus",
             {"background-color": |background_toggle_hover|},
         )
         focus: ".search-input"
         // With hover.
-        move-cursor-to: "#src-sidebar-toggle > button"
+        move-cursor-to: "#src-sidebar-toggle > button.collapse"
         assert-css: (
             "#src-sidebar-toggle > button:hover",
             {"background-color": |background_toggle_hover|},


### PR DESCRIPTION
Since the text isn't really important in itself, instead of updating it manually in the JS, we can let the CSS do it instead.

r? @notriddle 