### PR TITLE
Comment out `change-id` in `config.example.toml`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -29,8 +29,8 @@
 #  - A change in the default values
 #
 # If `change-id` does not match the version that is currently running,
-# `x.py` will prompt you to update it and check the related PR for more details.
-change-id = 118703
+# `x.py` will inform you about the changes made on bootstrap.
+# change-id = <latest change id in src/bootstrap/src/utils/change_tracker.rs>
 
 # =============================================================================
 # Tweaking how LLVM is compiled

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -597,19 +597,19 @@ cc = ["@davidtwco", "@wesleywiser"]
 message = """
 This PR modifies `src/bootstrap/src/core/config`.
 
-If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs` and `change-id` in `config.example.toml`.
+If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs`.
 """
 [mentions."src/bootstrap/defaults"]
 message = """
 This PR modifies `src/bootstrap/defaults`.
 
-If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs` and `change-id` in `config.example.toml`.
+If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs`.
 """
 [mentions."config.example.toml"]
 message = """
 This PR modifies `config.example.toml`.
 
-If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs` and `change-id` in `config.example.toml`.
+If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs`.
 """
 
 [mentions."src/bootstrap/defaults/config.compiler.toml"]


### PR DESCRIPTION
This way, we only update CONFIG_CHANGE_HISTORY for major changes, which is much simpler (and updating example.toml doesn't make much sense)

r? @Kobzol (as this was mainly your idea)