### PR TITLE
Hide foreign `#[doc(hidden)]` paths in import suggestions

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1476,7 +1476,7 @@ pub fn reveal_opaque_types_in_bounds<'tcx>(
     val.fold_with(&mut visitor)
 }
 
-/// Determines whether an item is annotated with `doc(hidden)`.
+/// Determines whether an item is directly annotated with `doc(hidden)`.
 fn is_doc_hidden(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     tcx.get_attrs(def_id, sym::doc)
         .filter_map(|attr| attr.meta_item_list())

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2194,15 +2194,20 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
     fn find_module(&mut self, def_id: DefId) -> Option<(Module<'a>, ImportSuggestion)> {
         let mut result = None;
         let mut seen_modules = FxHashSet::default();
-        let mut worklist = vec![(self.r.graph_root, ThinVec::new())];
+        let root_did = self.r.graph_root.def_id();
+        let mut worklist = vec![(
+            self.r.graph_root,
+            ThinVec::new(),
+            root_did.is_local() || !self.r.tcx.is_doc_hidden(root_did),
+        )];
 
-        while let Some((in_module, path_segments)) = worklist.pop() {
+        while let Some((in_module, path_segments, doc_visible)) = worklist.pop() {
             // abort if the module is already found
             if result.is_some() {
                 break;
             }
 
-            in_module.for_each_child(self.r, |_, ident, _, name_binding| {
+            in_module.for_each_child(self.r, |r, ident, _, name_binding| {
                 // abort if the module is already found or if name_binding is private external
                 if result.is_some() || !name_binding.vis.is_visible_locally() {
                     return;
@@ -2212,6 +2217,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     let mut path_segments = path_segments.clone();
                     path_segments.push(ast::PathSegment::from_ident(ident));
                     let module_def_id = module.def_id();
+                    let doc_visible = doc_visible
+                        && (module_def_id.is_local() || !r.tcx.is_doc_hidden(module_def_id));
                     if module_def_id == def_id {
                         let path =
                             Path { span: name_binding.span, segments: path_segments, tokens: None };
@@ -2222,6 +2229,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                 descr: "module",
                                 path,
                                 accessible: true,
+                                doc_visible,
                                 note: None,
                                 via_import: false,
                             },
@@ -2229,7 +2237,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     } else {
                         // add the module to the lookup
                         if seen_modules.insert(module_def_id) {
-                            worklist.push((module, path_segments));
+                            worklist.push((module, path_segments, doc_visible));
                         }
                     }
                 }

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -8,8 +8,6 @@ help: consider importing one of these items
    |
 LL + use core::marker::PhantomData;
    |
-LL + use serde::__private::PhantomData;
-   |
 LL + use std::marker::PhantomData;
    |
 

--- a/tests/ui/suggestions/auxiliary/hidden-struct.rs
+++ b/tests/ui/suggestions/auxiliary/hidden-struct.rs
@@ -1,0 +1,17 @@
+#[doc(hidden)]
+pub mod hidden {
+    pub struct Foo;
+}
+
+pub mod hidden1 {
+    #[doc(hidden)]
+    pub struct Foo;
+}
+
+
+#[doc(hidden)]
+pub(crate) mod hidden2 {
+    pub struct Bar;
+}
+
+pub use hidden2::Bar;

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
@@ -1,0 +1,15 @@
+// aux-build:hidden-struct.rs
+// compile-flags: --crate-type lib
+
+extern crate hidden_struct;
+
+#[doc(hidden)]
+mod local {
+    pub struct Foo;
+}
+
+pub fn test(_: Foo) {}
+//~^ ERROR cannot find type `Foo` in this scope
+
+pub fn test2(_: Bar) {}
+//~^ ERROR cannot find type `Bar` in this scope

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -1,0 +1,25 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:11:16
+   |
+LL | pub fn test(_: Foo) {}
+   |                ^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use local::Foo;
+   |
+
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:14:17
+   |
+LL | pub fn test2(_: Bar) {}
+   |                 ^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use hidden_struct::Bar;
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.rs
+++ b/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.rs
@@ -1,8 +1,8 @@
 #![feature(type_alias_impl_trait)]
 
-pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
+pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
 //~^ ERROR use of undeclared lifetime name `'db`
-//~| ERROR cannot find type `Key` in this scope
+//~| ERROR cannot find type `LocalKey` in this scope
 //~| ERROR unconstrained opaque type
 //~| ERROR unconstrained opaque type
 

--- a/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.stderr
@@ -1,43 +1,43 @@
 error[E0261]: use of undeclared lifetime name `'db`
   --> $DIR/nested-impl-trait-in-tait.rs:3:40
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |                                        ^^^ undeclared lifetime
    |
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the bound lifetime-generic with a new `'db` lifetime
    |
-LL | pub type Tait = impl for<'db> Iterator<Item = (&'db Key, impl Iterator)>;
+LL | pub type Tait = impl for<'db> Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |                      ++++++++
 help: consider introducing lifetime `'db` here
    |
-LL | pub type Tait<'db> = impl Iterator<Item = (&'db Key, impl Iterator)>;
+LL | pub type Tait<'db> = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |              +++++
 
-error[E0412]: cannot find type `Key` in this scope
+error[E0412]: cannot find type `LocalKey` in this scope
   --> $DIR/nested-impl-trait-in-tait.rs:3:44
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
-   |                                            ^^^ not found in this scope
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
+   |                                            ^^^^^^^^ not found in this scope
    |
 help: consider importing this struct
    |
-LL + use std::thread::local_impl::Key;
+LL + use std::thread::LocalKey;
    |
 
 error: unconstrained opaque type
   --> $DIR/nested-impl-trait-in-tait.rs:3:17
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Tait` must be used in combination with a concrete type within the same module
 
 error: unconstrained opaque type
-  --> $DIR/nested-impl-trait-in-tait.rs:3:49
+  --> $DIR/nested-impl-trait-in-tait.rs:3:54
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
-   |                                                 ^^^^^^^^^^^^^
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
+   |                                                      ^^^^^^^^^^^^^
    |
    = note: `Tait` must be used in combination with a concrete type within the same module
 


### PR DESCRIPTION
Stops the compiler from suggesting to import foreign `#[doc(hidden)]` paths.

@rustbot label A-suggestion-diagnostics