### PR TITLE
Fix crash due to `CrateItem::kind()` not handling constructors

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! For now, we are developing everything inside `rustc`, thus, we keep this module private.
 
-use rustc_hir::def::DefKind;
+use rustc_hir::def::{CtorKind, DefKind};
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::AllocId;
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
@@ -88,14 +88,17 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
         | DefKind::Field
         | DefKind::LifetimeParam
         | DefKind::Impl { .. }
-        | DefKind::Ctor(_, _)
         | DefKind::GlobalAsm => {
             unreachable!("Not a valid item kind: {kind:?}");
         }
-        DefKind::Closure | DefKind::AssocFn | DefKind::Fn => ItemKind::Fn,
-        DefKind::Const | DefKind::InlineConst | DefKind::AssocConst | DefKind::AnonConst => {
-            ItemKind::Const
+        DefKind::Ctor(_, CtorKind::Fn) | DefKind::Closure | DefKind::AssocFn | DefKind::Fn => {
+            ItemKind::Fn
         }
+        DefKind::Ctor(_, CtorKind::Const)
+        | DefKind::Const
+        | DefKind::InlineConst
+        | DefKind::AssocConst
+        | DefKind::AnonConst => ItemKind::Const,
         DefKind::Static(_) => ItemKind::Static,
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! For now, we are developing everything inside `rustc`, thus, we keep this module private.
 
-use rustc_hir::def::{CtorKind, DefKind};
+use rustc_hir::def::DefKind;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::AllocId;
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
@@ -15,7 +15,7 @@ use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use stable_mir::abi::Layout;
 use stable_mir::mir::mono::InstanceDef;
 use stable_mir::ty::{ConstId, Span};
-use stable_mir::ItemKind;
+use stable_mir::{CtorKind, ItemKind};
 use std::ops::RangeInclusive;
 use tracing::debug;
 
@@ -91,15 +91,13 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
         | DefKind::GlobalAsm => {
             unreachable!("Not a valid item kind: {kind:?}");
         }
-        DefKind::Ctor(_, CtorKind::Fn) | DefKind::Closure | DefKind::AssocFn | DefKind::Fn => {
-            ItemKind::Fn
+        DefKind::Closure | DefKind::AssocFn | DefKind::Fn => ItemKind::Fn,
+        DefKind::Const | DefKind::InlineConst | DefKind::AssocConst | DefKind::AnonConst => {
+            ItemKind::Const
         }
-        DefKind::Ctor(_, CtorKind::Const)
-        | DefKind::Const
-        | DefKind::InlineConst
-        | DefKind::AssocConst
-        | DefKind::AnonConst => ItemKind::Const,
         DefKind::Static(_) => ItemKind::Static,
+        DefKind::Ctor(_, rustc_hir::def::CtorKind::Const) => ItemKind::Ctor(CtorKind::Const),
+        DefKind::Ctor(_, rustc_hir::def::CtorKind::Fn) => ItemKind::Ctor(CtorKind::Fn),
     }
 }
 

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -91,6 +91,13 @@ pub enum ItemKind {
     Fn,
     Static,
     Const,
+    Ctor(CtorKind),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+pub enum CtorKind {
+    Const,
+    Fn,
 }
 
 pub type Filename = String;

--- a/tests/ui-fulldeps/stable-mir/check_item_kind.rs
+++ b/tests/ui-fulldeps/stable-mir/check_item_kind.rs
@@ -1,0 +1,78 @@
+// run-pass
+//! Test that item kind works as expected.
+
+// ignore-stage1
+// ignore-cross-compile
+// ignore-remote
+// ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
+// edition: 2021
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+#![feature(control_flow_enum)]
+
+extern crate rustc_middle;
+#[macro_use]
+extern crate rustc_smir;
+extern crate rustc_driver;
+extern crate rustc_interface;
+extern crate stable_mir;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::rustc_internal;
+use stable_mir::*;
+use std::io::Write;
+use std::ops::ControlFlow;
+
+const CRATE_NAME: &str = "input";
+
+/// This function uses the Stable MIR APIs to get information about the test crate.
+fn test_item_kind(_tcx: TyCtxt<'_>) -> ControlFlow<()> {
+    let items = stable_mir::all_local_items();
+    assert_eq!(items.len(), 3);
+    // Constructor item.
+    for item in items {
+        let expected_kind = match item.name().as_str() {
+            "Dummy" => ItemKind::Fn,
+            "dummy" => ItemKind::Fn,
+            "DUMMY_CONST" => ItemKind::Const,
+            name => unreachable!("Unexpected item {name}"),
+        };
+        assert_eq!(item.kind(), expected_kind, "Mismatched type for {}", item.name());
+    }
+    ControlFlow::Continue(())
+}
+
+/// This test will generate and analyze a dummy crate using the stable mir.
+/// For that, it will first write the dummy crate into a file.
+/// Then it will create a `StableMir` using custom arguments and then
+/// it will run the compiler.
+fn main() {
+    let path = "item_kind_input.rs";
+    generate_input(&path).unwrap();
+    let args = vec![
+        "rustc".to_string(),
+        "-Cpanic=abort".to_string(),
+        "--crate-type=lib".to_string(),
+        "--crate-name".to_string(),
+        CRATE_NAME.to_string(),
+        path.to_string(),
+    ];
+    run!(args, tcx, test_item_kind(tcx)).unwrap();
+}
+
+fn generate_input(path: &str) -> std::io::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    write!(
+        file,
+        r#"
+        pub struct Dummy(u32);
+        pub const DUMMY_CONST: Dummy = Dummy(0);
+
+        pub fn dummy() -> Dummy {{
+            Dummy(5)
+        }}
+        "#
+    )?;
+    Ok(())
+}

--- a/tests/ui-fulldeps/stable-mir/check_item_kind.rs
+++ b/tests/ui-fulldeps/stable-mir/check_item_kind.rs
@@ -29,12 +29,13 @@ const CRATE_NAME: &str = "input";
 /// This function uses the Stable MIR APIs to get information about the test crate.
 fn test_item_kind(_tcx: TyCtxt<'_>) -> ControlFlow<()> {
     let items = stable_mir::all_local_items();
-    assert_eq!(items.len(), 3);
+    assert_eq!(items.len(), 4);
     // Constructor item.
     for item in items {
         let expected_kind = match item.name().as_str() {
-            "Dummy" => ItemKind::Fn,
+            "Dummy" => ItemKind::Ctor(CtorKind::Fn),
             "dummy" => ItemKind::Fn,
+            "unit" => ItemKind::Fn,
             "DUMMY_CONST" => ItemKind::Const,
             name => unreachable!("Unexpected item {name}"),
         };
@@ -68,9 +69,14 @@ fn generate_input(path: &str) -> std::io::Result<()> {
         r#"
         pub struct Dummy(u32);
         pub const DUMMY_CONST: Dummy = Dummy(0);
+        pub struct DummyUnit;
 
         pub fn dummy() -> Dummy {{
             Dummy(5)
+        }}
+
+        pub fn unit() -> DummyUnit {{
+            DummyUnit
         }}
         "#
     )?;


### PR DESCRIPTION
Also add a method to get the instance instantiation arguments, and include that information in the instance debug.