### PR TITLE
Add core::cmp::reversed function

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -668,6 +668,29 @@ impl<T: Clone> Clone for Reverse<T> {
     }
 }
 
+/// A helper function for reverse ordering.
+///
+/// This function is a helper to be passed to functions like [`Vec::sort_by`], to
+/// sort in reverse order.
+///
+/// [`Vec::sort_by`]: ../../std/vec/struct.Vec.html#method.sort_by
+///
+/// # Examples
+///
+/// ```
+/// #![feature(cmp_by_reversed)]
+/// use core::cmp;
+///
+/// let mut v = vec![4, 6, 3, 1, 5, 2];
+/// v.sort_by(cmp::reversed);
+/// assert_eq!(v, vec![6, 5, 4, 3, 2, 1]);
+/// ```
+#[unstable(feature = "cmp_by_reversed", issue = "none")]
+#[inline]
+pub fn reversed<T: Ord>(a: &T, b: &T) -> Ordering {
+    a.cmp(b).reverse()
+}
+
 /// Trait for types that form a [total order](https://en.wikipedia.org/wiki/Total_order).
 ///
 /// Implementations must be consistent with the [`PartialOrd`] implementation, and ensure


### PR DESCRIPTION
This PR adds a `cmp::reversed` function for use with `sort_by`, `sort_unstable_by`, and other similar functions.

This seems like an API hole, since the suggested way of reverse-sorting tends to require importing `std::cmp::Ord` for access to the `cmp` method. That is, rather than something like this:

```rust
use std::cmp::Ord;
v.sort_by(|a, b| b.cmp(a));
```

this PR makes it possible to simply do this:

```rust
v.sort_by(std::cmp::reversed);
```

This not only avoids having to import a trait for a single use, but also makes the intent much more clear, spelling out the reverse ordering in plain English. Similar solutions using `std::cmp::Reverse` either have issues with lifetimes (`v.cmp_by_key(std::cmp::Reverse)`) or non-copy types (`v.cmp_by_key(|&x| std::cmp::Reverse(x))`).

I anticipate that I'll need to open a tracking issue and have the name undergo some bikeshedding (`reverse`? `descending`?), so just let me know!