### PR TITLE
Run Miri and mir-opt tests without a target linker

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1611,7 +1611,12 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
                 .ensure(dist::DebuggerScripts { sysroot: builder.sysroot(compiler), host: target });
         }
 
-        builder.ensure(compile::Std::new(compiler, target));
+        if suite == "mir-opt" {
+            builder.ensure(compile::Std::new_for_mir_opt_tests(compiler, target));
+        } else {
+            builder.ensure(compile::Std::new(compiler, target));
+        }
+
         // ensure that `libproc_macro` is available on the host.
         builder.ensure(compile::Std::new(compiler, compiler.host));
 
@@ -1619,7 +1624,7 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         builder.ensure(TestHelpers { target: compiler.host });
 
         // As well as the target, except for plain wasm32, which can't build it
-        if !target.contains("wasm") || target.contains("emscripten") {
+        if suite != "mir-opt" && !target.contains("wasm") && !target.contains("emscripten") {
             builder.ensure(TestHelpers { target });
         }
 

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -62,8 +62,14 @@ impl Finder {
 }
 
 pub fn check(build: &mut Build) {
-    let skip_target_sanity =
+    let mut skip_target_sanity =
         env::var_os("BOOTSTRAP_SKIP_TARGET_SANITY").is_some_and(|s| s == "1" || s == "true");
+
+    // Skip target sanity checks when we are doing anything with mir-opt tests or Miri
+    let skipped_paths = [OsStr::new("mir-opt"), OsStr::new("miri")];
+    skip_target_sanity |= build.config.paths.iter().any(|path| {
+        path.components().any(|component| skipped_paths.contains(&component.as_os_str()))
+    });
 
     let path = env::var_os("PATH").unwrap_or_default();
     // On Windows, quotes are invalid characters for filename paths, and if

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -37,7 +37,6 @@ else
 fi
 # We natively run this script on x86_64-unknown-linux-gnu and x86_64-pc-windows-msvc.
 # Also cover some other targets via cross-testing, in particular all tier 1 targets.
-export BOOTSTRAP_SKIP_TARGET_SANITY=1 # we don't need `cc` for these targets
 case $HOST_TARGET in
   x86_64-unknown-linux-gnu)
     # Only this branch runs in PR CI.
@@ -62,4 +61,3 @@ case $HOST_TARGET in
     exit 1
     ;;
 esac
-unset BOOTSTRAP_SKIP_TARGET_SANITY

--- a/tests/mir-opt/remove_never_const.rs
+++ b/tests/mir-opt/remove_never_const.rs
@@ -3,9 +3,6 @@
 // consts in codegen. We also have tests for this that catches the error, see
 // tests/ui/consts/const-eval/index-out-of-bounds-never-type.rs.
 
-// Force generation of optimized mir for functions that do not reach codegen.
-// compile-flags: --emit mir,link
-
 #![feature(never_type)]
 
 struct PrintName<T>(T);


### PR DESCRIPTION
Normally, we need a linker for the target to build the standard library. That's only because `std` declares crate-type lib and dylib; building the dylib is what creates a need for the linker.

But for mir-opt tests (and for Miri) we do not need to build a `libstd.so`. So with this PR, when we build the standard library for mir-opt tests, instead of `cargo build` we run `cargo rustc --crate-type=lib` which overrides the configured crate types in `std`'s manifest.

I've also swapped in what seems to me a better hack than `BOOTSTRAP_SKIP_TARGET_SANITY` to prevent cross-interpreting with Miri from checking for a target linker and expanded it to mir-opt tests too. Whether it's actually better is up to a reviewer.