### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,10 @@
+Version 1.74.1 (2023-12-07)
+===========================
+
+- [Resolved spurious STATUS_ACCESS_VIOLATIONs in LLVM](https://github.com/rust-lang/rust/pull/118464)
+- [Clarify guarantees for std::mem::discriminant](https://github.com/rust-lang/rust/pull/118006)
+- [Fix some subtyping-related regressions](https://github.com/rust-lang/rust/pull/116415)
+
 Version 1.74.0 (2023-11-16)
 ==========================
 

--- a/compiler/rustc_llvm/llvm-wrapper/CoverageMappingWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/CoverageMappingWrapper.cpp
@@ -139,6 +139,9 @@ extern "C" void LLVMRustCoverageWriteMappingToBuffer(
            RustMappingRegions, NumMappingRegions)) {
     MappingRegions.emplace_back(
         fromRust(Region.Count), fromRust(Region.FalseCount),
+#if LLVM_VERSION_GE(18, 0)
+        coverage::CounterMappingRegion::MCDCParameters{},
+#endif
         Region.FileID, Region.ExpandedFileID,
         Region.LineStart, Region.ColumnStart, Region.LineEnd, Region.ColumnEnd,
         fromRust(Region.Kind));

--- a/config.example.toml
+++ b/config.example.toml
@@ -29,8 +29,8 @@
 #  - A change in the default values
 #
 # If `change-id` does not match the version that is currently running,
-# `x.py` will prompt you to update it and check the related PR for more details.
-change-id = 118703
+# `x.py` will inform you about the changes made on bootstrap.
+# change-id = <latest change id in src/bootstrap/src/utils/change_tracker.rs>
 
 # =============================================================================
 # Tweaking how LLVM is compiled

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -597,19 +597,19 @@ cc = ["@davidtwco", "@wesleywiser"]
 message = """
 This PR modifies `src/bootstrap/src/core/config`.
 
-If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs` and `change-id` in `config.example.toml`.
+If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs`.
 """
 [mentions."src/bootstrap/defaults"]
 message = """
 This PR modifies `src/bootstrap/defaults`.
 
-If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs` and `change-id` in `config.example.toml`.
+If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs`.
 """
 [mentions."config.example.toml"]
 message = """
 This PR modifies `config.example.toml`.
 
-If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs` and `change-id` in `config.example.toml`.
+If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/utils/change_tracker.rs`.
 """
 
 [mentions."src/bootstrap/defaults/config.compiler.toml"]


### PR DESCRIPTION
Successful merges:

 - #118941 (llvm-wrapper: adapt for LLVM API changes)
 - #119068 (Copy 1.74.1 release notes to master)
 - #119080 (Comment out `change-id` in `config.example.toml`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118941,119068,119080)
<!-- homu-ignore:end -->