### PR TITLE
Desugar `yield` in `async gen` correctly, ensure `gen` always returns unit

### DIFF
--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -650,9 +650,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         },
                     )
                 }
-                // For a `gen {}` block created as a `gen fn` body, we need the return type to be
-                // ().
-                Some(hir::CoroutineKind::Gen(hir::CoroutineSource::Fn)) => self.tcx.types.unit,
+                // All `gen {}` and `async gen {}` must return unit.
+                Some(hir::CoroutineKind::Gen(_) | hir::CoroutineKind::AsyncGen(_)) => {
+                    self.tcx.types.unit
+                }
 
                 _ => astconv.ty_infer(None, decl.output.span()),
             },

--- a/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
+++ b/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
@@ -1,0 +1,17 @@
+// compile-flags: --edition 2024 -Zunstable-options
+// check-pass
+
+#![feature(async_iterator, gen_blocks, noop_waker)]
+
+use std::{async_iter::AsyncIterator, pin::pin, task::{Context, Waker}};
+
+async gen fn gen_fn() -> &'static str {
+    yield "hello"
+}
+
+pub fn main() {
+    let async_iterator = pin!(gen_fn());
+    let waker = Waker::noop();
+    let ctx = &mut Context::from_waker(&waker);
+    async_iterator.poll_next(ctx);
+}

--- a/tests/ui/coroutine/return-types-diverge.rs
+++ b/tests/ui/coroutine/return-types-diverge.rs
@@ -1,0 +1,20 @@
+// compile-flags: --edition 2024 -Zunstable-options
+// check-pass
+
+#![feature(gen_blocks)]
+
+fn diverge() -> ! { loop {} }
+
+async gen fn async_gen_fn() -> i32 { diverge() }
+
+gen fn gen_fn() -> i32 { diverge() }
+
+fn async_gen_block() {
+    async gen { yield (); diverge() };
+}
+
+fn gen_block() {
+    gen { yield (); diverge() };
+}
+
+fn main() {}

--- a/tests/ui/coroutine/return-types.rs
+++ b/tests/ui/coroutine/return-types.rs
@@ -1,0 +1,21 @@
+// compile-flags: --edition 2024 -Zunstable-options
+
+#![feature(gen_blocks)]
+
+async gen fn async_gen_fn() -> i32 { 0 }
+//~^ ERROR mismatched types
+
+gen fn gen_fn() -> i32 { 0 }
+//~^ ERROR mismatched types
+
+fn async_gen_block() {
+    async gen { yield (); 1 };
+    //~^ ERROR mismatched types
+}
+
+fn gen_block() {
+    gen { yield (); 1 };
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/coroutine/return-types.stderr
+++ b/tests/ui/coroutine/return-types.stderr
@@ -1,0 +1,31 @@
+error[E0308]: mismatched types
+  --> $DIR/return-types.rs:5:38
+   |
+LL | async gen fn async_gen_fn() -> i32 { 0 }
+   |                                ---   ^ expected `()`, found integer
+   |                                |
+   |                                expected `()` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/return-types.rs:8:26
+   |
+LL | gen fn gen_fn() -> i32 { 0 }
+   |                    ---   ^ expected `()`, found integer
+   |                    |
+   |                    expected `()` because of return type
+
+error[E0308]: mismatched types
+  --> $DIR/return-types.rs:12:27
+   |
+LL |     async gen { yield (); 1 };
+   |                           ^ expected `()`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/return-types.rs:17:21
+   |
+LL |     gen { yield (); 1 };
+   |                     ^ expected `()`, found integer
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
1. Ensure `async gen` blocks desugar `yield $expr` to `task_context = yield async_gen_ready($expr)`. Previously we were not assigning the `task_context` correctly, meaning that `yield` expressions in async generators returned type `ResumeTy` instead of `()`, and that we were not storing the `task_context`  (which is probably unsound if we were reading the old task-context which has an invalidated borrow or something...)
2. Ensure that all `(async?) gen` blocks and `(async?) gen` fns return unit. Previously we were only checking this for `gen fn`, meaning that `gen {}` and `async gen {}` and `async gen fn` were allowed to return values that weren't unit. This is why #119058 was an ICE rather than an E0308.

Fixes #119058.