### PR TITLE
Encode `CoroutineKind` directly

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -241,7 +241,7 @@ provide! { tcx, def_id, other, cdata,
     rendered_const => { table }
     asyncness => { table_direct }
     fn_arg_names => { table }
-    coroutine_kind => { table }
+    coroutine_kind => { table_direct }
     trait_def => { table }
     deduced_param_attrs => { table }
     is_type_alias_impl_trait => {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1428,9 +1428,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 }
             }
             if def_kind == DefKind::Closure
-                && let Some(data) = self.tcx.coroutine_kind(def_id)
+                && let Some(coroutine_kind) = self.tcx.coroutine_kind(def_id)
             {
-                record!(self.tables.coroutine_kind[def_id] <- data);
+                self.tables.coroutine_kind.set(def_id.index, Some(coroutine_kind));
             }
             if let DefKind::Enum | DefKind::Struct | DefKind::Union = def_kind {
                 self.encode_info_for_adt(local_id);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -443,7 +443,7 @@ define_tables! {
     rendered_const: Table<DefIndex, LazyValue<String>>,
     asyncness: Table<DefIndex, ty::Asyncness>,
     fn_arg_names: Table<DefIndex, LazyArray<Ident>>,
-    coroutine_kind: Table<DefIndex, LazyValue<hir::CoroutineKind>>,
+    coroutine_kind: Table<DefIndex, hir::CoroutineKind>,
     trait_def: Table<DefIndex, LazyValue<ty::TraitDef>>,
     trait_item_def_id: Table<DefIndex, RawDefId>,
     expn_that_defined: Table<DefIndex, LazyValue<ExpnId>>,

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -205,6 +205,21 @@ fixed_size_enum! {
 }
 
 fixed_size_enum! {
+    hir::CoroutineKind {
+        ( Coroutine                               )
+        ( Gen(hir::CoroutineSource::Block)        )
+        ( Gen(hir::CoroutineSource::Fn)           )
+        ( Gen(hir::CoroutineSource::Closure)      )
+        ( Async(hir::CoroutineSource::Block)      )
+        ( Async(hir::CoroutineSource::Fn)         )
+        ( Async(hir::CoroutineSource::Closure)    )
+        ( AsyncGen(hir::CoroutineSource::Block)   )
+        ( AsyncGen(hir::CoroutineSource::Fn)      )
+        ( AsyncGen(hir::CoroutineSource::Closure) )
+    }
+}
+
+fixed_size_enum! {
     ty::AssocItemContainer {
         ( TraitContainer )
         ( ImplContainer  )


### PR DESCRIPTION
Probably a quick optimization?

r? @ghost