### PR TITLE
Rearrange `config.codegen.toml` to match `config.compiler.toml`

### DIFF
--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -16,9 +16,9 @@ backtrace-on-ice = true
 lto = "off"
 
 [llvm]
-# build llvm from source
+# Will download LLVM from CI if available on your platform.
 download-ci-llvm = "if-unchanged"
-# This enables debug-assertions in LLVM,
+# This enables debug-assertions in LLVM (or downloads a CI build with assertions),
 # catching logic errors in codegen much earlier in the process.
 assertions = true
 # enable warnings during the llvm compilation

--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -3,15 +3,6 @@
 # Contributors working on the compiler will probably expect compiler docs to be generated.
 compiler-docs = true
 
-[llvm]
-# This enables debug-assertions in LLVM,
-# catching logic errors in codegen much earlier in the process.
-assertions = true
-# enable warnings during the llvm compilation
-enable-warnings = true
-# build llvm from source
-download-ci-llvm = "if-unchanged"
-
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations
 # where adding `debug!()` appears to do nothing.
@@ -23,3 +14,12 @@ incremental = true
 backtrace-on-ice = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
+
+[llvm]
+# build llvm from source
+download-ci-llvm = "if-unchanged"
+# This enables debug-assertions in LLVM,
+# catching logic errors in codegen much earlier in the process.
+assertions = true
+# enable warnings during the llvm compilation
+enable-warnings = true


### PR DESCRIPTION
This makes it easier to compare the two profiles and see which parts are different.

No functional changes.