### PR TITLE
Give temporaries in if let guards correct scopes

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -179,10 +179,10 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
 fn resolve_arm<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, arm: &'tcx hir::Arm<'tcx>) {
     let prev_cx = visitor.cx;
 
-    visitor.enter_scope(Scope { id: arm.hir_id.local_id, data: ScopeData::Node });
-    visitor.cx.var_parent = visitor.cx.parent;
+    visitor.terminating_scopes.insert(arm.hir_id.local_id);
 
-    visitor.terminating_scopes.insert(arm.body.hir_id.local_id);
+    visitor.enter_node_scope_with_dtor(arm.hir_id.local_id);
+    visitor.cx.var_parent = visitor.cx.parent;
 
     if let Some(hir::Guard::If(expr)) = arm.guard {
         visitor.terminating_scopes.insert(expr.hir_id.local_id);

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -27,10 +27,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub(crate) fn as_local_rvalue(
         &mut self,
         block: BasicBlock,
-        expr: &Expr<'tcx>,
+        expr_id: ExprId,
     ) -> BlockAnd<Rvalue<'tcx>> {
         let local_scope = self.local_scope();
-        self.as_rvalue(block, Some(local_scope), expr)
+        self.as_rvalue(block, Some(local_scope), expr_id)
     }
 
     /// Compile `expr`, yielding an rvalue.
@@ -38,11 +38,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         mut block: BasicBlock,
         scope: Option<region::Scope>,
-        expr: &Expr<'tcx>,
+        expr_id: ExprId,
     ) -> BlockAnd<Rvalue<'tcx>> {
+        let this = self;
+        let expr = &this.thir[expr_id];
         debug!("expr_as_rvalue(block={:?}, scope={:?}, expr={:?})", block, scope, expr);
 
-        let this = self;
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
 
@@ -50,9 +51,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::ThreadLocalRef(did) => block.and(Rvalue::ThreadLocalRef(did)),
             ExprKind::Scope { region_scope, lint_level, value } => {
                 let region_scope = (region_scope, source_info);
-                this.in_scope(region_scope, lint_level, |this| {
-                    this.as_rvalue(block, scope, &this.thir[value])
-                })
+                this.in_scope(region_scope, lint_level, |this| this.as_rvalue(block, scope, value))
             }
             ExprKind::Repeat { value, count } => {
                 if Some(0) == count.try_eval_target_usize(this.tcx, this.param_env) {
@@ -62,7 +61,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         block = this.as_operand(
                             block,
                             scope,
-                            &this.thir[value],
+                            value,
                             LocalInfo::Boring,
                             NeedsTemporary::No
                         )
@@ -75,31 +74,21 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block = this.as_operand(
                         block,
                         scope,
-                        &this.thir[lhs],
+                        lhs,
                         LocalInfo::Boring,
                         NeedsTemporary::Maybe
                     )
                 );
                 let rhs = unpack!(
-                    block = this.as_operand(
-                        block,
-                        scope,
-                        &this.thir[rhs],
-                        LocalInfo::Boring,
-                        NeedsTemporary::No
-                    )
+                    block =
+                        this.as_operand(block, scope, rhs, LocalInfo::Boring, NeedsTemporary::No)
                 );
                 this.build_binary_op(block, op, expr_span, expr.ty, lhs, rhs)
             }
             ExprKind::Unary { op, arg } => {
                 let arg = unpack!(
-                    block = this.as_operand(
-                        block,
-                        scope,
-                        &this.thir[arg],
-                        LocalInfo::Boring,
-                        NeedsTemporary::No
-                    )
+                    block =
+                        this.as_operand(block, scope, arg, LocalInfo::Boring, NeedsTemporary::No)
                 );
                 // Check for -MIN on signed integers
                 if this.check_overflow && op == UnOp::Neg && expr.ty.is_signed() {
@@ -126,7 +115,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.and(Rvalue::UnaryOp(op, arg))
             }
             ExprKind::Box { value } => {
-                let value = &this.thir[value];
+                let value_ty = this.thir[value].ty;
                 let tcx = this.tcx;
 
                 // `exchange_malloc` is unsafe but box is safe, so need a new scope.
@@ -142,7 +131,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     synth_info,
                     size,
-                    Rvalue::NullaryOp(NullOp::SizeOf, value.ty),
+                    Rvalue::NullaryOp(NullOp::SizeOf, value_ty),
                 );
 
                 let align = this.temp(tcx.types.usize, expr_span);
@@ -150,7 +139,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     synth_info,
                     align,
-                    Rvalue::NullaryOp(NullOp::AlignOf, value.ty),
+                    Rvalue::NullaryOp(NullOp::AlignOf, value_ty),
                 );
 
                 // malloc some memory of suitable size and align:
@@ -192,7 +181,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
 
                 // Transmute `*mut u8` to the box (thus far, uninitialized):
-                let box_ = Rvalue::ShallowInitBox(Operand::Move(storage), value.ty);
+                let box_ = Rvalue::ShallowInitBox(Operand::Move(storage), value_ty);
                 this.cfg.push_assign(block, source_info, Place::from(result), box_);
 
                 // initialize the box contents:
@@ -200,24 +189,24 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block = this.expr_into_dest(
                         this.tcx.mk_place_deref(Place::from(result)),
                         block,
-                        value
+                        value,
                     )
                 );
                 block.and(Rvalue::Use(Operand::Move(Place::from(result))))
             }
             ExprKind::Cast { source } => {
-                let source = &this.thir[source];
+                let source_expr = &this.thir[source];
 
                 // Casting an enum to an integer is equivalent to computing the discriminant and casting the
                 // discriminant. Previously every backend had to repeat the logic for this operation. Now we
                 // create all the steps directly in MIR with operations all backends need to support anyway.
-                let (source, ty) = if let ty::Adt(adt_def, ..) = source.ty.kind()
+                let (source, ty) = if let ty::Adt(adt_def, ..) = source_expr.ty.kind()
                     && adt_def.is_enum()
                 {
                     let discr_ty = adt_def.repr().discr_type().to_ty(this.tcx);
                     let temp = unpack!(block = this.as_temp(block, scope, source, Mutability::Not));
-                    let layout = this.tcx.layout_of(this.param_env.and(source.ty));
-                    let discr = this.temp(discr_ty, source.span);
+                    let layout = this.tcx.layout_of(this.param_env.and(source_expr.ty));
+                    let discr = this.temp(discr_ty, source_expr.span);
                     this.cfg.push_assign(
                         block,
                         source_info,
@@ -296,7 +285,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     (op, ty)
                 } else {
-                    let ty = source.ty;
+                    let ty = source_expr.ty;
                     let source = unpack!(
                         block = this.as_operand(
                             block,
@@ -310,7 +299,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 };
                 let from_ty = CastTy::from_ty(ty);
                 let cast_ty = CastTy::from_ty(expr.ty);
-                debug!("ExprKind::Cast from_ty={from_ty:?}, cast_ty={:?}/{cast_ty:?}", expr.ty,);
+                debug!("ExprKind::Cast from_ty={from_ty:?}, cast_ty={:?}/{cast_ty:?}", expr.ty);
                 let cast_kind = mir_cast_kind(ty, expr.ty);
                 block.and(Rvalue::Cast(cast_kind, source, expr.ty))
             }
@@ -319,7 +308,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block = this.as_operand(
                         block,
                         scope,
-                        &this.thir[source],
+                        source,
                         LocalInfo::Boring,
                         NeedsTemporary::No
                     )
@@ -363,7 +352,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             block = this.as_operand(
                                 block,
                                 scope,
-                                &this.thir[f],
+                                f,
                                 LocalInfo::Boring,
                                 NeedsTemporary::Maybe
                             )
@@ -384,7 +373,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             block = this.as_operand(
                                 block,
                                 scope,
-                                &this.thir[f],
+                                f,
                                 LocalInfo::Boring,
                                 NeedsTemporary::Maybe
                             )
@@ -416,8 +405,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // ```
                 //
                 for (thir_place, cause, hir_id) in fake_reads.into_iter() {
-                    let place_builder =
-                        unpack!(block = this.as_place_builder(block, &this.thir[*thir_place]));
+                    let place_builder = unpack!(block = this.as_place_builder(block, *thir_place));
 
                     if let Some(mir_place) = place_builder.try_to_place(this) {
                         this.cfg.push_fake_read(
@@ -434,8 +422,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .into_iter()
                     .copied()
                     .map(|upvar| {
-                        let upvar = &this.thir[upvar];
-                        match Category::of(&upvar.kind) {
+                        let upvar_expr = &this.thir[upvar];
+                        match Category::of(&upvar_expr.kind) {
                             // Use as_place to avoid creating a temporary when
                             // moving a variable into a closure, so that
                             // borrowck knows which variables to mark as being
@@ -453,18 +441,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 // borrow captures when capturing an immutable
                                 // variable. This is sound because the mutation
                                 // that caused the capture will cause an error.
-                                match upvar.kind {
+                                match upvar_expr.kind {
                                     ExprKind::Borrow {
                                         borrow_kind:
                                             BorrowKind::Mut { kind: MutBorrowKind::Default },
                                         arg,
                                     } => unpack!(
                                         block = this.limit_capture_mutability(
-                                            upvar.span,
-                                            upvar.ty,
+                                            upvar_expr.span,
+                                            upvar_expr.ty,
                                             scope,
                                             block,
-                                            &this.thir[arg],
+                                            arg,
                                         )
                                     ),
                                     _ => {
@@ -498,7 +486,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.and(Rvalue::Aggregate(result, operands))
             }
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
-                block = unpack!(this.stmt_expr(block, expr, None));
+                block = unpack!(this.stmt_expr(block, expr_id, None));
                 block.and(Rvalue::Use(Operand::Constant(Box::new(ConstOperand {
                     span: expr_span,
                     user_ty: None,
@@ -553,8 +541,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     Some(Category::Rvalue(RvalueFunc::AsRvalue) | Category::Constant)
                 ));
                 let operand = unpack!(
-                    block =
-                        this.as_operand(block, scope, expr, LocalInfo::Boring, NeedsTemporary::No)
+                    block = this.as_operand(
+                        block,
+                        scope,
+                        expr_id,
+                        LocalInfo::Boring,
+                        NeedsTemporary::No,
+                    )
                 );
                 block.and(Rvalue::Use(operand))
             }
@@ -719,9 +712,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         outer_source_info: SourceInfo,
     ) -> BlockAnd<Rvalue<'tcx>> {
         let this = self;
-        let value = &this.thir[value];
-        let elem_ty = value.ty;
-        if let Some(Category::Constant) = Category::of(&value.kind) {
+        let value_expr = &this.thir[value];
+        let elem_ty = value_expr.ty;
+        if let Some(Category::Constant) = Category::of(&value_expr.kind) {
             // Repeating a const does nothing
         } else {
             // For a non-const, we may need to generate an appropriate `Drop`
@@ -754,7 +747,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         upvar_ty: Ty<'tcx>,
         temp_lifetime: Option<region::Scope>,
         mut block: BasicBlock,
-        arg: &Expr<'tcx>,
+        arg: ExprId,
     ) -> BlockAnd<Operand<'tcx>> {
         let this = self;
 

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -19,12 +19,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         &mut self,
         destination: Place<'tcx>,
         mut block: BasicBlock,
-        expr: &Expr<'tcx>,
+        expr_id: ExprId,
     ) -> BlockAnd<()> {
         // since we frequently have to reference `self` from within a
         // closure, where `self` would be shadowed, it's easier to
         // just use the name `this` uniformly
         let this = self;
+        let expr = &this.thir[expr_id];
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
 
@@ -40,20 +41,25 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let region_scope = (region_scope, source_info);
                 ensure_sufficient_stack(|| {
                     this.in_scope(region_scope, lint_level, |this| {
-                        this.expr_into_dest(destination, block, &this.thir[value])
+                        this.expr_into_dest(destination, block, value)
                     })
                 })
             }
             ExprKind::Block { block: ast_block } => {
                 this.ast_block(destination, block, ast_block, source_info)
             }
-            ExprKind::Match { scrutinee, ref arms, .. } => {
-                this.match_expr(destination, expr_span, block, &this.thir[scrutinee], arms)
-            }
+            ExprKind::Match { scrutinee, ref arms, .. } => this.match_expr(
+                destination,
+                block,
+                scrutinee,
+                arms,
+                expr_span,
+                this.thir[scrutinee].span,
+            ),
             ExprKind::If { cond, then, else_opt, if_then_scope } => {
                 let then_blk;
-                let then_expr = &this.thir[then];
-                let then_source_info = this.source_info(then_expr.span);
+                let then_span = this.thir[then].span;
+                let then_source_info = this.source_info(then_span);
                 let condition_scope = this.local_scope();
 
                 let mut else_blk = unpack!(
@@ -62,27 +68,24 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         LintLevel::Inherited,
                         |this| {
                             let source_info = if this.is_let(cond) {
-                                let variable_scope = this.new_source_scope(
-                                    then_expr.span,
-                                    LintLevel::Inherited,
-                                    None,
-                                );
+                                let variable_scope =
+                                    this.new_source_scope(then_span, LintLevel::Inherited, None);
                                 this.source_scope = variable_scope;
-                                SourceInfo { span: then_expr.span, scope: variable_scope }
+                                SourceInfo { span: then_span, scope: variable_scope }
                             } else {
-                                this.source_info(then_expr.span)
+                                this.source_info(then_span)
                             };
                             let (then_block, else_block) =
-                                this.in_if_then_scope(condition_scope, then_expr.span, |this| {
+                                this.in_if_then_scope(condition_scope, then_span, |this| {
                                     let then_blk = unpack!(this.then_else_break(
                                         block,
-                                        &this.thir[cond],
+                                        cond,
                                         Some(condition_scope),
                                         condition_scope,
                                         source_info
                                     ));
 
-                                    this.expr_into_dest(destination, then_blk, then_expr)
+                                    this.expr_into_dest(destination, then_blk, then)
                                 });
                             then_block.and(else_block)
                         },
@@ -90,7 +93,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 );
 
                 else_blk = if let Some(else_opt) = else_opt {
-                    unpack!(this.expr_into_dest(destination, else_blk, &this.thir[else_opt]))
+                    unpack!(this.expr_into_dest(destination, else_blk, else_opt))
                 } else {
                     // Body of the `if` expression without an `else` clause must return `()`, thus
                     // we implicitly generate an `else {}` if it is not specified.
@@ -107,7 +110,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Let { expr, ref pat } => {
                 let scope = this.local_scope();
                 let (true_block, false_block) = this.in_if_then_scope(scope, expr_span, |this| {
-                    this.lower_let_expr(block, &this.thir[expr], pat, scope, None, expr_span, true)
+                    this.lower_let_expr(block, expr, pat, scope, None, expr_span, true)
                 });
 
                 this.cfg.push_assign_constant(
@@ -138,14 +141,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 join_block.unit()
             }
             ExprKind::NeverToAny { source } => {
-                let source = &this.thir[source];
+                let source_expr = &this.thir[source];
                 let is_call =
-                    matches!(source.kind, ExprKind::Call { .. } | ExprKind::InlineAsm { .. });
+                    matches!(source_expr.kind, ExprKind::Call { .. } | ExprKind::InlineAsm { .. });
 
                 // (#66975) Source could be a const of type `!`, so has to
                 // exist in the generated MIR.
                 unpack!(
-                    block = this.as_temp(block, Some(this.local_scope()), source, Mutability::Mut,)
+                    block = this.as_temp(block, Some(this.local_scope()), source, Mutability::Mut)
                 );
 
                 // This is an optimization. If the expression was a call then we already have an
@@ -166,7 +169,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     this.in_if_then_scope(condition_scope, expr.span, |this| {
                         this.then_else_break(
                             block,
-                            &this.thir[lhs],
+                            lhs,
                             Some(condition_scope),
                             condition_scope,
                             source_info,
@@ -192,7 +195,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         const_: Const::from_bool(this.tcx, constant),
                     },
                 );
-                let rhs = unpack!(this.expr_into_dest(destination, continuation, &this.thir[rhs]));
+                let rhs = unpack!(this.expr_into_dest(destination, continuation, rhs));
                 let target = this.cfg.start_new_block();
                 this.cfg.goto(rhs, source_info, target);
                 this.cfg.goto(short_circuit, source_info, target);
@@ -231,8 +234,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     // introduce a unit temporary as the destination for the loop body.
                     let tmp = this.get_unit_temp();
                     // Execute the body, branching back to the test.
-                    let body_block_end =
-                        unpack!(this.expr_into_dest(tmp, body_block, &this.thir[body]));
+                    let body_block_end = unpack!(this.expr_into_dest(tmp, body_block, body));
                     this.cfg.goto(body_block_end, source_info, loop_block);
 
                     // Loops are only exited by `break` expressions.
@@ -240,11 +242,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 })
             }
             ExprKind::Call { ty: _, fun, ref args, from_hir_call, fn_span } => {
-                let fun = unpack!(block = this.as_local_operand(block, &this.thir[fun]));
+                let fun = unpack!(block = this.as_local_operand(block, fun));
                 let args: Vec<_> = args
                     .into_iter()
                     .copied()
-                    .map(|arg| unpack!(block = this.as_local_call_operand(block, &this.thir[arg])))
+                    .map(|arg| unpack!(block = this.as_local_call_operand(block, arg)))
                     .collect();
 
                 let success = this.cfg.start_new_block();
@@ -280,16 +282,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.diverge_from(block);
                 success.unit()
             }
-            ExprKind::Use { source } => this.expr_into_dest(destination, block, &this.thir[source]),
+            ExprKind::Use { source } => this.expr_into_dest(destination, block, source),
             ExprKind::Borrow { arg, borrow_kind } => {
-                let arg = &this.thir[arg];
                 // We don't do this in `as_rvalue` because we use `as_place`
                 // for borrow expressions, so we cannot create an `RValue` that
                 // remains valid across user code. `as_rvalue` is usually called
                 // by this method anyway, so this shouldn't cause too many
                 // unnecessary temporaries.
                 let arg_place = match borrow_kind {
-                    BorrowKind::Shared => unpack!(block = this.as_read_only_place(block, arg)),
+                    BorrowKind::Shared => {
+                        unpack!(block = this.as_read_only_place(block, arg))
+                    }
                     _ => unpack!(block = this.as_place(block, arg)),
                 };
                 let borrow = Rvalue::Ref(this.tcx.lifetimes.re_erased, borrow_kind, arg_place);
@@ -297,7 +300,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.unit()
             }
             ExprKind::AddressOf { mutability, arg } => {
-                let arg = &this.thir[arg];
                 let place = match mutability {
                     hir::Mutability::Not => this.as_read_only_place(block, arg),
                     hir::Mutability::Mut => this.as_place(block, arg),
@@ -332,7 +334,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 block = this.as_operand(
                                     block,
                                     Some(scope),
-                                    &this.thir[f.expr],
+                                    f.expr,
                                     LocalInfo::AggregateTemp,
                                     NeedsTemporary::Maybe,
                                 )
@@ -344,8 +346,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let field_names = adt_def.variant(variant_index).fields.indices();
 
                 let fields = if let Some(FruInfo { base, field_types }) = base {
-                    let place_builder =
-                        unpack!(block = this.as_place_builder(block, &this.thir[*base]));
+                    let place_builder = unpack!(block = this.as_place_builder(block, *base));
 
                     // MIR does not natively support FRU, so for each
                     // base-supplied field, generate an operand that
@@ -398,19 +399,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .map(|op| match *op {
                         thir::InlineAsmOperand::In { reg, expr } => mir::InlineAsmOperand::In {
                             reg,
-                            value: unpack!(block = this.as_local_operand(block, &this.thir[expr])),
+                            value: unpack!(block = this.as_local_operand(block, expr)),
                         },
                         thir::InlineAsmOperand::Out { reg, late, expr } => {
                             mir::InlineAsmOperand::Out {
                                 reg,
                                 late,
-                                place: expr.map(|expr| {
-                                    unpack!(block = this.as_place(block, &this.thir[expr]))
-                                }),
+                                place: expr.map(|expr| unpack!(block = this.as_place(block, expr))),
                             }
                         }
                         thir::InlineAsmOperand::InOut { reg, late, expr } => {
-                            let place = unpack!(block = this.as_place(block, &this.thir[expr]));
+                            let place = unpack!(block = this.as_place(block, expr));
                             mir::InlineAsmOperand::InOut {
                                 reg,
                                 late,
@@ -423,11 +422,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             mir::InlineAsmOperand::InOut {
                                 reg,
                                 late,
-                                in_value: unpack!(
-                                    block = this.as_local_operand(block, &this.thir[in_expr])
-                                ),
+                                in_value: unpack!(block = this.as_local_operand(block, in_expr)),
                                 out_place: out_expr.map(|out_expr| {
-                                    unpack!(block = this.as_place(block, &this.thir[out_expr]))
+                                    unpack!(block = this.as_place(block, out_expr))
                                 }),
                             }
                         }
@@ -488,7 +485,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             // These cases don't actually need a destination
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
-                unpack!(block = this.stmt_expr(block, expr, None));
+                unpack!(block = this.stmt_expr(block, expr_id, None));
                 this.cfg.push_assign_unit(block, source_info, destination, this.tcx);
                 block.unit()
             }
@@ -497,7 +494,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::Break { .. }
             | ExprKind::Return { .. }
             | ExprKind::Become { .. } => {
-                unpack!(block = this.stmt_expr(block, expr, None));
+                unpack!(block = this.stmt_expr(block, expr_id, None));
                 // No assign, as these have type `!`.
                 block.unit()
             }
@@ -509,7 +506,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::ValueTypeAscription { .. } => {
                 debug_assert!(Category::of(&expr.kind) == Some(Category::Place));
 
-                let place = unpack!(block = this.as_place(block, expr));
+                let place = unpack!(block = this.as_place(block, expr_id));
                 let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place));
                 this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
@@ -524,7 +521,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     this.local_decls.push(LocalDecl::new(expr.ty, expr.span));
                 }
 
-                let place = unpack!(block = this.as_place(block, expr));
+                let place = unpack!(block = this.as_place(block, expr_id));
                 let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place));
                 this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
@@ -536,7 +533,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block = this.as_operand(
                         block,
                         Some(scope),
-                        &this.thir[value],
+                        value,
                         LocalInfo::Boring,
                         NeedsTemporary::No
                     )
@@ -582,7 +579,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     _ => true,
                 });
 
-                let rvalue = unpack!(block = this.as_local_rvalue(block, expr));
+                let rvalue = unpack!(block = this.as_local_rvalue(block, expr_id));
                 this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
             }

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -396,6 +396,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let arm_scope = (arm.scope, arm_source_info);
                 let match_scope = self.local_scope();
                 self.in_scope(arm_scope, arm.lint_level, |this| {
+                    let old_dedup_scope =
+                        mem::replace(&mut this.fixed_temps_scope, Some(arm.scope));
+
                     // `try_to_place` may fail if it is unable to resolve the given
                     // `PlaceBuilder` inside a closure. In this case, we don't want to include
                     // a scrutinee place. `scrutinee_place_builder` will fail to be resolved
@@ -426,6 +429,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         Some((arm, match_scope)),
                         false,
                     );
+
+                    this.fixed_temps_scope = old_dedup_scope;
 
                     if let Some(source_scope) = scope {
                         this.source_scope = source_scope;

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -210,6 +210,12 @@ struct Builder<'a, 'tcx> {
     /// finish building it.
     guard_context: Vec<GuardFrame>,
 
+    /// Temporaries with fixed indexes. Used so that if-let guards on arms
+    /// with an or-pattern are only created once.
+    fixed_temps: FxHashMap<ExprId, Local>,
+    /// Scope of temporaries that should be deduplicated using [Self::fixed_temps].
+    fixed_temps_scope: Option<region::Scope>,
+
     /// Maps `HirId`s of variable bindings to the `Local`s created for them.
     /// (A match binding can have two locals; the 2nd is for the arm's guard.)
     var_indices: FxHashMap<LocalVarId, LocalsForNode>,
@@ -752,6 +758,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             source_scopes: IndexVec::new(),
             source_scope: OUTERMOST_SOURCE_SCOPE,
             guard_context: vec![],
+            fixed_temps: Default::default(),
+            fixed_temps_scope: None,
             in_scope_unsafe: safety,
             local_decls: IndexVec::from_elem_n(LocalDecl::new(return_ty, return_span), 1),
             canonical_user_type_annotations: IndexVec::new(),

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -89,7 +89,7 @@ use rustc_hir::HirId;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
-use rustc_middle::thir::{Expr, LintLevel};
+use rustc_middle::thir::{ExprId, LintLevel};
 use rustc_session::lint::Level;
 use rustc_span::{Span, DUMMY_SP};
 
@@ -592,7 +592,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub(crate) fn break_scope(
         &mut self,
         mut block: BasicBlock,
-        value: Option<&Expr<'tcx>>,
+        value: Option<ExprId>,
         target: BreakableTarget,
         source_info: SourceInfo,
     ) -> BlockAnd<()> {

--- a/tests/ui/drop/dynamic-drop.rs
+++ b/tests/ui/drop/dynamic-drop.rs
@@ -343,6 +343,17 @@ fn if_let_guard(a: &Allocator, c: bool, d: i32) {
     }
 }
 
+fn if_let_guard_2(a: &Allocator, num: i32) {
+    let d = a.alloc();
+    match num {
+        #[allow(irrefutable_let_patterns)]
+        1 | 2 if let Ptr(ref _idx, _) = a.alloc() => {
+            a.alloc();
+        }
+        _ => {}
+    }
+}
+
 fn panic_after_return(a: &Allocator) -> Ptr<'_> {
     // Panic in the drop of `p` or `q` can leak
     let exceptions = vec![8, 9];
@@ -514,6 +525,9 @@ fn main() {
     run_test(|a| if_let_guard(a, false, 0));
     run_test(|a| if_let_guard(a, false, 1));
     run_test(|a| if_let_guard(a, false, 2));
+    run_test(|a| if_let_guard_2(a, 0));
+    run_test(|a| if_let_guard_2(a, 1));
+    run_test(|a| if_let_guard_2(a, 2));
 
     run_test(|a| {
         panic_after_return(a);

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/drop-order.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/drop-order.rs
@@ -1,0 +1,59 @@
+// check drop order of temporaries create in match guards.
+// For normal guards all temporaries are dropped before the body of the arm.
+// For let guards temporaries live until the end of the arm.
+
+// run-pass
+
+#![feature(if_let_guard)]
+#![allow(irrefutable_let_patterns)]
+
+use std::sync::Mutex;
+
+static A: Mutex<Vec<i32>> = Mutex::new(Vec::new());
+
+struct D(i32);
+
+fn make_d(x: i32) -> D {
+    A.lock().unwrap().push(x);
+    D(x)
+}
+
+impl Drop for D {
+    fn drop(&mut self) {
+        A.lock().unwrap().push(!self.0);
+    }
+}
+
+fn if_guard(num: i32) {
+    let _d = make_d(1);
+    match num {
+        1 | 2 if make_d(2).0 == 2 => {
+            make_d(3);
+        }
+        _ => {}
+    }
+}
+
+fn if_let_guard(num: i32) {
+    let _d = make_d(1);
+    match num {
+        1 | 2 if let D(ref _x) = make_d(2) => {
+            make_d(3);
+        }
+        _ => {}
+    }
+}
+
+fn main() {
+    if_guard(1);
+    if_guard(2);
+    if_let_guard(1);
+    if_let_guard(2);
+    let expected =  [
+        1, 2, !2, 3, !3, !1,
+        1, 2, !2, 3, !3, !1,
+        1, 2, 3, !3, !2, !1,
+        1, 2, 3, !3, !2, !1,
+    ];
+    assert_eq!(*A.lock().unwrap(), expected);
+}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/loop-mutability.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/loop-mutability.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![feature(if_let_guard)]
+
+fn split_last(_: &()) -> Option<(&i32, &i32)> {
+    None
+}
+
+fn assign_twice() {
+    loop {
+        match () {
+            #[allow(irrefutable_let_patterns)]
+            () if let _ = split_last(&()) => {}
+            _ => {}
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/scoping-consistency-async.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/scoping-consistency-async.rs
@@ -1,0 +1,32 @@
+// Check that temporaries in if-let guards are correctly scoped.
+// Regression test for #116079.
+
+// build-pass
+// edition:2018
+// -Zvalidate-mir
+
+#![feature(if_let_guard)]
+
+static mut A: [i32; 5] = [1, 2, 3, 4, 5];
+
+async fn fun() {
+    unsafe {
+        match A {
+            _ => (),
+            i if let Some(1) = async { Some(1) }.await => (),
+            _ => (),
+        }
+    }
+}
+
+async fn funner() {
+    unsafe {
+        match A {
+            _ => (),
+            _ | _ if let Some(1) = async { Some(1) }.await => (),
+            _ => (),
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/scoping-consistency.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/scoping-consistency.rs
@@ -1,0 +1,24 @@
+// Check that temporaries in if-let guards are correctly scoped.
+
+// build-pass
+// -Zvalidate-mir
+
+#![feature(if_let_guard)]
+
+fn fun() {
+    match 0 {
+        _ => (),
+        _ if let Some(s) = std::convert::identity(&Some(String::new())) => {}
+        _ => (),
+    }
+}
+
+fn funner() {
+    match 0 {
+        _ => (),
+        _ | _ if let Some(s) = std::convert::identity(&Some(String::new())) => {}
+        _ => (),
+    }
+}
+
+fn main() {}

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -124,7 +124,7 @@ body:
                                                                         body: 
                                                                             Expr {
                                                                                 ty: bool
-                                                                                temp_lifetime: Some(Node(13))
+                                                                                temp_lifetime: Some(Node(12))
                                                                                 span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0)
                                                                                 kind: 
                                                                                     Scope {
@@ -133,7 +133,7 @@ body:
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: bool
-                                                                                                temp_lifetime: Some(Node(13))
+                                                                                                temp_lifetime: Some(Node(12))
                                                                                                 span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0)
                                                                                                 kind: 
                                                                                                     Literal( lit: Spanned { node: Bool(true), span: $DIR/thir-tree-match.rs:17:36: 17:40 (#0) }, neg: false)
@@ -176,7 +176,7 @@ body:
                                                                         body: 
                                                                             Expr {
                                                                                 ty: bool
-                                                                                temp_lifetime: Some(Node(19))
+                                                                                temp_lifetime: Some(Node(18))
                                                                                 span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0)
                                                                                 kind: 
                                                                                     Scope {
@@ -185,7 +185,7 @@ body:
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: bool
-                                                                                                temp_lifetime: Some(Node(19))
+                                                                                                temp_lifetime: Some(Node(18))
                                                                                                 span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0)
                                                                                                 kind: 
                                                                                                     Literal( lit: Spanned { node: Bool(false), span: $DIR/thir-tree-match.rs:18:27: 18:32 (#0) }, neg: false)
@@ -220,7 +220,7 @@ body:
                                                                         body: 
                                                                             Expr {
                                                                                 ty: bool
-                                                                                temp_lifetime: Some(Node(24))
+                                                                                temp_lifetime: Some(Node(23))
                                                                                 span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0)
                                                                                 kind: 
                                                                                     Scope {
@@ -229,7 +229,7 @@ body:
                                                                                         value:
                                                                                             Expr {
                                                                                                 ty: bool
-                                                                                                temp_lifetime: Some(Node(24))
+                                                                                                temp_lifetime: Some(Node(23))
                                                                                                 span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0)
                                                                                                 kind: 
                                                                                                     Literal( lit: Spanned { node: Bool(true), span: $DIR/thir-tree-match.rs:19:24: 19:28 (#0) }, neg: false)


### PR DESCRIPTION
Temporaries in if-let guards have scopes that escape the match arm, this causes problems because the drops might be for temporaries that are not storage live. This PR changes the scope of temporaries in if-let guards to be limited to the arm:

```rust
_ if let Some(s) = std::convert::identity(&Some(String::new())) => {}
//                Temporary for Some(String::new()) is dropped here ^
```

We also now deduplicate temporaries between copies of the guard created for or-patterns:

```rust
// Only create a single Some(String::new()) temporary variable
_ | _ if let Some(s) = std::convert::identity(&Some(String::new())) => {}
```

This changes MIR building to pass around `ExprId`s rather than `Expr`s so that we have a way to index different expressions.

cc #51114
Closes #116079 