### PR TITLE
MIR-only rlibs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -209,8 +209,14 @@ fn exported_symbols_provider_local(
     if allocator_kind_for_codegen(tcx).is_some() {
         for symbol_name in ALLOCATOR_METHODS
             .iter()
-            .map(|method| format!("__rust_{}", method.name))
-            .chain(["__rust_alloc_error_handler".to_string(), OomStrategy::SYMBOL.to_string()])
+            .flat_map(|method| {
+                [format!("__rust_{}", method.name), format!("__rdl_{}", method.name)]
+            })
+            .chain([
+                "__rust_alloc_error_handler".to_string(),
+                OomStrategy::SYMBOL.to_string(),
+                "__rg_oom".to_string(),
+            ])
         {
             let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(tcx, &symbol_name));
 
@@ -356,6 +362,27 @@ fn exported_symbols_provider_local(
                     // Any other symbols don't qualify for sharing
                 }
             }
+        }
+    }
+
+    if tcx.building_mir_only_rlib() {
+        for def_id in tcx.mir_keys(()) {
+            if !matches!(tcx.def_kind(def_id.to_def_id()), DefKind::Static { .. }) {
+                continue;
+            }
+            if tcx.is_reachable_non_generic(def_id.to_def_id()) {
+                continue;
+            }
+            let codegen_attrs = tcx.codegen_fn_attrs(def_id.to_def_id());
+            symbols.push((ExportedSymbol::NonGeneric(def_id.to_def_id()), SymbolExportInfo {
+                level: symbol_export_level(tcx, def_id.to_def_id()),
+                kind: if codegen_attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL) {
+                    SymbolExportKind::Tls
+                } else {
+                    SymbolExportKind::Data
+                },
+                used: true,
+            }));
         }
     }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -806,6 +806,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(mir_emit_retag, true);
     tracked!(mir_enable_passes, vec![("DestProp".to_string(), false)]);
     tracked!(mir_keep_place_mention, true);
+    tracked!(mir_only_rlibs, true);
     tracked!(mir_opt_level, Some(4));
     tracked!(move_size_limit, Some(4096));
     tracked!(mutable_noalias, false);

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -572,6 +572,14 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
                     .filter_map(|(cnum, data)| data.used().then_some(cnum)),
             )
         },
+        mir_only_crates: |tcx, ()| {
+            tcx.untracked().cstore.freeze();
+            let store = CStore::from_tcx(tcx);
+            let crates = store
+                .iter_crate_data()
+                .filter_map(|(cnum, data)| if data.root.is_mir_only { Some(cnum) } else { None });
+            tcx.arena.alloc_from_iter(crates)
+        },
         ..providers.queries
     };
     provide_extern(&mut providers.extern_queries);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -275,6 +275,7 @@ pub(crate) struct CrateRoot {
     debugger_visualizers: LazyArray<DebuggerVisualizerFile>,
 
     exported_symbols: LazyArray<(ExportedSymbol<'static>, SymbolExportInfo)>,
+    is_mir_only: bool,
 
     syntax_contexts: SyntaxContextTable,
     expn_data: ExpnDataTable,

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -91,6 +91,17 @@ impl<'tcx> MonoItem<'tcx> {
     }
 
     pub fn instantiation_mode(&self, tcx: TyCtxt<'tcx>) -> InstantiationMode {
+        // Always do LocalCopy codegen when building a MIR-only rlib
+        if tcx.building_mir_only_rlib() {
+            return InstantiationMode::LocalCopy;
+        }
+        // If this is a monomorphization from a MIR-only rlib and we are building another lib, do
+        // local codegen.
+        if tcx.mir_only_crates(()).iter().any(|c| *c == self.def_id().krate)
+            && tcx.crate_types() == &[rustc_session::config::CrateType::Rlib]
+        {
+            return InstantiationMode::LocalCopy;
+        }
         let generate_cgu_internal_copies = tcx
             .sess
             .opts

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2371,6 +2371,11 @@ rustc_queries! {
         desc { "estimating codegen size of `{}`", key }
         cache_on_disk_if { true }
     }
+
+    query mir_only_crates(_: ()) -> &'tcx [CrateNum] {
+        eval_always
+        desc { "fetching all foreign crates built in mir-only mode" }
+    }
 }
 
 rustc_query_append! { define_callbacks! }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1799,6 +1799,10 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn dcx(self) -> DiagCtxtHandle<'tcx> {
         self.sess.dcx()
     }
+
+    pub fn building_mir_only_rlib(self) -> bool {
+        self.sess.opts.unstable_opts.mir_only_rlibs && self.crate_types() == &[CrateType::Rlib]
+    }
 }
 
 impl<'tcx> TyCtxtAt<'tcx> {

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -145,6 +145,12 @@ fn partition<'tcx, I>(
 where
     I: Iterator<Item = MonoItem<'tcx>>,
 {
+    if tcx.building_mir_only_rlib() {
+        let cgu_name_builder = &mut CodegenUnitNameBuilder::new(tcx);
+        let cgu_name = fallback_cgu_name(cgu_name_builder);
+        return vec![CodegenUnit::new(cgu_name)];
+    }
+
     let _prof_timer = tcx.prof.generic_activity("cgu_partitioning");
 
     let cx = &PartitioningCx { tcx, usage_map };
@@ -169,6 +175,10 @@ where
         debug_dump(tcx, "MERGE", &codegen_units);
     }
 
+    if !codegen_units.is_sorted_by(|a, b| a.name().as_str() < b.name().as_str()) {
+        bug!("unsorted CGUs");
+    }
+
     // Make as many symbols "internal" as possible, so LLVM has more freedom to
     // optimize.
     if !tcx.sess.link_dead_code() {
@@ -189,7 +199,12 @@ where
         for cgu in codegen_units.iter() {
             names += &format!("- {}\n", cgu.name());
         }
-        bug!("unsorted CGUs:\n{names}");
+        codegen_units.sort_by(|a, b| a.name().as_str().cmp(b.name().as_str()));
+        let mut sorted_names = String::new();
+        for cgu in codegen_units.iter() {
+            sorted_names += &format!("- {}\n", cgu.name());
+        }
+        bug!("unsorted CGUs:\n{names}\n{sorted_names}");
     }
 
     codegen_units
@@ -213,6 +228,9 @@ where
     let cgu_name_builder = &mut CodegenUnitNameBuilder::new(cx.tcx);
     let cgu_name_cache = &mut UnordMap::default();
 
+    let start_fn = cx.tcx.lang_items().start_fn();
+    let entry_fn = cx.tcx.entry_fn(()).map(|(id, _)| id);
+
     for mono_item in mono_items {
         // Handle only root (GloballyShared) items directly here. Inlined (LocalCopy) items
         // are handled at the bottom of the loop based on reachability, with one exception.
@@ -221,7 +239,8 @@ where
         match mono_item.instantiation_mode(cx.tcx) {
             InstantiationMode::GloballyShared { .. } => {}
             InstantiationMode::LocalCopy => {
-                if Some(mono_item.def_id()) != cx.tcx.lang_items().start_fn() {
+                let def_id = mono_item.def_id();
+                if ![start_fn, entry_fn].contains(&Some(def_id)) {
                     continue;
                 }
             }
@@ -243,7 +262,7 @@ where
 
         let cgu = codegen_units.entry(cgu_name).or_insert_with(|| CodegenUnit::new(cgu_name));
 
-        let mut can_be_internalized = true;
+        let mut can_be_internalized = false;
         let (linkage, visibility) = mono_item_linkage_and_visibility(
             cx.tcx,
             &mono_item,
@@ -486,7 +505,7 @@ fn merge_codegen_units<'tcx>(
         // If we didn't zero-pad the sorted-by-name order would be `XYZ-cgu.0`,
         // `XYZ-cgu.1`, `XYZ-cgu.10`, `XYZ-cgu.11`, ..., `XYZ-cgu.2`, etc.
         codegen_units.sort_by_key(|cgu| cmp::Reverse(cgu.size_estimate()));
-        let num_digits = codegen_units.len().ilog10() as usize + 1;
+        let num_digits = std::hint::black_box(codegen_units.len().ilog10() as usize + 1);
         for (index, cgu) in codegen_units.iter_mut().enumerate() {
             // Note: `WorkItem::short_description` depends on this name ending
             // with `-cgu.` followed by a numeric suffix. Please keep it in

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1890,6 +1890,8 @@ options! {
     mir_keep_place_mention: bool = (false, parse_bool, [TRACKED],
         "keep place mention MIR statements, interpreted e.g., by miri; implies -Zmir-opt-level=0 \
         (default: no)"),
+    mir_only_rlibs: bool = (false, parse_bool, [TRACKED],
+        "only generate MIR when building rlibs (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::mir_opt_level` instead of this field")]
     mir_opt_level: Option<usize> = (None, parse_opt_number, [TRACKED],
         "MIR optimization level (0-4; default: 1 in non optimized builds and 2 in optimized builds)"),


### PR DESCRIPTION
Final status update:

I'm going to stop maintaining this branch, because I think this has basically zero chance of landing and minimal utility even if it did. If you want "delayed codegen" we already have `-Zcross-crate-inline-threshold=always` and that functionality is trivial to maintain. What this branch would bring is also delaying codegen for statics, which is not very interesting in terms of improving compile time. What it could _theoretically_ do (and I think the hope for MIR-only rlibs was always) is make a MIR-only rlib an intermediate artifact that can be lowered with various codegen options. In practice I think the utility of that is quite dubious, since after just macro expansion the IR is already quite target-specific. This can be made to work pretty well in some scenarios, but it will always be a second-class approach and comes with a substantial amount of complexity in the compiler, and would probably have a very long trail of bugs both in the compiler and in third-party crates if MIR-only rlibs were ever used seriously (people often accidentally depend on the addresses of things being stable, which they are only if they are monomorphized a certain way).

So: If you want _nearly_ MIR-only rlibs, just use `-Zcross-crate-inline-threshold=always`.

---

Status update: The strategy I implemented in this PR is to make builds of non-rlib crates monomorphize *everything* they need. I was quite thorough about this and had to add a handful of hacks to make it happen.

But I now believe that was a mistake, because of how it breaks proc-macro crates. I think those crates can only work if they are able to cooperate with the compiler correctly to share types across the proc-macro bridge. Currently this is achieved by linking both against the libstd dylib, which contains monomorphizations of the allocator shims and probably a handful of other things. So in order to make this work, I at least need to figure out how to make the compiler expose all the monomorphizations of the standard library, and make the proc-macro crates link against those instead of monomorphizing their own.

---

Originally I was just trying to imitate MIR-only rlibs with `-Zcross-crate-inline-threshold=yes`, but I think I have enough skill to actually implement the behavior. We shall see.

At time of writing, set `RUSTFLAGS=-Zmir-only-libs` and if each session that Cargo kicks off only compiles an rlib or an executable, every rlib should contain only MIR and the build should work. Any other configuration probably explodes unceremoniously.