### PR TITLE
E0761: module directory has .rs suffix

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0761.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0761.md
@@ -15,7 +15,7 @@ fn foo() {}
 
 mod ambiguous_module; // error: file for module `ambiguous_module`
                       // found at both ambiguous_module.rs and
-                      // ambiguous_module.rs/mod.rs
+                      // ambiguous_module/mod.rs
 ```
 
 Please remove this ambiguity by deleting/renaming one of the candidate files.


### PR DESCRIPTION
`rustc --explain E0761` example seems wrong.