### PR TITLE
fix: diagnostic for casting reference to slice

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -576,25 +576,19 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         match self.expr_ty.kind() {
             ty::Ref(_, _, mt) => {
                 let mtstr = mt.prefix_str();
-                if self.cast_ty.is_trait() {
-                    match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
-                        Ok(s) => {
-                            err.span_suggestion(
-                                self.cast_span,
-                                "try casting to a reference instead",
-                                format!("&{mtstr}{s}"),
-                                Applicability::MachineApplicable,
-                            );
-                        }
-                        Err(_) => {
-                            let msg = format!("did you mean `&{mtstr}{tstr}`?");
-                            err.span_help(self.cast_span, msg);
-                        }
+                match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
+                    Ok(s) => {
+                        err.span_suggestion(
+                            self.cast_span,
+                            "try casting to a reference instead",
+                            format!("&{mtstr}{s}"),
+                            Applicability::MachineApplicable,
+                        );
                     }
-                } else {
-                    let msg =
-                        format!("consider using an implicit coercion to `&{mtstr}{tstr}` instead");
-                    err.span_help(self.span, msg);
+                    Err(_) => {
+                        let msg = format!("did you mean `&{mtstr}{tstr}`?");
+                        err.span_help(self.cast_span, msg);
+                    }
                 }
             }
             ty::Adt(def, ..) if def.is_box() => {

--- a/tests/ui/cast/cast-to-slice.rs
+++ b/tests/ui/cast/cast-to-slice.rs
@@ -1,0 +1,8 @@
+fn main() {
+    "example".as_bytes() as [char];
+    //~^ ERROR cast to unsized type
+
+    let arr: &[u8] = &[0, 2, 3];
+    arr as [char];
+    //~^ ERROR cast to unsized type
+}

--- a/tests/ui/cast/cast-to-slice.stderr
+++ b/tests/ui/cast/cast-to-slice.stderr
@@ -1,0 +1,19 @@
+error[E0620]: cast to unsized type: `&[u8]` as `[char]`
+  --> $DIR/cast-to-slice.rs:2:5
+   |
+LL |     "example".as_bytes() as [char]; 
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^------
+   |                             |
+   |                             help: try casting to a reference instead: `&[char]`
+
+error[E0620]: cast to unsized type: `&[u8]` as `[char]`
+  --> $DIR/cast-to-slice.rs:6:5
+   |
+LL |     arr as [char];
+   |     ^^^^^^^------
+   |            |
+   |            help: try casting to a reference instead: `&[char]`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0620`.

--- a/tests/ui/cast/cast-to-slice.stderr
+++ b/tests/ui/cast/cast-to-slice.stderr
@@ -1,7 +1,7 @@
 error[E0620]: cast to unsized type: `&[u8]` as `[char]`
   --> $DIR/cast-to-slice.rs:2:5
    |
-LL |     "example".as_bytes() as [char]; 
+LL |     "example".as_bytes() as [char];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^------
    |                             |
    |                             help: try casting to a reference instead: `&[char]`

--- a/tests/ui/error-codes/E0620.stderr
+++ b/tests/ui/error-codes/E0620.stderr
@@ -2,13 +2,9 @@ error[E0620]: cast to unsized type: `&[usize; 2]` as `[usize]`
   --> $DIR/E0620.rs:2:16
    |
 LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using an implicit coercion to `&[usize]` instead
-  --> $DIR/E0620.rs:2:16
-   |
-LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^-------
+   |                                 |
+   |                                 help: try casting to a reference instead: `&[usize]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-17441.stderr
+++ b/tests/ui/issues/issue-17441.stderr
@@ -2,13 +2,9 @@ error[E0620]: cast to unsized type: `&[usize; 2]` as `[usize]`
   --> $DIR/issue-17441.rs:2:16
    |
 LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using an implicit coercion to `&[usize]` instead
-  --> $DIR/issue-17441.rs:2:16
-   |
-LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^-------
+   |                                 |
+   |                                 help: try casting to a reference instead: `&[usize]`
 
 error[E0620]: cast to unsized type: `Box<usize>` as `dyn Debug`
   --> $DIR/issue-17441.rs:5:16


### PR DESCRIPTION
fixes:  #118790

Removes `if self.cast_ty.is_trait()` to produce the same diagnostic for cast to slice and trait.