### PR TITLE
Fix name error in aarch64_apple_watchos tier 3 target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
@@ -4,7 +4,7 @@ use crate::spec::{Target, TargetOptions};
 pub fn target() -> Target {
     let base = opts("watchos", Arch::Arm64);
     Target {
-        llvm_target: "aarch-apple-watchos".into(),
+        llvm_target: "aarch64-apple-watchos".into(),
         pointer_width: 64,
         data_layout: "e-m:o-i64:64-i128:128-n32:64-S128".into(),
         arch: "aarch64".into(),


### PR DESCRIPTION
fix llvm_target wrong name `aarch-apple-watchos` to `aarch64-apple-watchos`, sorry for my mistake.

previous pr: https://github.com/rust-lang/rust/pull/119074

r? compiler-team