### PR TITLE
Add the function body span to StableMIR

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -37,6 +37,7 @@ impl<'tcx> Stable<'tcx> for mir::Body<'tcx> {
             self.arg_count,
             self.var_debug_info.iter().map(|info| info.stable(tables)).collect(),
             self.spread_arg.stable(tables),
+            self.span.stable(tables),
         )
     }
 }

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -27,6 +27,9 @@ pub struct Body {
     ///
     /// This is used for the "rust-call" ABI such as closures.
     pub(super) spread_arg: Option<Local>,
+
+    /// The span that covers the entire function body.
+    pub span: Span,
 }
 
 pub type BasicBlockIdx = usize;
@@ -42,6 +45,7 @@ impl Body {
         arg_count: usize,
         var_debug_info: Vec<VarDebugInfo>,
         spread_arg: Option<Local>,
+        span: Span,
     ) -> Self {
         // If locals doesn't contain enough entries, it can lead to panics in
         // `ret_local`, `arg_locals`, and `inner_locals`.
@@ -49,7 +53,7 @@ impl Body {
             locals.len() > arg_count,
             "A Body must contain at least a local for the return value and each of the function's arguments"
         );
-        Self { blocks, locals, arg_count, var_debug_info, spread_arg }
+        Self { blocks, locals, arg_count, var_debug_info, spread_arg, span }
     }
 
     /// Return local that holds this function's return value.

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -133,7 +133,7 @@ pub trait MirVisitor {
     }
 
     fn super_body(&mut self, body: &Body) {
-        let Body { blocks, locals: _, arg_count, var_debug_info, spread_arg: _ } = body;
+        let Body { blocks, locals: _, arg_count, var_debug_info, spread_arg: _, span } = body;
 
         for bb in blocks {
             self.visit_basic_block(bb);
@@ -153,6 +153,8 @@ pub trait MirVisitor {
         for info in var_debug_info.iter() {
             self.visit_var_debug_info(info);
         }
+
+        self.visit_span(span)
     }
 
     fn super_basic_block(&mut self, bb: &BasicBlock) {


### PR DESCRIPTION
We were missing the body span, which differs from the function definition span, since it covers the entire function body.

r? @ouz-a 