### PR TITLE
resolve: Eagerly feed closure visibilities

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -60,7 +60,7 @@ use rustc_hir::def_id::{LocalDefId, LocalDefIdMap, CRATE_DEF_ID, LOCAL_CRATE};
 use rustc_hir::{ConstArg, GenericArg, ItemLocalMap, ParamName, TraitCandidate};
 use rustc_index::{Idx, IndexSlice, IndexVec};
 use rustc_middle::span_bug;
-use rustc_middle::ty::{ResolverAstLowering, TyCtxt, Visibility};
+use rustc_middle::ty::{ResolverAstLowering, TyCtxt};
 use rustc_session::parse::{add_feature_diagnostics, feature_err};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{DesugaringKind, Span, DUMMY_SP};
@@ -1650,10 +1650,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             opaque_ty_span,
         );
         debug!(?opaque_ty_def_id);
-
-        // Meaningless, but provided so that all items have visibilities.
-        let parent_mod = self.tcx.parent_module_from_def_id(opaque_ty_def_id).to_def_id();
-        self.tcx.feed_local_def_id(opaque_ty_def_id).visibility(Visibility::Restricted(parent_mod));
 
         // Map from captured (old) lifetime to synthetic (new) lifetime.
         // Used to resolve lifetimes in the bounds of the opaque.

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -1765,15 +1765,6 @@ impl<'tcx> PrivateItemsInPublicInterfacesChecker<'tcx, '_> {
 
 pub fn provide(providers: &mut Providers) {
     *providers = Providers {
-        visibility: |tcx, def_id| {
-            // Unique types created for closures participate in type privacy checking.
-            // They have visibilities inherited from the module they are defined in.
-            // FIXME: Consider evaluating visibilities for closures eagerly, like for all
-            // other nodes. However, unlike for others, for closures it may cause a perf
-            // regression, because closure visibilities are not commonly queried.
-            assert_eq!(tcx.def_kind(def_id), DefKind::Closure);
-            ty::Visibility::Restricted(tcx.parent_module_from_def_id(def_id).to_def_id())
-        },
         effective_visibilities,
         check_private_in_public,
         check_mod_privacy,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1225,10 +1225,7 @@ impl<'tcx> Resolver<'_, 'tcx> {
         );
 
         // FIXME: remove `def_span` body, pass in the right spans here and call `tcx.at().create_def()`
-        let def_id = self.tcx.untracked().definitions.write().create_def(parent, data);
-
-        let feed = self.tcx.feed_local_def_id(def_id);
-        feed.def_kind(def_kind);
+        let def_id = self.tcx.create_def(parent, name, def_kind);
 
         // Create the definition.
         if expn_id != ExpnId::root() {


### PR DESCRIPTION
Also factor out all tcx-dependent operations performed for every created definition into `TyCtxt::create_def`.

Addresses https://github.com/rust-lang/rust/pull/118657#discussion_r1421424277