### PR TITLE
Suggest Upgrading Compiler for Gated Features

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -48,7 +48,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             );
             if !is_stable && !self.tcx.features().asm_experimental_arch {
                 feature_err(
-                    &self.tcx.sess.parse_sess,
+                    &self.tcx.sess,
                     sym::asm_experimental_arch,
                     sp,
                     "inline assembly is not stable yet on this architecture",
@@ -63,13 +63,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             self.dcx().emit_err(AttSyntaxOnlyX86 { span: sp });
         }
         if asm.options.contains(InlineAsmOptions::MAY_UNWIND) && !self.tcx.features().asm_unwind {
-            feature_err(
-                &self.tcx.sess.parse_sess,
-                sym::asm_unwind,
-                sp,
-                "the `may_unwind` option is unstable",
-            )
-            .emit();
+            feature_err(&self.tcx.sess, sym::asm_unwind, sp, "the `may_unwind` option is unstable")
+                .emit();
         }
 
         let mut clobber_abis = FxIndexMap::default();
@@ -183,7 +178,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     InlineAsmOperand::Const { anon_const } => {
                         if !self.tcx.features().asm_const {
                             feature_err(
-                                &sess.parse_sess,
+                                sess,
                                 sym::asm_const,
                                 *op_sp,
                                 "const operands for inline assembly are unstable",

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1512,7 +1512,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             Some(hir::CoroutineKind::Coroutine(_)) => {
                 if !self.tcx.features().coroutines {
                     rustc_session::parse::feature_err(
-                        &self.tcx.sess.parse_sess,
+                        &self.tcx.sess,
                         sym::coroutines,
                         span,
                         "yield syntax is experimental",
@@ -1524,7 +1524,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             None => {
                 if !self.tcx.features().coroutines {
                     rustc_session::parse::feature_err(
-                        &self.tcx.sess.parse_sess,
+                        &self.tcx.sess,
                         sym::coroutines,
                         span,
                         "yield syntax is experimental",

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1043,7 +1043,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         {
                             add_feature_diagnostics(
                                 &mut err,
-                                &self.tcx.sess.parse_sess,
+                                &self.tcx.sess,
                                 sym::return_type_notation,
                             );
                         }
@@ -2310,7 +2310,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     hir::ArrayLen::Infer(self.lower_node_id(c.id), self.lower_span(c.value.span))
                 } else {
                     feature_err(
-                        &self.tcx.sess.parse_sess,
+                        &self.tcx.sess,
                         sym::generic_arg_infer,
                         c.value.span,
                         "using `_` for array lengths is unstable",

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -17,14 +17,12 @@ use crate::errors;
 macro_rules! gate {
     ($visitor:expr, $feature:ident, $span:expr, $explain:expr) => {{
         if !$visitor.features.$feature && !$span.allows_unstable(sym::$feature) {
-            feature_err(&$visitor.sess.parse_sess, sym::$feature, $span, $explain).emit();
+            feature_err(&$visitor.sess, sym::$feature, $span, $explain).emit();
         }
     }};
     ($visitor:expr, $feature:ident, $span:expr, $explain:expr, $help:expr) => {{
         if !$visitor.features.$feature && !$span.allows_unstable(sym::$feature) {
-            feature_err(&$visitor.sess.parse_sess, sym::$feature, $span, $explain)
-                .with_help($help)
-                .emit();
+            feature_err(&$visitor.sess, sym::$feature, $span, $explain).with_help($help).emit();
         }
     }};
 }
@@ -33,7 +31,7 @@ macro_rules! gate {
 macro_rules! gate_alt {
     ($visitor:expr, $has_feature:expr, $name:expr, $span:expr, $explain:expr) => {{
         if !$has_feature && !$span.allows_unstable($name) {
-            feature_err(&$visitor.sess.parse_sess, $name, $span, $explain).emit();
+            feature_err(&$visitor.sess, $name, $span, $explain).emit();
         }
     }};
 }
@@ -45,7 +43,7 @@ macro_rules! gate_multi {
             let spans: Vec<_> =
                 $spans.filter(|span| !span.allows_unstable(sym::$feature)).collect();
             if !spans.is_empty() {
-                feature_err(&$visitor.sess.parse_sess, sym::$feature, spans, $explain).emit();
+                feature_err(&$visitor.sess, sym::$feature, spans, $explain).emit();
             }
         }
     }};
@@ -55,7 +53,7 @@ macro_rules! gate_multi {
 macro_rules! gate_legacy {
     ($visitor:expr, $feature:ident, $span:expr, $explain:expr) => {{
         if !$visitor.features.$feature && !$span.allows_unstable(sym::$feature) {
-            feature_warn(&$visitor.sess.parse_sess, sym::$feature, $span, $explain);
+            feature_warn(&$visitor.sess, sym::$feature, $span, $explain);
         }
     }};
 }
@@ -91,14 +89,7 @@ impl<'a> PostExpansionVisitor<'a> {
         match abi::is_enabled(self.features, span, symbol_unescaped.as_str()) {
             Ok(()) => (),
             Err(abi::AbiDisabled::Unstable { feature, explain }) => {
-                feature_err_issue(
-                    &self.sess.parse_sess,
-                    feature,
-                    span,
-                    GateIssue::Language,
-                    explain,
-                )
-                .emit();
+                feature_err_issue(&self.sess, feature, span, GateIssue::Language, explain).emit();
             }
             Err(abi::AbiDisabled::Unrecognized) => {
                 if self.sess.opts.pretty.map_or(true, |ppm| ppm.needs_hir()) {
@@ -571,13 +562,8 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
                 if let Ok(snippet) = sm.span_to_snippet(span)
                     && snippet == "!"
                 {
-                    feature_err(
-                        &sess.parse_sess,
-                        sym::never_patterns,
-                        span,
-                        "`!` patterns are experimental",
-                    )
-                    .emit();
+                    feature_err(sess, sym::never_patterns, span, "`!` patterns are experimental")
+                        .emit();
                 } else {
                     let suggestion = span.shrink_to_hi();
                     sess.dcx().emit_err(errors::MatchArmWithNoBody { span, suggestion });

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -22,7 +22,7 @@ pub fn expand_cfg(
         Ok(cfg) => {
             let matches_cfg = attr::cfg_matches(
                 &cfg,
-                &cx.sess.parse_sess,
+                &cx.sess,
                 cx.current_expansion.lint_node_id,
                 Some(cx.ecfg.features),
             );

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -107,7 +107,7 @@ pub fn expand_include<'cx>(
         return DummyResult::any(sp);
     };
     // The file will be added to the code map by the parser
-    let file = match resolve_path(&cx.sess.parse_sess, file.as_str(), sp) {
+    let file = match resolve_path(&cx.sess, file.as_str(), sp) {
         Ok(f) => f,
         Err(err) => {
             err.emit();
@@ -179,7 +179,7 @@ pub fn expand_include_str(
     let Some(file) = get_single_str_from_tts(cx, sp, tts, "include_str!") else {
         return DummyResult::any(sp);
     };
-    let file = match resolve_path(&cx.sess.parse_sess, file.as_str(), sp) {
+    let file = match resolve_path(&cx.sess, file.as_str(), sp) {
         Ok(f) => f,
         Err(err) => {
             err.emit();
@@ -213,7 +213,7 @@ pub fn expand_include_bytes(
     let Some(file) = get_single_str_from_tts(cx, sp, tts, "include_bytes!") else {
         return DummyResult::any(sp);
     };
-    let file = match resolve_path(&cx.sess.parse_sess, file.as_str(), sp) {
+    let file = match resolve_path(&cx.sess, file.as_str(), sp) {
         Ok(f) => f,
         Err(err) => {
             err.emit();

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2860,7 +2860,7 @@ fn add_dynamic_crate(cmd: &mut dyn Linker, sess: &Session, cratepath: &Path) {
 
 fn relevant_lib(sess: &Session, lib: &NativeLib) -> bool {
     match lib.cfg {
-        Some(ref cfg) => rustc_attr::cfg_matches(cfg, &sess.parse_sess, CRATE_NODE_ID, None),
+        Some(ref cfg) => rustc_attr::cfg_matches(cfg, sess, CRATE_NODE_ID, None),
         None => true,
     }
 }

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -155,7 +155,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     Some([item]) if item.has_name(sym::linker) => {
                         if !tcx.features().used_with_arg {
                             feature_err(
-                                &tcx.sess.parse_sess,
+                                &tcx.sess,
                                 sym::used_with_arg,
                                 attr.span,
                                 "`#[used(linker)]` is currently unstable",
@@ -167,7 +167,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     Some([item]) if item.has_name(sym::compiler) => {
                         if !tcx.features().used_with_arg {
                             feature_err(
-                                &tcx.sess.parse_sess,
+                                &tcx.sess,
                                 sym::used_with_arg,
                                 attr.span,
                                 "`#[used(compiler)]` is currently unstable",
@@ -251,7 +251,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                     && !attr.span.allows_unstable(sym::closure_track_caller)
                 {
                     feature_err(
-                        &tcx.sess.parse_sess,
+                        &tcx.sess,
                         sym::closure_track_caller,
                         attr.span,
                         "`#[track_caller]` on closures is currently unstable",
@@ -304,7 +304,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                         // `#[target_feature]` on `main` and `start`.
                     } else if !tcx.features().target_feature_11 {
                         feature_err(
-                            &tcx.sess.parse_sess,
+                            &tcx.sess,
                             sym::target_feature_11,
                             attr.span,
                             "`#[target_feature(..)]` can only be applied to `unsafe` functions",

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -82,7 +82,7 @@ pub fn from_target_feature(
             };
             if !allowed {
                 feature_err(
-                    &tcx.sess.parse_sess,
+                    &tcx.sess,
                     feature_gate.unwrap(),
                     item.span(),
                     format!("the target feature `{feature}` is currently unstable"),

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -64,7 +64,7 @@ impl<'tcx> NonConstOp<'tcx> for FloatingPointOp {
 
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
         feature_err(
-            &ccx.tcx.sess.parse_sess,
+            &ccx.tcx.sess,
             sym::const_fn_floating_point_arithmetic,
             span,
             format!("floating point arithmetic is not allowed in {}s", ccx.const_kind()),
@@ -553,7 +553,7 @@ impl<'tcx> NonConstOp<'tcx> for RawMutPtrDeref {
 
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
         feature_err(
-            &ccx.tcx.sess.parse_sess,
+            &ccx.tcx.sess,
             sym::const_mut_refs,
             span,
             format!("dereferencing raw mutable pointers in {}s is unstable", ccx.const_kind(),),
@@ -624,7 +624,7 @@ pub mod ty {
 
         fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
             feature_err(
-                &ccx.tcx.sess.parse_sess,
+                &ccx.tcx.sess,
                 sym::const_mut_refs,
                 span,
                 format!("mutable references are not allowed in {}s", ccx.const_kind()),

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1150,7 +1150,7 @@ impl<'a> ExtCtxt<'a> {
 ///
 /// This unifies the logic used for resolving `include_X!`.
 pub fn resolve_path(
-    parse_sess: &ParseSess,
+    parse_sess: &Session,
     path: impl Into<PathBuf>,
     span: Span,
 ) -> PResult<'_, PathBuf> {
@@ -1166,7 +1166,7 @@ pub fn resolve_path(
                 .expect("attempting to resolve a file path in an external file"),
             FileName::DocTest(path, _) => path,
             other => {
-                return Err(parse_sess.dcx.create_err(errors::ResolveRelativePath {
+                return Err(parse_sess.dcx().create_err(errors::ResolveRelativePath {
                     span,
                     path: parse_sess.source_map().filename_for_diagnostics(&other).to_string(),
                 }));
@@ -1390,7 +1390,7 @@ pub fn parse_macro_name_and_helper_attrs(
 /// asserts in old versions of those crates and their wide use in the ecosystem.
 /// See issue #73345 for more details.
 /// FIXME(#73933): Remove this eventually.
-fn pretty_printing_compatibility_hack(item: &Item, sess: &ParseSess) -> bool {
+fn pretty_printing_compatibility_hack(item: &Item, sess: &Session) -> bool {
     let name = item.ident.name;
     if name == sym::ProceduralMasqueradeDummyType {
         if let ast::ItemKind::Enum(enum_def, _) = &item.kind {
@@ -1418,7 +1418,7 @@ fn pretty_printing_compatibility_hack(item: &Item, sess: &ParseSess) -> bool {
                             };
 
                             if crate_matches {
-                                sess.buffer_lint_with_diagnostic(
+                                sess.parse_sess.buffer_lint_with_diagnostic(
                                         PROC_MACRO_BACK_COMPAT,
                                         item.ident.span,
                                         ast::CRATE_NODE_ID,
@@ -1439,7 +1439,7 @@ fn pretty_printing_compatibility_hack(item: &Item, sess: &ParseSess) -> bool {
     false
 }
 
-pub(crate) fn ann_pretty_printing_compatibility_hack(ann: &Annotatable, sess: &ParseSess) -> bool {
+pub(crate) fn ann_pretty_printing_compatibility_hack(ann: &Annotatable, sess: &Session) -> bool {
     let item = match ann {
         Annotatable::Item(item) => item,
         Annotatable::Stmt(stmt) => match &stmt.kind {
@@ -1451,7 +1451,7 @@ pub(crate) fn ann_pretty_printing_compatibility_hack(ann: &Annotatable, sess: &P
     pretty_printing_compatibility_hack(item, sess)
 }
 
-pub(crate) fn nt_pretty_printing_compatibility_hack(nt: &Nonterminal, sess: &ParseSess) -> bool {
+pub(crate) fn nt_pretty_printing_compatibility_hack(nt: &Nonterminal, sess: &Session) -> bool {
     let item = match nt {
         Nonterminal::NtItem(item) => item,
         Nonterminal::NtStmt(stmt) => match &stmt.kind {

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -256,12 +256,7 @@ impl<'a> StripUnconfigured<'a> {
             );
         }
 
-        if !attr::cfg_matches(
-            &cfg_predicate,
-            &self.sess.parse_sess,
-            self.lint_node_id,
-            self.features,
-        ) {
+        if !attr::cfg_matches(&cfg_predicate, &self.sess, self.lint_node_id, self.features) {
             return vec![];
         }
 
@@ -369,12 +364,7 @@ impl<'a> StripUnconfigured<'a> {
         };
         (
             parse_cfg(&meta_item, self.sess).map_or(true, |meta_item| {
-                attr::cfg_matches(
-                    meta_item,
-                    &self.sess.parse_sess,
-                    self.lint_node_id,
-                    self.features,
-                )
+                attr::cfg_matches(meta_item, &self.sess, self.lint_node_id, self.features)
             }),
             Some(meta_item),
         )
@@ -385,7 +375,7 @@ impl<'a> StripUnconfigured<'a> {
     pub(crate) fn maybe_emit_expr_attr_err(&self, attr: &Attribute) {
         if self.features.is_some_and(|features| !features.stmt_expr_attributes) {
             let mut err = feature_err(
-                &self.sess.parse_sess,
+                &self.sess,
                 sym::stmt_expr_attributes,
                 attr.span,
                 "attributes on expressions are experimental",

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -5,7 +5,8 @@ use rustc_ast::token::{self, Delimiter, Token};
 use rustc_ast::{tokenstream, NodeId};
 use rustc_ast_pretty::pprust;
 use rustc_feature::Features;
-use rustc_session::parse::{feature_err, ParseSess};
+use rustc_session::parse::feature_err;
+use rustc_session::Session;
 use rustc_span::symbol::{kw, sym, Ident};
 
 use rustc_span::edition::Edition;
@@ -38,7 +39,7 @@ const VALID_FRAGMENT_NAMES_MSG: &str = "valid fragment specifiers are \
 pub(super) fn parse(
     input: &tokenstream::TokenStream,
     parsing_patterns: bool,
-    sess: &ParseSess,
+    sess: &Session,
     node_id: NodeId,
     features: &Features,
     edition: Edition,
@@ -84,7 +85,7 @@ pub(super) fn parse(
                                                     "invalid fragment specifier `{}`",
                                                     frag.name
                                                 );
-                                                sess.dcx
+                                                sess.dcx()
                                                     .struct_span_err(span, msg)
                                                     .with_help(VALID_FRAGMENT_NAMES_MSG)
                                                     .emit();
@@ -113,7 +114,7 @@ pub(super) fn parse(
 }
 
 /// Asks for the `macro_metavar_expr` feature if it is not already declared
-fn maybe_emit_macro_metavar_expr_feature(features: &Features, sess: &ParseSess, span: Span) {
+fn maybe_emit_macro_metavar_expr_feature(features: &Features, sess: &Session, span: Span) {
     if !features.macro_metavar_expr {
         let msg = "meta-variable expressions are unstable";
         feature_err(sess, sym::macro_metavar_expr, span, msg).emit();
@@ -138,7 +139,7 @@ fn parse_tree<'a>(
     tree: &'a tokenstream::TokenTree,
     outer_trees: &mut impl Iterator<Item = &'a tokenstream::TokenTree>,
     parsing_patterns: bool,
-    sess: &ParseSess,
+    sess: &Session,
     node_id: NodeId,
     features: &Features,
     edition: Edition,
@@ -174,7 +175,8 @@ fn parse_tree<'a>(
                                 // The delimiter is `{`. This indicates the beginning
                                 // of a meta-variable expression (e.g. `${count(ident)}`).
                                 // Try to parse the meta-variable expression.
-                                match MetaVarExpr::parse(tts, delim_span.entire(), sess) {
+                                match MetaVarExpr::parse(tts, delim_span.entire(), &sess.parse_sess)
+                                {
                                     Err(err) => {
                                         err.emit();
                                         // Returns early the same read `$` to avoid spanning
@@ -195,7 +197,7 @@ fn parse_tree<'a>(
                             _ => {
                                 let tok = pprust::token_kind_to_string(&token::OpenDelim(delim));
                                 let msg = format!("expected `(` or `{{`, found `{tok}`");
-                                sess.dcx.span_err(delim_span.entire(), msg);
+                                sess.dcx().span_err(delim_span.entire(), msg);
                             }
                         }
                     }
@@ -244,7 +246,7 @@ fn parse_tree<'a>(
                 Some(tokenstream::TokenTree::Token(token, _)) => {
                     let msg =
                         format!("expected identifier, found `{}`", pprust::token_to_string(token),);
-                    sess.dcx.span_err(token.span, msg);
+                    sess.dcx().span_err(token.span, msg);
                     TokenTree::MetaVar(token.span, Ident::empty())
                 }
 
@@ -313,7 +315,7 @@ fn parse_kleene_op<'a>(
 fn parse_sep_and_kleene_op<'a>(
     input: &mut impl Iterator<Item = &'a tokenstream::TokenTree>,
     span: Span,
-    sess: &ParseSess,
+    sess: &Session,
 ) -> (Option<Token>, KleeneToken) {
     // We basically look at two token trees here, denoted as #1 and #2 below
     let span = match parse_kleene_op(input, span) {
@@ -325,7 +327,7 @@ fn parse_sep_and_kleene_op<'a>(
             // #2 is the `?` Kleene op, which does not take a separator (error)
             Ok(Ok((KleeneOp::ZeroOrOne, span))) => {
                 // Error!
-                sess.dcx.span_err(
+                sess.dcx().span_err(
                     token.span,
                     "the `?` macro repetition operator does not take a separator",
                 );
@@ -346,7 +348,7 @@ fn parse_sep_and_kleene_op<'a>(
     };
 
     // If we ever get to this point, we have experienced an "unexpected token" error
-    sess.dcx.span_err(span, "expected one of: `*`, `+`, or `?`");
+    sess.dcx().span_err(span, "expected one of: `*`, `+`, or `?`");
 
     // Return a dummy
     (None, KleeneToken::new(KleeneOp::ZeroOrMore, span))
@@ -355,9 +357,10 @@ fn parse_sep_and_kleene_op<'a>(
 // `$$` or a meta-variable is the lhs of a macro but shouldn't.
 //
 // For example, `macro_rules! foo { ( ${length()} ) => {} }`
-fn span_dollar_dollar_or_metavar_in_the_lhs_err(sess: &ParseSess, token: &Token) {
-    sess.dcx.span_err(token.span, format!("unexpected token: {}", pprust::token_to_string(token)));
-    sess.dcx.span_note(
+fn span_dollar_dollar_or_metavar_in_the_lhs_err(sess: &Session, token: &Token) {
+    sess.dcx()
+        .span_err(token.span, format!("unexpected token: {}", pprust::token_to_string(token)));
+    sess.dcx().span_note(
         token.span,
         "`$$` and meta-variable expressions are not allowed inside macro parameter definitions",
     );

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -119,7 +119,7 @@ impl MultiItemModifier for DeriveProcMacro {
         // We need special handling for statement items
         // (e.g. `fn foo() { #[derive(Debug)] struct Bar; }`)
         let is_stmt = matches!(item, Annotatable::Stmt(..));
-        let hack = crate::base::ann_pretty_printing_compatibility_hack(&item, &ecx.sess.parse_sess);
+        let hack = crate::base::ann_pretty_printing_compatibility_hack(&item, &ecx.sess);
         let input = if hack {
             let nt = match item {
                 Annotatable::Item(item) => token::NtItem(item),

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -258,7 +258,7 @@ impl FromInternal<(TokenStream, &mut Rustc<'_, '_>)> for Vec<TokenTree<TokenStre
                     // represented as a delimited group.
                     // FIXME: It needs to be removed, but there are some
                     // compatibility issues (see #73345).
-                    if crate::base::nt_pretty_printing_compatibility_hack(&nt.0, rustc.sess()) {
+                    if crate::base::nt_pretty_printing_compatibility_hack(&nt.0, rustc.ecx.sess) {
                         trees.extend(Self::from_internal((stream, rustc)));
                     } else {
                         trees.push(TokenTree::Group(Group {

--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -59,7 +59,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             if trait_segment.args().parenthesized == hir::GenericArgsParentheses::ParenSugar {
                 // For now, require that parenthetical notation be used only with `Fn()` etc.
                 feature_err(
-                    &self.tcx().sess.parse_sess,
+                    &self.tcx().sess,
                     sym::unboxed_closures,
                     span,
                     "parenthetical notation is only stable when used with `Fn`-family traits",
@@ -75,7 +75,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         if trait_segment.args().parenthesized != hir::GenericArgsParentheses::ParenSugar {
             // For now, require that parenthetical notation be used only with `Fn()` etc.
             let mut err = feature_err(
-                &sess.parse_sess,
+                sess,
                 sym::unboxed_closures,
                 span,
                 "the precise format of `Fn`-family traits' type parameters is subject to change",

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -996,7 +996,7 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
 
     if adt.is_union() && !tcx.features().transparent_unions {
         feature_err(
-            &tcx.sess.parse_sess,
+            &tcx.sess,
             sym::transparent_unions,
             tcx.def_span(adt.did()),
             "transparent unions are unstable",
@@ -1128,7 +1128,7 @@ fn check_enum(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     if repr_type_ty == tcx.types.i128 || repr_type_ty == tcx.types.u128 {
         if !tcx.features().repr128 {
             feature_err(
-                &tcx.sess.parse_sess,
+                &tcx.sess,
                 sym::repr128,
                 tcx.def_span(def_id),
                 "repr with 128-bit type is unstable",

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -293,7 +293,7 @@ fn default_body_is_unstable(
 
     rustc_session::parse::add_feature_diagnostics_for_issue(
         &mut err,
-        &tcx.sess.parse_sess,
+        &tcx.sess,
         feature,
         rustc_feature::GateIssue::Library(issue),
         false,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1591,7 +1591,7 @@ fn check_method_receiver<'tcx>(
             return Err(if receiver_is_valid(wfcx, span, receiver_ty, self_ty, true) {
                 // Report error; would have worked with `arbitrary_self_types`.
                 feature_err(
-                    &tcx.sess.parse_sess,
+                    &tcx.sess,
                     sym::arbitrary_self_types,
                     span,
                     format!(

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1189,12 +1189,13 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                         && !self.tcx.asyncness(lifetime_ref.hir_id.owner.def_id).is_async()
                         && !self.tcx.features().anonymous_lifetime_in_impl_trait
                     {
-                        let mut diag = rustc_session::parse::feature_err(
-                            &self.tcx.sess.parse_sess,
-                            sym::anonymous_lifetime_in_impl_trait,
-                            lifetime_ref.ident.span,
-                            "anonymous lifetimes in `impl Trait` are unstable",
-                        );
+                        let mut diag: rustc_errors::DiagnosticBuilder<'_> =
+                            rustc_session::parse::feature_err(
+                                &self.tcx.sess,
+                                sym::anonymous_lifetime_in_impl_trait,
+                                lifetime_ref.ident.span,
+                                "anonymous lifetimes in `impl Trait` are unstable",
+                            );
 
                         if let Some(generics) =
                             self.tcx.hir().get_generics(lifetime_ref.hir_id.owner.def_id)

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -639,7 +639,7 @@ fn check_feature_inherent_assoc_ty(tcx: TyCtxt<'_>, span: Span) {
         use rustc_session::parse::feature_err;
         use rustc_span::symbol::sym;
         feature_err(
-            &tcx.sess.parse_sess,
+            &tcx.sess,
             sym::inherent_associated_types,
             span,
             "inherent associated types are unstable",

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -133,13 +133,8 @@ fn require_c_abi_if_c_variadic(tcx: TyCtxt<'_>, decl: &hir::FnDecl<'_>, abi: Abi
         // Using this ABI would be ok, if the feature for additional ABI support was enabled.
         // Return CONVENTIONS_STABLE, because we want the other error to look the same.
         (false, true) => {
-            feature_err(
-                &tcx.sess.parse_sess,
-                sym::extended_varargs_abi_support,
-                span,
-                UNSTABLE_EXPLAIN,
-            )
-            .emit();
+            feature_err(&tcx.sess, sym::extended_varargs_abi_support, span, UNSTABLE_EXPLAIN)
+                .emit();
             CONVENTIONS_STABLE
         }
 

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -704,7 +704,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
         if has_unsized_tuple_coercion && !self.tcx.features().unsized_tuple_coercion {
             feature_err(
-                &self.tcx.sess.parse_sess,
+                &self.tcx.sess,
                 sym::unsized_tuple_coercion,
                 self.cause.span,
                 "unsized tuple coercion is not stable enough for use and is subject to change",

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1865,7 +1865,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         (ty::Adt(adt, _), ty::Adt(base_adt, _)) if adt == base_adt);
                     if self.tcx.sess.is_nightly_build() && same_adt {
                         feature_err(
-                            &self.tcx.sess.parse_sess,
+                            &self.tcx.sess,
                             sym::type_changing_struct_update,
                             base_expr.span,
                             "type changing struct updating is experimental",
@@ -3262,7 +3262,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                     if !self.tcx.features().offset_of_enum {
                         rustc_session::parse::feature_err(
-                            &self.tcx.sess.parse_sess,
+                            &self.tcx.sess,
                             sym::offset_of_enum,
                             ident.span,
                             "using enums in offset_of is experimental",

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1306,10 +1306,7 @@ impl<'tcx> LateLintPass<'tcx> for UngatedAsyncFnTrackCaller {
             cx.emit_spanned_lint(
                 UNGATED_ASYNC_FN_TRACK_CALLER,
                 attr.span,
-                BuiltinUngatedAsyncFnTrackCaller {
-                    label: span,
-                    parse_sess: &cx.tcx.sess.parse_sess,
-                },
+                BuiltinUngatedAsyncFnTrackCaller { label: span, session: &cx.tcx.sess },
             );
         }
     }

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -786,7 +786,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                             if let ast::LitKind::Str(rationale, _) = name_value.kind {
                                 if !self.features.lint_reasons {
                                     feature_err(
-                                        &self.sess.parse_sess,
+                                        &self.sess,
                                         sym::lint_reasons,
                                         item.span,
                                         "lint reasons are experimental",
@@ -1074,7 +1074,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                             lint.note(fluent::lint_note);
                             rustc_session::parse::add_feature_diagnostics_for_issue(
                                 lint,
-                                &self.sess.parse_sess,
+                                &self.sess,
                                 feature,
                                 GateIssue::Language,
                                 lint_from_cli,

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -13,7 +13,7 @@ use rustc_macros::{LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::{
     inhabitedness::InhabitedPredicate, Clause, PolyExistentialTraitRef, Ty, TyCtxt,
 };
-use rustc_session::parse::ParseSess;
+use rustc_session::Session;
 use rustc_span::{edition::Edition, sym, symbol::Ident, Span, Symbol};
 
 use crate::{
@@ -235,7 +235,7 @@ pub struct BuiltinUnstableFeatures;
 // lint_ungated_async_fn_track_caller
 pub struct BuiltinUngatedAsyncFnTrackCaller<'a> {
     pub label: Span,
-    pub parse_sess: &'a ParseSess,
+    pub session: &'a Session,
 }
 
 impl<'a> DecorateLint<'a, ()> for BuiltinUngatedAsyncFnTrackCaller<'_> {
@@ -243,7 +243,7 @@ impl<'a> DecorateLint<'a, ()> for BuiltinUngatedAsyncFnTrackCaller<'_> {
         diag.span_label(self.label, fluent::lint_label);
         rustc_session::parse::add_feature_diagnostics(
             diag,
-            self.parse_sess,
+            self.session,
             sym::async_fn_track_caller,
         );
     }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -82,7 +82,7 @@ pub(crate) fn collect(tcx: TyCtxt<'_>, LocalCrate: LocalCrate) -> Vec<NativeLib>
 
 pub(crate) fn relevant_lib(sess: &Session, lib: &NativeLib) -> bool {
     match lib.cfg {
-        Some(ref cfg) => attr::cfg_matches(cfg, &sess.parse_sess, CRATE_NODE_ID, None),
+        Some(ref cfg) => attr::cfg_matches(cfg, sess, CRATE_NODE_ID, None),
         None => true,
     }
 }
@@ -163,7 +163,7 @@ impl<'tcx> Collector<'tcx> {
                             "link-arg" => {
                                 if !features.link_arg_attribute {
                                     feature_err(
-                                        &sess.parse_sess,
+                                        sess,
                                         sym::link_arg_attribute,
                                         span,
                                         "link kind `link-arg` is unstable",
@@ -206,13 +206,8 @@ impl<'tcx> Collector<'tcx> {
                             continue;
                         };
                         if !features.link_cfg {
-                            feature_err(
-                                &sess.parse_sess,
-                                sym::link_cfg,
-                                item.span(),
-                                "link cfg is unstable",
-                            )
-                            .emit();
+                            feature_err(sess, sym::link_cfg, item.span(), "link cfg is unstable")
+                                .emit();
                         }
                         cfg = Some(link_cfg.clone());
                     }
@@ -277,7 +272,7 @@ impl<'tcx> Collector<'tcx> {
                     macro report_unstable_modifier($feature: ident) {
                         if !features.$feature {
                             feature_err(
-                                &sess.parse_sess,
+                                sess,
                                 sym::$feature,
                                 span,
                                 format!("linking modifier `{modifier}` is unstable"),

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -116,8 +116,7 @@ pub fn report_unstable(
     if is_soft {
         soft_handler(SOFT_UNSTABLE, span, msg)
     } else {
-        let mut err =
-            feature_err_issue(&sess.parse_sess, feature, span, GateIssue::Library(issue), msg);
+        let mut err = feature_err_issue(sess, feature, span, GateIssue::Library(issue), msg);
         if let Some((inner_types, msg, sugg, applicability)) = suggestion {
             err.span_suggestion(inner_types, msg, sugg, applicability);
         }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1170,7 +1170,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         sym::rust_logo => {
                             if !self.tcx.features().rustdoc_internals {
                                 feature_err(
-                                    &self.tcx.sess.parse_sess,
+                                    &self.tcx.sess,
                                     sym::rustdoc_internals,
                                     meta.span(),
                                     "the `#[doc(rust_logo)]` attribute is used for Rust branding",
@@ -1815,7 +1815,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         (target, self.tcx.features().fn_align)
                     {
                         feature_err(
-                            &self.tcx.sess.parse_sess,
+                            &self.tcx.sess,
                             sym::fn_align,
                             hint.span(),
                             "`repr(align)` attributes on functions are unstable",

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -147,7 +147,7 @@ impl<'tcx> CheckConstVisitor<'tcx> {
             [missing_primary, ref missing_secondary @ ..] => {
                 let msg =
                     format!("{} is not allowed in a `{}`", expr.name(), const_kind.keyword_name());
-                let mut err = feature_err(&tcx.sess.parse_sess, *missing_primary, span, msg);
+                let mut err = feature_err(&tcx.sess, *missing_primary, span, msg);
 
                 // If multiple feature gates would be required to enable this expression, include
                 // them as help messages. Don't emit a separate error for each missing feature gate.

--- a/compiler/rustc_passes/src/debugger_visualizer.rs
+++ b/compiler/rustc_passes/src/debugger_visualizer.rs
@@ -45,14 +45,13 @@ impl DebuggerVisualizerCollector<'_> {
                     }
                 };
 
-            let file =
-                match resolve_path(&self.sess.parse_sess, visualizer_path.as_str(), attr.span) {
-                    Ok(file) => file,
-                    Err(err) => {
-                        err.emit();
-                        return;
-                    }
-                };
+            let file = match resolve_path(&self.sess, visualizer_path.as_str(), attr.span) {
+                Ok(file) => file,
+                Err(err) => {
+                    err.emit();
+                    return;
+                }
+            };
 
             match std::fs::read(&file) {
                 Ok(contents) => {

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -135,7 +135,7 @@ fn configure_main(tcx: TyCtxt<'_>, visitor: &EntryContext<'_>) -> Option<(DefId,
             if main_def.is_import && !tcx.features().imported_main {
                 let span = main_def.span;
                 feature_err(
-                    &tcx.sess.parse_sess,
+                    &tcx.sess,
                     sym::imported_main,
                     span,
                     "using an imported function as entry point `main` is experimental",

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -594,13 +594,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             if soft_custom_inner_attributes_gate {
                 self.tcx.sess.parse_sess.buffer_lint(SOFT_UNSTABLE, path.span, node_id, msg);
             } else {
-                feature_err(
-                    &self.tcx.sess.parse_sess,
-                    sym::custom_inner_attributes,
-                    path.span,
-                    msg,
-                )
-                .emit();
+                feature_err(&self.tcx.sess, sym::custom_inner_attributes, path.span, msg).emit();
             }
         }
 

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -25,7 +25,7 @@ session_feature_diagnostic_help =
     add `#![feature({$feature})]` to the crate attributes to enable
 
 session_feature_suggest_upgrade_compiler =
-    this compiler is version {$version} built on {$date}, consider upgrading?
+    this compiler was built on {$date}; consider upgrading it if it is out of date
 
 session_file_is_not_writeable = output file {$file} is not writeable -- check its permissions
 

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -24,6 +24,9 @@ session_feature_diagnostic_for_issue =
 session_feature_diagnostic_help =
     add `#![feature({$feature})]` to the crate attributes to enable
 
+session_feature_suggest_upgrade_compiler =
+    this compiler is version {$version} built on {$date}, consider upgrading?
+
 session_file_is_not_writeable = output file {$file} is not writeable -- check its permissions
 
 session_file_write_fail = failed to write `{$path}` due to error `{$err}`

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -1,6 +1,5 @@
 use std::num::NonZeroU32;
 
-use crate::parse::ParseSess;
 use rustc_ast::token;
 use rustc_ast::util::literal::LitError;
 use rustc_errors::{
@@ -9,6 +8,8 @@ use rustc_errors::{
 use rustc_macros::Diagnostic;
 use rustc_span::{BytePos, Span, Symbol};
 use rustc_target::spec::{SplitDebuginfo, StackProtector, TargetTriple};
+
+use crate::parse::ParseSess;
 
 pub struct FeatureGateError {
     pub span: MultiSpan,
@@ -33,16 +34,18 @@ pub struct FeatureDiagnosticForIssue {
 #[derive(Subdiagnostic)]
 #[note(session_feature_suggest_upgrade_compiler)]
 pub struct SuggestUpgradeCompiler {
-    version: &'static str,
     date: &'static str,
 }
 
 impl SuggestUpgradeCompiler {
-    pub fn new() -> Self {
-        let version = option_env!("CFG_VERSION").unwrap_or("unknown");
-        let date = option_env!("CFG_VER_DATE").unwrap_or("unknown");
+    pub fn ui_testing() -> Self {
+        Self { date: "YYYY-MM-DD" }
+    }
 
-        Self { version, date }
+    pub fn new() -> Option<Self> {
+        let date = option_env!("CFG_VER_DATE")?;
+
+        Some(Self { date })
     }
 }
 

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -31,6 +31,22 @@ pub struct FeatureDiagnosticForIssue {
 }
 
 #[derive(Subdiagnostic)]
+#[note(session_feature_suggest_upgrade_compiler)]
+pub struct SuggestUpgradeCompiler {
+    version: &'static str,
+    date: &'static str,
+}
+
+impl SuggestUpgradeCompiler {
+    pub fn new() -> Self {
+        let version = option_env!("CFG_VERSION").unwrap_or("unknown");
+        let date = option_env!("CFG_VER_DATE").unwrap_or("unknown");
+
+        Self { version, date }
+    }
+}
+
+#[derive(Subdiagnostic)]
 #[help(session_feature_diagnostic_help)]
 pub struct FeatureDiagnosticHelp {
     pub feature: Symbol,

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -4,6 +4,7 @@
 use crate::config::{Cfg, CheckCfg};
 use crate::errors::{
     CliFeatureDiagnosticHelp, FeatureDiagnosticForIssue, FeatureDiagnosticHelp, FeatureGateError,
+    SuggestUpgradeCompiler,
 };
 use crate::lint::{
     builtin::UNSTABLE_SYNTAX_PRE_EXPANSION, BufferedEarlyLint, BuiltinLintDiagnostics, Lint, LintId,
@@ -179,6 +180,8 @@ pub fn add_feature_diagnostics_for_issue(
         } else {
             err.subdiagnostic(FeatureDiagnosticHelp { feature });
         }
+
+        err.subdiagnostic(SuggestUpgradeCompiler::new());
     }
 }
 

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -77,6 +77,7 @@ impl SymbolGallery {
     }
 }
 
+// todo: this function now accepts `Session` instead of `ParseSess` and should be relocated
 /// Construct a diagnostic for a language feature error due to the given `span`.
 /// The `feature`'s `Symbol` is the one you used in `unstable.rs` and `rustc_span::symbols`.
 #[track_caller]

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -9,6 +9,7 @@ use crate::errors::{
 use crate::lint::{
     builtin::UNSTABLE_SYNTAX_PRE_EXPANSION, BufferedEarlyLint, BuiltinLintDiagnostics, Lint, LintId,
 };
+use crate::Session;
 use rustc_ast::node_id::NodeId;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync::{AppendOnlyVec, Lock, Lrc};
@@ -80,7 +81,7 @@ impl SymbolGallery {
 /// The `feature`'s `Symbol` is the one you used in `unstable.rs` and `rustc_span::symbols`.
 #[track_caller]
 pub fn feature_err(
-    sess: &ParseSess,
+    sess: &Session,
     feature: Symbol,
     span: impl Into<MultiSpan>,
     explain: impl Into<DiagnosticMessage>,
@@ -94,7 +95,7 @@ pub fn feature_err(
 /// Almost always, you want to use this for a language feature. If so, prefer `feature_err`.
 #[track_caller]
 pub fn feature_err_issue(
-    sess: &ParseSess,
+    sess: &Session,
     feature: Symbol,
     span: impl Into<MultiSpan>,
     issue: GateIssue,
@@ -104,12 +105,14 @@ pub fn feature_err_issue(
 
     // Cancel an earlier warning for this same error, if it exists.
     if let Some(span) = span.primary_span() {
-        if let Some(err) = sess.dcx.steal_diagnostic(span, StashKey::EarlySyntaxWarning) {
+        if let Some(err) = sess.parse_sess.dcx.steal_diagnostic(span, StashKey::EarlySyntaxWarning)
+        {
             err.cancel()
         }
     }
 
-    let mut err = sess.dcx.create_err(FeatureGateError { span, explain: explain.into() });
+    let mut err =
+        sess.parse_sess.dcx.create_err(FeatureGateError { span, explain: explain.into() });
     add_feature_diagnostics_for_issue(&mut err, sess, feature, issue, false);
     err
 }
@@ -118,7 +121,7 @@ pub fn feature_err_issue(
 ///
 /// This diagnostic is only a warning and *does not cause compilation to fail*.
 #[track_caller]
-pub fn feature_warn(sess: &ParseSess, feature: Symbol, span: Span, explain: &'static str) {
+pub fn feature_warn(sess: &Session, feature: Symbol, span: Span, explain: &'static str) {
     feature_warn_issue(sess, feature, span, GateIssue::Language, explain);
 }
 
@@ -132,13 +135,13 @@ pub fn feature_warn(sess: &ParseSess, feature: Symbol, span: Span, explain: &'st
 #[allow(rustc::untranslatable_diagnostic)]
 #[track_caller]
 pub fn feature_warn_issue(
-    sess: &ParseSess,
+    sess: &Session,
     feature: Symbol,
     span: Span,
     issue: GateIssue,
     explain: &'static str,
 ) {
-    let mut err = sess.dcx.struct_span_warn(span, explain);
+    let mut err = sess.parse_sess.dcx.struct_span_warn(span, explain);
     add_feature_diagnostics_for_issue(&mut err, sess, feature, issue, false);
 
     // Decorate this as a future-incompatibility lint as in rustc_middle::lint::struct_lint_level
@@ -153,7 +156,7 @@ pub fn feature_warn_issue(
 }
 
 /// Adds the diagnostics for a feature to an existing error.
-pub fn add_feature_diagnostics(err: &mut Diagnostic, sess: &ParseSess, feature: Symbol) {
+pub fn add_feature_diagnostics(err: &mut Diagnostic, sess: &Session, feature: Symbol) {
     add_feature_diagnostics_for_issue(err, sess, feature, GateIssue::Language, false);
 }
 
@@ -164,7 +167,7 @@ pub fn add_feature_diagnostics(err: &mut Diagnostic, sess: &ParseSess, feature: 
 /// `add_feature_diagnostics`.
 pub fn add_feature_diagnostics_for_issue(
     err: &mut Diagnostic,
-    sess: &ParseSess,
+    sess: &Session,
     feature: Symbol,
     issue: GateIssue,
     feature_from_cli: bool,
@@ -174,14 +177,18 @@ pub fn add_feature_diagnostics_for_issue(
     }
 
     // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
-    if sess.unstable_features.is_nightly_build() {
+    if sess.parse_sess.unstable_features.is_nightly_build() {
         if feature_from_cli {
             err.subdiagnostic(CliFeatureDiagnosticHelp { feature });
         } else {
             err.subdiagnostic(FeatureDiagnosticHelp { feature });
         }
 
-        err.subdiagnostic(SuggestUpgradeCompiler::new());
+        if sess.opts.unstable_opts.ui_testing {
+            err.subdiagnostic(SuggestUpgradeCompiler::ui_testing());
+        } else if let Some(suggestion) = SuggestUpgradeCompiler::new() {
+            err.subdiagnostic(suggestion);
+        }
     }
 }
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -318,7 +318,7 @@ impl Session {
         if err.code.is_none() {
             err.code(error_code!(E0658));
         }
-        add_feature_diagnostics(&mut err, &self.parse_sess, feature);
+        add_feature_diagnostics(&mut err, self, feature);
         err
     }
 

--- a/src/librustdoc/passes/check_custom_code_classes.rs
+++ b/src/librustdoc/passes/check_custom_code_classes.rs
@@ -65,9 +65,10 @@ pub(crate) fn look_for_custom_classes<'tcx>(cx: &DocContext<'tcx>, item: &Item) 
 
     if !tests.custom_classes_found.is_empty() {
         let span = item.attr_span(cx.tcx);
-        let sess = &cx.tcx.sess.parse_sess;
-        let mut err =
-            sess.dcx.struct_span_warn(span, "custom classes in code blocks will change behaviour");
+        let sess = &cx.tcx.sess;
+        let mut err = sess
+            .dcx()
+            .struct_span_warn(span, "custom classes in code blocks will change behaviour");
         add_feature_diagnostics_for_issue(
             &mut err,
             sess,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1223,7 +1223,7 @@ impl LinkCollector<'_, '_> {
         )
         .unwrap_or_else(|| item.attr_span(self.cx.tcx));
         rustc_session::parse::feature_err(
-            &self.cx.tcx.sess.parse_sess,
+            &self.cx.tcx.sess,
             sym::intra_doc_pointers,
             span,
             "linking to associated items of raw pointers is experimental",

--- a/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.rs
+++ b/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.rs
@@ -6,6 +6,7 @@
 //~^^^ WARNING custom classes in code blocks will change behaviour
 //~| NOTE found these custom classes: class=language-c
 //~| NOTE see issue #79483 <https://github.com/rust-lang/rust/issues/79483>
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 //~| HELP add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
 pub struct Bar;
 

--- a/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.stderr
+++ b/tests/rustdoc-ui/feature-gate-custom_code_classes_in_docs.stderr
@@ -8,6 +8,7 @@ LL | | /// ```
    |
    = note: see issue #79483 <https://github.com/rust-lang/rust/issues/79483> for more information
    = help: add `#![feature(custom_code_classes_in_docs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: found these custom classes: class=language-c
 
 warning: 1 warning emitted

--- a/tests/rustdoc-ui/feature-gate-doc_cfg_hide.stderr
+++ b/tests/rustdoc-ui/feature-gate-doc_cfg_hide.stderr
@@ -6,6 +6,7 @@ LL | #![doc(cfg_hide(test))]
    |
    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
    = help: add `#![feature(doc_cfg_hide)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/intra-doc/feature-gate-intra-doc-pointers.stderr
+++ b/tests/rustdoc-ui/intra-doc/feature-gate-intra-doc-pointers.stderr
@@ -6,6 +6,7 @@ LL | //! [pointer::add]
    |
    = note: see issue #80896 <https://github.com/rust-lang/rust/issues/80896> for more information
    = help: add `#![feature(intra_doc_pointers)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: rustdoc does not allow disambiguating between `*const` and `*mut`, and pointers are unstable until it does
 
 error[E0658]: linking to associated items of raw pointers is experimental
@@ -16,6 +17,7 @@ LL | //! [pointer::wrapping_add]
    |
    = note: see issue #80896 <https://github.com/rust-lang/rust/issues/80896> for more information
    = help: add `#![feature(intra_doc_pointers)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: rustdoc does not allow disambiguating between `*const` and `*mut`, and pointers are unstable until it does
 
 error: aborting due to 2 previous errors

--- a/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.rs
+++ b/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.rs
@@ -5,3 +5,4 @@
 //~^ ERROR unknown lint
 //~| NOTE lint is unstable
 //~| NOTE see issue
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date

--- a/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.stderr
+++ b/tests/rustdoc-ui/lints/feature-gate-rustdoc_missing_doc_code_examples.stderr
@@ -7,6 +7,7 @@ LL | #![allow(rustdoc::missing_doc_code_examples)]
    = note: the `rustdoc::missing_doc_code_examples` lint is unstable
    = note: see issue #101730 <https://github.com/rust-lang/rust/issues/101730> for more information
    = help: add `#![feature(rustdoc_missing_doc_code_examples)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 note: the lint level is defined here
   --> $DIR/feature-gate-rustdoc_missing_doc_code_examples.rs:2:9
    |

--- a/tests/ui-fulldeps/hash-stable-is-unstable.rs
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.rs
@@ -1,16 +1,31 @@
+// ignore-stage1
 // compile-flags: -Zdeduplicate-diagnostics=yes
 extern crate rustc_data_structures;
 //~^ use of unstable library feature 'rustc_private'
+//~| NOTE: issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 extern crate rustc_macros;
 //~^ use of unstable library feature 'rustc_private'
+//~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 extern crate rustc_query_system;
 //~^ use of unstable library feature 'rustc_private'
+//~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 use rustc_macros::HashStable;
 //~^ use of unstable library feature 'rustc_private'
+//~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 #[derive(HashStable)]
 //~^ use of unstable library feature 'rustc_private'
+//~| NOTE: in this expansion of #[derive(HashStable)]
+//~| NOTE: in this expansion of #[derive(HashStable)]
+//~| NOTE: in this expansion of #[derive(HashStable)]
+//~| NOTE: in this expansion of #[derive(HashStable)]
+//~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 struct Test;
 
 fn main() {}

--- a/tests/ui-fulldeps/hash-stable-is-unstable.stderr
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.stderr
@@ -1,47 +1,52 @@
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:2:1
+  --> $DIR/hash-stable-is-unstable.rs:3:1
    |
 LL | extern crate rustc_data_structures;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:4:1
+  --> $DIR/hash-stable-is-unstable.rs:7:1
    |
 LL | extern crate rustc_macros;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:6:1
+  --> $DIR/hash-stable-is-unstable.rs:11:1
    |
 LL | extern crate rustc_query_system;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:9:5
+  --> $DIR/hash-stable-is-unstable.rs:16:5
    |
 LL | use rustc_macros::HashStable;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:12:10
+  --> $DIR/hash-stable-is-unstable.rs:21:10
    |
 LL | #[derive(HashStable)]
    |          ^^^^^^^^^^
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the derive macro `HashStable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors

--- a/tests/ui-fulldeps/pathless-extern-unstable.rs
+++ b/tests/ui-fulldeps/pathless-extern-unstable.rs
@@ -1,4 +1,5 @@
 // edition:2018
+// ignore-stage1
 // compile-flags:--extern rustc_middle
 
 // Test that `--extern rustc_middle` fails with `rustc_private`.

--- a/tests/ui-fulldeps/pathless-extern-unstable.stderr
+++ b/tests/ui-fulldeps/pathless-extern-unstable.stderr
@@ -1,11 +1,12 @@
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/pathless-extern-unstable.rs:6:9
+  --> $DIR/pathless-extern-unstable.rs:7:9
    |
 LL | pub use rustc_middle;
    |         ^^^^^^^^^^^^
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/array-slice-vec/suggest-array-length.stderr
+++ b/tests/ui/array-slice-vec/suggest-array-length.stderr
@@ -48,6 +48,7 @@ LL |     const Foo: [i32; _] = [1, 2, 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:8:26
@@ -57,6 +58,7 @@ LL |     const REF_FOO: &[u8; _] = &[1];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:11:20
@@ -66,6 +68,7 @@ LL |     let foo: [i32; _] = [1, 2, 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:14:20
@@ -75,6 +78,7 @@ LL |     let bar: [i32; _] = [0; 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:17:25
@@ -84,6 +88,7 @@ LL |     let ref_foo: &[i32; _] = &[1, 2, 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:20:25
@@ -93,6 +98,7 @@ LL |     let ref_bar: &[i32; _] = &[0; 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:23:35
@@ -102,6 +108,7 @@ LL |     let multiple_ref_foo: &&[i32; _] = &&[1, 2, 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -23,6 +23,7 @@ LL | fn foo<A: TraitWAssocConst<A=32>>() {
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
   --> $DIR/issue-105330.rs:15:29
@@ -32,6 +33,7 @@ LL | fn main<A: TraitWAssocConst<A=32>>() {
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in impl headers
   --> $DIR/issue-105330.rs:6:27

--- a/tests/ui/associated-consts/issue-93835.stderr
+++ b/tests/ui/associated-consts/issue-93835.stderr
@@ -24,6 +24,7 @@ LL |     type_ascribe!(p, a<p:p<e=6>>);
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/issue-93835.rs:4:24
@@ -33,6 +34,7 @@ LL |     type_ascribe!(p, a<p:p<e=6>>);
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/associated-inherent-types/assoc-inherent-unstable.stderr
+++ b/tests/ui/associated-inherent-types/assoc-inherent-unstable.stderr
@@ -5,6 +5,7 @@ LL | type Data = aux::Owner::Data;
    |             ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(data)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-inherent-types/dont-select-if-disabled.stderr
+++ b/tests/ui/associated-inherent-types/dont-select-if-disabled.stderr
@@ -17,6 +17,7 @@ LL | impl S { type P = (); }
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
@@ -28,6 +28,7 @@ LL |     type Item = &[T];
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0223]: ambiguous associated type
   --> $DIR/issue-109071.rs:15:22

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -28,6 +28,7 @@ LL |     type AssocType3 = T;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/issue-109768.rs:10:56

--- a/tests/ui/associated-type-bounds/issue-99828.stderr
+++ b/tests/ui/associated-type-bounds/issue-99828.stderr
@@ -6,6 +6,7 @@ LL | fn get_iter(vec: &[i32]) -> impl Iterator<Item = {}> + '_ {
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: expected type, found constant
   --> $DIR/issue-99828.rs:1:50

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -12,6 +12,7 @@ LL | fn foo<T: Trait<method(i32): Send>>() {}
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/bad-inputs-and-output.rs:14:17
@@ -21,6 +22,7 @@ LL | fn bar<T: Trait<method() -> (): Send>>() {}
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bad-inputs-and-output.rs:3:12

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Trait<method(i32): Send>>() {}
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/feature-async-closure.stderr
+++ b/tests/ui/async-await/feature-async-closure.stderr
@@ -6,6 +6,7 @@ LL |     let _ = async || {};
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
    = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: to use an async block, remove the `||`: `async {`
 
 error: aborting due to 1 previous error

--- a/tests/ui/async-await/feature-async-for-loop.stderr
+++ b/tests/ui/async-await/feature-async-for-loop.stderr
@@ -6,6 +6,7 @@ LL |         for await _i in core::async_iter::from_iter(0..3) {
    |
    = note: see issue #118898 <https://github.com/rust-lang/rust/issues/118898> for more information
    = help: add `#![feature(async_for_loop)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `for await` loops are experimental
   --> $DIR/feature-async-for-loop.rs:17:13
@@ -15,6 +16,7 @@ LL |         for await _i in core::async_iter::from_iter(0..3) {
    |
    = note: see issue #118898 <https://github.com/rust-lang/rust/issues/118898> for more information
    = help: add `#![feature(async_for_loop)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issues/issue-95307.stderr
+++ b/tests/ui/async-await/issues/issue-95307.stderr
@@ -12,6 +12,7 @@ LL |     async fn new() -> [u8; _];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/track-caller/async-block.afn.stderr
+++ b/tests/ui/async-await/track-caller/async-block.afn.stderr
@@ -6,6 +6,7 @@ LL |     let _ = #[track_caller] async {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-block.rs:15:13
@@ -15,6 +16,7 @@ LL |     let _ = #[track_caller] async {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-block.rs:23:17
@@ -24,6 +26,7 @@ LL |         let _ = #[track_caller] async {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/async-await/track-caller/async-block.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/async-block.nofeat.stderr
@@ -6,6 +6,7 @@ LL |     let _ = #[track_caller] async {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-block.rs:15:13
@@ -15,6 +16,7 @@ LL |     let _ = #[track_caller] async {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-block.rs:23:17
@@ -24,6 +26,7 @@ LL |         let _ = #[track_caller] async {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
@@ -6,6 +6,7 @@ LL |     let _ = #[track_caller] async || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:15:13
@@ -15,6 +16,7 @@ LL |     let _ = #[track_caller] async || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:21:13
@@ -24,6 +26,7 @@ LL |     let _ = #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:29:17
@@ -33,6 +36,7 @@ LL |         let _ = #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:37:9
@@ -42,6 +46,7 @@ LL |         #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:47:13
@@ -51,6 +56,7 @@ LL |             #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
   --> $DIR/async-closure-gate.rs:27:5

--- a/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
@@ -6,6 +6,7 @@ LL |     let _ = #[track_caller] async || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:15:13
@@ -15,6 +16,7 @@ LL |     let _ = #[track_caller] async || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:21:13
@@ -24,6 +26,7 @@ LL |     let _ = #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:29:17
@@ -33,6 +36,7 @@ LL |         let _ = #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:37:9
@@ -42,6 +46,7 @@ LL |         #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/async-closure-gate.rs:47:13
@@ -51,6 +56,7 @@ LL |             #[track_caller] || {
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
   --> $DIR/async-closure-gate.rs:27:5

--- a/tests/ui/async-await/track-caller/panic-track-caller.cls.stderr
+++ b/tests/ui/async-await/track-caller/panic-track-caller.cls.stderr
@@ -11,6 +11,7 @@ LL | | }
    |
    = note: see issue #110011 <https://github.com/rust-lang/rust/issues/110011> for more information
    = help: add `#![feature(async_fn_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(ungated_async_fn_track_caller)]` on by default
 
 warning: `#[track_caller]` on async functions is a no-op
@@ -26,6 +27,7 @@ LL | |     }
    |
    = note: see issue #110011 <https://github.com/rust-lang/rust/issues/110011> for more information
    = help: add `#![feature(async_fn_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: 2 warnings emitted
 

--- a/tests/ui/async-await/track-caller/panic-track-caller.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/panic-track-caller.nofeat.stderr
@@ -11,6 +11,7 @@ LL | | }
    |
    = note: see issue #110011 <https://github.com/rust-lang/rust/issues/110011> for more information
    = help: add `#![feature(async_fn_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(ungated_async_fn_track_caller)]` on by default
 
 warning: `#[track_caller]` on async functions is a no-op
@@ -26,6 +27,7 @@ LL | |     }
    |
    = note: see issue #110011 <https://github.com/rust-lang/rust/issues/110011> for more information
    = help: add `#![feature(async_fn_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: 2 warnings emitted
 

--- a/tests/ui/auto-traits/issue-117789.stderr
+++ b/tests/ui/auto-traits/issue-117789.stderr
@@ -14,6 +14,7 @@ LL | auto trait Trait<P> {}
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(auto_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/auto-traits/pre-cfg.stderr
+++ b/tests/ui/auto-traits/pre-cfg.stderr
@@ -6,6 +6,7 @@ LL | auto trait Foo {}
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(auto_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/bounds-lifetime.stderr
+++ b/tests/ui/bounds-lifetime.stderr
@@ -24,6 +24,7 @@ LL | type D = for<'a, T> fn();
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: only lifetime parameters can be used in this context
   --> $DIR/bounds-lifetime.rs:5:18
@@ -33,6 +34,7 @@ LL | type E = dyn for<T, U> Fn();
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/box/alloc-unstable-fail.stderr
+++ b/tests/ui/box/alloc-unstable-fail.stderr
@@ -6,6 +6,7 @@ LL |     let _boxed: Box<u32, _> = Box::new(10);
    |
    = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.stderr
+++ b/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.stderr
@@ -6,6 +6,7 @@ LL | fn efiapi(f: extern "efiapi" fn(usize, ...)) {
    |
    = note: see issue #100189 <https://github.com/rust-lang/rust/issues/100189> for more information
    = help: add `#![feature(extended_varargs_abi_support)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
   --> $DIR/feature-gate-extended_varargs_abi_support.rs:1:14
@@ -21,6 +22,7 @@ LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
    |
    = note: see issue #100189 <https://github.com/rust-lang/rust/issues/100189> for more information
    = help: add `#![feature(extended_varargs_abi_support)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
   --> $DIR/feature-gate-extended_varargs_abi_support.rs:6:12
@@ -36,6 +38,7 @@ LL | fn win(f: extern "win64" fn(usize, ...)) {
    |
    = note: see issue #100189 <https://github.com/rust-lang/rust/issues/100189> for more information
    = help: add `#![feature(extended_varargs_abi_support)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
   --> $DIR/feature-gate-extended_varargs_abi_support.rs:11:11

--- a/tests/ui/cfg/cfg-false-feature.stderr
+++ b/tests/ui/cfg/cfg-false-feature.stderr
@@ -6,6 +6,7 @@ LL | trait A = Clone;
    |
    = note: see issue #41517 <https://github.com/rust-lang/rust/issues/41517> for more information
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 
@@ -17,6 +18,7 @@ LL |     let box _ = Box::new(0);
    |
    = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.rs
+++ b/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.rs
@@ -8,6 +8,7 @@ fn main() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.stderr
+++ b/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.stderr
@@ -6,9 +6,10 @@ LL |     let mut c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/arrays-completely-captured.rs:11:5
+  --> $DIR/arrays-completely-captured.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +21,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing m[] -> MutBorrow
-  --> $DIR/arrays-completely-captured.rs:14:9
+  --> $DIR/arrays-completely-captured.rs:15:9
    |
 LL |         m[0] += 10;
    |         ^
 note: Capturing m[] -> MutBorrow
-  --> $DIR/arrays-completely-captured.rs:17:9
+  --> $DIR/arrays-completely-captured.rs:18:9
    |
 LL |         m[1] += 40;
    |         ^
 
 error: Min Capture analysis includes:
-  --> $DIR/arrays-completely-captured.rs:11:5
+  --> $DIR/arrays-completely-captured.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -43,7 +44,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture m[] -> MutBorrow
-  --> $DIR/arrays-completely-captured.rs:14:9
+  --> $DIR/arrays-completely-captured.rs:15:9
    |
 LL |         m[0] += 10;
    |         ^

--- a/tests/ui/closures/2229_closure_analysis/by_value.rs
+++ b/tests/ui/closures/2229_closure_analysis/by_value.rs
@@ -18,6 +18,7 @@ fn big_box() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/by_value.stderr
+++ b/tests/ui/closures/2229_closure_analysis/by_value.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/by_value.rs:21:5
+  --> $DIR/by_value.rs:22:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +21,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
-  --> $DIR/by_value.rs:24:17
+  --> $DIR/by_value.rs:25:17
    |
 LL |         let p = t.0.0;
    |                 ^^^^^
 note: Capturing t[(1, 0)] -> ImmBorrow
-  --> $DIR/by_value.rs:27:29
+  --> $DIR/by_value.rs:28:29
    |
 LL |         println!("{} {:?}", t.1, p);
    |                             ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/by_value.rs:21:5
+  --> $DIR/by_value.rs:22:5
    |
 LL | /     || {
 LL | |
@@ -43,12 +44,12 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/by_value.rs:24:17
+  --> $DIR/by_value.rs:25:17
    |
 LL |         let p = t.0.0;
    |                 ^^^^^
 note: Min Capture t[(1, 0)] -> ImmBorrow
-  --> $DIR/by_value.rs:27:29
+  --> $DIR/by_value.rs:28:29
    |
 LL |         println!("{} {:?}", t.1, p);
    |                             ^^^

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
@@ -15,6 +15,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-1.rs:18:5
+  --> $DIR/capture-analysis-1.rs:19:5
    |
 LL | /     || {
 LL | |
@@ -20,28 +21,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[] -> ImmBorrow
-  --> $DIR/capture-analysis-1.rs:21:26
+  --> $DIR/capture-analysis-1.rs:22:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 note: Capturing p[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-analysis-1.rs:24:26
+  --> $DIR/capture-analysis-1.rs:25:26
    |
 LL |         println!("{:?}", p.x);
    |                          ^^^
 note: Capturing q[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-analysis-1.rs:27:26
+  --> $DIR/capture-analysis-1.rs:28:26
    |
 LL |         println!("{:?}", q.x);
    |                          ^^^
 note: Capturing q[] -> ImmBorrow
-  --> $DIR/capture-analysis-1.rs:29:26
+  --> $DIR/capture-analysis-1.rs:30:26
    |
 LL |         println!("{:?}", q);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-1.rs:18:5
+  --> $DIR/capture-analysis-1.rs:19:5
    |
 LL | /     || {
 LL | |
@@ -53,12 +54,12 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> ImmBorrow
-  --> $DIR/capture-analysis-1.rs:21:26
+  --> $DIR/capture-analysis-1.rs:22:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 note: Min Capture q[] -> ImmBorrow
-  --> $DIR/capture-analysis-1.rs:29:26
+  --> $DIR/capture-analysis-1.rs:30:26
    |
 LL |         println!("{:?}", q);
    |                          ^

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
@@ -14,6 +14,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-2.rs:17:5
+  --> $DIR/capture-analysis-2.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +21,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-2.rs:20:18
+  --> $DIR/capture-analysis-2.rs:21:18
    |
 LL |         let _x = p.x;
    |                  ^^^
 note: Capturing p[] -> ImmBorrow
-  --> $DIR/capture-analysis-2.rs:23:26
+  --> $DIR/capture-analysis-2.rs:24:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-2.rs:17:5
+  --> $DIR/capture-analysis-2.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -43,7 +44,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> ByValue
-  --> $DIR/capture-analysis-2.rs:20:18
+  --> $DIR/capture-analysis-2.rs:21:18
    |
 LL |         let _x = p.x;
    |                  ^^^ p[] captured as ByValue here

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
@@ -19,6 +19,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-3.rs:22:5
+  --> $DIR/capture-analysis-3.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +21,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0),(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-3.rs:25:18
+  --> $DIR/capture-analysis-3.rs:26:18
    |
 LL |         let _x = a.b.c;
    |                  ^^^^^
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-analysis-3.rs:28:26
+  --> $DIR/capture-analysis-3.rs:29:26
    |
 LL |         println!("{:?}", a.b);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-3.rs:22:5
+  --> $DIR/capture-analysis-3.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -43,7 +44,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-3.rs:25:18
+  --> $DIR/capture-analysis-3.rs:26:18
    |
 LL |         let _x = a.b.c;
    |                  ^^^^^ a[(0, 0)] captured as ByValue here

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
@@ -19,6 +19,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-analysis-4.rs:22:5
+  --> $DIR/capture-analysis-4.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +21,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-4.rs:25:18
+  --> $DIR/capture-analysis-4.rs:26:18
    |
 LL |         let _x = a.b;
    |                  ^^^
 note: Capturing a[(0, 0),(0, 0)] -> ImmBorrow
-  --> $DIR/capture-analysis-4.rs:28:26
+  --> $DIR/capture-analysis-4.rs:29:26
    |
 LL |         println!("{:?}", a.b.c);
    |                          ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-analysis-4.rs:22:5
+  --> $DIR/capture-analysis-4.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -43,7 +44,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ByValue
-  --> $DIR/capture-analysis-4.rs:25:18
+  --> $DIR/capture-analysis-4.rs:26:18
    |
 LL |         let _x = a.b;
    |                  ^^^

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
@@ -13,6 +13,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-disjoint-field-struct.rs:16:5
+  --> $DIR/capture-disjoint-field-struct.rs:17:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-disjoint-field-struct.rs:19:24
+  --> $DIR/capture-disjoint-field-struct.rs:20:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-disjoint-field-struct.rs:16:5
+  --> $DIR/capture-disjoint-field-struct.rs:17:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-disjoint-field-struct.rs:19:24
+  --> $DIR/capture-disjoint-field-struct.rs:20:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
@@ -8,6 +8,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-disjoint-field-tuple.rs:11:5
+  --> $DIR/capture-disjoint-field-tuple.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-disjoint-field-tuple.rs:14:24
+  --> $DIR/capture-disjoint-field-tuple.rs:15:24
    |
 LL |         println!("{}", t.0);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-disjoint-field-tuple.rs:11:5
+  --> $DIR/capture-disjoint-field-tuple.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ImmBorrow
-  --> $DIR/capture-disjoint-field-tuple.rs:14:24
+  --> $DIR/capture-disjoint-field-tuple.rs:15:24
    |
 LL |         println!("{}", t.0);
    |                        ^^^

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.rs
@@ -16,6 +16,7 @@ fn multi_variant_enum() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
@@ -47,6 +48,7 @@ fn single_variant_enum() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.stderr
@@ -6,18 +6,20 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/capture-enums.rs:47:13
+  --> $DIR/capture-enums.rs:48:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/capture-enums.rs:19:5
+  --> $DIR/capture-enums.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -29,28 +31,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing point[] -> ImmBorrow
-  --> $DIR/capture-enums.rs:22:41
+  --> $DIR/capture-enums.rs:23:41
    |
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
 note: Capturing point[(2, 0)] -> ByValue
-  --> $DIR/capture-enums.rs:22:41
+  --> $DIR/capture-enums.rs:23:41
    |
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
 note: Capturing meta[] -> ImmBorrow
-  --> $DIR/capture-enums.rs:29:35
+  --> $DIR/capture-enums.rs:30:35
    |
 LL |         if let Info::Meta(_, v) = meta {
    |                                   ^^^^
 note: Capturing meta[(1, 1)] -> ByValue
-  --> $DIR/capture-enums.rs:29:35
+  --> $DIR/capture-enums.rs:30:35
    |
 LL |         if let Info::Meta(_, v) = meta {
    |                                   ^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-enums.rs:19:5
+  --> $DIR/capture-enums.rs:20:5
    |
 LL | /     || {
 LL | |
@@ -62,18 +64,18 @@ LL | |     };
    | |_____^
    |
 note: Min Capture point[] -> ByValue
-  --> $DIR/capture-enums.rs:22:41
+  --> $DIR/capture-enums.rs:23:41
    |
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
 note: Min Capture meta[] -> ByValue
-  --> $DIR/capture-enums.rs:29:35
+  --> $DIR/capture-enums.rs:30:35
    |
 LL |         if let Info::Meta(_, v) = meta {
    |                                   ^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/capture-enums.rs:50:5
+  --> $DIR/capture-enums.rs:52:5
    |
 LL | /     || {
 LL | |
@@ -85,13 +87,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing point[(2, 0)] -> ByValue
-  --> $DIR/capture-enums.rs:53:47
+  --> $DIR/capture-enums.rs:55:47
    |
 LL |         let SingleVariant::Point(_, _, str) = point;
    |                                               ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/capture-enums.rs:50:5
+  --> $DIR/capture-enums.rs:52:5
    |
 LL | /     || {
 LL | |
@@ -103,7 +105,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture point[(2, 0)] -> ByValue
-  --> $DIR/capture-enums.rs:53:47
+  --> $DIR/capture-enums.rs:55:47
    |
 LL |         let SingleVariant::Point(_, _, str) = point;
    |                                               ^^^^^

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.rs
@@ -34,6 +34,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.stderr
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/deep-multilevel-struct.rs:37:5
+  --> $DIR/deep-multilevel-struct.rs:38:5
    |
 LL | /     || {
 LL | |
@@ -20,23 +21,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0),(0, 0),(0, 0)] -> ImmBorrow
-  --> $DIR/deep-multilevel-struct.rs:40:18
+  --> $DIR/deep-multilevel-struct.rs:41:18
    |
 LL |         let x = &p.a.p.x;
    |                  ^^^^^^^
 note: Capturing p[(1, 0),(1, 0),(1, 0)] -> MutBorrow
-  --> $DIR/deep-multilevel-struct.rs:42:9
+  --> $DIR/deep-multilevel-struct.rs:43:9
    |
 LL |         p.b.q.y = 9;
    |         ^^^^^^^
 note: Capturing p[] -> ImmBorrow
-  --> $DIR/deep-multilevel-struct.rs:45:26
+  --> $DIR/deep-multilevel-struct.rs:46:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/deep-multilevel-struct.rs:37:5
+  --> $DIR/deep-multilevel-struct.rs:38:5
    |
 LL | /     || {
 LL | |
@@ -48,7 +49,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> MutBorrow
-  --> $DIR/deep-multilevel-struct.rs:42:9
+  --> $DIR/deep-multilevel-struct.rs:43:9
    |
 LL |         p.b.q.y = 9;
    |         ^^^^^^^ p[] captured as MutBorrow here

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.rs
@@ -8,6 +8,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.stderr
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/deep-multilevel-tuple.rs:11:5
+  --> $DIR/deep-multilevel-tuple.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -20,23 +21,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),(0, 0),(0, 0)] -> ImmBorrow
-  --> $DIR/deep-multilevel-tuple.rs:14:18
+  --> $DIR/deep-multilevel-tuple.rs:15:18
    |
 LL |         let x = &t.0.0.0;
    |                  ^^^^^^^
 note: Capturing t[(1, 0),(1, 0),(1, 0)] -> MutBorrow
-  --> $DIR/deep-multilevel-tuple.rs:16:9
+  --> $DIR/deep-multilevel-tuple.rs:17:9
    |
 LL |         t.1.1.1 = 9;
    |         ^^^^^^^
 note: Capturing t[] -> ImmBorrow
-  --> $DIR/deep-multilevel-tuple.rs:19:26
+  --> $DIR/deep-multilevel-tuple.rs:20:26
    |
 LL |         println!("{:?}", t);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/deep-multilevel-tuple.rs:11:5
+  --> $DIR/deep-multilevel-tuple.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -48,7 +49,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[] -> MutBorrow
-  --> $DIR/deep-multilevel-tuple.rs:16:9
+  --> $DIR/deep-multilevel-tuple.rs:17:9
    |
 LL |         t.1.1.1 = 9;
    |         ^^^^^^^ t[] captured as MutBorrow here

--- a/tests/ui/closures/2229_closure_analysis/destructure_patterns.rs
+++ b/tests/ui/closures/2229_closure_analysis/destructure_patterns.rs
@@ -10,6 +10,7 @@ fn arrays() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -38,6 +39,7 @@ fn structs() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -58,6 +60,7 @@ fn tuples() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/destructure_patterns.stderr
+++ b/tests/ui/closures/2229_closure_analysis/destructure_patterns.stderr
@@ -6,27 +6,30 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/destructure_patterns.rs:38:13
+  --> $DIR/destructure_patterns.rs:39:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/destructure_patterns.rs:58:13
+  --> $DIR/destructure_patterns.rs:60:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/destructure_patterns.rs:13:5
+  --> $DIR/destructure_patterns.rs:14:5
    |
 LL | /     || {
 LL | |
@@ -38,23 +41,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/destructure_patterns.rs:16:29
+  --> $DIR/destructure_patterns.rs:17:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/destructure_patterns.rs:16:29
+  --> $DIR/destructure_patterns.rs:17:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/destructure_patterns.rs:16:29
+  --> $DIR/destructure_patterns.rs:17:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/destructure_patterns.rs:13:5
+  --> $DIR/destructure_patterns.rs:14:5
    |
 LL | /     || {
 LL | |
@@ -66,13 +69,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture arr[] -> ByValue
-  --> $DIR/destructure_patterns.rs:16:29
+  --> $DIR/destructure_patterns.rs:17:29
    |
 LL |         let [a, b, .., e] = arr;
    |                             ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/destructure_patterns.rs:41:5
+  --> $DIR/destructure_patterns.rs:43:5
    |
 LL | /     || {
 LL | |
@@ -84,18 +87,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> MutBorrow
-  --> $DIR/destructure_patterns.rs:44:58
+  --> $DIR/destructure_patterns.rs:46:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 note: Capturing p[(2, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:44:58
+  --> $DIR/destructure_patterns.rs:46:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/destructure_patterns.rs:41:5
+  --> $DIR/destructure_patterns.rs:43:5
    |
 LL | /     || {
 LL | |
@@ -107,18 +110,18 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> MutBorrow
-  --> $DIR/destructure_patterns.rs:44:58
+  --> $DIR/destructure_patterns.rs:46:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 note: Min Capture p[(2, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:44:58
+  --> $DIR/destructure_patterns.rs:46:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
    |                                                          ^
 
 error: First Pass analysis includes:
-  --> $DIR/destructure_patterns.rs:61:5
+  --> $DIR/destructure_patterns.rs:64:5
    |
 LL | /     || {
 LL | |
@@ -130,23 +133,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0)] -> MutBorrow
-  --> $DIR/destructure_patterns.rs:64:54
+  --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Capturing t[(1, 0)] -> ImmBorrow
-  --> $DIR/destructure_patterns.rs:64:54
+  --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Capturing t[(2, 0),(0, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:64:54
+  --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 
 error: Min Capture analysis includes:
-  --> $DIR/destructure_patterns.rs:61:5
+  --> $DIR/destructure_patterns.rs:64:5
    |
 LL | /     || {
 LL | |
@@ -158,17 +161,17 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> MutBorrow
-  --> $DIR/destructure_patterns.rs:64:54
+  --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Min Capture t[(1, 0)] -> ImmBorrow
-  --> $DIR/destructure_patterns.rs:64:54
+  --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
 note: Min Capture t[(2, 0),(0, 0)] -> ByValue
-  --> $DIR/destructure_patterns.rs:64:54
+  --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^

--- a/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.rs
+++ b/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.rs
@@ -8,6 +8,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.stderr
+++ b/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:11:5
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing s[] -> ImmBorrow
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:14:69
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:15:69
    |
 LL |         println!("This uses new capture analyysis to capture s={}", s);
    |                                                                     ^
 
 error: Min Capture analysis includes:
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:11:5
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:12:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture s[] -> ImmBorrow
-  --> $DIR/feature-gate-capture_disjoint_fields.rs:14:69
+  --> $DIR/feature-gate-capture_disjoint_fields.rs:15:69
    |
 LL |         println!("This uses new capture analyysis to capture s={}", s);
    |                                                                     ^

--- a/tests/ui/closures/2229_closure_analysis/issue-87378.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-87378.rs
@@ -14,6 +14,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/issue-87378.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-87378.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/issue-87378.rs:17:5
+  --> $DIR/issue-87378.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing u[(0, 0)] -> ImmBorrow
-  --> $DIR/issue-87378.rs:20:17
+  --> $DIR/issue-87378.rs:21:17
    |
 LL |        unsafe { u.value }
    |                 ^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/issue-87378.rs:17:5
+  --> $DIR/issue-87378.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture u[] -> ImmBorrow
-  --> $DIR/issue-87378.rs:20:17
+  --> $DIR/issue-87378.rs:21:17
    |
 LL |        unsafe { u.value }
    |                 ^^^^^^^

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.rs
@@ -20,6 +20,7 @@ pub fn test1() {
     let x = #[rustc_capture_analysis] move || {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{:?}", f.0);
@@ -47,6 +48,7 @@ fn test2() {
     let c = #[rustc_capture_analysis] move || {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", character.hp)

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
@@ -6,15 +6,17 @@ LL |     let x = #[rustc_capture_analysis] move || {
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/issue-88476.rs:47:13
+  --> $DIR/issue-88476.rs:48:13
    |
 LL |     let c = #[rustc_capture_analysis] move || {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
   --> $DIR/issue-88476.rs:20:39
@@ -30,7 +32,7 @@ LL | |     };
    | |_____^
    |
 note: Capturing f[(0, 0)] -> ImmBorrow
-  --> $DIR/issue-88476.rs:25:26
+  --> $DIR/issue-88476.rs:26:26
    |
 LL |         println!("{:?}", f.0);
    |                          ^^^
@@ -49,13 +51,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture f[] -> ByValue
-  --> $DIR/issue-88476.rs:25:26
+  --> $DIR/issue-88476.rs:26:26
    |
 LL |         println!("{:?}", f.0);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/issue-88476.rs:47:39
+  --> $DIR/issue-88476.rs:48:39
    |
 LL |       let c = #[rustc_capture_analysis] move || {
    |  _______________________________________^
@@ -68,13 +70,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing character[(0, 0)] -> ImmBorrow
-  --> $DIR/issue-88476.rs:52:24
+  --> $DIR/issue-88476.rs:54:24
    |
 LL |         println!("{}", character.hp)
    |                        ^^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/issue-88476.rs:47:39
+  --> $DIR/issue-88476.rs:48:39
    |
 LL |       let c = #[rustc_capture_analysis] move || {
    |  _______________________________________^
@@ -87,7 +89,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture character[(0, 0)] -> ByValue
-  --> $DIR/issue-88476.rs:52:24
+  --> $DIR/issue-88476.rs:54:24
    |
 LL |         println!("{}", character.hp)
    |                        ^^^^^^^^^^^^

--- a/tests/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.rs
@@ -12,6 +12,7 @@ fn simple_move_closure() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -30,6 +31,7 @@ fn simple_ref() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -51,6 +53,7 @@ fn struct_contains_ref_to_another_struct_1() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -74,6 +77,7 @@ fn struct_contains_ref_to_another_struct_2() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -96,6 +100,7 @@ fn struct_contains_ref_to_another_struct_3() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -117,6 +122,7 @@ fn truncate_box_derefs() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -133,6 +139,7 @@ fn truncate_box_derefs() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -150,6 +157,7 @@ fn truncate_box_derefs() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     move || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -172,6 +180,7 @@ fn box_mut_1() {
     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| First Pass analysis includes:
     //~| NOTE: Capturing box_p_foo[Deref,Deref,(0, 0)] -> MutBorrow
     //~| Min Capture analysis includes:
@@ -189,6 +198,7 @@ fn box_mut_2() {
     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| First Pass analysis includes:
     //~| NOTE: Capturing p_foo[Deref,Deref,(0, 0)] -> MutBorrow
     //~| Min Capture analysis includes:
@@ -202,6 +212,7 @@ fn returned_closure_owns_copy_type_data() -> impl Fn() -> i32 {
     let c = #[rustc_capture_analysis] move || x;
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| First Pass analysis includes:
     //~| NOTE: Capturing x[] -> ImmBorrow
     //~| Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -6,123 +6,134 @@ LL |     let mut c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:30:17
+  --> $DIR/move_closure.rs:31:17
    |
 LL |     let mut c = #[rustc_capture_analysis]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:51:17
+  --> $DIR/move_closure.rs:53:17
    |
 LL |     let mut c = #[rustc_capture_analysis]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:74:17
+  --> $DIR/move_closure.rs:77:17
    |
 LL |     let mut c = #[rustc_capture_analysis]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:96:17
+  --> $DIR/move_closure.rs:100:17
    |
 LL |     let mut c = #[rustc_capture_analysis]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:117:13
+  --> $DIR/move_closure.rs:122:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:133:13
+  --> $DIR/move_closure.rs:139:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:150:13
+  --> $DIR/move_closure.rs:157:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:172:13
+  --> $DIR/move_closure.rs:180:13
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:189:13
+  --> $DIR/move_closure.rs:198:13
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/move_closure.rs:202:13
+  --> $DIR/move_closure.rs:212:13
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:202:39
+  --> $DIR/move_closure.rs:212:39
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                       ^^^^^^^^^
    |
 note: Capturing x[] -> ImmBorrow
-  --> $DIR/move_closure.rs:202:47
+  --> $DIR/move_closure.rs:212:47
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                               ^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:202:39
+  --> $DIR/move_closure.rs:212:39
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                       ^^^^^^^^^
    |
 note: Min Capture x[] -> ByValue
-  --> $DIR/move_closure.rs:202:47
+  --> $DIR/move_closure.rs:212:47
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                               ^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:15:5
+  --> $DIR/move_closure.rs:16:5
    |
 LL | /     move || {
 LL | |
@@ -134,13 +145,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),(0, 0)] -> MutBorrow
-  --> $DIR/move_closure.rs:18:9
+  --> $DIR/move_closure.rs:19:9
    |
 LL |         t.0.0 = "new S".into();
    |         ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:15:5
+  --> $DIR/move_closure.rs:16:5
    |
 LL | /     move || {
 LL | |
@@ -152,13 +163,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0),(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:18:9
+  --> $DIR/move_closure.rs:19:9
    |
 LL |         t.0.0 = "new S".into();
    |         ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:33:5
+  --> $DIR/move_closure.rs:35:5
    |
 LL | /     move || {
 LL | |
@@ -170,13 +181,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing ref_s[Deref] -> MutBorrow
-  --> $DIR/move_closure.rs:36:9
+  --> $DIR/move_closure.rs:38:9
    |
 LL |         *ref_s += 10;
    |         ^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:33:5
+  --> $DIR/move_closure.rs:35:5
    |
 LL | /     move || {
 LL | |
@@ -188,13 +199,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture ref_s[] -> ByValue
-  --> $DIR/move_closure.rs:36:9
+  --> $DIR/move_closure.rs:38:9
    |
 LL |         *ref_s += 10;
    |         ^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:54:5
+  --> $DIR/move_closure.rs:57:5
    |
 LL | /     move || {
 LL | |
@@ -206,13 +217,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> MutBorrow
-  --> $DIR/move_closure.rs:57:9
+  --> $DIR/move_closure.rs:60:9
    |
 LL |         t.0.0 = "new s".into();
    |         ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:54:5
+  --> $DIR/move_closure.rs:57:5
    |
 LL | /     move || {
 LL | |
@@ -224,13 +235,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:57:9
+  --> $DIR/move_closure.rs:60:9
    |
 LL |         t.0.0 = "new s".into();
    |         ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:77:5
+  --> $DIR/move_closure.rs:81:5
    |
 LL | /     move || {
 LL | |
@@ -242,13 +253,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
-  --> $DIR/move_closure.rs:80:18
+  --> $DIR/move_closure.rs:84:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:77:5
+  --> $DIR/move_closure.rs:81:5
    |
 LL | /     move || {
 LL | |
@@ -260,13 +271,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:80:18
+  --> $DIR/move_closure.rs:84:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:99:5
+  --> $DIR/move_closure.rs:104:5
    |
 LL | /     move || {
 LL | |
@@ -278,13 +289,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:102:18
+  --> $DIR/move_closure.rs:107:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:99:5
+  --> $DIR/move_closure.rs:104:5
    |
 LL | /     move || {
 LL | |
@@ -296,13 +307,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/move_closure.rs:102:18
+  --> $DIR/move_closure.rs:107:18
    |
 LL |         let _t = t.0.0;
    |                  ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:120:5
+  --> $DIR/move_closure.rs:126:5
    |
 LL | /     move || {
 LL | |
@@ -314,13 +325,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[Deref,(0, 0)] -> ImmBorrow
-  --> $DIR/move_closure.rs:123:18
+  --> $DIR/move_closure.rs:129:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:120:5
+  --> $DIR/move_closure.rs:126:5
    |
 LL | /     move || {
 LL | |
@@ -332,13 +343,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[] -> ByValue
-  --> $DIR/move_closure.rs:123:18
+  --> $DIR/move_closure.rs:129:18
    |
 LL |         let _t = b.0;
    |                  ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:136:5
+  --> $DIR/move_closure.rs:143:5
    |
 LL | /     move || {
 LL | |
@@ -350,13 +361,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[Deref,(0, 0)] -> ImmBorrow
-  --> $DIR/move_closure.rs:139:24
+  --> $DIR/move_closure.rs:146:24
    |
 LL |         println!("{}", b.0);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:136:5
+  --> $DIR/move_closure.rs:143:5
    |
 LL | /     move || {
 LL | |
@@ -368,13 +379,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[] -> ByValue
-  --> $DIR/move_closure.rs:139:24
+  --> $DIR/move_closure.rs:146:24
    |
 LL |         println!("{}", b.0);
    |                        ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:153:5
+  --> $DIR/move_closure.rs:161:5
    |
 LL | /     move || {
 LL | |
@@ -386,13 +397,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(1, 0),Deref,(0, 0)] -> ImmBorrow
-  --> $DIR/move_closure.rs:156:24
+  --> $DIR/move_closure.rs:164:24
    |
 LL |         println!("{}", t.1.0);
    |                        ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:153:5
+  --> $DIR/move_closure.rs:161:5
    |
 LL | /     move || {
 LL | |
@@ -404,55 +415,55 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(1, 0)] -> ByValue
-  --> $DIR/move_closure.rs:156:24
+  --> $DIR/move_closure.rs:164:24
    |
 LL |         println!("{}", t.1.0);
    |                        ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:172:39
+  --> $DIR/move_closure.rs:180:39
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: Capturing box_p_foo[Deref,Deref,(0, 0)] -> MutBorrow
-  --> $DIR/move_closure.rs:172:47
+  --> $DIR/move_closure.rs:180:47
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                               ^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:172:39
+  --> $DIR/move_closure.rs:180:39
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: Min Capture box_p_foo[] -> ByValue
-  --> $DIR/move_closure.rs:172:47
+  --> $DIR/move_closure.rs:180:47
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                               ^^^^^^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/move_closure.rs:189:39
+  --> $DIR/move_closure.rs:198:39
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^
    |
 note: Capturing p_foo[Deref,Deref,(0, 0)] -> MutBorrow
-  --> $DIR/move_closure.rs:189:47
+  --> $DIR/move_closure.rs:198:47
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                               ^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/move_closure.rs:189:39
+  --> $DIR/move_closure.rs:198:39
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^
    |
 note: Min Capture p_foo[] -> ByValue
-  --> $DIR/move_closure.rs:189:47
+  --> $DIR/move_closure.rs:198:47
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                               ^^^^^^^

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-1.rs
@@ -22,6 +22,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-1.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/multilevel-path-1.rs:25:5
+  --> $DIR/multilevel-path-1.rs:26:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing w[(0, 0)] -> ImmBorrow
-  --> $DIR/multilevel-path-1.rs:28:19
+  --> $DIR/multilevel-path-1.rs:29:19
    |
 LL |         let wp = &w.p;
    |                   ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/multilevel-path-1.rs:25:5
+  --> $DIR/multilevel-path-1.rs:26:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture w[(0, 0)] -> ImmBorrow
-  --> $DIR/multilevel-path-1.rs:28:19
+  --> $DIR/multilevel-path-1.rs:29:19
    |
 LL |         let wp = &w.p;
    |                   ^^^

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-2.rs
@@ -17,6 +17,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
         //~^ ERROR: attributes on expressions are experimental
         //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-2.stderr
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-2.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/multilevel-path-2.rs:20:5
+  --> $DIR/multilevel-path-2.rs:21:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing w[(0, 0),(0, 0)] -> ImmBorrow
-  --> $DIR/multilevel-path-2.rs:23:24
+  --> $DIR/multilevel-path-2.rs:24:24
    |
 LL |         println!("{}", w.p.x);
    |                        ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/multilevel-path-2.rs:20:5
+  --> $DIR/multilevel-path-2.rs:21:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture w[(0, 0),(0, 0)] -> ImmBorrow
-  --> $DIR/multilevel-path-2.rs:23:24
+  --> $DIR/multilevel-path-2.rs:24:24
    |
 LL |         println!("{}", w.p.x);
    |                        ^^^^^

--- a/tests/ui/closures/2229_closure_analysis/nested-closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/nested-closure.rs
@@ -19,6 +19,7 @@ fn main() {
     let mut c1 = #[rustc_capture_analysis]
         //~^ ERROR: attributes on expressions are experimental
         //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -29,6 +30,7 @@ fn main() {
         let mut c2 = #[rustc_capture_analysis]
         //~^ ERROR: attributes on expressions are experimental
         //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
         || p.y += incr;
         //~^ ERROR: First Pass analysis includes:
         //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/nested-closure.stderr
+++ b/tests/ui/closures/2229_closure_analysis/nested-closure.stderr
@@ -6,52 +6,54 @@ LL |     let mut c1 = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/nested-closure.rs:29:22
+  --> $DIR/nested-closure.rs:30:22
    |
 LL |         let mut c2 = #[rustc_capture_analysis]
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/nested-closure.rs:32:9
+  --> $DIR/nested-closure.rs:34:9
    |
 LL |         || p.y += incr;
    |         ^^^^^^^^^^^^^^
    |
 note: Capturing p[(1, 0)] -> MutBorrow
-  --> $DIR/nested-closure.rs:32:12
+  --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^
 note: Capturing incr[] -> ImmBorrow
-  --> $DIR/nested-closure.rs:32:19
+  --> $DIR/nested-closure.rs:34:19
    |
 LL |         || p.y += incr;
    |                   ^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/nested-closure.rs:32:9
+  --> $DIR/nested-closure.rs:34:9
    |
 LL |         || p.y += incr;
    |         ^^^^^^^^^^^^^^
    |
 note: Min Capture p[(1, 0)] -> MutBorrow
-  --> $DIR/nested-closure.rs:32:12
+  --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^
 note: Min Capture incr[] -> ImmBorrow
-  --> $DIR/nested-closure.rs:32:19
+  --> $DIR/nested-closure.rs:34:19
    |
 LL |         || p.y += incr;
    |                   ^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/nested-closure.rs:22:5
+  --> $DIR/nested-closure.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -63,23 +65,23 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> ImmBorrow
-  --> $DIR/nested-closure.rs:25:24
+  --> $DIR/nested-closure.rs:26:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 note: Capturing p[(1, 0)] -> MutBorrow
-  --> $DIR/nested-closure.rs:32:12
+  --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^
 note: Capturing p[(1, 0)] -> ImmBorrow
-  --> $DIR/nested-closure.rs:42:24
+  --> $DIR/nested-closure.rs:44:24
    |
 LL |         println!("{}", p.y);
    |                        ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/nested-closure.rs:22:5
+  --> $DIR/nested-closure.rs:23:5
    |
 LL | /     || {
 LL | |
@@ -91,12 +93,12 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> ImmBorrow
-  --> $DIR/nested-closure.rs:25:24
+  --> $DIR/nested-closure.rs:26:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
 note: Min Capture p[(1, 0)] -> MutBorrow
-  --> $DIR/nested-closure.rs:32:12
+  --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^

--- a/tests/ui/closures/2229_closure_analysis/optimization/edge_case.rs
+++ b/tests/ui/closures/2229_closure_analysis/optimization/edge_case.rs
@@ -20,6 +20,7 @@ fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
     let c = #[rustc_capture_analysis] || drop(&m.a.0);
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
     //~| NOTE: Capturing m[Deref,(0, 0),Deref,(0, 0)] -> ImmBorrow

--- a/tests/ui/closures/2229_closure_analysis/optimization/edge_case.stderr
+++ b/tests/ui/closures/2229_closure_analysis/optimization/edge_case.stderr
@@ -6,6 +6,7 @@ LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
   --> $DIR/edge_case.rs:20:39

--- a/tests/ui/closures/2229_closure_analysis/path-with-array-access.rs
+++ b/tests/ui/closures/2229_closure_analysis/path-with-array-access.rs
@@ -23,6 +23,7 @@ fn main() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/path-with-array-access.stderr
+++ b/tests/ui/closures/2229_closure_analysis/path-with-array-access.stderr
@@ -6,9 +6,10 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/path-with-array-access.rs:26:5
+  --> $DIR/path-with-array-access.rs:27:5
    |
 LL | /     || {
 LL | |
@@ -20,13 +21,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing pent[(0, 0)] -> ImmBorrow
-  --> $DIR/path-with-array-access.rs:29:24
+  --> $DIR/path-with-array-access.rs:30:24
    |
 LL |         println!("{}", pent.points[5].x);
    |                        ^^^^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/path-with-array-access.rs:26:5
+  --> $DIR/path-with-array-access.rs:27:5
    |
 LL | /     || {
 LL | |
@@ -38,7 +39,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture pent[(0, 0)] -> ImmBorrow
-  --> $DIR/path-with-array-access.rs:29:24
+  --> $DIR/path-with-array-access.rs:30:24
    |
 LL |         println!("{}", pent.points[5].x);
    |                        ^^^^^^^^^^^

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
@@ -23,6 +23,7 @@ fn test_one() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
@@ -49,6 +50,7 @@ fn test_two() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
@@ -75,6 +77,7 @@ fn test_three() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
@@ -6,27 +6,30 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:49:13
+  --> $DIR/preserve_field_drop_order.rs:50:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/preserve_field_drop_order.rs:75:13
+  --> $DIR/preserve_field_drop_order.rs:77:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:26:5
+  --> $DIR/preserve_field_drop_order.rs:27:5
    |
 LL | /     || {
 LL | |
@@ -38,28 +41,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:29:26
+  --> $DIR/preserve_field_drop_order.rs:30:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:32:26
+  --> $DIR/preserve_field_drop_order.rs:33:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:36:26
+  --> $DIR/preserve_field_drop_order.rs:37:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Capturing b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:39:26
+  --> $DIR/preserve_field_drop_order.rs:40:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:26:5
+  --> $DIR/preserve_field_drop_order.rs:27:5
    |
 LL | /     || {
 LL | |
@@ -71,28 +74,28 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:29:26
+  --> $DIR/preserve_field_drop_order.rs:30:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:32:26
+  --> $DIR/preserve_field_drop_order.rs:33:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:36:26
+  --> $DIR/preserve_field_drop_order.rs:37:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:39:26
+  --> $DIR/preserve_field_drop_order.rs:40:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:52:5
+  --> $DIR/preserve_field_drop_order.rs:54:5
    |
 LL | /     || {
 LL | |
@@ -104,28 +107,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:55:26
+  --> $DIR/preserve_field_drop_order.rs:57:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:58:26
+  --> $DIR/preserve_field_drop_order.rs:60:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:62:26
+  --> $DIR/preserve_field_drop_order.rs:64:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Capturing b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:65:26
+  --> $DIR/preserve_field_drop_order.rs:67:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:52:5
+  --> $DIR/preserve_field_drop_order.rs:54:5
    |
 LL | /     || {
 LL | |
@@ -137,28 +140,28 @@ LL | |     };
    | |_____^
    |
 note: Min Capture a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:58:26
+  --> $DIR/preserve_field_drop_order.rs:60:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:55:26
+  --> $DIR/preserve_field_drop_order.rs:57:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Min Capture b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:65:26
+  --> $DIR/preserve_field_drop_order.rs:67:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:62:26
+  --> $DIR/preserve_field_drop_order.rs:64:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 
 error: First Pass analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:78:5
+  --> $DIR/preserve_field_drop_order.rs:81:5
    |
 LL | /     || {
 LL | |
@@ -170,28 +173,28 @@ LL | |     };
    | |_____^
    |
 note: Capturing b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:81:26
+  --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Capturing a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:84:26
+  --> $DIR/preserve_field_drop_order.rs:87:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
 note: Capturing a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:87:26
+  --> $DIR/preserve_field_drop_order.rs:90:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Capturing b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:91:26
+  --> $DIR/preserve_field_drop_order.rs:94:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/preserve_field_drop_order.rs:78:5
+  --> $DIR/preserve_field_drop_order.rs:81:5
    |
 LL | /     || {
 LL | |
@@ -203,22 +206,22 @@ LL | |     };
    | |_____^
    |
 note: Min Capture b[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:91:26
+  --> $DIR/preserve_field_drop_order.rs:94:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
 note: Min Capture b[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:81:26
+  --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
 note: Min Capture a[(0, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:87:26
+  --> $DIR/preserve_field_drop_order.rs:90:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
 note: Min Capture a[(1, 0)] -> ImmBorrow
-  --> $DIR/preserve_field_drop_order.rs:84:26
+  --> $DIR/preserve_field_drop_order.rs:87:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^

--- a/tests/ui/closures/2229_closure_analysis/repr_packed.rs
+++ b/tests/ui/closures/2229_closure_analysis/repr_packed.rs
@@ -14,6 +14,7 @@ fn test_alignment_not_affected() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -44,6 +45,7 @@ fn test_alignment_affected() {
     let mut c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -79,6 +81,7 @@ fn test_truncation_when_ref_and_move() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/repr_packed.stderr
+++ b/tests/ui/closures/2229_closure_analysis/repr_packed.stderr
@@ -6,27 +6,30 @@ LL |     let mut c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/repr_packed.rs:44:17
+  --> $DIR/repr_packed.rs:45:17
    |
 LL |     let mut c = #[rustc_capture_analysis]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/repr_packed.rs:79:13
+  --> $DIR/repr_packed.rs:81:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/repr_packed.rs:17:5
+  --> $DIR/repr_packed.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -38,18 +41,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing foo[] -> ImmBorrow
-  --> $DIR/repr_packed.rs:20:24
+  --> $DIR/repr_packed.rs:21:24
    |
 LL |         let z1: &u8 = &foo.x;
    |                        ^^^^^
 note: Capturing foo[] -> MutBorrow
-  --> $DIR/repr_packed.rs:22:32
+  --> $DIR/repr_packed.rs:23:32
    |
 LL |         let z2: &mut u8 = &mut foo.y;
    |                                ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/repr_packed.rs:17:5
+  --> $DIR/repr_packed.rs:18:5
    |
 LL | /     || {
 LL | |
@@ -61,13 +64,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture foo[] -> MutBorrow
-  --> $DIR/repr_packed.rs:22:32
+  --> $DIR/repr_packed.rs:23:32
    |
 LL |         let z2: &mut u8 = &mut foo.y;
    |                                ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/repr_packed.rs:47:5
+  --> $DIR/repr_packed.rs:49:5
    |
 LL | /     || {
 LL | |
@@ -79,18 +82,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing foo[] -> ImmBorrow
-  --> $DIR/repr_packed.rs:50:28
+  --> $DIR/repr_packed.rs:52:28
    |
 LL |         let z1: &String = &foo.x;
    |                            ^^^^^
 note: Capturing foo[] -> MutBorrow
-  --> $DIR/repr_packed.rs:52:33
+  --> $DIR/repr_packed.rs:54:33
    |
 LL |         let z2: &mut u16 = &mut foo.y;
    |                                 ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/repr_packed.rs:47:5
+  --> $DIR/repr_packed.rs:49:5
    |
 LL | /     || {
 LL | |
@@ -102,13 +105,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture foo[] -> MutBorrow
-  --> $DIR/repr_packed.rs:52:33
+  --> $DIR/repr_packed.rs:54:33
    |
 LL |         let z2: &mut u16 = &mut foo.y;
    |                                 ^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/repr_packed.rs:82:5
+  --> $DIR/repr_packed.rs:85:5
    |
 LL | /     || {
 LL | |
@@ -120,18 +123,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing foo[] -> ImmBorrow
-  --> $DIR/repr_packed.rs:85:24
+  --> $DIR/repr_packed.rs:88:24
    |
 LL |         println!("{}", foo.x);
    |                        ^^^^^
 note: Capturing foo[(0, 0)] -> ByValue
-  --> $DIR/repr_packed.rs:89:18
+  --> $DIR/repr_packed.rs:92:18
    |
 LL |         let _z = foo.x;
    |                  ^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/repr_packed.rs:82:5
+  --> $DIR/repr_packed.rs:85:5
    |
 LL | /     || {
 LL | |
@@ -143,7 +146,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture foo[] -> ByValue
-  --> $DIR/repr_packed.rs:85:24
+  --> $DIR/repr_packed.rs:88:24
    |
 LL |         println!("{}", foo.x);
    |                        ^^^^^ foo[] used here

--- a/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.rs
+++ b/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.rs
@@ -23,6 +23,7 @@ fn main() {
     let mut c = #[rustc_capture_analysis]
         //~^ ERROR: attributes on expressions are experimental
         //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+        //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.stderr
+++ b/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.stderr
@@ -6,9 +6,10 @@ LL |     let mut c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/simple-struct-min-capture.rs:26:5
+  --> $DIR/simple-struct-min-capture.rs:27:5
    |
 LL | /     || {
 LL | |
@@ -20,18 +21,18 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> MutBorrow
-  --> $DIR/simple-struct-min-capture.rs:29:9
+  --> $DIR/simple-struct-min-capture.rs:30:9
    |
 LL |         p.x += 10;
    |         ^^^
 note: Capturing p[] -> ImmBorrow
-  --> $DIR/simple-struct-min-capture.rs:32:26
+  --> $DIR/simple-struct-min-capture.rs:33:26
    |
 LL |         println!("{:?}", p);
    |                          ^
 
 error: Min Capture analysis includes:
-  --> $DIR/simple-struct-min-capture.rs:26:5
+  --> $DIR/simple-struct-min-capture.rs:27:5
    |
 LL | /     || {
 LL | |
@@ -43,7 +44,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> MutBorrow
-  --> $DIR/simple-struct-min-capture.rs:29:9
+  --> $DIR/simple-struct-min-capture.rs:30:9
    |
 LL |         p.x += 10;
    |         ^^^ p[] captured as MutBorrow here

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
@@ -25,6 +25,7 @@ fn unsafe_imm() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
      || unsafe {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -45,6 +46,7 @@ fn unsafe_mut() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
@@ -6,18 +6,20 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/unsafe_ptr.rs:45:13
+  --> $DIR/unsafe_ptr.rs:46:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/unsafe_ptr.rs:28:6
+  --> $DIR/unsafe_ptr.rs:29:6
    |
 LL | /      || unsafe {
 LL | |
@@ -29,13 +31,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
-  --> $DIR/unsafe_ptr.rs:31:26
+  --> $DIR/unsafe_ptr.rs:32:26
    |
 LL |         println!("{:?}", (*t.0).s);
    |                          ^^^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/unsafe_ptr.rs:28:6
+  --> $DIR/unsafe_ptr.rs:29:6
    |
 LL | /      || unsafe {
 LL | |
@@ -47,13 +49,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ImmBorrow
-  --> $DIR/unsafe_ptr.rs:31:26
+  --> $DIR/unsafe_ptr.rs:32:26
    |
 LL |         println!("{:?}", (*t.0).s);
    |                          ^^^^^^^^
 
 error: First Pass analysis includes:
-  --> $DIR/unsafe_ptr.rs:48:5
+  --> $DIR/unsafe_ptr.rs:50:5
    |
 LL | /     || {
 LL | |
@@ -65,13 +67,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[Deref,(0, 0)] -> ImmBorrow
-  --> $DIR/unsafe_ptr.rs:51:31
+  --> $DIR/unsafe_ptr.rs:53:31
    |
 LL |         let x = unsafe { &mut (*p).s };
    |                               ^^^^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/unsafe_ptr.rs:48:5
+  --> $DIR/unsafe_ptr.rs:50:5
    |
 LL | /     || {
 LL | |
@@ -83,7 +85,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[] -> ImmBorrow
-  --> $DIR/unsafe_ptr.rs:51:31
+  --> $DIR/unsafe_ptr.rs:53:31
    |
 LL |         let x = unsafe { &mut (*p).s };
    |                               ^^^^^^

--- a/tests/ui/closures/2229_closure_analysis/wild_patterns.rs
+++ b/tests/ui/closures/2229_closure_analysis/wild_patterns.rs
@@ -22,6 +22,7 @@ fn wild_struct() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -40,6 +41,7 @@ fn wild_tuple() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
@@ -58,6 +60,7 @@ fn wild_arr() {
     let c = #[rustc_capture_analysis]
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:

--- a/tests/ui/closures/2229_closure_analysis/wild_patterns.stderr
+++ b/tests/ui/closures/2229_closure_analysis/wild_patterns.stderr
@@ -6,27 +6,30 @@ LL |     let c = #[rustc_capture_analysis]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/wild_patterns.rs:40:13
+  --> $DIR/wild_patterns.rs:41:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/wild_patterns.rs:58:13
+  --> $DIR/wild_patterns.rs:60:13
    |
 LL |     let c = #[rustc_capture_analysis]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: First Pass analysis includes:
-  --> $DIR/wild_patterns.rs:25:5
+  --> $DIR/wild_patterns.rs:26:5
    |
 LL | /     || {
 LL | |
@@ -38,13 +41,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing p[(0, 0)] -> ImmBorrow
-  --> $DIR/wild_patterns.rs:29:37
+  --> $DIR/wild_patterns.rs:30:37
    |
 LL |         let Point { x: _x, y: _ } = p;
    |                                     ^
 
 error: Min Capture analysis includes:
-  --> $DIR/wild_patterns.rs:25:5
+  --> $DIR/wild_patterns.rs:26:5
    |
 LL | /     || {
 LL | |
@@ -56,13 +59,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture p[(0, 0)] -> ImmBorrow
-  --> $DIR/wild_patterns.rs:29:37
+  --> $DIR/wild_patterns.rs:30:37
    |
 LL |         let Point { x: _x, y: _ } = p;
    |                                     ^
 
 error: First Pass analysis includes:
-  --> $DIR/wild_patterns.rs:43:5
+  --> $DIR/wild_patterns.rs:45:5
    |
 LL | /     || {
 LL | |
@@ -74,13 +77,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing t[(0, 0)] -> ByValue
-  --> $DIR/wild_patterns.rs:47:23
+  --> $DIR/wild_patterns.rs:49:23
    |
 LL |         let (_x, _) = t;
    |                       ^
 
 error: Min Capture analysis includes:
-  --> $DIR/wild_patterns.rs:43:5
+  --> $DIR/wild_patterns.rs:45:5
    |
 LL | /     || {
 LL | |
@@ -92,13 +95,13 @@ LL | |     };
    | |_____^
    |
 note: Min Capture t[(0, 0)] -> ByValue
-  --> $DIR/wild_patterns.rs:47:23
+  --> $DIR/wild_patterns.rs:49:23
    |
 LL |         let (_x, _) = t;
    |                       ^
 
 error: First Pass analysis includes:
-  --> $DIR/wild_patterns.rs:61:5
+  --> $DIR/wild_patterns.rs:64:5
    |
 LL | /     || {
 LL | |
@@ -110,13 +113,13 @@ LL | |     };
    | |_____^
    |
 note: Capturing arr[Index] -> ByValue
-  --> $DIR/wild_patterns.rs:65:23
+  --> $DIR/wild_patterns.rs:68:23
    |
 LL |         let [_x, _] = arr;
    |                       ^^^
 
 error: Min Capture analysis includes:
-  --> $DIR/wild_patterns.rs:61:5
+  --> $DIR/wild_patterns.rs:64:5
    |
 LL | /     || {
 LL | |
@@ -128,7 +131,7 @@ LL | |     };
    | |_____^
    |
 note: Min Capture arr[] -> ByValue
-  --> $DIR/wild_patterns.rs:65:23
+  --> $DIR/wild_patterns.rs:68:23
    |
 LL |         let [_x, _] = arr;
    |                       ^^^

--- a/tests/ui/closures/binder/disallow-const.stderr
+++ b/tests/ui/closures/binder/disallow-const.stderr
@@ -6,6 +6,7 @@ LL |     for<const N: i32> || -> () {};
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/binder/disallow-ty.stderr
+++ b/tests/ui/closures/binder/disallow-ty.stderr
@@ -6,6 +6,7 @@ LL |     for<T> || -> () {};
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/gate_test.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/gate_test.stderr
@@ -6,6 +6,7 @@ LL |         core::mem::transmute::<usize, extern "C-cmse-nonsecure-call" fn(i32
    |
    = note: see issue #81391 <https://github.com/rust-lang/rust/issues/81391> for more information
    = help: add `#![feature(abi_c_cmse_nonsecure_call)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/gate_test.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/gate_test.stderr
@@ -6,6 +6,7 @@ LL | #[cmse_nonsecure_entry]
    |
    = note: see issue #75835 <https://github.com/rust-lang/rust/issues/75835> for more information
    = help: add `#![feature(cmse_nonsecure_entry)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0775]: `#[cmse_nonsecure_entry]` is only valid for targets with the TrustZone-M extension
   --> $DIR/gate_test.rs:4:1

--- a/tests/ui/conditional-compilation/cfg-attr-crate-2.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-crate-2.stderr
@@ -6,6 +6,7 @@ LL | #![cfg_attr(broken, no_core)]
    |
    = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
@@ -6,6 +6,7 @@ LL | #![cfg_attr(broken, no_core, no_std)]
    |
    = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
@@ -6,6 +6,7 @@ LL | #![cfg_attr(broken, no_std, no_core)]
    |
    = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/cfg-generic-params.stderr
+++ b/tests/ui/conditional-compilation/cfg-generic-params.stderr
@@ -36,6 +36,7 @@ LL | type FnBad = for<#[cfg(no)] 'a, #[cfg(yes)] T> fn();
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: only lifetime parameters can be used in this context
   --> $DIR/cfg-generic-params.rs:11:51
@@ -45,6 +46,7 @@ LL | type PolyBad = dyn for<#[cfg(no)] 'a, #[cfg(yes)] T> Copy;
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: only lifetime parameters can be used in this context
   --> $DIR/cfg-generic-params.rs:15:54
@@ -54,6 +56,7 @@ LL | struct WhereBad where for<#[cfg(no)] 'a, #[cfg(yes)] T> u8: Copy;
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/conditional-compilation/cfg_accessible-unstable.stderr
+++ b/tests/ui/conditional-compilation/cfg_accessible-unstable.stderr
@@ -6,6 +6,7 @@ LL | #[cfg_accessible(std)]
    |
    = note: see issue #64797 <https://github.com/rust-lang/rust/issues/64797> for more information
    = help: add `#![feature(cfg_accessible)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -6,6 +6,7 @@ LL | impl Foo<N = 3> for Bar {
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-89013-no-kw.rs:9:6

--- a/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/tests/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -18,6 +18,7 @@ LL | impl Foo<N = const 3> for Bar {
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-89013.rs:9:6

--- a/tests/ui/consts/async-block.without_feature.stderr
+++ b/tests/ui/consts/async-block.without_feature.stderr
@@ -6,6 +6,7 @@ LL | const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
    |
    = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `async` blocks are not allowed in statics
   --> $DIR/async-block.rs:15:51
@@ -15,6 +16,7 @@ LL | static _FUT: &(dyn Future<Output = ()> + Sync) = &async {};
    |
    = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-address-of-interior-mut.stderr
+++ b/tests/ui/consts/const-address-of-interior-mut.stderr
@@ -6,6 +6,7 @@ LL | const A: () = { let x = Cell::new(2); &raw const x; };
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:7:40
@@ -15,6 +16,7 @@ LL | static B: () = { let x = Cell::new(2); &raw const x; };
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:9:44
@@ -24,6 +26,7 @@ LL | static mut C: () = { let x = Cell::new(2); &raw const x; };
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:13:13
@@ -33,6 +36,7 @@ LL |     let y = &raw const x;
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-address-of-mut.stderr
+++ b/tests/ui/consts/const-address-of-mut.stderr
@@ -6,6 +6,7 @@ LL | const A: () = { let mut x = 2; &raw mut x; };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw mutable references are not allowed in statics
   --> $DIR/const-address-of-mut.rs:5:33
@@ -15,6 +16,7 @@ LL | static B: () = { let mut x = 2; &raw mut x; };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw mutable references are not allowed in statics
   --> $DIR/const-address-of-mut.rs:7:37
@@ -24,6 +26,7 @@ LL | static mut C: () = { let mut x = 2; &raw mut x; };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw mutable references are not allowed in constant functions
   --> $DIR/const-address-of-mut.rs:11:13
@@ -33,6 +36,7 @@ LL |     let y = &raw mut x;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-eval/issue-114994-fail.stderr
+++ b/tests/ui/consts/const-eval/issue-114994-fail.stderr
@@ -6,6 +6,7 @@ LL | const fn use_mut_const_fn(_f: &mut fn(&mut String)) {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/issue-114994-fail.rs:10:33
@@ -15,6 +16,7 @@ LL | const fn use_mut_const_tuple_fn(_f: (fn(), &mut u32)) {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/issue-65394.stderr
+++ b/tests/ui/consts/const-eval/issue-65394.stderr
@@ -6,6 +6,7 @@ LL |     let r = &mut x;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0493]: destructor of `Vec<i32>` cannot be evaluated at compile-time
   --> $DIR/issue-65394.rs:7:9

--- a/tests/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
+++ b/tests/ui/consts/const-extern-fn/const-extern-fn-min-const-fn.stderr
@@ -6,6 +6,7 @@ LL | const unsafe extern "C" fn use_float() { 1.0 + 1.0; }
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: pointers cannot be cast to integers during const eval
   --> $DIR/const-extern-fn-min-const-fn.rs:7:48

--- a/tests/ui/consts/const-extern-fn/feature-gate-const_extern_fn.stderr
+++ b/tests/ui/consts/const-extern-fn/feature-gate-const_extern_fn.stderr
@@ -6,6 +6,7 @@ LL | const extern "cdecl" fn foo4() {}
    |
    = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cdecl` as a `const fn` ABI is unstable
   --> $DIR/feature-gate-const_extern_fn.rs:11:21
@@ -15,6 +16,7 @@ LL | const unsafe extern "cdecl" fn bar4() {}
    |
    = note: see issue #64926 <https://github.com/rust-lang/rust/issues/64926> for more information
    = help: add `#![feature(const_extern_fn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-fn-error.stderr
+++ b/tests/ui/consts/const-fn-error.stderr
@@ -12,6 +12,7 @@ LL | |     }
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0015]: cannot convert `std::ops::Range<usize>` into an iterator in constant functions
   --> $DIR/const-fn-error.rs:5:14
@@ -32,6 +33,7 @@ LL |     for i in 0..x {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0015]: cannot call non-const fn `<std::ops::Range<usize> as Iterator>::next` in constant functions
   --> $DIR/const-fn-error.rs:5:14

--- a/tests/ui/consts/const-for-feature-gate.stderr
+++ b/tests/ui/consts/const-for-feature-gate.stderr
@@ -6,6 +6,7 @@ LL |     for _ in 0..5 {}
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-multi-ref.stderr
+++ b/tests/ui/consts/const-multi-ref.stderr
@@ -6,6 +6,7 @@ LL |     let p = &mut a;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-multi-ref.rs:16:13
@@ -15,6 +16,7 @@ LL |     let p = &a;
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-mut-refs/feature-gate-const_mut_refs.stderr
+++ b/tests/ui/consts/const-mut-refs/feature-gate-const_mut_refs.stderr
@@ -6,6 +6,7 @@ LL | const fn foo(x: &mut i32) -> i32 {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-mut-refs/issue-76510.32bit.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.32bit.stderr
@@ -12,6 +12,7 @@ LL | const S: &'static mut str = &mut " hello ";
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/issue-76510.rs:5:29

--- a/tests/ui/consts/const-mut-refs/issue-76510.64bit.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.64bit.stderr
@@ -12,6 +12,7 @@ LL | const S: &'static mut str = &mut " hello ";
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/issue-76510.rs:5:29

--- a/tests/ui/consts/const-suggest-feature.stderr
+++ b/tests/ui/consts/const-suggest-feature.stderr
@@ -6,6 +6,7 @@ LL |     *std::ptr::null_mut() = 0;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-try-feature-gate.stderr
+++ b/tests/ui/consts/const-try-feature-gate.stderr
@@ -6,6 +6,7 @@ LL |     Some(())?;
    |
    = note: see issue #74935 <https://github.com/rust-lang/rust/issues/74935> for more information
    = help: add `#![feature(const_try)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const_fn_floating_point_arithmetic.stock.stderr
+++ b/tests/ui/consts/const_fn_floating_point_arithmetic.stock.stderr
@@ -6,6 +6,7 @@ LL | const fn add(f: f32) -> f32 { f + 2.0 }
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/const_fn_floating_point_arithmetic.rs:10:31
@@ -15,6 +16,7 @@ LL | const fn sub(f: f32) -> f32 { 2.0 - f }
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/const_fn_floating_point_arithmetic.rs:12:39
@@ -24,6 +26,7 @@ LL | const fn mul(f: f32, g: f32) -> f32 { f * g }
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/const_fn_floating_point_arithmetic.rs:14:39
@@ -33,6 +36,7 @@ LL | const fn div(f: f32, g: f32) -> f32 { f / g }
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: floating point arithmetic is not allowed in constant functions
   --> $DIR/const_fn_floating_point_arithmetic.rs:16:31
@@ -42,6 +46,7 @@ LL | const fn neg(f: f32) -> f32 { -f }
    |
    = note: see issue #57241 <https://github.com/rust-lang/rust/issues/57241> for more information
    = help: add `#![feature(const_fn_floating_point_arithmetic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/const_let_assign3.stderr
+++ b/tests/ui/consts/const_let_assign3.stderr
@@ -6,6 +6,7 @@ LL |     const fn foo(&mut self, x: u32) {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:14:5
@@ -15,6 +16,7 @@ LL |     s.foo(3);
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:20:13
@@ -24,6 +26,7 @@ LL |     let y = &mut x;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/control-flow/loop.stderr
+++ b/tests/ui/consts/control-flow/loop.stderr
@@ -8,6 +8,7 @@ LL | |     }
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `for` is not allowed in a `const`
   --> $DIR/loop.rs:57:5
@@ -19,6 +20,7 @@ LL | |     }
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/control-flow/try.stderr
+++ b/tests/ui/consts/control-flow/try.stderr
@@ -6,6 +6,7 @@ LL |     x?;
    |
    = note: see issue #74935 <https://github.com/rust-lang/rust/issues/74935> for more information
    = help: add `#![feature(const_try)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/gate-do-not-const-check.stderr
+++ b/tests/ui/consts/gate-do-not-const-check.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_do_not_const_check]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/min_const_fn/address_of.stderr
+++ b/tests/ui/consts/min_const_fn/address_of.stderr
@@ -6,6 +6,7 @@ LL |     let b = &raw mut a;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw mutable references are not allowed in constant functions
   --> $DIR/address_of.rs:13:17
@@ -15,6 +16,7 @@ LL |         let b = &raw mut a;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn.stderr
@@ -14,6 +14,7 @@ LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:39:36
@@ -23,6 +24,7 @@ LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:39:45
@@ -32,6 +34,7 @@ LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0493]: destructor of `Foo<T>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:46:28
@@ -49,6 +52,7 @@ LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:48:42
@@ -58,6 +62,7 @@ LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:48:51
@@ -67,6 +72,7 @@ LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0493]: destructor of `Foo<T>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:55:27
@@ -84,6 +90,7 @@ LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:57:38
@@ -93,6 +100,7 @@ LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:57:47
@@ -102,6 +110,7 @@ LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:64:25
@@ -111,6 +120,7 @@ LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:64:39
@@ -120,6 +130,7 @@ LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/min_const_fn.rs:64:48
@@ -129,6 +140,7 @@ LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0013]: constant functions cannot refer to statics
   --> $DIR/min_const_fn.rs:89:27
@@ -190,6 +202,7 @@ LL | const fn inc(x: &mut i32) { *x += 1 }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0493]: destructor of `AlanTuring<impl std::fmt::Debug>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:122:19

--- a/tests/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn_unsafe_bad.stderr
@@ -6,6 +6,7 @@ LL | const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
   --> $DIR/min_const_fn_unsafe_bad.rs:4:70
@@ -15,6 +16,7 @@ LL | const unsafe fn bad_const_unsafe_deref_raw(x: *mut usize) -> usize { *x }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
   --> $DIR/min_const_fn_unsafe_bad.rs:7:83
@@ -24,6 +26,7 @@ LL | const unsafe fn bad_const_unsafe_deref_raw_ref(x: *mut usize) -> &'static u
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
   --> $DIR/min_const_fn_unsafe_bad.rs:10:80
@@ -33,6 +36,7 @@ LL | const unsafe fn bad_const_unsafe_deref_raw_underscore(x: *mut usize) { let 
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/tests/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -6,6 +6,7 @@ LL |     let b = &mut a;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/mutable_borrow.rs:12:17
@@ -15,6 +16,7 @@ LL |         let b = &mut a;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/static_mut_containing_mut_ref2.stock.stderr
+++ b/tests/ui/consts/static_mut_containing_mut_ref2.stock.stderr
@@ -21,6 +21,7 @@ LL |     *(&mut STDERR_BUFFER_SPACE) = 42;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/consts/write_to_mut_ref_dest.stock.stderr
+++ b/tests/ui/consts/write_to_mut_ref_dest.stock.stderr
@@ -6,6 +6,7 @@ LL |         let b: *mut u32 = &mut a;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constants is unstable
   --> $DIR/write_to_mut_ref_dest.rs:12:18
@@ -15,6 +16,7 @@ LL |         unsafe { *b = 5; }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coroutine/async_gen_fn.e2024.stderr
+++ b/tests/ui/coroutine/async_gen_fn.e2024.stderr
@@ -6,6 +6,7 @@ LL | async gen fn foo() {}
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/gen_block.e2024.stderr
+++ b/tests/ui/coroutine/gen_block.e2024.stderr
@@ -6,6 +6,7 @@ LL |     let _ = || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0282]: type annotations needed
   --> $DIR/gen_block.rs:6:13

--- a/tests/ui/coroutine/gen_block.none.stderr
+++ b/tests/ui/coroutine/gen_block.none.stderr
@@ -32,6 +32,7 @@ LL |     let _ = || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
   --> $DIR/gen_block.rs:15:16
@@ -41,6 +42,7 @@ LL |     let _ = || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors

--- a/tests/ui/coroutine/gen_fn.e2024.stderr
+++ b/tests/ui/coroutine/gen_fn.e2024.stderr
@@ -6,6 +6,7 @@ LL | gen fn foo() {}
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/diagnostic_namespace/feature-gate-diagnostic_namespace.stderr
+++ b/tests/ui/diagnostic_namespace/feature-gate-diagnostic_namespace.stderr
@@ -6,6 +6,7 @@ LL | #[diagnostic::non_existing_attribute]
    |
    = note: see issue #111996 <https://github.com/rust-lang/rust/issues/111996> for more information
    = help: add `#![feature(diagnostic_namespace)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[diagnostic]` attribute name space is experimental
   --> $DIR/feature-gate-diagnostic_namespace.rs:7:3
@@ -15,6 +16,7 @@ LL | #[diagnostic::non_existing_attribute(with_option = "foo")]
    |
    = note: see issue #111996 <https://github.com/rust-lang/rust/issues/111996> for more information
    = help: add `#![feature(diagnostic_namespace)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown diagnostic attribute
   --> $DIR/feature-gate-diagnostic_namespace.rs:1:15

--- a/tests/ui/diagnostic_namespace/on_unimplemented/feature-gate-diagnostic_on_unimplemented.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/feature-gate-diagnostic_on_unimplemented.stderr
@@ -6,6 +6,7 @@ LL | #[diagnostic::on_unimplemented(message = "Foo")]
    |
    = note: see issue #111996 <https://github.com/rust-lang/rust/issues/111996> for more information
    = help: add `#![feature(diagnostic_namespace)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dyn-star/feature-gate-dyn_star.stderr
+++ b/tests/ui/dyn-star/feature-gate-dyn_star.stderr
@@ -6,6 +6,7 @@ LL | pub fn dyn_star_parameter(_: &dyn* Send) {
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dyn-star/gated-span.stderr
+++ b/tests/ui/dyn-star/gated-span.stderr
@@ -6,6 +6,7 @@ LL | t!(dyn* Send);
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dyn-star/no-explicit-dyn-star-cast.stderr
+++ b/tests/ui/dyn-star/no-explicit-dyn-star-cast.stderr
@@ -6,6 +6,7 @@ LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `dyn*` trait objects are experimental
   --> $DIR/no-explicit-dyn-star-cast.rs:5:34
@@ -15,6 +16,7 @@ LL |     let dyn_i: dyn* Debug = i as dyn* Debug;
    |
    = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
    = help: add `#![feature(dyn_star)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0606]: casting `usize` as `dyn* Debug` is invalid
   --> $DIR/no-explicit-dyn-star-cast.rs:5:29

--- a/tests/ui/error-codes/E0017.stderr
+++ b/tests/ui/error-codes/E0017.stderr
@@ -42,6 +42,7 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0764]: mutable references are not allowed in the final value of statics
   --> $DIR/E0017.rs:8:39

--- a/tests/ui/error-codes/E0388.stderr
+++ b/tests/ui/error-codes/E0388.stderr
@@ -27,6 +27,7 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0764]: mutable references are not allowed in the final value of statics
   --> $DIR/E0388.rs:6:39

--- a/tests/ui/error-codes/E0396.stderr
+++ b/tests/ui/error-codes/E0396.stderr
@@ -6,6 +6,7 @@ LL | const VALUE: u8 = unsafe { *REG_ADDR };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
   --> $DIR/E0396.rs:10:11
@@ -15,6 +16,7 @@ LL |     match *INFALLIBLE {}
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
   --> $DIR/E0396.rs:10:11
@@ -24,6 +26,7 @@ LL |     match *INFALLIBLE {}
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0658]: dereferencing raw mutable pointers in constants is unstable
@@ -34,6 +37,7 @@ LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: dereferencing raw mutable pointers in constants is unstable
   --> $DIR/E0396.rs:14:36
@@ -43,6 +47,7 @@ LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors

--- a/tests/ui/error-codes/E0658.stderr
+++ b/tests/ui/error-codes/E0658.stderr
@@ -6,6 +6,7 @@ LL | enum Foo {
    |
    = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
    = help: add `#![feature(repr128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/explore-issue-38412.stderr
+++ b/tests/ui/explore-issue-38412.stderr
@@ -6,6 +6,7 @@ LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_un
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:28:5
@@ -15,6 +16,7 @@ LL |     r.a_unstable_undeclared_pub;
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0616]: field `b_crate` of struct `Record` is private
   --> $DIR/explore-issue-38412.rs:29:7
@@ -42,6 +44,7 @@ LL |     t.2;
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0616]: field `3` of struct `pub_and_stability::Tuple` is private
   --> $DIR/explore-issue-38412.rs:36:7
@@ -69,6 +72,7 @@ LL |     r.unstable_undeclared_trait_method();
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:46:7
@@ -78,6 +82,7 @@ LL |     r.unstable_undeclared();
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0624]: method `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:48:7
@@ -120,6 +125,7 @@ LL |     t.unstable_undeclared_trait_method();
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:59:7
@@ -129,6 +135,7 @@ LL |     t.unstable_undeclared();
    |
    = note: see issue #38412 <https://github.com/rust-lang/rust/issues/38412> for more information
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0624]: method `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:61:7

--- a/tests/ui/expr/if/attrs/stmt-expr-gated.stderr
+++ b/tests/ui/expr/if/attrs/stmt-expr-gated.stderr
@@ -6,6 +6,7 @@ LL |     let _ = #[deny(warnings)] if true {
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.stderr
+++ b/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.stderr
@@ -40,6 +40,7 @@ LL |     type Item = [T] where [T]: Sized;
    |
    = note: see issue #43467 <https://github.com/rust-lang/rust/issues/43467> for more information
    = help: add `#![feature(extern_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/feature-gates/doc-rust-logo.stderr
+++ b/tests/ui/feature-gates/doc-rust-logo.stderr
@@ -6,6 +6,7 @@ LL | #![doc(rust_logo)]
    |
    = note: see issue #90418 <https://github.com/rust-lang/rust/issues/90418> for more information
    = help: add `#![feature(rustdoc_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.stderr
@@ -6,6 +6,7 @@ LL | extern "avr-non-blocking-interrupt" fn fu() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:13:8
@@ -15,6 +16,7 @@ LL | extern "avr-interrupt" fn f() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:17:12
@@ -24,6 +26,7 @@ LL |     extern "avr-interrupt" fn m();
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:19:12
@@ -33,6 +36,7 @@ LL |     extern "avr-non-blocking-interrupt" fn mu();
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:22:12
@@ -42,6 +46,7 @@ LL |     extern "avr-interrupt" fn dm() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:24:12
@@ -51,6 +56,7 @@ LL |     extern "avr-non-blocking-interrupt" fn dmu() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:30:12
@@ -60,6 +66,7 @@ LL |     extern "avr-interrupt" fn m() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:32:12
@@ -69,6 +76,7 @@ LL |     extern "avr-non-blocking-interrupt" fn mu() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:37:12
@@ -78,6 +86,7 @@ LL |     extern "avr-interrupt" fn im() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:39:12
@@ -87,6 +96,7 @@ LL |     extern "avr-non-blocking-interrupt" fn imu() {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:43:18
@@ -96,6 +106,7 @@ LL | type TA = extern "avr-interrupt" fn();
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:45:19
@@ -105,6 +116,7 @@ LL | type TAU = extern "avr-non-blocking-interrupt" fn();
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:48:8
@@ -114,6 +126,7 @@ LL | extern "avr-interrupt" {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: avr-interrupt and avr-non-blocking-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-avr-interrupt.rs:50:8
@@ -123,6 +136,7 @@ LL | extern "avr-non-blocking-interrupt" {}
    |
    = note: see issue #69664 <https://github.com/rust-lang/rust/issues/69664> for more information
    = help: add `#![feature(abi_avr_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
@@ -6,6 +6,7 @@ LL | extern "msp430-interrupt" fn f() {}
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-msp430-interrupt.rs:12:12
@@ -15,6 +16,7 @@ LL |     extern "msp430-interrupt" fn m();
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-msp430-interrupt.rs:15:12
@@ -24,6 +26,7 @@ LL |     extern "msp430-interrupt" fn dm() {}
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-msp430-interrupt.rs:21:12
@@ -33,6 +36,7 @@ LL |     extern "msp430-interrupt" fn m() {}
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-msp430-interrupt.rs:26:12
@@ -42,6 +46,7 @@ LL |     extern "msp430-interrupt" fn im() {}
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-msp430-interrupt.rs:30:18
@@ -51,6 +56,7 @@ LL | type TA = extern "msp430-interrupt" fn();
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-msp430-interrupt.rs:33:8
@@ -60,6 +66,7 @@ LL | extern "msp430-interrupt" {}
    |
    = note: see issue #38487 <https://github.com/rust-lang/rust/issues/38487> for more information
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-abi-riscv-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-riscv-interrupt.stderr
@@ -6,6 +6,7 @@ LL | extern "riscv-interrupt-m" fn f() {}
    |
    = note: see issue #111889 <https://github.com/rust-lang/rust/issues/111889> for more information
    = help: add `#![feature(abi_riscv_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: riscv-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-riscv-interrupt.rs:13:8
@@ -15,6 +16,7 @@ LL | extern "riscv-interrupt-s" fn f_s() {}
    |
    = note: see issue #111889 <https://github.com/rust-lang/rust/issues/111889> for more information
    = help: add `#![feature(abi_riscv_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: riscv-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-riscv-interrupt.rs:17:12
@@ -24,6 +26,7 @@ LL |     extern "riscv-interrupt-m" fn m();
    |
    = note: see issue #111889 <https://github.com/rust-lang/rust/issues/111889> for more information
    = help: add `#![feature(abi_riscv_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: riscv-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-riscv-interrupt.rs:23:12
@@ -33,6 +36,7 @@ LL |     extern "riscv-interrupt-m" fn m() {}
    |
    = note: see issue #111889 <https://github.com/rust-lang/rust/issues/111889> for more information
    = help: add `#![feature(abi_riscv_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: riscv-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-riscv-interrupt.rs:28:12
@@ -42,6 +46,7 @@ LL |     extern "riscv-interrupt-m" fn im() {}
    |
    = note: see issue #111889 <https://github.com/rust-lang/rust/issues/111889> for more information
    = help: add `#![feature(abi_riscv_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: riscv-interrupt ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi-riscv-interrupt.rs:32:18
@@ -51,6 +56,7 @@ LL | type TA = extern "riscv-interrupt-m" fn();
    |
    = note: see issue #111889 <https://github.com/rust-lang/rust/issues/111889> for more information
    = help: add `#![feature(abi_riscv_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
@@ -6,6 +6,7 @@ LL | extern "x86-interrupt" fn f7() {}
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:10:12
@@ -15,6 +16,7 @@ LL |     extern "x86-interrupt" fn m7();
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:11:12
@@ -24,6 +26,7 @@ LL |     extern "x86-interrupt" fn dm7() {}
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:18:12
@@ -33,6 +36,7 @@ LL |     extern "x86-interrupt" fn m7() {}
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:23:12
@@ -42,6 +46,7 @@ LL |     extern "x86-interrupt" fn im7() {}
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:26:18
@@ -51,6 +56,7 @@ LL | type A7 = extern "x86-interrupt" fn();
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi-x86-interrupt.rs:28:8
@@ -60,6 +66,7 @@ LL | extern "x86-interrupt" {}
    |
    = note: see issue #40180 <https://github.com/rust-lang/rust/issues/40180> for more information
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-abi.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi.stderr
@@ -5,6 +5,7 @@ LL | extern "rust-intrinsic" fn f1() {}
    |        ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:17:8
@@ -14,6 +15,7 @@ LL | extern "platform-intrinsic" fn f2() {}
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:19:8
@@ -23,6 +25,7 @@ LL | extern "rust-call" fn f4(_: ()) {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:23:12
@@ -31,6 +34,7 @@ LL |     extern "rust-intrinsic" fn m1();
    |            ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:25:12
@@ -40,6 +44,7 @@ LL |     extern "platform-intrinsic" fn m2();
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:27:12
@@ -49,6 +54,7 @@ LL |     extern "rust-call" fn m4(_: ());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:29:12
@@ -58,6 +64,7 @@ LL |     extern "rust-call" fn dm4(_: ()) {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:36:12
@@ -66,6 +73,7 @@ LL |     extern "rust-intrinsic" fn m1() {}
    |            ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:38:12
@@ -75,6 +83,7 @@ LL |     extern "platform-intrinsic" fn m2() {}
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:40:12
@@ -84,6 +93,7 @@ LL |     extern "rust-call" fn m4(_: ()) {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:45:12
@@ -92,6 +102,7 @@ LL |     extern "rust-intrinsic" fn im1() {}
    |            ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:47:12
@@ -101,6 +112,7 @@ LL |     extern "platform-intrinsic" fn im2() {}
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:49:12
@@ -110,6 +122,7 @@ LL |     extern "rust-call" fn im4(_: ()) {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:53:18
@@ -118,6 +131,7 @@ LL | type A1 = extern "rust-intrinsic" fn();
    |                  ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:54:18
@@ -127,6 +141,7 @@ LL | type A2 = extern "platform-intrinsic" fn();
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:55:18
@@ -136,6 +151,7 @@ LL | type A4 = extern "rust-call" fn(_: ());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:58:8
@@ -144,6 +160,7 @@ LL | extern "rust-intrinsic" {}
    |        ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:59:8
@@ -153,6 +170,7 @@ LL | extern "platform-intrinsic" {}
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:60:8
@@ -162,6 +180,7 @@ LL | extern "rust-call" {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
   --> $DIR/feature-gate-abi.rs:23:32

--- a/tests/ui/feature-gates/feature-gate-abi_amdgpu_kernel.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_amdgpu_kernel.stderr
@@ -6,6 +6,7 @@ LL | extern "amdgpu-kernel" fn fu() {}
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:11:12
@@ -15,6 +16,7 @@ LL |     extern "amdgpu-kernel" fn mu();
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:12:12
@@ -24,6 +26,7 @@ LL |     extern "amdgpu-kernel" fn dmu() {}
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:18:12
@@ -33,6 +36,7 @@ LL |     extern "amdgpu-kernel" fn mu() {}
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:23:12
@@ -42,6 +46,7 @@ LL |     extern "amdgpu-kernel" fn imu() {}
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:27:19
@@ -51,6 +56,7 @@ LL | type TAU = extern "amdgpu-kernel" fn();
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:29:8
@@ -60,6 +66,7 @@ LL | extern "amdgpu-kernel" {}
    |
    = note: see issue #51575 <https://github.com/rust-lang/rust/issues/51575> for more information
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0570]: `"amdgpu-kernel"` is not a supported ABI for the current target
   --> $DIR/feature-gate-abi_amdgpu_kernel.rs:29:1

--- a/tests/ui/feature-gates/feature-gate-abi_ptx.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_ptx.stderr
@@ -6,6 +6,7 @@ LL | extern "ptx-kernel" fn fu() {}
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi_ptx.rs:11:12
@@ -15,6 +16,7 @@ LL |     extern "ptx-kernel" fn mu();
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi_ptx.rs:12:12
@@ -24,6 +26,7 @@ LL |     extern "ptx-kernel" fn dmu() {}
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi_ptx.rs:17:12
@@ -33,6 +36,7 @@ LL |     extern "ptx-kernel" fn mu() {}
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi_ptx.rs:21:12
@@ -42,6 +46,7 @@ LL |     extern "ptx-kernel" fn imu() {}
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi_ptx.rs:24:19
@@ -51,6 +56,7 @@ LL | type TAU = extern "ptx-kernel" fn();
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi_ptx.rs:26:8
@@ -60,6 +66,7 @@ LL | extern "ptx-kernel" {}
    |
    = note: see issue #38788 <https://github.com/rust-lang/rust/issues/38788> for more information
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-abi_unadjusted.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_unadjusted.stderr
@@ -5,6 +5,7 @@ LL | extern "unadjusted" fn foo() {
    |        ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_unadjusted)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-alloc-error-handler.stderr
+++ b/tests/ui/feature-gates/feature-gate-alloc-error-handler.stderr
@@ -6,6 +6,7 @@ LL | #[alloc_error_handler]
    |
    = note: see issue #51540 <https://github.com/rust-lang/rust/issues/51540> for more information
    = help: add `#![feature(alloc_error_handler)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-allocator_internals.stderr
+++ b/tests/ui/feature-gates/feature-gate-allocator_internals.stderr
@@ -5,6 +5,7 @@ LL | #![default_lib_allocator]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allocator_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
@@ -8,6 +8,7 @@ LL | bar!();
    | ------ in this macro invocation
    |
    = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
@@ -8,6 +8,7 @@ LL | bar!();
    | ------ in this macro invocation
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -5,6 +5,7 @@ LL | #[allow_internal_unstable()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: attribute should be applied to a macro
   --> $DIR/feature-gate-allow-internal-unstable-struct.rs:4:1

--- a/tests/ui/feature-gates/feature-gate-allow-internal-unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-allow-internal-unstable.stderr
@@ -5,6 +5,7 @@ LL | #[allow_internal_unstable()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
+++ b/tests/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
@@ -6,6 +6,7 @@ LL |     fn foo(self: Ptr<Self>) {}
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0658]: `Box<Ptr<Bar>>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -16,6 +17,7 @@ LL |     fn bar(self: Box<Ptr<Self>>) {}
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0658]: `Ptr<Self>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -26,6 +28,7 @@ LL |     fn foo(self: Ptr<Self>);
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
+++ b/tests/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
@@ -6,6 +6,7 @@ LL |     fn foo(self: *const Self) {}
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0658]: `*const ()` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -16,6 +17,7 @@ LL |     fn bar(self: *const Self) {}
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error[E0658]: `*const Self` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -26,6 +28,7 @@ LL |     fn bar(self: *const Self);
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/feature-gates/feature-gate-asm_const.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_const.stderr
@@ -6,6 +6,7 @@ LL |     asm!("mov eax, {}", const N + 1);
    |
    = note: see issue #93332 <https://github.com/rust-lang/rust/issues/93332> for more information
    = help: add `#![feature(asm_const)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const operands for inline assembly are unstable
   --> $DIR/feature-gate-asm_const.rs:13:29
@@ -15,6 +16,7 @@ LL |         asm!("mov eax, {}", const 123);
    |
    = note: see issue #93332 <https://github.com/rust-lang/rust/issues/93332> for more information
    = help: add `#![feature(asm_const)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_arch.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_arch.stderr
@@ -6,6 +6,7 @@ LL |     asm!("");
    |
    = note: see issue #93335 <https://github.com/rust-lang/rust/issues/93335> for more information
    = help: add `#![feature(asm_experimental_arch)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-asm_unwind.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_unwind.stderr
@@ -6,6 +6,7 @@ LL |         asm!("", options(may_unwind));
    |
    = note: see issue #93334 <https://github.com/rust-lang/rust/issues/93334> for more information
    = help: add `#![feature(asm_unwind)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-assoc-type-defaults.stderr
+++ b/tests/ui/feature-gates/feature-gate-assoc-type-defaults.stderr
@@ -6,6 +6,7 @@ LL |     type Bar = u8;
    |
    = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
    = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-associated_const_equality.stderr
+++ b/tests/ui/feature-gates/feature-gate-associated_const_equality.stderr
@@ -6,6 +6,7 @@ LL | fn foo<A: TraitWAssocConst<A=32>>() {}
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -6,6 +6,7 @@ LL |     type A: Iterator<Item: Copy>;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:16:22
@@ -15,6 +16,7 @@ LL |     type B: Iterator<Item: 'static>;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:20:20
@@ -24,6 +26,7 @@ LL | struct _St1<T: Tr1<As1: Tr2>> {
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:27:18
@@ -33,6 +36,7 @@ LL | enum _En1<T: Tr1<As1: Tr2>> {
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:34:19
@@ -42,6 +46,7 @@ LL | union _Un1<T: Tr1<As1: Tr2>> {
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:41:37
@@ -51,6 +56,7 @@ LL | type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:44:22
@@ -60,6 +66,7 @@ LL | fn _apit(_: impl Tr1<As1: Copy>) {}
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:46:26
@@ -69,6 +76,7 @@ LL | fn _apit_dyn(_: &dyn Tr1<As1: Copy>) {}
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:49:24
@@ -78,6 +86,7 @@ LL | fn _rpit() -> impl Tr1<As1: Copy> { S1 }
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:52:31
@@ -87,6 +96,7 @@ LL | fn _rpit_dyn() -> Box<dyn Tr1<As1: Copy>> { Box::new(S1) }
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:55:23
@@ -96,6 +106,7 @@ LL | const _cdef: impl Tr1<As1: Copy> = S1;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:61:24
@@ -105,6 +116,7 @@ LL | static _sdef: impl Tr1<As1: Copy> = S1;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:68:21
@@ -114,6 +126,7 @@ LL |     let _: impl Tr1<As1: Copy> = S1;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in const types
   --> $DIR/feature-gate-associated_type_bounds.rs:55:14

--- a/tests/ui/feature-gates/feature-gate-auto-traits.stderr
+++ b/tests/ui/feature-gates/feature-gate-auto-traits.stderr
@@ -6,6 +6,7 @@ LL | auto trait AutoDummyTrait {}
    |
    = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
    = help: add `#![feature(auto_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
   --> $DIR/feature-gate-auto-traits.rs:9:6
@@ -15,6 +16,7 @@ LL | impl !AutoDummyTrait for DummyStruct {}
    |
    = note: see issue #68318 <https://github.com/rust-lang/rust/issues/68318> for more information
    = help: add `#![feature(negative_impls)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-box_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-box_patterns.stderr
@@ -6,6 +6,7 @@ LL |     let box x = Box::new('c');
    |
    = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-builtin_syntax.stderr
+++ b/tests/ui/feature-gates/feature-gate-builtin_syntax.stderr
@@ -6,6 +6,7 @@ LL |     builtin # offset_of(Foo, v);
    |
    = note: see issue #110680 <https://github.com/rust-lang/rust/issues/110680> for more information
    = help: add `#![feature(builtin_syntax)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-c_variadic.stderr
+++ b/tests/ui/feature-gates/feature-gate-c_variadic.stderr
@@ -6,6 +6,7 @@ LL | pub unsafe extern "C" fn test(_: i32, ap: ...) { }
    |
    = note: see issue #44930 <https://github.com/rust-lang/rust/issues/44930> for more information
    = help: add `#![feature(c_variadic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-cfg-relocation-model.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-relocation-model.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(relocation_model = "pic")]
    |
    = note: see issue #114929 <https://github.com/rust-lang/rust/issues/114929> for more information
    = help: add `#![feature(cfg_relocation_model)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-cfg-sanitizer_cfi.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-sanitizer_cfi.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(sanitizer_cfi_generalize_pointers)]
    |
    = note: see issue #89653 <https://github.com/rust-lang/rust/issues/89653> for more information
    = help: add `#![feature(cfg_sanitizer_cfi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(sanitizer_cfi_normalize_integers)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-sanitizer_cfi.rs:5:7
@@ -15,6 +16,7 @@ LL | #[cfg(sanitizer_cfi_normalize_integers)]
    |
    = note: see issue #89653 <https://github.com/rust-lang/rust/issues/89653> for more information
    = help: add `#![feature(cfg_sanitizer_cfi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-cfg-target-abi.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-abi.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(target_abi = "x")]
    |
    = note: see issue #80970 <https://github.com/rust-lang/rust/issues/80970> for more information
    = help: add `#![feature(cfg_target_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_abi)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-abi.rs:4:12
@@ -15,6 +16,7 @@ LL | #[cfg_attr(target_abi = "x", x)]
    |
    = note: see issue #80970 <https://github.com/rust-lang/rust/issues/80970> for more information
    = help: add `#![feature(cfg_target_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_abi)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-abi.rs:7:19
@@ -24,6 +26,7 @@ LL | #[cfg(not(any(all(target_abi = "x"))))]
    |
    = note: see issue #80970 <https://github.com/rust-lang/rust/issues/80970> for more information
    = help: add `#![feature(cfg_target_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_abi)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-abi.rs:11:10
@@ -33,6 +36,7 @@ LL |     cfg!(target_abi = "x");
    |
    = note: see issue #80970 <https://github.com/rust-lang/rust/issues/80970> for more information
    = help: add `#![feature(cfg_target_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-cfg-target-compact.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-compact.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(target(os = "x"))]
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:4:12
@@ -15,6 +16,7 @@ LL | #[cfg_attr(target(os = "x"), x)]
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:7:19
@@ -24,6 +26,7 @@ LL | #[cfg(not(any(all(target(os = "x")))))]
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: compact `cfg(target(..))` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-compact.rs:11:10
@@ -33,6 +36,7 @@ LL |     cfg!(target(os = "x"));
    |
    = note: see issue #96901 <https://github.com/rust-lang/rust/issues/96901> for more information
    = help: add `#![feature(cfg_target_compact)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-cfg-target-has-atomic-equal-alignment.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-has-atomic-equal-alignment.stderr
@@ -6,6 +6,7 @@ LL |     cfg!(target_has_atomic_equal_alignment = "8");
    |
    = note: see issue #93822 <https://github.com/rust-lang/rust/issues/93822> for more information
    = help: add `#![feature(cfg_target_has_atomic_equal_alignment)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic-equal-alignment.rs:4:10
@@ -15,6 +16,7 @@ LL |     cfg!(target_has_atomic_equal_alignment = "16");
    |
    = note: see issue #93822 <https://github.com/rust-lang/rust/issues/93822> for more information
    = help: add `#![feature(cfg_target_has_atomic_equal_alignment)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic-equal-alignment.rs:6:10
@@ -24,6 +26,7 @@ LL |     cfg!(target_has_atomic_equal_alignment = "32");
    |
    = note: see issue #93822 <https://github.com/rust-lang/rust/issues/93822> for more information
    = help: add `#![feature(cfg_target_has_atomic_equal_alignment)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic-equal-alignment.rs:8:10
@@ -33,6 +36,7 @@ LL |     cfg!(target_has_atomic_equal_alignment = "64");
    |
    = note: see issue #93822 <https://github.com/rust-lang/rust/issues/93822> for more information
    = help: add `#![feature(cfg_target_has_atomic_equal_alignment)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic-equal-alignment.rs:10:10
@@ -42,6 +46,7 @@ LL |     cfg!(target_has_atomic_equal_alignment = "128");
    |
    = note: see issue #93822 <https://github.com/rust-lang/rust/issues/93822> for more information
    = help: add `#![feature(cfg_target_has_atomic_equal_alignment)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_equal_alignment)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic-equal-alignment.rs:12:10
@@ -51,6 +56,7 @@ LL |     cfg!(target_has_atomic_equal_alignment = "ptr");
    |
    = note: see issue #93822 <https://github.com/rust-lang/rust/issues/93822> for more information
    = help: add `#![feature(cfg_target_has_atomic_equal_alignment)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
@@ -6,6 +6,7 @@ LL |     cfg!(target_has_atomic_load_store = "8");
    |
    = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:4:10
@@ -15,6 +16,7 @@ LL |     cfg!(target_has_atomic_load_store = "16");
    |
    = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:6:10
@@ -24,6 +26,7 @@ LL |     cfg!(target_has_atomic_load_store = "32");
    |
    = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:8:10
@@ -33,6 +36,7 @@ LL |     cfg!(target_has_atomic_load_store = "64");
    |
    = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:10:10
@@ -42,6 +46,7 @@ LL |     cfg!(target_has_atomic_load_store = "128");
    |
    = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:12:10
@@ -51,6 +56,7 @@ LL |     cfg!(target_has_atomic_load_store = "ptr");
    |
    = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
    = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
@@ -6,6 +6,7 @@ LL |     #[cfg_attr(target_thread_local, thread_local)]
    |
    = note: see issue #29594 <https://github.com/rust-lang/rust/issues/29594> for more information
    = help: add `#![feature(cfg_target_thread_local)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-cfg-version.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-version.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(version(42))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: expected a version literal
   --> $DIR/feature-gate-cfg-version.rs:1:15
@@ -21,6 +22,7 @@ LL | #[cfg(version(1.20))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: expected a version literal
   --> $DIR/feature-gate-cfg-version.rs:4:15
@@ -36,6 +38,7 @@ LL | #[cfg(version("1.44"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(version)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-version.rs:10:11
@@ -45,6 +48,7 @@ LL | #[cfg(not(version("1.44")))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(version)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-version.rs:14:7
@@ -54,6 +58,7 @@ LL | #[cfg(version("1.43", "1.44", "1.45"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: expected single version literal
   --> $DIR/feature-gate-cfg-version.rs:14:7
@@ -69,6 +74,7 @@ LL | #[cfg(version(false))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: expected a version literal
   --> $DIR/feature-gate-cfg-version.rs:17:15
@@ -84,6 +90,7 @@ LL | #[cfg(version("foo"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:20:15
@@ -99,6 +106,7 @@ LL | #[cfg(version("999"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:23:15
@@ -114,6 +122,7 @@ LL | #[cfg(version("-1"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:26:15
@@ -129,6 +138,7 @@ LL | #[cfg(version("65536"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:29:15
@@ -144,6 +154,7 @@ LL | #[cfg(version("0"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:32:15
@@ -159,6 +170,7 @@ LL | #[cfg(version("1.0"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `cfg(version)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-version.rs:38:7
@@ -168,6 +180,7 @@ LL | #[cfg(version("1.65536.2"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:38:15
@@ -183,6 +196,7 @@ LL | #[cfg(version("1.20.0-stable"))]
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown version literal format, assuming it refers to a future version
   --> $DIR/feature-gate-cfg-version.rs:41:15
@@ -198,6 +212,7 @@ LL |     assert!(cfg!(version("1.42")));
    |
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 19 previous errors; 7 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-cfg_overflow_checks.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg_overflow_checks.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(overflow_checks)]
    |
    = note: see issue #111466 <https://github.com/rust-lang/rust/issues/111466> for more information
    = help: add `#![feature(cfg_overflow_checks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-cfg_sanitize.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg_sanitize.stderr
@@ -6,6 +6,7 @@ LL | #[cfg(not(sanitize = "thread"))]
    |
    = note: see issue #39699 <https://github.com/rust-lang/rust/issues/39699> for more information
    = help: add `#![feature(cfg_sanitize)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-cfi_encoding.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfi_encoding.stderr
@@ -6,6 +6,7 @@ LL | #[cfi_encoding = "3Bar"]
    |
    = note: see issue #89653 <https://github.com/rust-lang/rust/issues/89653> for more information
    = help: add `#![feature(cfi_encoding)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-closure_lifetime_binder.stderr
+++ b/tests/ui/feature-gates/feature-gate-closure_lifetime_binder.stderr
@@ -6,6 +6,7 @@ LL |     for<> || -> () {};
    |
    = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
    = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider removing `for<...>`
 
 error[E0658]: `for<...>` binders for closures are experimental
@@ -16,6 +17,7 @@ LL |     for<'a> || -> () {};
    |
    = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
    = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider removing `for<...>`
 
 error[E0658]: `for<...>` binders for closures are experimental
@@ -26,6 +28,7 @@ LL |     for<'a, 'b> |_: &'a ()| -> () {};
    |
    = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
    = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider removing `for<...>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/feature-gates/feature-gate-closure_track_caller.stderr
+++ b/tests/ui/feature-gates/feature-gate-closure_track_caller.stderr
@@ -6,6 +6,7 @@ LL |     let _closure = #[track_caller] || {};
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/feature-gate-closure_track_caller.rs:7:22
@@ -15,6 +16,7 @@ LL |     let _coroutine = #[track_caller] || { yield; };
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
   --> $DIR/feature-gate-closure_track_caller.rs:8:19
@@ -24,6 +26,7 @@ LL |     let _future = #[track_caller] async {};
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-collapse_debuginfo.stderr
+++ b/tests/ui/feature-gates/feature-gate-collapse_debuginfo.stderr
@@ -6,6 +6,7 @@ LL | #[collapse_debuginfo]
    |
    = note: see issue #100758 <https://github.com/rust-lang/rust/issues/100758> for more information
    = help: add `#![feature(collapse_debuginfo)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-compiler-builtins.stderr
+++ b/tests/ui/feature-gates/feature-gate-compiler-builtins.stderr
@@ -5,6 +5,7 @@ LL | #![compiler_builtins]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(compiler_builtins)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-concat_bytes.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_bytes.stderr
@@ -6,6 +6,7 @@ LL |     let a = concat_bytes!(b'A', b"BC");
    |
    = note: see issue #87555 <https://github.com/rust-lang/rust/issues/87555> for more information
    = help: add `#![feature(concat_bytes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-concat_idents.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents.stderr
@@ -6,6 +6,7 @@ LL |     let a = concat_idents!(X, Y_1);
    |
    = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents.rs:6:13
@@ -15,6 +16,7 @@ LL |     let b = concat_idents!(X, Y_2);
    |
    = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -6,6 +6,7 @@ LL |     concat_idents!(a, b);
    |
    = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0425]: cannot find value `ab` in this scope
   --> $DIR/feature-gate-concat_idents2.rs:2:5

--- a/tests/ui/feature-gates/feature-gate-concat_idents3.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents3.stderr
@@ -6,6 +6,7 @@ LL |     assert_eq!(10, concat_idents!(X, Y_1));
    |
    = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents3.rs:6:20
@@ -15,6 +16,7 @@ LL |     assert_eq!(20, concat_idents!(X, Y_2));
    |
    = note: see issue #29599 <https://github.com/rust-lang/rust/issues/29599> for more information
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-coroutines.e2024.stderr
+++ b/tests/ui/feature-gates/feature-gate-coroutines.e2024.stderr
@@ -6,6 +6,7 @@ LL |     yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
   --> $DIR/feature-gate-coroutines.rs:9:16
@@ -15,6 +16,7 @@ LL |     let _ = || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0627]: yield expression outside of coroutine literal
   --> $DIR/feature-gate-coroutines.rs:5:5

--- a/tests/ui/feature-gates/feature-gate-coroutines.none.stderr
+++ b/tests/ui/feature-gates/feature-gate-coroutines.none.stderr
@@ -6,6 +6,7 @@ LL |     yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
   --> $DIR/feature-gate-coroutines.rs:9:16
@@ -15,6 +16,7 @@ LL |     let _ = || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
   --> $DIR/feature-gate-coroutines.rs:16:5
@@ -24,6 +26,7 @@ LL |     yield;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
   --> $DIR/feature-gate-coroutines.rs:17:5
@@ -33,6 +36,7 @@ LL |     yield 0;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: yield syntax is experimental
   --> $DIR/feature-gate-coroutines.rs:5:5
@@ -42,6 +46,7 @@ LL |     yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0658]: yield syntax is experimental
@@ -52,6 +57,7 @@ LL |     let _ = || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0627]: yield expression outside of coroutine literal

--- a/tests/ui/feature-gates/feature-gate-coverage-attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-coverage-attribute.stderr
@@ -14,6 +14,7 @@ LL | #[coverage(off)]
    |
    = note: see issue #84605 <https://github.com/rust-lang/rust/issues/84605> for more information
    = help: add `#![feature(coverage_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-custom_mir.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.stderr
@@ -5,6 +5,7 @@ LL | #[custom_mir(dialect = "built")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(custom_mir)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
@@ -6,6 +6,7 @@ LL | #[test_case]
    |
    = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom test frameworks are an unstable feature
   --> $DIR/feature-gate-custom_test_frameworks.rs:1:1
@@ -15,6 +16,7 @@ LL | #![test_runner(main)]
    |
    = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
    = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-decl_macro.stderr
+++ b/tests/ui/feature-gates/feature-gate-decl_macro.stderr
@@ -6,6 +6,7 @@ LL | macro m() {}
    |
    = note: see issue #39412 <https://github.com/rust-lang/rust/issues/39412> for more information
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-deprecated_safe.stderr
+++ b/tests/ui/feature-gates/feature-gate-deprecated_safe.stderr
@@ -6,6 +6,7 @@ LL | #[deprecated_safe(since = "TBD", note = "...")]
    |
    = note: see issue #94978 <https://github.com/rust-lang/rust/issues/94978> for more information
    = help: add `#![feature(deprecated_safe)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[deprecated_safe]` attribute is an experimental feature
   --> $DIR/feature-gate-deprecated_safe.rs:4:1
@@ -15,6 +16,7 @@ LL | #[deprecated_safe(since = "TBD", note = "...")]
    |
    = note: see issue #94978 <https://github.com/rust-lang/rust/issues/94978> for more information
    = help: add `#![feature(deprecated_safe)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-doc_cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-doc_cfg.stderr
@@ -6,6 +6,7 @@ LL | #[doc(cfg(unix))]
    |
    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-doc_masked.stderr
+++ b/tests/ui/feature-gates/feature-gate-doc_masked.stderr
@@ -6,6 +6,7 @@ LL | #[doc(masked)]
    |
    = note: see issue #44027 <https://github.com/rust-lang/rust/issues/44027> for more information
    = help: add `#![feature(doc_masked)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-doc_notable_trait.stderr
+++ b/tests/ui/feature-gates/feature-gate-doc_notable_trait.stderr
@@ -6,6 +6,7 @@ LL | #[doc(notable_trait)]
    |
    = note: see issue #45040 <https://github.com/rust-lang/rust/issues/45040> for more information
    = help: add `#![feature(doc_notable_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
+++ b/tests/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
@@ -6,6 +6,7 @@ LL |         0 .. 3 => {}
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-explicit_tail_calls.stderr
+++ b/tests/ui/feature-gates/feature-gate-explicit_tail_calls.stderr
@@ -6,6 +6,7 @@ LL |     become bottom();
    |
    = note: see issue #112788 <https://github.com/rust-lang/rust/issues/112788> for more information
    = help: add `#![feature(explicit_tail_calls)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `become` expression is experimental
   --> $DIR/feature-gate-explicit_tail_calls.rs:6:5
@@ -15,6 +16,7 @@ LL |     become you();
    |
    = note: see issue #112788 <https://github.com/rust-lang/rust/issues/112788> for more information
    = help: add `#![feature(explicit_tail_calls)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-extern_types.stderr
+++ b/tests/ui/feature-gates/feature-gate-extern_types.stderr
@@ -6,6 +6,7 @@ LL |     type T;
    |
    = note: see issue #43467 <https://github.com/rust-lang/rust/issues/43467> for more information
    = help: add `#![feature(extern_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-ffi_const.stderr
+++ b/tests/ui/feature-gates/feature-gate-ffi_const.stderr
@@ -6,6 +6,7 @@ LL |     #[ffi_const]
    |
    = note: see issue #58328 <https://github.com/rust-lang/rust/issues/58328> for more information
    = help: add `#![feature(ffi_const)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-ffi_pure.stderr
+++ b/tests/ui/feature-gates/feature-gate-ffi_pure.stderr
@@ -6,6 +6,7 @@ LL |     #[ffi_pure]
    |
    = note: see issue #58329 <https://github.com/rust-lang/rust/issues/58329> for more information
    = help: add `#![feature(ffi_pure)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-ffi_returns_twice.stderr
+++ b/tests/ui/feature-gates/feature-gate-ffi_returns_twice.stderr
@@ -6,6 +6,7 @@ LL |     #[ffi_returns_twice]
    |
    = note: see issue #58314 <https://github.com/rust-lang/rust/issues/58314> for more information
    = help: add `#![feature(ffi_returns_twice)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -6,6 +6,7 @@ LL | #[repr(align(16))]
    |
    = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
    = help: add `#![feature(fn_align)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-fn_delegation.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_delegation.stderr
@@ -6,6 +6,7 @@ LL | reuse to_reuse::foo;
    |
    = note: see issue #118212 <https://github.com/rust-lang/rust/issues/118212> for more information
    = help: add `#![feature(fn_delegation)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-format_args_nl.stderr
+++ b/tests/ui/feature-gates/feature-gate-format_args_nl.stderr
@@ -5,6 +5,7 @@ LL |     format_args_nl!("");
    |     ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(format_args_nl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-fundamental.stderr
+++ b/tests/ui/feature-gates/feature-gate-fundamental.stderr
@@ -6,6 +6,7 @@ LL | #[fundamental]
    |
    = note: see issue #29635 <https://github.com/rust-lang/rust/issues/29635> for more information
    = help: add `#![feature(fundamental)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-gen_blocks.e2024.stderr
+++ b/tests/ui/feature-gates/feature-gate-gen_blocks.e2024.stderr
@@ -6,6 +6,7 @@ LL |     gen {};
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: gen blocks are experimental
   --> $DIR/feature-gate-gen_blocks.rs:12:5
@@ -15,6 +16,7 @@ LL |     async gen {};
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: gen blocks are experimental
   --> $DIR/feature-gate-gen_blocks.rs:22:5
@@ -24,6 +26,7 @@ LL |     gen {};
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: gen blocks are experimental
   --> $DIR/feature-gate-gen_blocks.rs:25:5
@@ -33,6 +36,7 @@ LL |     async gen {};
    |
    = note: see issue #117078 <https://github.com/rust-lang/rust/issues/117078> for more information
    = help: add `#![feature(gen_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0282]: type annotations needed
   --> $DIR/feature-gate-gen_blocks.rs:5:5

--- a/tests/ui/feature-gates/feature-gate-generic_arg_infer.normal.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic_arg_infer.normal.stderr
@@ -18,6 +18,7 @@ LL |     let _y: [u8; _] = [0; 3];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/feature-gate-generic_arg_infer.rs:20:20
@@ -36,6 +37,7 @@ LL |     let _x: [u8; 3] = [0; _];
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-generic_associated_types_extended.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic_associated_types_extended.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_error]
    | ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
@@ -6,6 +6,7 @@ LL |     type Bar = impl std::fmt::Debug;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl Trait` in associated types is unstable
   --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
@@ -15,6 +16,7 @@ LL |     type Bop = impl std::fmt::Debug;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:5
@@ -24,6 +26,7 @@ LL |     type Bop = impl std::fmt::Debug;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: unconstrained opaque type
   --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_fn_trait_return.stderr
@@ -7,6 +7,7 @@ LL | fn f() -> impl Fn() -> impl Sized { || () }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
    = note: see issue #99697 <https://github.com/rust-lang/rust/issues/99697> for more information
    = help: add `#![feature(impl_trait_in_fn_trait_return)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in the return type of `Fn` trait bounds
   --> $DIR/feature-gate-impl_trait_in_fn_trait_return.rs:3:32
@@ -17,6 +18,7 @@ LL | fn g() -> &'static dyn Fn() -> impl Sized { &|| () }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
    = note: see issue #99697 <https://github.com/rust-lang/rust/issues/99697> for more information
    = help: add `#![feature(impl_trait_in_fn_trait_return)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-imported_main.stderr
+++ b/tests/ui/feature-gates/feature-gate-imported_main.stderr
@@ -6,6 +6,7 @@ LL | use foo::bar as main;
    |
    = note: see issue #28937 <https://github.com/rust-lang/rust/issues/28937> for more information
    = help: add `#![feature(imported_main)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-inherent_associated_types.stderr
+++ b/tests/ui/feature-gates/feature-gate-inherent_associated_types.stderr
@@ -6,6 +6,7 @@ LL |     type Bar = isize;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-inline_const.stderr
+++ b/tests/ui/feature-gates/feature-gate-inline_const.stderr
@@ -6,6 +6,7 @@ LL |     let _ = const {
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-inline_const_pat.stderr
+++ b/tests/ui/feature-gates/feature-gate-inline_const_pat.stderr
@@ -6,6 +6,7 @@ LL |     let const { () } = ();
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const_pat)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-intrinsics.stderr
+++ b/tests/ui/feature-gates/feature-gate-intrinsics.stderr
@@ -5,6 +5,7 @@ LL | extern "rust-intrinsic" {
    |        ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-intrinsics.rs:5:8
@@ -13,6 +14,7 @@ LL | extern "rust-intrinsic" fn baz() {}
    |        ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0093]: unrecognized intrinsic function: `bar`
   --> $DIR/feature-gate-intrinsics.rs:2:5

--- a/tests/ui/feature-gates/feature-gate-is_sorted.stderr
+++ b/tests/ui/feature-gates/feature-gate-is_sorted.stderr
@@ -6,6 +6,7 @@ LL |     assert!([1, 2, 2, 9].iter().is_sorted());
    |
    = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
   --> $DIR/feature-gate-is_sorted.rs:5:39
@@ -15,6 +16,7 @@ LL |     assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
    |
    = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
   --> $DIR/feature-gate-is_sorted.rs:9:26
@@ -24,6 +26,7 @@ LL |     assert!([1, 2, 2, 9].is_sorted());
    |
    = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
   --> $DIR/feature-gate-is_sorted.rs:11:32
@@ -33,6 +36,7 @@ LL |     assert!(![-2i32, -1, 0, 3].is_sorted_by_key(|n| n.abs()));
    |
    = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-lang-items.stderr
+++ b/tests/ui/feature-gates/feature-gate-lang-items.stderr
@@ -5,6 +5,7 @@ LL | #[lang = "foo"]
    | ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0522]: definition of an unknown language item: `foo`
   --> $DIR/feature-gate-lang-items.rs:1:1

--- a/tests/ui/feature-gates/feature-gate-large-assignments.stderr
+++ b/tests/ui/feature-gates/feature-gate-large-assignments.stderr
@@ -6,6 +6,7 @@ LL | #![move_size_limit = "42"]
    |
    = note: see issue #83518 <https://github.com/rust-lang/rust/issues/83518> for more information
    = help: add `#![feature(large_assignments)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-link-arg-attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-link-arg-attribute.stderr
@@ -6,6 +6,7 @@ LL | #[link(kind = "link-arg", name = "foo")]
    |
    = note: see issue #99427 <https://github.com/rust-lang/rust/issues/99427> for more information
    = help: add `#![feature(link_arg_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-link_cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-link_cfg.stderr
@@ -5,6 +5,7 @@ LL | #[link(name = "foo", cfg(foo))]
    |                      ^^^^^^^^
    |
    = help: add `#![feature(link_cfg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
+++ b/tests/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
@@ -6,6 +6,7 @@ LL |     fn sqrt(x: f32) -> f32;
    |
    = note: see issue #29602 <https://github.com/rust-lang/rust/issues/29602> for more information
    = help: add `#![feature(link_llvm_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-linkage.stderr
+++ b/tests/ui/feature-gates/feature-gate-linkage.stderr
@@ -6,6 +6,7 @@ LL |     #[linkage = "extern_weak"] static foo: *mut isize;
    |
    = note: see issue #29603 <https://github.com/rust-lang/rust/issues/29603> for more information
    = help: add `#![feature(linkage)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-lint-reasons.stderr
+++ b/tests/ui/feature-gates/feature-gate-lint-reasons.stderr
@@ -6,6 +6,7 @@ LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |
    = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: lint reasons are experimental
   --> $DIR/feature-gate-lint-reasons.rs:1:28
@@ -15,6 +16,7 @@ LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |
    = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/feature-gates/feature-gate-log_syntax.stderr
+++ b/tests/ui/feature-gates/feature-gate-log_syntax.stderr
@@ -6,6 +6,7 @@ LL |     log_syntax!()
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(log_syntax)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-log_syntax2.stderr
+++ b/tests/ui/feature-gates/feature-gate-log_syntax2.stderr
@@ -6,6 +6,7 @@ LL |     println!("{:?}", log_syntax!());
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(log_syntax)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-marker_trait_attr.stderr
+++ b/tests/ui/feature-gates/feature-gate-marker_trait_attr.stderr
@@ -6,6 +6,7 @@ LL | #[marker] trait ExplicitMarker {}
    |
    = note: see issue #29864 <https://github.com/rust-lang/rust/issues/29864> for more information
    = help: add `#![feature(marker_trait_attr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-may-dangle.stderr
+++ b/tests/ui/feature-gates/feature-gate-may-dangle.stderr
@@ -6,6 +6,7 @@ LL | unsafe impl<#[may_dangle] A> Drop for Pt<A> {
    |
    = note: see issue #34761 <https://github.com/rust-lang/rust/issues/34761> for more information
    = help: add `#![feature(dropck_eyepatch)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-more-qualified-paths.stderr
+++ b/tests/ui/feature-gates/feature-gate-more-qualified-paths.stderr
@@ -6,6 +6,7 @@ LL |     let <Foo as A>::Assoc { br } = StructStruct { br: 2 };
    |
    = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: usage of qualified paths in this context is experimental
   --> $DIR/feature-gate-more-qualified-paths.rs:5:13
@@ -15,6 +16,7 @@ LL |     let _ = <Foo as A>::Assoc { br: 2 };
    |
    = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: usage of qualified paths in this context is experimental
   --> $DIR/feature-gate-more-qualified-paths.rs:7:9
@@ -24,6 +26,7 @@ LL |     let <E>::V(..) = E::V(0);
    |
    = note: see issue #86935 <https://github.com/rust-lang/rust/issues/86935> for more information
    = help: add `#![feature(more_qualified_paths)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-multiple_supertrait_upcastable.stderr
+++ b/tests/ui/feature-gates/feature-gate-multiple_supertrait_upcastable.stderr
@@ -6,6 +6,7 @@ LL | #![deny(multiple_supertrait_upcastable)]
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: unknown lint: `multiple_supertrait_upcastable`
@@ -16,6 +17,7 @@ LL | #![warn(multiple_supertrait_upcastable)]
    |
    = note: the `multiple_supertrait_upcastable` lint is unstable
    = help: add `#![feature(multiple_supertrait_upcastable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -6,6 +6,7 @@ LL | #[naked]
    |
    = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
   --> $DIR/feature-gate-naked_functions.rs:11:1
@@ -15,6 +16,7 @@ LL | #[naked]
    |
    = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.stderr
+++ b/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.stderr
@@ -6,6 +6,7 @@ LL | #[link(name = "foo", kind = "dylib", modifiers = "+as-needed")]
    |
    = note: see issue #81490 <https://github.com/rust-lang/rust/issues/81490> for more information
    = help: add `#![feature(native_link_modifiers_as_needed)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-needs-allocator.stderr
+++ b/tests/ui/feature-gates/feature-gate-needs-allocator.stderr
@@ -5,6 +5,7 @@ LL | #![needs_allocator]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(allocator_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -29,6 +29,7 @@ LL |     let (Ok(_x) | Err(&!)) = res.as_ref();
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `!` patterns are experimental
   --> $DIR/feature-gate-never_patterns.rs:15:13
@@ -38,6 +39,7 @@ LL |             !
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `!` patterns are experimental
   --> $DIR/feature-gate-never_patterns.rs:21:13
@@ -47,6 +49,7 @@ LL |             !
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `!` patterns are experimental
   --> $DIR/feature-gate-never_patterns.rs:26:13
@@ -56,6 +59,7 @@ LL |             ! => {}
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:39:9
@@ -83,6 +87,7 @@ LL |         Err(!),
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `!` patterns are experimental
   --> $DIR/feature-gate-never_patterns.rs:55:13
@@ -92,6 +97,7 @@ LL |         Err(!) if false,
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:65:9

--- a/tests/ui/feature-gates/feature-gate-never_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_type.stderr
@@ -6,6 +6,7 @@ LL | type Ma = (u32, !, i32);
    |
    = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:8:20
@@ -15,6 +16,7 @@ LL | type Meeshka = Vec<!>;
    |
    = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:9:24
@@ -24,6 +26,7 @@ LL | type Mow = &'static fn(!) -> !;
    |
    = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:10:27
@@ -33,6 +36,7 @@ LL | type Skwoz = &'static mut !;
    |
    = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:13:16
@@ -42,6 +46,7 @@ LL |     type Wub = !;
    |
    = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
    = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-no_core.stderr
+++ b/tests/ui/feature-gates/feature-gate-no_core.stderr
@@ -6,6 +6,7 @@ LL | #![no_core]
    |
    = note: see issue #29639 <https://github.com/rust-lang/rust/issues/29639> for more information
    = help: add `#![feature(no_core)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-no_sanitize.stderr
+++ b/tests/ui/feature-gates/feature-gate-no_sanitize.stderr
@@ -6,6 +6,7 @@ LL | #[no_sanitize(address)]
    |
    = note: see issue #39699 <https://github.com/rust-lang/rust/issues/39699> for more information
    = help: add `#![feature(no_sanitize)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
@@ -7,6 +7,7 @@ LL | #![deny(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
@@ -18,6 +19,7 @@ LL | #![allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:15:5
@@ -28,6 +30,7 @@ LL |     #[allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:15:5
@@ -38,6 +41,7 @@ LL |     #[allow(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
@@ -49,6 +53,7 @@ LL |     #[warn(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: unknown lint: `non_exhaustive_omitted_patterns`
   --> $DIR/feature-gate-non_exhaustive_omitted_patterns_lint.rs:24:5
@@ -59,6 +64,7 @@ LL |     #[warn(non_exhaustive_omitted_patterns)]
    = note: the `non_exhaustive_omitted_patterns` lint is unstable
    = note: see issue #89554 <https://github.com/rust-lang/rust/issues/89554> for more information
    = help: add `#![feature(non_exhaustive_omitted_patterns_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0004]: non-exhaustive patterns: `Foo::C` not covered

--- a/tests/ui/feature-gates/feature-gate-non_lifetime_binders.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_lifetime_binders.stderr
@@ -6,6 +6,7 @@ LL | fn foo() where for<T> T:, {}
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-offset-of-enum.stderr
+++ b/tests/ui/feature-gates/feature-gate-offset-of-enum.stderr
@@ -15,6 +15,7 @@ LL |     offset_of!(Alpha, One);
    |
    = note: see issue #106655 <https://github.com/rust-lang/rust/issues/106655> for more information
    = help: add `#![feature(offset_of_enum)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0795]: `One` is an enum variant; expected field at end of `offset_of`
   --> $DIR/feature-gate-offset-of-enum.rs:12:23
@@ -30,6 +31,7 @@ LL |     offset_of!(Alpha, Two.0);
    |
    = note: see issue #106655 <https://github.com/rust-lang/rust/issues/106655> for more information
    = help: add `#![feature(offset_of_enum)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-omit-gdb-pretty-printer-section.stderr
+++ b/tests/ui/feature-gates/feature-gate-omit-gdb-pretty-printer-section.stderr
@@ -5,6 +5,7 @@ LL | #[omit_gdb_pretty_printer_section]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(omit_gdb_pretty_printer_section)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-optimize_attribute.stderr
+++ b/tests/ui/feature-gates/feature-gate-optimize_attribute.stderr
@@ -6,6 +6,7 @@ LL | #[optimize(size)]
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
   --> $DIR/feature-gate-optimize_attribute.rs:10:1
@@ -15,6 +16,7 @@ LL | #[optimize(speed)]
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
   --> $DIR/feature-gate-optimize_attribute.rs:13:1
@@ -24,6 +26,7 @@ LL | #[optimize(banana)]
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
   --> $DIR/feature-gate-optimize_attribute.rs:4:1
@@ -33,6 +36,7 @@ LL | #[optimize(size)]
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[optimize]` attribute is an experimental feature
   --> $DIR/feature-gate-optimize_attribute.rs:2:1
@@ -42,6 +46,7 @@ LL | #![optimize(speed)]
    |
    = note: see issue #54882 <https://github.com/rust-lang/rust/issues/54882> for more information
    = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0722]: invalid argument
   --> $DIR/feature-gate-optimize_attribute.rs:13:12

--- a/tests/ui/feature-gates/feature-gate-prelude_import.stderr
+++ b/tests/ui/feature-gates/feature-gate-prelude_import.stderr
@@ -5,6 +5,7 @@ LL | #[prelude_import]
    | ^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(prelude_import)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-proc_macro_byte_character.stderr
+++ b/tests/ui/feature-gates/feature-gate-proc_macro_byte_character.stderr
@@ -6,6 +6,7 @@ LL |     Literal::byte_character(b'a');
    |
    = note: see issue #115268 <https://github.com/rust-lang/rust/issues/115268> for more information
    = help: add `#![feature(proc_macro_byte_character)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-profiler-runtime.stderr
+++ b/tests/ui/feature-gates/feature-gate-profiler-runtime.stderr
@@ -5,6 +5,7 @@ LL | #![profiler_runtime]
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(profiler_runtime)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-register_tool.stderr
+++ b/tests/ui/feature-gates/feature-gate-register_tool.stderr
@@ -6,6 +6,7 @@ LL | #![register_tool(tool)]
    |
    = note: see issue #66079 <https://github.com/rust-lang/rust/issues/66079> for more information
    = help: add `#![feature(register_tool)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -6,6 +6,7 @@ LL | #[repr(simd)]
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: SIMD types are experimental and possibly buggy
   --> $DIR/feature-gate-repr-simd.rs:6:1
@@ -15,6 +16,7 @@ LL | #[repr(simd)]
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0566]: conflicting representation hints
   --> $DIR/feature-gate-repr-simd.rs:4:8

--- a/tests/ui/feature-gates/feature-gate-repr128.stderr
+++ b/tests/ui/feature-gates/feature-gate-repr128.stderr
@@ -6,6 +6,7 @@ LL | enum A {
    |
    = note: see issue #56071 <https://github.com/rust-lang/rust/issues/56071> for more information
    = help: add `#![feature(repr128)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.cfg.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Trait<m(): Send>>() {}
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: parenthesized generic arguments cannot be used in associated type constraints
   --> $DIR/feature-gate-return_type_notation.rs:14:17

--- a/tests/ui/feature-gates/feature-gate-return_type_notation.no.stderr
+++ b/tests/ui/feature-gates/feature-gate-return_type_notation.no.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Trait<m(): Send>>() {}
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/feature-gates/feature-gate-rust_cold_cc.stderr
+++ b/tests/ui/feature-gates/feature-gate-rust_cold_cc.stderr
@@ -6,6 +6,7 @@ LL | extern "rust-cold" fn fu() {}
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-cold is experimental and subject to change
   --> $DIR/feature-gate-rust_cold_cc.rs:6:12
@@ -15,6 +16,7 @@ LL |     extern "rust-cold" fn mu();
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-cold is experimental and subject to change
   --> $DIR/feature-gate-rust_cold_cc.rs:7:12
@@ -24,6 +26,7 @@ LL |     extern "rust-cold" fn dmu() {}
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-cold is experimental and subject to change
   --> $DIR/feature-gate-rust_cold_cc.rs:12:12
@@ -33,6 +36,7 @@ LL |     extern "rust-cold" fn mu() {}
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-cold is experimental and subject to change
   --> $DIR/feature-gate-rust_cold_cc.rs:16:12
@@ -42,6 +46,7 @@ LL |     extern "rust-cold" fn imu() {}
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-cold is experimental and subject to change
   --> $DIR/feature-gate-rust_cold_cc.rs:19:19
@@ -51,6 +56,7 @@ LL | type TAU = extern "rust-cold" fn();
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-cold is experimental and subject to change
   --> $DIR/feature-gate-rust_cold_cc.rs:21:8
@@ -60,6 +66,7 @@ LL | extern "rust-cold" {}
    |
    = note: see issue #97544 <https://github.com/rust-lang/rust/issues/97544> for more information
    = help: add `#![feature(rust_cold_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
@@ -6,6 +6,7 @@ LL | #[rustc_allow_const_fn_unstable()]
    |
    = note: see issue #69399 <https://github.com/rust-lang/rust/issues/69399> for more information
    = help: add `#![feature(rustc_allow_const_fn_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_variance]
    | ^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
   --> $DIR/feature-gate-rustc-attrs-1.rs:4:1
@@ -13,6 +14,7 @@ LL | #[rustc_error]
    | ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to enable niche optimizations in libcore and libstd and will never be stable
   --> $DIR/feature-gate-rustc-attrs-1.rs:5:1
@@ -21,6 +23,7 @@ LL | #[rustc_nonnull_optimization_guaranteed]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-rustc-attrs.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc-attrs.stderr
@@ -41,6 +41,7 @@ LL | #[rustc_dummy]
    | ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-rustdoc_internals.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustdoc_internals.stderr
@@ -6,6 +6,7 @@ LL | #[doc(keyword = "match")]
    |
    = note: see issue #90418 <https://github.com/rust-lang/rust/issues/90418> for more information
    = help: add `#![feature(rustdoc_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[doc(fake_variadic)]` is meant for internal use only
   --> $DIR/feature-gate-rustdoc_internals.rs:7:1
@@ -15,6 +16,7 @@ LL | #[doc(fake_variadic)]
    |
    = note: see issue #90418 <https://github.com/rust-lang/rust/issues/90418> for more information
    = help: add `#![feature(rustdoc_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-simd.stderr
@@ -6,6 +6,7 @@ LL | #[repr(simd)]
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-start.stderr
+++ b/tests/ui/feature-gates/feature-gate-start.stderr
@@ -6,6 +6,7 @@ LL | fn foo(_: isize, _: *const *const u8) -> isize { 0 }
    |
    = note: see issue #29633 <https://github.com/rust-lang/rust/issues/29633> for more information
    = help: add `#![feature(start)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
+++ b/tests/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
@@ -6,6 +6,7 @@ LL | const X: i32 = #[allow(dead_code)] 8;
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-strict_provenance.stderr
+++ b/tests/ui/feature-gates/feature-gate-strict_provenance.stderr
@@ -7,6 +7,7 @@ LL | #![deny(fuzzy_provenance_casts)]
    = note: the `fuzzy_provenance_casts` lint is unstable
    = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
    = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: unknown lint: `lossy_provenance_casts`
@@ -18,6 +19,7 @@ LL | #![deny(lossy_provenance_casts)]
    = note: the `lossy_provenance_casts` lint is unstable
    = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
    = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/feature-gate-test_unstable_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-test_unstable_lint.stderr
@@ -6,6 +6,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/feature-gates/feature-gate-thread_local.stderr
+++ b/tests/ui/feature-gates/feature-gate-thread_local.stderr
@@ -6,6 +6,7 @@ LL | #[thread_local]
    |
    = note: see issue #29594 <https://github.com/rust-lang/rust/issues/29594> for more information
    = help: add `#![feature(thread_local)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-trace_macros.stderr
+++ b/tests/ui/feature-gates/feature-gate-trace_macros.stderr
@@ -6,6 +6,7 @@ LL |     trace_macros!(true);
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-trait-alias.stderr
+++ b/tests/ui/feature-gates/feature-gate-trait-alias.stderr
@@ -6,6 +6,7 @@ LL | trait Foo = Default;
    |
    = note: see issue #41517 <https://github.com/rust-lang/rust/issues/41517> for more information
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-transparent_unions.stderr
+++ b/tests/ui/feature-gates/feature-gate-transparent_unions.stderr
@@ -6,6 +6,7 @@ LL | union OkButUnstableUnion {
    |
    = note: see issue #60405 <https://github.com/rust-lang/rust/issues/60405> for more information
    = help: add `#![feature(transparent_unions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-try_blocks.stderr
+++ b/tests/ui/feature-gates/feature-gate-try_blocks.stderr
@@ -10,6 +10,7 @@ LL | |     };
    |
    = note: see issue #31436 <https://github.com/rust-lang/rust/issues/31436> for more information
    = help: add `#![feature(try_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-type_ascription.stderr
+++ b/tests/ui/feature-gates/feature-gate-type_ascription.stderr
@@ -6,6 +6,7 @@ LL |     let a = type_ascribe!(10, u8);
    |
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
    = help: add `#![feature(type_ascription)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-type_privacy_lints.stderr
+++ b/tests/ui/feature-gates/feature-gate-type_privacy_lints.stderr
@@ -7,6 +7,7 @@ LL | #![warn(unnameable_types)]
    = note: the `unnameable_types` lint is unstable
    = note: see issue #48054 <https://github.com/rust-lang/rust/issues/48054> for more information
    = help: add `#![feature(type_privacy_lints)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -6,6 +6,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:22:12
@@ -15,6 +16,7 @@ LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:12
@@ -24,6 +26,7 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:39:12
@@ -33,6 +36,7 @@ LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
@@ -42,6 +46,7 @@ LL | impl Fn<()> for Foo {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0183]: manual implementations of `Fn` are experimental
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
@@ -79,6 +84,7 @@ LL | impl FnMut<()> for Bar {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0183]: manual implementations of `FnMut` are experimental
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
@@ -96,6 +102,7 @@ LL | impl FnOnce<()> for Baz {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0183]: manual implementations of `FnOnce` are experimental
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
@@ -6,6 +6,7 @@ LL |     f.call(());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:5:7
@@ -15,6 +16,7 @@ LL |     f.call_mut(());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:6:7
@@ -24,6 +26,7 @@ LL |     f.call_once(());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
@@ -6,6 +6,7 @@ LL |     Fn::call(&f, ());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:5:5
@@ -15,6 +16,7 @@ LL |     FnMut::call_mut(&mut f, ());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:6:5
@@ -24,6 +26,7 @@ LL |     FnOnce::call_once(f, ());
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -6,6 +6,7 @@ LL |     extern "rust-call" fn call_once(self, (a, b): (u32, u32)) -> u32 {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures.rs:5:6
@@ -15,6 +16,7 @@ LL | impl FnOnce<(u32, u32)> for Test {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0183]: manual implementations of `FnOnce` are experimental
   --> $DIR/feature-gate-unboxed-closures.rs:5:6

--- a/tests/ui/feature-gates/feature-gate-unix_sigpipe.stderr
+++ b/tests/ui/feature-gates/feature-gate-unix_sigpipe.stderr
@@ -6,6 +6,7 @@ LL | #[unix_sigpipe = "inherit"]
    |
    = note: see issue #97889 <https://github.com/rust-lang/rust/issues/97889> for more information
    = help: add `#![feature(unix_sigpipe)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-unnamed_fields.stderr
+++ b/tests/ui/feature-gates/feature-gate-unnamed_fields.stderr
@@ -6,6 +6,7 @@ LL |     _: union {
    |
    = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
    = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: unnamed fields are not yet fully implemented
   --> $DIR/feature-gate-unnamed_fields.rs:3:8
@@ -21,6 +22,7 @@ LL | |     }
    |
    = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
    = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: unnamed fields are not yet fully implemented
   --> $DIR/feature-gate-unnamed_fields.rs:13:5
@@ -30,6 +32,7 @@ LL |     _: struct {
    |
    = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
    = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: unnamed fields are not yet fully implemented
   --> $DIR/feature-gate-unnamed_fields.rs:13:8
@@ -45,6 +48,7 @@ LL | |     }
    |
    = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
    = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: unnamed fields are not yet fully implemented
   --> $DIR/feature-gate-unnamed_fields.rs:23:5
@@ -54,6 +58,7 @@ LL |     _: S
    |
    = note: see issue #49804 <https://github.com/rust-lang/rust/issues/49804> for more information
    = help: add `#![feature(unnamed_fields)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: anonymous unions are unimplemented
   --> $DIR/feature-gate-unnamed_fields.rs:3:8

--- a/tests/ui/feature-gates/feature-gate-unsized_tuple_coercion.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_tuple_coercion.stderr
@@ -6,6 +6,7 @@ LL |     let _ : &(dyn Send,) = &((),);
    |
    = note: see issue #42877 <https://github.com/rust-lang/rust/issues/42877> for more information
    = help: add `#![feature(unsized_tuple_coercion)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-used_with_arg.stderr
+++ b/tests/ui/feature-gates/feature-gate-used_with_arg.stderr
@@ -6,6 +6,7 @@ LL | #[used(linker)]
    |
    = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
    = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `#[used(compiler)]` is currently unstable
   --> $DIR/feature-gate-used_with_arg.rs:4:1
@@ -15,6 +16,7 @@ LL | #[used(compiler)]
    |
    = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
    = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-vectorcall.stderr
+++ b/tests/ui/feature-gates/feature-gate-vectorcall.stderr
@@ -5,6 +5,7 @@ LL | extern "vectorcall" fn f() {}
    |        ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-vectorcall.rs:15:12
@@ -13,6 +14,7 @@ LL |     extern "vectorcall" fn m();
    |            ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-vectorcall.rs:17:12
@@ -21,6 +23,7 @@ LL |     extern "vectorcall" fn dm() {}
    |            ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-vectorcall.rs:22:12
@@ -29,6 +32,7 @@ LL |     extern "vectorcall" fn m() {}
    |            ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-vectorcall.rs:26:12
@@ -37,6 +41,7 @@ LL |     extern "vectorcall" fn im() {}
    |            ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-vectorcall.rs:29:18
@@ -45,6 +50,7 @@ LL | type TA = extern "vectorcall" fn();
    |                  ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-vectorcall.rs:31:8
@@ -53,6 +59,7 @@ LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^
    |
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-wasm_abi.stderr
+++ b/tests/ui/feature-gates/feature-gate-wasm_abi.stderr
@@ -6,6 +6,7 @@ LL | extern "wasm" fn fu() {}
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: wasm ABI is experimental and subject to change
   --> $DIR/feature-gate-wasm_abi.rs:11:12
@@ -15,6 +16,7 @@ LL |     extern "wasm" fn mu();
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: wasm ABI is experimental and subject to change
   --> $DIR/feature-gate-wasm_abi.rs:12:12
@@ -24,6 +26,7 @@ LL |     extern "wasm" fn dmu() {}
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: wasm ABI is experimental and subject to change
   --> $DIR/feature-gate-wasm_abi.rs:17:12
@@ -33,6 +36,7 @@ LL |     extern "wasm" fn mu() {}
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: wasm ABI is experimental and subject to change
   --> $DIR/feature-gate-wasm_abi.rs:21:12
@@ -42,6 +46,7 @@ LL |     extern "wasm" fn imu() {}
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: wasm ABI is experimental and subject to change
   --> $DIR/feature-gate-wasm_abi.rs:24:19
@@ -51,6 +56,7 @@ LL | type TAU = extern "wasm" fn();
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: wasm ABI is experimental and subject to change
   --> $DIR/feature-gate-wasm_abi.rs:26:8
@@ -60,6 +66,7 @@ LL | extern "wasm" {}
    |
    = note: see issue #83788 <https://github.com/rust-lang/rust/issues/83788> for more information
    = help: add `#![feature(wasm_abi)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-yeet_expr-in-cfg.stderr
+++ b/tests/ui/feature-gates/feature-gate-yeet_expr-in-cfg.stderr
@@ -6,6 +6,7 @@ LL |         do yeet
    |
    = note: see issue #96373 <https://github.com/rust-lang/rust/issues/96373> for more information
    = help: add `#![feature(yeet_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `do yeet` expression is experimental
   --> $DIR/feature-gate-yeet_expr-in-cfg.rs:14:5
@@ -15,6 +16,7 @@ LL |     do yeet "hello";
    |
    = note: see issue #96373 <https://github.com/rust-lang/rust/issues/96373> for more information
    = help: add `#![feature(yeet_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-yeet_expr.stderr
+++ b/tests/ui/feature-gates/feature-gate-yeet_expr.stderr
@@ -6,6 +6,7 @@ LL |     do yeet
    |
    = note: see issue #96373 <https://github.com/rust-lang/rust/issues/96373> for more information
    = help: add `#![feature(yeet_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `do yeet` expression is experimental
   --> $DIR/feature-gate-yeet_expr.rs:8:5
@@ -15,6 +16,7 @@ LL |     do yeet "hello";
    |
    = note: see issue #96373 <https://github.com/rust-lang/rust/issues/96373> for more information
    = help: add `#![feature(yeet_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
@@ -5,6 +5,7 @@ LL |         extern "rust-intrinsic" {
    |                ^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.rs
@@ -13,6 +13,7 @@
 //~^ ERROR: `macro_export` attribute cannot be used at crate level
 #![rustc_main] //~ ERROR: the `#[rustc_main]` attribute is used internally to specify
 //~^ ERROR: `rustc_main` attribute cannot be used at crate level
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 #![start]
 //~^ ERROR: `start` attribute cannot be used at crate level
 #![repr()]

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -5,9 +5,10 @@ LL | #![rustc_main]
    | ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: attribute must be of the form `#[inline]` or `#[inline(always|never)]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:46:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:47:5
    |
 LL |     #[inline = "2100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^
@@ -17,37 +18,37 @@ LL |     #[inline = "2100"] fn f() { }
    = note: `#[deny(ill_formed_attribute_input)]` on by default
 
 error: `start` attribute can only be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:125:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:126:1
    |
 LL | #[start]
    | ^^^^^^^^
 
 error: `start` attribute can only be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:128:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:129:17
    |
 LL |     mod inner { #![start] }
    |                 ^^^^^^^^^
 
 error: `start` attribute can only be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:133:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:134:5
    |
 LL |     #[start] struct S;
    |     ^^^^^^^^
 
 error: `start` attribute can only be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:136:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:137:5
    |
 LL |     #[start] type T = S;
    |     ^^^^^^^^
 
 error: `start` attribute can only be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:139:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:140:5
    |
 LL |     #[start] impl S { }
    |     ^^^^^^^^
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:31:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:32:1
    |
 LL |   #[inline]
    |   ^^^^^^^^^
@@ -62,7 +63,7 @@ LL | | }
    | |_- not a function or closure
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:65:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:66:1
    |
 LL |   #[no_link]
    |   ^^^^^^^^^^
@@ -77,7 +78,7 @@ LL | | }
    | |_- not an `extern crate` item
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:91:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:92:1
    |
 LL |   #[export_name = "2200"]
    |   ^^^^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +93,7 @@ LL | | }
    | |_- not a free function, impl method or static
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:143:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:144:8
    |
 LL |   #[repr(C)]
    |          ^
@@ -107,19 +108,19 @@ LL | | }
    | |_- not a struct, enum, or union
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:25:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:26:1
    |
 LL | #![no_link]
    | ^^^^^^^^^^^ not an `extern crate` item
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:27:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:28:1
    |
 LL | #![export_name = "2200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^ not a free function, impl method or static
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:29:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:30:1
    |
 LL | #![inline]
    | ^^^^^^^^^^ not a function or closure
@@ -155,7 +156,7 @@ LL + #[rustc_main]
    |
 
 error: `start` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:16:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:17:1
    |
 LL | #![start]
    | ^^^^^^^^^
@@ -170,7 +171,7 @@ LL + #[start]
    |
 
 error: `repr` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:18:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:19:1
    |
 LL | #![repr()]
    | ^^^^^^^^^^
@@ -185,7 +186,7 @@ LL + #[repr()]
    |
 
 error: `path` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:20:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:21:1
    |
 LL | #![path = "3800"]
    | ^^^^^^^^^^^^^^^^^
@@ -200,7 +201,7 @@ LL + #[path = "3800"]
    |
 
 error: `automatically_derived` attribute cannot be used at crate level
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:22:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:23:1
    |
 LL | #![automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,115 +216,115 @@ LL + #[automatically_derived]
    |
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:42:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:43:17
    |
 LL |     mod inner { #![inline] }
    |     ------------^^^^^^^^^^-- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:52:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:53:5
    |
 LL |     #[inline] struct S;
    |     ^^^^^^^^^ --------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:56:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:57:5
    |
 LL |     #[inline] type T = S;
    |     ^^^^^^^^^ ----------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:60:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:61:5
    |
 LL |     #[inline] impl S { }
    |     ^^^^^^^^^ ---------- not a function or closure
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:70:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:71:17
    |
 LL |     mod inner { #![no_link] }
    |     ------------^^^^^^^^^^^-- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:74:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:75:5
    |
 LL |     #[no_link] fn f() { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:78:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:79:5
    |
 LL |     #[no_link] struct S;
    |     ^^^^^^^^^^ --------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:82:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:83:5
    |
 LL |     #[no_link]type T = S;
    |     ^^^^^^^^^^----------- not an `extern crate` item
 
 error: attribute should be applied to an `extern crate` item
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:86:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:87:5
    |
 LL |     #[no_link] impl S { }
    |     ^^^^^^^^^^ ---------- not an `extern crate` item
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:96:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:97:17
    |
 LL |     mod inner { #![export_name="2200"] }
    |     ------------^^^^^^^^^^^^^^^^^^^^^^-- not a free function, impl method or static
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:102:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:103:5
    |
 LL |     #[export_name = "2200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ --------- not a free function, impl method or static
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:106:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:107:5
    |
 LL |     #[export_name = "2200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ ----------- not a free function, impl method or static
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:110:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:111:5
    |
 LL |     #[export_name = "2200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^ ---------- not a free function, impl method or static
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:115:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:116:9
    |
 LL |         #[export_name = "2200"] fn foo();
    |         ^^^^^^^^^^^^^^^^^^^^^^^ --------- not a free function, impl method or static
 
 error: attribute should be applied to a free function, impl method or static
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:119:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:120:9
    |
 LL |         #[export_name = "2200"] fn bar() {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^ ----------- not a free function, impl method or static
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:147:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:148:25
    |
 LL |     mod inner { #![repr(C)] }
    |     --------------------^---- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:151:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:152:12
    |
 LL |     #[repr(C)] fn f() { }
    |            ^   ---------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:157:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:158:12
    |
 LL |     #[repr(C)] type T = S;
    |            ^   ----------- not a struct, enum, or union
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:161:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:162:12
    |
 LL |     #[repr(C)] impl S { }
    |            ^   ---------- not a struct, enum, or union

--- a/tests/ui/feature-gates/issue-43106-gating-of-derive.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-derive.stderr
@@ -21,6 +21,7 @@ LL |     mod inner { #![derive(Debug)] }
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0774]: `derive` may only be applied to `struct`s, `enum`s and `union`s
   --> $DIR/issue-43106-gating-of-derive.rs:7:17

--- a/tests/ui/feature-gates/issue-49983-see-issue-0.stderr
+++ b/tests/ui/feature-gates/issue-49983-see-issue-0.stderr
@@ -5,6 +5,7 @@ LL | #[allow(unused_imports)] use core::ptr::Unique;
    |                              ^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(ptr_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/rustc-private.stderr
+++ b/tests/ui/feature-gates/rustc-private.stderr
@@ -6,6 +6,7 @@ LL | extern crate libc;
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/soft-syntax-gates-with-errors.stderr
+++ b/tests/ui/feature-gates/soft-syntax-gates-with-errors.stderr
@@ -6,6 +6,7 @@ LL | macro a() {}
    |
    = note: see issue #39412 <https://github.com/rust-lang/rust/issues/39412> for more information
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `macro` is experimental
   --> $DIR/soft-syntax-gates-with-errors.rs:16:5
@@ -15,6 +16,7 @@ LL |     macro c() {}
    |
    = note: see issue #39412 <https://github.com/rust-lang/rust/issues/39412> for more information
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/soft-syntax-gates-without-errors.stderr
+++ b/tests/ui/feature-gates/soft-syntax-gates-without-errors.stderr
@@ -6,6 +6,7 @@ LL | macro b() {}
    |
    = note: see issue #39412 <https://github.com/rust-lang/rust/issues/39412> for more information
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 
@@ -17,6 +18,7 @@ LL |     macro e() {}
    |
    = note: see issue #39412 <https://github.com/rust-lang/rust/issues/39412> for more information
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/feature-gates/trace_macros-gate.stderr
+++ b/tests/ui/feature-gates/trace_macros-gate.stderr
@@ -6,6 +6,7 @@ LL |     trace_macros!();
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-gate.rs:4:5
@@ -21,6 +22,7 @@ LL |     trace_macros!(true);
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:7:5
@@ -30,6 +32,7 @@ LL |     trace_macros!(false);
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:10:26
@@ -42,6 +45,7 @@ LL |     expando!(true);
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `expando` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors

--- a/tests/ui/generic-const-items/feature-gate-generic_const_items.stderr
+++ b/tests/ui/generic-const-items/feature-gate-generic_const_items.stderr
@@ -6,6 +6,7 @@ LL |     const ONE<T>: i32;
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:6:5
@@ -16,6 +17,7 @@ LL | |         A: Copy;
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:11:12
@@ -25,6 +27,7 @@ LL | const CONST<T>: i32 = 0;
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:14:12
@@ -34,6 +37,7 @@ LL | const EMPTY<>: i32 = 0;
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:18:1
@@ -44,6 +48,7 @@ LL | |     String: Clone;
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:28:22
@@ -53,6 +58,7 @@ LL | discard! { const FREE<T>: () = (); }
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:31:33
@@ -62,6 +68,7 @@ LL | discard! { impl () { const ASSOC<const N: ()>: () = (); } }
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/feature-gate-generic_const_items.rs:34:43
@@ -71,6 +78,7 @@ LL | discard! { impl () { const ASSOC: i32 = 0 where String: Copy; } }
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
@@ -6,6 +6,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    |
    = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
@@ -20,6 +20,7 @@ LL |         if let n @ 2..3|4 = x {
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions1.rs:14:23
@@ -29,6 +30,7 @@ LL |         } else if let 2..3 | 4 = x {
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/half-open-range-patterns/range_pat_interactions3.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions3.stderr
@@ -6,6 +6,7 @@ LL |             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const_pat)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:10:17
@@ -15,6 +16,7 @@ LL |             1 | -3..0 => first_or.push(x),
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:12:18
@@ -24,6 +26,7 @@ LL |             y @ (0..5 | 6) => or_two.push(y),
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:14:17
@@ -33,6 +36,7 @@ LL |             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:18:17
@@ -42,6 +46,7 @@ LL |             y @ ..-7 => assert_eq!(y, -8),
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
@@ -6,6 +6,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    |
    = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/slice_pattern_syntax_problem1.rs:4:23
@@ -15,6 +16,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/slice_pattern_syntax_problem1.rs:4:32
@@ -24,6 +26,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    |
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-wrong-kind.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-wrong-kind.stderr
@@ -6,6 +6,7 @@ LL | fn a() where for<T> T: Copy {}
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: only lifetime parameters can be used in this context
   --> $DIR/hrtb-wrong-kind.rs:4:24
@@ -15,6 +16,7 @@ LL | fn b() where for<const C: usize> [(); C]: Copy {}
    |
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = help: add `#![feature(non_lifetime_binders)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-78722-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722-2.stderr
@@ -25,6 +25,7 @@ LL |         let f: F = async { 1 };
    |
    = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-78722.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722.stderr
@@ -6,6 +6,7 @@ LL |         let f: F = async { 1 };
    |
    = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0271]: expected `{async block@$DIR/issue-78722.rs:10:13: 10:21}` to be a future that resolves to `u8`, but it resolves to `()`
   --> $DIR/issue-78722.rs:8:30

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -24,6 +24,7 @@ LL |     type Out = impl Debug;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl Trait` in type aliases is unstable
   --> $DIR/where-allowed.rs:154:23
@@ -33,6 +34,7 @@ LL | type InTypeAlias<R> = impl Debug;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl Trait` in type aliases is unstable
   --> $DIR/where-allowed.rs:157:39
@@ -42,6 +44,7 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer parameters
   --> $DIR/where-allowed.rs:18:40

--- a/tests/ui/imports/issue-37887.stderr
+++ b/tests/ui/imports/issue-37887.stderr
@@ -14,6 +14,7 @@ LL |     extern crate libc;
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/inference/inference_unstable_forced.stderr
+++ b/tests/ui/inference/inference_unstable_forced.stderr
@@ -6,6 +6,7 @@ LL |     assert_eq!('x'.ipu_flatten(), 0);
    |
    = note: see issue #99999 <https://github.com/rust-lang/rust/issues/99999> for more information
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/internal/internal-unstable-noallow.stderr
+++ b/tests/ui/internal/internal-unstable-noallow.stderr
@@ -5,6 +5,7 @@ LL |     call_unstable_noallow!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `call_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'struct_field'
@@ -14,6 +15,7 @@ LL |     construct_unstable_noallow!(0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(struct_field)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `construct_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'method'
@@ -23,6 +25,7 @@ LL |     |x: internal_unstable::Foo| { call_method_noallow!(x) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(method)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `call_method_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'struct2_field'
@@ -32,6 +35,7 @@ LL |     |x: internal_unstable::Bar| { access_field_noallow!(x) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(struct2_field)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `access_field_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/tests/ui/internal/internal-unstable-thread-local.stderr
+++ b/tests/ui/internal/internal-unstable-thread-local.stderr
@@ -5,6 +5,7 @@ LL | thread_local!(static BAR: () = internal_unstable::unstable());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/internal/internal-unstable.stderr
+++ b/tests/ui/internal/internal-unstable.stderr
@@ -5,6 +5,7 @@ LL |     pass_through_allow!(internal_unstable::unstable());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:42:27
@@ -13,6 +14,7 @@ LL |     pass_through_noallow!(internal_unstable::unstable());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:46:22
@@ -21,6 +23,7 @@ LL |     println!("{:?}", internal_unstable::unstable());
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:48:10
@@ -29,6 +32,7 @@ LL |     bar!(internal_unstable::unstable());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:18:9
@@ -40,6 +44,7 @@ LL |     bar!(internal_unstable::unstable());
    |     ----------------------------------- in this macro invocation
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `foo` which comes from the expansion of the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors

--- a/tests/ui/intrinsics/feature-gate-safe-intrinsic.stderr
+++ b/tests/ui/intrinsics/feature-gate-safe-intrinsic.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_safe_intrinsic]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: attribute should be applied to intrinsic functions
   --> $DIR/feature-gate-safe-intrinsic.rs:1:1

--- a/tests/ui/intrinsics/unchecked_math_unstable.stderr
+++ b/tests/ui/intrinsics/unchecked_math_unstable.stderr
@@ -5,6 +5,7 @@ LL |         let add = std::intrinsics::unchecked_add(x, y);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:5:19
@@ -13,6 +14,7 @@ LL |         let sub = std::intrinsics::unchecked_sub(x, y);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:6:19
@@ -21,6 +23,7 @@ LL |         let mul = std::intrinsics::unchecked_mul(x, y);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-20313.stderr
+++ b/tests/ui/issues/issue-20313.stderr
@@ -6,6 +6,7 @@ LL |     fn sqrt(x: f32) -> f32;
    |
    = note: see issue #29602 <https://github.com/rust-lang/rust/issues/29602> for more information
    = help: add `#![feature(link_llvm_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-23024.stderr
+++ b/tests/ui/issues/issue-23024.stderr
@@ -6,6 +6,7 @@ LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0107]: missing generics for trait `Fn`
   --> $DIR/issue-23024.rs:8:39

--- a/tests/ui/issues/issue-32782.stderr
+++ b/tests/ui/issues/issue-32782.stderr
@@ -8,6 +8,7 @@ LL | foo!();
    | ------ in this macro invocation
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-50582.stderr
+++ b/tests/ui/issues/issue-50582.stderr
@@ -6,6 +6,7 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0277]: cannot add `()` to `{integer}`
   --> $DIR/issue-50582.rs:2:18

--- a/tests/ui/issues/issue-50585.stderr
+++ b/tests/ui/issues/issue-50585.stderr
@@ -6,6 +6,7 @@ LL |     |y: Vec<[(); for x in 0..2 {}]>| {};
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
   --> $DIR/issue-50585.rs:2:18

--- a/tests/ui/issues/issue-52489.stderr
+++ b/tests/ui/issues/issue-52489.stderr
@@ -5,6 +5,7 @@ LL | use issue_52489;
    |     ^^^^^^^^^^^
    |
    = help: add `#![feature(issue_52489_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lang-items/issue-83471.stderr
+++ b/tests/ui/lang-items/issue-83471.stderr
@@ -11,6 +11,7 @@ LL | #[lang = "sized"]
    | ^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: language items are subject to change
   --> $DIR/issue-83471.rs:11:1
@@ -19,6 +20,7 @@ LL | #[lang = "fn"]
    | ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: anonymous parameters are deprecated and will be removed in the next edition
   --> $DIR/issue-83471.rs:15:13

--- a/tests/ui/linkage-attr/linkage4.stderr
+++ b/tests/ui/linkage-attr/linkage4.stderr
@@ -6,6 +6,7 @@ LL | #[linkage = "external"]
    |
    = note: see issue #29603 <https://github.com/rust-lang/rust/issues/29603> for more information
    = help: add `#![feature(linkage)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/lint-output-format.stderr
+++ b/tests/ui/lint/lint-output-format.stderr
@@ -5,6 +5,7 @@ LL | extern crate lint_output_format;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-output-format.rs:7:26
@@ -13,6 +14,7 @@ LL | use lint_output_format::{foo, bar};
    |                          ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-output-format.rs:7:31
@@ -21,6 +23,7 @@ LL | use lint_output_format::{foo, bar};
    |                               ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-output-format.rs:12:14
@@ -29,6 +32,7 @@ LL |     let _y = bar();
    |              ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/lint-stability-2.stderr
+++ b/tests/ui/lint/lint-stability-2.stderr
@@ -5,6 +5,7 @@ LL |         foo.method_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:42:9
@@ -13,6 +14,7 @@ LL |         Foo::method_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:44:9
@@ -21,6 +23,7 @@ LL |         <Foo>::method_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:46:13
@@ -29,6 +32,7 @@ LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:48:9
@@ -37,6 +41,7 @@ LL |         <Foo>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:51:13
@@ -45,6 +50,7 @@ LL |         foo.method_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:53:9
@@ -53,6 +59,7 @@ LL |         Foo::method_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:55:9
@@ -61,6 +68,7 @@ LL |         <Foo>::method_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:57:13
@@ -69,6 +77,7 @@ LL |         foo.trait_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:59:9
@@ -77,6 +86,7 @@ LL |         <Foo>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:62:13
@@ -85,6 +95,7 @@ LL |         foo.method_unstable();
    |             ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:63:9
@@ -93,6 +104,7 @@ LL |         Foo::method_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:64:9
@@ -101,6 +113,7 @@ LL |         <Foo>::method_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:65:13
@@ -109,6 +122,7 @@ LL |         foo.trait_unstable();
    |             ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:66:9
@@ -117,6 +131,7 @@ LL |         <Foo>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:68:13
@@ -125,6 +140,7 @@ LL |         foo.method_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:70:9
@@ -133,6 +149,7 @@ LL |         Foo::method_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:72:9
@@ -141,6 +158,7 @@ LL |         <Foo>::method_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:74:13
@@ -149,6 +167,7 @@ LL |         foo.trait_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:76:9
@@ -157,6 +176,7 @@ LL |         <Foo>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:131:13
@@ -165,6 +185,7 @@ LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:133:9
@@ -173,6 +194,7 @@ LL |         <Foo>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:135:13
@@ -181,6 +203,7 @@ LL |         foo.trait_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:137:9
@@ -189,6 +212,7 @@ LL |         <Foo>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:139:13
@@ -197,6 +221,7 @@ LL |         foo.trait_unstable();
    |             ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:140:9
@@ -205,6 +230,7 @@ LL |         <Foo>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:141:13
@@ -213,6 +239,7 @@ LL |         foo.trait_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:143:9
@@ -221,6 +248,7 @@ LL |         <Foo>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:154:13
@@ -229,6 +257,7 @@ LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:156:13
@@ -237,6 +266,7 @@ LL |         foo.trait_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:158:13
@@ -245,6 +275,7 @@ LL |         foo.trait_unstable();
    |             ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:159:13
@@ -253,6 +284,7 @@ LL |         foo.trait_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 32 previous errors
 

--- a/tests/ui/lint/lint-stability-fields.stderr
+++ b/tests/ui/lint/lint-stability-fields.stderr
@@ -5,6 +5,7 @@ LL |         let x = Unstable {
    |                 ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:66:13
@@ -13,6 +14,7 @@ LL |         let Unstable {
    |             ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:72:13
@@ -21,6 +23,7 @@ LL |         let Unstable
    |             ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:77:17
@@ -29,6 +32,7 @@ LL |         let x = reexport::Unstable2(1, 2, 3);
    |                 ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:79:17
@@ -37,6 +41,7 @@ LL |         let x = Unstable2(1, 2, 3);
    |                 ^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:85:13
@@ -45,6 +50,7 @@ LL |         let Unstable2
    |             ^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:90:13
@@ -53,6 +59,7 @@ LL |         let Unstable2
    |             ^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:95:17
@@ -61,6 +68,7 @@ LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:105:13
@@ -69,6 +77,7 @@ LL |         let Deprecated {
    |             ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:111:13
@@ -77,6 +86,7 @@ LL |         let Deprecated
    |             ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:115:17
@@ -85,6 +95,7 @@ LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:121:13
@@ -93,6 +104,7 @@ LL |         let Deprecated2
    |             ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:126:13
@@ -101,6 +113,7 @@ LL |         let Deprecated2
    |             ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:21:13
@@ -109,6 +122,7 @@ LL |             override1: 2,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:22:13
@@ -117,6 +131,7 @@ LL |             override2: 3,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:27:17
@@ -125,6 +140,7 @@ LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:28:17
@@ -133,6 +149,7 @@ LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:33:13
@@ -141,6 +158,7 @@ LL |             override1: _,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:34:13
@@ -149,6 +167,7 @@ LL |             override2: _,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:43:17
@@ -157,6 +176,7 @@ LL |         let _ = x.1;
    |                 ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:44:17
@@ -165,6 +185,7 @@ LL |         let _ = x.2;
    |                 ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:48:20
@@ -173,6 +194,7 @@ LL |                    _,
    |                    ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:49:20
@@ -181,6 +203,7 @@ LL |                    _,
    |                    ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:57:13
@@ -189,6 +212,7 @@ LL |             inherit: 1,
    |             ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:59:13
@@ -197,6 +221,7 @@ LL |             override2: 3,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:62:17
@@ -205,6 +230,7 @@ LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:64:17
@@ -213,6 +239,7 @@ LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:67:13
@@ -221,6 +248,7 @@ LL |             inherit: _,
    |             ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:69:13
@@ -229,6 +257,7 @@ LL |             override2: _
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:81:17
@@ -237,6 +266,7 @@ LL |         let _ = x.0;
    |                 ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:83:17
@@ -245,6 +275,7 @@ LL |         let _ = x.2;
    |                 ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:86:14
@@ -253,6 +284,7 @@ LL |             (_,
    |              ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:88:14
@@ -261,6 +293,7 @@ LL |              _)
    |              ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:96:13
@@ -269,6 +302,7 @@ LL |             inherit: 1,
    |             ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:98:13
@@ -277,6 +311,7 @@ LL |             override2: 3,
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:101:17
@@ -285,6 +320,7 @@ LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:103:17
@@ -293,6 +329,7 @@ LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:106:13
@@ -301,6 +338,7 @@ LL |             inherit: _,
    |             ^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:108:13
@@ -309,6 +347,7 @@ LL |             override2: _
    |             ^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:117:17
@@ -317,6 +356,7 @@ LL |         let _ = x.0;
    |                 ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:119:17
@@ -325,6 +365,7 @@ LL |         let _ = x.2;
    |                 ^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:122:14
@@ -333,6 +374,7 @@ LL |             (_,
    |              ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:124:14
@@ -341,6 +383,7 @@ LL |              _)
    |              ^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 43 previous errors
 

--- a/tests/ui/lint/lint-stability.stderr
+++ b/tests/ui/lint/lint-stability.stderr
@@ -5,6 +5,7 @@ LL |     extern crate stability_cfg2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:45:9
@@ -13,6 +14,7 @@ LL |         deprecated_unstable();
    |         ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:47:9
@@ -21,6 +23,7 @@ LL |         Trait::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:49:9
@@ -29,6 +32,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:52:9
@@ -37,6 +41,7 @@ LL |         deprecated_unstable_text();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:54:9
@@ -45,6 +50,7 @@ LL |         Trait::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:56:9
@@ -53,6 +59,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:59:9
@@ -61,6 +68,7 @@ LL |         unstable();
    |         ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:60:9
@@ -69,6 +77,7 @@ LL |         Trait::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:61:9
@@ -77,6 +86,7 @@ LL |         <Foo as Trait>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:63:9
@@ -85,6 +95,7 @@ LL |         unstable_text();
    |         ^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:65:9
@@ -93,6 +104,7 @@ LL |         Trait::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:67:9
@@ -101,6 +113,7 @@ LL |         <Foo as Trait>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:99:17
@@ -109,6 +122,7 @@ LL |         let _ = DeprecatedUnstableStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:103:17
@@ -117,6 +131,7 @@ LL |         let _ = UnstableStruct { i: 0 };
    |                 ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:107:17
@@ -125,6 +140,7 @@ LL |         let _ = DeprecatedUnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:109:17
@@ -133,6 +149,7 @@ LL |         let _ = UnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:113:17
@@ -141,6 +158,7 @@ LL |         let _ = Enum::DeprecatedUnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:115:17
@@ -149,6 +167,7 @@ LL |         let _ = Enum::UnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:119:17
@@ -157,6 +176,7 @@ LL |         let _ = DeprecatedUnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:121:17
@@ -165,6 +185,7 @@ LL |         let _ = UnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:130:25
@@ -173,6 +194,7 @@ LL |         macro_test_arg!(deprecated_unstable_text());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:144:9
@@ -181,6 +203,7 @@ LL |         Trait::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:146:9
@@ -189,6 +212,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:148:9
@@ -197,6 +221,7 @@ LL |         Trait::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:150:9
@@ -205,6 +230,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:152:9
@@ -213,6 +239,7 @@ LL |         Trait::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:153:9
@@ -221,6 +248,7 @@ LL |         <Foo as Trait>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:154:9
@@ -229,6 +257,7 @@ LL |         Trait::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:156:9
@@ -237,6 +266,7 @@ LL |         <Foo as Trait>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:172:10
@@ -245,6 +275,7 @@ LL |     impl UnstableTrait for S { }
    |          ^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:174:24
@@ -253,6 +284,7 @@ LL |     trait LocalTrait : UnstableTrait { }
    |                        ^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:179:9
@@ -261,6 +293,7 @@ LL |         fn trait_unstable(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:184:5
@@ -269,6 +302,7 @@ LL |     extern crate inherited_stability;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:185:9
@@ -277,6 +311,7 @@ LL |     use self::inherited_stability::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:188:9
@@ -285,6 +320,7 @@ LL |         unstable();
    |         ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:191:9
@@ -293,6 +329,7 @@ LL |         stable_mod::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:194:9
@@ -301,6 +338,7 @@ LL |         unstable_mod::deprecated();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:195:9
@@ -309,6 +347,7 @@ LL |         unstable_mod::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:197:17
@@ -317,6 +356,7 @@ LL |         let _ = Unstable::UnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:198:17
@@ -325,6 +365,7 @@ LL |         let _ = Unstable::StableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:88:48
@@ -333,6 +374,7 @@ LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
    |                                                ^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:92:13
@@ -341,6 +383,7 @@ LL |             TypeUnstable = u8,
    |             ^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 43 previous errors
 

--- a/tests/ui/lint/must_not_suspend/feature-gate-must_not_suspend.stderr
+++ b/tests/ui/lint/must_not_suspend/feature-gate-must_not_suspend.stderr
@@ -6,6 +6,7 @@ LL | #[must_not_suspend = "You gotta use Umm's, ya know?"]
    |
    = note: see issue #83310 <https://github.com/rust-lang/rust/issues/83310> for more information
    = help: add `#![feature(must_not_suspend)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/must_not_suspend/gated.stderr
+++ b/tests/ui/lint/must_not_suspend/gated.stderr
@@ -7,6 +7,7 @@ LL | #![deny(must_not_suspend)]
    = note: the `must_not_suspend` lint is unstable
    = note: see issue #83310 <https://github.com/rust-lang/rust/issues/83310> for more information
    = help: add `#![feature(must_not_suspend)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: 1 warning emitted

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_missing_feature_gate.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_missing_feature_gate.stderr
@@ -6,6 +6,7 @@ LL | #[expect(unused)]
    |
    = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
    = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
+++ b/tests/ui/lint/unused/unused-doc-comments-edge-cases.stderr
@@ -12,6 +12,7 @@ LL |     /// useless doc comment
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: `///` is for documentation comments. For a plain comment, use `//`.
 
 error: unused doc comment

--- a/tests/ui/macros/issue-68060.rs
+++ b/tests/ui/macros/issue-68060.rs
@@ -8,6 +8,7 @@ fn main() {
             #[track_caller]
             //~^ ERROR: `#[track_caller]` on closures is currently unstable
             //~| NOTE: see issue #87417
+            //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
             |_| (),
             //~^ NOTE: not a function
         )

--- a/tests/ui/macros/issue-68060.stderr
+++ b/tests/ui/macros/issue-68060.stderr
@@ -21,6 +21,7 @@ LL |             #[track_caller]
    |
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/macro-stability.stderr
+++ b/tests/ui/macros/macro-stability.stderr
@@ -5,6 +5,7 @@ LL |     local_unstable!();
    |     ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'local_unstable'
   --> $DIR/macro-stability.rs:23:5
@@ -13,6 +14,7 @@ LL |     local_unstable_modern!();
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_macros'
   --> $DIR/macro-stability.rs:24:5
@@ -21,6 +23,7 @@ LL |     unstable_macro!();
    |     ^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_macros)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: use of deprecated macro `deprecated_macro`: deprecation note
   --> $DIR/macro-stability.rs:27:5

--- a/tests/ui/macros/rfc-3086-metavar-expr/required-feature.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/required-feature.stderr
@@ -6,6 +6,7 @@ LL |         ${ count($e) }
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:11:16
@@ -15,6 +16,7 @@ LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:11:20
@@ -24,6 +26,7 @@ LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:11:39
@@ -33,6 +36,7 @@ LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:11:43
@@ -42,6 +46,7 @@ LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:22:13
@@ -51,6 +56,7 @@ LL |         $( ${ignore($e)} ${index()} )*
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:22:27
@@ -60,6 +66,7 @@ LL |         $( ${ignore($e)} ${index()} )*
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:30:19
@@ -69,6 +76,7 @@ LL |         0 $( + 1 ${ignore($i)} )*
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:37:13
@@ -78,6 +86,7 @@ LL |         $( ${ignore($e)} ${length()} )*
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: meta-variable expressions are unstable
   --> $DIR/required-feature.rs:37:27
@@ -87,6 +96,7 @@ LL |         $( ${ignore($e)} ${length()} )*
    |
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/never_type/issue-52443.stderr
+++ b/tests/ui/never_type/issue-52443.stderr
@@ -14,6 +14,7 @@ LL |     [(); { for _ in 0usize.. {}; 0}];
    |
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
   --> $DIR/issue-52443.rs:2:10
@@ -59,6 +60,7 @@ LL |     [(); { for _ in 0usize.. {}; 0}];
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0015]: cannot call non-const fn `<RangeFrom<usize> as Iterator>::next` in constants
   --> $DIR/issue-52443.rs:9:21

--- a/tests/ui/offset-of/offset-of-unstable.stderr
+++ b/tests/ui/offset-of/offset-of-unstable.stderr
@@ -5,6 +5,7 @@ LL |         Unstable,
    |         ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/offset-of-unstable.rs:23:9
@@ -13,6 +14,7 @@ LL |         UnstableWithStableFieldType,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/offset-of-unstable.rs:28:9
@@ -21,6 +23,7 @@ LL |         UnstableWithStableFieldType,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/offset-of-unstable.rs:12:5
@@ -33,6 +36,7 @@ LL | |     );
    | |_____^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
@@ -42,6 +46,7 @@ LL |     offset_of!(StableWithUnstableField, unstable);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
@@ -51,6 +56,7 @@ LL |     offset_of!(StableWithUnstableFieldType, stable.unstable);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
@@ -64,6 +70,7 @@ LL | |     );
    | |_____^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
@@ -77,6 +84,7 @@ LL | |     );
    | |_____^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors

--- a/tests/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
+++ b/tests/ui/on-unimplemented/feature-gate-on-unimplemented.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_on_unimplemented = "test error `{Self}` with `{Bar}`"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/or-patterns/or-patterns-syntactic-pass.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-pass.stderr
@@ -6,6 +6,7 @@ LL |     let (box 0 | 1); // Unstable; we *can* change the precedence if we want
    |
    = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/panic-runtime/needs-gate.stderr
+++ b/tests/ui/panic-runtime/needs-gate.stderr
@@ -6,6 +6,7 @@ LL | #![panic_runtime]
    |
    = note: see issue #32837 <https://github.com/rust-lang/rust/issues/32837> for more information
    = help: add `#![feature(panic_runtime)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[needs_panic_runtime]` attribute is an experimental feature
   --> $DIR/needs-gate.rs:5:1
@@ -15,6 +16,7 @@ LL | #![needs_panic_runtime]
    |
    = note: see issue #32837 <https://github.com/rust-lang/rust/issues/32837> for more information
    = help: add `#![feature(needs_panic_runtime)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/constraints-before-generic-args-syntactic-pass.stderr
+++ b/tests/ui/parser/constraints-before-generic-args-syntactic-pass.stderr
@@ -6,6 +6,7 @@ LL |     foo::<T = u8, T: Ord, String>();
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 
@@ -17,6 +18,7 @@ LL |     foo::<T = u8, 'a, T: Ord>();
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -50,6 +50,7 @@ LL |     type Y;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:9:5
@@ -59,6 +60,7 @@ LL |     type Z: Ord;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:13:5
@@ -68,6 +70,7 @@ LL |     type W: Ord where Self: Eq;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
@@ -77,6 +80,7 @@ LL |     type W where Self: Eq;
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0592]: duplicate definitions with name `W`
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5

--- a/tests/ui/parser/issues/issue-118531-ice.stderr
+++ b/tests/ui/parser/issues/issue-118531-ice.stderr
@@ -26,6 +26,7 @@ LL |     #[attr]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: cannot find attribute `attr` in this scope
   --> $DIR/issue-118531-ice.rs:5:7

--- a/tests/ui/parser/recover/recover-assoc-const-constraint.stderr
+++ b/tests/ui/parser/recover/recover-assoc-const-constraint.stderr
@@ -6,6 +6,7 @@ LL |     bar::<Item = 42>();
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
   --> $DIR/recover-assoc-const-constraint.rs:5:11
@@ -15,6 +16,7 @@ LL |     bar::<Item = { 42 }>();
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/recover/recover-quantified-closure.stderr
+++ b/tests/ui/parser/recover/recover-quantified-closure.stderr
@@ -12,6 +12,7 @@ LL |     for<'a> |x: &'a u8| *x + 1;
    |
    = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
    = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider removing `for<...>`
 
 error[E0658]: `for<...>` binders for closures are experimental
@@ -22,6 +23,7 @@ LL |     for <Foo>::Bar in x {}
    |
    = note: see issue #97362 <https://github.com/rust-lang/rust/issues/97362> for more information
    = help: add `#![feature(closure_lifetime_binder)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider removing `for<...>`
 
 error: implicit types in closure signatures are forbidden when `for<...>` is present

--- a/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.stderr
+++ b/tests/ui/pattern/range-pattern-meant-to-be-slice-rest-pattern.stderr
@@ -23,6 +23,7 @@ LL |         [1, rest..] => println!("{rest:?}"),
    |
    = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/rest-pat-syntactic.stderr
+++ b/tests/ui/pattern/rest-pat-syntactic.stderr
@@ -6,6 +6,7 @@ LL |     let box ..;
    |
    = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 
@@ -17,6 +18,7 @@ LL |                 box ..,
    |
    = note: see issue #29641 <https://github.com/rust-lang/rust/issues/29641> for more information
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
    = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
 

--- a/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
+++ b/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
@@ -23,6 +23,7 @@ LL |     type U = impl Copy;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/usefulness/issue-119778-type-error-ice.stderr
+++ b/tests/ui/pattern/usefulness/issue-119778-type-error-ice.stderr
@@ -28,6 +28,7 @@ LL |     type U = impl Copy;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pin-macro/cant_access_internals.stderr
+++ b/tests/ui/pin-macro/cant_access_internals.stderr
@@ -5,6 +5,7 @@ LL |     mem::take(phantom_pinned.pointer);
    |               ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unsafe_pin_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/attr-stmt-expr.stderr
+++ b/tests/ui/proc-macro/attr-stmt-expr.stderr
@@ -6,6 +6,7 @@ LL |     #[expect_my_macro_expr]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/attr-stmt-expr.rs:62:5
@@ -15,6 +16,7 @@ LL |     #[expect_expr]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/tests/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -14,6 +14,7 @@ LL | mod module;
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: non-inline modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:24:5
@@ -23,6 +24,7 @@ LL |     mod inner;
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: non-inline modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:33:9
@@ -32,6 +34,7 @@ LL |         mod inner;
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: non-inline modules in proc macro input are unstable
   --> $DIR/attributes-on-modules-fail.rs:42:5
@@ -41,6 +44,7 @@ LL |     mod inner;
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0412]: cannot find type `Y` in this scope
   --> $DIR/attributes-on-modules-fail.rs:10:14

--- a/tests/ui/proc-macro/expand-to-unstable.stderr
+++ b/tests/ui/proc-macro/expand-to-unstable.stderr
@@ -5,6 +5,7 @@ LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the derive macro `Unstable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
@@ -6,6 +6,7 @@ LL | #![print_attr]
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: non-inline modules in proc macro input are unstable
   --> $DIR/inner-attr-non-inline-mod.rs:14:1
@@ -15,6 +16,7 @@ LL | mod module_with_attrs;
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom inner attributes are unstable
   --> $DIR/inner-attr-non-inline-mod.rs:14:1
@@ -24,6 +26,7 @@ LL | mod module_with_attrs;
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: custom inner attributes are unstable
   --> $DIR/module_with_attrs.rs:3:4

--- a/tests/ui/proc-macro/issue-83510.stderr
+++ b/tests/ui/proc-macro/issue-83510.stderr
@@ -30,6 +30,7 @@ LL | issue_83510::dance_like_you_want_to_ice!();
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/tests/ui/proc-macro/proc-macro-gates.stderr
+++ b/tests/ui/proc-macro/proc-macro-gates.stderr
@@ -6,6 +6,7 @@ LL |     #![empty_attr]
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inner macro attributes are unstable
   --> $DIR/proc-macro-gates.rs:14:8
@@ -15,6 +16,7 @@ LL |     #![empty_attr]
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: key-value macro attributes are not supported
   --> $DIR/proc-macro-gates.rs:17:1
@@ -30,6 +32,7 @@ LL |     #[empty_attr]
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom attributes cannot be applied to statements
   --> $DIR/proc-macro-gates.rs:30:5
@@ -39,6 +42,7 @@ LL |     #[empty_attr]
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom attributes cannot be applied to statements
   --> $DIR/proc-macro-gates.rs:34:5
@@ -48,6 +52,7 @@ LL |     #[empty_attr]
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom attributes cannot be applied to expressions
   --> $DIR/proc-macro-gates.rs:38:14
@@ -57,6 +62,7 @@ LL |     let _x = #[identity_attr] 2;
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom attributes cannot be applied to expressions
   --> $DIR/proc-macro-gates.rs:41:15
@@ -66,6 +72,7 @@ LL |     let _x = [#[identity_attr] 2];
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom attributes cannot be applied to expressions
   --> $DIR/proc-macro-gates.rs:44:14
@@ -75,6 +82,7 @@ LL |     let _x = #[identity_attr] println!();
    |
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: inner macro attributes are unstable
   --> $DIR/proc-macro-gates.rs:49:8

--- a/tests/ui/raw-ref-op/feature-raw-ref-op.stderr
+++ b/tests/ui/raw-ref-op/feature-raw-ref-op.stderr
@@ -6,6 +6,7 @@ LL |     &raw const a;
    |
    = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw address of syntax is experimental
   --> $DIR/feature-raw-ref-op.rs:14:5
@@ -15,6 +16,7 @@ LL |     &raw mut a;
    |
    = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw address of syntax is experimental
   --> $DIR/feature-raw-ref-op.rs:19:13
@@ -24,6 +26,7 @@ LL |     let x = &raw const y;
    |
    = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw address of syntax is experimental
   --> $DIR/feature-raw-ref-op.rs:20:13
@@ -33,6 +36,7 @@ LL |     let x = &raw mut y;
    |
    = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw address of syntax is experimental
   --> $DIR/feature-raw-ref-op.rs:7:10
@@ -42,6 +46,7 @@ LL | is_expr!(&raw const a);
    |
    = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: raw address of syntax is experimental
   --> $DIR/feature-raw-ref-op.rs:8:10
@@ -51,6 +56,7 @@ LL | is_expr!(&raw mut a);
    |
    = note: see issue #64490 <https://github.com/rust-lang/rust/issues/64490> for more information
    = help: add `#![feature(raw_ref_op)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/repr/explicit-rust-repr-conflicts.stderr
+++ b/tests/ui/repr/explicit-rust-repr-conflicts.stderr
@@ -6,6 +6,7 @@ LL | #[repr(Rust, simd)]
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0566]: conflicting representation hints
   --> $DIR/explicit-rust-repr-conflicts.rs:1:8

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -6,6 +6,7 @@ LL |             if #[deny(unused_mut)]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `!` patterns are experimental
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14
@@ -15,6 +16,7 @@ LL |         Some(!)
    |
    = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: a guard on a never pattern will never be run
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:7:13

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/feature-gate.no_gate.stderr
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/feature-gate.no_gate.stderr
@@ -6,6 +6,7 @@ LL | impl std::marker::StructuralPartialEq for Foo { }
    |
    = note: see issue #31434 <https://github.com/rust-lang/rust/issues/31434> for more information
    = help: add `#![feature(structural_match)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'structural_match'
   --> $DIR/feature-gate.rs:31:6
@@ -15,6 +16,7 @@ LL | impl std::marker::StructuralEq for Foo { }
    |
    = note: see issue #31434 <https://github.com/rust-lang/rust/issues/31434> for more information
    = help: add `#![feature(structural_match)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -154,6 +154,7 @@ LL |         () if let 0 = 1 => {}
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
@@ -164,6 +165,7 @@ LL |         () if true && let 0 = 1 => {}
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
@@ -174,6 +176,7 @@ LL |         () if let 0 = 1 && true => {}
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
@@ -184,6 +187,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
@@ -194,6 +198,7 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
@@ -204,6 +209,7 @@ LL |         () if let 0 = 1 => {}
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `let` expressions in this position are unstable
@@ -214,6 +220,7 @@ LL |         () if true && let 0 = 1 => {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:20:15
@@ -223,6 +230,7 @@ LL |         () if let 0 = 1 && true => {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:34:15
@@ -232,6 +240,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:34:28
@@ -241,6 +250,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:43:15
@@ -250,6 +260,7 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 23 previous errors
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/feature-gate-target_feature_11.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/feature-gate-target_feature_11.stderr
@@ -8,6 +8,7 @@ LL | fn foo() {}
    |
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2397-do-not-recommend/unstable-feature.stderr
+++ b/tests/ui/rfcs/rfc-2397-do-not-recommend/unstable-feature.stderr
@@ -6,6 +6,7 @@ LL | #[do_not_recommend]
    |
    = note: see issue #51992 <https://github.com/rust-lang/rust/issues/51992> for more information
    = help: add `#![feature(do_not_recommend)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
@@ -37,6 +37,7 @@ LL |     if true && let 0 = 1 {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:17:8
@@ -46,6 +47,7 @@ LL |     if let 0 = 1 && true {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:20:8
@@ -55,6 +57,7 @@ LL |     if let Range { start: _, end: _ } = (true..true) && false {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:23:8
@@ -64,6 +67,7 @@ LL |     if let 1 = 1 && let true = { true } && false {
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:23:21
@@ -73,6 +77,7 @@ LL |     if let 1 = 1 && let true = { true } && false {
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:32:19
@@ -82,6 +87,7 @@ LL |     while true && let 0 = 1 {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:35:11
@@ -91,6 +97,7 @@ LL |     while let 0 = 1 && true {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `let` expressions in this position are unstable
   --> $DIR/feature-gate.rs:38:11
@@ -100,6 +107,7 @@ LL |     while let Range { start: _, end: _ } = (true..true) && false {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/issue-93150.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/issue-93150.stderr
@@ -6,6 +6,7 @@ LL |         _ if let true = true && true => {}
    |
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `let` expressions in this position are unstable
@@ -16,6 +17,7 @@ LL |         _ if let true = true && true => {}
    |
    = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
    = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2528-type-changing-struct-update/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2528-type-changing-struct-update/feature-gate.stderr
@@ -6,6 +6,7 @@ LL |         ..m1
    |
    = note: see issue #86555 <https://github.com/rust-lang/rust/issues/86555> for more information
    = help: add `#![feature(type_changing_struct_update)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
   --> $DIR/feature-gate.rs:22:11

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-gate.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-gate.stderr
@@ -5,6 +5,7 @@ LL | #[derive_const(Default)]
    |   ^^^^^^^^^^^^
    |
    = help: add `#![feature(derive_const)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
@@ -6,6 +6,7 @@ LL |     const move || {
    |
    = note: see issue #106003 <https://github.com/rust-lang/rust/issues/106003> for more information
    = help: add `#![feature(const_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: `~const` can only be applied to `#[const_trait]` traits
   --> $DIR/ice-112822-expected-type-for-param.rs:3:32

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/feature-gate.stock.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/feature-gate.stock.stderr
@@ -6,6 +6,7 @@ LL | impl const T for S {}
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
   --> $DIR/feature-gate.rs:13:15
@@ -15,6 +16,7 @@ LL | const fn f<A: ~const T>() {}
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
   --> $DIR/feature-gate.rs:14:9
@@ -24,6 +26,7 @@ LL | fn g<A: const T>() {}
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
   --> $DIR/feature-gate.rs:18:17
@@ -33,6 +36,7 @@ LL | discard! { impl ~const T }
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const trait impls are experimental
   --> $DIR/feature-gate.rs:19:17
@@ -42,6 +46,7 @@ LL | discard! { impl const T }
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `const_trait` is a temporary placeholder for marking a trait that is suitable for `const` `impls` and all default bodies as `const`, which may be removed or renamed in the future.
   --> $DIR/feature-gate.rs:8:1
@@ -51,6 +56,7 @@ LL | #[const_trait]
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/gate.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/gate.stderr
@@ -6,6 +6,7 @@ LL |     (const || {})();
    |
    = note: see issue #106003 <https://github.com/rust-lang/rust/issues/106003> for more information
    = help: add `#![feature(const_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const closures are experimental
   --> $DIR/gate.rs:12:5
@@ -15,6 +16,7 @@ LL | e!((const || {}));
    |
    = note: see issue #106003 <https://github.com/rust-lang/rust/issues/106003> for more information
    = help: add `#![feature(const_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/hir-const-check.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/hir-const-check.stderr
@@ -6,6 +6,7 @@ LL |         Some(())?;
    |
    = note: see issue #74935 <https://github.com/rust-lang/rust/issues/74935> for more information
    = help: add `#![feature(const_try)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/mbe-const-trait-bound-theoretical-regression.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/mbe-const-trait-bound-theoretical-regression.stderr
@@ -24,6 +24,7 @@ LL | demo! { dyn const }
    |
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -214,6 +214,7 @@ LL | const CONSTANT<T: ~const Trait>: () = ();
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/tilde-const-invalid-places.rs:29:19
@@ -223,6 +224,7 @@ LL |     const CONSTANT<T: ~const Trait>: ();
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/tilde-const-invalid-places.rs:37:19
@@ -232,6 +234,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: generic const items are experimental
   --> $DIR/tilde-const-invalid-places.rs:47:19
@@ -241,6 +244,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    |
    = note: see issue #113521 <https://github.com/rust-lang/rust/issues/113521> for more information
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/tilde-const-invalid-places.rs:44:5
@@ -250,6 +254,7 @@ LL |     type Type<T: ~const Trait> = ();
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0392]: parameter `T` is never used
   --> $DIR/tilde-const-invalid-places.rs:11:19

--- a/tests/ui/rustdoc/feature-gate-doc_primitive.stderr
+++ b/tests/ui/rustdoc/feature-gate-doc_primitive.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_doc_primitive = "usize"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
@@ -6,6 +6,7 @@ LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    |
    = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
    = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error: aborting due to 1 previous error

--- a/tests/ui/span/gated-features-attr-spans.stderr
+++ b/tests/ui/span/gated-features-attr-spans.stderr
@@ -6,6 +6,7 @@ LL | #[repr(simd)]
    |
    = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
+++ b/tests/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
@@ -8,6 +8,7 @@ LL | | }
    |
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: add `#![feature(specialization)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/specialization/specialization-feature-gate-default.stderr
+++ b/tests/ui/specialization/specialization-feature-gate-default.stderr
@@ -6,6 +6,7 @@ LL |     default fn foo(&self) {}
    |
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: add `#![feature(specialization)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/stability-attribute/accidental-stable-in-unstable.stderr
+++ b/tests/ui/stability-attribute/accidental-stable-in-unstable.stderr
@@ -5,6 +5,7 @@ LL | use core::unicode::UNICODE_VERSION;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unicode_internals)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/stability-attribute/allow-unstable-reexport.stderr
+++ b/tests/ui/stability-attribute/allow-unstable-reexport.stderr
@@ -5,6 +5,7 @@ LL | pub use lint_stability::unstable as unstable2;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/allow-unstable-reexport.rs:28:5
@@ -13,6 +14,7 @@ LL |     unstable();
    |     ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/allow-unstable-reexport.rs:29:5
@@ -21,6 +23,7 @@ LL |     unstable_text();
    |     ^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/stability-attribute/allowed-through-unstable.stderr
+++ b/tests/ui/stability-attribute/allowed-through-unstable.stderr
@@ -6,6 +6,7 @@ LL | use allowed_through_unstable_core::unstable_module::NewStableTraitNotAllowe
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/stability-attribute/default-body-stability-err.stderr
+++ b/tests/ui/stability-attribute/default-body-stability-err.stderr
@@ -7,6 +7,7 @@ LL | impl JustTrait for Type {}
    = note: default implementation of `CONSTANT` is unstable
    = note: use of unstable library feature 'constant_default_body'
    = help: add `#![feature(constant_default_body)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0046]: not all trait items implemented, missing: `fun`
   --> $DIR/default-body-stability-err.rs:10:1
@@ -17,6 +18,7 @@ LL | impl JustTrait for Type {}
    = note: default implementation of `fun` is unstable
    = note: use of unstable library feature 'fun_default_body'
    = help: add `#![feature(fun_default_body)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0046]: not all trait items implemented, missing: `fun2`
   --> $DIR/default-body-stability-err.rs:10:1
@@ -27,6 +29,7 @@ LL | impl JustTrait for Type {}
    = note: default implementation of `fun2` is unstable
    = note: use of unstable library feature 'fun_default_body': reason
    = help: add `#![feature(fun_default_body)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0046]: not all trait items implemented, missing: `eq`
   --> $DIR/default-body-stability-err.rs:15:1
@@ -42,6 +45,7 @@ LL | | }
    = note: default implementation of `eq` is unstable
    = note: use of unstable library feature 'eq_default_body'
    = help: add `#![feature(eq_default_body)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/stability-attribute/generics-default-stability-trait.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-trait.stderr
@@ -5,6 +5,7 @@ LL | impl Trait1<usize> for S {
    |             ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability-trait.rs:20:13
@@ -13,6 +14,7 @@ LL | impl Trait1<isize> for S {
    |             ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability-trait.rs:24:13
@@ -21,6 +23,7 @@ LL | impl Trait2<usize> for S {
    |             ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -5,6 +5,7 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    |                                             ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
   --> $DIR/generics-default-stability-where.rs:7:6

--- a/tests/ui/stability-attribute/generics-default-stability.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability.stderr
@@ -223,6 +223,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:27:20
@@ -231,6 +232,7 @@ LL |     let _: Struct1<usize> = STRUCT1;
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:28:20
@@ -239,6 +241,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:57:27
@@ -247,6 +250,7 @@ LL |     let _: Struct3<isize, usize> = STRUCT3;
    |                           ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:59:27
@@ -255,6 +259,7 @@ LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:60:27
@@ -263,6 +268,7 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:84:20
@@ -271,6 +277,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:90:20
@@ -279,6 +286,7 @@ LL |     let _: Struct5<usize> = STRUCT5;
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:92:20
@@ -287,6 +295,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                    ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:100:19
@@ -295,6 +304,7 @@ LL |     let _: Alias1<isize> = Alias1::Some(1);
    |                   ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:104:19
@@ -303,6 +313,7 @@ LL |     let _: Alias1<usize> = ALIAS1;
    |                   ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:105:19
@@ -311,6 +322,7 @@ LL |     let _: Alias1<isize> = Alias1::Some(0);
    |                   ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:133:26
@@ -319,6 +331,7 @@ LL |     let _: Alias3<isize, usize> = ALIAS3;
    |                          ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:135:26
@@ -327,6 +340,7 @@ LL |     let _: Alias3<isize, isize> = Alias3::Ok(0);
    |                          ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:136:26
@@ -335,6 +349,7 @@ LL |     let _: Alias3<usize, usize> = Alias3::Ok(0);
    |                          ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:158:19
@@ -343,6 +358,7 @@ LL |     let _: Alias5<isize> = Alias5::Some(1);
    |                   ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:163:19
@@ -351,6 +367,7 @@ LL |     let _: Alias5<usize> = ALIAS5;
    |                   ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:165:19
@@ -359,6 +376,7 @@ LL |     let _: Alias5<isize> = Alias5::Some(0);
    |                   ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:172:18
@@ -367,6 +385,7 @@ LL |     let _: Enum1<isize> = Enum1::Some(1);
    |                  ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:176:18
@@ -375,6 +394,7 @@ LL |     let _: Enum1<usize> = ENUM1;
    |                  ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:177:18
@@ -383,6 +403,7 @@ LL |     let _: Enum1<isize> = Enum1::Some(0);
    |                  ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:205:25
@@ -391,6 +412,7 @@ LL |     let _: Enum3<isize, usize> = ENUM3;
    |                         ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:207:25
@@ -399,6 +421,7 @@ LL |     let _: Enum3<isize, isize> = Enum3::Ok(0);
    |                         ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:208:25
@@ -407,6 +430,7 @@ LL |     let _: Enum3<usize, usize> = Enum3::Ok(0);
    |                         ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:230:18
@@ -415,6 +439,7 @@ LL |     let _: Enum5<isize> = Enum5::Some(1);
    |                  ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:235:18
@@ -423,6 +448,7 @@ LL |     let _: Enum5<usize> = ENUM5;
    |                  ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_default'
   --> $DIR/generics-default-stability.rs:237:18
@@ -431,6 +457,7 @@ LL |     let _: Enum5<isize> = Enum5::Some(0);
    |                  ^^^^^
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'box_alloc_param'
   --> $DIR/generics-default-stability.rs:244:24
@@ -439,6 +466,7 @@ LL |     let _: Box1<isize, System> = Box1::new(1);
    |                        ^^^^^^
    |
    = help: add `#![feature(box_alloc_param)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: use of deprecated field `unstable_generic_param::Struct4::field`: test
   --> $DIR/generics-default-stability.rs:71:39

--- a/tests/ui/stability-attribute/issue-28075.stderr
+++ b/tests/ui/stability-attribute/issue-28075.stderr
@@ -5,6 +5,7 @@ LL | use lint_stability::{unstable, deprecated};
    |                      ^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/stability-attribute/issue-28388-3.stderr
+++ b/tests/ui/stability-attribute/issue-28388-3.stderr
@@ -5,6 +5,7 @@ LL | use lint_stability::UnstableEnum::{};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/stability-attribute/stability-attribute-implies-no-feature.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-implies-no-feature.stderr
@@ -6,6 +6,7 @@ LL | use stability_attribute_implies::{foo, foobar};
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(foobar)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'foobar'
   --> $DIR/stability-attribute-implies-no-feature.rs:12:5
@@ -15,6 +16,7 @@ LL |     foobar();
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(foobar)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/stability-attribute/stability-attribute-issue.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-issue.stderr
@@ -6,6 +6,7 @@ LL |     unstable();
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': message
   --> $DIR/stability-attribute-issue.rs:10:5
@@ -15,6 +16,7 @@ LL |     unstable_msg();
    |
    = note: see issue #2 <https://github.com/rust-lang/rust/issues/2> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/stability-attribute/stable-in-unstable.stderr
+++ b/tests/ui/stability-attribute/stable-in-unstable.stderr
@@ -6,6 +6,7 @@ LL |     use stable_in_unstable_core::new_unstable_module;
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/stable-in-unstable.rs:17:9
@@ -15,6 +16,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/stable-in-unstable.rs:29:9
@@ -24,6 +26,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/stable-in-unstable.rs:39:10
@@ -33,6 +36,7 @@ LL |     impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalTy
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/stable-in-unstable.rs:49:56
@@ -42,6 +46,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::{OldTrait};
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/stable-in-unstable.rs:53:9
@@ -51,6 +56,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::*;
    |
    = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/stability-attribute/suggest-vec-allocator-api.stderr
+++ b/tests/ui/stability-attribute/suggest-vec-allocator-api.stderr
@@ -8,6 +8,7 @@ LL |     let _: Vec<u8, _> = vec![];
    |
    = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'allocator_api'
   --> $DIR/suggest-vec-allocator-api.rs:6:9
@@ -17,6 +18,7 @@ LL |         _> = vec![];
    |
    = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider wrapping the inner types in tuple
    |
 LL ~     let _: Vec<(
@@ -32,6 +34,7 @@ LL |     let _boxed: Box<u32, _> = Box::new(10);
    |
    = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'allocator_api'
   --> $DIR/suggest-vec-allocator-api.rs:7:24
@@ -43,6 +46,7 @@ LL |     let _ = Vec::<u16, _>::new();
    |
    = note: see issue #32838 <https://github.com/rust-lang/rust/issues/32838> for more information
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/stmt_expr_attrs_no_feature.stderr
+++ b/tests/ui/stmt_expr_attrs_no_feature.stderr
@@ -6,6 +6,7 @@ LL |     #[rustfmt::skip]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:95:18
@@ -15,6 +16,7 @@ LL |     fn y(a: [u8; #[rustc_dummy] 5]);
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:102:19
@@ -24,6 +26,7 @@ LL |     const Y: u8 = #[rustc_dummy] 5;
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:108:19
@@ -33,6 +36,7 @@ LL |     const Y: [u8; #[rustc_dummy] 5];
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:114:18
@@ -42,6 +46,7 @@ LL |     field2: [u8; #[rustc_dummy] 5]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:119:10
@@ -51,6 +56,7 @@ LL |     [u8; #[rustc_dummy] 5]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:125:14
@@ -60,6 +66,7 @@ LL |         [u8; #[rustc_dummy] 5]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:130:22
@@ -69,6 +76,7 @@ LL |         field2: [u8; #[rustc_dummy] 5]
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:138:14
@@ -78,6 +86,7 @@ LL |         6 => #[rustc_dummy] (),
    |
    = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -6,6 +6,7 @@ LL |     F: Fn<i32, Output = i32>,
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/fn-trait-notation.rs:6:8
@@ -15,6 +16,7 @@ LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/fn-trait-notation.rs:7:8
@@ -24,6 +26,7 @@ LL |     H: Fn<(i32,), Output = i32>,
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0059]: type parameter to bare `Fn` trait must be a tuple
   --> $DIR/fn-trait-notation.rs:4:8

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -131,6 +131,7 @@ LL |     fn f(_: impl Iterator<Item = &()>) {}
    |                                   ^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
@@ -143,6 +144,7 @@ LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
    |                                       ^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next() }
@@ -155,6 +157,7 @@ LL |     fn f(_: impl Iterator<Item = &'_ ()>) {}
    |                                   ^^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
@@ -167,6 +170,7 @@ LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() 
    |                                       ^^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.next() }
@@ -179,6 +183,7 @@ LL |     fn f(_: impl Foo) {}
    |                  ^^^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn f<'a>(_: impl Foo<'a>) {}
@@ -191,6 +196,7 @@ LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                      ^^^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo<'a>) -> Option<&()> { x.next() }
@@ -203,6 +209,7 @@ LL |     fn f(_: impl Foo<()>) {}
    |                      ^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn f<'a>(_: impl Foo<'a, ()>) {}
@@ -215,6 +222,7 @@ LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                          ^ expected named lifetime parameter
    |
    = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }

--- a/tests/ui/suggestions/missing-assoc-fn.stderr
+++ b/tests/ui/suggestions/missing-assoc-fn.stderr
@@ -6,6 +6,7 @@ LL |     fn bat<T: TraitB<Item: Copy>>(_: T) -> Self;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0046]: not all trait items implemented, missing: `foo`, `bar`, `baz`, `bat`
   --> $DIR/missing-assoc-fn.rs:14:1

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -17,6 +17,7 @@ LL |     let _: Vec<A:B> = A::B;
    |
    = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
   --> $DIR/type-ascription-instead-of-path-in-type.rs:6:12

--- a/tests/ui/target-feature/gate.stderr
+++ b/tests/ui/target-feature/gate.stderr
@@ -6,6 +6,7 @@ LL | #[target_feature(enable = "avx512bw")]
    |
    = note: see issue #44839 <https://github.com/rust-lang/rust/issues/44839> for more information
    = help: add `#![feature(avx512_target_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -31,6 +31,7 @@ unsafe fn foo() {}
 #[target_feature(enable = "sse2")]
 //~^ ERROR `#[target_feature(..)]` can only be applied to `unsafe` functions
 //~| NOTE see issue #69098
+//~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 fn bar() {}
 //~^ NOTE not an `unsafe` function
 
@@ -102,6 +103,7 @@ impl Quux for Foo {
     #[target_feature(enable = "sse2")]
     //~^ ERROR `#[target_feature(..)]` can only be applied to `unsafe` functions
     //~| NOTE see issue #69098
+    //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     fn foo() {}
     //~^ NOTE not an `unsafe` function
 }

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -32,7 +32,7 @@ LL | extern "Rust" {}
    | ---------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:37:1
+  --> $DIR/invalid-attribute.rs:38:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | mod another {}
    | -------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:42:1
+  --> $DIR/invalid-attribute.rs:43:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL | const FOO: usize = 7;
    | --------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:47:1
+  --> $DIR/invalid-attribute.rs:48:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | struct Foo;
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:52:1
+  --> $DIR/invalid-attribute.rs:53:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL | enum Bar {}
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:57:1
+  --> $DIR/invalid-attribute.rs:58:1
    |
 LL |   #[target_feature(enable = "sse2")]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +81,7 @@ LL | | }
    | |_- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:65:1
+  --> $DIR/invalid-attribute.rs:66:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL | type Uwu = ();
    | -------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:70:1
+  --> $DIR/invalid-attribute.rs:71:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL | trait Baz {}
    | ------------ not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:80:1
+  --> $DIR/invalid-attribute.rs:81:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL | static A: () = ();
    | ------------------ not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:85:1
+  --> $DIR/invalid-attribute.rs:86:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL | impl Quux for u8 {}
    | ------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:92:1
+  --> $DIR/invalid-attribute.rs:93:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL | impl Foo {}
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:110:5
+  --> $DIR/invalid-attribute.rs:112:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL | |     }
    | |_____- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:118:5
+  --> $DIR/invalid-attribute.rs:120:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,15 +175,16 @@ LL | fn bar() {}
    |
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: cannot use `#[inline(always)]` with `#[target_feature]`
-  --> $DIR/invalid-attribute.rs:75:1
+  --> $DIR/invalid-attribute.rs:76:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:102:5
+  --> $DIR/invalid-attribute.rs:103:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,9 +194,10 @@ LL |     fn foo() {}
    |
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0046]: not all trait items implemented, missing: `foo`
-  --> $DIR/invalid-attribute.rs:87:1
+  --> $DIR/invalid-attribute.rs:88:1
    |
 LL | impl Quux for u8 {}
    | ^^^^^^^^^^^^^^^^ missing `foo` in implementation

--- a/tests/ui/thread-local/thread-local-static.stderr
+++ b/tests/ui/thread-local/thread-local-static.stderr
@@ -29,6 +29,7 @@ LL | const fn g(x: &mut [u32; 8]) {
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0625]: thread-local statics cannot be accessed at compile-time
   --> $DIR/thread-local-static.rs:10:28
@@ -52,6 +53,7 @@ LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 5 previous errors; 1 warning emitted
 

--- a/tests/ui/tool-attributes/diagnostic_item.stderr
+++ b/tests/ui/tool-attributes/diagnostic_item.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_diagnostic_item = "foomp"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/track-diagnostics/track6.stderr
+++ b/tests/ui/track-diagnostics/track6.stderr
@@ -7,6 +7,7 @@ LL |     default fn bar() {}
    |
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: add `#![feature(specialization)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/alias/generic-default-in-dyn.stderr
+++ b/tests/ui/traits/alias/generic-default-in-dyn.stderr
@@ -6,6 +6,7 @@ LL | trait SendEqAlias<T> = PartialEq;
    |
    = note: see issue #41517 <https://github.com/rust-lang/rust/issues/41517> for more information
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0393]: the type parameter `Rhs` must be explicitly specified
   --> $DIR/generic-default-in-dyn.rs:4:19

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.stderr
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_must_implement_one_of(eq, neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -44,6 +44,7 @@ LL | use std::ops::DispatchFromDyn;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(dispatch_from_dyn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'dispatch_from_dyn'
   --> $DIR/issue-78372.rs:3:9
@@ -52,6 +53,7 @@ LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(dispatch_from_dyn)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0378]: the trait `DispatchFromDyn` may only be implemented for a coercion between structures
   --> $DIR/issue-78372.rs:3:1

--- a/tests/ui/traits/negative-impls/feature-gate-negative_impls.stderr
+++ b/tests/ui/traits/negative-impls/feature-gate-negative_impls.stderr
@@ -6,6 +6,7 @@ LL | impl !MyTrait for u32 {}
    |
    = note: see issue #68318 <https://github.com/rust-lang/rust/issues/68318> for more information
    = help: add `#![feature(negative_impls)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/dont-ice-on-assoc-projection.stderr
+++ b/tests/ui/traits/next-solver/dont-ice-on-assoc-projection.stderr
@@ -6,6 +6,7 @@ LL | impl<T> Foo for T where T: Bar<ASSOC = 0> {}
    |
    = note: see issue #92827 <https://github.com/rust-lang/rust/issues/92827> for more information
    = help: add `#![feature(associated_const_equality)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0119]: conflicting implementations of trait `Foo` for type `()`
   --> $DIR/dont-ice-on-assoc-projection.rs:15:1

--- a/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.stderr
@@ -6,6 +6,7 @@ LL | use std::mem::BikeshedIntrinsicFrom;
    |
    = note: see issue #99571 <https://github.com/rust-lang/rust/issues/99571> for more information
    = help: add `#![feature(transmutability)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature 'transmutability'
   --> $DIR/feature-missing.rs:8:5
@@ -15,6 +16,7 @@ LL | use std::mem::Assume;
    |
    = note: see issue #99571 <https://github.com/rust-lang/rust/issues/99571> for more information
    = help: add `#![feature(transmutability)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/issue-60371.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-60371.stderr
@@ -6,6 +6,7 @@ LL |     type Item = impl Bug;
    |
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0277]: the trait bound `(): Bug` is not satisfied
   --> $DIR/issue-60371.rs:10:40

--- a/tests/ui/typeck/issue-105946.stderr
+++ b/tests/ui/typeck/issue-105946.stderr
@@ -17,6 +17,7 @@ LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |
    = note: see issue #67264 <https://github.com/rust-lang/rust/issues/67264> for more information
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
   --> $DIR/issue-105946.rs:2:12

--- a/tests/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
@@ -6,6 +6,7 @@ LL |     let x: Box<dyn Foo(isize)>;
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
@@ -6,6 +6,7 @@ LL | fn bar1(x: &dyn Fn<(), Output=()>) {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/unboxed-closure-sugar-not-used-on-fn.rs:7:28
@@ -15,6 +16,7 @@ LL | fn bar2<T>(x: &T) where T: Fn<()> {
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unknown-unstable-lints/deny-unstable-lint-command-line.stderr
+++ b/tests/ui/unknown-unstable-lints/deny-unstable-lint-command-line.stderr
@@ -2,6 +2,7 @@ error: unknown lint: `test_unstable_lint`
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `-Zcrate-attr="feature(test_unstable_lint)"` to the command-line options to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: requested on the command line with `-D unknown-lints`
 
 error: aborting due to 1 previous error

--- a/tests/ui/unknown-unstable-lints/deny-unstable-lint-inline.stderr
+++ b/tests/ui/unknown-unstable-lints/deny-unstable-lint-inline.stderr
@@ -6,6 +6,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 note: the lint level is defined here
   --> $DIR/deny-unstable-lint-inline.rs:3:9
    |

--- a/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-command-line.stderr
+++ b/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-command-line.stderr
@@ -2,6 +2,7 @@ warning: unknown lint: `test_unstable_lint`
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `-Zcrate-attr="feature(test_unstable_lint)"` to the command-line options to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: requested on the command line with `-W unknown-lints`
 
 warning: 1 warning emitted

--- a/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-inline.stderr
+++ b/tests/ui/unknown-unstable-lints/warn-unknown-unstable-lint-inline.stderr
@@ -6,6 +6,7 @@ LL | #![allow(test_unstable_lint)]
    |
    = note: the `test_unstable_lint` lint is unstable
    = help: add `#![feature(test_unstable_lint)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 note: the lint level is defined here
   --> $DIR/warn-unknown-unstable-lint-inline.rs:3:9
    |

--- a/tests/ui/unsafe/ranged_ints2_const.stderr
+++ b/tests/ui/unsafe/ranged_ints2_const.stderr
@@ -14,6 +14,7 @@ LL |     let y = &mut x.0;
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/ranged_ints2_const.rs:18:22
@@ -23,6 +24,7 @@ LL |     let y = unsafe { &mut x.0 };
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/ranged_ints2_const.rs:24:22
@@ -32,6 +34,7 @@ LL |     unsafe { let y = &mut x.0; }
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/unsafe/ranged_ints3_const.stderr
+++ b/tests/ui/unsafe/ranged_ints3_const.stderr
@@ -14,6 +14,7 @@ LL |     let y = &x.0;
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/ranged_ints3_const.rs:19:22
@@ -23,6 +24,7 @@ LL |     let y = unsafe { &x.0 };
    |
    = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
    = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This PR addresses #117318

I have a few questions:

1. Do we want to specify the current version and release date of the compiler? I have added this in via environment variables, which I found in the code for the rustc cli where it handles the `--version` flag
  a. How can I handle the changing message in the tests?
3. Do we want to only show this message when the compiler is old?
  a. How can we determine when the compiler is old?

I'll wait until we figure out the message to bless the tests