### PR TITLE
Document recovered field in `VariantData`.

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2788,6 +2788,8 @@ pub enum VariantData {
     /// Struct variant.
     ///
     /// E.g., `Bar { .. }` as in `enum Foo { Bar { .. } }`.
+    ///
+    /// The `bool` is whether it was recovered by the parser.
     Struct(ThinVec<FieldDef>, bool),
     /// Tuple variant.
     ///

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2848,7 +2848,9 @@ pub enum VariantData<'hir> {
     /// A struct variant.
     ///
     /// E.g., `Bar { .. }` as in `enum Foo { Bar { .. } }`.
-    Struct(&'hir [FieldDef<'hir>], /* recovered */ bool),
+    ///
+    /// The `bool` is whether it was recovered by the parser.
+    Struct(&'hir [FieldDef<'hir>], bool),
     /// A tuple variant.
     ///
     /// E.g., `Bar(..)` as in `enum Foo { Bar(..) }`.


### PR DESCRIPTION
In hir, their was a comment, but it didn't show up in rustdoc. In the AST, it was entirely undocumented, and the meaning could only be figured out by looking at usages. Hopefully this helps the next person looking at this.