### PR TITLE
Implement `array::repeat`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -10,8 +10,7 @@ use crate::convert::Infallible;
 use crate::error::Error;
 use crate::fmt;
 use crate::hash::{self, Hash};
-use crate::intrinsics::transmute_unchecked;
-use crate::iter::UncheckedIterator;
+use crate::iter::{repeat_n, UncheckedIterator};
 use crate::mem::{self, MaybeUninit};
 use crate::ops::{
     ChangeOutputType, ControlFlow, FromResidual, Index, IndexMut, NeverShortCircuit, Residual, Try,
@@ -30,12 +29,16 @@ pub use iter::IntoIter;
 
 /// Creates an array of type `[T; N]` by repeatedly cloning a value.
 ///
-/// The value will be used as the last element of the resulting array, so it
-/// will be cloned N - 1 times. If N is zero, the value will be dropped.
+/// This is the same as `[val; N]`, but it also works for types that do not
+/// implement [`Copy`].
+///
+/// The provided value will be used as an element of the resulting array and
+/// will be cloned N - 1 times to fill up the rest. If N is zero, the value
+/// will be dropped.
 ///
 /// # Example
 ///
-/// Creating muliple copies of a string:
+/// Creating muliple copies of a `String`:
 /// ```rust
 /// #![feature(array_repeat)]
 ///
@@ -48,19 +51,7 @@ pub use iter::IntoIter;
 #[inline]
 #[unstable(feature = "array_repeat", issue = "none")]
 pub fn repeat<T: Clone, const N: usize>(val: T) -> [T; N] {
-    match N {
-        // SAFETY: we know N to be 0 at this point.
-        0 => unsafe { transmute_unchecked::<[T; 0], [T; N]>([]) },
-        // SAFETY: we know N to be 1 at this point.
-        1 => unsafe { transmute_unchecked::<[T; 1], [T; N]>([val]) },
-        _ => {
-            let mut array = MaybeUninit::uninit_array::<N>();
-            try_from_fn_erased(&mut array[..N - 1], NeverShortCircuit::wrap_mut_1(|_| val.clone()));
-            array[N - 1].write(val);
-            // SAFETY: all elements were initialized.
-            unsafe { MaybeUninit::array_assume_init(array) }
-        }
-    }
+    from_trusted_iterator(repeat_n(val, N))
 }
 
 /// Creates an array of type [T; N], where each element `T` is the returned value from `cb`

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -49,7 +49,7 @@ pub use iter::IntoIter;
 /// assert_eq!(strings, ["Hello there!", "Hello there!"]);
 /// ```
 #[inline]
-#[unstable(feature = "array_repeat", issue = "none")]
+#[unstable(feature = "array_repeat", issue = "126695")]
 pub fn repeat<T: Clone, const N: usize>(val: T) -> [T; N] {
     from_trusted_iterator(repeat_n(val, N))
 }

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -10,6 +10,7 @@ use crate::convert::Infallible;
 use crate::error::Error;
 use crate::fmt;
 use crate::hash::{self, Hash};
+use crate::intrinsics::transmute_unchecked;
 use crate::iter::UncheckedIterator;
 use crate::mem::{self, MaybeUninit};
 use crate::ops::{
@@ -26,6 +27,41 @@ pub(crate) use drain::drain_array_with;
 
 #[stable(feature = "array_value_iter", since = "1.51.0")]
 pub use iter::IntoIter;
+
+/// Creates an array of type `[T; N]` by repeatedly cloning a value.
+///
+/// The value will be used as the last element of the resulting array, so it
+/// will be cloned N - 1 times. If N is zero, the value will be dropped.
+///
+/// # Example
+///
+/// Creating muliple copies of a string:
+/// ```rust
+/// #![feature(array_repeat)]
+///
+/// use std::array;
+///
+/// let string = "Hello there!".to_string();
+/// let strings = array::repeat(string);
+/// assert_eq!(strings, ["Hello there!", "Hello there!"]);
+/// ```
+#[inline]
+#[unstable(feature = "array_repeat", issue = "none")]
+pub fn repeat<T: Clone, const N: usize>(val: T) -> [T; N] {
+    match N {
+        // SAFETY: we know N to be 0 at this point.
+        0 => unsafe { transmute_unchecked::<[T; 0], [T; N]>([]) },
+        // SAFETY: we know N to be 1 at this point.
+        1 => unsafe { transmute_unchecked::<[T; 1], [T; N]>([val]) },
+        _ => {
+            let mut array = MaybeUninit::uninit_array::<N>();
+            try_from_fn_erased(&mut array[..N - 1], NeverShortCircuit::wrap_mut_1(|_| val.clone()));
+            array[N - 1].write(val);
+            // SAFETY: all elements were initialized.
+            unsafe { MaybeUninit::array_assume_init(array) }
+        }
+    }
+}
 
 /// Creates an array of type [T; N], where each element `T` is the returned value from `cb`
 /// using that element's index.

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -1,4 +1,4 @@
-use crate::iter::{FusedIterator, TrustedLen};
+use crate::iter::{FusedIterator, TrustedLen, UncheckedIterator};
 use crate::mem::ManuallyDrop;
 use crate::num::NonZero;
 
@@ -193,3 +193,5 @@ impl<A: Clone> FusedIterator for RepeatN<A> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
 unsafe impl<A: Clone> TrustedLen for RepeatN<A> {}
+#[unstable(feature = "trusted_len_next_unchecked", issue = "37572")]
+impl<A: Clone> UncheckedIterator for RepeatN<A> {}

--- a/tests/codegen/array-repeat.rs
+++ b/tests/codegen/array-repeat.rs
@@ -1,0 +1,15 @@
+// compile-flags: -O
+
+#![crate_type = "lib"]
+#![feature(array_repeat)]
+
+use std::array::repeat;
+
+// CHECK-LABEL: @byte_repeat
+#[no_mangle]
+fn byte_repeat(b: u8) -> [u8; 1024] {
+    // CHECK-NOT: alloca
+    // CHECK-NOT: store
+    // CHECK: memset
+    repeat(b)
+}

--- a/tests/codegen/array-repeat.rs
+++ b/tests/codegen/array-repeat.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O
+//@ compile-flags: -O
 
 #![crate_type = "lib"]
 #![feature(array_repeat)]


### PR DESCRIPTION
See rust-lang/libs-team#310.

I've decided to make the function use the input value as last element instead of cloning it to every position and dropping it, and to make this part of the API so that callers are not surprised by this behaviour.

TODO: open a tracking issue. I'll wait for the ACP to be accepted, first.

@rustbot label +T-libs-api +T-libs
r? libs