### PR TITLE
improve container runner script

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -36,6 +36,11 @@ root_dir="`dirname $src_dir`"
 objdir=$root_dir/obj
 dist=$objdir/build/dist
 
+
+if [ -d "$root_dir/.git" ]; then
+    IS_GIT_SOURCE=1
+fi
+
 source "$ci_dir/shared.sh"
 
 CACHE_DOMAIN="${CACHE_DOMAIN:-ci-caches.rust-lang.org}"
@@ -249,9 +254,13 @@ if [ "$dev" = "1" ]
 then
   # Interactive + TTY
   args="$args -it"
-  command="/bin/bash"
+  if [ $IS_GIT_SOURCE -eq 1 ]; then
+    command=(/bin/bash -c 'git config --global --add safe.directory /checkout;bash')
+  else
+    command=(/bin/bash)
+  fi
 else
-  command="/checkout/src/ci/run.sh"
+  command=(/checkout/src/ci/run.sh)
 fi
 
 if [ "$CI" != "" ]; then
@@ -301,7 +310,7 @@ docker \
   --init \
   --rm \
   rust-ci \
-  $command
+  "${command[@]}"
 
 cat $objdir/${SUMMARY_FILE} >> "${GITHUB_STEP_SUMMARY}"
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -199,6 +199,14 @@ else
     args="$args --env SCCACHE_DIR=/sccache --volume $HOME/.cache/sccache:/sccache"
 fi
 
+# By default, container volumes are bound as read-only; therefore doing experimental work
+# or debugging within the container environment (such as fetching submodules and
+# building them) is not possible. Setting READ_ONLY_SRC to 0 enables this capability by
+# binding the volumes in read-write mode.
+if [ "$READ_ONLY_SRC" != "0" ]; then
+    SRC_MOUNT_OPTION=":ro"
+fi
+
 # Run containers as privileged as it should give them access to some more
 # syscalls such as ptrace and whatnot. In the upgrade to LLVM 5.0 it was
 # discovered that the leak sanitizer apparently needs these syscalls nowadays so
@@ -233,7 +241,7 @@ if [ -f /.dockerenv ]; then
   docker cp . checkout:/checkout
   args="$args --volumes-from checkout"
 else
-  args="$args --volume $root_dir:/checkout:ro"
+  args="$args --volume $root_dir:/checkout$SRC_MOUNT_OPTION"
   args="$args --volume $objdir:/checkout/obj"
   args="$args --volume $HOME/.cargo:/cargo"
   args="$args --volume $HOME/rustsrc:$HOME/rustsrc"


### PR DESCRIPTION
First commit fixes #118930

Second commit is mostly for development purposes. In read-only mode submodules cannot be initialized due to access limitations (see the log below), which means that tools cannot be built.

```sh
Updating submodule src/tools/cargo
error: could not lock config file .git/config: Read-only file system
error: could not lock config file .git/config: Read-only file system
fatal: Failed to register url for submodule path 'src/tools/cargo'
error: could not lock config file .git/config: Read-only file system
error: could not lock config file .git/config: Read-only file system
fatal: Failed to register url for submodule path 'src/tools/cargo'
Build completed unsuccessfully in 0:00:00

```