### PR TITLE
Use a hardcoded constant instead of calling OpenProcessToken.

### DIFF
--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -1,5 +1,6 @@
 //! Implementation of `std::os` functionality for Windows.
 
+#![cfg_attr(bootstrap, allow(unexpected_cfgs))]
 #![allow(nonstandard_style)]
 
 #[cfg(test)]
@@ -318,13 +319,33 @@ pub fn temp_dir() -> PathBuf {
     super::fill_utf16_buf(|buf, sz| unsafe { c::GetTempPath2W(sz, buf) }, super::os2path).unwrap()
 }
 
-#[cfg(not(target_vendor = "uwp"))]
+#[cfg(all(not(target_vendor = "uwp"), not(target_vendor = "win7")))]
 fn home_dir_crt() -> Option<PathBuf> {
     unsafe {
-        // The magic constant -4 can be used as the token passed to GetUserProfileDirectoryW below
-        // instead of us having to go through these multiple steps to get a token. However this is
-        // not implemented on Windows 7, only Windows 8 and up. When we drop support for Windows 7
-        // we can simplify this code. See #90144 for details.
+        // Defined in processthreadsapi.h.
+        const CURRENT_PROCESS_TOKEN: usize = -4_isize as usize;
+
+        super::fill_utf16_buf(
+            |buf, mut sz| {
+                match c::GetUserProfileDirectoryW(
+                    ptr::invalid_mut(CURRENT_PROCESS_TOKEN),
+                    buf,
+                    &mut sz,
+                ) {
+                    0 if api::get_last_error().code != c::ERROR_INSUFFICIENT_BUFFER => 0,
+                    0 => sz,
+                    _ => sz - 1, // sz includes the null terminator
+                }
+            },
+            super::os2path,
+        )
+        .ok()
+    }
+}
+
+#[cfg(target_vendor = "win7")]
+fn home_dir_crt() -> Option<PathBuf> {
+    unsafe {
         use crate::sys::handle::Handle;
 
         let me = c::GetCurrentProcess();

--- a/library/std/src/sys/pal/windows/os.rs
+++ b/library/std/src/sys/pal/windows/os.rs
@@ -1,6 +1,5 @@
 //! Implementation of `std::os` functionality for Windows.
 
-#![cfg_attr(bootstrap, allow(unexpected_cfgs))]
 #![allow(nonstandard_style)]
 
 #[cfg(test)]


### PR DESCRIPTION
Now that Win 7 support is dropped, we can resurrect #90144.

GetCurrentProcessToken is defined in processthreadsapi.h as:

FORCEINLINE
HANDLE
GetCurrentProcessToken (
    VOID
    )
{
    return (HANDLE)(LONG_PTR) -4;
}

Since it's very unlikely that this constant will ever change, let's just use it instead of making calls to get the same information.