### PR TITLE
create `LifetimeRes::Fresh` firstly when lower lifetime binder

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -874,15 +874,18 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         binder: NodeId,
         generic_params: &[GenericParam],
     ) -> &'hir [hir::GenericParam<'hir>] {
-        let mut generic_params: Vec<_> = self
-            .lower_generic_params_mut(generic_params, hir::GenericParamSource::Binder)
-            .collect();
+        let mut params = vec![];
+
         let extra_lifetimes = self.resolver.take_extra_lifetime_params(binder);
         debug!(?extra_lifetimes);
-        generic_params.extend(extra_lifetimes.into_iter().filter_map(|(ident, node_id, res)| {
+        params.extend(extra_lifetimes.into_iter().filter_map(|(ident, node_id, res)| {
             self.lifetime_res_to_generic_param(ident, node_id, res, hir::GenericParamSource::Binder)
         }));
-        let generic_params = self.arena.alloc_from_iter(generic_params);
+
+        params
+            .extend(self.lower_generic_params_mut(generic_params, hir::GenericParamSource::Binder));
+
+        let generic_params = self.arena.alloc_from_iter(params);
         debug!(?generic_params);
 
         generic_params

--- a/tests/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/tests/ui/anonymous-higher-ranked-lifetime.stderr
@@ -26,7 +26,7 @@ LL |     f2(|_: (), _: ()| {});
    |     |
    |     expected due to this
    |
-   = note: expected closure signature `for<'a, 'b> fn(&'a (), &'b ()) -> _`
+   = note: expected closure signature `for<'b, 'a> fn(&'a (), &'b ()) -> _`
               found closure signature `fn((), ()) -> _`
 note: required by a bound in `f2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:17:25
@@ -66,7 +66,7 @@ LL |     f4(|_: (), _: ()| {});
    |     |
    |     expected due to this
    |
-   = note: expected closure signature `for<'r, 'a> fn(&'a (), &'r ()) -> _`
+   = note: expected closure signature `for<'a, 'r> fn(&'a (), &'r ()) -> _`
               found closure signature `fn((), ()) -> _`
 note: required by a bound in `f4`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:19:25
@@ -206,7 +206,7 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     |
    |     expected due to this
    |
-   = note: expected closure signature `for<'t0, 'a> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
+   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
               found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:30:25

--- a/tests/ui/traits/non_lifetime_binders/issue-118697.rs
+++ b/tests/ui/traits/non_lifetime_binders/issue-118697.rs
@@ -1,0 +1,8 @@
+#![allow(incomplete_features)]
+#![feature(non_lifetime_binders)]
+
+type T = dyn for<V = A(&())> Fn(());
+//~^ ERROR cannot find type `A` in this scope
+//~| ERROR late-bound type parameter not allowed on trait object types
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/issue-118697.stderr
+++ b/tests/ui/traits/non_lifetime_binders/issue-118697.stderr
@@ -1,0 +1,15 @@
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/issue-118697.rs:4:22
+   |
+LL | type T = dyn for<V = A(&())> Fn(());
+   |                      ^ not found in this scope
+
+error: late-bound type parameter not allowed on trait object types
+  --> $DIR/issue-118697.rs:4:18
+   |
+LL | type T = dyn for<V = A(&())> Fn(());
+   |                  ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #118697

Rearrange the sequence to ensure that no null def id is read when lowering the lifetime.