### PR TITLE
Adjust the ignore-compare-mode-next-solver for hangs

### DIFF
--- a/tests/ui/issues/issue-22638.rs
+++ b/tests/ui/issues/issue-22638.rs
@@ -1,6 +1,7 @@
 // build-fail
 // normalize-stderr-test: "<\{closure@.+`" -> "$$CLOSURE`"
 // normalize-stderr-test: ".nll/" -> "/"
+// ignore-compare-mode-next-solver (hangs)
 
 #![allow(unused)]
 

--- a/tests/ui/issues/issue-22638.stderr
+++ b/tests/ui/issues/issue-22638.stderr
@@ -1,11 +1,11 @@
 error: reached the recursion limit while instantiating `A::matches::$CLOSURE`
-  --> $DIR/issue-22638.rs:56:9
+  --> $DIR/issue-22638.rs:57:9
    |
 LL |         a.matches(f)
    |         ^^^^^^^^^^^^
    |
 note: `A::matches` defined here
-  --> $DIR/issue-22638.rs:15:5
+  --> $DIR/issue-22638.rs:16:5
    |
 LL |     pub fn matches<F: Fn()>(&self, f: &F) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/issues/issue-67552.rs
+++ b/tests/ui/issues/issue-67552.rs
@@ -1,7 +1,6 @@
 // build-fail
 // compile-flags: -Copt-level=0
 // normalize-stderr-test: ".nll/" -> "/"
-// ignore-compare-mode-next-solver (hangs)
 
 fn main() {
     rec(Empty);

--- a/tests/ui/issues/issue-67552.stderr
+++ b/tests/ui/issues/issue-67552.stderr
@@ -1,11 +1,11 @@
 error: reached the recursion limit while instantiating `rec::<&mut &mut &mut &mut &mut ...>`
-  --> $DIR/issue-67552.rs:30:9
+  --> $DIR/issue-67552.rs:29:9
    |
 LL |         rec(identity(&mut it))
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `rec` defined here
-  --> $DIR/issue-67552.rs:23:1
+  --> $DIR/issue-67552.rs:22:1
    |
 LL | / fn rec<T>(mut it: T)
 LL | | where

--- a/tests/ui/recursion/issue-95134.rs
+++ b/tests/ui/recursion/issue-95134.rs
@@ -3,7 +3,6 @@
 // compile-flags: -Copt-level=0
 // dont-check-failure-status
 // dont-check-compiler-stderr
-// ignore-compare-mode-next-solver (hangs)
 
 pub fn encode_num<Writer: ExampleWriter>(n: u32, mut writer: Writer) -> Result<(), Writer::Error> {
     if n > 15 {

--- a/tests/ui/type-alias-impl-trait/self-referential-3.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-3.rs
@@ -1,3 +1,5 @@
+// ignore-compare-mode-next-solver (hangs)
+
 #![feature(type_alias_impl_trait)]
 
 type Bar<'a, 'b> = impl PartialEq<Bar<'a, 'b>> + std::fmt::Debug;

--- a/tests/ui/type-alias-impl-trait/self-referential-3.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-3.stderr
@@ -1,5 +1,5 @@
 error[E0277]: can't compare `&i32` with `Bar<'a, 'b>`
-  --> $DIR/self-referential-3.rs:5:31
+  --> $DIR/self-referential-3.rs:7:31
    |
 LL | fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == Bar<'a, 'b>`

--- a/tests/ui/type-alias-impl-trait/self-referential-4.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential-4.rs
@@ -1,3 +1,5 @@
+// ignore-compare-mode-next-solver (hangs)
+
 #![feature(type_alias_impl_trait)]
 
 type Bar<'a, 'b> = impl PartialEq<Bar<'b, 'static>> + std::fmt::Debug;

--- a/tests/ui/type-alias-impl-trait/self-referential-4.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-4.stderr
@@ -1,5 +1,5 @@
 error[E0277]: can't compare `&i32` with `Bar<'b, 'static>`
-  --> $DIR/self-referential-4.rs:5:31
+  --> $DIR/self-referential-4.rs:7:31
    |
 LL | fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == Bar<'b, 'static>`
@@ -10,7 +10,7 @@ LL |     i
    = help: the trait `PartialEq` is implemented for `i32`
 
 error[E0277]: can't compare `&i32` with `Foo<'static, 'b>`
-  --> $DIR/self-referential-4.rs:11:31
+  --> $DIR/self-referential-4.rs:13:31
    |
 LL | fn foo<'a, 'b>(i: &'a i32) -> Foo<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == Foo<'static, 'b>`
@@ -21,7 +21,7 @@ LL |     i
    = help: the trait `PartialEq` is implemented for `i32`
 
 error[E0277]: can't compare `&i32` with `Moo<'static, 'a>`
-  --> $DIR/self-referential-4.rs:17:31
+  --> $DIR/self-referential-4.rs:19:31
    |
 LL | fn moo<'a, 'b>(i: &'a i32) -> Moo<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == Moo<'static, 'a>`

--- a/tests/ui/type-alias-impl-trait/self-referential.rs
+++ b/tests/ui/type-alias-impl-trait/self-referential.rs
@@ -1,3 +1,5 @@
+// ignore-compare-mode-next-solver (hangs)
+
 #![feature(type_alias_impl_trait)]
 
 type Bar<'a, 'b> = impl PartialEq<Bar<'b, 'a>> + std::fmt::Debug;

--- a/tests/ui/type-alias-impl-trait/self-referential.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential.stderr
@@ -1,5 +1,5 @@
 error[E0277]: can't compare `&i32` with `Bar<'b, 'a>`
-  --> $DIR/self-referential.rs:5:31
+  --> $DIR/self-referential.rs:7:31
    |
 LL | fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == Bar<'b, 'a>`
@@ -11,7 +11,7 @@ LL |     i
    = help: the trait `PartialEq` is implemented for `i32`
 
 error[E0277]: can't compare `&i32` with `(i32, Foo<'a, 'b>::{opaque#0})`
-  --> $DIR/self-referential.rs:12:31
+  --> $DIR/self-referential.rs:14:31
    |
 LL | fn foo<'a, 'b>(i: &'a i32) -> Foo<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == (i32, Foo<'a, 'b>::{opaque#0})`
@@ -23,7 +23,7 @@ LL |     (42, i)
    = help: the trait `PartialEq` is implemented for `i32`
 
 error[E0277]: can't compare `&i32` with `(i32, Moo<'b, 'a>::{opaque#0})`
-  --> $DIR/self-referential.rs:19:31
+  --> $DIR/self-referential.rs:21:31
    |
 LL | fn moo<'a, 'b>(i: &'a i32) -> Moo<'a, 'b> {
    |                               ^^^^^^^^^^^ no implementation for `&i32 == (i32, Moo<'b, 'a>::{opaque#0})`


### PR DESCRIPTION
Some new tests hang, some old tests don't hang.

r? lcnr or anyone in @rust-lang/initiative-trait-system-refactor