### PR TITLE
Add method to get instance instantiation arguments

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -341,6 +341,12 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         instance.ty(tables.tcx, ParamEnv::reveal_all()).stable(&mut *tables)
     }
 
+    fn instance_args(&self, def: InstanceDef) -> GenericArgs {
+        let mut tables = self.0.borrow_mut();
+        let instance = tables.instances[def];
+        instance.args.stable(&mut *tables)
+    }
+
     fn instance_abi(&self, def: InstanceDef) -> Result<FnAbi, Error> {
         let mut tables = self.0.borrow_mut();
         let instance = tables.instances[def];

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -125,6 +125,9 @@ pub trait Context {
     /// Get the instance type with generic substitutions applied and lifetimes erased.
     fn instance_ty(&self, instance: InstanceDef) -> Ty;
 
+    /// Get the instantiation types.
+    fn instance_args(&self, def: InstanceDef) -> GenericArgs;
+
     /// Get the instance.
     fn instance_def_id(&self, instance: InstanceDef) -> DefId;
 

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -35,6 +35,11 @@ pub enum InstanceKind {
 }
 
 impl Instance {
+    /// Get the arguments this instance was instantiated with.
+    pub fn args(&self) -> GenericArgs {
+        with(|cx| cx.instance_args(self.def))
+    }
+
     /// Get the body of an Instance. The body will be eagerly monomorphized.
     pub fn body(&self) -> Option<Body> {
         with(|context| context.instance_body(self.def))
@@ -148,6 +153,7 @@ impl Debug for Instance {
         f.debug_struct("Instance")
             .field("kind", &self.kind)
             .field("def", &self.mangled_name())
+            .field("args", &self.args())
             .finish()
     }
 }


### PR DESCRIPTION
Add a method to get the instance instantiation arguments, and include that information in the instance debug.