### PR TITLE
rework `-Zverbose`

### DIFF
--- a/compiler/rustc_driver_impl/src/pretty.rs
+++ b/compiler/rustc_driver_impl/src/pretty.rs
@@ -146,7 +146,7 @@ impl<'a> pprust_ast::PpAnn for AstHygieneAnn<'a> {
             }
             pprust_ast::AnnNode::Crate(_) => {
                 s.s.hardbreak();
-                let verbose = self.sess.verbose();
+                let verbose = self.sess.verbose_internals();
                 s.synth_comment(rustc_span::hygiene::debug_hygiene_data(verbose));
                 s.s.hardbreak_if_not_bol();
             }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -187,8 +187,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Expectation<'tcx>,
         args: &'tcx [hir::Expr<'tcx>],
     ) -> Ty<'tcx> {
-        if self.tcx().sess.verbose() {
-            // make this code only run with -Zverbose because it is probably slow
+        if self.tcx().sess.verbose_internals() {
+            // make this code only run with -Zverbose-internals because it is probably slow
             if let Ok(lint_str) = self.tcx.sess.source_map().span_to_snippet(expr.span) {
                 if !lint_str.contains('\n') {
                     debug!("expr text: {lint_str}");

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1206,6 +1206,23 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             s.push_highlighted(mutbl.prefix_str());
         }
 
+        fn maybe_highlight<T: Eq + ToString>(
+            t1: T,
+            t2: T,
+            (buf1, buf2): &mut (DiagnosticStyledString, DiagnosticStyledString),
+            tcx: TyCtxt<'_>,
+        ) {
+            let highlight = t1 != t2;
+            let (t1, t2) = if highlight || tcx.sess.opts.verbose {
+                (t1.to_string(), t2.to_string())
+            } else {
+                // The two types are the same, elide and don't highlight.
+                ("_".into(), "_".into())
+            };
+            buf1.push(t1, highlight);
+            buf2.push(t2, highlight);
+        }
+
         fn cmp_ty_refs<'tcx>(
             r1: ty::Region<'tcx>,
             mut1: hir::Mutability,
@@ -1302,7 +1319,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         if lifetimes.0 != lifetimes.1 {
                             values.0.push_highlighted(l1);
                             values.1.push_highlighted(l2);
-                        } else if lifetimes.0.is_bound() {
+                        } else if lifetimes.0.is_bound() || self.tcx.sess.opts.verbose {
                             values.0.push_normal(l1);
                             values.1.push_normal(l2);
                         } else {
@@ -1323,7 +1340,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     let num_display_types = consts_offset - regions_len;
                     for (i, (ta1, ta2)) in type_arguments.take(num_display_types).enumerate() {
                         let i = i + regions_len;
-                        if ta1 == ta2 && !self.tcx.sess.verbose_internals() {
+                        if ta1 == ta2 && !self.tcx.sess.opts.verbose {
                             values.0.push_normal("_");
                             values.1.push_normal("_");
                         } else {
@@ -1337,13 +1354,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     let const_arguments = sub1.consts().zip(sub2.consts());
                     for (i, (ca1, ca2)) in const_arguments.enumerate() {
                         let i = i + consts_offset;
-                        if ca1 == ca2 && !self.tcx.sess.verbose_internals() {
-                            values.0.push_normal("_");
-                            values.1.push_normal("_");
-                        } else {
-                            values.0.push_highlighted(ca1.to_string());
-                            values.1.push_highlighted(ca2.to_string());
-                        }
+                        maybe_highlight(ca1, ca2, &mut values, self.tcx);
                         self.push_comma(&mut values.0, &mut values.1, len, i);
                     }
 
@@ -1507,16 +1518,9 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             (ty::FnPtr(sig1), ty::FnPtr(sig2)) => self.cmp_fn_sig(sig1, sig2),
 
             _ => {
-                if t1 == t2 && !self.tcx.sess.verbose_internals() {
-                    // The two types are the same, elide and don't highlight.
-                    (DiagnosticStyledString::normal("_"), DiagnosticStyledString::normal("_"))
-                } else {
-                    // We couldn't find anything in common, highlight everything.
-                    (
-                        DiagnosticStyledString::highlighted(t1.to_string()),
-                        DiagnosticStyledString::highlighted(t2.to_string()),
-                    )
-                }
+                let mut strs = (DiagnosticStyledString::new(), DiagnosticStyledString::new());
+                maybe_highlight(t1, t2, &mut strs, self.tcx);
+                strs
             }
         }
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1323,7 +1323,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     let num_display_types = consts_offset - regions_len;
                     for (i, (ta1, ta2)) in type_arguments.take(num_display_types).enumerate() {
                         let i = i + regions_len;
-                        if ta1 == ta2 && !self.tcx.sess.verbose() {
+                        if ta1 == ta2 && !self.tcx.sess.verbose_internals() {
                             values.0.push_normal("_");
                             values.1.push_normal("_");
                         } else {
@@ -1337,7 +1337,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     let const_arguments = sub1.consts().zip(sub2.consts());
                     for (i, (ca1, ca2)) in const_arguments.enumerate() {
                         let i = i + consts_offset;
-                        if ca1 == ca2 && !self.tcx.sess.verbose() {
+                        if ca1 == ca2 && !self.tcx.sess.verbose_internals() {
                             values.0.push_normal("_");
                             values.1.push_normal("_");
                         } else {
@@ -1507,7 +1507,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             (ty::FnPtr(sig1), ty::FnPtr(sig2)) => self.cmp_fn_sig(sig1, sig2),
 
             _ => {
-                if t1 == t2 && !self.tcx.sess.verbose() {
+                if t1 == t2 && !self.tcx.sess.verbose_internals() {
                     // The two types are the same, elide and don't highlight.
                     (DiagnosticStyledString::normal("_"), DiagnosticStyledString::normal("_"))
                 } else {

--- a/compiler/rustc_infer/src/traits/structural_impls.rs
+++ b/compiler/rustc_infer/src/traits/structural_impls.rs
@@ -17,7 +17,7 @@ impl<'tcx, T: fmt::Debug> fmt::Debug for Normalized<'tcx, T> {
 
 impl<'tcx, O: fmt::Debug> fmt::Debug for traits::Obligation<'tcx, O> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if ty::tls::with(|tcx| tcx.sess.verbose()) {
+        if ty::tls::with(|tcx| tcx.sess.verbose_internals()) {
             write!(
                 f,
                 "Obligation(predicate={:?}, cause={:?}, param_env={:?}, depth={})",

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -714,7 +714,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(unpretty, Some("expanded".to_string()));
     untracked!(unstable_options, true);
     untracked!(validate_mir, true);
-    untracked!(verbose, true);
+    untracked!(verbose_internals, true);
     untracked!(write_long_types_to_disk, false);
     // tidy-alphabetical-end
 

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -627,7 +627,11 @@ where
                 w,
                 "{:A$} // {}{}",
                 indented_body,
-                if tcx.sess.verbose() { format!("{current_location:?}: ") } else { String::new() },
+                if tcx.sess.verbose_internals() {
+                    format!("{current_location:?}: ")
+                } else {
+                    String::new()
+                },
                 comment(tcx, statement.source_info),
                 A = ALIGN,
             )?;
@@ -652,7 +656,11 @@ where
             w,
             "{:A$} // {}{}",
             indented_terminator,
-            if tcx.sess.verbose() { format!("{current_location:?}: ") } else { String::new() },
+            if tcx.sess.verbose_internals() {
+                format!("{current_location:?}: ")
+            } else {
+                String::new()
+            },
             comment(tcx, data.terminator().source_info),
             A = ALIGN,
         )?;
@@ -943,7 +951,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 
                 // When printing regions, add trailing space if necessary.
                 let print_region = ty::tls::with(|tcx| {
-                    tcx.sess.verbose() || tcx.sess.opts.unstable_opts.identify_regions
+                    tcx.sess.verbose_internals() || tcx.sess.opts.unstable_opts.identify_regions
                 });
                 let region = if print_region {
                     let mut region = region.to_string();
@@ -1668,7 +1676,7 @@ fn pretty_print_const_value_tcx<'tcx>(
 ) -> fmt::Result {
     use crate::ty::print::PrettyPrinter;
 
-    if tcx.sess.verbose() {
+    if tcx.sess.verbose_internals() {
         fmt.write_str(&format!("ConstValue({ct:?}: {ty})"))?;
         return Ok(());
     }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -177,7 +177,7 @@ impl<'tcx> ObligationCause<'tcx> {
 
         // NOTE(flaper87): As of now, it keeps track of the whole error
         // chain. Ideally, we should have a way to configure this either
-        // by using -Z verbose or just a CLI argument.
+        // by using -Z verbose-internals or just a CLI argument.
         self.code =
             variant(DerivedObligationCause { parent_trait_pred, parent_code: self.code }).into();
         self

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -326,7 +326,7 @@ impl<'tcx> Generics {
             own_params.start = 1;
         }
 
-        let verbose = tcx.sess.verbose();
+        let verbose = tcx.sess.verbose_internals();
 
         // Filter the default arguments.
         //
@@ -342,7 +342,7 @@ impl<'tcx> Generics {
                 param.default_value(tcx).is_some_and(|default| {
                     default.instantiate(tcx, args) == args[param.index as usize]
                 })
-                // filter out trailing effect params, if we're not in `-Zverbose`.
+                // filter out trailing effect params, if we're not in `-Zverbose-internals`.
                 || (!verbose && matches!(param.kind, GenericParamDefKind::Const { is_host_effect: true, .. }))
             })
             .count();

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -744,7 +744,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 // only affect certain debug messages (e.g. messages printed
                 // from `rustc_middle::ty` during the computation of `tcx.predicates_of`),
                 // and should have no effect on any compiler output.
-                // [Unless `-Zverbose` is used, e.g. in the output of
+                // [Unless `-Zverbose-internals` is used, e.g. in the output of
                 // `tests/ui/nll/ty-outlives/impl-trait-captures.rs`, for
                 // example.]
                 if self.should_print_verbose() {
@@ -829,7 +829,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             ty::CoroutineWitness(did, args) => {
                 p!(write("{{"));
-                if !self.tcx().sess.verbose() {
+                if !self.tcx().sess.verbose_internals() {
                     p!("coroutine witness");
                     // FIXME(eddyb) should use `def_span`.
                     if let Some(did) = did.as_local() {
@@ -1698,7 +1698,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     }
 
     fn should_print_verbose(&self) -> bool {
-        self.tcx().sess.verbose()
+        self.tcx().sess.verbose_internals()
     }
 }
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -315,8 +315,11 @@ pub(crate) fn create_query_frame<
             ty::print::with_forced_impl_filename_line!(do_describe(tcx, key))
         )
     );
-    let description =
-        if tcx.sess.verbose() { format!("{description} [{name:?}]") } else { description };
+    let description = if tcx.sess.verbose_internals() {
+        format!("{description} [{name:?}]")
+    } else {
+        description
+    };
     let span = if kind == dep_graph::dep_kinds::def_span || with_no_queries() {
         // The `def_span` query is used to calculate `default_span`,
         // so exit to avoid infinite recursion.

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1116,6 +1116,7 @@ impl Default for Options {
             working_dir: RealFileName::LocalPath(std::env::current_dir().unwrap()),
             color: ColorConfig::Auto,
             logical_env: FxIndexMap::default(),
+            verbose: false,
         }
     }
 }
@@ -2916,6 +2917,8 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         RealFileName::LocalPath(path.into_owned())
     };
 
+    let verbose = matches.opt_present("verbose") || unstable_opts.verbose_internals;
+
     Options {
         assert_incr_state,
         crate_types,
@@ -2957,6 +2960,7 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         working_dir,
         color,
         logical_env,
+        verbose,
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -223,6 +223,8 @@ top_level_options!(
         /// The (potentially remapped) working directory
         working_dir: RealFileName [TRACKED],
         color: ColorConfig [UNTRACKED],
+
+        verbose: bool [UNTRACKED],
     }
 );
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1989,8 +1989,8 @@ written to standard error output)"),
         "use legacy .ctors section for initializers rather than .init_array"),
     validate_mir: bool = (false, parse_bool, [UNTRACKED],
         "validate MIR after each transformation"),
-    #[rustc_lint_opt_deny_field_access("use `Session::verbose` instead of this field")]
-    verbose: bool = (false, parse_bool, [UNTRACKED],
+    #[rustc_lint_opt_deny_field_access("use `Session::verbose_internals` instead of this field")]
+    verbose_internals: bool = (false, parse_bool, [UNTRACKED],
         "in general, enable more debug printouts (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::verify_llvm_ir` instead of this field")]
     verify_llvm_ir: bool = (false, parse_bool, [TRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -974,8 +974,8 @@ impl Session {
 // JUSTIFICATION: defn of the suggested wrapper fns
 #[allow(rustc::bad_opt_access)]
 impl Session {
-    pub fn verbose(&self) -> bool {
-        self.opts.unstable_opts.verbose
+    pub fn verbose_internals(&self) -> bool {
+        self.opts.unstable_opts.verbose_internals
     }
 
     pub fn print_llvm_stats(&self) -> bool {

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -214,7 +214,7 @@ impl<'tcx> Printer<'tcx> for SymbolPrinter<'tcx> {
             | ty::Coroutine(def_id, args, _) => self.print_def_path(def_id, args),
 
             // The `pretty_print_type` formatting of array size depends on
-            // -Zverbose flag, so we cannot reuse it here.
+            // -Zverbose-internals flag, so we cannot reuse it here.
             ty::Array(ty, size) => {
                 self.write_str("[")?;
                 self.print_type(ty)?;
@@ -255,7 +255,7 @@ impl<'tcx> Printer<'tcx> for SymbolPrinter<'tcx> {
         // only print integers
         match (ct.kind(), ct.ty().kind()) {
             (ty::ConstKind::Value(ty::ValTree::Leaf(scalar)), ty::Int(_) | ty::Uint(_)) => {
-                // The `pretty_print_const` formatting depends on -Zverbose
+                // The `pretty_print_const` formatting depends on -Zverbose-internals
                 // flag, so we cannot reuse it here.
                 let signed = matches!(ct.ty().kind(), ty::Int(_));
                 write!(

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -343,7 +343,7 @@ _Note:_ The order of these lint level arguments is taken into account, see [lint
 ## `-Z`: set unstable options
 
 This flag will allow you to set unstable options of rustc. In order to set multiple options,
-the -Z flag can be used multiple times. For example: `rustc -Z verbose -Z time-passes`.
+the -Z flag can be used multiple times. For example: `rustc -Z verbose-internals -Z time-passes`.
 Specifying options with -Z is only available on nightly. To view all available options
 run: `rustc -Z help`, or see [The Unstable Book](../unstable-book/index.html).
 

--- a/tests/mir-opt/nll/named_lifetimes_basic.rs
+++ b/tests/mir-opt/nll/named_lifetimes_basic.rs
@@ -5,7 +5,7 @@
 // between R0 and R1 properly.
 
 // compile-flags: -Zverbose-internals
-//                ^^^^^^^^^ force compiler to dump more region information
+//                ^^^^^^^^^^^^^^^^^^^ force compiler to dump more region information
 
 #![allow(warnings)]
 

--- a/tests/mir-opt/nll/named_lifetimes_basic.rs
+++ b/tests/mir-opt/nll/named_lifetimes_basic.rs
@@ -4,7 +4,7 @@
 // suitable variables and that we setup the outlives relationship
 // between R0 and R1 properly.
 
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 //                ^^^^^^^^^ force compiler to dump more region information
 
 #![allow(warnings)]

--- a/tests/mir-opt/nll/region_subtyping_basic.rs
+++ b/tests/mir-opt/nll/region_subtyping_basic.rs
@@ -4,7 +4,7 @@
 // including) the call to `use_x`. The `else` branch is not included.
 
 // compile-flags:-Zverbose-internals
-//               ^^^^^^^^^ force compiler to dump more region information
+//                ^^^^^^^^^^^^^^^^^^^ force compiler to dump more region information
 
 #![allow(warnings)]
 

--- a/tests/mir-opt/nll/region_subtyping_basic.rs
+++ b/tests/mir-opt/nll/region_subtyping_basic.rs
@@ -3,7 +3,7 @@
 // in the type of `p` includes the points after `&v[0]` up to (but not
 // including) the call to `use_x`. The `else` branch is not included.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 //               ^^^^^^^^^ force compiler to dump more region information
 
 #![allow(warnings)]

--- a/tests/ui/associated-types/substs-ppaux.rs
+++ b/tests/ui/associated-types/substs-ppaux.rs
@@ -1,7 +1,7 @@
 //
 // revisions: verbose normal
 //
-//[verbose] compile-flags: -Z verbose
+//[verbose] compile-flags: -Z verbose-internals
 
 trait Foo<'b, 'c, S=u32> {
     fn bar<'a, T>() where T: 'a {}

--- a/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.rs
+++ b/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Ztrim-diagnostic-paths=off -Zverbose
+// compile-flags: -Ztrim-diagnostic-paths=off -Zverbose-internals
 
 mod mod1 {
     pub fn f<T: std::fmt::Display>(t: T)

--- a/tests/ui/closures/print/closure-print-generic-verbose-1.rs
+++ b/tests/ui/closures/print/closure-print-generic-verbose-1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 fn to_fn_once<F:FnOnce()>(f: F) -> F { f }
 

--- a/tests/ui/closures/print/closure-print-generic-verbose-2.rs
+++ b/tests/ui/closures/print/closure-print-generic-verbose-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 mod mod1 {
     pub fn f<T: std::fmt::Display>(t: T)

--- a/tests/ui/closures/print/closure-print-verbose.rs
+++ b/tests/ui/closures/print/closure-print-verbose.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 // Same as closure-coerce-fn-1.rs
 

--- a/tests/ui/coroutine/print/coroutine-print-verbose-1.rs
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 // Same as: tests/ui/coroutine/issue-68112.stderr
 

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.rs
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 // Same as test/ui/coroutine/not-send-sync.rs
 #![feature(coroutines)]

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.rs
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 #![feature(coroutines, coroutine_trait)]
 

--- a/tests/ui/fn/signature-error-reporting-under-verbose.rs
+++ b/tests/ui/fn/signature-error-reporting-under-verbose.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 fn foo(_: i32, _: i32) {}
 

--- a/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
+++ b/tests/ui/impl-trait/erased-regions-in-hidden-ty.rs
@@ -1,5 +1,5 @@
 // revisions: current next
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 //[next] compile-flags: -Znext-solver
 // normalize-stderr-test "DefId\([^\)]+\)" -> "DefId(..)"
 

--- a/tests/ui/issues/issue-13482-2.rs
+++ b/tests/ui/issues/issue-13482-2.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Z verbose
+// compile-flags:-Z verbose-internals
 
 fn main() {
     let x = [1,2];

--- a/tests/ui/nll/closure-requirements/escape-argument-callee.rs
+++ b/tests/ui/nll/closure-requirements/escape-argument-callee.rs
@@ -12,7 +12,7 @@
 // that appear free in its type (hence, we see it before the closure's
 // "external requirements" report).
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/escape-argument.rs
+++ b/tests/ui/nll/closure-requirements/escape-argument.rs
@@ -12,7 +12,7 @@
 // basically checking that the MIR type checker correctly enforces the
 // closure signature.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/escape-upvar-nested.rs
+++ b/tests/ui/nll/closure-requirements/escape-upvar-nested.rs
@@ -5,7 +5,7 @@
 //
 // except that the closure does so via a second closure.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/escape-upvar-ref.rs
+++ b/tests/ui/nll/closure-requirements/escape-upvar-ref.rs
@@ -9,7 +9,7 @@
 // `'b`.  This relationship is propagated to the closure creator,
 // which reports an error.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.rs
@@ -1,7 +1,7 @@
 // Test where we fail to approximate due to demanding a postdom
 // relationship between our upper bounds.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-ref.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-ref.rs
@@ -12,7 +12,7 @@
 // Note: the use of `Cell` here is to introduce invariance. One less
 // variable.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.rs
@@ -2,7 +2,7 @@
 // where `'x` is bound in closure type but `'a` is free. This forces
 // us to approximate `'x` one way or the other.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.rs
@@ -3,7 +3,7 @@
 // because `'y` is higher-ranked but we know of no relations to other
 // regions. Note that `'static` shows up in the stderr output as `'0`.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.rs
@@ -4,7 +4,7 @@
 // relations to other regions. Note that `'static` shows up in the
 // stderr output as `'0`.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-approximated-val.rs
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-val.rs
@@ -5,7 +5,7 @@
 // relationships. In the 'main' variant, there are a number of
 // anonymous regions as well.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.rs
+++ b/tests/ui/nll/closure-requirements/propagate-despite-same-free-region.rs
@@ -3,7 +3,7 @@
 // need to propagate; but in fact we do because identity of free
 // regions is erased.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 // check-pass
 
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.rs
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.rs
@@ -7,7 +7,7 @@
 // as it knows of no relationships between `'x` and any
 // non-higher-ranked regions.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.rs
+++ b/tests/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.rs
@@ -7,7 +7,7 @@
 // as it only knows of regions that `'x` is outlived by, and none that
 // `'x` outlives.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/closure-requirements/propagate-from-trait-match.rs
+++ b/tests/ui/nll/closure-requirements/propagate-from-trait-match.rs
@@ -4,7 +4,7 @@
 // the same `'a` for which it implements `Trait`, which can only be the `'a`
 // from the function definition.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/tests/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.rs
+++ b/tests/ui/nll/closure-requirements/region-lbr-anon-does-not-outlive-static.rs
@@ -3,7 +3,7 @@
 // a variety of errors from the older, AST-based machinery (notably
 // borrowck), and then we get the NLL error at the end.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 fn foo(x: &u32) -> &'static u32 {
     &*x

--- a/tests/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.rs
+++ b/tests/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.rs
@@ -3,7 +3,7 @@
 // a variety of errors from the older, AST-based machinery (notably
 // borrowck), and then we get the NLL error at the end.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 fn foo<'a>(x: &'a u32) -> &'static u32 {
     &*x

--- a/tests/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.rs
+++ b/tests/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.rs
@@ -3,7 +3,7 @@
 // a variety of errors from the older, AST-based machinery (notably
 // borrowck), and then we get the NLL error at the end.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {
     &*x

--- a/tests/ui/nll/closure-requirements/region-lbr1-does-outlive-lbr2-because-implied-bound.rs
+++ b/tests/ui/nll/closure-requirements/region-lbr1-does-outlive-lbr2-because-implied-bound.rs
@@ -2,7 +2,7 @@
 // report an error because of the (implied) bound that `'b: 'a`.
 
 // check-pass
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 fn foo<'a, 'b>(x: &'a &'b u32) -> &'a u32 {
     &**x

--- a/tests/ui/nll/closure-requirements/return-wrong-bound-region.rs
+++ b/tests/ui/nll/closure-requirements/return-wrong-bound-region.rs
@@ -2,7 +2,7 @@
 // the first, but actually returns the second. This should fail within
 // the closure.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/nll/ty-outlives/impl-trait-captures.rs
+++ b/tests/ui/nll/ty-outlives/impl-trait-captures.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 

--- a/tests/ui/nll/ty-outlives/impl-trait-outlives.rs
+++ b/tests/ui/nll/ty-outlives/impl-trait-outlives.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 

--- a/tests/ui/nll/ty-outlives/projection-implied-bounds.rs
+++ b/tests/ui/nll/ty-outlives/projection-implied-bounds.rs
@@ -1,7 +1,7 @@
 // Test that we can deduce when projections like `T::Item` outlive the
 // function body. Test that this does not imply that `T: 'a` holds.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 use std::cell::Cell;
 

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.rs
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 // Tests closures that propagate an outlives relationship to their
 // creator where the subject is a projection with no regions (`<T as

--- a/tests/ui/nll/ty-outlives/projection-no-regions-fn.rs
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-fn.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 

--- a/tests/ui/nll/ty-outlives/projection-one-region-closure.rs
+++ b/tests/ui/nll/ty-outlives/projection-one-region-closure.rs
@@ -12,7 +12,7 @@
 //
 // Ensuring that both `T: 'a` and `'b: 'a` holds does work (`elements_outlive`).
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.rs
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.rs
@@ -4,7 +4,7 @@
 // case, the best way to satisfy the trait bound is to show that `'b:
 // 'a`, which can be done in various ways.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
+++ b/tests/ui/nll/ty-outlives/projection-one-region-trait-bound-static-closure.rs
@@ -2,7 +2,7 @@
 // outlive `'static`. In this case, we don't get any errors, and in fact
 // we don't even propagate constraints from the closures to the callers.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 // check-pass
 
 #![allow(warnings)]

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
@@ -5,7 +5,7 @@
 // the trait bound, and hence we propagate it to the caller as a type
 // test.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.rs
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-approximate-lower-bound.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.rs
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.rs
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-where-clause.rs
@@ -2,7 +2,7 @@
 // `correct_region` for an explanation of how this test is setup; it's
 // somewhat intricate.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/ty-outlives/ty-param-implied-bounds.rs
+++ b/tests/ui/nll/ty-outlives/ty-param-implied-bounds.rs
@@ -1,4 +1,4 @@
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 // check-pass
 
 // Test that we assume that universal types like `T` outlive the

--- a/tests/ui/nll/user-annotations/dump-adt-brace-struct.rs
+++ b/tests/ui/nll/user-annotations/dump-adt-brace-struct.rs
@@ -1,7 +1,7 @@
 // Unit test for the "user substitutions" that are annotated on each
 // node.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/tests/ui/nll/user-annotations/dump-fn-method.rs
+++ b/tests/ui/nll/user-annotations/dump-fn-method.rs
@@ -1,7 +1,7 @@
 // Unit test for the "user substitutions" that are annotated on each
 // node.
 
-// compile-flags:-Zverbose
+// compile-flags:-Zverbose-internals
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/symbol-names/types.rs
+++ b/tests/ui/symbol-names/types.rs
@@ -1,7 +1,7 @@
 // build-fail
 // revisions: legacy verbose-legacy
 // compile-flags: --crate-name=a -C symbol-mangling-version=legacy -Z unstable-options
-//[verbose-legacy]compile-flags: -Zverbose
+//[verbose-legacy]compile-flags: -Zverbose-internals
 // normalize-stderr-test: "h[[:xdigit:]]{16}" -> "h[HASH]"
 
 #![feature(never_type)]

--- a/tests/ui/symbol-names/verbose.rs
+++ b/tests/ui/symbol-names/verbose.rs
@@ -1,10 +1,10 @@
-// Regression test for issue #57596, where -Zverbose flag unintentionally
+// Regression test for issue #57596, where -Zverbose-internals flag unintentionally
 // affected produced symbols making it impossible to link between crates
 // with a different value of the flag (for symbols involving generic
 // arguments equal to defaults of their respective parameters).
 //
 // build-pass
-// compile-flags: -Zverbose
+// compile-flags: -Zverbose-internals
 
 pub fn error(msg: String) -> Box<dyn std::error::Error> {
   msg.into()

--- a/tests/ui/type/issue-94187-verbose-type-name.rs
+++ b/tests/ui/type/issue-94187-verbose-type-name.rs
@@ -1,8 +1,8 @@
-// Check to insure that the output of `std::any::type_name` does not change based on `-Zverbose`
+// Ensure the output of `std::any::type_name` does not change based on `-Zverbose-internals`
 // run-pass
 // edition: 2018
 // revisions: normal verbose
-// [verbose]compile-flags:-Zverbose
+// [verbose]compile-flags:-Zverbose-internals --verbose
 
 use std::any::type_name;
 

--- a/tests/ui/type/verbose.normal.stderr
+++ b/tests/ui/type/verbose.normal.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/verbose.rs:7:28
+   |
+LL |     let _: Foo<u32, i32> = Foo::<i32, i32> { x: 0, y: 0 };
+   |            -------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo<u32, i32>`, found `Foo<i32, i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Foo<u32, _>`
+              found struct `Foo<i32, _>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type/verbose.rs
+++ b/tests/ui/type/verbose.rs
@@ -1,0 +1,13 @@
+// revisions:verbose normal
+// [verbose]compile-flags:--verbose
+#![crate_type = "lib"]
+
+struct Foo<T, U> { x: T, y: U }
+fn bar() {
+    let _: Foo<u32, i32> = Foo::<i32, i32> { x: 0, y: 0 };
+    //~^ ERROR mismatched types
+    //[verbose]~| NOTE expected struct `Foo<u32, i32>`
+    //[normal]~| NOTE expected struct `Foo<u32, _>`
+    //~| NOTE expected `Foo<u32, i32>`
+    //~| NOTE expected due to this
+}

--- a/tests/ui/type/verbose.verbose.stderr
+++ b/tests/ui/type/verbose.verbose.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/verbose.rs:7:28
+   |
+LL |     let _: Foo<u32, i32> = Foo::<i32, i32> { x: 0, y: 0 };
+   |            -------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo<u32, i32>`, found `Foo<i32, i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Foo<u32, i32>`
+              found struct `Foo<i32, i32>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/where-clauses/higher-ranked-fn-type.rs
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.rs
@@ -1,5 +1,5 @@
 // revisions: quiet verbose
-// [verbose]compile-flags: -Zverbose
+// [verbose]compile-flags: -Zverbose-internals
 
 #![allow(unused_parens)]
 


### PR DESCRIPTION
implements the changes described in https://github.com/rust-lang/compiler-team/issues/706

the first commit is only a name change from `-Zverbose` to `-Zverbose-internals` and does not change behavior. the second commit changes diagnostics.

possible follow up work:
- `ty::pretty` could print more info with `--verbose` than it does currently. `-Z verbose-internals` shows too much info in a way that's not helpful to users. michael had ideas about this i didn't fully understand: https://rust-lang.zulipchat.com/#narrow/stream/233931-t-compiler.2Fmajor-changes/topic/uplift.20some.20-Zverbose.20calls.20and.20rename.20to.E2.80.A6.20compiler-team.23706/near/408984200
- `--verbose` should imply `-Z write-long-types-to-disk=no`. the code in `ty_string_with_limit` should take `--verbose` into account (apparently this affects `Ty::sort_string`, i'm not familiar with this code). writing a file to disk should suggest passing `--verbose`.

r? @compiler-errors cc @estebank