### PR TITLE
Tweak suggestions for bare trait used as a type

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/errors.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/errors.rs
@@ -605,7 +605,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let violations =
                     object_safety_violations_for_assoc_item(tcx, trait_def_id, *assoc_item);
                 if !violations.is_empty() {
-                    report_object_safety_error(tcx, *span, trait_def_id, &violations).emit();
+                    report_object_safety_error(tcx, *span, None, trait_def_id, &violations).emit();
                     object_safety_violations = true;
                 }
             }

--- a/compiler/rustc_hir_analysis/src/astconv/lint.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/lint.rs
@@ -122,6 +122,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     ],
                     Applicability::MachineApplicable,
                 );
+            } else {
+                // We'll emit the object safety error already, with a structured suggestion.
+                diag.downgrade_to_delayed_bug();
             }
             return true;
         }
@@ -145,6 +148,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             if !is_object_safe {
                 diag.note(format!("`{trait_name}` it is not object safe, so it can't be `dyn`"));
+                // We'll emit the object safety error already, with a structured suggestion.
+                diag.downgrade_to_delayed_bug();
             } else {
                 let sugg = if let hir::TyKind::TraitObject([_, _, ..], _, _) = self_ty.kind {
                     // There are more than one trait bound, we need surrounding parentheses.

--- a/compiler/rustc_hir_analysis/src/astconv/lint.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/lint.rs
@@ -2,6 +2,7 @@ use rustc_ast::TraitObjectSyntax;
 use rustc_errors::{Diagnostic, StashKey};
 use rustc_hir as hir;
 use rustc_lint_defs::{builtin::BARE_TRAIT_OBJECTS, Applicability};
+use rustc_span::Span;
 use rustc_trait_selection::traits::error_reporting::suggestions::NextTypeParamName;
 
 use super::AstConv;
@@ -32,30 +33,118 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             let of_trait_span = of_trait_ref.path.span;
             // make sure that we are not calling unwrap to abort during the compilation
-            let Ok(impl_trait_name) = tcx.sess.source_map().span_to_snippet(self_ty.span) else {
-                return;
-            };
             let Ok(of_trait_name) = tcx.sess.source_map().span_to_snippet(of_trait_span) else {
                 return;
             };
-            // check if the trait has generics, to make a correct suggestion
-            let param_name = generics.params.next_type_param_name(None);
 
-            let add_generic_sugg = if let Some(span) = generics.span_for_param_suggestion() {
-                (span, format!(", {param_name}: {impl_trait_name}"))
-            } else {
-                (generics.span, format!("<{param_name}: {impl_trait_name}>"))
+            let Ok(impl_trait_name) = self.tcx().sess.source_map().span_to_snippet(self_ty.span)
+            else {
+                return;
+            };
+            let Some(sugg) = self.generics_suggestion(generics, self_ty.span, &impl_trait_name)
+            else {
+                return;
             };
             diag.multipart_suggestion(
                 format!(
-                    "alternatively use a blanket \
-                     implementation to implement `{of_trait_name}` for \
+                    "alternatively use a blanket implementation to implement `{of_trait_name}` for \
                      all types that also implement `{impl_trait_name}`"
                 ),
-                vec![(self_ty.span, param_name), add_generic_sugg],
+                sugg,
                 Applicability::MaybeIncorrect,
             );
         }
+    }
+
+    fn generics_suggestion(
+        &self,
+        generics: &hir::Generics<'_>,
+        self_ty_span: Span,
+        impl_trait_name: &str,
+    ) -> Option<Vec<(Span, String)>> {
+        // check if the trait has generics, to make a correct suggestion
+        let param_name = generics.params.next_type_param_name(None);
+
+        let add_generic_sugg = if let Some(span) = generics.span_for_param_suggestion() {
+            (span, format!(", {param_name}: {impl_trait_name}"))
+        } else {
+            (generics.span, format!("<{param_name}: {impl_trait_name}>"))
+        };
+        Some(vec![(self_ty_span, param_name), add_generic_sugg])
+    }
+
+    /// Make sure that we are in the condition to suggest `impl Trait`.
+    fn maybe_lint_impl_trait(&self, self_ty: &hir::Ty<'_>, diag: &mut Diagnostic) -> bool {
+        let tcx = self.tcx();
+        let parent_id = tcx.hir().get_parent_item(self_ty.hir_id).def_id;
+        let (hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, generics, _), .. })
+        | hir::Node::TraitItem(hir::TraitItem {
+            kind: hir::TraitItemKind::Fn(sig, _),
+            generics,
+            ..
+        })) = tcx.hir_node_by_def_id(parent_id)
+        else {
+            return false;
+        };
+        let Ok(trait_name) = self.tcx().sess.source_map().span_to_snippet(self_ty.span) else {
+            return false;
+        };
+        let impl_sugg = vec![(self_ty.span.shrink_to_lo(), "impl ".to_string())];
+        if let hir::FnRetTy::Return(ty) = sig.decl.output
+            && ty.hir_id == self_ty.hir_id
+        {
+            diag.multipart_suggestion_verbose(
+                format!("use `impl {trait_name}` to return an opaque type, as long as you return a single underlying type"),
+                impl_sugg,
+                Applicability::MachineApplicable,
+            );
+            diag.multipart_suggestion_verbose(
+                "alternatively, you can return an owned trait object",
+                vec![
+                    (ty.span.shrink_to_lo(), "Box<dyn ".to_string()),
+                    (ty.span.shrink_to_hi(), ">".to_string()),
+                ],
+                Applicability::MachineApplicable,
+            );
+            return true;
+        }
+        for ty in sig.decl.inputs {
+            if ty.hir_id == self_ty.hir_id {
+                if let Some(sugg) = self.generics_suggestion(generics, self_ty.span, &trait_name) {
+                    diag.multipart_suggestion_verbose(
+                        format!("use a new generic type parameter, constrained by `{trait_name}`"),
+                        sugg,
+                        Applicability::MachineApplicable,
+                    );
+                    diag.multipart_suggestion_verbose(
+                        "you can also use an opaque type, but users won't be able to specify the \
+                         type parameter when calling the `fn`, having to rely exclusively on type \
+                         inference",
+                        impl_sugg,
+                        Applicability::MachineApplicable,
+                    );
+                }
+                let sugg = if let hir::TyKind::TraitObject([_, _, ..], _, _) = self_ty.kind {
+                    // There are more than one trait bound, we need surrounding parentheses.
+                    vec![
+                        (self_ty.span.shrink_to_lo(), "&(dyn ".to_string()),
+                        (self_ty.span.shrink_to_hi(), ")".to_string()),
+                    ]
+                } else {
+                    vec![(self_ty.span.shrink_to_lo(), "&dyn ".to_string())]
+                };
+                diag.multipart_suggestion_verbose(
+                    format!(
+                        "alternatively, use a trait object to accept any type that implements \
+                         `{trait_name}`, accessing its methods at runtime using dynamic dispatch",
+                    ),
+                    sugg,
+                    Applicability::MachineApplicable,
+                );
+                return true;
+            }
+        }
+        false
     }
 
     pub(super) fn maybe_lint_bare_trait(&self, self_ty: &hir::Ty<'_>, in_path: bool) {
@@ -98,7 +187,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let label = "add `dyn` keyword before this trait";
                 let mut diag =
                     rustc_errors::struct_span_err!(tcx.dcx(), self_ty.span, E0782, "{}", msg);
-                if self_ty.span.can_be_used_for_suggestions() {
+                if self_ty.span.can_be_used_for_suggestions()
+                    && !self.maybe_lint_impl_trait(self_ty, &mut diag)
+                {
                     diag.multipart_suggestion_verbose(
                         label,
                         sugg,
@@ -116,11 +207,15 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     self_ty.span,
                     msg,
                     |lint| {
-                        lint.multipart_suggestion_verbose(
-                            "use `dyn`",
-                            sugg,
-                            Applicability::MachineApplicable,
-                        );
+                        if self_ty.span.can_be_used_for_suggestions()
+                            && !self.maybe_lint_impl_trait(self_ty, lint)
+                        {
+                            lint.multipart_suggestion_verbose(
+                                "use `dyn`",
+                                sugg,
+                                Applicability::MachineApplicable,
+                            );
+                        }
                         self.maybe_lint_blanket_trait_impl(self_ty, lint);
                     },
                 );

--- a/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
@@ -140,6 +140,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let reported = report_object_safety_error(
                     tcx,
                     span,
+                    Some(hir_id),
                     item.trait_ref().def_id(),
                     &object_safety_violations,
                 )

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -114,7 +114,8 @@ pub(super) fn check_fn<'a, 'tcx>(
     let inputs_fn = fn_sig.inputs().iter().copied();
     for (idx, (param_ty, param)) in inputs_fn.chain(maybe_va_list).zip(body.params).enumerate() {
         // Check the pattern.
-        let ty_span = try { inputs_hir?.get(idx)?.span };
+        let ty: Option<&hir::Ty<'_>> = try { inputs_hir?.get(idx)? };
+        let ty_span = ty.map(|ty| ty.span);
         fcx.check_pat_top(param.pat, param_ty, ty_span, None, None);
 
         // Check that argument is Sized.
@@ -122,13 +123,13 @@ pub(super) fn check_fn<'a, 'tcx>(
             fcx.require_type_is_sized(
                 param_ty,
                 param.pat.span,
-                // ty_span == binding_span iff this is a closure parameter with no type ascription,
+                // ty.span == binding_span iff this is a closure parameter with no type ascription,
                 // or if it's an implicit `self` parameter
                 traits::SizedArgumentType(
                     if ty_span == Some(param.span) && tcx.is_closure(fn_def_id.into()) {
                         None
                     } else {
-                        ty_span
+                        ty.map(|ty| ty.hir_id)
                     },
                 ),
             );

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -60,7 +60,7 @@ pub(super) struct GatherLocalsVisitor<'a, 'tcx> {
     // parameters are special cases of patterns, but we want to handle them as
     // *distinct* cases. so track when we are hitting a pattern *within* an fn
     // parameter.
-    outermost_fn_param_pat: Option<Span>,
+    outermost_fn_param_pat: Option<(Span, hir::HirId)>,
 }
 
 impl<'a, 'tcx> GatherLocalsVisitor<'a, 'tcx> {
@@ -131,7 +131,8 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
     }
 
     fn visit_param(&mut self, param: &'tcx hir::Param<'tcx>) {
-        let old_outermost_fn_param_pat = self.outermost_fn_param_pat.replace(param.ty_span);
+        let old_outermost_fn_param_pat =
+            self.outermost_fn_param_pat.replace((param.ty_span, param.hir_id));
         intravisit::walk_param(self, param);
         self.outermost_fn_param_pat = old_outermost_fn_param_pat;
     }
@@ -141,7 +142,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
         if let PatKind::Binding(_, _, ident, _) = p.kind {
             let var_ty = self.assign(p.span, p.hir_id, None);
 
-            if let Some(ty_span) = self.outermost_fn_param_pat {
+            if let Some((ty_span, hir_id)) = self.outermost_fn_param_pat {
                 if !self.fcx.tcx.features().unsized_fn_params {
                     self.fcx.require_type_is_sized(
                         var_ty,
@@ -154,7 +155,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                             {
                                 None
                             } else {
-                                Some(ty_span)
+                                Some(hir_id)
                             },
                         ),
                     );

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -2,9 +2,10 @@ use super::ObjectSafetyViolation;
 
 use crate::infer::InferCtxt;
 use rustc_data_structures::fx::FxIndexSet;
-use rustc_errors::{struct_span_err, DiagnosticBuilder, MultiSpan};
+use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder, MultiSpan};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::intravisit::Map;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Span;
@@ -42,6 +43,7 @@ impl<'tcx> InferCtxt<'tcx> {
 pub fn report_object_safety_error<'tcx>(
     tcx: TyCtxt<'tcx>,
     span: Span,
+    hir_id: Option<hir::HirId>,
     trait_def_id: DefId,
     violations: &[ObjectSafetyViolation],
 ) -> DiagnosticBuilder<'tcx> {
@@ -59,6 +61,24 @@ pub fn report_object_safety_error<'tcx>(
     );
     err.span_label(span, format!("`{trait_str}` cannot be made into an object"));
 
+    if let Some(hir_id) = hir_id
+        && let Some(hir::Node::Ty(ty)) = tcx.hir().find(hir_id)
+        && let hir::TyKind::TraitObject([trait_ref, ..], ..) = ty.kind
+    {
+        let mut hir_id = hir_id;
+        while let hir::Node::Ty(ty) = tcx.hir().get_parent(hir_id) {
+            hir_id = ty.hir_id;
+        }
+        if tcx.hir().get_parent(hir_id).fn_sig().is_some() {
+            // Do not suggest `impl Trait` when dealing with things like super-traits.
+            err.span_suggestion_verbose(
+                ty.span.until(trait_ref.span),
+                "consider using an opaque type instead",
+                "impl ",
+                Applicability::MaybeIncorrect,
+            );
+        }
+    }
     let mut reported_violations = FxIndexSet::default();
     let mut multi_span = vec![];
     let mut messages = vec![];

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -289,7 +289,7 @@ pub enum ObligationCauseCode<'tcx> {
     /// Type of each variable must be `Sized`.
     VariableType(hir::HirId),
     /// Argument type must be `Sized`.
-    SizedArgumentType(Option<Span>),
+    SizedArgumentType(Option<hir::HirId>),
     /// Return type must be `Sized`.
     SizedReturnType,
     /// Yield type must be `Sized`.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -816,7 +816,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
                     ty::PredicateKind::ObjectSafe(trait_def_id) => {
                         let violations = self.tcx.object_safety_violations(trait_def_id);
-                        report_object_safety_error(self.tcx, span, trait_def_id, violations)
+                        report_object_safety_error(self.tcx, span, None, trait_def_id, violations)
                     }
 
                     ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(ty)) => {
@@ -924,7 +924,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
 
             TraitNotObjectSafe(did) => {
                 let violations = self.tcx.object_safety_violations(did);
-                report_object_safety_error(self.tcx, span, did, violations)
+                report_object_safety_error(self.tcx, span, None, did, violations)
             }
 
             SelectionError::NotConstEvaluatable(NotConstEvaluatable::MentionsInfer) => {

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -6,7 +6,7 @@ LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = help: unsized fn params are gated as an unstable feature
-help: function arguments must have a statically known size, borrowed types always have a known size
+help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: &[u8]| x }]> {
    |                                                +

--- a/tests/rustdoc-ui/issues/issue-105742.stderr
+++ b/tests/rustdoc-ui/issues/issue-105742.stderr
@@ -323,6 +323,10 @@ LL | ||     Output = <Self as SVec>::Item> as SVec>::Item,
 LL | |
 LL | |  > {
    | |__^ ...because it uses `Self` as a type parameter
+help: consider using an opaque type instead
+   |
+LL | pub fn next<'a, T>(s: &'a mut impl SVec<Item = T, Output = T>) {
+   |                               ~~~~
 
 error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:15:21

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
@@ -29,8 +29,8 @@ LL | fn bar(x: impl Foo) {
    |           ++++
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
-LL | fn bar(x: &Foo) {
-   |           +
+LL | fn bar(x: &dyn Foo) {
+   |           ++++
 
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_fn_params.rs:25:8
@@ -40,7 +40,7 @@ LL | fn qux(_: [()]) {}
    |
    = help: the trait `Sized` is not implemented for `[()]`
    = help: unsized fn params are gated as an unstable feature
-help: function arguments must have a statically known size, borrowed types always have a known size
+help: function arguments must have a statically known size, borrowed slices always have a known size
    |
 LL | fn qux(_: &[()]) {}
    |           +

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.fixed
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.fixed
@@ -1,0 +1,11 @@
+// run-rustfix
+#![deny(bare_trait_objects)]
+fn ord_prefer_dot(s: String) -> impl Ord {
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+    //~| ERROR the trait `Ord` cannot be made into an object
+    //~| WARNING this is accepted in the current edition (Rust 2015)
+    (s.starts_with("."), s)
+}
+fn main() {
+    let _ = ord_prefer_dot(String::new());
+}

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.fixed
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.fixed
@@ -1,9 +1,7 @@
 // run-rustfix
 #![deny(bare_trait_objects)]
 fn ord_prefer_dot(s: String) -> impl Ord {
-    //~^ ERROR trait objects without an explicit `dyn` are deprecated
-    //~| ERROR the trait `Ord` cannot be made into an object
-    //~| WARNING this is accepted in the current edition (Rust 2015)
+    //~^ ERROR the trait `Ord` cannot be made into an object
     (s.starts_with("."), s)
 }
 fn main() {

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.rs
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.rs
@@ -1,0 +1,11 @@
+// run-rustfix
+#![deny(bare_trait_objects)]
+fn ord_prefer_dot(s: String) -> Ord {
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+    //~| ERROR the trait `Ord` cannot be made into an object
+    //~| WARNING this is accepted in the current edition (Rust 2015)
+    (s.starts_with("."), s)
+}
+fn main() {
+    let _ = ord_prefer_dot(String::new());
+}

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.rs
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.rs
@@ -1,9 +1,7 @@
 // run-rustfix
 #![deny(bare_trait_objects)]
 fn ord_prefer_dot(s: String) -> Ord {
-    //~^ ERROR trait objects without an explicit `dyn` are deprecated
-    //~| ERROR the trait `Ord` cannot be made into an object
-    //~| WARNING this is accepted in the current edition (Rust 2015)
+    //~^ ERROR the trait `Ord` cannot be made into an object
     (s.starts_with("."), s)
 }
 fn main() {

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.stderr
@@ -1,0 +1,35 @@
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:3:33
+   |
+LL | fn ord_prefer_dot(s: String) -> Ord {
+   |                                 ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+note: the lint level is defined here
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:2:9
+   |
+LL | #![deny(bare_trait_objects)]
+   |         ^^^^^^^^^^^^^^^^^^
+help: `Ord` is not object safe, use `impl Ord` to return an opaque type, as long as you return a single underlying type
+   |
+LL | fn ord_prefer_dot(s: String) -> impl Ord {
+   |                                 ++++
+
+error[E0038]: the trait `Ord` cannot be made into an object
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:3:33
+   |
+LL | fn ord_prefer_dot(s: String) -> Ord {
+   |                                 ^^^ `Ord` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.stderr
@@ -1,21 +1,3 @@
-error: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:3:33
-   |
-LL | fn ord_prefer_dot(s: String) -> Ord {
-   |                                 ^^^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-note: the lint level is defined here
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:2:9
-   |
-LL | #![deny(bare_trait_objects)]
-   |         ^^^^^^^^^^^^^^^^^^
-help: `Ord` is not object safe, use `impl Ord` to return an opaque type, as long as you return a single underlying type
-   |
-LL | fn ord_prefer_dot(s: String) -> impl Ord {
-   |                                 ++++
-
 error[E0038]: the trait `Ord` cannot be made into an object
   --> $DIR/bare-trait-dont-suggest-dyn.rs:3:33
    |
@@ -29,7 +11,11 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+help: consider using an opaque type instead
+   |
+LL | fn ord_prefer_dot(s: String) -> impl Ord {
+   |                                 ++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -11,6 +11,10 @@ LL | trait Baz : Bar<Self> {
    |       ---   ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
    |       this trait cannot be made into an object...
+help: consider using an opaque type instead
+   |
+LL | fn make_baz<T:Baz>(t: &T) -> &impl Baz {
+   |                               ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-5035-2.stderr
+++ b/tests/ui/resolve/issue-5035-2.stderr
@@ -6,10 +6,6 @@ LL | fn foo(_x: K) {}
    |
    = help: the trait `Sized` is not implemented for `(dyn I + 'static)`
    = help: unsized fn params are gated as an unstable feature
-help: you can use `impl Trait` as the argument type
-   |
-LL | fn foo(_x: impl K) {}
-   |            ++++
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn foo(_x: &K) {}

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.rs
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.rs
@@ -1,0 +1,17 @@
+// edition:2021
+trait Foo {
+    fn dummy(&self) {}
+}
+
+// This should emit the less confusing error, not the more confusing one.
+
+fn foo(_x: Foo + Send) {
+    //~^ ERROR trait objects must include the `dyn` keyword
+}
+fn bar(x: Foo) -> Foo {
+    //~^ ERROR trait objects must include the `dyn` keyword
+    //~| ERROR trait objects must include the `dyn` keyword
+    x
+}
+
+fn main() {}

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -1,0 +1,56 @@
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/not-on-bare-trait-2021.rs:8:12
+   |
+LL | fn foo(_x: Foo + Send) {
+   |            ^^^^^^^^^^
+   |
+help: use a new generic type parameter, constrained by `Foo + Send`
+   |
+LL | fn foo<T: Foo + Send>(_x: T) {
+   |       +++++++++++++++     ~
+help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+   |
+LL | fn foo(_x: impl Foo + Send) {
+   |            ++++
+help: alternatively, use a trait object to accept any type that implements `Foo + Send`, accessing its methods at runtime using dynamic dispatch
+   |
+LL | fn foo(_x: &(dyn Foo + Send)) {
+   |            +++++           +
+
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/not-on-bare-trait-2021.rs:11:11
+   |
+LL | fn bar(x: Foo) -> Foo {
+   |           ^^^
+   |
+help: use a new generic type parameter, constrained by `Foo`
+   |
+LL | fn bar<T: Foo>(x: T) -> Foo {
+   |       ++++++++    ~
+help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+   |
+LL | fn bar(x: impl Foo) -> Foo {
+   |           ++++
+help: alternatively, use a trait object to accept any type that implements `Foo`, accessing its methods at runtime using dynamic dispatch
+   |
+LL | fn bar(x: &dyn Foo) -> Foo {
+   |           ++++
+
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/not-on-bare-trait-2021.rs:11:19
+   |
+LL | fn bar(x: Foo) -> Foo {
+   |                   ^^^
+   |
+help: use `impl Foo` to return an opaque type, as long as you return a single underlying type
+   |
+LL | fn bar(x: Foo) -> impl Foo {
+   |                   ++++
+help: alternatively, you can return an owned trait object
+   |
+LL | fn bar(x: Foo) -> Box<dyn Foo> {
+   |                   +++++++    +
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/traits/bound/not-on-bare-trait.rs
+++ b/tests/ui/traits/bound/not-on-bare-trait.rs
@@ -9,5 +9,8 @@ fn foo(_x: Foo + Send) {
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition
 }
+fn bar(_x: (dyn Foo + Send)) {
+    //~^ ERROR the size for values of type
+}
 
 fn main() {}

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -34,9 +34,26 @@ LL | fn foo(_x: impl Foo + Send) {
    |            ++++
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
-LL | fn foo(_x: &Foo + Send) {
+LL | fn foo(_x: &(Foo + Send)) {
+   |            ++          +
+
+error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
+  --> $DIR/not-on-bare-trait.rs:12:8
+   |
+LL | fn bar(_x: (dyn Foo + Send)) {
+   |        ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn bar(_x: impl (dyn Foo + Send)) {
+   |            ++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn bar(_x: &(dyn Foo + Send)) {
    |            +
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -7,10 +7,18 @@ LL | fn foo(_x: Foo + Send) {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: use `dyn`
+help: use a new generic type parameter, constrained by `Foo + Send`
    |
-LL | fn foo(_x: dyn Foo + Send) {
-   |            +++
+LL | fn foo<T: Foo + Send>(_x: T) {
+   |       +++++++++++++++     ~
+help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
+   |
+LL | fn foo(_x: impl Foo + Send) {
+   |            ++++
+help: alternatively, use a trait object to accept any type that implements `Foo + Send`, accessing its methods at runtime using dynamic dispatch
+   |
+LL | fn foo(_x: &(dyn Foo + Send)) {
+   |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:8

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -34,8 +34,8 @@ LL | fn foo(_x: impl Foo + Send) {
    |            ++++
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
-LL | fn foo(_x: &(Foo + Send)) {
-   |            ++          +
+LL | fn foo(_x: &(dyn Foo + Send)) {
+   |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:12:8
@@ -47,12 +47,12 @@ LL | fn bar(_x: (dyn Foo + Send)) {
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |
-LL | fn bar(_x: impl (dyn Foo + Send)) {
-   |            ++++
+LL | fn bar(_x: (impl Foo + Send)) {
+   |             ~~~~
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
-LL | fn bar(_x: &(dyn Foo + Send)) {
-   |            +
+LL | fn bar(_x: (&(dyn Foo + Send))) {
+   |             ++              +
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -14,6 +14,10 @@ LL | pub trait Bar: Foo<Assoc=()> {
    |           |    |   ...because it uses `Self` as a type parameter
    |           |    ...because it uses `Self` as a type parameter
    |           this trait cannot be made into an object...
+help: consider using an opaque type instead
+   |
+LL |            impl Bar
+   |            ~~~~
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
```
error[E0782]: trait objects must include the `dyn` keyword
  --> $DIR/not-on-bare-trait-2021.rs:11:11
   |
LL | fn bar(x: Foo) -> Foo {
   |           ^^^
   |
help: use a generic type parameter, constrained by the trait `Foo`
   |
LL | fn bar<T: Foo>(x: T) -> Foo {
   |       ++++++++    ~
help: you can also use `impl Foo`, but users won't be able to specify the type paramer when calling the `fn`, having to rely exclusively on type inference
   |
LL | fn bar(x: impl Foo) -> Foo {
   |           ++++
help: alternatively, use a trait object to accept any type that implements `Foo`, accessing its methods at runtime using dynamic dispatch
   |
LL | fn bar(x: &dyn Foo) -> Foo {
   |           ++++

error[E0782]: trait objects must include the `dyn` keyword
  --> $DIR/not-on-bare-trait-2021.rs:11:19
   |
LL | fn bar(x: Foo) -> Foo {
   |                   ^^^
   |
help: use `impl Foo` to return an opaque type, as long as you return a single underlying type
   |
LL | fn bar(x: Foo) -> impl Foo {
   |                   ++++
help: alternatively, you can return an owned trait object
   |
LL | fn bar(x: Foo) -> Box<dyn Foo> {
   |                   +++++++    +
```

Fix #119525:

```

error[E0038]: the trait `Ord` cannot be made into an object
  --> $DIR/bare-trait-dont-suggest-dyn.rs:3:33
   |
LL | fn ord_prefer_dot(s: String) -> Ord {
   |                                 ^^^ `Ord` cannot be made into an object
   |
note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
  --> $SRC_DIR/core/src/cmp.rs:LL:COL
   |
   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
   |
   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
help: consider using an opaque type instead
   |
LL | fn ord_prefer_dot(s: String) -> impl Ord {
   |                                 ++++
```