### PR TITLE
Require `#[must_use]` on `Diagnostic` structs to prevent future bugs

### DIFF
--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -4,6 +4,7 @@ use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_generic_type_with_parentheses, code = "E0214")]
+#[must_use]
 pub struct GenericTypeWithParentheses {
     #[primary_span]
     #[label]
@@ -24,6 +25,7 @@ pub struct UseAngleBrackets {
 #[derive(Diagnostic)]
 #[diag(ast_lowering_invalid_abi, code = "E0703")]
 #[note]
+#[must_use]
 pub struct InvalidAbi {
     #[primary_span]
     #[label]
@@ -65,6 +67,7 @@ pub struct InvalidAbiSuggestion {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_assoc_ty_parentheses)]
+#[must_use]
 pub struct AssocTyParentheses {
     #[primary_span]
     pub span: Span,
@@ -90,6 +93,7 @@ pub enum AssocTyParenthesesSub {
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_misplaced_impl_trait, code = "E0562")]
+#[must_use]
 pub struct MisplacedImplTrait<'a> {
     #[primary_span]
     pub span: Span,
@@ -98,6 +102,7 @@ pub struct MisplacedImplTrait<'a> {
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_misplaced_assoc_ty_binding)]
+#[must_use]
 pub struct MisplacedAssocTyBinding<'a> {
     #[primary_span]
     pub span: Span,
@@ -106,6 +111,7 @@ pub struct MisplacedAssocTyBinding<'a> {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_underscore_expr_lhs_assign)]
+#[must_use]
 pub struct UnderscoreExprLhsAssign {
     #[primary_span]
     #[label]
@@ -114,6 +120,7 @@ pub struct UnderscoreExprLhsAssign {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_base_expression_double_dot)]
+#[must_use]
 pub struct BaseExpressionDoubleDot {
     #[primary_span]
     #[label]
@@ -122,6 +129,7 @@ pub struct BaseExpressionDoubleDot {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_await_only_in_async_fn_and_blocks, code = "E0728")]
+#[must_use]
 pub struct AwaitOnlyInAsyncFnAndBlocks {
     #[primary_span]
     #[label]
@@ -132,6 +140,7 @@ pub struct AwaitOnlyInAsyncFnAndBlocks {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_coroutine_too_many_parameters, code = "E0628")]
+#[must_use]
 pub struct CoroutineTooManyParameters {
     #[primary_span]
     pub fn_decl_span: Span,
@@ -139,6 +148,7 @@ pub struct CoroutineTooManyParameters {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_closure_cannot_be_static, code = "E0697")]
+#[must_use]
 pub struct ClosureCannotBeStatic {
     #[primary_span]
     pub fn_decl_span: Span,
@@ -147,6 +157,7 @@ pub struct ClosureCannotBeStatic {
 #[derive(Diagnostic, Clone, Copy)]
 #[help]
 #[diag(ast_lowering_async_non_move_closure_not_supported, code = "E0708")]
+#[must_use]
 pub struct AsyncNonMoveClosureNotSupported {
     #[primary_span]
     pub fn_decl_span: Span,
@@ -154,6 +165,7 @@ pub struct AsyncNonMoveClosureNotSupported {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_functional_record_update_destructuring_assignment)]
+#[must_use]
 pub struct FunctionalRecordUpdateDestructuringAssignment {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -162,6 +174,7 @@ pub struct FunctionalRecordUpdateDestructuringAssignment {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_async_coroutines_not_supported, code = "E0727")]
+#[must_use]
 pub struct AsyncCoroutinesNotSupported {
     #[primary_span]
     pub span: Span,
@@ -169,6 +182,7 @@ pub struct AsyncCoroutinesNotSupported {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_inline_asm_unsupported_target, code = "E0472")]
+#[must_use]
 pub struct InlineAsmUnsupportedTarget {
     #[primary_span]
     pub span: Span,
@@ -176,6 +190,7 @@ pub struct InlineAsmUnsupportedTarget {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_att_syntax_only_x86)]
+#[must_use]
 pub struct AttSyntaxOnlyX86 {
     #[primary_span]
     pub span: Span,
@@ -183,6 +198,7 @@ pub struct AttSyntaxOnlyX86 {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_abi_specified_multiple_times)]
+#[must_use]
 pub struct AbiSpecifiedMultipleTimes {
     #[primary_span]
     pub abi_span: Span,
@@ -195,6 +211,7 @@ pub struct AbiSpecifiedMultipleTimes {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_clobber_abi_not_supported)]
+#[must_use]
 pub struct ClobberAbiNotSupported {
     #[primary_span]
     pub abi_span: Span,
@@ -203,6 +220,7 @@ pub struct ClobberAbiNotSupported {
 #[derive(Diagnostic)]
 #[note]
 #[diag(ast_lowering_invalid_abi_clobber_abi)]
+#[must_use]
 pub struct InvalidAbiClobberAbi {
     #[primary_span]
     pub abi_span: Span,
@@ -211,6 +229,7 @@ pub struct InvalidAbiClobberAbi {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_invalid_register)]
+#[must_use]
 pub struct InvalidRegister<'a> {
     #[primary_span]
     pub op_span: Span,
@@ -220,6 +239,7 @@ pub struct InvalidRegister<'a> {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_invalid_register_class)]
+#[must_use]
 pub struct InvalidRegisterClass<'a> {
     #[primary_span]
     pub op_span: Span,
@@ -229,6 +249,7 @@ pub struct InvalidRegisterClass<'a> {
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_invalid_asm_template_modifier_reg_class)]
+#[must_use]
 pub struct InvalidAsmTemplateModifierRegClass {
     #[primary_span]
     #[label(ast_lowering_template_modifier)]
@@ -249,6 +270,7 @@ pub enum InvalidAsmTemplateModifierRegClassSub {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_invalid_asm_template_modifier_const)]
+#[must_use]
 pub struct InvalidAsmTemplateModifierConst {
     #[primary_span]
     #[label(ast_lowering_template_modifier)]
@@ -259,6 +281,7 @@ pub struct InvalidAsmTemplateModifierConst {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_invalid_asm_template_modifier_sym)]
+#[must_use]
 pub struct InvalidAsmTemplateModifierSym {
     #[primary_span]
     #[label(ast_lowering_template_modifier)]
@@ -269,6 +292,7 @@ pub struct InvalidAsmTemplateModifierSym {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_register_class_only_clobber)]
+#[must_use]
 pub struct RegisterClassOnlyClobber {
     #[primary_span]
     pub op_span: Span,
@@ -277,6 +301,7 @@ pub struct RegisterClassOnlyClobber {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_register_conflict)]
+#[must_use]
 pub struct RegisterConflict<'a> {
     #[primary_span]
     #[label(ast_lowering_register1)]
@@ -292,6 +317,7 @@ pub struct RegisterConflict<'a> {
 #[derive(Diagnostic, Clone, Copy)]
 #[help]
 #[diag(ast_lowering_sub_tuple_binding)]
+#[must_use]
 pub struct SubTupleBinding<'a> {
     #[primary_span]
     #[label]
@@ -309,6 +335,7 @@ pub struct SubTupleBinding<'a> {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_extra_double_dot)]
+#[must_use]
 pub struct ExtraDoubleDot<'a> {
     #[primary_span]
     #[label]
@@ -321,6 +348,7 @@ pub struct ExtraDoubleDot<'a> {
 #[derive(Diagnostic, Clone, Copy)]
 #[note]
 #[diag(ast_lowering_misplaced_double_dot)]
+#[must_use]
 pub struct MisplacedDoubleDot {
     #[primary_span]
     pub span: Span,
@@ -328,6 +356,7 @@ pub struct MisplacedDoubleDot {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_misplaced_relax_trait_bound)]
+#[must_use]
 pub struct MisplacedRelaxTraitBound {
     #[primary_span]
     pub span: Span,
@@ -335,6 +364,7 @@ pub struct MisplacedRelaxTraitBound {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_not_supported_for_lifetime_binder_async_closure)]
+#[must_use]
 pub struct NotSupportedForLifetimeBinderAsyncClosure {
     #[primary_span]
     pub span: Span,
@@ -342,6 +372,7 @@ pub struct NotSupportedForLifetimeBinderAsyncClosure {
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_match_arm_with_no_body)]
+#[must_use]
 pub struct MatchArmWithNoBody {
     #[primary_span]
     pub span: Span,
@@ -351,6 +382,7 @@ pub struct MatchArmWithNoBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_never_pattern_with_body)]
+#[must_use]
 pub struct NeverPatternWithBody {
     #[primary_span]
     #[label]
@@ -360,6 +392,7 @@ pub struct NeverPatternWithBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_never_pattern_with_guard)]
+#[must_use]
 pub struct NeverPatternWithGuard {
     #[primary_span]
     #[suggestion(code = "", applicability = "maybe-incorrect")]
@@ -368,6 +401,7 @@ pub struct NeverPatternWithGuard {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_arbitrary_expression_in_pattern)]
+#[must_use]
 pub struct ArbitraryExpressionInPattern {
     #[primary_span]
     pub span: Span,
@@ -375,6 +409,7 @@ pub struct ArbitraryExpressionInPattern {
 
 #[derive(Diagnostic, Clone, Copy)]
 #[diag(ast_lowering_inclusive_range_with_no_end)]
+#[must_use]
 pub struct InclusiveRangeWithNoEnd {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -9,6 +9,7 @@ use crate::fluent_generated as fluent;
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_keyword_lifetime)]
+#[must_use]
 pub struct KeywordLifetime {
     #[primary_span]
     pub span: Span,
@@ -16,6 +17,7 @@ pub struct KeywordLifetime {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_invalid_label)]
+#[must_use]
 pub struct InvalidLabel {
     #[primary_span]
     pub span: Span,
@@ -24,6 +26,7 @@ pub struct InvalidLabel {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_visibility_not_permitted, code = "E0449")]
+#[must_use]
 pub struct VisibilityNotPermitted {
     #[primary_span]
     pub span: Span,
@@ -45,6 +48,7 @@ pub enum VisibilityNotPermittedNote {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_trait_fn_const, code = "E0379")]
+#[must_use]
 pub struct TraitFnConst {
     #[primary_span]
     #[label]
@@ -53,6 +57,7 @@ pub struct TraitFnConst {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_forbidden_lifetime_bound)]
+#[must_use]
 pub struct ForbiddenLifetimeBound {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -60,6 +65,7 @@ pub struct ForbiddenLifetimeBound {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_too_many)]
+#[must_use]
 pub struct FnParamTooMany {
     #[primary_span]
     pub span: Span,
@@ -68,6 +74,7 @@ pub struct FnParamTooMany {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_c_var_args_only)]
+#[must_use]
 pub struct FnParamCVarArgsOnly {
     #[primary_span]
     pub span: Span,
@@ -75,6 +82,7 @@ pub struct FnParamCVarArgsOnly {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_c_var_args_not_last)]
+#[must_use]
 pub struct FnParamCVarArgsNotLast {
     #[primary_span]
     pub span: Span,
@@ -82,6 +90,7 @@ pub struct FnParamCVarArgsNotLast {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_doc_comment)]
+#[must_use]
 pub struct FnParamDocComment {
     #[primary_span]
     #[label]
@@ -90,6 +99,7 @@ pub struct FnParamDocComment {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_forbidden_attr)]
+#[must_use]
 pub struct FnParamForbiddenAttr {
     #[primary_span]
     pub span: Span,
@@ -98,6 +108,7 @@ pub struct FnParamForbiddenAttr {
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_param_forbidden_self)]
 #[note]
+#[must_use]
 pub struct FnParamForbiddenSelf {
     #[primary_span]
     #[label]
@@ -106,6 +117,7 @@ pub struct FnParamForbiddenSelf {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_forbidden_default)]
+#[must_use]
 pub struct ForbiddenDefault {
     #[primary_span]
     pub span: Span,
@@ -115,6 +127,7 @@ pub struct ForbiddenDefault {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_assoc_const_without_body)]
+#[must_use]
 pub struct AssocConstWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -124,6 +137,7 @@ pub struct AssocConstWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_assoc_fn_without_body)]
+#[must_use]
 pub struct AssocFnWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -133,6 +147,7 @@ pub struct AssocFnWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_assoc_type_without_body)]
+#[must_use]
 pub struct AssocTypeWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -142,6 +157,7 @@ pub struct AssocTypeWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_const_without_body)]
+#[must_use]
 pub struct ConstWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -151,6 +167,7 @@ pub struct ConstWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_static_without_body)]
+#[must_use]
 pub struct StaticWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -160,6 +177,7 @@ pub struct StaticWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_ty_alias_without_body)]
+#[must_use]
 pub struct TyAliasWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -169,6 +187,7 @@ pub struct TyAliasWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fn_without_body)]
+#[must_use]
 pub struct FnWithoutBody {
     #[primary_span]
     pub span: Span,
@@ -199,6 +218,7 @@ pub enum ExternBlockSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_bound_in_context)]
+#[must_use]
 pub struct BoundInContext<'a> {
     #[primary_span]
     pub span: Span,
@@ -208,6 +228,7 @@ pub struct BoundInContext<'a> {
 #[derive(Diagnostic)]
 #[diag(ast_passes_extern_types_cannot)]
 #[note(ast_passes_extern_keyword_link)]
+#[must_use]
 pub struct ExternTypesCannotHave<'a> {
     #[primary_span]
     #[suggestion(code = "", applicability = "maybe-incorrect")]
@@ -221,6 +242,7 @@ pub struct ExternTypesCannotHave<'a> {
 #[derive(Diagnostic)]
 #[diag(ast_passes_body_in_extern)]
 #[note(ast_passes_extern_keyword_link)]
+#[must_use]
 pub struct BodyInExtern<'a> {
     #[primary_span]
     #[label(ast_passes_cannot_have)]
@@ -236,6 +258,7 @@ pub struct BodyInExtern<'a> {
 #[diag(ast_passes_fn_body_extern)]
 #[help]
 #[note(ast_passes_extern_keyword_link)]
+#[must_use]
 pub struct FnBodyInExtern {
     #[primary_span]
     #[label(ast_passes_cannot_have)]
@@ -248,6 +271,7 @@ pub struct FnBodyInExtern {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_extern_fn_qualifiers)]
+#[must_use]
 pub struct FnQualifierInExtern {
     #[primary_span]
     pub span: Span,
@@ -260,6 +284,7 @@ pub struct FnQualifierInExtern {
 #[derive(Diagnostic)]
 #[diag(ast_passes_extern_item_ascii)]
 #[note]
+#[must_use]
 pub struct ExternItemAscii {
     #[primary_span]
     pub span: Span,
@@ -269,6 +294,7 @@ pub struct ExternItemAscii {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_bad_c_variadic)]
+#[must_use]
 pub struct BadCVariadic {
     #[primary_span]
     pub span: Vec<Span>,
@@ -276,6 +302,7 @@ pub struct BadCVariadic {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_item_underscore)]
+#[must_use]
 pub struct ItemUnderscore<'a> {
     #[primary_span]
     #[label]
@@ -285,6 +312,7 @@ pub struct ItemUnderscore<'a> {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_nomangle_ascii, code = "E0754")]
+#[must_use]
 pub struct NoMangleAscii {
     #[primary_span]
     pub span: Span,
@@ -293,6 +321,7 @@ pub struct NoMangleAscii {
 #[derive(Diagnostic)]
 #[diag(ast_passes_module_nonascii, code = "E0754")]
 #[help]
+#[must_use]
 pub struct ModuleNonAscii {
     #[primary_span]
     pub span: Span,
@@ -301,6 +330,7 @@ pub struct ModuleNonAscii {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_auto_generic, code = "E0567")]
+#[must_use]
 pub struct AutoTraitGeneric {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -311,6 +341,7 @@ pub struct AutoTraitGeneric {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_auto_super_lifetime, code = "E0568")]
+#[must_use]
 pub struct AutoTraitBounds {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -321,6 +352,7 @@ pub struct AutoTraitBounds {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_auto_items, code = "E0380")]
+#[must_use]
 pub struct AutoTraitItems {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -332,6 +364,7 @@ pub struct AutoTraitItems {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_generic_before_constraints)]
+#[must_use]
 pub struct ArgsBeforeConstraint {
     #[primary_span]
     pub arg_spans: Vec<Span>,
@@ -367,6 +400,7 @@ impl AddToDiagnostic for EmptyLabelManySpans {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_pattern_in_fn_pointer, code = "E0561")]
+#[must_use]
 pub struct PatternFnPointer {
     #[primary_span]
     pub span: Span,
@@ -374,6 +408,7 @@ pub struct PatternFnPointer {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_trait_object_single_bound, code = "E0226")]
+#[must_use]
 pub struct TraitObjectBound {
     #[primary_span]
     pub span: Span,
@@ -381,6 +416,7 @@ pub struct TraitObjectBound {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_impl_trait_path, code = "E0667")]
+#[must_use]
 pub struct ImplTraitPath {
     #[primary_span]
     pub span: Span,
@@ -388,6 +424,7 @@ pub struct ImplTraitPath {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_nested_impl_trait, code = "E0666")]
+#[must_use]
 pub struct NestedImplTrait {
     #[primary_span]
     pub span: Span,
@@ -399,6 +436,7 @@ pub struct NestedImplTrait {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_at_least_one_trait)]
+#[must_use]
 pub struct AtLeastOneTrait {
     #[primary_span]
     pub span: Span,
@@ -406,6 +444,7 @@ pub struct AtLeastOneTrait {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_out_of_order_params)]
+#[must_use]
 pub struct OutOfOrderParams<'a> {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -419,6 +458,7 @@ pub struct OutOfOrderParams<'a> {
 #[derive(Diagnostic)]
 #[diag(ast_passes_obsolete_auto)]
 #[help]
+#[must_use]
 pub struct ObsoleteAuto {
     #[primary_span]
     pub span: Span,
@@ -426,6 +466,7 @@ pub struct ObsoleteAuto {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_unsafe_negative_impl, code = "E0198")]
+#[must_use]
 pub struct UnsafeNegativeImpl {
     #[primary_span]
     pub span: Span,
@@ -437,6 +478,7 @@ pub struct UnsafeNegativeImpl {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_inherent_cannot_be)]
+#[must_use]
 pub struct InherentImplCannot<'a> {
     #[primary_span]
     pub span: Span,
@@ -451,6 +493,7 @@ pub struct InherentImplCannot<'a> {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_inherent_cannot_be, code = "E0197")]
+#[must_use]
 pub struct InherentImplCannotUnsafe<'a> {
     #[primary_span]
     pub span: Span,
@@ -463,6 +506,7 @@ pub struct InherentImplCannotUnsafe<'a> {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_unsafe_item)]
+#[must_use]
 pub struct UnsafeItem {
     #[primary_span]
     pub span: Span,
@@ -471,6 +515,7 @@ pub struct UnsafeItem {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_fieldless_union)]
+#[must_use]
 pub struct FieldlessUnion {
     #[primary_span]
     pub span: Span,
@@ -479,6 +524,7 @@ pub struct FieldlessUnion {
 #[derive(Diagnostic)]
 #[diag(ast_passes_where_clause_after_type_alias)]
 #[note]
+#[must_use]
 pub struct WhereClauseAfterTypeAlias {
     #[primary_span]
     pub span: Span,
@@ -489,6 +535,7 @@ pub struct WhereClauseAfterTypeAlias {
 #[derive(Diagnostic)]
 #[diag(ast_passes_where_clause_before_type_alias)]
 #[note]
+#[must_use]
 pub struct WhereClauseBeforeTypeAlias {
     #[primary_span]
     pub span: Span,
@@ -512,6 +559,7 @@ pub struct WhereClauseBeforeTypeAliasSugg {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_generic_default_trailing)]
+#[must_use]
 pub struct GenericDefaultTrailing {
     #[primary_span]
     pub span: Span,
@@ -519,6 +567,7 @@ pub struct GenericDefaultTrailing {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_nested_lifetimes, code = "E0316")]
+#[must_use]
 pub struct NestedLifetimes {
     #[primary_span]
     pub span: Span,
@@ -527,6 +576,7 @@ pub struct NestedLifetimes {
 #[derive(Diagnostic)]
 #[diag(ast_passes_optional_trait_supertrait)]
 #[note]
+#[must_use]
 pub struct OptionalTraitSupertrait {
     #[primary_span]
     pub span: Span,
@@ -535,6 +585,7 @@ pub struct OptionalTraitSupertrait {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_optional_trait_object)]
+#[must_use]
 pub struct OptionalTraitObject {
     #[primary_span]
     pub span: Span,
@@ -542,6 +593,7 @@ pub struct OptionalTraitObject {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_tilde_const_disallowed)]
+#[must_use]
 pub struct TildeConstDisallowed {
     #[primary_span]
     pub span: Span,
@@ -581,6 +633,7 @@ pub enum TildeConstReason {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_optional_const_exclusive)]
+#[must_use]
 pub struct OptionalConstExclusive {
     #[primary_span]
     pub span: Span,
@@ -589,6 +642,7 @@ pub struct OptionalConstExclusive {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_const_and_async)]
+#[must_use]
 pub struct ConstAndAsync {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -602,6 +656,7 @@ pub struct ConstAndAsync {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_const_and_c_variadic)]
+#[must_use]
 pub struct ConstAndCVariadic {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -613,6 +668,7 @@ pub struct ConstAndCVariadic {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_pattern_in_foreign, code = "E0130")]
+#[must_use]
 pub struct PatternInForeign {
     #[primary_span]
     #[label]
@@ -621,6 +677,7 @@ pub struct PatternInForeign {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_pattern_in_bodiless, code = "E0642")]
+#[must_use]
 pub struct PatternInBodiless {
     #[primary_span]
     #[label]
@@ -630,6 +687,7 @@ pub struct PatternInBodiless {
 #[derive(Diagnostic)]
 #[diag(ast_passes_equality_in_where)]
 #[note]
+#[must_use]
 pub struct EqualityInWhere {
     #[primary_span]
     #[label]
@@ -669,6 +727,7 @@ pub struct AssociatedSuggestion2 {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_stability_outside_std, code = "E0734")]
+#[must_use]
 pub struct StabilityOutsideStd {
     #[primary_span]
     pub span: Span,
@@ -676,6 +735,7 @@ pub struct StabilityOutsideStd {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_feature_on_non_nightly, code = "E0554")]
+#[must_use]
 pub struct FeatureOnNonNightly {
     #[primary_span]
     pub span: Span,
@@ -708,6 +768,7 @@ impl AddToDiagnostic for StableFeature {
 #[derive(Diagnostic)]
 #[diag(ast_passes_incompatible_features)]
 #[help]
+#[must_use]
 pub struct IncompatibleFeatures {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -717,6 +778,7 @@ pub struct IncompatibleFeatures {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_show_span)]
+#[must_use]
 pub struct ShowSpan {
     #[primary_span]
     pub span: Span,
@@ -725,6 +787,7 @@ pub struct ShowSpan {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_negative_bound_not_supported)]
+#[must_use]
 pub struct NegativeBoundUnsupported {
     #[primary_span]
     pub span: Span,
@@ -732,6 +795,7 @@ pub struct NegativeBoundUnsupported {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_constraint_on_negative_bound)]
+#[must_use]
 pub struct ConstraintOnNegativeBound {
     #[primary_span]
     pub span: Span,
@@ -739,6 +803,7 @@ pub struct ConstraintOnNegativeBound {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_invalid_unnamed_field_ty)]
+#[must_use]
 pub struct InvalidUnnamedFieldTy {
     #[primary_span]
     pub span: Span,
@@ -748,6 +813,7 @@ pub struct InvalidUnnamedFieldTy {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_invalid_unnamed_field)]
+#[must_use]
 pub struct InvalidUnnamedField {
     #[primary_span]
     pub span: Span,
@@ -757,6 +823,7 @@ pub struct InvalidUnnamedField {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_anon_struct_or_union_not_allowed)]
+#[must_use]
 pub struct AnonStructOrUnionNotAllowed {
     #[primary_span]
     #[label]
@@ -766,6 +833,7 @@ pub struct AnonStructOrUnionNotAllowed {
 
 #[derive(Diagnostic)]
 #[diag(ast_passes_match_arm_with_no_body)]
+#[must_use]
 pub struct MatchArmWithNoBody {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -12,6 +12,7 @@ use crate::UnsupportedLiteralReason;
 
 #[derive(Diagnostic)]
 #[diag(attr_expected_one_cfg_pattern, code = "E0536")]
+#[must_use]
 pub(crate) struct ExpectedOneCfgPattern {
     #[primary_span]
     pub span: Span,
@@ -19,6 +20,7 @@ pub(crate) struct ExpectedOneCfgPattern {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_predicate, code = "E0537")]
+#[must_use]
 pub(crate) struct InvalidPredicate {
     #[primary_span]
     pub span: Span,
@@ -28,6 +30,7 @@ pub(crate) struct InvalidPredicate {
 
 #[derive(Diagnostic)]
 #[diag(attr_multiple_item, code = "E0538")]
+#[must_use]
 pub(crate) struct MultipleItem {
     #[primary_span]
     pub span: Span,
@@ -37,6 +40,7 @@ pub(crate) struct MultipleItem {
 
 #[derive(Diagnostic)]
 #[diag(attr_incorrect_meta_item, code = "E0539")]
+#[must_use]
 pub(crate) struct IncorrectMetaItem {
     #[primary_span]
     pub span: Span,
@@ -67,6 +71,7 @@ impl<'a> IntoDiagnostic<'a> for UnknownMetaItem<'_> {
 
 #[derive(Diagnostic)]
 #[diag(attr_missing_since, code = "E0542")]
+#[must_use]
 pub(crate) struct MissingSince {
     #[primary_span]
     pub span: Span,
@@ -74,6 +79,7 @@ pub(crate) struct MissingSince {
 
 #[derive(Diagnostic)]
 #[diag(attr_missing_note, code = "E0543")]
+#[must_use]
 pub(crate) struct MissingNote {
     #[primary_span]
     pub span: Span,
@@ -81,6 +87,7 @@ pub(crate) struct MissingNote {
 
 #[derive(Diagnostic)]
 #[diag(attr_multiple_stability_levels, code = "E0544")]
+#[must_use]
 pub(crate) struct MultipleStabilityLevels {
     #[primary_span]
     pub span: Span,
@@ -88,6 +95,7 @@ pub(crate) struct MultipleStabilityLevels {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_issue_string, code = "E0545")]
+#[must_use]
 pub(crate) struct InvalidIssueString {
     #[primary_span]
     pub span: Span,
@@ -146,6 +154,7 @@ impl InvalidIssueStringCause {
 
 #[derive(Diagnostic)]
 #[diag(attr_missing_feature, code = "E0546")]
+#[must_use]
 pub(crate) struct MissingFeature {
     #[primary_span]
     pub span: Span,
@@ -153,6 +162,7 @@ pub(crate) struct MissingFeature {
 
 #[derive(Diagnostic)]
 #[diag(attr_non_ident_feature, code = "E0546")]
+#[must_use]
 pub(crate) struct NonIdentFeature {
     #[primary_span]
     pub span: Span,
@@ -160,6 +170,7 @@ pub(crate) struct NonIdentFeature {
 
 #[derive(Diagnostic)]
 #[diag(attr_missing_issue, code = "E0547")]
+#[must_use]
 pub(crate) struct MissingIssue {
     #[primary_span]
     pub span: Span,
@@ -169,6 +180,7 @@ pub(crate) struct MissingIssue {
 // It is more similar to `IncorrectReprFormatGeneric`.
 #[derive(Diagnostic)]
 #[diag(attr_incorrect_repr_format_packed_one_or_zero_arg, code = "E0552")]
+#[must_use]
 pub(crate) struct IncorrectReprFormatPackedOneOrZeroArg {
     #[primary_span]
     pub span: Span,
@@ -176,6 +188,7 @@ pub(crate) struct IncorrectReprFormatPackedOneOrZeroArg {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_repr_hint_no_paren, code = "E0552")]
+#[must_use]
 pub(crate) struct InvalidReprHintNoParen {
     #[primary_span]
     pub span: Span,
@@ -185,6 +198,7 @@ pub(crate) struct InvalidReprHintNoParen {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_repr_hint_no_value, code = "E0552")]
+#[must_use]
 pub(crate) struct InvalidReprHintNoValue {
     #[primary_span]
     pub span: Span,
@@ -230,6 +244,7 @@ impl<'a> IntoDiagnostic<'a> for UnsupportedLiteral {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_repr_align_need_arg, code = "E0589")]
+#[must_use]
 pub(crate) struct InvalidReprAlignNeedArg {
     #[primary_span]
     #[suggestion(code = "align(...)", applicability = "has-placeholders")]
@@ -238,6 +253,7 @@ pub(crate) struct InvalidReprAlignNeedArg {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_repr_generic, code = "E0589")]
+#[must_use]
 pub(crate) struct InvalidReprGeneric<'a> {
     #[primary_span]
     pub span: Span,
@@ -248,6 +264,7 @@ pub(crate) struct InvalidReprGeneric<'a> {
 
 #[derive(Diagnostic)]
 #[diag(attr_incorrect_repr_format_align_one_arg, code = "E0693")]
+#[must_use]
 pub(crate) struct IncorrectReprFormatAlignOneArg {
     #[primary_span]
     pub span: Span,
@@ -255,6 +272,7 @@ pub(crate) struct IncorrectReprFormatAlignOneArg {
 
 #[derive(Diagnostic)]
 #[diag(attr_incorrect_repr_format_generic, code = "E0693")]
+#[must_use]
 pub(crate) struct IncorrectReprFormatGeneric<'a> {
     #[primary_span]
     pub span: Span,
@@ -306,6 +324,7 @@ impl<'a> IncorrectReprFormatGenericCause<'a> {
 
 #[derive(Diagnostic)]
 #[diag(attr_rustc_promotable_pairing, code = "E0717")]
+#[must_use]
 pub(crate) struct RustcPromotablePairing {
     #[primary_span]
     pub span: Span,
@@ -313,6 +332,7 @@ pub(crate) struct RustcPromotablePairing {
 
 #[derive(Diagnostic)]
 #[diag(attr_rustc_allowed_unstable_pairing, code = "E0789")]
+#[must_use]
 pub(crate) struct RustcAllowedUnstablePairing {
     #[primary_span]
     pub span: Span,
@@ -320,6 +340,7 @@ pub(crate) struct RustcAllowedUnstablePairing {
 
 #[derive(Diagnostic)]
 #[diag(attr_cfg_predicate_identifier)]
+#[must_use]
 pub(crate) struct CfgPredicateIdentifier {
     #[primary_span]
     pub span: Span,
@@ -327,6 +348,7 @@ pub(crate) struct CfgPredicateIdentifier {
 
 #[derive(Diagnostic)]
 #[diag(attr_deprecated_item_suggestion)]
+#[must_use]
 pub(crate) struct DeprecatedItemSuggestion {
     #[primary_span]
     pub span: Span,
@@ -340,6 +362,7 @@ pub(crate) struct DeprecatedItemSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(attr_expected_single_version_literal)]
+#[must_use]
 pub(crate) struct ExpectedSingleVersionLiteral {
     #[primary_span]
     pub span: Span,
@@ -347,6 +370,7 @@ pub(crate) struct ExpectedSingleVersionLiteral {
 
 #[derive(Diagnostic)]
 #[diag(attr_expected_version_literal)]
+#[must_use]
 pub(crate) struct ExpectedVersionLiteral {
     #[primary_span]
     pub span: Span,
@@ -354,6 +378,7 @@ pub(crate) struct ExpectedVersionLiteral {
 
 #[derive(Diagnostic)]
 #[diag(attr_expects_feature_list)]
+#[must_use]
 pub(crate) struct ExpectsFeatureList {
     #[primary_span]
     pub span: Span,
@@ -363,6 +388,7 @@ pub(crate) struct ExpectsFeatureList {
 
 #[derive(Diagnostic)]
 #[diag(attr_expects_features)]
+#[must_use]
 pub(crate) struct ExpectsFeatures {
     #[primary_span]
     pub span: Span,
@@ -372,6 +398,7 @@ pub(crate) struct ExpectsFeatures {
 
 #[derive(Diagnostic)]
 #[diag(attr_invalid_since)]
+#[must_use]
 pub(crate) struct InvalidSince {
     #[primary_span]
     pub span: Span,
@@ -379,6 +406,7 @@ pub(crate) struct InvalidSince {
 
 #[derive(Diagnostic)]
 #[diag(attr_soft_no_args)]
+#[must_use]
 pub(crate) struct SoftNoArgs {
     #[primary_span]
     pub span: Span,
@@ -386,6 +414,7 @@ pub(crate) struct SoftNoArgs {
 
 #[derive(Diagnostic)]
 #[diag(attr_unknown_version_literal)]
+#[must_use]
 pub(crate) struct UnknownVersionLiteral {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -7,6 +7,7 @@ use crate::diagnostics::RegionName;
 
 #[derive(Diagnostic)]
 #[diag(borrowck_move_unsized, code = "E0161")]
+#[must_use]
 pub(crate) struct MoveUnsized<'tcx> {
     pub ty: Ty<'tcx>,
     #[primary_span]
@@ -16,6 +17,7 @@ pub(crate) struct MoveUnsized<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_higher_ranked_lifetime_error)]
+#[must_use]
 pub(crate) struct HigherRankedLifetimeError {
     #[subdiagnostic]
     pub cause: Option<HigherRankedErrorCause>,
@@ -33,6 +35,7 @@ pub(crate) enum HigherRankedErrorCause {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_higher_ranked_subtype_error)]
+#[must_use]
 pub(crate) struct HigherRankedSubtypeError {
     #[primary_span]
     pub span: Span,
@@ -40,6 +43,7 @@ pub(crate) struct HigherRankedSubtypeError {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_generic_does_not_live_long_enough)]
+#[must_use]
 pub(crate) struct GenericDoesNotLiveLongEnough {
     pub kind: String,
     #[primary_span]
@@ -56,6 +60,7 @@ pub(crate) struct VarNeedNotMut {
 #[diag(borrowck_var_cannot_escape_closure)]
 #[note]
 #[note(borrowck_cannot_escape)]
+#[must_use]
 pub(crate) struct FnMutError {
     #[primary_span]
     pub span: Span,
@@ -103,6 +108,7 @@ pub(crate) enum FnMutReturnTypeErr {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_lifetime_constraints_error)]
+#[must_use]
 pub(crate) struct LifetimeOutliveErr {
     #[primary_span]
     pub span: Span,
@@ -282,6 +288,7 @@ pub(crate) enum CaptureVarCause {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_cannot_move_when_borrowed, code = "E0505")]
+#[must_use]
 pub(crate) struct MoveBorrow<'a> {
     pub place: &'a str,
     pub borrow_place: &'a str,
@@ -295,6 +302,7 @@ pub(crate) struct MoveBorrow<'a> {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_opaque_type_non_generic_param, code = "E0792")]
+#[must_use]
 pub(crate) struct NonGenericOpaqueTypeParam<'a, 'tcx> {
     pub ty: GenericArg<'tcx>,
     pub kind: &'a str,
@@ -455,6 +463,7 @@ pub(crate) enum TypeNoCopy<'a, 'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(borrowck_simd_shuffle_last_const)]
+#[must_use]
 pub(crate) struct SimdShuffleLastConst {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -7,6 +7,7 @@ use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_requires_cfg_pattern)]
+#[must_use]
 pub(crate) struct RequiresCfgPattern {
     #[primary_span]
     #[label]
@@ -15,6 +16,7 @@ pub(crate) struct RequiresCfgPattern {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_expected_one_cfg_pattern)]
+#[must_use]
 pub(crate) struct OneCfgPattern {
     #[primary_span]
     pub(crate) span: Span,
@@ -22,6 +24,7 @@ pub(crate) struct OneCfgPattern {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_alloc_error_must_be_fn)]
+#[must_use]
 pub(crate) struct AllocErrorMustBeFn {
     #[primary_span]
     pub(crate) span: Span,
@@ -29,6 +32,7 @@ pub(crate) struct AllocErrorMustBeFn {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_assert_requires_boolean)]
+#[must_use]
 pub(crate) struct AssertRequiresBoolean {
     #[primary_span]
     #[label]
@@ -37,6 +41,7 @@ pub(crate) struct AssertRequiresBoolean {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_assert_requires_expression)]
+#[must_use]
 pub(crate) struct AssertRequiresExpression {
     #[primary_span]
     pub(crate) span: Span,
@@ -46,6 +51,7 @@ pub(crate) struct AssertRequiresExpression {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_assert_missing_comma)]
+#[must_use]
 pub(crate) struct AssertMissingComma {
     #[primary_span]
     pub(crate) span: Span,
@@ -67,6 +73,7 @@ pub(crate) enum CfgAccessibleInvalid {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_cfg_accessible_indeterminate)]
+#[must_use]
 pub(crate) struct CfgAccessibleIndeterminate {
     #[primary_span]
     pub(crate) span: Span,
@@ -75,6 +82,7 @@ pub(crate) struct CfgAccessibleIndeterminate {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_missing_literal)]
 #[note]
+#[must_use]
 pub(crate) struct ConcatMissingLiteral {
     #[primary_span]
     pub(crate) spans: Vec<Span>,
@@ -82,6 +90,7 @@ pub(crate) struct ConcatMissingLiteral {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytestr)]
+#[must_use]
 pub(crate) struct ConcatBytestr {
     #[primary_span]
     pub(crate) span: Span,
@@ -89,6 +98,7 @@ pub(crate) struct ConcatBytestr {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_c_str_lit)]
+#[must_use]
 pub(crate) struct ConcatCStrLit {
     #[primary_span]
     pub(crate) span: Span,
@@ -96,6 +106,7 @@ pub(crate) struct ConcatCStrLit {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_export_macro_rules)]
+#[must_use]
 pub(crate) struct ExportMacroRules {
     #[primary_span]
     pub(crate) span: Span,
@@ -103,6 +114,7 @@ pub(crate) struct ExportMacroRules {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_proc_macro)]
+#[must_use]
 pub(crate) struct ProcMacro {
     #[primary_span]
     pub(crate) span: Span,
@@ -110,6 +122,7 @@ pub(crate) struct ProcMacro {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_invalid_crate_attribute)]
+#[must_use]
 pub(crate) struct InvalidCrateAttr {
     #[primary_span]
     pub(crate) span: Span,
@@ -117,6 +130,7 @@ pub(crate) struct InvalidCrateAttr {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_non_abi)]
+#[must_use]
 pub(crate) struct NonABI {
     #[primary_span]
     pub(crate) span: Span,
@@ -124,6 +138,7 @@ pub(crate) struct NonABI {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_trace_macros)]
+#[must_use]
 pub(crate) struct TraceMacros {
     #[primary_span]
     pub(crate) span: Span,
@@ -131,6 +146,7 @@ pub(crate) struct TraceMacros {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_bench_sig)]
+#[must_use]
 pub(crate) struct BenchSig {
     #[primary_span]
     pub(crate) span: Span,
@@ -138,6 +154,7 @@ pub(crate) struct BenchSig {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_test_arg_non_lifetime)]
+#[must_use]
 pub(crate) struct TestArgNonLifetime {
     #[primary_span]
     pub(crate) span: Span,
@@ -145,6 +162,7 @@ pub(crate) struct TestArgNonLifetime {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_should_panic)]
+#[must_use]
 pub(crate) struct ShouldPanic {
     #[primary_span]
     pub(crate) span: Span,
@@ -152,6 +170,7 @@ pub(crate) struct ShouldPanic {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_test_args)]
+#[must_use]
 pub(crate) struct TestArgs {
     #[primary_span]
     pub(crate) span: Span,
@@ -159,6 +178,7 @@ pub(crate) struct TestArgs {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_alloc_must_statics)]
+#[must_use]
 pub(crate) struct AllocMustStatics {
     #[primary_span]
     pub(crate) span: Span,
@@ -166,6 +186,7 @@ pub(crate) struct AllocMustStatics {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytes_invalid)]
+#[must_use]
 pub(crate) struct ConcatBytesInvalid {
     #[primary_span]
     pub(crate) span: Span,
@@ -210,6 +231,7 @@ pub(crate) enum ConcatBytesInvalidSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytes_oob)]
+#[must_use]
 pub(crate) struct ConcatBytesOob {
     #[primary_span]
     pub(crate) span: Span,
@@ -217,6 +239,7 @@ pub(crate) struct ConcatBytesOob {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytes_non_u8)]
+#[must_use]
 pub(crate) struct ConcatBytesNonU8 {
     #[primary_span]
     pub(crate) span: Span,
@@ -225,6 +248,7 @@ pub(crate) struct ConcatBytesNonU8 {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytes_missing_literal)]
 #[note]
+#[must_use]
 pub(crate) struct ConcatBytesMissingLiteral {
     #[primary_span]
     pub(crate) spans: Vec<Span>,
@@ -232,6 +256,7 @@ pub(crate) struct ConcatBytesMissingLiteral {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytes_array)]
+#[must_use]
 pub(crate) struct ConcatBytesArray {
     #[primary_span]
     pub(crate) span: Span,
@@ -242,6 +267,7 @@ pub(crate) struct ConcatBytesArray {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_bytes_bad_repeat)]
+#[must_use]
 pub(crate) struct ConcatBytesBadRepeat {
     #[primary_span]
     pub(crate) span: Span,
@@ -249,6 +275,7 @@ pub(crate) struct ConcatBytesBadRepeat {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_idents_missing_args)]
+#[must_use]
 pub(crate) struct ConcatIdentsMissingArgs {
     #[primary_span]
     pub(crate) span: Span,
@@ -256,6 +283,7 @@ pub(crate) struct ConcatIdentsMissingArgs {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_idents_missing_comma)]
+#[must_use]
 pub(crate) struct ConcatIdentsMissingComma {
     #[primary_span]
     pub(crate) span: Span,
@@ -263,6 +291,7 @@ pub(crate) struct ConcatIdentsMissingComma {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_concat_idents_ident_args)]
+#[must_use]
 pub(crate) struct ConcatIdentsIdentArgs {
     #[primary_span]
     pub(crate) span: Span,
@@ -270,6 +299,7 @@ pub(crate) struct ConcatIdentsIdentArgs {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_bad_derive_target, code = "E0774")]
+#[must_use]
 pub(crate) struct BadDeriveTarget {
     #[primary_span]
     #[label]
@@ -280,10 +310,12 @@ pub(crate) struct BadDeriveTarget {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_tests_not_support)]
+#[must_use]
 pub(crate) struct TestsNotSupport {}
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_unexpected_lit, code = "E0777")]
+#[must_use]
 pub(crate) struct BadDeriveLit {
     #[primary_span]
     #[label]
@@ -302,6 +334,7 @@ pub(crate) enum BadDeriveLitHelp {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_derive_path_args_list)]
+#[must_use]
 pub(crate) struct DerivePathArgsList {
     #[suggestion(code = "", applicability = "machine-applicable")]
     #[primary_span]
@@ -310,6 +343,7 @@ pub(crate) struct DerivePathArgsList {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_derive_path_args_value)]
+#[must_use]
 pub(crate) struct DerivePathArgsValue {
     #[suggestion(code = "", applicability = "machine-applicable")]
     #[primary_span]
@@ -319,6 +353,7 @@ pub(crate) struct DerivePathArgsValue {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_no_default_variant)]
 #[help]
+#[must_use]
 pub(crate) struct NoDefaultVariant {
     #[primary_span]
     pub(crate) span: Span,
@@ -342,6 +377,7 @@ pub(crate) struct NoDefaultVariantSugg {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_multiple_defaults)]
 #[note]
+#[must_use]
 pub(crate) struct MultipleDefaults {
     #[primary_span]
     pub(crate) span: Span,
@@ -368,6 +404,7 @@ pub(crate) struct MultipleDefaultsSugg {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_non_unit_default)]
 #[help]
+#[must_use]
 pub(crate) struct NonUnitDefault {
     #[primary_span]
     pub(crate) span: Span,
@@ -376,6 +413,7 @@ pub(crate) struct NonUnitDefault {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_non_exhaustive_default)]
 #[help]
+#[must_use]
 pub(crate) struct NonExhaustiveDefault {
     #[primary_span]
     pub(crate) span: Span,
@@ -386,6 +424,7 @@ pub(crate) struct NonExhaustiveDefault {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_multiple_default_attrs)]
 #[note]
+#[must_use]
 pub(crate) struct MultipleDefaultAttrs {
     #[primary_span]
     pub(crate) span: Span,
@@ -413,6 +452,7 @@ pub(crate) struct MultipleDefaultAttrsSugg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_default_arg)]
+#[must_use]
 pub(crate) struct DefaultHasArg {
     #[primary_span]
     #[suggestion(code = "#[default]", style = "hidden", applicability = "maybe-incorrect")]
@@ -421,6 +461,7 @@ pub(crate) struct DefaultHasArg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_derive_macro_call)]
+#[must_use]
 pub(crate) struct DeriveMacroCall {
     #[primary_span]
     pub(crate) span: Span,
@@ -428,6 +469,7 @@ pub(crate) struct DeriveMacroCall {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_cannot_derive_union)]
+#[must_use]
 pub(crate) struct DeriveUnion {
     #[primary_span]
     pub(crate) span: Span,
@@ -435,6 +477,7 @@ pub(crate) struct DeriveUnion {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_env_takes_args)]
+#[must_use]
 pub(crate) struct EnvTakesArgs {
     #[primary_span]
     pub(crate) span: Span,
@@ -481,6 +524,7 @@ pub(crate) enum EnvNotDefined<'a> {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_requires_string)]
+#[must_use]
 pub(crate) struct FormatRequiresString {
     #[primary_span]
     pub(crate) span: Span,
@@ -488,6 +532,7 @@ pub(crate) struct FormatRequiresString {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_duplicate_arg)]
+#[must_use]
 pub(crate) struct FormatDuplicateArg {
     #[primary_span]
     pub(crate) span: Span,
@@ -500,6 +545,7 @@ pub(crate) struct FormatDuplicateArg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_positional_after_named)]
+#[must_use]
 pub(crate) struct PositionalAfterNamed {
     #[primary_span]
     #[label]
@@ -510,6 +556,7 @@ pub(crate) struct PositionalAfterNamed {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_string_invalid)]
+#[must_use]
 pub(crate) struct InvalidFormatString {
     #[primary_span]
     #[label]
@@ -568,6 +615,7 @@ pub(crate) enum InvalidFormatStringSuggestion {
 #[diag(builtin_macros_format_no_arg_named)]
 #[note]
 #[note(builtin_macros_note2)]
+#[must_use]
 pub(crate) struct FormatNoArgNamed {
     #[primary_span]
     pub(crate) span: Span,
@@ -577,6 +625,7 @@ pub(crate) struct FormatNoArgNamed {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_unknown_trait)]
 #[note]
+#[must_use]
 pub(crate) struct FormatUnknownTrait<'a> {
     #[primary_span]
     pub(crate) span: Span,
@@ -601,6 +650,7 @@ pub struct FormatUnknownTraitSugg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_unused_arg)]
+#[must_use]
 pub(crate) struct FormatUnusedArg {
     #[primary_span]
     #[label(builtin_macros_format_unused_arg)]
@@ -626,6 +676,7 @@ impl AddToDiagnostic for FormatUnusedArg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_unused_args)]
+#[must_use]
 pub(crate) struct FormatUnusedArgs {
     #[primary_span]
     pub(crate) unused: Vec<Span>,
@@ -637,6 +688,7 @@ pub(crate) struct FormatUnusedArgs {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_pos_mismatch)]
+#[must_use]
 pub(crate) struct FormatPositionalMismatch {
     #[primary_span]
     pub(crate) span: MultiSpan,
@@ -648,6 +700,7 @@ pub(crate) struct FormatPositionalMismatch {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_format_redundant_args)]
+#[must_use]
 pub(crate) struct FormatRedundantArgs {
     #[primary_span]
     pub(crate) span: MultiSpan,
@@ -669,6 +722,7 @@ pub(crate) struct FormatRedundantArgsSugg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_test_case_non_item)]
+#[must_use]
 pub(crate) struct TestCaseNonItem {
     #[primary_span]
     pub(crate) span: Span,
@@ -676,6 +730,7 @@ pub(crate) struct TestCaseNonItem {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_test_bad_fn)]
+#[must_use]
 pub(crate) struct TestBadFn {
     #[primary_span]
     pub(crate) span: Span,
@@ -686,6 +741,7 @@ pub(crate) struct TestBadFn {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_explicit_register_name)]
+#[must_use]
 pub(crate) struct AsmExplicitRegisterName {
     #[primary_span]
     pub(crate) span: Span,
@@ -693,6 +749,7 @@ pub(crate) struct AsmExplicitRegisterName {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_mutually_exclusive)]
+#[must_use]
 pub(crate) struct AsmMutuallyExclusive {
     #[primary_span]
     pub(crate) spans: Vec<Span>,
@@ -702,6 +759,7 @@ pub(crate) struct AsmMutuallyExclusive {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_pure_combine)]
+#[must_use]
 pub(crate) struct AsmPureCombine {
     #[primary_span]
     pub(crate) spans: Vec<Span>,
@@ -709,6 +767,7 @@ pub(crate) struct AsmPureCombine {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_pure_no_output)]
+#[must_use]
 pub(crate) struct AsmPureNoOutput {
     #[primary_span]
     pub(crate) spans: Vec<Span>,
@@ -716,6 +775,7 @@ pub(crate) struct AsmPureNoOutput {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_modifier_invalid)]
+#[must_use]
 pub(crate) struct AsmModifierInvalid {
     #[primary_span]
     pub(crate) span: Span,
@@ -723,6 +783,7 @@ pub(crate) struct AsmModifierInvalid {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_requires_template)]
+#[must_use]
 pub(crate) struct AsmRequiresTemplate {
     #[primary_span]
     pub(crate) span: Span,
@@ -730,6 +791,7 @@ pub(crate) struct AsmRequiresTemplate {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_expected_comma)]
+#[must_use]
 pub(crate) struct AsmExpectedComma {
     #[primary_span]
     #[label]
@@ -738,6 +800,7 @@ pub(crate) struct AsmExpectedComma {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_underscore_input)]
+#[must_use]
 pub(crate) struct AsmUnderscoreInput {
     #[primary_span]
     pub(crate) span: Span,
@@ -745,6 +808,7 @@ pub(crate) struct AsmUnderscoreInput {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_sym_no_path)]
+#[must_use]
 pub(crate) struct AsmSymNoPath {
     #[primary_span]
     pub(crate) span: Span,
@@ -752,6 +816,7 @@ pub(crate) struct AsmSymNoPath {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_expected_other)]
+#[must_use]
 pub(crate) struct AsmExpectedOther {
     #[primary_span]
     #[label(builtin_macros_asm_expected_other)]
@@ -761,6 +826,7 @@ pub(crate) struct AsmExpectedOther {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_duplicate_arg)]
+#[must_use]
 pub(crate) struct AsmDuplicateArg {
     #[primary_span]
     #[label(builtin_macros_arg)]
@@ -772,6 +838,7 @@ pub(crate) struct AsmDuplicateArg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_pos_after)]
+#[must_use]
 pub(crate) struct AsmPositionalAfter {
     #[primary_span]
     #[label(builtin_macros_pos)]
@@ -784,6 +851,7 @@ pub(crate) struct AsmPositionalAfter {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_noreturn)]
+#[must_use]
 pub(crate) struct AsmNoReturn {
     #[primary_span]
     pub(crate) outputs_sp: Vec<Span>,
@@ -791,6 +859,7 @@ pub(crate) struct AsmNoReturn {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_global_asm_clobber_abi)]
+#[must_use]
 pub(crate) struct GlobalAsmClobberAbi {
     #[primary_span]
     pub(crate) spans: Vec<Span>,
@@ -822,6 +891,7 @@ impl<'a> IntoDiagnostic<'a> for AsmClobberNoReg {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_asm_opt_already_provided)]
+#[must_use]
 pub(crate) struct AsmOptAlreadyprovided {
     #[primary_span]
     #[label]
@@ -833,6 +903,7 @@ pub(crate) struct AsmOptAlreadyprovided {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_test_runner_invalid)]
+#[must_use]
 pub(crate) struct TestRunnerInvalid {
     #[primary_span]
     pub(crate) span: Span,
@@ -840,6 +911,7 @@ pub(crate) struct TestRunnerInvalid {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_test_runner_nargs)]
+#[must_use]
 pub(crate) struct TestRunnerNargs {
     #[primary_span]
     pub(crate) span: Span,
@@ -847,6 +919,7 @@ pub(crate) struct TestRunnerNargs {
 
 #[derive(Diagnostic)]
 #[diag(builtin_macros_expected_register_class_or_explicit_register)]
+#[must_use]
 pub(crate) struct ExpectedRegisterClassOrExplicitRegister {
     #[primary_span]
     pub(crate) span: Span,

--- a/compiler/rustc_codegen_gcc/src/errors.rs
+++ b/compiler/rustc_codegen_gcc/src/errors.rs
@@ -11,6 +11,7 @@ use crate::fluent_generated as fluent;
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_unknown_ctarget_feature_prefix)]
 #[note]
+#[must_use]
 pub(crate) struct UnknownCTargetFeaturePrefix<'a> {
     pub feature: &'a str,
 }
@@ -18,6 +19,7 @@ pub(crate) struct UnknownCTargetFeaturePrefix<'a> {
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_unknown_ctarget_feature)]
 #[note]
+#[must_use]
 pub(crate) struct UnknownCTargetFeature<'a> {
     pub feature: &'a str,
     #[subdiagnostic]
@@ -46,10 +48,12 @@ impl IntoDiagnosticArg for ExitCode {
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_lto_not_supported)]
+#[must_use]
 pub(crate) struct LTONotSupported;
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_unwinding_inline_asm)]
+#[must_use]
 pub(crate) struct UnwindingInlineAsm {
     #[primary_span]
     pub span: Span,
@@ -57,6 +61,7 @@ pub(crate) struct UnwindingInlineAsm {
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_invalid_minimum_alignment)]
+#[must_use]
 pub(crate) struct InvalidMinimumAlignment {
     pub err: String,
 }
@@ -64,6 +69,7 @@ pub(crate) struct InvalidMinimumAlignment {
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_tied_target_features)]
 #[help]
+#[must_use]
 pub(crate) struct TiedTargetFeatures {
     #[primary_span]
     pub span: Span,
@@ -72,6 +78,7 @@ pub(crate) struct TiedTargetFeatures {
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_copy_bitcode)]
+#[must_use]
 pub(crate) struct CopyBitcode {
     pub err: std::io::Error,
 }
@@ -79,24 +86,29 @@ pub(crate) struct CopyBitcode {
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_dynamic_linking_with_lto)]
 #[note]
+#[must_use]
 pub(crate) struct DynamicLinkingWithLTO;
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_load_bitcode)]
+#[must_use]
 pub(crate) struct LoadBitcode {
     name: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_lto_disallowed)]
+#[must_use]
 pub(crate) struct LtoDisallowed;
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_lto_dylib)]
+#[must_use]
 pub(crate) struct LtoDylib;
 
 #[derive(Diagnostic)]
 #[diag(codegen_gcc_lto_bitcode_from_rlib)]
+#[must_use]
 pub(crate) struct LtoBitcodeFromRlib {
     pub gcc_err: String,
 }

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -13,6 +13,7 @@ use rustc_span::Span;
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_unknown_ctarget_feature_prefix)]
 #[note]
+#[must_use]
 pub(crate) struct UnknownCTargetFeaturePrefix<'a> {
     pub feature: &'a str,
 }
@@ -20,6 +21,7 @@ pub(crate) struct UnknownCTargetFeaturePrefix<'a> {
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_unknown_ctarget_feature)]
 #[note]
+#[must_use]
 pub(crate) struct UnknownCTargetFeature<'a> {
     pub feature: &'a str,
     #[subdiagnostic]
@@ -29,6 +31,7 @@ pub(crate) struct UnknownCTargetFeature<'a> {
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_unstable_ctarget_feature)]
 #[note]
+#[must_use]
 pub(crate) struct UnstableCTargetFeature<'a> {
     pub feature: &'a str,
 }
@@ -43,6 +46,7 @@ pub(crate) enum PossibleFeature<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_error_creating_import_library)]
+#[must_use]
 pub(crate) struct ErrorCreatingImportLibrary<'a> {
     pub lib_name: &'a str,
     pub error: String,
@@ -50,6 +54,7 @@ pub(crate) struct ErrorCreatingImportLibrary<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_symbol_already_defined)]
+#[must_use]
 pub(crate) struct SymbolAlreadyDefined<'a> {
     #[primary_span]
     pub span: Span,
@@ -58,28 +63,33 @@ pub(crate) struct SymbolAlreadyDefined<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_invalid_minimum_alignment_not_power_of_two)]
+#[must_use]
 pub(crate) struct InvalidMinimumAlignmentNotPowerOfTwo {
     pub align: u64,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_invalid_minimum_alignment_too_large)]
+#[must_use]
 pub(crate) struct InvalidMinimumAlignmentTooLarge {
     pub align: u64,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_sanitizer_memtag_requires_mte)]
+#[must_use]
 pub(crate) struct SanitizerMemtagRequiresMte;
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_error_writing_def_file)]
+#[must_use]
 pub(crate) struct ErrorWritingDEFFile {
     pub error: std::io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_error_calling_dlltool)]
+#[must_use]
 pub(crate) struct ErrorCallingDllTool<'a> {
     pub dlltool_path: Cow<'a, str>,
     pub error: std::io::Error,
@@ -87,6 +97,7 @@ pub(crate) struct ErrorCallingDllTool<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_dlltool_fail_import_library)]
+#[must_use]
 pub(crate) struct DlltoolFailImportLibrary<'a> {
     pub dlltool_path: Cow<'a, str>,
     pub dlltool_args: String,
@@ -97,6 +108,7 @@ pub(crate) struct DlltoolFailImportLibrary<'a> {
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_dynamic_linking_with_lto)]
 #[note]
+#[must_use]
 pub(crate) struct DynamicLinkingWithLTO;
 
 pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
@@ -139,18 +151,22 @@ impl IntoDiagnostic<'_, ErrorGuaranteed> for TargetFeatureDisableOrEnable<'_> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_lto_disallowed)]
+#[must_use]
 pub(crate) struct LtoDisallowed;
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_lto_dylib)]
+#[must_use]
 pub(crate) struct LtoDylib;
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_lto_proc_macro)]
+#[must_use]
 pub(crate) struct LtoProcMacro;
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_lto_bitcode_from_rlib)]
+#[must_use]
 pub(crate) struct LtoBitcodeFromRlib {
     pub llvm_err: String,
 }
@@ -210,6 +226,7 @@ impl<G: EmissionGuarantee> IntoDiagnostic<'_, G> for WithLlvmError<'_> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_from_llvm_optimization_diag)]
+#[must_use]
 pub(crate) struct FromLlvmOptimizationDiag<'a> {
     pub filename: &'a str,
     pub line: std::ffi::c_uint,
@@ -221,12 +238,14 @@ pub(crate) struct FromLlvmOptimizationDiag<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_from_llvm_diag)]
+#[must_use]
 pub(crate) struct FromLlvmDiag {
     pub message: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_write_bytecode)]
+#[must_use]
 pub(crate) struct WriteBytecode<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -234,12 +253,14 @@ pub(crate) struct WriteBytecode<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_copy_bitcode)]
+#[must_use]
 pub(crate) struct CopyBitcode {
     pub err: std::io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_llvm_unknown_debuginfo_compression)]
+#[must_use]
 pub struct UnknownCompression {
     pub algorithm: &'static str,
 }

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -19,6 +19,7 @@ use std::process::ExitStatus;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_incorrect_cgu_reuse_type)]
+#[must_use]
 pub struct IncorrectCguReuseType<'a> {
     #[primary_span]
     pub span: Span,
@@ -30,6 +31,7 @@ pub struct IncorrectCguReuseType<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_cgu_not_recorded)]
+#[must_use]
 pub struct CguNotRecorded<'a> {
     pub cgu_user_name: &'a str,
     pub cgu_name: &'a str,
@@ -37,6 +39,7 @@ pub struct CguNotRecorded<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_reuse_kind)]
+#[must_use]
 pub struct UnknownReuseKind {
     #[primary_span]
     pub span: Span,
@@ -45,6 +48,7 @@ pub struct UnknownReuseKind {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_missing_query_depgraph)]
+#[must_use]
 pub struct MissingQueryDepGraph {
     #[primary_span]
     pub span: Span,
@@ -52,6 +56,7 @@ pub struct MissingQueryDepGraph {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_malformed_cgu_name)]
+#[must_use]
 pub struct MalformedCguName {
     #[primary_span]
     pub span: Span,
@@ -61,6 +66,7 @@ pub struct MalformedCguName {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_no_module_named)]
+#[must_use]
 pub struct NoModuleNamed<'a> {
     #[primary_span]
     pub span: Span,
@@ -71,6 +77,7 @@ pub struct NoModuleNamed<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_field_associated_value_expected)]
+#[must_use]
 pub struct FieldAssociatedValueExpected {
     #[primary_span]
     pub span: Span,
@@ -79,6 +86,7 @@ pub struct FieldAssociatedValueExpected {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_no_field)]
+#[must_use]
 pub struct NoField {
     #[primary_span]
     pub span: Span,
@@ -87,42 +95,50 @@ pub struct NoField {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_lib_def_write_failure)]
+#[must_use]
 pub struct LibDefWriteFailure {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_version_script_write_failure)]
+#[must_use]
 pub struct VersionScriptWriteFailure {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_symbol_file_write_failure)]
+#[must_use]
 pub struct SymbolFileWriteFailure {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_ld64_unimplemented_modifier)]
+#[must_use]
 pub struct Ld64UnimplementedModifier;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_linker_unsupported_modifier)]
+#[must_use]
 pub struct LinkerUnsupportedModifier;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_L4Bender_exporting_symbols_unimplemented)]
+#[must_use]
 pub struct L4BenderExportingSymbolsUnimplemented;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_no_natvis_directory)]
+#[must_use]
 pub struct NoNatvisDirectory {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_copy_path_buf)]
+#[must_use]
 pub struct CopyPathBuf {
     pub source_file: PathBuf,
     pub output_path: PathBuf,
@@ -132,6 +148,7 @@ pub struct CopyPathBuf {
 // Reports Paths using `Debug` implementation rather than Path's `Display` implementation.
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_copy_path)]
+#[must_use]
 pub struct CopyPath<'a> {
     from: DebugArgPath<'a>,
     to: DebugArgPath<'a>,
@@ -154,30 +171,35 @@ impl IntoDiagnosticArg for DebugArgPath<'_> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_binary_output_to_tty)]
+#[must_use]
 pub struct BinaryOutputToTty {
     pub shorthand: &'static str,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_ignoring_emit_path)]
+#[must_use]
 pub struct IgnoringEmitPath {
     pub extension: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_ignoring_output)]
+#[must_use]
 pub struct IgnoringOutput {
     pub extension: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_create_temp_dir)]
+#[must_use]
 pub struct CreateTempDir {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_add_native_library)]
+#[must_use]
 pub struct AddNativeLibrary {
     pub library_path: PathBuf,
     pub error: Error,
@@ -185,6 +207,7 @@ pub struct AddNativeLibrary {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_multiple_external_func_decl)]
+#[must_use]
 pub struct MultipleExternalFuncDecl<'a> {
     #[primary_span]
     pub span: Span,
@@ -433,27 +456,33 @@ impl IntoDiagnostic<'_> for LinkingFailed<'_> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_link_exe_unexpected_error)]
+#[must_use]
 pub struct LinkExeUnexpectedError;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_repair_vs_build_tools)]
+#[must_use]
 pub struct RepairVSBuildTools;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_missing_cpp_build_tool_component)]
+#[must_use]
 pub struct MissingCppBuildToolComponent;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_select_cpp_build_tool_workload)]
+#[must_use]
 pub struct SelectCppBuildToolWorkload;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_visual_studio_not_installed)]
+#[must_use]
 pub struct VisualStudioNotInstalled;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_linker_not_found)]
 #[note]
+#[must_use]
 pub struct LinkerNotFound {
     pub linker_path: PathBuf,
     pub error: Error,
@@ -463,6 +492,7 @@ pub struct LinkerNotFound {
 #[diag(codegen_ssa_unable_to_exe_linker)]
 #[note]
 #[note(codegen_ssa_command_note)]
+#[must_use]
 pub struct UnableToExeLinker {
     pub linker_path: PathBuf,
     pub error: Error,
@@ -471,19 +501,23 @@ pub struct UnableToExeLinker {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_msvc_missing_linker)]
+#[must_use]
 pub struct MsvcMissingLinker;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_check_installed_visual_studio)]
+#[must_use]
 pub struct CheckInstalledVisualStudio;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_insufficient_vs_code_product)]
+#[must_use]
 pub struct InsufficientVSCodeProduct;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_processing_dymutil_failed)]
 #[note]
+#[must_use]
 pub struct ProcessingDymutilFailed {
     pub status: ExitStatus,
     pub output: String,
@@ -492,6 +526,7 @@ pub struct ProcessingDymutilFailed {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unable_to_run_dsymutil)]
 #[note]
+#[must_use]
 pub struct UnableToRunDsymutil {
     pub error: Error,
 }
@@ -499,6 +534,7 @@ pub struct UnableToRunDsymutil {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_stripping_debug_info_failed)]
 #[note]
+#[must_use]
 pub struct StrippingDebugInfoFailed<'a> {
     pub util: &'a str,
     pub status: ExitStatus,
@@ -507,6 +543,7 @@ pub struct StrippingDebugInfoFailed<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unable_to_run)]
+#[must_use]
 pub struct UnableToRun<'a> {
     pub util: &'a str,
     pub error: Error,
@@ -514,24 +551,29 @@ pub struct UnableToRun<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_linker_file_stem)]
+#[must_use]
 pub struct LinkerFileStem;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_static_library_native_artifacts)]
+#[must_use]
 pub struct StaticLibraryNativeArtifacts;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_static_library_native_artifacts_to_file)]
+#[must_use]
 pub struct StaticLibraryNativeArtifactsToFile<'a> {
     pub path: &'a Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_link_script_unavailable)]
+#[must_use]
 pub struct LinkScriptUnavailable;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_link_script_write_failure)]
+#[must_use]
 pub struct LinkScriptWriteFailure {
     pub path: PathBuf,
     pub error: Error,
@@ -539,6 +581,7 @@ pub struct LinkScriptWriteFailure {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_failed_to_write)]
+#[must_use]
 pub struct FailedToWrite {
     pub path: PathBuf,
     pub error: Error,
@@ -546,6 +589,7 @@ pub struct FailedToWrite {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unable_to_write_debugger_visualizer)]
+#[must_use]
 pub struct UnableToWriteDebuggerVisualizer {
     pub path: PathBuf,
     pub error: Error,
@@ -553,6 +597,7 @@ pub struct UnableToWriteDebuggerVisualizer {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_rlib_archive_build_failure)]
+#[must_use]
 pub struct RlibArchiveBuildFailure {
     pub error: Error,
 }
@@ -586,6 +631,7 @@ pub enum ExtractBundledLibsError<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unsupported_arch)]
+#[must_use]
 pub struct UnsupportedArch<'a> {
     pub arch: &'a str,
     pub os: &'a str,
@@ -599,17 +645,20 @@ pub enum AppleSdkRootError<'a> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_read_file)]
+#[must_use]
 pub struct ReadFileError {
     pub message: std::io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unsupported_link_self_contained)]
+#[must_use]
 pub struct UnsupportedLinkSelfContained;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_archive_build_failure)]
 // Public for rustc_codegen_llvm::back::archive
+#[must_use]
 pub struct ArchiveBuildFailure {
     pub error: std::io::Error,
 }
@@ -617,12 +666,14 @@ pub struct ArchiveBuildFailure {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_archive_kind)]
 // Public for rustc_codegen_llvm::back::archive
+#[must_use]
 pub struct UnknownArchiveKind<'a> {
     pub kind: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_expected_coverage_symbol)]
+#[must_use]
 pub struct ExpectedCoverageSymbol {
     #[primary_span]
     pub span: Span,
@@ -630,6 +681,7 @@ pub struct ExpectedCoverageSymbol {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_expected_used_symbol)]
+#[must_use]
 pub struct ExpectedUsedSymbol {
     #[primary_span]
     pub span: Span,
@@ -638,6 +690,7 @@ pub struct ExpectedUsedSymbol {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_multiple_main_functions)]
 #[help]
+#[must_use]
 pub struct MultipleMainFunctions {
     #[primary_span]
     pub span: Span,
@@ -645,18 +698,21 @@ pub struct MultipleMainFunctions {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_metadata_object_file_write)]
+#[must_use]
 pub struct MetadataObjectFileWrite {
     pub error: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_invalid_windows_subsystem)]
+#[must_use]
 pub struct InvalidWindowsSubsystem {
     pub subsystem: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_shuffle_indices_evaluation)]
+#[must_use]
 pub struct ShuffleIndicesEvaluation {
     #[primary_span]
     pub span: Span,
@@ -664,18 +720,22 @@ pub struct ShuffleIndicesEvaluation {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_missing_memory_ordering)]
+#[must_use]
 pub struct MissingMemoryOrdering;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_atomic_ordering)]
+#[must_use]
 pub struct UnknownAtomicOrdering;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_atomic_compare_exchange)]
+#[must_use]
 pub struct AtomicCompareExchange;
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_unknown_atomic_operation)]
+#[must_use]
 pub struct UnknownAtomicOperation;
 
 #[derive(Diagnostic)]
@@ -1053,6 +1113,7 @@ impl IntoDiagnosticArg for ExpectedPointerMutability {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_invalid_no_sanitize)]
 #[note]
+#[must_use]
 pub struct InvalidNoSanitize {
     #[primary_span]
     pub span: Span,
@@ -1061,6 +1122,7 @@ pub struct InvalidNoSanitize {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_invalid_link_ordinal_nargs)]
 #[note]
+#[must_use]
 pub struct InvalidLinkOrdinalNargs {
     #[primary_span]
     pub span: Span,
@@ -1069,6 +1131,7 @@ pub struct InvalidLinkOrdinalNargs {
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_illegal_link_ordinal_format)]
 #[note]
+#[must_use]
 pub struct InvalidLinkOrdinalFormat {
     #[primary_span]
     pub span: Span,
@@ -1076,6 +1139,7 @@ pub struct InvalidLinkOrdinalFormat {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_target_feature_safe_trait)]
+#[must_use]
 pub struct TargetFeatureSafeTrait {
     #[primary_span]
     #[label]
@@ -1086,6 +1150,7 @@ pub struct TargetFeatureSafeTrait {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_failed_to_get_layout)]
+#[must_use]
 pub struct FailedToGetLayout<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -1095,6 +1160,7 @@ pub struct FailedToGetLayout<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(codegen_ssa_error_creating_remark_dir)]
+#[must_use]
 pub struct ErrorCreatingRemarkDir {
     pub error: std::io::Error,
 }

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -16,6 +16,7 @@ use rustc_target::abi::{Size, WrappingRange};
 
 #[derive(Diagnostic)]
 #[diag(const_eval_dangling_ptr_in_final)]
+#[must_use]
 pub(crate) struct DanglingPtrInFinal {
     #[primary_span]
     pub span: Span,
@@ -23,6 +24,7 @@ pub(crate) struct DanglingPtrInFinal {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unstable_in_stable)]
+#[must_use]
 pub(crate) struct UnstableInStable {
     pub gate: String,
     #[primary_span]
@@ -42,6 +44,7 @@ pub(crate) struct UnstableInStable {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_thread_local_access, code = "E0625")]
+#[must_use]
 pub(crate) struct NonConstOpErr {
     #[primary_span]
     pub span: Span,
@@ -50,6 +53,7 @@ pub(crate) struct NonConstOpErr {
 #[derive(Diagnostic)]
 #[diag(const_eval_static_access, code = "E0013")]
 #[help]
+#[must_use]
 pub(crate) struct StaticAccessErr {
     #[primary_span]
     pub span: Span,
@@ -63,6 +67,7 @@ pub(crate) struct StaticAccessErr {
 #[diag(const_eval_raw_ptr_to_int)]
 #[note]
 #[note(const_eval_note2)]
+#[must_use]
 pub(crate) struct RawPtrToIntErr {
     #[primary_span]
     pub span: Span,
@@ -71,6 +76,7 @@ pub(crate) struct RawPtrToIntErr {
 #[derive(Diagnostic)]
 #[diag(const_eval_raw_ptr_comparison)]
 #[note]
+#[must_use]
 pub(crate) struct RawPtrComparisonErr {
     #[primary_span]
     pub span: Span,
@@ -78,6 +84,7 @@ pub(crate) struct RawPtrComparisonErr {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_panic_non_str)]
+#[must_use]
 pub(crate) struct PanicNonStrErr {
     #[primary_span]
     pub span: Span,
@@ -85,6 +92,7 @@ pub(crate) struct PanicNonStrErr {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_mut_deref, code = "E0658")]
+#[must_use]
 pub(crate) struct MutDerefErr {
     #[primary_span]
     pub span: Span,
@@ -93,6 +101,7 @@ pub(crate) struct MutDerefErr {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_transient_mut_borrow, code = "E0658")]
+#[must_use]
 pub(crate) struct TransientMutBorrowErr {
     #[primary_span]
     pub span: Span,
@@ -101,6 +110,7 @@ pub(crate) struct TransientMutBorrowErr {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_transient_mut_borrow_raw, code = "E0658")]
+#[must_use]
 pub(crate) struct TransientMutBorrowErrRaw {
     #[primary_span]
     pub span: Span,
@@ -109,6 +119,7 @@ pub(crate) struct TransientMutBorrowErrRaw {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_max_num_nodes_in_const)]
+#[must_use]
 pub(crate) struct MaxNumNodesInConstErr {
     #[primary_span]
     pub span: Option<Span>,
@@ -117,6 +128,7 @@ pub(crate) struct MaxNumNodesInConstErr {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unallowed_fn_pointer_call)]
+#[must_use]
 pub(crate) struct UnallowedFnPointerCall {
     #[primary_span]
     pub span: Span,
@@ -125,6 +137,7 @@ pub(crate) struct UnallowedFnPointerCall {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unstable_const_fn)]
+#[must_use]
 pub(crate) struct UnstableConstFn {
     #[primary_span]
     pub span: Span,
@@ -133,6 +146,7 @@ pub(crate) struct UnstableConstFn {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unallowed_mutable_refs, code = "E0764")]
+#[must_use]
 pub(crate) struct UnallowedMutableRefs {
     #[primary_span]
     pub span: Span,
@@ -143,6 +157,7 @@ pub(crate) struct UnallowedMutableRefs {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unallowed_mutable_refs_raw, code = "E0764")]
+#[must_use]
 pub(crate) struct UnallowedMutableRefsRaw {
     #[primary_span]
     pub span: Span,
@@ -152,6 +167,7 @@ pub(crate) struct UnallowedMutableRefsRaw {
 }
 #[derive(Diagnostic)]
 #[diag(const_eval_non_const_fmt_macro_call, code = "E0015")]
+#[must_use]
 pub(crate) struct NonConstFmtMacroCall {
     #[primary_span]
     pub span: Span,
@@ -160,6 +176,7 @@ pub(crate) struct NonConstFmtMacroCall {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_non_const_fn_call, code = "E0015")]
+#[must_use]
 pub(crate) struct NonConstFnCall {
     #[primary_span]
     pub span: Span,
@@ -169,6 +186,7 @@ pub(crate) struct NonConstFnCall {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unallowed_op_in_const_context)]
+#[must_use]
 pub(crate) struct UnallowedOpInConstContext {
     #[primary_span]
     pub span: Span,
@@ -177,6 +195,7 @@ pub(crate) struct UnallowedOpInConstContext {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unallowed_heap_allocations, code = "E0010")]
+#[must_use]
 pub(crate) struct UnallowedHeapAllocations {
     #[primary_span]
     #[label]
@@ -188,6 +207,7 @@ pub(crate) struct UnallowedHeapAllocations {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_unallowed_inline_asm, code = "E0015")]
+#[must_use]
 pub(crate) struct UnallowedInlineAsm {
     #[primary_span]
     pub span: Span,
@@ -197,6 +217,7 @@ pub(crate) struct UnallowedInlineAsm {
 #[derive(Diagnostic)]
 #[diag(const_eval_unsupported_untyped_pointer)]
 #[note]
+#[must_use]
 pub(crate) struct UnsupportedUntypedPointer {
     #[primary_span]
     pub span: Span,
@@ -204,6 +225,7 @@ pub(crate) struct UnsupportedUntypedPointer {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_interior_mutable_data_refer, code = "E0492")]
+#[must_use]
 pub(crate) struct InteriorMutableDataRefer {
     #[primary_span]
     #[label]
@@ -217,6 +239,7 @@ pub(crate) struct InteriorMutableDataRefer {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_interior_mutability_borrow)]
+#[must_use]
 pub(crate) struct InteriorMutabilityBorrow {
     #[primary_span]
     pub span: Span,
@@ -232,6 +255,7 @@ pub struct LongRunning {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_long_running)]
+#[must_use]
 pub struct LongRunningWarn {
     #[primary_span]
     #[label]
@@ -270,6 +294,7 @@ pub struct RawBytesNote {
 #[derive(Diagnostic)]
 #[diag(const_eval_match_eq_non_const, code = "E0015")]
 #[note]
+#[must_use]
 pub struct NonConstMatchEq<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -279,6 +304,7 @@ pub struct NonConstMatchEq<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_for_loop_into_iter_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstForLoopIntoIter<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -288,6 +314,7 @@ pub struct NonConstForLoopIntoIter<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_question_branch_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstQuestionBranch<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -297,6 +324,7 @@ pub struct NonConstQuestionBranch<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_question_from_residual_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstQuestionFromResidual<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -306,6 +334,7 @@ pub struct NonConstQuestionFromResidual<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_try_block_from_output_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstTryBlockFromOutput<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -315,6 +344,7 @@ pub struct NonConstTryBlockFromOutput<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_await_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstAwait<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -324,6 +354,7 @@ pub struct NonConstAwait<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_closure_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstClosure {
     #[primary_span]
     pub span: Span,
@@ -357,6 +388,7 @@ pub struct ConsiderDereferencing {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_operator_non_const, code = "E0015")]
+#[must_use]
 pub struct NonConstOperator {
     #[primary_span]
     pub span: Span,
@@ -368,6 +400,7 @@ pub struct NonConstOperator {
 #[derive(Diagnostic)]
 #[diag(const_eval_deref_coercion_non_const, code = "E0015")]
 #[note]
+#[must_use]
 pub struct NonConstDerefCoercion<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -380,6 +413,7 @@ pub struct NonConstDerefCoercion<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_live_drop, code = "E0493")]
+#[must_use]
 pub struct LiveDrop<'tcx> {
     #[primary_span]
     #[label]
@@ -392,6 +426,7 @@ pub struct LiveDrop<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_error, code = "E0080")]
+#[must_use]
 pub struct ConstEvalError {
     #[primary_span]
     pub span: Span,
@@ -411,6 +446,7 @@ pub struct WriteThroughImmutablePointer {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_nullary_intrinsic_fail)]
+#[must_use]
 pub struct NullaryIntrinsicError {
     #[primary_span]
     pub span: Span,
@@ -418,6 +454,7 @@ pub struct NullaryIntrinsicError {
 
 #[derive(Diagnostic)]
 #[diag(const_eval_undefined_behavior, code = "E0080")]
+#[must_use]
 pub struct UndefinedBehavior {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_driver_impl/src/session_diagnostics.rs
+++ b/compiler/rustc_driver_impl/src/session_diagnostics.rs
@@ -2,20 +2,24 @@ use rustc_macros::{Diagnostic, Subdiagnostic};
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_rlink_unable_to_read)]
+#[must_use]
 pub(crate) struct RlinkUnableToRead {
     pub err: std::io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_rlink_wrong_file_type)]
+#[must_use]
 pub(crate) struct RLinkWrongFileType;
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_rlink_empty_version_number)]
+#[must_use]
 pub(crate) struct RLinkEmptyVersionNumber;
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_rlink_encoding_version_mismatch)]
+#[must_use]
 pub(crate) struct RLinkEncodingVersionMismatch {
     pub version_array: String,
     pub rlink_version: u32,
@@ -23,6 +27,7 @@ pub(crate) struct RLinkEncodingVersionMismatch {
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_rlink_rustc_version_mismatch)]
+#[must_use]
 pub(crate) struct RLinkRustcVersionMismatch<'a> {
     pub rustc_version: String,
     pub current_version: &'a str,
@@ -30,24 +35,29 @@ pub(crate) struct RLinkRustcVersionMismatch<'a> {
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_rlink_no_a_file)]
+#[must_use]
 pub(crate) struct RlinkNotAFile;
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice)]
+#[must_use]
 pub(crate) struct Ice;
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_bug_report)]
+#[must_use]
 pub(crate) struct IceBugReport<'a> {
     pub bug_report_url: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_bug_report_internal_feature)]
+#[must_use]
 pub(crate) struct IceBugReportInternalFeature;
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_version)]
+#[must_use]
 pub(crate) struct IceVersion<'a> {
     pub version: &'a str,
     pub triple: &'a str,
@@ -55,12 +65,14 @@ pub(crate) struct IceVersion<'a> {
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_path)]
+#[must_use]
 pub(crate) struct IcePath {
     pub path: std::path::PathBuf,
 }
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_path_error)]
+#[must_use]
 pub(crate) struct IcePathError {
     pub path: std::path::PathBuf,
     pub error: String,
@@ -76,10 +88,12 @@ pub(crate) struct IcePathErrorEnv {
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_flags)]
+#[must_use]
 pub(crate) struct IceFlags {
     pub flags: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(driver_impl_ice_exclude_cargo_defaults)]
+#[must_use]
 pub(crate) struct IceExcludeCargoDefaults;

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 
 #[derive(Diagnostic)]
 #[diag(expand_expr_repeat_no_syntax_vars)]
+#[must_use]
 pub(crate) struct NoSyntaxVarsExprRepeat {
     #[primary_span]
     pub span: Span,
@@ -14,6 +15,7 @@ pub(crate) struct NoSyntaxVarsExprRepeat {
 
 #[derive(Diagnostic)]
 #[diag(expand_must_repeat_once)]
+#[must_use]
 pub(crate) struct MustRepeatOnce {
     #[primary_span]
     pub span: Span,
@@ -21,6 +23,7 @@ pub(crate) struct MustRepeatOnce {
 
 #[derive(Diagnostic)]
 #[diag(expand_count_repetition_misplaced)]
+#[must_use]
 pub(crate) struct CountRepetitionMisplaced {
     #[primary_span]
     pub span: Span,
@@ -28,6 +31,7 @@ pub(crate) struct CountRepetitionMisplaced {
 
 #[derive(Diagnostic)]
 #[diag(expand_meta_var_expr_unrecognized_var)]
+#[must_use]
 pub(crate) struct MetaVarExprUnrecognizedVar {
     #[primary_span]
     pub span: Span,
@@ -36,6 +40,7 @@ pub(crate) struct MetaVarExprUnrecognizedVar {
 
 #[derive(Diagnostic)]
 #[diag(expand_var_still_repeating)]
+#[must_use]
 pub(crate) struct VarStillRepeating {
     #[primary_span]
     pub span: Span,
@@ -44,6 +49,7 @@ pub(crate) struct VarStillRepeating {
 
 #[derive(Diagnostic)]
 #[diag(expand_meta_var_dif_seq_matchers)]
+#[must_use]
 pub(crate) struct MetaVarsDifSeqMatchers {
     #[primary_span]
     pub span: Span,
@@ -52,6 +58,7 @@ pub(crate) struct MetaVarsDifSeqMatchers {
 
 #[derive(Diagnostic)]
 #[diag(expand_resolve_relative_path)]
+#[must_use]
 pub(crate) struct ResolveRelativePath {
     #[primary_span]
     pub span: Span,
@@ -60,6 +67,7 @@ pub(crate) struct ResolveRelativePath {
 
 #[derive(Diagnostic)]
 #[diag(expand_macro_const_stability)]
+#[must_use]
 pub(crate) struct MacroConstStability {
     #[primary_span]
     #[label]
@@ -70,6 +78,7 @@ pub(crate) struct MacroConstStability {
 
 #[derive(Diagnostic)]
 #[diag(expand_macro_body_stability)]
+#[must_use]
 pub(crate) struct MacroBodyStability {
     #[primary_span]
     #[label]
@@ -80,6 +89,7 @@ pub(crate) struct MacroBodyStability {
 
 #[derive(Diagnostic)]
 #[diag(expand_attr_no_arguments)]
+#[must_use]
 pub(crate) struct AttrNoArguments {
     #[primary_span]
     pub span: Span,
@@ -87,6 +97,7 @@ pub(crate) struct AttrNoArguments {
 
 #[derive(Diagnostic)]
 #[diag(expand_not_a_meta_item)]
+#[must_use]
 pub(crate) struct NotAMetaItem {
     #[primary_span]
     pub span: Span,
@@ -94,6 +105,7 @@ pub(crate) struct NotAMetaItem {
 
 #[derive(Diagnostic)]
 #[diag(expand_only_one_word)]
+#[must_use]
 pub(crate) struct OnlyOneWord {
     #[primary_span]
     pub span: Span,
@@ -101,6 +113,7 @@ pub(crate) struct OnlyOneWord {
 
 #[derive(Diagnostic)]
 #[diag(expand_cannot_be_name_of_macro)]
+#[must_use]
 pub(crate) struct CannotBeNameOfMacro<'a> {
     #[primary_span]
     pub span: Span,
@@ -110,6 +123,7 @@ pub(crate) struct CannotBeNameOfMacro<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_arg_not_attributes)]
+#[must_use]
 pub(crate) struct ArgumentNotAttributes {
     #[primary_span]
     pub span: Span,
@@ -117,6 +131,7 @@ pub(crate) struct ArgumentNotAttributes {
 
 #[derive(Diagnostic)]
 #[diag(expand_attributes_wrong_form)]
+#[must_use]
 pub(crate) struct AttributesWrongForm {
     #[primary_span]
     pub span: Span,
@@ -124,6 +139,7 @@ pub(crate) struct AttributesWrongForm {
 
 #[derive(Diagnostic)]
 #[diag(expand_attribute_meta_item)]
+#[must_use]
 pub(crate) struct AttributeMetaItem {
     #[primary_span]
     pub span: Span,
@@ -131,6 +147,7 @@ pub(crate) struct AttributeMetaItem {
 
 #[derive(Diagnostic)]
 #[diag(expand_attribute_single_word)]
+#[must_use]
 pub(crate) struct AttributeSingleWord {
     #[primary_span]
     pub span: Span,
@@ -138,6 +155,7 @@ pub(crate) struct AttributeSingleWord {
 
 #[derive(Diagnostic)]
 #[diag(expand_helper_attribute_name_invalid)]
+#[must_use]
 pub(crate) struct HelperAttributeNameInvalid {
     #[primary_span]
     pub span: Span,
@@ -146,6 +164,7 @@ pub(crate) struct HelperAttributeNameInvalid {
 
 #[derive(Diagnostic)]
 #[diag(expand_expected_comma_in_list)]
+#[must_use]
 pub(crate) struct ExpectedCommaInList {
     #[primary_span]
     pub span: Span,
@@ -153,6 +172,7 @@ pub(crate) struct ExpectedCommaInList {
 
 #[derive(Diagnostic)]
 #[diag(expand_only_one_argument)]
+#[must_use]
 pub(crate) struct OnlyOneArgument<'a> {
     #[primary_span]
     pub span: Span,
@@ -161,6 +181,7 @@ pub(crate) struct OnlyOneArgument<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_takes_no_arguments)]
+#[must_use]
 pub(crate) struct TakesNoArguments<'a> {
     #[primary_span]
     pub span: Span,
@@ -169,6 +190,7 @@ pub(crate) struct TakesNoArguments<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_feature_removed, code = "E0557")]
+#[must_use]
 pub(crate) struct FeatureRemoved<'a> {
     #[primary_span]
     #[label]
@@ -185,6 +207,7 @@ pub(crate) struct FeatureRemovedReason<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_feature_not_allowed, code = "E0725")]
+#[must_use]
 pub(crate) struct FeatureNotAllowed {
     #[primary_span]
     pub span: Span,
@@ -194,6 +217,7 @@ pub(crate) struct FeatureNotAllowed {
 #[derive(Diagnostic)]
 #[diag(expand_recursion_limit_reached)]
 #[help]
+#[must_use]
 pub(crate) struct RecursionLimitReached<'a> {
     #[primary_span]
     pub span: Span,
@@ -204,6 +228,7 @@ pub(crate) struct RecursionLimitReached<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_malformed_feature_attribute, code = "E0556")]
+#[must_use]
 pub(crate) struct MalformedFeatureAttribute {
     #[primary_span]
     pub span: Span,
@@ -228,6 +253,7 @@ pub(crate) enum MalformedFeatureAttributeHelp {
 
 #[derive(Diagnostic)]
 #[diag(expand_remove_expr_not_supported)]
+#[must_use]
 pub(crate) struct RemoveExprNotSupported {
     #[primary_span]
     pub span: Span,
@@ -269,6 +295,7 @@ pub(crate) enum InvalidCfg {
 
 #[derive(Diagnostic)]
 #[diag(expand_wrong_fragment_kind)]
+#[must_use]
 pub(crate) struct WrongFragmentKind<'a> {
     #[primary_span]
     pub span: Span,
@@ -278,6 +305,7 @@ pub(crate) struct WrongFragmentKind<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_unsupported_key_value)]
+#[must_use]
 pub(crate) struct UnsupportedKeyValue {
     #[primary_span]
     pub span: Span,
@@ -286,6 +314,7 @@ pub(crate) struct UnsupportedKeyValue {
 #[derive(Diagnostic)]
 #[diag(expand_incomplete_parse)]
 #[note]
+#[must_use]
 pub(crate) struct IncompleteParse<'a> {
     #[primary_span]
     pub span: Span,
@@ -308,6 +337,7 @@ pub(crate) struct IncompleteParse<'a> {
 
 #[derive(Diagnostic)]
 #[diag(expand_remove_node_not_supported)]
+#[must_use]
 pub(crate) struct RemoveNodeNotSupported {
     #[primary_span]
     pub span: Span,
@@ -316,6 +346,7 @@ pub(crate) struct RemoveNodeNotSupported {
 
 #[derive(Diagnostic)]
 #[diag(expand_module_circular)]
+#[must_use]
 pub(crate) struct ModuleCircular {
     #[primary_span]
     pub span: Span,
@@ -324,6 +355,7 @@ pub(crate) struct ModuleCircular {
 
 #[derive(Diagnostic)]
 #[diag(expand_module_in_block)]
+#[must_use]
 pub(crate) struct ModuleInBlock {
     #[primary_span]
     pub span: Span,
@@ -343,6 +375,7 @@ pub(crate) struct ModuleInBlockName {
 #[diag(expand_module_file_not_found, code = "E0583")]
 #[help]
 #[note]
+#[must_use]
 pub(crate) struct ModuleFileNotFound {
     #[primary_span]
     pub span: Span,
@@ -354,6 +387,7 @@ pub(crate) struct ModuleFileNotFound {
 #[derive(Diagnostic)]
 #[diag(expand_module_multiple_candidates, code = "E0761")]
 #[help]
+#[must_use]
 pub(crate) struct ModuleMultipleCandidates {
     #[primary_span]
     pub span: Span,
@@ -364,6 +398,7 @@ pub(crate) struct ModuleMultipleCandidates {
 
 #[derive(Diagnostic)]
 #[diag(expand_trace_macro)]
+#[must_use]
 pub struct TraceMacro {
     #[primary_span]
     pub span: Span,
@@ -371,6 +406,7 @@ pub struct TraceMacro {
 
 #[derive(Diagnostic)]
 #[diag(expand_proc_macro_panicked)]
+#[must_use]
 pub(crate) struct ProcMacroPanicked {
     #[primary_span]
     pub span: Span,
@@ -386,6 +422,7 @@ pub(crate) struct ProcMacroPanickedHelp {
 
 #[derive(Diagnostic)]
 #[diag(expand_proc_macro_derive_tokens)]
+#[must_use]
 pub struct ProcMacroDeriveTokens {
     #[primary_span]
     pub span: Span,
@@ -393,6 +430,7 @@ pub struct ProcMacroDeriveTokens {
 
 #[derive(Diagnostic)]
 #[diag(expand_duplicate_matcher_binding)]
+#[must_use]
 pub struct DuplicateMatcherBinding {
     #[primary_span]
     #[label]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -11,6 +11,7 @@ use rustc_span::{symbol::Ident, Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_ambiguous_assoc_item)]
+#[must_use]
 pub struct AmbiguousAssocItem<'a> {
     #[primary_span]
     #[label]
@@ -22,6 +23,7 @@ pub struct AmbiguousAssocItem<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_assoc_kind_mismatch)]
+#[must_use]
 pub struct AssocKindMismatch {
     #[primary_span]
     #[label]
@@ -53,6 +55,7 @@ pub struct AssocKindMismatchWrapInBracesSugg {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_assoc_item_not_found, code = "E0220")]
+#[must_use]
 pub struct AssocItemNotFound<'a> {
     #[primary_span]
     pub span: Span,
@@ -123,6 +126,7 @@ pub enum AssocItemNotFoundSugg<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_unrecognized_atomic_operation, code = "E0092")]
+#[must_use]
 pub struct UnrecognizedAtomicOperation<'a> {
     #[primary_span]
     #[label]
@@ -132,6 +136,7 @@ pub struct UnrecognizedAtomicOperation<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_wrong_number_of_generic_arguments_to_intrinsic, code = "E0094")]
+#[must_use]
 pub struct WrongNumberOfGenericArgumentsToIntrinsic<'a> {
     #[primary_span]
     #[label]
@@ -143,6 +148,7 @@ pub struct WrongNumberOfGenericArgumentsToIntrinsic<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_unrecognized_intrinsic_function, code = "E0093")]
+#[must_use]
 pub struct UnrecognizedIntrinsicFunction {
     #[primary_span]
     #[label]
@@ -152,6 +158,7 @@ pub struct UnrecognizedIntrinsicFunction {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_lifetimes_or_bounds_mismatch_on_trait, code = "E0195")]
+#[must_use]
 pub struct LifetimesOrBoundsMismatchOnTrait {
     #[primary_span]
     #[label]
@@ -168,6 +175,7 @@ pub struct LifetimesOrBoundsMismatchOnTrait {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_async_trait_impl_should_be_async)]
+#[must_use]
 pub struct AsyncTraitImplShouldBeAsync {
     #[primary_span]
     // #[label]
@@ -179,6 +187,7 @@ pub struct AsyncTraitImplShouldBeAsync {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_drop_impl_on_wrong_item, code = "E0120")]
+#[must_use]
 pub struct DropImplOnWrongItem {
     #[primary_span]
     #[label]
@@ -187,6 +196,7 @@ pub struct DropImplOnWrongItem {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_field_already_declared, code = "E0124")]
+#[must_use]
 pub struct FieldAlreadyDeclared {
     pub field_name: Ident,
     #[primary_span]
@@ -198,6 +208,7 @@ pub struct FieldAlreadyDeclared {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_copy_impl_on_type_with_dtor, code = "E0184")]
+#[must_use]
 pub struct CopyImplOnTypeWithDtor {
     #[primary_span]
     #[label]
@@ -206,6 +217,7 @@ pub struct CopyImplOnTypeWithDtor {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_multiple_relaxed_default_bounds, code = "E0203")]
+#[must_use]
 pub struct MultipleRelaxedDefaultBounds {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -213,6 +225,7 @@ pub struct MultipleRelaxedDefaultBounds {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_copy_impl_on_non_adt, code = "E0206")]
+#[must_use]
 pub struct CopyImplOnNonAdt {
     #[primary_span]
     #[label]
@@ -221,6 +234,7 @@ pub struct CopyImplOnNonAdt {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_const_param_ty_impl_on_non_adt)]
+#[must_use]
 pub struct ConstParamTyImplOnNonAdt {
     #[primary_span]
     #[label]
@@ -229,6 +243,7 @@ pub struct ConstParamTyImplOnNonAdt {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_trait_object_declared_with_no_traits, code = "E0224")]
+#[must_use]
 pub struct TraitObjectDeclaredWithNoTraits {
     #[primary_span]
     pub span: Span,
@@ -238,6 +253,7 @@ pub struct TraitObjectDeclaredWithNoTraits {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_ambiguous_lifetime_bound, code = "E0227")]
+#[must_use]
 pub struct AmbiguousLifetimeBound {
     #[primary_span]
     pub span: Span,
@@ -245,6 +261,7 @@ pub struct AmbiguousLifetimeBound {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_assoc_type_binding_not_allowed, code = "E0229")]
+#[must_use]
 pub struct AssocTypeBindingNotAllowed {
     #[primary_span]
     #[label]
@@ -265,6 +282,7 @@ pub struct ParenthesizedFnTraitExpansion {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_typeof_reserved_keyword_used, code = "E0516")]
+#[must_use]
 pub struct TypeofReservedKeywordUsed<'tcx> {
     pub ty: Ty<'tcx>,
     #[primary_span]
@@ -276,6 +294,7 @@ pub struct TypeofReservedKeywordUsed<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_value_of_associated_struct_already_specified, code = "E0719")]
+#[must_use]
 pub struct ValueOfAssociatedStructAlreadySpecified {
     #[primary_span]
     #[label]
@@ -289,6 +308,7 @@ pub struct ValueOfAssociatedStructAlreadySpecified {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_unconstrained_opaque_type)]
 #[note]
+#[must_use]
 pub struct UnconstrainedOpaqueType {
     #[primary_span]
     pub span: Span,
@@ -299,6 +319,7 @@ pub struct UnconstrainedOpaqueType {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_tait_forward_compat)]
 #[note]
+#[must_use]
 pub struct TaitForwardCompat {
     #[primary_span]
     pub span: Span,
@@ -377,6 +398,7 @@ impl<'a> IntoDiagnostic<'a> for MissingTypeParams {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_manual_implementation, code = "E0183")]
 #[help]
+#[must_use]
 pub struct ManualImplementation {
     #[primary_span]
     #[label]
@@ -386,6 +408,7 @@ pub struct ManualImplementation {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_substs_on_overridden_impl)]
+#[must_use]
 pub struct SubstsOnOverriddenImpl {
     #[primary_span]
     pub span: Span,
@@ -393,6 +416,7 @@ pub struct SubstsOnOverriddenImpl {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_const_impl_for_non_const_trait)]
+#[must_use]
 pub struct ConstImplForNonConstTrait {
     #[primary_span]
     pub trait_ref_span: Span,
@@ -407,6 +431,7 @@ pub struct ConstImplForNonConstTrait {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_const_bound_for_non_const_trait)]
+#[must_use]
 pub struct ConstBoundForNonConstTrait {
     #[primary_span]
     pub span: Span,
@@ -414,6 +439,7 @@ pub struct ConstBoundForNonConstTrait {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_self_in_impl_self)]
+#[must_use]
 pub struct SelfInImplSelf {
     #[primary_span]
     pub span: MultiSpan,
@@ -423,6 +449,7 @@ pub struct SelfInImplSelf {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_linkage_type, code = "E0791")]
+#[must_use]
 pub(crate) struct LinkageType {
     #[primary_span]
     pub span: Span,
@@ -431,6 +458,7 @@ pub(crate) struct LinkageType {
 #[derive(Diagnostic)]
 #[help]
 #[diag(hir_analysis_auto_deref_reached_recursion_limit, code = "E0055")]
+#[must_use]
 pub struct AutoDerefReachedRecursionLimit<'a> {
     #[primary_span]
     #[label]
@@ -442,6 +470,7 @@ pub struct AutoDerefReachedRecursionLimit<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_where_clause_on_main, code = "E0646")]
+#[must_use]
 pub(crate) struct WhereClauseOnMain {
     #[primary_span]
     pub span: Span,
@@ -451,6 +480,7 @@ pub(crate) struct WhereClauseOnMain {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_track_caller_on_main)]
+#[must_use]
 pub(crate) struct TrackCallerOnMain {
     #[primary_span]
     #[suggestion(applicability = "maybe-incorrect", code = "")]
@@ -461,6 +491,7 @@ pub(crate) struct TrackCallerOnMain {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_target_feature_on_main)]
+#[must_use]
 pub(crate) struct TargetFeatureOnMain {
     #[primary_span]
     #[label(hir_analysis_target_feature_on_main)]
@@ -469,6 +500,7 @@ pub(crate) struct TargetFeatureOnMain {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_start_not_track_caller)]
+#[must_use]
 pub(crate) struct StartTrackCaller {
     #[primary_span]
     pub span: Span,
@@ -478,6 +510,7 @@ pub(crate) struct StartTrackCaller {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_start_not_target_feature)]
+#[must_use]
 pub(crate) struct StartTargetFeature {
     #[primary_span]
     pub span: Span,
@@ -487,6 +520,7 @@ pub(crate) struct StartTargetFeature {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_start_not_async, code = "E0752")]
+#[must_use]
 pub(crate) struct StartAsync {
     #[primary_span]
     #[label]
@@ -495,6 +529,7 @@ pub(crate) struct StartAsync {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_start_function_where, code = "E0647")]
+#[must_use]
 pub(crate) struct StartFunctionWhere {
     #[primary_span]
     #[label]
@@ -503,6 +538,7 @@ pub(crate) struct StartFunctionWhere {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_start_function_parameters, code = "E0132")]
+#[must_use]
 pub(crate) struct StartFunctionParameters {
     #[primary_span]
     #[label]
@@ -511,6 +547,7 @@ pub(crate) struct StartFunctionParameters {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_main_function_return_type_generic, code = "E0131")]
+#[must_use]
 pub(crate) struct MainFunctionReturnTypeGeneric {
     #[primary_span]
     pub span: Span,
@@ -518,6 +555,7 @@ pub(crate) struct MainFunctionReturnTypeGeneric {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_main_function_async, code = "E0752")]
+#[must_use]
 pub(crate) struct MainFunctionAsync {
     #[primary_span]
     pub span: Span,
@@ -527,6 +565,7 @@ pub(crate) struct MainFunctionAsync {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_main_function_generic_parameters, code = "E0131")]
+#[must_use]
 pub(crate) struct MainFunctionGenericParameters {
     #[primary_span]
     pub span: Span,
@@ -536,6 +575,7 @@ pub(crate) struct MainFunctionGenericParameters {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_variadic_function_compatible_convention, code = "E0045")]
+#[must_use]
 pub(crate) struct VariadicFunctionCompatibleConvention<'a> {
     #[primary_span]
     #[label]
@@ -573,6 +613,7 @@ pub(crate) enum CannotCaptureLateBound {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_variances_of)]
+#[must_use]
 pub(crate) struct VariancesOf {
     #[primary_span]
     pub span: Span,
@@ -581,6 +622,7 @@ pub(crate) struct VariancesOf {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_type_of)]
+#[must_use]
 pub(crate) struct TypeOf<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -589,6 +631,7 @@ pub(crate) struct TypeOf<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_pass_to_variadic_function, code = "E0617")]
+#[must_use]
 pub(crate) struct PassToVariadicFunction<'tcx, 'a> {
     #[primary_span]
     pub span: Span,
@@ -603,6 +646,7 @@ pub(crate) struct PassToVariadicFunction<'tcx, 'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_cast_thin_pointer_to_fat_pointer, code = "E0607")]
+#[must_use]
 pub(crate) struct CastThinPointerToFatPointer<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -612,6 +656,7 @@ pub(crate) struct CastThinPointerToFatPointer<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_invalid_union_field, code = "E0740")]
+#[must_use]
 pub(crate) struct InvalidUnionField {
     #[primary_span]
     pub field_span: Span,
@@ -623,6 +668,7 @@ pub(crate) struct InvalidUnionField {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_return_type_notation_on_non_rpitit)]
+#[must_use]
 pub(crate) struct ReturnTypeNotationOnNonRpitit<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -644,6 +690,7 @@ pub(crate) struct InvalidUnionFieldSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_return_type_notation_equality_bound)]
+#[must_use]
 pub(crate) struct ReturnTypeNotationEqualityBound {
     #[primary_span]
     pub span: Span,
@@ -651,6 +698,7 @@ pub(crate) struct ReturnTypeNotationEqualityBound {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_placeholder_not_allowed_item_signatures, code = "E0121")]
+#[must_use]
 pub(crate) struct PlaceholderNotAllowedItemSignatures {
     #[primary_span]
     #[label]
@@ -660,6 +708,7 @@ pub(crate) struct PlaceholderNotAllowedItemSignatures {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_associated_type_trait_uninferred_generic_params, code = "E0212")]
+#[must_use]
 pub(crate) struct AssociatedTypeTraitUninferredGenericParams {
     #[primary_span]
     pub span: Span,
@@ -687,6 +736,7 @@ pub(crate) struct AssociatedTypeTraitUninferredGenericParamsMultipartSuggestion 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_enum_discriminant_overflowed, code = "E0370")]
 #[note]
+#[must_use]
 pub(crate) struct EnumDiscriminantOverflowed {
     #[primary_span]
     #[label]
@@ -699,6 +749,7 @@ pub(crate) struct EnumDiscriminantOverflowed {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_paren_sugar_attribute)]
 #[help]
+#[must_use]
 pub(crate) struct ParenSugarAttribute {
     #[primary_span]
     pub span: Span,
@@ -706,6 +757,7 @@ pub(crate) struct ParenSugarAttribute {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_must_implement_one_of_attribute)]
+#[must_use]
 pub(crate) struct MustImplementOneOfAttribute {
     #[primary_span]
     pub span: Span,
@@ -713,6 +765,7 @@ pub(crate) struct MustImplementOneOfAttribute {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_must_be_name_of_associated_function)]
+#[must_use]
 pub(crate) struct MustBeNameOfAssociatedFunction {
     #[primary_span]
     pub span: Span,
@@ -720,6 +773,7 @@ pub(crate) struct MustBeNameOfAssociatedFunction {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_function_not_have_default_implementation)]
+#[must_use]
 pub(crate) struct FunctionNotHaveDefaultImplementation {
     #[primary_span]
     pub span: Span,
@@ -729,6 +783,7 @@ pub(crate) struct FunctionNotHaveDefaultImplementation {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_must_implement_not_function)]
+#[must_use]
 pub(crate) struct MustImplementNotFunction {
     #[primary_span]
     pub span: Span,
@@ -751,6 +806,7 @@ pub(crate) struct MustImplementNotFunctionNote {}
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_function_not_found_in_trait)]
+#[must_use]
 pub(crate) struct FunctionNotFoundInTrait {
     #[primary_span]
     pub span: Span,
@@ -759,6 +815,7 @@ pub(crate) struct FunctionNotFoundInTrait {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_functions_names_duplicated)]
 #[note]
+#[must_use]
 pub(crate) struct FunctionNamesDuplicated {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -767,6 +824,7 @@ pub(crate) struct FunctionNamesDuplicated {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_simd_ffi_highly_experimental)]
 #[help]
+#[must_use]
 pub(crate) struct SIMDFFIHighlyExperimental {
     #[primary_span]
     pub span: Span,
@@ -797,6 +855,7 @@ pub enum ImplNotMarkedDefault {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_missing_trait_item, code = "E0046")]
+#[must_use]
 pub(crate) struct MissingTraitItem {
     #[primary_span]
     #[label]
@@ -848,6 +907,7 @@ pub(crate) struct MissingTraitItemSuggestionNone {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_missing_one_of_trait_item, code = "E0046")]
+#[must_use]
 pub(crate) struct MissingOneOfTraitItem {
     #[primary_span]
     #[label]
@@ -860,6 +920,7 @@ pub(crate) struct MissingOneOfTraitItem {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_missing_trait_item_unstable, code = "E0046")]
 #[note]
+#[must_use]
 pub(crate) struct MissingTraitItemUnstable {
     #[primary_span]
     pub span: Span,
@@ -874,6 +935,7 @@ pub(crate) struct MissingTraitItemUnstable {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_transparent_enum_variant, code = "E0731")]
+#[must_use]
 pub(crate) struct TransparentEnumVariant {
     #[primary_span]
     #[label]
@@ -888,6 +950,7 @@ pub(crate) struct TransparentEnumVariant {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_transparent_non_zero_sized_enum, code = "E0690")]
+#[must_use]
 pub(crate) struct TransparentNonZeroSizedEnum<'a> {
     #[primary_span]
     #[label]
@@ -900,6 +963,7 @@ pub(crate) struct TransparentNonZeroSizedEnum<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_transparent_non_zero_sized, code = "E0690")]
+#[must_use]
 pub(crate) struct TransparentNonZeroSized<'a> {
     #[primary_span]
     #[label]
@@ -912,6 +976,7 @@ pub(crate) struct TransparentNonZeroSized<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_too_large_static)]
+#[must_use]
 pub(crate) struct TooLargeStatic {
     #[primary_span]
     pub span: Span,
@@ -920,6 +985,7 @@ pub(crate) struct TooLargeStatic {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_specialization_trait)]
 #[help]
+#[must_use]
 pub(crate) struct SpecializationTrait {
     #[primary_span]
     pub span: Span,
@@ -927,6 +993,7 @@ pub(crate) struct SpecializationTrait {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_closure_implicit_hrtb)]
+#[must_use]
 pub(crate) struct ClosureImplicitHrtb {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -936,6 +1003,7 @@ pub(crate) struct ClosureImplicitHrtb {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_empty_specialization)]
+#[must_use]
 pub(crate) struct EmptySpecialization {
     #[primary_span]
     pub span: Span,
@@ -945,6 +1013,7 @@ pub(crate) struct EmptySpecialization {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_const_specialize)]
+#[must_use]
 pub(crate) struct ConstSpecialize {
     #[primary_span]
     pub span: Span,
@@ -952,6 +1021,7 @@ pub(crate) struct ConstSpecialize {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_static_specialize)]
+#[must_use]
 pub(crate) struct StaticSpecialize {
     #[primary_span]
     pub span: Span,
@@ -959,6 +1029,7 @@ pub(crate) struct StaticSpecialize {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_missing_tilde_const)]
+#[must_use]
 pub(crate) struct MissingTildeConst {
     #[primary_span]
     pub span: Span,
@@ -1048,6 +1119,7 @@ pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_ty_outside, code = "E0390")]
 #[help]
+#[must_use]
 pub struct InherentTyOutside {
     #[primary_span]
     #[help(hir_analysis_span_help)]
@@ -1056,6 +1128,7 @@ pub struct InherentTyOutside {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = "E0378")]
+#[must_use]
 pub struct DispatchFromDynCoercion<'a> {
     #[primary_span]
     pub span: Span,
@@ -1068,6 +1141,7 @@ pub struct DispatchFromDynCoercion<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_dispatch_from_dyn_repr, code = "E0378")]
+#[must_use]
 pub struct DispatchFromDynRepr {
     #[primary_span]
     pub span: Span,
@@ -1076,6 +1150,7 @@ pub struct DispatchFromDynRepr {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_ty_outside_relevant, code = "E0390")]
 #[help]
+#[must_use]
 pub struct InherentTyOutsideRelevant {
     #[primary_span]
     pub span: Span,
@@ -1086,6 +1161,7 @@ pub struct InherentTyOutsideRelevant {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_ty_outside_new, code = "E0116")]
 #[note]
+#[must_use]
 pub struct InherentTyOutsideNew {
     #[primary_span]
     #[label]
@@ -1095,6 +1171,7 @@ pub struct InherentTyOutsideNew {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_ty_outside_primitive, code = "E0390")]
 #[help]
+#[must_use]
 pub struct InherentTyOutsidePrimitive {
     #[primary_span]
     pub span: Span,
@@ -1105,6 +1182,7 @@ pub struct InherentTyOutsidePrimitive {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_primitive_ty, code = "E0390")]
 #[help]
+#[must_use]
 pub struct InherentPrimitiveTy<'a> {
     #[primary_span]
     pub span: Span,
@@ -1121,6 +1199,7 @@ pub struct InherentPrimitiveTyNote<'a> {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_dyn, code = "E0785")]
 #[note]
+#[must_use]
 pub struct InherentDyn {
     #[primary_span]
     #[label]
@@ -1130,6 +1209,7 @@ pub struct InherentDyn {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_nominal, code = "E0118")]
 #[note]
+#[must_use]
 pub struct InherentNominal {
     #[primary_span]
     #[label]
@@ -1139,6 +1219,7 @@ pub struct InherentNominal {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_dispatch_from_dyn_zst, code = "E0378")]
 #[note]
+#[must_use]
 pub struct DispatchFromDynZST<'a> {
     #[primary_span]
     pub span: Span,
@@ -1148,6 +1229,7 @@ pub struct DispatchFromDynZST<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = "E0378")]
+#[must_use]
 pub struct DispatchFromDynSingle<'a> {
     #[primary_span]
     pub span: Span,
@@ -1159,6 +1241,7 @@ pub struct DispatchFromDynSingle<'a> {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_dispatch_from_dyn_multi, code = "E0378")]
 #[note]
+#[must_use]
 pub struct DispatchFromDynMulti {
     #[primary_span]
     pub span: Span,
@@ -1170,6 +1253,7 @@ pub struct DispatchFromDynMulti {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = "E0376")]
+#[must_use]
 pub struct DispatchFromDynStruct<'a> {
     #[primary_span]
     pub span: Span,
@@ -1178,6 +1262,7 @@ pub struct DispatchFromDynStruct<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = "E0377")]
+#[must_use]
 pub struct DispatchFromDynSame<'a> {
     #[primary_span]
     pub span: Span,
@@ -1190,6 +1275,7 @@ pub struct DispatchFromDynSame<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = "E0374")]
+#[must_use]
 pub struct CoerceUnsizedOneField<'a> {
     #[primary_span]
     pub span: Span,
@@ -1201,6 +1287,7 @@ pub struct CoerceUnsizedOneField<'a> {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_multi, code = "E0375")]
 #[note]
+#[must_use]
 pub struct CoerceUnsizedMulti {
     #[primary_span]
     #[label]
@@ -1213,6 +1300,7 @@ pub struct CoerceUnsizedMulti {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_unsized_may, code = "E0378")]
+#[must_use]
 pub struct CoerceUnsizedMay<'a> {
     #[primary_span]
     pub span: Span,
@@ -1221,6 +1309,7 @@ pub struct CoerceUnsizedMay<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_trait_cannot_impl_for_ty, code = "E0204")]
+#[must_use]
 pub struct TraitCannotImplForTy {
     #[primary_span]
     pub span: Span,
@@ -1244,6 +1333,7 @@ pub struct ImplForTyRequires {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_traits_with_defualt_impl, code = "E0321")]
 #[note]
+#[must_use]
 pub struct TraitsWithDefaultImpl<'a> {
     #[primary_span]
     pub span: Span,
@@ -1254,6 +1344,7 @@ pub struct TraitsWithDefaultImpl<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_cross_crate_traits, code = "E0321")]
+#[must_use]
 pub struct CrossCrateTraits<'a> {
     #[primary_span]
     #[label]
@@ -1264,6 +1355,7 @@ pub struct CrossCrateTraits<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_cross_crate_traits_defined, code = "E0321")]
+#[must_use]
 pub struct CrossCrateTraitsDefined {
     #[primary_span]
     #[label]
@@ -1274,6 +1366,7 @@ pub struct CrossCrateTraitsDefined {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_ty_param_first_local, code = "E0210")]
 #[note]
+#[must_use]
 pub struct TyParamFirstLocal<'a> {
     #[primary_span]
     #[label]
@@ -1287,6 +1380,7 @@ pub struct TyParamFirstLocal<'a> {
 #[derive(Diagnostic)]
 #[diag(hir_analysis_ty_param_some, code = "E0210")]
 #[note]
+#[must_use]
 pub struct TyParamSome<'a> {
     #[primary_span]
     #[label]

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -16,6 +16,7 @@ use rustc_span::{
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_field_multiply_specified_in_initializer, code = "E0062")]
+#[must_use]
 pub struct FieldMultiplySpecifiedInInitializer {
     #[primary_span]
     #[label]
@@ -27,6 +28,7 @@ pub struct FieldMultiplySpecifiedInInitializer {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_return_stmt_outside_of_fn_body, code = "E0572")]
+#[must_use]
 pub struct ReturnStmtOutsideOfFnBody {
     #[primary_span]
     pub span: Span,
@@ -56,6 +58,7 @@ impl IntoDiagnosticArg for ReturnLikeStatementKind {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_rustcall_incorrect_args)]
+#[must_use]
 pub struct RustCallIncorrectArgs {
     #[primary_span]
     pub span: Span,
@@ -63,6 +66,7 @@ pub struct RustCallIncorrectArgs {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_yield_expr_outside_of_coroutine, code = "E0627")]
+#[must_use]
 pub struct YieldExprOutsideOfCoroutine {
     #[primary_span]
     pub span: Span,
@@ -70,6 +74,7 @@ pub struct YieldExprOutsideOfCoroutine {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_struct_expr_non_exhaustive, code = "E0639")]
+#[must_use]
 pub struct StructExprNonExhaustive {
     #[primary_span]
     pub span: Span,
@@ -78,6 +83,7 @@ pub struct StructExprNonExhaustive {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_method_call_on_unknown_raw_pointee, code = "E0699")]
+#[must_use]
 pub struct MethodCallOnUnknownRawPointee {
     #[primary_span]
     pub span: Span,
@@ -86,6 +92,7 @@ pub struct MethodCallOnUnknownRawPointee {
 #[derive(Diagnostic)]
 #[diag(hir_typeck_missing_fn_lang_items)]
 #[help]
+#[must_use]
 pub struct MissingFnLangItems {
     #[primary_span]
     pub span: Span,
@@ -93,6 +100,7 @@ pub struct MissingFnLangItems {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_functional_record_update_on_non_struct, code = "E0436")]
+#[must_use]
 pub struct FunctionalRecordUpdateOnNonStruct {
     #[primary_span]
     pub span: Span,
@@ -100,6 +108,7 @@ pub struct FunctionalRecordUpdateOnNonStruct {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_address_of_temporary_taken, code = "E0745")]
+#[must_use]
 pub struct AddressOfTemporaryTaken {
     #[primary_span]
     #[label]
@@ -146,6 +155,7 @@ pub enum ExpectedReturnTypeLabel<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_explicit_destructor, code = "E0040")]
+#[must_use]
 pub struct ExplicitDestructorCall {
     #[primary_span]
     #[label]
@@ -169,6 +179,7 @@ pub enum ExplicitDestructorCallSugg {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_missing_parentheses_in_range, code = "E0689")]
+#[must_use]
 pub struct MissingParenthesesInRange {
     #[primary_span]
     #[label(hir_typeck_missing_parentheses_in_range)]
@@ -195,6 +206,7 @@ pub struct AddMissingParenthesesInRange {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_op_trait_generic_params)]
+#[must_use]
 pub struct OpMethodGenericParams {
     #[primary_span]
     pub span: Span,
@@ -322,6 +334,7 @@ impl HelpUseLatestEdition {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_invalid_callee, code = "E0618")]
+#[must_use]
 pub struct InvalidCallee {
     #[primary_span]
     pub span: Span,
@@ -330,6 +343,7 @@ pub struct InvalidCallee {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_int_to_fat, code = "E0606")]
+#[must_use]
 pub struct IntToWide<'tcx> {
     #[primary_span]
     #[label(hir_typeck_int_to_fat_label)]
@@ -411,6 +425,7 @@ impl AddToDiagnostic for RemoveSemiForCoerce {
 #[derive(Diagnostic)]
 #[diag(hir_typeck_const_select_must_be_const)]
 #[help]
+#[must_use]
 pub struct ConstSelectMustBeConst {
     #[primary_span]
     pub span: Span,
@@ -420,6 +435,7 @@ pub struct ConstSelectMustBeConst {
 #[diag(hir_typeck_const_select_must_be_fn)]
 #[note]
 #[help]
+#[must_use]
 pub struct ConstSelectMustBeFn<'a> {
     #[primary_span]
     pub span: Span,
@@ -428,6 +444,7 @@ pub struct ConstSelectMustBeFn<'a> {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_union_pat_multiple_fields)]
+#[must_use]
 pub struct UnionPatMultipleFields {
     #[primary_span]
     pub span: Span,
@@ -435,6 +452,7 @@ pub struct UnionPatMultipleFields {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_union_pat_dotdot)]
+#[must_use]
 pub struct UnionPatDotDot {
     #[primary_span]
     pub span: Span,
@@ -456,6 +474,7 @@ pub struct UseIsEmpty {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_arg_mismatch_indeterminate)]
+#[must_use]
 pub struct ArgMismatchIndeterminate {
     #[primary_span]
     pub span: Span,
@@ -511,6 +530,7 @@ pub struct TrivialCast<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_no_associated_item, code = "E0599")]
+#[must_use]
 pub struct NoAssociatedItem {
     #[primary_span]
     pub span: Span,
@@ -533,6 +553,7 @@ pub struct CandidateTraitNote {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_cannot_cast_to_bool, code = "E0054")]
+#[must_use]
 pub struct CannotCastToBool<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -550,6 +571,7 @@ pub struct CastEnumDrop<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_cast_unknown_pointer, code = "E0641")]
+#[must_use]
 pub struct CastUnknownPointer {
     #[primary_span]
     pub span: Span,
@@ -601,6 +623,7 @@ pub enum CannotCastToBoolHelp {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_ctor_is_private, code = "E0603")]
+#[must_use]
 pub struct CtorIsPrivate {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_incremental/src/errors.rs
+++ b/compiler/rustc_incremental/src/errors.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 #[derive(Diagnostic)]
 #[diag(incremental_unrecognized_depnode)]
+#[must_use]
 pub struct UnrecognizedDepNode {
     #[primary_span]
     pub span: Span,
@@ -12,6 +13,7 @@ pub struct UnrecognizedDepNode {
 
 #[derive(Diagnostic)]
 #[diag(incremental_missing_depnode)]
+#[must_use]
 pub struct MissingDepNode {
     #[primary_span]
     pub span: Span,
@@ -19,6 +21,7 @@ pub struct MissingDepNode {
 
 #[derive(Diagnostic)]
 #[diag(incremental_missing_if_this_changed)]
+#[must_use]
 pub struct MissingIfThisChanged {
     #[primary_span]
     pub span: Span,
@@ -26,6 +29,7 @@ pub struct MissingIfThisChanged {
 
 #[derive(Diagnostic)]
 #[diag(incremental_ok)]
+#[must_use]
 pub struct Ok {
     #[primary_span]
     pub span: Span,
@@ -33,6 +37,7 @@ pub struct Ok {
 
 #[derive(Diagnostic)]
 #[diag(incremental_no_path)]
+#[must_use]
 pub struct NoPath {
     #[primary_span]
     pub span: Span,
@@ -42,6 +47,7 @@ pub struct NoPath {
 
 #[derive(Diagnostic)]
 #[diag(incremental_assertion_auto)]
+#[must_use]
 pub struct AssertionAuto<'a> {
     #[primary_span]
     pub span: Span,
@@ -51,6 +57,7 @@ pub struct AssertionAuto<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_undefined_clean_dirty_assertions_item)]
+#[must_use]
 pub struct UndefinedCleanDirtyItem {
     #[primary_span]
     pub span: Span,
@@ -59,6 +66,7 @@ pub struct UndefinedCleanDirtyItem {
 
 #[derive(Diagnostic)]
 #[diag(incremental_undefined_clean_dirty_assertions)]
+#[must_use]
 pub struct UndefinedCleanDirty {
     #[primary_span]
     pub span: Span,
@@ -67,6 +75,7 @@ pub struct UndefinedCleanDirty {
 
 #[derive(Diagnostic)]
 #[diag(incremental_repeated_depnode_label)]
+#[must_use]
 pub struct RepeatedDepNodeLabel<'a> {
     #[primary_span]
     pub span: Span,
@@ -75,6 +84,7 @@ pub struct RepeatedDepNodeLabel<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_unrecognized_depnode_label)]
+#[must_use]
 pub struct UnrecognizedDepNodeLabel<'a> {
     #[primary_span]
     pub span: Span,
@@ -83,6 +93,7 @@ pub struct UnrecognizedDepNodeLabel<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_not_dirty)]
+#[must_use]
 pub struct NotDirty<'a> {
     #[primary_span]
     pub span: Span,
@@ -91,6 +102,7 @@ pub struct NotDirty<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_not_clean)]
+#[must_use]
 pub struct NotClean<'a> {
     #[primary_span]
     pub span: Span,
@@ -99,6 +111,7 @@ pub struct NotClean<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_not_loaded)]
+#[must_use]
 pub struct NotLoaded<'a> {
     #[primary_span]
     pub span: Span,
@@ -107,6 +120,7 @@ pub struct NotLoaded<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_unknown_item)]
+#[must_use]
 pub struct UnknownItem {
     #[primary_span]
     pub span: Span,
@@ -115,6 +129,7 @@ pub struct UnknownItem {
 
 #[derive(Diagnostic)]
 #[diag(incremental_no_cfg)]
+#[must_use]
 pub struct NoCfg {
     #[primary_span]
     pub span: Span,
@@ -122,6 +137,7 @@ pub struct NoCfg {
 
 #[derive(Diagnostic)]
 #[diag(incremental_associated_value_expected_for)]
+#[must_use]
 pub struct AssociatedValueExpectedFor {
     #[primary_span]
     pub span: Span,
@@ -130,6 +146,7 @@ pub struct AssociatedValueExpectedFor {
 
 #[derive(Diagnostic)]
 #[diag(incremental_associated_value_expected)]
+#[must_use]
 pub struct AssociatedValueExpected {
     #[primary_span]
     pub span: Span,
@@ -137,6 +154,7 @@ pub struct AssociatedValueExpected {
 
 #[derive(Diagnostic)]
 #[diag(incremental_unchecked_clean)]
+#[must_use]
 pub struct UncheckedClean {
     #[primary_span]
     pub span: Span,
@@ -144,6 +162,7 @@ pub struct UncheckedClean {
 
 #[derive(Diagnostic)]
 #[diag(incremental_delete_old)]
+#[must_use]
 pub struct DeleteOld<'a> {
     pub name: &'a str,
     pub path: PathBuf,
@@ -152,6 +171,7 @@ pub struct DeleteOld<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_create_new)]
+#[must_use]
 pub struct CreateNew<'a> {
     pub name: &'a str,
     pub path: PathBuf,
@@ -160,6 +180,7 @@ pub struct CreateNew<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_write_new)]
+#[must_use]
 pub struct WriteNew<'a> {
     pub name: &'a str,
     pub path: PathBuf,
@@ -168,6 +189,7 @@ pub struct WriteNew<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_canonicalize_path)]
+#[must_use]
 pub struct CanonicalizePath {
     pub path: PathBuf,
     pub err: std::io::Error,
@@ -175,6 +197,7 @@ pub struct CanonicalizePath {
 
 #[derive(Diagnostic)]
 #[diag(incremental_create_incr_comp_dir)]
+#[must_use]
 pub struct CreateIncrCompDir<'a> {
     pub tag: &'a str,
     pub path: &'a Path,
@@ -183,6 +206,7 @@ pub struct CreateIncrCompDir<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_create_lock)]
+#[must_use]
 pub struct CreateLock<'a> {
     pub lock_err: std::io::Error,
     pub session_dir: &'a Path,
@@ -195,6 +219,7 @@ pub struct CreateLock<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_delete_lock)]
+#[must_use]
 pub struct DeleteLock<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -202,12 +227,14 @@ pub struct DeleteLock<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_hard_link_failed)]
+#[must_use]
 pub struct HardLinkFailed<'a> {
     pub path: &'a Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(incremental_delete_partial)]
+#[must_use]
 pub struct DeletePartial<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -215,6 +242,7 @@ pub struct DeletePartial<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_delete_full)]
+#[must_use]
 pub struct DeleteFull<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -222,6 +250,7 @@ pub struct DeleteFull<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_finalize)]
+#[must_use]
 pub struct Finalize<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -229,6 +258,7 @@ pub struct Finalize<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_invalid_gc_failed)]
+#[must_use]
 pub struct InvalidGcFailed<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -236,6 +266,7 @@ pub struct InvalidGcFailed<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_finalized_gc_failed)]
+#[must_use]
 pub struct FinalizedGcFailed<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -243,6 +274,7 @@ pub struct FinalizedGcFailed<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_session_gc_failed)]
+#[must_use]
 pub struct SessionGcFailed<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -250,14 +282,17 @@ pub struct SessionGcFailed<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_assert_not_loaded)]
+#[must_use]
 pub struct AssertNotLoaded;
 
 #[derive(Diagnostic)]
 #[diag(incremental_assert_loaded)]
+#[must_use]
 pub struct AssertLoaded;
 
 #[derive(Diagnostic)]
 #[diag(incremental_delete_incompatible)]
+#[must_use]
 pub struct DeleteIncompatible {
     pub path: PathBuf,
     pub err: std::io::Error,
@@ -265,6 +300,7 @@ pub struct DeleteIncompatible {
 
 #[derive(Diagnostic)]
 #[diag(incremental_load_dep_graph)]
+#[must_use]
 pub struct LoadDepGraph {
     pub path: PathBuf,
     pub err: std::io::Error,
@@ -272,6 +308,7 @@ pub struct LoadDepGraph {
 
 #[derive(Diagnostic)]
 #[diag(incremental_write_dep_graph)]
+#[must_use]
 pub struct WriteDepGraph<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -279,6 +316,7 @@ pub struct WriteDepGraph<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_move_dep_graph)]
+#[must_use]
 pub struct MoveDepGraph<'a> {
     pub from: &'a Path,
     pub to: &'a Path,
@@ -287,6 +325,7 @@ pub struct MoveDepGraph<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_create_dep_graph)]
+#[must_use]
 pub struct CreateDepGraph<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,
@@ -294,6 +333,7 @@ pub struct CreateDepGraph<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_copy_workproduct_to_cache)]
+#[must_use]
 pub struct CopyWorkProductToCache<'a> {
     pub from: &'a Path,
     pub to: &'a Path,
@@ -302,6 +342,7 @@ pub struct CopyWorkProductToCache<'a> {
 
 #[derive(Diagnostic)]
 #[diag(incremental_delete_workproduct)]
+#[must_use]
 pub struct DeleteWorkProduct<'a> {
     pub path: &'a Path,
     pub err: std::io::Error,

--- a/compiler/rustc_infer/src/errors/mod.rs
+++ b/compiler/rustc_infer/src/errors/mod.rs
@@ -22,6 +22,7 @@ pub mod note_and_explain;
 
 #[derive(Diagnostic)]
 #[diag(infer_opaque_hidden_type)]
+#[must_use]
 pub struct OpaqueHiddenTypeDiag {
     #[primary_span]
     #[label]
@@ -34,6 +35,7 @@ pub struct OpaqueHiddenTypeDiag {
 
 #[derive(Diagnostic)]
 #[diag(infer_type_annotations_needed, code = "E0282")]
+#[must_use]
 pub struct AnnotationRequired<'a> {
     #[primary_span]
     pub span: Span,
@@ -52,6 +54,7 @@ pub struct AnnotationRequired<'a> {
 // Copy of `AnnotationRequired` for E0283
 #[derive(Diagnostic)]
 #[diag(infer_type_annotations_needed, code = "E0283")]
+#[must_use]
 pub struct AmbiguousImpl<'a> {
     #[primary_span]
     pub span: Span,
@@ -70,6 +73,7 @@ pub struct AmbiguousImpl<'a> {
 // Copy of `AnnotationRequired` for E0284
 #[derive(Diagnostic)]
 #[diag(infer_type_annotations_needed, code = "E0284")]
+#[must_use]
 pub struct AmbiguousReturn<'a> {
     #[primary_span]
     pub span: Span,
@@ -428,6 +432,7 @@ impl AddToDiagnostic for AddLifetimeParamsSuggestion<'_> {
 
 #[derive(Diagnostic)]
 #[diag(infer_lifetime_mismatch, code = "E0623")]
+#[must_use]
 pub struct LifetimeMismatch<'a> {
     #[primary_span]
     pub span: Span,
@@ -486,6 +491,7 @@ pub enum ImplicitStaticLifetimeSubdiag {
 
 #[derive(Diagnostic)]
 #[diag(infer_mismatched_static_lifetime)]
+#[must_use]
 pub struct MismatchedStaticLifetime<'a> {
     #[primary_span]
     pub cause_span: Span,
@@ -740,6 +746,7 @@ impl<'tcx> ActualImplExplNotes<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(infer_trait_placeholder_mismatch)]
+#[must_use]
 pub struct TraitPlaceholderMismatch<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -781,6 +788,7 @@ pub struct RelationshipHelp;
 
 #[derive(Diagnostic)]
 #[diag(infer_trait_impl_diff)]
+#[must_use]
 pub struct TraitImplDiff {
     #[primary_span]
     #[label(infer_found)]
@@ -826,6 +834,7 @@ impl AddToDiagnostic for DynTraitConstraintSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(infer_but_calling_introduces, code = "E0772")]
+#[must_use]
 pub struct ButCallingIntroduces {
     #[label(infer_label1)]
     pub param_ty_span: Span,
@@ -885,6 +894,7 @@ impl AddToDiagnostic for MoreTargeted {
 
 #[derive(Diagnostic)]
 #[diag(infer_but_needs_to_satisfy, code = "E0759")]
+#[must_use]
 pub struct ButNeedsToSatisfy {
     #[primary_span]
     pub sp: Span,
@@ -911,6 +921,7 @@ pub struct ButNeedsToSatisfy {
 
 #[derive(Diagnostic)]
 #[diag(infer_outlives_content, code = "E0312")]
+#[must_use]
 pub struct OutlivesContent<'a> {
     #[primary_span]
     pub span: Span,
@@ -920,6 +931,7 @@ pub struct OutlivesContent<'a> {
 
 #[derive(Diagnostic)]
 #[diag(infer_outlives_bound, code = "E0476")]
+#[must_use]
 pub struct OutlivesBound<'a> {
     #[primary_span]
     pub span: Span,
@@ -929,6 +941,7 @@ pub struct OutlivesBound<'a> {
 
 #[derive(Diagnostic)]
 #[diag(infer_fulfill_req_lifetime, code = "E0477")]
+#[must_use]
 pub struct FulfillReqLifetime<'a> {
     #[primary_span]
     pub span: Span,
@@ -939,6 +952,7 @@ pub struct FulfillReqLifetime<'a> {
 
 #[derive(Diagnostic)]
 #[diag(infer_lf_bound_not_satisfied, code = "E0478")]
+#[must_use]
 pub struct LfBoundNotSatisfied<'a> {
     #[primary_span]
     pub span: Span,
@@ -948,6 +962,7 @@ pub struct LfBoundNotSatisfied<'a> {
 
 #[derive(Diagnostic)]
 #[diag(infer_ref_longer_than_data, code = "E0491")]
+#[must_use]
 pub struct RefLongerThanData<'a> {
     #[primary_span]
     pub span: Span,
@@ -1124,6 +1139,7 @@ pub enum PlaceholderRelationLfNotSatisfied {
 
 #[derive(Diagnostic)]
 #[diag(infer_opaque_captures_lifetime, code = "E0700")]
+#[must_use]
 pub struct OpaqueCapturesLifetime<'tcx> {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_interface/src/errors.rs
+++ b/compiler/rustc_interface/src/errors.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 #[derive(Diagnostic)]
 #[diag(interface_ferris_identifier)]
+#[must_use]
 pub struct FerrisIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -17,6 +18,7 @@ pub struct FerrisIdentifier {
 
 #[derive(Diagnostic)]
 #[diag(interface_emoji_identifier)]
+#[must_use]
 pub struct EmojiIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -25,14 +27,17 @@ pub struct EmojiIdentifier {
 
 #[derive(Diagnostic)]
 #[diag(interface_mixed_bin_crate)]
+#[must_use]
 pub struct MixedBinCrate;
 
 #[derive(Diagnostic)]
 #[diag(interface_mixed_proc_macro_crate)]
+#[must_use]
 pub struct MixedProcMacroCrate;
 
 #[derive(Diagnostic)]
 #[diag(interface_error_writing_dependencies)]
+#[must_use]
 pub struct ErrorWritingDependencies<'a> {
     pub path: &'a Path,
     pub error: io::Error,
@@ -40,12 +45,14 @@ pub struct ErrorWritingDependencies<'a> {
 
 #[derive(Diagnostic)]
 #[diag(interface_input_file_would_be_overwritten)]
+#[must_use]
 pub struct InputFileWouldBeOverWritten<'a> {
     pub path: &'a Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(interface_generated_file_conflicts_with_directory)]
+#[must_use]
 pub struct GeneratedFileConflictsWithDirectory<'a> {
     pub input_path: &'a Path,
     pub dir_path: &'a Path,
@@ -53,20 +60,24 @@ pub struct GeneratedFileConflictsWithDirectory<'a> {
 
 #[derive(Diagnostic)]
 #[diag(interface_temps_dir_error)]
+#[must_use]
 pub struct TempsDirError;
 
 #[derive(Diagnostic)]
 #[diag(interface_out_dir_error)]
+#[must_use]
 pub struct OutDirError;
 
 #[derive(Diagnostic)]
 #[diag(interface_cant_emit_mir)]
+#[must_use]
 pub struct CantEmitMIR {
     pub error: io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(interface_rustc_error_fatal)]
+#[must_use]
 pub struct RustcErrorFatal {
     #[primary_span]
     pub span: Span,
@@ -74,6 +85,7 @@ pub struct RustcErrorFatal {
 
 #[derive(Diagnostic)]
 #[diag(interface_rustc_error_unexpected_annotation)]
+#[must_use]
 pub struct RustcErrorUnexpectedAnnotation {
     #[primary_span]
     pub span: Span,
@@ -81,6 +93,7 @@ pub struct RustcErrorUnexpectedAnnotation {
 
 #[derive(Diagnostic)]
 #[diag(interface_failed_writing_file)]
+#[must_use]
 pub struct FailedWritingFile<'a> {
     pub path: &'a Path,
     pub error: io::Error,
@@ -88,10 +101,12 @@ pub struct FailedWritingFile<'a> {
 
 #[derive(Diagnostic)]
 #[diag(interface_proc_macro_crate_panic_abort)]
+#[must_use]
 pub struct ProcMacroCratePanicAbort;
 
 #[derive(Diagnostic)]
 #[diag(interface_unsupported_crate_type_for_target)]
+#[must_use]
 pub struct UnsupportedCrateTypeForTarget<'a> {
     pub crate_type: CrateType,
     pub target_triple: &'a TargetTriple,
@@ -99,16 +114,20 @@ pub struct UnsupportedCrateTypeForTarget<'a> {
 
 #[derive(Diagnostic)]
 #[diag(interface_multiple_output_types_adaption)]
+#[must_use]
 pub struct MultipleOutputTypesAdaption;
 
 #[derive(Diagnostic)]
 #[diag(interface_ignoring_extra_filename)]
+#[must_use]
 pub struct IgnoringExtraFilename;
 
 #[derive(Diagnostic)]
 #[diag(interface_ignoring_out_dir)]
+#[must_use]
 pub struct IgnoringOutDir;
 
 #[derive(Diagnostic)]
 #[diag(interface_multiple_output_types_to_stdout)]
+#[must_use]
 pub struct MultipleOutputTypesToStdout;

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -6,6 +6,7 @@ use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(lint_overruled_attribute, code = "E0453")]
+#[must_use]
 pub struct OverruledAttribute<'a> {
     #[primary_span]
     pub span: Span,
@@ -49,6 +50,7 @@ impl AddToDiagnostic for OverruledAttributeSub {
 
 #[derive(Diagnostic)]
 #[diag(lint_malformed_attribute, code = "E0452")]
+#[must_use]
 pub struct MalformedAttribute {
     #[primary_span]
     pub span: Span,
@@ -68,6 +70,7 @@ pub enum MalformedAttributeSub {
 
 #[derive(Diagnostic)]
 #[diag(lint_unknown_tool_in_scoped_lint, code = "E0710")]
+#[must_use]
 pub struct UnknownToolInScopedLint {
     #[primary_span]
     pub span: Option<Span>,
@@ -79,6 +82,7 @@ pub struct UnknownToolInScopedLint {
 
 #[derive(Diagnostic)]
 #[diag(lint_builtin_ellipsis_inclusive_range_patterns, code = "E0783")]
+#[must_use]
 pub struct BuiltinEllipsisInclusiveRangePatterns {
     #[primary_span]
     pub span: Span,
@@ -96,12 +100,14 @@ pub struct RequestedLevel<'a> {
 
 #[derive(Diagnostic)]
 #[diag(lint_unsupported_group, code = "E0602")]
+#[must_use]
 pub struct UnsupportedGroup {
     pub lint_group: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(lint_check_name_unknown_tool, code = "E0602")]
+#[must_use]
 pub struct CheckNameUnknownTool<'a> {
     pub tool_name: Symbol,
     #[subdiagnostic]

--- a/compiler/rustc_macros/src/diagnostics/mod.rs
+++ b/compiler/rustc_macros/src/diagnostics/mod.rs
@@ -22,6 +22,7 @@ use synstructure::Structure;
 /// # use rustc_middle::ty::Ty;
 /// #[derive(Diagnostic)]
 /// #[diag(borrowck_move_out_of_borrow, code = "E0505")]
+/// #[must_use]
 /// pub struct MoveOutOfBorrowError<'tcx> {
 ///     pub name: Ident,
 ///     pub ty: Ty<'tcx>,

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -619,6 +619,12 @@ impl SubdiagnosticVariant {
         let name = attr.path().segments.last().unwrap().ident.to_string();
         let name = name.as_str();
 
+        // We want diagnostic structs to be marked `#[must_use]`, so we must
+        // allow it as a no-op attr here.
+        if name == "must_use" {
+            return Ok(None);
+        }
+
         let mut kind = match name {
             "label" => SubdiagnosticKind::Label,
             "note" => SubdiagnosticKind::Note,

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -616,8 +616,6 @@ impl SubdiagnosticVariant {
             return Ok(None);
         }
 
-        let span = attr.span().unwrap();
-
         let name = attr.path().segments.last().unwrap().ident.to_string();
         let name = name.as_str();
 
@@ -666,6 +664,8 @@ impl SubdiagnosticVariant {
                 }
             }
         };
+
+        let span = attr.span().unwrap();
 
         let list = match &attr.meta {
             Meta::List(list) => {

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -14,12 +14,14 @@ use crate::locator::CrateFlavor;
 
 #[derive(Diagnostic)]
 #[diag(metadata_rlib_required)]
+#[must_use]
 pub struct RlibRequired {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_lib_required)]
+#[must_use]
 pub struct LibRequired<'a> {
     pub crate_name: Symbol,
     pub kind: &'a str,
@@ -28,6 +30,7 @@ pub struct LibRequired<'a> {
 #[derive(Diagnostic)]
 #[diag(metadata_rustc_lib_required)]
 #[help]
+#[must_use]
 pub struct RustcLibRequired<'a> {
     pub crate_name: Symbol,
     pub kind: &'a str,
@@ -36,12 +39,14 @@ pub struct RustcLibRequired<'a> {
 #[derive(Diagnostic)]
 #[diag(metadata_crate_dep_multiple)]
 #[help]
+#[must_use]
 pub struct CrateDepMultiple {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_two_panic_runtimes)]
+#[must_use]
 pub struct TwoPanicRuntimes {
     pub prev_name: Symbol,
     pub cur_name: Symbol,
@@ -49,6 +54,7 @@ pub struct TwoPanicRuntimes {
 
 #[derive(Diagnostic)]
 #[diag(metadata_bad_panic_strategy)]
+#[must_use]
 pub struct BadPanicStrategy {
     pub runtime: Symbol,
     pub strategy: PanicStrategy,
@@ -56,6 +62,7 @@ pub struct BadPanicStrategy {
 
 #[derive(Diagnostic)]
 #[diag(metadata_required_panic_strategy)]
+#[must_use]
 pub struct RequiredPanicStrategy {
     pub crate_name: Symbol,
     pub found_strategy: PanicStrategy,
@@ -64,6 +71,7 @@ pub struct RequiredPanicStrategy {
 
 #[derive(Diagnostic)]
 #[diag(metadata_incompatible_panic_in_drop_strategy)]
+#[must_use]
 pub struct IncompatiblePanicInDropStrategy {
     pub crate_name: Symbol,
     pub found_strategy: PanicStrategy,
@@ -72,6 +80,7 @@ pub struct IncompatiblePanicInDropStrategy {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_names_in_link)]
+#[must_use]
 pub struct MultipleNamesInLink {
     #[primary_span]
     pub span: Span,
@@ -79,6 +88,7 @@ pub struct MultipleNamesInLink {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_kinds_in_link)]
+#[must_use]
 pub struct MultipleKindsInLink {
     #[primary_span]
     pub span: Span,
@@ -86,6 +96,7 @@ pub struct MultipleKindsInLink {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_name_form)]
+#[must_use]
 pub struct LinkNameForm {
     #[primary_span]
     pub span: Span,
@@ -93,6 +104,7 @@ pub struct LinkNameForm {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_kind_form)]
+#[must_use]
 pub struct LinkKindForm {
     #[primary_span]
     pub span: Span,
@@ -100,6 +112,7 @@ pub struct LinkKindForm {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_modifiers_form)]
+#[must_use]
 pub struct LinkModifiersForm {
     #[primary_span]
     pub span: Span,
@@ -107,6 +120,7 @@ pub struct LinkModifiersForm {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_cfg_form)]
+#[must_use]
 pub struct LinkCfgForm {
     #[primary_span]
     pub span: Span,
@@ -114,6 +128,7 @@ pub struct LinkCfgForm {
 
 #[derive(Diagnostic)]
 #[diag(metadata_wasm_import_form)]
+#[must_use]
 pub struct WasmImportForm {
     #[primary_span]
     pub span: Span,
@@ -121,6 +136,7 @@ pub struct WasmImportForm {
 
 #[derive(Diagnostic)]
 #[diag(metadata_empty_link_name, code = "E0454")]
+#[must_use]
 pub struct EmptyLinkName {
     #[primary_span]
     #[label]
@@ -129,6 +145,7 @@ pub struct EmptyLinkName {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_framework_apple, code = "E0455")]
+#[must_use]
 pub struct LinkFrameworkApple {
     #[primary_span]
     pub span: Span,
@@ -136,6 +153,7 @@ pub struct LinkFrameworkApple {
 
 #[derive(Diagnostic)]
 #[diag(metadata_framework_only_windows, code = "E0455")]
+#[must_use]
 pub struct FrameworkOnlyWindows {
     #[primary_span]
     pub span: Span,
@@ -143,6 +161,7 @@ pub struct FrameworkOnlyWindows {
 
 #[derive(Diagnostic)]
 #[diag(metadata_unknown_link_kind, code = "E0458")]
+#[must_use]
 pub struct UnknownLinkKind<'a> {
     #[primary_span]
     #[label]
@@ -152,6 +171,7 @@ pub struct UnknownLinkKind<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_link_modifiers)]
+#[must_use]
 pub struct MultipleLinkModifiers {
     #[primary_span]
     pub span: Span,
@@ -159,6 +179,7 @@ pub struct MultipleLinkModifiers {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_cfgs)]
+#[must_use]
 pub struct MultipleCfgs {
     #[primary_span]
     pub span: Span,
@@ -166,6 +187,7 @@ pub struct MultipleCfgs {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_cfg_single_predicate)]
+#[must_use]
 pub struct LinkCfgSinglePredicate {
     #[primary_span]
     pub span: Span,
@@ -173,6 +195,7 @@ pub struct LinkCfgSinglePredicate {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_wasm_import)]
+#[must_use]
 pub struct MultipleWasmImport {
     #[primary_span]
     pub span: Span,
@@ -180,6 +203,7 @@ pub struct MultipleWasmImport {
 
 #[derive(Diagnostic)]
 #[diag(metadata_unexpected_link_arg)]
+#[must_use]
 pub struct UnexpectedLinkArg {
     #[primary_span]
     pub span: Span,
@@ -187,6 +211,7 @@ pub struct UnexpectedLinkArg {
 
 #[derive(Diagnostic)]
 #[diag(metadata_invalid_link_modifier)]
+#[must_use]
 pub struct InvalidLinkModifier {
     #[primary_span]
     pub span: Span,
@@ -194,6 +219,7 @@ pub struct InvalidLinkModifier {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_modifiers)]
+#[must_use]
 pub struct MultipleModifiers<'a> {
     #[primary_span]
     pub span: Span,
@@ -202,6 +228,7 @@ pub struct MultipleModifiers<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_bundle_needs_static)]
+#[must_use]
 pub struct BundleNeedsStatic {
     #[primary_span]
     pub span: Span,
@@ -209,6 +236,7 @@ pub struct BundleNeedsStatic {
 
 #[derive(Diagnostic)]
 #[diag(metadata_whole_archive_needs_static)]
+#[must_use]
 pub struct WholeArchiveNeedsStatic {
     #[primary_span]
     pub span: Span,
@@ -216,6 +244,7 @@ pub struct WholeArchiveNeedsStatic {
 
 #[derive(Diagnostic)]
 #[diag(metadata_as_needed_compatibility)]
+#[must_use]
 pub struct AsNeededCompatibility {
     #[primary_span]
     pub span: Span,
@@ -223,6 +252,7 @@ pub struct AsNeededCompatibility {
 
 #[derive(Diagnostic)]
 #[diag(metadata_unknown_link_modifier)]
+#[must_use]
 pub struct UnknownLinkModifier<'a> {
     #[primary_span]
     pub span: Span,
@@ -231,6 +261,7 @@ pub struct UnknownLinkModifier<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_incompatible_wasm_link)]
+#[must_use]
 pub struct IncompatibleWasmLink {
     #[primary_span]
     pub span: Span,
@@ -238,6 +269,7 @@ pub struct IncompatibleWasmLink {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_requires_name, code = "E0459")]
+#[must_use]
 pub struct LinkRequiresName {
     #[primary_span]
     #[label]
@@ -246,6 +278,7 @@ pub struct LinkRequiresName {
 
 #[derive(Diagnostic)]
 #[diag(metadata_raw_dylib_no_nul)]
+#[must_use]
 pub struct RawDylibNoNul {
     #[primary_span]
     pub span: Span,
@@ -253,6 +286,7 @@ pub struct RawDylibNoNul {
 
 #[derive(Diagnostic)]
 #[diag(metadata_link_ordinal_raw_dylib)]
+#[must_use]
 pub struct LinkOrdinalRawDylib {
     #[primary_span]
     pub span: Span,
@@ -260,28 +294,33 @@ pub struct LinkOrdinalRawDylib {
 
 #[derive(Diagnostic)]
 #[diag(metadata_lib_framework_apple)]
+#[must_use]
 pub struct LibFrameworkApple;
 
 #[derive(Diagnostic)]
 #[diag(metadata_empty_renaming_target)]
+#[must_use]
 pub struct EmptyRenamingTarget<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_renaming_no_link)]
+#[must_use]
 pub struct RenamingNoLink<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_renamings)]
+#[must_use]
 pub struct MultipleRenamings<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_no_link_mod_override)]
+#[must_use]
 pub struct NoLinkModOverride {
     #[primary_span]
     pub span: Option<Span>,
@@ -289,6 +328,7 @@ pub struct NoLinkModOverride {
 
 #[derive(Diagnostic)]
 #[diag(metadata_unsupported_abi_i686)]
+#[must_use]
 pub struct UnsupportedAbiI686 {
     #[primary_span]
     pub span: Span,
@@ -296,6 +336,7 @@ pub struct UnsupportedAbiI686 {
 
 #[derive(Diagnostic)]
 #[diag(metadata_unsupported_abi)]
+#[must_use]
 pub struct UnsupportedAbi {
     #[primary_span]
     pub span: Span,
@@ -303,12 +344,14 @@ pub struct UnsupportedAbi {
 
 #[derive(Diagnostic)]
 #[diag(metadata_fail_create_file_encoder)]
+#[must_use]
 pub struct FailCreateFileEncoder {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_fail_write_file)]
+#[must_use]
 pub struct FailWriteFile<'a> {
     pub path: &'a Path,
     pub err: Error,
@@ -316,12 +359,14 @@ pub struct FailWriteFile<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_crate_not_panic_runtime)]
+#[must_use]
 pub struct CrateNotPanicRuntime {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_no_panic_strategy)]
+#[must_use]
 pub struct NoPanicStrategy {
     pub crate_name: Symbol,
     pub strategy: PanicStrategy,
@@ -329,16 +374,19 @@ pub struct NoPanicStrategy {
 
 #[derive(Diagnostic)]
 #[diag(metadata_profiler_builtins_needs_core)]
+#[must_use]
 pub struct ProfilerBuiltinsNeedsCore;
 
 #[derive(Diagnostic)]
 #[diag(metadata_not_profiler_runtime)]
+#[must_use]
 pub struct NotProfilerRuntime {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_no_multiple_global_alloc)]
+#[must_use]
 pub struct NoMultipleGlobalAlloc {
     #[primary_span]
     #[label]
@@ -349,6 +397,7 @@ pub struct NoMultipleGlobalAlloc {
 
 #[derive(Diagnostic)]
 #[diag(metadata_no_multiple_alloc_error_handler)]
+#[must_use]
 pub struct NoMultipleAllocErrorHandler {
     #[primary_span]
     #[label]
@@ -359,6 +408,7 @@ pub struct NoMultipleAllocErrorHandler {
 
 #[derive(Diagnostic)]
 #[diag(metadata_conflicting_global_alloc)]
+#[must_use]
 pub struct ConflictingGlobalAlloc {
     pub crate_name: Symbol,
     pub other_crate_name: Symbol,
@@ -366,6 +416,7 @@ pub struct ConflictingGlobalAlloc {
 
 #[derive(Diagnostic)]
 #[diag(metadata_conflicting_alloc_error_handler)]
+#[must_use]
 pub struct ConflictingAllocErrorHandler {
     pub crate_name: Symbol,
     pub other_crate_name: Symbol,
@@ -373,10 +424,12 @@ pub struct ConflictingAllocErrorHandler {
 
 #[derive(Diagnostic)]
 #[diag(metadata_global_alloc_required)]
+#[must_use]
 pub struct GlobalAllocRequired;
 
 #[derive(Diagnostic)]
 #[diag(metadata_no_transitive_needs_dep)]
+#[must_use]
 pub struct NoTransitiveNeedsDep<'a> {
     pub crate_name: Symbol,
     pub needs_crate_name: &'a str,
@@ -385,6 +438,7 @@ pub struct NoTransitiveNeedsDep<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_failed_write_error)]
+#[must_use]
 pub struct FailedWriteError {
     pub filename: PathBuf,
     pub err: Error,
@@ -392,6 +446,7 @@ pub struct FailedWriteError {
 
 #[derive(Diagnostic)]
 #[diag(metadata_failed_copy_to_stdout)]
+#[must_use]
 pub struct FailedCopyToStdout {
     pub filename: PathBuf,
     pub err: Error,
@@ -399,10 +454,12 @@ pub struct FailedCopyToStdout {
 
 #[derive(Diagnostic)]
 #[diag(metadata_binary_output_to_tty)]
+#[must_use]
 pub struct BinaryOutputToTty;
 
 #[derive(Diagnostic)]
 #[diag(metadata_missing_native_library)]
+#[must_use]
 pub struct MissingNativeLibrary<'a> {
     libname: &'a str,
     #[subdiagnostic]
@@ -445,12 +502,14 @@ pub struct SuggestLibraryName<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_failed_create_tempdir)]
+#[must_use]
 pub struct FailedCreateTempdir {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_failed_create_file)]
+#[must_use]
 pub struct FailedCreateFile<'a> {
     pub filename: &'a Path,
     pub err: Error,
@@ -458,12 +517,14 @@ pub struct FailedCreateFile<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_failed_create_encoded_metadata)]
+#[must_use]
 pub struct FailedCreateEncodedMetadata {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag(metadata_non_ascii_name)]
+#[must_use]
 pub struct NonAsciiName {
     #[primary_span]
     pub span: Span,
@@ -472,6 +533,7 @@ pub struct NonAsciiName {
 
 #[derive(Diagnostic)]
 #[diag(metadata_extern_location_not_exist)]
+#[must_use]
 pub struct ExternLocationNotExist<'a> {
     #[primary_span]
     pub span: Span,
@@ -481,6 +543,7 @@ pub struct ExternLocationNotExist<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_extern_location_not_file)]
+#[must_use]
 pub struct ExternLocationNotFile<'a> {
     #[primary_span]
     pub span: Span,
@@ -514,6 +577,7 @@ impl IntoDiagnostic<'_> for MultipleCandidates {
 
 #[derive(Diagnostic)]
 #[diag(metadata_symbol_conflicts_current, code = "E0519")]
+#[must_use]
 pub struct SymbolConflictsCurrent {
     #[primary_span]
     pub span: Span,
@@ -522,6 +586,7 @@ pub struct SymbolConflictsCurrent {
 
 #[derive(Diagnostic)]
 #[diag(metadata_stable_crate_id_collision)]
+#[must_use]
 pub struct StableCrateIdCollision {
     #[primary_span]
     pub span: Span,
@@ -531,6 +596,7 @@ pub struct StableCrateIdCollision {
 
 #[derive(Diagnostic)]
 #[diag(metadata_dl_error)]
+#[must_use]
 pub struct DlError {
     #[primary_span]
     pub span: Span,
@@ -541,6 +607,7 @@ pub struct DlError {
 #[diag(metadata_newer_crate_version, code = "E0460")]
 #[note]
 #[note(metadata_found_crate_versions)]
+#[must_use]
 pub struct NewerCrateVersion {
     #[primary_span]
     pub span: Span,
@@ -552,6 +619,7 @@ pub struct NewerCrateVersion {
 #[derive(Diagnostic)]
 #[diag(metadata_no_crate_with_triple, code = "E0461")]
 #[note(metadata_found_crate_versions)]
+#[must_use]
 pub struct NoCrateWithTriple<'a> {
     #[primary_span]
     pub span: Span,
@@ -565,6 +633,7 @@ pub struct NoCrateWithTriple<'a> {
 #[diag(metadata_found_staticlib, code = "E0462")]
 #[note(metadata_found_crate_versions)]
 #[help]
+#[must_use]
 pub struct FoundStaticlib {
     #[primary_span]
     pub span: Span,
@@ -577,6 +646,7 @@ pub struct FoundStaticlib {
 #[diag(metadata_incompatible_rustc, code = "E0514")]
 #[note(metadata_found_crate_versions)]
 #[help]
+#[must_use]
 pub struct IncompatibleRustc {
     #[primary_span]
     pub span: Span,
@@ -679,6 +749,7 @@ impl IntoDiagnostic<'_> for CannotFindCrate {
 
 #[derive(Diagnostic)]
 #[diag(metadata_crate_location_unknown_type)]
+#[must_use]
 pub struct CrateLocationUnknownType<'a> {
     #[primary_span]
     pub span: Span,
@@ -688,6 +759,7 @@ pub struct CrateLocationUnknownType<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_lib_filename_form)]
+#[must_use]
 pub struct LibFilenameForm<'a> {
     #[primary_span]
     pub span: Span,
@@ -697,6 +769,7 @@ pub struct LibFilenameForm<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_multiple_import_name_type)]
+#[must_use]
 pub struct MultipleImportNameType {
     #[primary_span]
     pub span: Span,
@@ -704,6 +777,7 @@ pub struct MultipleImportNameType {
 
 #[derive(Diagnostic)]
 #[diag(metadata_import_name_type_form)]
+#[must_use]
 pub struct ImportNameTypeForm {
     #[primary_span]
     pub span: Span,
@@ -711,6 +785,7 @@ pub struct ImportNameTypeForm {
 
 #[derive(Diagnostic)]
 #[diag(metadata_import_name_type_x86)]
+#[must_use]
 pub struct ImportNameTypeX86 {
     #[primary_span]
     pub span: Span,
@@ -718,6 +793,7 @@ pub struct ImportNameTypeX86 {
 
 #[derive(Diagnostic)]
 #[diag(metadata_unknown_import_name_type)]
+#[must_use]
 pub struct UnknownImportNameType<'a> {
     #[primary_span]
     pub span: Span,
@@ -726,6 +802,7 @@ pub struct UnknownImportNameType<'a> {
 
 #[derive(Diagnostic)]
 #[diag(metadata_import_name_type_raw)]
+#[must_use]
 pub struct ImportNameTypeRaw {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -10,6 +10,7 @@ use crate::ty::Ty;
 #[derive(Diagnostic)]
 #[diag(middle_drop_check_overflow, code = "E0320")]
 #[note]
+#[must_use]
 pub struct DropCheckOverflow<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -19,6 +20,7 @@ pub struct DropCheckOverflow<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(middle_opaque_hidden_type_mismatch)]
+#[must_use]
 pub struct OpaqueHiddenTypeMismatch<'tcx> {
     pub self_ty: Ty<'tcx>,
     pub other_ty: Ty<'tcx>,
@@ -45,6 +47,7 @@ pub enum TypeMismatchReason {
 
 #[derive(Diagnostic)]
 #[diag(middle_limit_invalid)]
+#[must_use]
 pub struct LimitInvalid<'a> {
     #[primary_span]
     pub span: Span,
@@ -56,6 +59,7 @@ pub struct LimitInvalid<'a> {
 #[derive(Diagnostic)]
 #[diag(middle_recursion_limit_reached)]
 #[help]
+#[must_use]
 pub struct RecursionLimitReached<'tcx> {
     pub ty: Ty<'tcx>,
     pub suggested_limit: rustc_session::Limit,
@@ -63,6 +67,7 @@ pub struct RecursionLimitReached<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(middle_const_eval_non_int)]
+#[must_use]
 pub struct ConstEvalNonIntError {
     #[primary_span]
     pub span: Span,
@@ -70,6 +75,7 @@ pub struct ConstEvalNonIntError {
 
 #[derive(Diagnostic)]
 #[diag(middle_strict_coherence_needs_negative_coherence)]
+#[must_use]
 pub(crate) struct StrictCoherenceNeedsNegativeCoherence {
     #[primary_span]
     pub span: Span,
@@ -79,6 +85,7 @@ pub(crate) struct StrictCoherenceNeedsNegativeCoherence {
 
 #[derive(Diagnostic)]
 #[diag(middle_requires_lang_item)]
+#[must_use]
 pub(crate) struct RequiresLangItem {
     #[primary_span]
     pub span: Option<Span>,
@@ -87,6 +94,7 @@ pub(crate) struct RequiresLangItem {
 
 #[derive(Diagnostic)]
 #[diag(middle_const_not_used_in_type_alias)]
+#[must_use]
 pub(super) struct ConstNotUsedTraitAlias {
     pub ct: String,
     #[primary_span]
@@ -139,6 +147,7 @@ pub enum LayoutError<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(middle_adjust_for_foreign_abi_error)]
+#[must_use]
 pub struct UnsupportedFnAbi {
     pub arch: Symbol,
     pub abi: &'static str,
@@ -146,6 +155,7 @@ pub struct UnsupportedFnAbi {
 
 #[derive(Diagnostic)]
 #[diag(middle_erroneous_constant)]
+#[must_use]
 pub struct ErroneousConstant {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -631,6 +631,7 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for MakeSuggestableFolder<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(middle_const_not_used_in_type_alias)]
+#[must_use]
 pub(super) struct ConstNotUsedTraitAlias {
     pub ct: String,
     #[primary_span]

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -140,6 +140,7 @@ pub struct UnsafeOpInUnsafeFnCallToFunctionWithRequiresUnsafe<'a> {
 #[derive(Diagnostic)]
 #[diag(mir_build_call_to_unsafe_fn_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct CallToUnsafeFunctionRequiresUnsafe<'a> {
     #[primary_span]
     #[label]
@@ -152,6 +153,7 @@ pub struct CallToUnsafeFunctionRequiresUnsafe<'a> {
 #[derive(Diagnostic)]
 #[diag(mir_build_call_to_unsafe_fn_requires_unsafe_nameless, code = "E0133")]
 #[note]
+#[must_use]
 pub struct CallToUnsafeFunctionRequiresUnsafeNameless {
     #[primary_span]
     #[label]
@@ -163,6 +165,7 @@ pub struct CallToUnsafeFunctionRequiresUnsafeNameless {
 #[derive(Diagnostic)]
 #[diag(mir_build_call_to_unsafe_fn_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[note]
+#[must_use]
 pub struct CallToUnsafeFunctionRequiresUnsafeUnsafeOpInUnsafeFnAllowed<'a> {
     #[primary_span]
     #[label]
@@ -178,6 +181,7 @@ pub struct CallToUnsafeFunctionRequiresUnsafeUnsafeOpInUnsafeFnAllowed<'a> {
     code = "E0133"
 )]
 #[note]
+#[must_use]
 pub struct CallToUnsafeFunctionRequiresUnsafeNamelessUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -189,6 +193,7 @@ pub struct CallToUnsafeFunctionRequiresUnsafeNamelessUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_inline_assembly_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct UseOfInlineAssemblyRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -200,6 +205,7 @@ pub struct UseOfInlineAssemblyRequiresUnsafe {
 #[derive(Diagnostic)]
 #[diag(mir_build_inline_assembly_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[note]
+#[must_use]
 pub struct UseOfInlineAssemblyRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -211,6 +217,7 @@ pub struct UseOfInlineAssemblyRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_initializing_type_with_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct InitializingTypeWithRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -225,6 +232,7 @@ pub struct InitializingTypeWithRequiresUnsafe {
     code = "E0133"
 )]
 #[note]
+#[must_use]
 pub struct InitializingTypeWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -236,6 +244,7 @@ pub struct InitializingTypeWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_mutable_static_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct UseOfMutableStaticRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -247,6 +256,7 @@ pub struct UseOfMutableStaticRequiresUnsafe {
 #[derive(Diagnostic)]
 #[diag(mir_build_mutable_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[note]
+#[must_use]
 pub struct UseOfMutableStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -258,6 +268,7 @@ pub struct UseOfMutableStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_extern_static_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct UseOfExternStaticRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -269,6 +280,7 @@ pub struct UseOfExternStaticRequiresUnsafe {
 #[derive(Diagnostic)]
 #[diag(mir_build_extern_static_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[note]
+#[must_use]
 pub struct UseOfExternStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -280,6 +292,7 @@ pub struct UseOfExternStaticRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_deref_raw_pointer_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct DerefOfRawPointerRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -291,6 +304,7 @@ pub struct DerefOfRawPointerRequiresUnsafe {
 #[derive(Diagnostic)]
 #[diag(mir_build_deref_raw_pointer_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[note]
+#[must_use]
 pub struct DerefOfRawPointerRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -302,6 +316,7 @@ pub struct DerefOfRawPointerRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_union_field_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct AccessToUnionFieldRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -313,6 +328,7 @@ pub struct AccessToUnionFieldRequiresUnsafe {
 #[derive(Diagnostic)]
 #[diag(mir_build_union_field_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[note]
+#[must_use]
 pub struct AccessToUnionFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -324,6 +340,7 @@ pub struct AccessToUnionFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
 #[derive(Diagnostic)]
 #[diag(mir_build_mutation_of_layout_constrained_field_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct MutationOfLayoutConstrainedFieldRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -338,6 +355,7 @@ pub struct MutationOfLayoutConstrainedFieldRequiresUnsafe {
     code = "E0133"
 )]
 #[note]
+#[must_use]
 pub struct MutationOfLayoutConstrainedFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -349,6 +367,7 @@ pub struct MutationOfLayoutConstrainedFieldRequiresUnsafeUnsafeOpInUnsafeFnAllow
 #[derive(Diagnostic)]
 #[diag(mir_build_borrow_of_layout_constrained_field_requires_unsafe, code = "E0133")]
 #[note]
+#[must_use]
 pub struct BorrowOfLayoutConstrainedFieldRequiresUnsafe {
     #[primary_span]
     #[label]
@@ -363,6 +382,7 @@ pub struct BorrowOfLayoutConstrainedFieldRequiresUnsafe {
     code = "E0133"
 )]
 #[note]
+#[must_use]
 pub struct BorrowOfLayoutConstrainedFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
@@ -374,6 +394,7 @@ pub struct BorrowOfLayoutConstrainedFieldRequiresUnsafeUnsafeOpInUnsafeFnAllowed
 #[derive(Diagnostic)]
 #[diag(mir_build_call_to_fn_with_requires_unsafe, code = "E0133")]
 #[help]
+#[must_use]
 pub struct CallToFunctionWithRequiresUnsafe<'a> {
     #[primary_span]
     #[label]
@@ -392,6 +413,7 @@ pub struct CallToFunctionWithRequiresUnsafe<'a> {
 #[derive(Diagnostic)]
 #[diag(mir_build_call_to_fn_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed, code = "E0133")]
 #[help]
+#[must_use]
 pub struct CallToFunctionWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed<'a> {
     #[primary_span]
     #[label]
@@ -539,6 +561,7 @@ pub struct NonExhaustiveMatchAllArmsGuarded;
 
 #[derive(Diagnostic)]
 #[diag(mir_build_static_in_pattern, code = "E0158")]
+#[must_use]
 pub struct StaticInPattern {
     #[primary_span]
     pub span: Span,
@@ -546,6 +569,7 @@ pub struct StaticInPattern {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_assoc_const_in_pattern, code = "E0158")]
+#[must_use]
 pub struct AssocConstInPattern {
     #[primary_span]
     pub span: Span,
@@ -553,6 +577,7 @@ pub struct AssocConstInPattern {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_const_param_in_pattern, code = "E0158")]
+#[must_use]
 pub struct ConstParamInPattern {
     #[primary_span]
     pub span: Span,
@@ -560,6 +585,7 @@ pub struct ConstParamInPattern {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_non_const_path, code = "E0080")]
+#[must_use]
 pub struct NonConstPath {
     #[primary_span]
     pub span: Span,
@@ -576,6 +602,7 @@ pub struct UnreachablePattern {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_const_pattern_depends_on_generic_parameter)]
+#[must_use]
 pub struct ConstPatternDependsOnGenericParameter {
     #[primary_span]
     pub span: Span,
@@ -583,6 +610,7 @@ pub struct ConstPatternDependsOnGenericParameter {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_could_not_eval_const_pattern)]
+#[must_use]
 pub struct CouldNotEvalConstPattern {
     #[primary_span]
     pub span: Span,
@@ -590,6 +618,7 @@ pub struct CouldNotEvalConstPattern {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_lower_range_bound_must_be_less_than_or_equal_to_upper, code = "E0030")]
+#[must_use]
 pub struct LowerRangeBoundMustBeLessThanOrEqualToUpper {
     #[primary_span]
     #[label]
@@ -600,6 +629,7 @@ pub struct LowerRangeBoundMustBeLessThanOrEqualToUpper {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_literal_in_range_out_of_bounds)]
+#[must_use]
 pub struct LiteralOutOfRange<'tcx> {
     #[primary_span]
     #[label]
@@ -611,6 +641,7 @@ pub struct LiteralOutOfRange<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_lower_range_bound_must_be_less_than_upper, code = "E0579")]
+#[must_use]
 pub struct LowerRangeBoundMustBeLessThanUpper {
     #[primary_span]
     pub span: Span,
@@ -675,6 +706,7 @@ pub struct IrrefutableLetPatternsWhileLet {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_borrow_of_moved_value)]
+#[must_use]
 pub struct BorrowOfMovedValue<'tcx> {
     #[primary_span]
     #[label]
@@ -690,6 +722,7 @@ pub struct BorrowOfMovedValue<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_multiple_mut_borrows)]
+#[must_use]
 pub struct MultipleMutBorrows {
     #[primary_span]
     pub span: Span,
@@ -699,6 +732,7 @@ pub struct MultipleMutBorrows {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_already_borrowed)]
+#[must_use]
 pub struct AlreadyBorrowed {
     #[primary_span]
     pub span: Span,
@@ -708,6 +742,7 @@ pub struct AlreadyBorrowed {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_already_mut_borrowed)]
+#[must_use]
 pub struct AlreadyMutBorrowed {
     #[primary_span]
     pub span: Span,
@@ -717,6 +752,7 @@ pub struct AlreadyMutBorrowed {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_moved_while_borrowed)]
+#[must_use]
 pub struct MovedWhileBorrowed {
     #[primary_span]
     pub span: Span,
@@ -748,6 +784,7 @@ pub enum Conflict {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_union_pattern)]
+#[must_use]
 pub struct UnionPattern {
     #[primary_span]
     pub span: Span,
@@ -756,6 +793,7 @@ pub struct UnionPattern {
 #[derive(Diagnostic)]
 #[diag(mir_build_type_not_structural)]
 #[note(mir_build_type_not_structural_tip)]
+#[must_use]
 #[note(mir_build_type_not_structural_more_info)]
 pub struct TypeNotStructural<'tcx> {
     #[primary_span]
@@ -765,6 +803,7 @@ pub struct TypeNotStructural<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_invalid_pattern)]
+#[must_use]
 pub struct InvalidPattern<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -773,6 +812,7 @@ pub struct InvalidPattern<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_unsized_pattern)]
+#[must_use]
 pub struct UnsizedPattern<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -811,6 +851,7 @@ pub struct NonPartialEqMatch<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_pattern_not_covered, code = "E0005")]
+#[must_use]
 pub(crate) struct PatternNotCovered<'s, 'tcx> {
     #[primary_span]
     pub span: Span,
@@ -915,6 +956,7 @@ pub enum MiscPatternSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(mir_build_rustc_box_attribute_error)]
+#[must_use]
 pub struct RustcBoxAttributeError {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_mir_dataflow/src/errors.rs
+++ b/compiler/rustc_mir_dataflow/src/errors.rs
@@ -3,6 +3,7 @@ use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_path_must_end_in_filename)]
+#[must_use]
 pub(crate) struct PathMustEndInFilename {
     #[primary_span]
     pub span: Span,
@@ -10,6 +11,7 @@ pub(crate) struct PathMustEndInFilename {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_unknown_formatter)]
+#[must_use]
 pub(crate) struct UnknownFormatter {
     #[primary_span]
     pub span: Span,
@@ -17,6 +19,7 @@ pub(crate) struct UnknownFormatter {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_duplicate_values_for)]
+#[must_use]
 pub(crate) struct DuplicateValuesFor {
     #[primary_span]
     pub span: Span,
@@ -25,6 +28,7 @@ pub(crate) struct DuplicateValuesFor {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_requires_an_argument)]
+#[must_use]
 pub(crate) struct RequiresAnArgument {
     #[primary_span]
     pub span: Span,
@@ -33,10 +37,12 @@ pub(crate) struct RequiresAnArgument {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_stop_after_dataflow_ended_compilation)]
+#[must_use]
 pub(crate) struct StopAfterDataFlowEndedCompilation;
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_peek_must_be_place_or_ref_place)]
+#[must_use]
 pub(crate) struct PeekMustBePlaceOrRefPlace {
     #[primary_span]
     pub span: Span,
@@ -44,6 +50,7 @@ pub(crate) struct PeekMustBePlaceOrRefPlace {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_peek_must_be_not_temporary)]
+#[must_use]
 pub(crate) struct PeekMustBeNotTemporary {
     #[primary_span]
     pub span: Span,
@@ -51,6 +58,7 @@ pub(crate) struct PeekMustBeNotTemporary {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_peek_bit_not_set)]
+#[must_use]
 pub(crate) struct PeekBitNotSet {
     #[primary_span]
     pub span: Span,
@@ -58,6 +66,7 @@ pub(crate) struct PeekBitNotSet {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_peek_argument_not_a_local)]
+#[must_use]
 pub(crate) struct PeekArgumentNotALocal {
     #[primary_span]
     pub span: Span,
@@ -65,6 +74,7 @@ pub(crate) struct PeekArgumentNotALocal {
 
 #[derive(Diagnostic)]
 #[diag(mir_dataflow_peek_argument_untracked)]
+#[must_use]
 pub(crate) struct PeekArgumentUntracked {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -37,6 +37,7 @@ pub(crate) enum ConstMutate {
 #[note]
 #[note(mir_transform_note_ub)]
 #[help]
+#[must_use]
 pub(crate) struct UnalignedPackedRef {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -8,6 +8,7 @@ use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(monomorphize_recursion_limit)]
+#[must_use]
 pub struct RecursionLimit {
     #[primary_span]
     pub span: Span,
@@ -23,6 +24,7 @@ pub struct RecursionLimit {
 #[derive(Diagnostic)]
 #[diag(monomorphize_type_length_limit)]
 #[help(monomorphize_consider_type_length_limit)]
+#[must_use]
 pub struct TypeLengthLimit {
     #[primary_span]
     pub span: Span,
@@ -35,6 +37,7 @@ pub struct TypeLengthLimit {
 
 #[derive(Diagnostic)]
 #[diag(monomorphize_no_optimized_mir)]
+#[must_use]
 pub struct NoOptimizedMir {
     #[note]
     pub span: Span,
@@ -77,6 +80,7 @@ pub struct LargeAssignmentsLint {
 
 #[derive(Diagnostic)]
 #[diag(monomorphize_symbol_already_defined)]
+#[must_use]
 pub struct SymbolAlreadyDefined {
     #[primary_span]
     pub span: Option<Span>,
@@ -85,12 +89,14 @@ pub struct SymbolAlreadyDefined {
 
 #[derive(Diagnostic)]
 #[diag(monomorphize_couldnt_dump_mono_stats)]
+#[must_use]
 pub struct CouldntDumpMonoStats {
     pub error: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(monomorphize_encountered_error_while_instantiating)]
+#[must_use]
 pub struct EncounteredErrorWhileInstantiating {
     #[primary_span]
     pub span: Span,
@@ -99,6 +105,7 @@ pub struct EncounteredErrorWhileInstantiating {
 
 #[derive(Diagnostic)]
 #[diag(monomorphize_unknown_cgu_collection_mode)]
+#[must_use]
 pub struct UnknownCguCollectionMode<'a> {
     pub mode: &'a str,
 }

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -14,6 +14,7 @@ use crate::parser::{ForbiddenLetReason, TokenDescription};
 
 #[derive(Diagnostic)]
 #[diag(parse_maybe_report_ambiguous_plus)]
+#[must_use]
 pub(crate) struct AmbiguousPlus {
     pub sum_ty: String,
     #[primary_span]
@@ -23,6 +24,7 @@ pub(crate) struct AmbiguousPlus {
 
 #[derive(Diagnostic)]
 #[diag(parse_maybe_recover_from_bad_type_plus, code = "E0178")]
+#[must_use]
 pub(crate) struct BadTypePlus {
     pub ty: String,
     #[primary_span]
@@ -57,6 +59,7 @@ pub(crate) enum BadTypePlusSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_maybe_recover_from_bad_qpath_stage_2)]
+#[must_use]
 pub(crate) struct BadQPathStage2 {
     #[primary_span]
     pub span: Span,
@@ -75,6 +78,7 @@ pub(crate) struct WrapType {
 
 #[derive(Diagnostic)]
 #[diag(parse_incorrect_semicolon)]
+#[must_use]
 pub(crate) struct IncorrectSemicolon<'a> {
     #[primary_span]
     #[suggestion(style = "short", code = "", applicability = "machine-applicable")]
@@ -86,6 +90,7 @@ pub(crate) struct IncorrectSemicolon<'a> {
 
 #[derive(Diagnostic)]
 #[diag(parse_incorrect_use_of_await)]
+#[must_use]
 pub(crate) struct IncorrectUseOfAwait {
     #[primary_span]
     #[suggestion(parse_parentheses_suggestion, code = "", applicability = "machine-applicable")]
@@ -94,6 +99,7 @@ pub(crate) struct IncorrectUseOfAwait {
 
 #[derive(Diagnostic)]
 #[diag(parse_incorrect_use_of_await)]
+#[must_use]
 pub(crate) struct IncorrectAwait {
     #[primary_span]
     pub span: Span,
@@ -105,6 +111,7 @@ pub(crate) struct IncorrectAwait {
 
 #[derive(Diagnostic)]
 #[diag(parse_in_in_typo)]
+#[must_use]
 pub(crate) struct InInTypo {
     #[primary_span]
     pub span: Span,
@@ -114,6 +121,7 @@ pub(crate) struct InInTypo {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_variable_declaration)]
+#[must_use]
 pub(crate) struct InvalidVariableDeclaration {
     #[primary_span]
     pub span: Span,
@@ -139,6 +147,7 @@ pub(crate) enum InvalidVariableDeclarationSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_switch_ref_box_order)]
+#[must_use]
 pub(crate) struct SwitchRefBoxOrder {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "box ref")]
@@ -147,6 +156,7 @@ pub(crate) struct SwitchRefBoxOrder {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_comparison_operator)]
+#[must_use]
 pub(crate) struct InvalidComparisonOperator {
     #[primary_span]
     pub span: Span,
@@ -176,6 +186,7 @@ pub(crate) enum InvalidComparisonOperatorSub {
 #[derive(Diagnostic)]
 #[diag(parse_invalid_logical_operator)]
 #[note]
+#[must_use]
 pub(crate) struct InvalidLogicalOperator {
     #[primary_span]
     pub span: Span,
@@ -204,6 +215,7 @@ pub(crate) enum InvalidLogicalOperatorSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_tilde_is_not_unary_operator)]
+#[must_use]
 pub(crate) struct TildeAsUnaryOperator(
     #[primary_span]
     #[suggestion(style = "short", applicability = "machine-applicable", code = "!")]
@@ -212,6 +224,7 @@ pub(crate) struct TildeAsUnaryOperator(
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_token_after_not)]
+#[must_use]
 pub(crate) struct NotAsNegationOperator {
     #[primary_span]
     pub negated: Span,
@@ -249,6 +262,7 @@ pub enum NotAsNegationOperatorSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_malformed_loop_label)]
+#[must_use]
 pub(crate) struct MalformedLoopLabel {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "{correct_label}")]
@@ -258,6 +272,7 @@ pub(crate) struct MalformedLoopLabel {
 
 #[derive(Diagnostic)]
 #[diag(parse_lifetime_in_borrow_expression)]
+#[must_use]
 pub(crate) struct LifetimeInBorrowExpression {
     #[primary_span]
     pub span: Span,
@@ -268,14 +283,17 @@ pub(crate) struct LifetimeInBorrowExpression {
 
 #[derive(Diagnostic)]
 #[diag(parse_field_expression_with_generic)]
+#[must_use]
 pub(crate) struct FieldExpressionWithGeneric(#[primary_span] pub Span);
 
 #[derive(Diagnostic)]
 #[diag(parse_macro_invocation_with_qualified_path)]
+#[must_use]
 pub(crate) struct MacroInvocationWithQualifiedPath(#[primary_span] pub Span);
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_token_after_label)]
+#[must_use]
 pub(crate) struct UnexpectedTokenAfterLabel {
     #[primary_span]
     #[label(parse_unexpected_token_after_label)]
@@ -298,6 +316,7 @@ pub(crate) struct UnexpectedTokenAfterLabelSugg {
 #[derive(Diagnostic)]
 #[diag(parse_require_colon_after_labeled_expression)]
 #[note]
+#[must_use]
 pub(crate) struct RequireColonAfterLabeledExpression {
     #[primary_span]
     pub span: Span,
@@ -310,6 +329,7 @@ pub(crate) struct RequireColonAfterLabeledExpression {
 #[derive(Diagnostic)]
 #[diag(parse_do_catch_syntax_removed)]
 #[note]
+#[must_use]
 pub(crate) struct DoCatchSyntaxRemoved {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "try")]
@@ -318,6 +338,7 @@ pub(crate) struct DoCatchSyntaxRemoved {
 
 #[derive(Diagnostic)]
 #[diag(parse_float_literal_requires_integer_part)]
+#[must_use]
 pub(crate) struct FloatLiteralRequiresIntegerPart {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "{correct}")]
@@ -327,6 +348,7 @@ pub(crate) struct FloatLiteralRequiresIntegerPart {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_semicolon_before_array)]
+#[must_use]
 pub(crate) struct MissingSemicolonBeforeArray {
     #[primary_span]
     pub open_delim: Span,
@@ -336,6 +358,7 @@ pub(crate) struct MissingSemicolonBeforeArray {
 
 #[derive(Diagnostic)]
 #[diag(parse_expect_dotdot_not_dotdotdot)]
+#[must_use]
 pub(crate) struct MissingDotDot {
     #[primary_span]
     pub token_span: Span,
@@ -345,6 +368,7 @@ pub(crate) struct MissingDotDot {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_block_macro_segment)]
+#[must_use]
 pub(crate) struct InvalidBlockMacroSegment {
     #[primary_span]
     pub span: Span,
@@ -365,6 +389,7 @@ pub(crate) struct WrapInExplicitBlock {
 
 #[derive(Diagnostic)]
 #[diag(parse_if_expression_missing_then_block)]
+#[must_use]
 pub(crate) struct IfExpressionMissingThenBlock {
     #[primary_span]
     pub if_span: Span,
@@ -385,6 +410,7 @@ pub(crate) enum IfExpressionMissingThenBlockSub {
 #[derive(Diagnostic)]
 #[diag(parse_ternary_operator)]
 #[help]
+#[must_use]
 pub struct TernaryOperator {
     #[primary_span]
     pub span: Span,
@@ -399,6 +425,7 @@ pub(crate) struct IfExpressionLetSomeSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_if_expression_missing_condition)]
+#[must_use]
 pub(crate) struct IfExpressionMissingCondition {
     #[primary_span]
     #[label(parse_condition_label)]
@@ -410,6 +437,7 @@ pub(crate) struct IfExpressionMissingCondition {
 #[derive(Diagnostic)]
 #[diag(parse_expected_expression_found_let)]
 #[note]
+#[must_use]
 pub(crate) struct ExpectedExpressionFoundLet {
     #[primary_span]
     pub span: Span,
@@ -445,6 +473,7 @@ pub(crate) struct MaybeComparison {
 
 #[derive(Diagnostic)]
 #[diag(parse_expect_eq_instead_of_eqeq)]
+#[must_use]
 pub(crate) struct ExpectedEqForLetExpr {
     #[primary_span]
     pub span: Span,
@@ -454,6 +483,7 @@ pub(crate) struct ExpectedEqForLetExpr {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_else_block)]
+#[must_use]
 pub(crate) struct ExpectedElseBlock {
     #[primary_span]
     pub first_tok_span: Span,
@@ -466,6 +496,7 @@ pub(crate) struct ExpectedElseBlock {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_struct_field)]
+#[must_use]
 pub(crate) struct ExpectedStructField {
     #[primary_span]
     #[label]
@@ -477,6 +508,7 @@ pub(crate) struct ExpectedStructField {
 
 #[derive(Diagnostic)]
 #[diag(parse_outer_attribute_not_allowed_on_if_else)]
+#[must_use]
 pub(crate) struct OuterAttributeNotAllowedOnIfElse {
     #[primary_span]
     pub last: Span,
@@ -494,6 +526,7 @@ pub(crate) struct OuterAttributeNotAllowedOnIfElse {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_in_in_for_loop)]
+#[must_use]
 pub(crate) struct MissingInInForLoop {
     #[primary_span]
     pub span: Span,
@@ -517,6 +550,7 @@ pub(crate) enum MissingInInForLoopSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_expression_in_for_loop)]
+#[must_use]
 pub(crate) struct MissingExpressionInForLoop {
     #[primary_span]
     #[suggestion(
@@ -530,6 +564,7 @@ pub(crate) struct MissingExpressionInForLoop {
 #[derive(Diagnostic)]
 #[diag(parse_loop_else)]
 #[note]
+#[must_use]
 pub(crate) struct LoopElseNotSupported {
     #[primary_span]
     pub span: Span,
@@ -540,6 +575,7 @@ pub(crate) struct LoopElseNotSupported {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_comma_after_match_arm)]
+#[must_use]
 pub(crate) struct MissingCommaAfterMatchArm {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = ",")]
@@ -549,6 +585,7 @@ pub(crate) struct MissingCommaAfterMatchArm {
 #[derive(Diagnostic)]
 #[diag(parse_catch_after_try)]
 #[help]
+#[must_use]
 pub(crate) struct CatchAfterTry {
     #[primary_span]
     pub span: Span,
@@ -557,6 +594,7 @@ pub(crate) struct CatchAfterTry {
 #[derive(Diagnostic)]
 #[diag(parse_gen_fn)]
 #[help]
+#[must_use]
 pub(crate) struct GenFn {
     #[primary_span]
     pub span: Span,
@@ -565,6 +603,7 @@ pub(crate) struct GenFn {
 #[derive(Diagnostic)]
 #[diag(parse_comma_after_base_struct)]
 #[note]
+#[must_use]
 pub(crate) struct CommaAfterBaseStruct {
     #[primary_span]
     pub span: Span,
@@ -574,6 +613,7 @@ pub(crate) struct CommaAfterBaseStruct {
 
 #[derive(Diagnostic)]
 #[diag(parse_eq_field_init)]
+#[must_use]
 pub(crate) struct EqFieldInit {
     #[primary_span]
     pub span: Span,
@@ -583,6 +623,7 @@ pub(crate) struct EqFieldInit {
 
 #[derive(Diagnostic)]
 #[diag(parse_dotdotdot)]
+#[must_use]
 pub(crate) struct DotDotDot {
     #[primary_span]
     #[suggestion(parse_suggest_exclusive_range, applicability = "maybe-incorrect", code = "..")]
@@ -592,6 +633,7 @@ pub(crate) struct DotDotDot {
 
 #[derive(Diagnostic)]
 #[diag(parse_left_arrow_operator)]
+#[must_use]
 pub(crate) struct LeftArrowOperator {
     #[primary_span]
     #[suggestion(applicability = "maybe-incorrect", code = "< -")]
@@ -600,6 +642,7 @@ pub(crate) struct LeftArrowOperator {
 
 #[derive(Diagnostic)]
 #[diag(parse_remove_let)]
+#[must_use]
 pub(crate) struct RemoveLet {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "")]
@@ -608,6 +651,7 @@ pub(crate) struct RemoveLet {
 
 #[derive(Diagnostic)]
 #[diag(parse_use_eq_instead)]
+#[must_use]
 pub(crate) struct UseEqInstead {
     #[primary_span]
     #[suggestion(style = "short", applicability = "machine-applicable", code = "=")]
@@ -616,6 +660,7 @@ pub(crate) struct UseEqInstead {
 
 #[derive(Diagnostic)]
 #[diag(parse_use_empty_block_not_semi)]
+#[must_use]
 pub(crate) struct UseEmptyBlockNotSemi {
     #[primary_span]
     #[suggestion(style = "hidden", applicability = "machine-applicable", code = "{{}}")]
@@ -624,6 +669,7 @@ pub(crate) struct UseEmptyBlockNotSemi {
 
 #[derive(Diagnostic)]
 #[diag(parse_comparison_interpreted_as_generic)]
+#[must_use]
 pub(crate) struct ComparisonInterpretedAsGeneric {
     #[primary_span]
     #[label(parse_label_comparison)]
@@ -637,6 +683,7 @@ pub(crate) struct ComparisonInterpretedAsGeneric {
 
 #[derive(Diagnostic)]
 #[diag(parse_shift_interpreted_as_generic)]
+#[must_use]
 pub(crate) struct ShiftInterpretedAsGeneric {
     #[primary_span]
     #[label(parse_label_comparison)]
@@ -659,6 +706,7 @@ pub(crate) struct ComparisonOrShiftInterpretedAsGenericSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_found_expr_would_be_stmt)]
+#[must_use]
 pub(crate) struct FoundExprWouldBeStmt {
     #[primary_span]
     #[label]
@@ -670,6 +718,7 @@ pub(crate) struct FoundExprWouldBeStmt {
 
 #[derive(Diagnostic)]
 #[diag(parse_leading_plus_not_supported)]
+#[must_use]
 pub(crate) struct LeadingPlusNotSupported {
     #[primary_span]
     #[label]
@@ -687,6 +736,7 @@ pub(crate) struct LeadingPlusNotSupported {
 
 #[derive(Diagnostic)]
 #[diag(parse_parentheses_with_struct_fields)]
+#[must_use]
 pub(crate) struct ParenthesesWithStructFields {
     #[primary_span]
     pub span: Span,
@@ -715,6 +765,7 @@ pub(crate) struct NoFieldsForFnCall {
 
 #[derive(Diagnostic)]
 #[diag(parse_labeled_loop_in_break)]
+#[must_use]
 pub(crate) struct LabeledLoopInBreak {
     #[primary_span]
     pub span: Span,
@@ -736,6 +787,7 @@ pub(crate) struct WrapExpressionInParentheses {
 
 #[derive(Diagnostic)]
 #[diag(parse_array_brackets_instead_of_braces)]
+#[must_use]
 pub(crate) struct ArrayBracketsInsteadOfSpaces {
     #[primary_span]
     pub span: Span,
@@ -754,6 +806,7 @@ pub(crate) struct ArrayBracketsInsteadOfSpacesSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_match_arm_body_without_braces)]
+#[must_use]
 pub(crate) struct MatchArmBodyWithoutBraces {
     #[primary_span]
     #[label(parse_label_statements)]
@@ -768,6 +821,7 @@ pub(crate) struct MatchArmBodyWithoutBraces {
 #[derive(Diagnostic)]
 #[diag(parse_inclusive_range_extra_equals)]
 #[note]
+#[must_use]
 pub(crate) struct InclusiveRangeExtraEquals {
     #[primary_span]
     #[suggestion(
@@ -781,6 +835,7 @@ pub(crate) struct InclusiveRangeExtraEquals {
 
 #[derive(Diagnostic)]
 #[diag(parse_inclusive_range_match_arrow)]
+#[must_use]
 pub(crate) struct InclusiveRangeMatchArrow {
     #[primary_span]
     pub arrow: Span,
@@ -793,6 +848,7 @@ pub(crate) struct InclusiveRangeMatchArrow {
 #[derive(Diagnostic)]
 #[diag(parse_inclusive_range_no_end, code = "E0586")]
 #[note]
+#[must_use]
 pub(crate) struct InclusiveRangeNoEnd {
     #[primary_span]
     #[suggestion(
@@ -826,6 +882,7 @@ pub(crate) enum MatchArmBodyWithoutBracesSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_struct_literal_not_allowed_here)]
+#[must_use]
 pub(crate) struct StructLiteralNotAllowedHere {
     #[primary_span]
     pub span: Span,
@@ -844,6 +901,7 @@ pub(crate) struct StructLiteralNotAllowedHereSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_interpolated_expression)]
+#[must_use]
 pub(crate) struct InvalidInterpolatedExpression {
     #[primary_span]
     pub span: Span,
@@ -851,6 +909,7 @@ pub(crate) struct InvalidInterpolatedExpression {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_literal_suffix_on_tuple_index)]
+#[must_use]
 pub(crate) struct InvalidLiteralSuffixOnTupleIndex {
     #[primary_span]
     #[label]
@@ -864,6 +923,7 @@ pub(crate) struct InvalidLiteralSuffixOnTupleIndex {
 
 #[derive(Diagnostic)]
 #[diag(parse_non_string_abi_literal)]
+#[must_use]
 pub(crate) struct NonStringAbiLiteral {
     #[primary_span]
     #[suggestion(code = "\"C\"", applicability = "maybe-incorrect")]
@@ -872,6 +932,7 @@ pub(crate) struct NonStringAbiLiteral {
 
 #[derive(Diagnostic)]
 #[diag(parse_mismatched_closing_delimiter)]
+#[must_use]
 pub(crate) struct MismatchedClosingDelimiter {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -887,6 +948,7 @@ pub(crate) struct MismatchedClosingDelimiter {
 #[derive(Diagnostic)]
 #[diag(parse_incorrect_visibility_restriction, code = "E0704")]
 #[help]
+#[must_use]
 pub(crate) struct IncorrectVisibilityRestriction {
     #[primary_span]
     #[suggestion(code = "in {inner_str}", applicability = "machine-applicable")]
@@ -896,6 +958,7 @@ pub(crate) struct IncorrectVisibilityRestriction {
 
 #[derive(Diagnostic)]
 #[diag(parse_assignment_else_not_allowed)]
+#[must_use]
 pub(crate) struct AssignmentElseNotAllowed {
     #[primary_span]
     pub span: Span,
@@ -903,6 +966,7 @@ pub(crate) struct AssignmentElseNotAllowed {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_statement_after_outer_attr)]
+#[must_use]
 pub(crate) struct ExpectedStatementAfterOuterAttr {
     #[primary_span]
     pub span: Span,
@@ -911,6 +975,7 @@ pub(crate) struct ExpectedStatementAfterOuterAttr {
 #[derive(Diagnostic)]
 #[diag(parse_doc_comment_does_not_document_anything, code = "E0585")]
 #[help]
+#[must_use]
 pub(crate) struct DocCommentDoesNotDocumentAnything {
     #[primary_span]
     pub span: Span,
@@ -920,6 +985,7 @@ pub(crate) struct DocCommentDoesNotDocumentAnything {
 
 #[derive(Diagnostic)]
 #[diag(parse_const_let_mutually_exclusive)]
+#[must_use]
 pub(crate) struct ConstLetMutuallyExclusive {
     #[primary_span]
     #[suggestion(code = "const", applicability = "maybe-incorrect")]
@@ -928,6 +994,7 @@ pub(crate) struct ConstLetMutuallyExclusive {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_expression_in_let_else)]
+#[must_use]
 pub(crate) struct InvalidExpressionInLetElse {
     #[primary_span]
     pub span: Span,
@@ -938,6 +1005,7 @@ pub(crate) struct InvalidExpressionInLetElse {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_curly_in_let_else)]
+#[must_use]
 pub(crate) struct InvalidCurlyInLetElse {
     #[primary_span]
     pub span: Span,
@@ -948,6 +1016,7 @@ pub(crate) struct InvalidCurlyInLetElse {
 #[derive(Diagnostic)]
 #[diag(parse_compound_assignment_expression_in_let)]
 #[help]
+#[must_use]
 pub(crate) struct CompoundAssignmentExpressionInLet {
     #[primary_span]
     #[suggestion(style = "short", code = "=", applicability = "maybe-incorrect")]
@@ -957,6 +1026,7 @@ pub(crate) struct CompoundAssignmentExpressionInLet {
 #[derive(Diagnostic)]
 #[diag(parse_suffixed_literal_in_attribute)]
 #[help]
+#[must_use]
 pub(crate) struct SuffixedLiteralInAttribute {
     #[primary_span]
     pub span: Span,
@@ -964,6 +1034,7 @@ pub(crate) struct SuffixedLiteralInAttribute {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_meta_item)]
+#[must_use]
 pub(crate) struct InvalidMetaItem {
     #[primary_span]
     pub span: Span,
@@ -1142,6 +1213,7 @@ pub(crate) enum ExpectedSemiSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_struct_literal_body_without_path)]
+#[must_use]
 pub(crate) struct StructLiteralBodyWithoutPath {
     #[primary_span]
     pub span: Span,
@@ -1160,6 +1232,7 @@ pub(crate) struct StructLiteralBodyWithoutPathSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_struct_literal_needing_parens)]
+#[must_use]
 pub(crate) struct StructLiteralNeedingParens {
     #[primary_span]
     pub span: Span,
@@ -1178,6 +1251,7 @@ pub(crate) struct StructLiteralNeedingParensSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_unmatched_angle_brackets)]
+#[must_use]
 pub(crate) struct UnmatchedAngleBrackets {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -1187,6 +1261,7 @@ pub(crate) struct UnmatchedAngleBrackets {
 
 #[derive(Diagnostic)]
 #[diag(parse_generic_parameters_without_angle_brackets)]
+#[must_use]
 pub(crate) struct GenericParamsWithoutAngleBrackets {
     #[primary_span]
     pub span: Span,
@@ -1205,6 +1280,7 @@ pub(crate) struct GenericParamsWithoutAngleBracketsSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_comparison_operators_cannot_be_chained)]
+#[must_use]
 pub(crate) struct ComparisonOperatorsCannotBeChained {
     #[primary_span]
     pub span: Vec<Span>,
@@ -1246,6 +1322,7 @@ pub(crate) enum ComparisonOperatorsCannotBeChainedSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_question_mark_in_type)]
+#[must_use]
 pub(crate) struct QuestionMarkInType {
     #[primary_span]
     #[label]
@@ -1265,6 +1342,7 @@ pub(crate) struct QuestionMarkInTypeSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_parentheses_in_for_head)]
+#[must_use]
 pub(crate) struct ParenthesesInForHead {
     #[primary_span]
     pub span: Vec<Span>,
@@ -1283,6 +1361,7 @@ pub(crate) struct ParenthesesInForHeadSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_parentheses_in_match_arm_pattern)]
+#[must_use]
 pub(crate) struct ParenthesesInMatchPat {
     #[primary_span]
     pub span: Vec<Span>,
@@ -1301,6 +1380,7 @@ pub(crate) struct ParenthesesInMatchPatSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_doc_comment_on_param_type)]
+#[must_use]
 pub(crate) struct DocCommentOnParamType {
     #[primary_span]
     #[label]
@@ -1309,6 +1389,7 @@ pub(crate) struct DocCommentOnParamType {
 
 #[derive(Diagnostic)]
 #[diag(parse_attribute_on_param_type)]
+#[must_use]
 pub(crate) struct AttributeOnParamType {
     #[primary_span]
     #[label]
@@ -1317,6 +1398,7 @@ pub(crate) struct AttributeOnParamType {
 
 #[derive(Diagnostic)]
 #[diag(parse_pattern_method_param_without_body, code = "E0642")]
+#[must_use]
 pub(crate) struct PatternMethodParamWithoutBody {
     #[primary_span]
     #[suggestion(code = "_", applicability = "machine-applicable")]
@@ -1325,6 +1407,7 @@ pub(crate) struct PatternMethodParamWithoutBody {
 
 #[derive(Diagnostic)]
 #[diag(parse_self_param_not_first)]
+#[must_use]
 pub(crate) struct SelfParamNotFirst {
     #[primary_span]
     #[label]
@@ -1333,6 +1416,7 @@ pub(crate) struct SelfParamNotFirst {
 
 #[derive(Diagnostic)]
 #[diag(parse_const_generic_without_braces)]
+#[must_use]
 pub(crate) struct ConstGenericWithoutBraces {
     #[primary_span]
     pub span: Span,
@@ -1351,6 +1435,7 @@ pub(crate) struct ConstGenericWithoutBracesSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_const_param_declaration)]
+#[must_use]
 pub(crate) struct UnexpectedConstParamDeclaration {
     #[primary_span]
     #[label]
@@ -1383,6 +1468,7 @@ pub(crate) enum UnexpectedConstParamDeclarationSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_const_in_generic_param)]
+#[must_use]
 pub(crate) struct UnexpectedConstInGenericParam {
     #[primary_span]
     pub span: Span,
@@ -1392,6 +1478,7 @@ pub(crate) struct UnexpectedConstInGenericParam {
 
 #[derive(Diagnostic)]
 #[diag(parse_async_move_order_incorrect)]
+#[must_use]
 pub(crate) struct AsyncMoveOrderIncorrect {
     #[primary_span]
     #[suggestion(style = "verbose", code = "async move", applicability = "maybe-incorrect")]
@@ -1400,6 +1487,7 @@ pub(crate) struct AsyncMoveOrderIncorrect {
 
 #[derive(Diagnostic)]
 #[diag(parse_double_colon_in_bound)]
+#[must_use]
 pub(crate) struct DoubleColonInBound {
     #[primary_span]
     pub span: Span,
@@ -1409,6 +1497,7 @@ pub(crate) struct DoubleColonInBound {
 
 #[derive(Diagnostic)]
 #[diag(parse_fn_ptr_with_generics)]
+#[must_use]
 pub(crate) struct FnPtrWithGenerics {
     #[primary_span]
     pub span: Span,
@@ -1458,6 +1547,7 @@ impl AddToDiagnostic for FnTraitMissingParen {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_if_with_if)]
+#[must_use]
 pub(crate) struct UnexpectedIfWithIf(
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = " ", style = "verbose")]
@@ -1466,6 +1556,7 @@ pub(crate) struct UnexpectedIfWithIf(
 
 #[derive(Diagnostic)]
 #[diag(parse_maybe_fn_typo_with_impl)]
+#[must_use]
 pub(crate) struct FnTypoWithImpl {
     #[primary_span]
     #[suggestion(applicability = "maybe-incorrect", code = "impl", style = "verbose")]
@@ -1474,6 +1565,7 @@ pub(crate) struct FnTypoWithImpl {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_fn_path_found_fn_keyword)]
+#[must_use]
 pub(crate) struct ExpectedFnPathFoundFnKeyword {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "Fn", style = "verbose")]
@@ -1482,6 +1574,7 @@ pub(crate) struct ExpectedFnPathFoundFnKeyword {
 
 #[derive(Diagnostic)]
 #[diag(parse_path_single_colon)]
+#[must_use]
 pub(crate) struct PathSingleColon {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = "::")]
@@ -1493,6 +1586,7 @@ pub(crate) struct PathSingleColon {
 
 #[derive(Diagnostic)]
 #[diag(parse_colon_as_semi)]
+#[must_use]
 pub(crate) struct ColonAsSemi {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = ";")]
@@ -1504,6 +1598,7 @@ pub(crate) struct ColonAsSemi {
 
 #[derive(Diagnostic)]
 #[diag(parse_where_clause_before_tuple_struct_body)]
+#[must_use]
 pub(crate) struct WhereClauseBeforeTupleStructBody {
     #[primary_span]
     #[label]
@@ -1528,6 +1623,7 @@ pub(crate) struct WhereClauseBeforeTupleStructBodySugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_async_fn_in_2015, code = "E0670")]
+#[must_use]
 pub(crate) struct AsyncFnIn2015 {
     #[primary_span]
     #[label]
@@ -1545,6 +1641,7 @@ pub(crate) struct AsyncBlockIn2015 {
 
 #[derive(Diagnostic)]
 #[diag(parse_async_move_block_in_2015)]
+#[must_use]
 pub(crate) struct AsyncMoveBlockIn2015 {
     #[primary_span]
     pub span: Span,
@@ -1552,6 +1649,7 @@ pub(crate) struct AsyncMoveBlockIn2015 {
 
 #[derive(Diagnostic)]
 #[diag(parse_self_argument_pointer)]
+#[must_use]
 pub(crate) struct SelfArgumentPointer {
     #[primary_span]
     #[label]
@@ -1560,6 +1658,7 @@ pub(crate) struct SelfArgumentPointer {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_token_after_dot)]
+#[must_use]
 pub struct UnexpectedTokenAfterDot<'a> {
     #[primary_span]
     pub span: Span,
@@ -1569,6 +1668,7 @@ pub struct UnexpectedTokenAfterDot<'a> {
 #[derive(Diagnostic)]
 #[diag(parse_visibility_not_followed_by_item)]
 #[help]
+#[must_use]
 pub(crate) struct VisibilityNotFollowedByItem {
     #[primary_span]
     #[label]
@@ -1579,6 +1679,7 @@ pub(crate) struct VisibilityNotFollowedByItem {
 #[derive(Diagnostic)]
 #[diag(parse_default_not_followed_by_item)]
 #[note]
+#[must_use]
 pub(crate) struct DefaultNotFollowedByItem {
     #[primary_span]
     #[label]
@@ -1631,6 +1732,7 @@ pub(crate) enum AmbiguousMissingKwForItemSub {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_fn_params)]
+#[must_use]
 pub(crate) struct MissingFnParams {
     #[primary_span]
     #[suggestion(code = "()", applicability = "machine-applicable", style = "short")]
@@ -1639,6 +1741,7 @@ pub(crate) struct MissingFnParams {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_trait_in_trait_impl)]
+#[must_use]
 pub(crate) struct MissingTraitInTraitImpl {
     #[primary_span]
     #[suggestion(parse_suggestion_add_trait, code = " Trait ", applicability = "has-placeholders")]
@@ -1649,6 +1752,7 @@ pub(crate) struct MissingTraitInTraitImpl {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_for_in_trait_impl)]
+#[must_use]
 pub(crate) struct MissingForInTraitImpl {
     #[primary_span]
     #[suggestion(style = "short", code = " for ", applicability = "machine-applicable")]
@@ -1657,6 +1761,7 @@ pub(crate) struct MissingForInTraitImpl {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_trait_in_trait_impl_found_type)]
+#[must_use]
 pub(crate) struct ExpectedTraitInTraitImplFoundType {
     #[primary_span]
     pub span: Span,
@@ -1664,6 +1769,7 @@ pub(crate) struct ExpectedTraitInTraitImplFoundType {
 
 #[derive(Diagnostic)]
 #[diag(parse_extra_impl_keyword_in_trait_impl)]
+#[must_use]
 pub(crate) struct ExtraImplKeywordInTraitImpl {
     #[primary_span]
     #[suggestion(code = "", applicability = "maybe-incorrect")]
@@ -1674,6 +1780,7 @@ pub(crate) struct ExtraImplKeywordInTraitImpl {
 
 #[derive(Diagnostic)]
 #[diag(parse_bounds_not_allowed_on_trait_aliases)]
+#[must_use]
 pub(crate) struct BoundsNotAllowedOnTraitAliases {
     #[primary_span]
     pub span: Span,
@@ -1681,6 +1788,7 @@ pub(crate) struct BoundsNotAllowedOnTraitAliases {
 
 #[derive(Diagnostic)]
 #[diag(parse_trait_alias_cannot_be_auto)]
+#[must_use]
 pub(crate) struct TraitAliasCannotBeAuto {
     #[primary_span]
     #[label(parse_trait_alias_cannot_be_auto)]
@@ -1689,6 +1797,7 @@ pub(crate) struct TraitAliasCannotBeAuto {
 
 #[derive(Diagnostic)]
 #[diag(parse_trait_alias_cannot_be_unsafe)]
+#[must_use]
 pub(crate) struct TraitAliasCannotBeUnsafe {
     #[primary_span]
     #[label(parse_trait_alias_cannot_be_unsafe)]
@@ -1697,6 +1806,7 @@ pub(crate) struct TraitAliasCannotBeUnsafe {
 
 #[derive(Diagnostic)]
 #[diag(parse_associated_static_item_not_allowed)]
+#[must_use]
 pub(crate) struct AssociatedStaticItemNotAllowed {
     #[primary_span]
     pub span: Span,
@@ -1704,6 +1814,7 @@ pub(crate) struct AssociatedStaticItemNotAllowed {
 
 #[derive(Diagnostic)]
 #[diag(parse_extern_crate_name_with_dashes)]
+#[must_use]
 pub(crate) struct ExternCrateNameWithDashes {
     #[primary_span]
     #[label]
@@ -1722,6 +1833,7 @@ pub(crate) struct ExternCrateNameWithDashesSugg {
 #[derive(Diagnostic)]
 #[diag(parse_extern_item_cannot_be_const)]
 #[note]
+#[must_use]
 pub(crate) struct ExternItemCannotBeConst {
     #[primary_span]
     pub ident_span: Span,
@@ -1731,6 +1843,7 @@ pub(crate) struct ExternItemCannotBeConst {
 
 #[derive(Diagnostic)]
 #[diag(parse_const_global_cannot_be_mutable)]
+#[must_use]
 pub(crate) struct ConstGlobalCannotBeMutable {
     #[primary_span]
     #[label]
@@ -1741,6 +1854,7 @@ pub(crate) struct ConstGlobalCannotBeMutable {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_const_type)]
+#[must_use]
 pub(crate) struct MissingConstType {
     #[primary_span]
     #[suggestion(code = "{colon} <type>", applicability = "has-placeholders")]
@@ -1751,6 +1865,7 @@ pub(crate) struct MissingConstType {
 }
 
 #[derive(Diagnostic)]
+#[must_use]
 #[diag(parse_enum_struct_mutually_exclusive)]
 pub(crate) struct EnumStructMutuallyExclusive {
     #[primary_span]
@@ -1812,6 +1927,7 @@ impl UnexpectedTokenAfterStructName {
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_self_in_generic_parameters)]
 #[note]
+#[must_use]
 pub(crate) struct UnexpectedSelfInGenericParameters {
     #[primary_span]
     pub span: Span,
@@ -1819,6 +1935,7 @@ pub(crate) struct UnexpectedSelfInGenericParameters {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_default_value_for_lifetime_in_generic_parameters)]
+#[must_use]
 pub(crate) struct UnexpectedDefaultValueForLifetimeInGenericParameters {
     #[primary_span]
     #[label]
@@ -1827,6 +1944,7 @@ pub(crate) struct UnexpectedDefaultValueForLifetimeInGenericParameters {
 
 #[derive(Diagnostic)]
 #[diag(parse_multiple_where_clauses)]
+#[must_use]
 pub(crate) struct MultipleWhereClauses {
     #[primary_span]
     pub span: Span,
@@ -1876,6 +1994,7 @@ pub(crate) enum TopLevelOrPatternNotAllowed {
 
 #[derive(Diagnostic)]
 #[diag(parse_cannot_be_raw_ident)]
+#[must_use]
 pub struct CannotBeRawIdent {
     #[primary_span]
     pub span: Span,
@@ -1884,6 +2003,7 @@ pub struct CannotBeRawIdent {
 
 #[derive(Diagnostic)]
 #[diag(parse_cr_doc_comment)]
+#[must_use]
 pub struct CrDocComment {
     #[primary_span]
     pub span: Span,
@@ -1892,6 +2012,7 @@ pub struct CrDocComment {
 
 #[derive(Diagnostic)]
 #[diag(parse_no_digits_literal, code = "E0768")]
+#[must_use]
 pub struct NoDigitsLiteral {
     #[primary_span]
     pub span: Span,
@@ -1899,6 +2020,7 @@ pub struct NoDigitsLiteral {
 
 #[derive(Diagnostic)]
 #[diag(parse_invalid_digit_literal)]
+#[must_use]
 pub struct InvalidDigitLiteral {
     #[primary_span]
     pub span: Span,
@@ -1907,6 +2029,7 @@ pub struct InvalidDigitLiteral {
 
 #[derive(Diagnostic)]
 #[diag(parse_empty_exponent_float)]
+#[must_use]
 pub struct EmptyExponentFloat {
     #[primary_span]
     pub span: Span,
@@ -1914,6 +2037,7 @@ pub struct EmptyExponentFloat {
 
 #[derive(Diagnostic)]
 #[diag(parse_float_literal_unsupported_base)]
+#[must_use]
 pub struct FloatLiteralUnsupportedBase {
     #[primary_span]
     pub span: Span,
@@ -1923,6 +2047,7 @@ pub struct FloatLiteralUnsupportedBase {
 #[derive(Diagnostic)]
 #[diag(parse_unknown_prefix)]
 #[note]
+#[must_use]
 pub struct UnknownPrefix<'a> {
     #[primary_span]
     #[label]
@@ -1958,6 +2083,7 @@ pub enum UnknownPrefixSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_too_many_hashes)]
+#[must_use]
 pub struct TooManyHashes {
     #[primary_span]
     pub span: Span,
@@ -1966,6 +2092,7 @@ pub struct TooManyHashes {
 
 #[derive(Diagnostic)]
 #[diag(parse_unknown_start_of_token)]
+#[must_use]
 pub struct UnknownTokenStart {
     #[primary_span]
     pub span: Span,
@@ -2225,6 +2352,7 @@ pub(crate) enum TopLevelOrPatternNotAllowedSugg {
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_vert_vert_before_function_parameter)]
 #[note(parse_note_pattern_alternatives_use_single_vert)]
+#[must_use]
 pub(crate) struct UnexpectedVertVertBeforeFunctionParam {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2233,6 +2361,7 @@ pub(crate) struct UnexpectedVertVertBeforeFunctionParam {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_vert_vert_in_pattern)]
+#[must_use]
 pub(crate) struct UnexpectedVertVertInPattern {
     #[primary_span]
     #[suggestion(code = "|", applicability = "machine-applicable")]
@@ -2243,6 +2372,7 @@ pub(crate) struct UnexpectedVertVertInPattern {
 
 #[derive(Diagnostic)]
 #[diag(parse_trailing_vert_not_allowed)]
+#[must_use]
 pub(crate) struct TrailingVertNotAllowed {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2256,6 +2386,7 @@ pub(crate) struct TrailingVertNotAllowed {
 
 #[derive(Diagnostic)]
 #[diag(parse_dotdotdot_rest_pattern)]
+#[must_use]
 pub(crate) struct DotDotDotRestPattern {
     #[primary_span]
     #[suggestion(style = "short", code = "..", applicability = "machine-applicable")]
@@ -2265,6 +2396,7 @@ pub(crate) struct DotDotDotRestPattern {
 
 #[derive(Diagnostic)]
 #[diag(parse_pattern_on_wrong_side_of_at)]
+#[must_use]
 pub(crate) struct PatternOnWrongSideOfAt {
     #[primary_span]
     #[suggestion(code = "{whole_pat}", applicability = "machine-applicable")]
@@ -2279,6 +2411,7 @@ pub(crate) struct PatternOnWrongSideOfAt {
 #[derive(Diagnostic)]
 #[diag(parse_expected_binding_left_of_at)]
 #[note]
+#[must_use]
 pub(crate) struct ExpectedBindingLeftOfAt {
     #[primary_span]
     pub whole_span: Span,
@@ -2290,6 +2423,7 @@ pub(crate) struct ExpectedBindingLeftOfAt {
 
 #[derive(Diagnostic)]
 #[diag(parse_ambiguous_range_pattern)]
+#[must_use]
 pub(crate) struct AmbiguousRangePattern {
     #[primary_span]
     #[suggestion(code = "({pat})", applicability = "maybe-incorrect")]
@@ -2299,6 +2433,7 @@ pub(crate) struct AmbiguousRangePattern {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_lifetime_in_pattern)]
+#[must_use]
 pub(crate) struct UnexpectedLifetimeInPattern {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2308,6 +2443,7 @@ pub(crate) struct UnexpectedLifetimeInPattern {
 
 #[derive(Diagnostic)]
 #[diag(parse_ref_mut_order_incorrect)]
+#[must_use]
 pub(crate) struct RefMutOrderIncorrect {
     #[primary_span]
     #[suggestion(code = "ref mut", applicability = "machine-applicable")]
@@ -2335,6 +2471,7 @@ pub(crate) enum InvalidMutInPattern {
 
 #[derive(Diagnostic)]
 #[diag(parse_repeated_mut_in_pattern)]
+#[must_use]
 pub(crate) struct RepeatedMutInPattern {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2343,6 +2480,7 @@ pub(crate) struct RepeatedMutInPattern {
 
 #[derive(Diagnostic)]
 #[diag(parse_dot_dot_dot_range_to_pattern_not_allowed)]
+#[must_use]
 pub(crate) struct DotDotDotRangeToPatternNotAllowed {
     #[primary_span]
     #[suggestion(style = "short", code = "..=", applicability = "machine-applicable")]
@@ -2351,6 +2489,7 @@ pub(crate) struct DotDotDotRangeToPatternNotAllowed {
 
 #[derive(Diagnostic)]
 #[diag(parse_enum_pattern_instead_of_identifier)]
+#[must_use]
 pub(crate) struct EnumPatternInsteadOfIdentifier {
     #[primary_span]
     pub span: Span,
@@ -2358,6 +2497,7 @@ pub(crate) struct EnumPatternInsteadOfIdentifier {
 
 #[derive(Diagnostic)]
 #[diag(parse_dot_dot_dot_for_remaining_fields)]
+#[must_use]
 pub(crate) struct DotDotDotForRemainingFields {
     #[primary_span]
     #[suggestion(code = "..", style = "verbose", applicability = "machine-applicable")]
@@ -2367,6 +2507,7 @@ pub(crate) struct DotDotDotForRemainingFields {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_comma_after_pattern_field)]
+#[must_use]
 pub(crate) struct ExpectedCommaAfterPatternField {
     #[primary_span]
     pub span: Span,
@@ -2374,6 +2515,7 @@ pub(crate) struct ExpectedCommaAfterPatternField {
 
 #[derive(Diagnostic)]
 #[diag(parse_return_types_use_thin_arrow)]
+#[must_use]
 pub(crate) struct ReturnTypesUseThinArrow {
     #[primary_span]
     #[suggestion(style = "short", code = "->", applicability = "machine-applicable")]
@@ -2382,6 +2524,7 @@ pub(crate) struct ReturnTypesUseThinArrow {
 
 #[derive(Diagnostic)]
 #[diag(parse_need_plus_after_trait_object_lifetime)]
+#[must_use]
 pub(crate) struct NeedPlusAfterTraitObjectLifetime {
     #[primary_span]
     pub span: Span,
@@ -2389,6 +2532,7 @@ pub(crate) struct NeedPlusAfterTraitObjectLifetime {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_mut_or_const_in_raw_pointer_type)]
+#[must_use]
 pub(crate) struct ExpectedMutOrConstInRawPointerType {
     #[primary_span]
     pub span: Span,
@@ -2398,6 +2542,7 @@ pub(crate) struct ExpectedMutOrConstInRawPointerType {
 
 #[derive(Diagnostic)]
 #[diag(parse_lifetime_after_mut)]
+#[must_use]
 pub(crate) struct LifetimeAfterMut {
     #[primary_span]
     pub span: Span,
@@ -2408,6 +2553,7 @@ pub(crate) struct LifetimeAfterMut {
 
 #[derive(Diagnostic)]
 #[diag(parse_dyn_after_mut)]
+#[must_use]
 pub(crate) struct DynAfterMut {
     #[primary_span]
     #[suggestion(code = "&mut dyn", applicability = "machine-applicable")]
@@ -2416,6 +2562,7 @@ pub(crate) struct DynAfterMut {
 
 #[derive(Diagnostic)]
 #[diag(parse_fn_pointer_cannot_be_const)]
+#[must_use]
 pub(crate) struct FnPointerCannotBeConst {
     #[primary_span]
     pub span: Span,
@@ -2426,6 +2573,7 @@ pub(crate) struct FnPointerCannotBeConst {
 
 #[derive(Diagnostic)]
 #[diag(parse_fn_pointer_cannot_be_async)]
+#[must_use]
 pub(crate) struct FnPointerCannotBeAsync {
     #[primary_span]
     pub span: Span,
@@ -2436,6 +2584,7 @@ pub(crate) struct FnPointerCannotBeAsync {
 
 #[derive(Diagnostic)]
 #[diag(parse_nested_c_variadic_type, code = "E0743")]
+#[must_use]
 pub(crate) struct NestedCVariadicType {
     #[primary_span]
     pub span: Span,
@@ -2444,6 +2593,7 @@ pub(crate) struct NestedCVariadicType {
 #[derive(Diagnostic)]
 #[diag(parse_invalid_dyn_keyword)]
 #[help]
+#[must_use]
 pub(crate) struct InvalidDynKeyword {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2473,6 +2623,7 @@ impl HelpUseLatestEdition {
 
 #[derive(Diagnostic)]
 #[diag(parse_box_syntax_removed)]
+#[must_use]
 pub struct BoxSyntaxRemoved<'a> {
     #[primary_span]
     #[suggestion(
@@ -2486,6 +2637,7 @@ pub struct BoxSyntaxRemoved<'a> {
 
 #[derive(Diagnostic)]
 #[diag(parse_bad_return_type_notation_output)]
+#[must_use]
 pub(crate) struct BadReturnTypeNotationOutput {
     #[primary_span]
     #[suggestion(code = "", applicability = "maybe-incorrect")]
@@ -2494,6 +2646,7 @@ pub(crate) struct BadReturnTypeNotationOutput {
 
 #[derive(Diagnostic)]
 #[diag(parse_bad_return_type_notation_dotdot)]
+#[must_use]
 pub(crate) struct BadReturnTypeNotationDotDot {
     #[primary_span]
     #[suggestion(code = "", applicability = "maybe-incorrect")]
@@ -2502,6 +2655,7 @@ pub(crate) struct BadReturnTypeNotationDotDot {
 
 #[derive(Diagnostic)]
 #[diag(parse_bad_assoc_type_bounds)]
+#[must_use]
 pub(crate) struct BadAssocTypeBounds {
     #[primary_span]
     #[label]
@@ -2510,6 +2664,7 @@ pub(crate) struct BadAssocTypeBounds {
 
 #[derive(Diagnostic)]
 #[diag(parse_attr_after_generic)]
+#[must_use]
 pub(crate) struct AttrAfterGeneric {
     #[primary_span]
     #[label]
@@ -2518,6 +2673,7 @@ pub(crate) struct AttrAfterGeneric {
 
 #[derive(Diagnostic)]
 #[diag(parse_attr_without_generics)]
+#[must_use]
 pub(crate) struct AttrWithoutGenerics {
     #[primary_span]
     #[label]
@@ -2526,6 +2682,7 @@ pub(crate) struct AttrWithoutGenerics {
 
 #[derive(Diagnostic)]
 #[diag(parse_where_generics)]
+#[must_use]
 pub(crate) struct WhereOnGenerics {
     #[primary_span]
     #[label]
@@ -2534,6 +2691,7 @@ pub(crate) struct WhereOnGenerics {
 
 #[derive(Diagnostic)]
 #[diag(parse_generics_in_path)]
+#[must_use]
 pub(crate) struct GenericsInPath {
     #[primary_span]
     pub span: Vec<Span>,
@@ -2542,6 +2700,7 @@ pub(crate) struct GenericsInPath {
 #[derive(Diagnostic)]
 #[diag(parse_assoc_lifetime)]
 #[help]
+#[must_use]
 pub(crate) struct AssocLifetime {
     #[primary_span]
     pub span: Span,
@@ -2551,6 +2710,7 @@ pub(crate) struct AssocLifetime {
 
 #[derive(Diagnostic)]
 #[diag(parse_tilde_const_lifetime)]
+#[must_use]
 pub(crate) struct TildeConstLifetime {
     #[primary_span]
     pub span: Span,
@@ -2558,6 +2718,7 @@ pub(crate) struct TildeConstLifetime {
 
 #[derive(Diagnostic)]
 #[diag(parse_modifier_lifetime)]
+#[must_use]
 pub(crate) struct ModifierLifetime {
     #[primary_span]
     #[suggestion(style = "tool-only", applicability = "maybe-incorrect", code = "")]
@@ -2567,6 +2728,7 @@ pub(crate) struct ModifierLifetime {
 
 #[derive(Diagnostic)]
 #[diag(parse_parenthesized_lifetime)]
+#[must_use]
 pub(crate) struct ParenthesizedLifetime {
     #[primary_span]
     pub span: Span,
@@ -2577,6 +2739,7 @@ pub(crate) struct ParenthesizedLifetime {
 
 #[derive(Diagnostic)]
 #[diag(parse_const_bounds_missing_tilde)]
+#[must_use]
 pub(crate) struct ConstMissingTilde {
     #[primary_span]
     pub span: Span,
@@ -2586,6 +2749,7 @@ pub(crate) struct ConstMissingTilde {
 
 #[derive(Diagnostic)]
 #[diag(parse_underscore_literal_suffix)]
+#[must_use]
 pub(crate) struct UnderscoreLiteralSuffix {
     #[primary_span]
     pub span: Span,
@@ -2593,6 +2757,7 @@ pub(crate) struct UnderscoreLiteralSuffix {
 
 #[derive(Diagnostic)]
 #[diag(parse_expect_label_found_ident)]
+#[must_use]
 pub(crate) struct ExpectedLabelFoundIdent {
     #[primary_span]
     pub span: Span,
@@ -2603,6 +2768,7 @@ pub(crate) struct ExpectedLabelFoundIdent {
 #[derive(Diagnostic)]
 #[diag(parse_inappropriate_default)]
 #[note]
+#[must_use]
 pub(crate) struct InappropriateDefault {
     #[primary_span]
     #[label]
@@ -2613,6 +2779,7 @@ pub(crate) struct InappropriateDefault {
 
 #[derive(Diagnostic)]
 #[diag(parse_recover_import_as_use)]
+#[must_use]
 pub(crate) struct RecoverImportAsUse {
     #[primary_span]
     #[suggestion(code = "use", applicability = "machine-applicable", style = "short")]
@@ -2623,6 +2790,7 @@ pub(crate) struct RecoverImportAsUse {
 #[derive(Diagnostic)]
 #[diag(parse_single_colon_import_path)]
 #[note]
+#[must_use]
 pub(crate) struct SingleColonImportPath {
     #[primary_span]
     #[suggestion(code = "::", applicability = "machine-applicable", style = "short")]
@@ -2632,6 +2800,7 @@ pub(crate) struct SingleColonImportPath {
 #[derive(Diagnostic)]
 #[diag(parse_bad_item_kind)]
 #[help]
+#[must_use]
 pub(crate) struct BadItemKind {
     #[primary_span]
     pub span: Span,
@@ -2641,6 +2810,7 @@ pub(crate) struct BadItemKind {
 
 #[derive(Diagnostic)]
 #[diag(parse_single_colon_struct_type)]
+#[must_use]
 pub(crate) struct SingleColonStructType {
     #[primary_span]
     #[suggestion(code = "::", applicability = "maybe-incorrect", style = "verbose")]
@@ -2649,6 +2819,7 @@ pub(crate) struct SingleColonStructType {
 
 #[derive(Diagnostic)]
 #[diag(parse_equals_struct_default)]
+#[must_use]
 pub(crate) struct EqualsStructDefault {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2657,6 +2828,7 @@ pub(crate) struct EqualsStructDefault {
 
 #[derive(Diagnostic)]
 #[diag(parse_macro_rules_missing_bang)]
+#[must_use]
 pub(crate) struct MacroRulesMissingBang {
     #[primary_span]
     pub span: Span,
@@ -2666,6 +2838,7 @@ pub(crate) struct MacroRulesMissingBang {
 
 #[derive(Diagnostic)]
 #[diag(parse_macro_name_remove_bang)]
+#[must_use]
 pub(crate) struct MacroNameRemoveBang {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2674,6 +2847,7 @@ pub(crate) struct MacroNameRemoveBang {
 
 #[derive(Diagnostic)]
 #[diag(parse_macro_rules_visibility)]
+#[must_use]
 pub(crate) struct MacroRulesVisibility<'a> {
     #[primary_span]
     #[suggestion(code = "#[macro_export]", applicability = "maybe-incorrect")]
@@ -2684,6 +2858,7 @@ pub(crate) struct MacroRulesVisibility<'a> {
 #[derive(Diagnostic)]
 #[diag(parse_macro_invocation_visibility)]
 #[help]
+#[must_use]
 pub(crate) struct MacroInvocationVisibility<'a> {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2693,6 +2868,7 @@ pub(crate) struct MacroInvocationVisibility<'a> {
 
 #[derive(Diagnostic)]
 #[diag(parse_nested_adt)]
+#[must_use]
 pub(crate) struct NestedAdt<'a> {
     #[primary_span]
     pub span: Span,
@@ -2704,6 +2880,7 @@ pub(crate) struct NestedAdt<'a> {
 
 #[derive(Diagnostic)]
 #[diag(parse_function_body_equals_expr)]
+#[must_use]
 pub(crate) struct FunctionBodyEqualsExpr {
     #[primary_span]
     pub span: Span,
@@ -2722,6 +2899,7 @@ pub(crate) struct FunctionBodyEqualsExprSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_box_not_pat)]
+#[must_use]
 pub(crate) struct BoxNotPat {
     #[primary_span]
     pub span: Span,
@@ -2734,6 +2912,7 @@ pub(crate) struct BoxNotPat {
 
 #[derive(Diagnostic)]
 #[diag(parse_unmatched_angle)]
+#[must_use]
 pub(crate) struct UnmatchedAngle {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -2743,6 +2922,7 @@ pub(crate) struct UnmatchedAngle {
 
 #[derive(Diagnostic)]
 #[diag(parse_missing_plus_in_bounds)]
+#[must_use]
 pub(crate) struct MissingPlusBounds {
     #[primary_span]
     pub span: Span,
@@ -2753,6 +2933,7 @@ pub(crate) struct MissingPlusBounds {
 
 #[derive(Diagnostic)]
 #[diag(parse_incorrect_parens_trait_bounds)]
+#[must_use]
 pub(crate) struct IncorrectParensTraitBounds {
     #[primary_span]
     pub span: Vec<Span>,
@@ -2774,6 +2955,7 @@ pub(crate) struct IncorrectParensTraitBoundsSugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_kw_bad_case)]
+#[must_use]
 pub(crate) struct KwBadCase<'a> {
     #[primary_span]
     #[suggestion(code = "{kw}", applicability = "machine-applicable")]
@@ -2783,6 +2965,7 @@ pub(crate) struct KwBadCase<'a> {
 
 #[derive(Diagnostic)]
 #[diag(parse_meta_bad_delim)]
+#[must_use]
 pub(crate) struct MetaBadDelim {
     #[primary_span]
     pub span: Span,
@@ -2792,6 +2975,7 @@ pub(crate) struct MetaBadDelim {
 
 #[derive(Diagnostic)]
 #[diag(parse_cfg_attr_bad_delim)]
+#[must_use]
 pub(crate) struct CfgAttrBadDelim {
     #[primary_span]
     pub span: Span,
@@ -2811,6 +2995,7 @@ pub(crate) struct MetaBadDelimSugg {
 #[derive(Diagnostic)]
 #[diag(parse_malformed_cfg_attr)]
 #[note]
+#[must_use]
 pub(crate) struct MalformedCfgAttr {
     #[primary_span]
     #[suggestion(code = "{sugg}")]
@@ -2820,6 +3005,7 @@ pub(crate) struct MalformedCfgAttr {
 
 #[derive(Diagnostic)]
 #[diag(parse_unknown_builtin_construct)]
+#[must_use]
 pub(crate) struct UnknownBuiltinConstruct {
     #[primary_span]
     pub span: Span,
@@ -2828,6 +3014,7 @@ pub(crate) struct UnknownBuiltinConstruct {
 
 #[derive(Diagnostic)]
 #[diag(parse_expected_builtin_ident)]
+#[must_use]
 pub(crate) struct ExpectedBuiltinIdent {
     #[primary_span]
     pub span: Span,
@@ -2835,6 +3022,7 @@ pub(crate) struct ExpectedBuiltinIdent {
 
 #[derive(Diagnostic)]
 #[diag(parse_static_with_generics)]
+#[must_use]
 pub(crate) struct StaticWithGenerics {
     #[primary_span]
     pub span: Span,
@@ -2842,6 +3030,7 @@ pub(crate) struct StaticWithGenerics {
 
 #[derive(Diagnostic)]
 #[diag(parse_where_clause_before_const_body)]
+#[must_use]
 pub(crate) struct WhereClauseBeforeConstBody {
     #[primary_span]
     #[label]
@@ -2866,6 +3055,7 @@ pub(crate) struct WhereClauseBeforeConstBodySugg {
 
 #[derive(Diagnostic)]
 #[diag(parse_generic_args_in_pat_require_turbofish_syntax)]
+#[must_use]
 pub(crate) struct GenericArgsInPatRequireTurbofishSyntax {
     #[primary_span]
     pub span: Span,
@@ -2880,6 +3070,7 @@ pub(crate) struct GenericArgsInPatRequireTurbofishSyntax {
 
 #[derive(Diagnostic)]
 #[diag(parse_transpose_dyn_or_impl)]
+#[must_use]
 pub(crate) struct TransposeDynOrImpl<'a> {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -19,6 +19,7 @@ use crate::lang_items::Duplicate;
 
 #[derive(Diagnostic)]
 #[diag(passes_incorrect_do_not_recommend_location)]
+#[must_use]
 pub struct IncorrectDoNotRecommendLocation {
     #[primary_span]
     pub span: Span,
@@ -56,6 +57,7 @@ pub struct IgnoredInlineAttrConstants;
 
 #[derive(Diagnostic)]
 #[diag(passes_inline_not_fn_or_closure, code = "E0518")]
+#[must_use]
 pub struct InlineNotFnOrClosure {
     #[primary_span]
     pub attr_span: Span,
@@ -77,6 +79,7 @@ pub struct IgnoredCoverageFnDefn;
 
 #[derive(Diagnostic)]
 #[diag(passes_coverage_not_coverable, code = "E0788")]
+#[must_use]
 pub struct IgnoredCoverageNotCoverable {
     #[primary_span]
     pub attr_span: Span,
@@ -86,6 +89,7 @@ pub struct IgnoredCoverageNotCoverable {
 
 #[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_fn)]
+#[must_use]
 pub struct AttrShouldBeAppliedToFn {
     #[primary_span]
     pub attr_span: Span,
@@ -96,6 +100,7 @@ pub struct AttrShouldBeAppliedToFn {
 
 #[derive(Diagnostic)]
 #[diag(passes_naked_tracked_caller, code = "E0736")]
+#[must_use]
 pub struct NakedTrackedCaller {
     #[primary_span]
     pub attr_span: Span,
@@ -103,6 +108,7 @@ pub struct NakedTrackedCaller {
 
 #[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_fn, code = "E0739")]
+#[must_use]
 pub struct TrackedCallerWrongLocation {
     #[primary_span]
     pub attr_span: Span,
@@ -113,6 +119,7 @@ pub struct TrackedCallerWrongLocation {
 
 #[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_struct_enum, code = "E0701")]
+#[must_use]
 pub struct NonExhaustiveWrongLocation {
     #[primary_span]
     pub attr_span: Span,
@@ -122,6 +129,7 @@ pub struct NonExhaustiveWrongLocation {
 
 #[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_trait)]
+#[must_use]
 pub struct AttrShouldBeAppliedToTrait {
     #[primary_span]
     pub attr_span: Span,
@@ -135,6 +143,7 @@ pub struct TargetFeatureOnStatement;
 
 #[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_static)]
+#[must_use]
 pub struct AttrShouldBeAppliedToStatic {
     #[primary_span]
     pub attr_span: Span,
@@ -144,6 +153,7 @@ pub struct AttrShouldBeAppliedToStatic {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_expect_str)]
+#[must_use]
 pub struct DocExpectStr<'a> {
     #[primary_span]
     pub attr_span: Span,
@@ -152,6 +162,7 @@ pub struct DocExpectStr<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_empty)]
+#[must_use]
 pub struct DocAliasEmpty<'a> {
     #[primary_span]
     pub span: Span,
@@ -160,6 +171,7 @@ pub struct DocAliasEmpty<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_bad_char)]
+#[must_use]
 pub struct DocAliasBadChar<'a> {
     #[primary_span]
     pub span: Span,
@@ -169,6 +181,7 @@ pub struct DocAliasBadChar<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_start_end)]
+#[must_use]
 pub struct DocAliasStartEnd<'a> {
     #[primary_span]
     pub span: Span,
@@ -177,6 +190,7 @@ pub struct DocAliasStartEnd<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_bad_location)]
+#[must_use]
 pub struct DocAliasBadLocation<'a> {
     #[primary_span]
     pub span: Span,
@@ -186,6 +200,7 @@ pub struct DocAliasBadLocation<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_not_an_alias)]
+#[must_use]
 pub struct DocAliasNotAnAlias<'a> {
     #[primary_span]
     pub span: Span,
@@ -201,6 +216,7 @@ pub struct DocAliasDuplicated {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_not_string_literal)]
+#[must_use]
 pub struct DocAliasNotStringLiteral {
     #[primary_span]
     pub span: Span,
@@ -208,6 +224,7 @@ pub struct DocAliasNotStringLiteral {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_alias_malformed)]
+#[must_use]
 pub struct DocAliasMalformed {
     #[primary_span]
     pub span: Span,
@@ -215,6 +232,7 @@ pub struct DocAliasMalformed {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_keyword_empty_mod)]
+#[must_use]
 pub struct DocKeywordEmptyMod {
     #[primary_span]
     pub span: Span,
@@ -222,6 +240,7 @@ pub struct DocKeywordEmptyMod {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_keyword_not_mod)]
+#[must_use]
 pub struct DocKeywordNotMod {
     #[primary_span]
     pub span: Span,
@@ -229,6 +248,7 @@ pub struct DocKeywordNotMod {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_keyword_invalid_ident)]
+#[must_use]
 pub struct DocKeywordInvalidIdent {
     #[primary_span]
     pub span: Span,
@@ -237,6 +257,7 @@ pub struct DocKeywordInvalidIdent {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_fake_variadic_not_valid)]
+#[must_use]
 pub struct DocFakeVariadicNotValid {
     #[primary_span]
     pub span: Span,
@@ -244,6 +265,7 @@ pub struct DocFakeVariadicNotValid {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_keyword_only_impl)]
+#[must_use]
 pub struct DocKeywordOnlyImpl {
     #[primary_span]
     pub span: Span,
@@ -252,6 +274,7 @@ pub struct DocKeywordOnlyImpl {
 #[derive(Diagnostic)]
 #[diag(passes_doc_inline_conflict)]
 #[help]
+#[must_use]
 pub struct DocKeywordConflict {
     #[primary_span]
     pub spans: MultiSpan,
@@ -288,6 +311,7 @@ pub struct DocMaskedNotExternCrateSelf {
 
 #[derive(Diagnostic)]
 #[diag(passes_doc_attr_not_crate_level)]
+#[must_use]
 pub struct DocAttrNotCrateLevel<'a> {
     #[primary_span]
     pub span: Span,
@@ -344,6 +368,7 @@ pub struct DocInvalid;
 
 #[derive(Diagnostic)]
 #[diag(passes_pass_by_value)]
+#[must_use]
 pub struct PassByValue {
     #[primary_span]
     pub attr_span: Span,
@@ -353,6 +378,7 @@ pub struct PassByValue {
 
 #[derive(Diagnostic)]
 #[diag(passes_allow_incoherent_impl)]
+#[must_use]
 pub struct AllowIncoherentImpl {
     #[primary_span]
     pub attr_span: Span,
@@ -362,6 +388,7 @@ pub struct AllowIncoherentImpl {
 
 #[derive(Diagnostic)]
 #[diag(passes_has_incoherent_inherent_impl)]
+#[must_use]
 pub struct HasIncoherentInherentImpl {
     #[primary_span]
     pub attr_span: Span,
@@ -371,6 +398,7 @@ pub struct HasIncoherentInherentImpl {
 
 #[derive(Diagnostic)]
 #[diag(passes_both_ffi_const_and_pure, code = "E0757")]
+#[must_use]
 pub struct BothFfiConstAndPure {
     #[primary_span]
     pub attr_span: Span,
@@ -378,6 +406,7 @@ pub struct BothFfiConstAndPure {
 
 #[derive(Diagnostic)]
 #[diag(passes_ffi_pure_invalid_target, code = "E0755")]
+#[must_use]
 pub struct FfiPureInvalidTarget {
     #[primary_span]
     pub attr_span: Span,
@@ -385,6 +414,7 @@ pub struct FfiPureInvalidTarget {
 
 #[derive(Diagnostic)]
 #[diag(passes_ffi_const_invalid_target, code = "E0756")]
+#[must_use]
 pub struct FfiConstInvalidTarget {
     #[primary_span]
     pub attr_span: Span,
@@ -392,6 +422,7 @@ pub struct FfiConstInvalidTarget {
 
 #[derive(Diagnostic)]
 #[diag(passes_ffi_returns_twice_invalid_target, code = "E0724")]
+#[must_use]
 pub struct FfiReturnsTwiceInvalidTarget {
     #[primary_span]
     pub attr_span: Span,
@@ -413,6 +444,7 @@ pub struct MustUseNoEffect {
 
 #[derive(Diagnostic)]
 #[diag(passes_must_not_suspend)]
+#[must_use]
 pub struct MustNotSuspend {
     #[primary_span]
     pub attr_span: Span,
@@ -450,6 +482,7 @@ pub struct LinkName<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_no_link)]
+#[must_use]
 pub struct NoLink {
     #[primary_span]
     pub attr_span: Span,
@@ -459,6 +492,7 @@ pub struct NoLink {
 
 #[derive(Diagnostic)]
 #[diag(passes_export_name)]
+#[must_use]
 pub struct ExportName {
     #[primary_span]
     pub attr_span: Span,
@@ -468,6 +502,7 @@ pub struct ExportName {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_layout_scalar_valid_range_not_struct)]
+#[must_use]
 pub struct RustcLayoutScalarValidRangeNotStruct {
     #[primary_span]
     pub attr_span: Span,
@@ -477,6 +512,7 @@ pub struct RustcLayoutScalarValidRangeNotStruct {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_layout_scalar_valid_range_arg)]
+#[must_use]
 pub struct RustcLayoutScalarValidRangeArg {
     #[primary_span]
     pub attr_span: Span,
@@ -484,6 +520,7 @@ pub struct RustcLayoutScalarValidRangeArg {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_legacy_const_generics_only)]
+#[must_use]
 pub struct RustcLegacyConstGenericsOnly {
     #[primary_span]
     pub attr_span: Span,
@@ -493,6 +530,7 @@ pub struct RustcLegacyConstGenericsOnly {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_legacy_const_generics_index)]
+#[must_use]
 pub struct RustcLegacyConstGenericsIndex {
     #[primary_span]
     pub attr_span: Span,
@@ -502,6 +540,7 @@ pub struct RustcLegacyConstGenericsIndex {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_legacy_const_generics_index_exceed)]
+#[must_use]
 pub struct RustcLegacyConstGenericsIndexExceed {
     #[primary_span]
     #[label]
@@ -511,6 +550,7 @@ pub struct RustcLegacyConstGenericsIndexExceed {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_legacy_const_generics_index_negative)]
+#[must_use]
 pub struct RustcLegacyConstGenericsIndexNegative {
     #[primary_span]
     pub invalid_args: Vec<Span>,
@@ -518,6 +558,7 @@ pub struct RustcLegacyConstGenericsIndexNegative {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_dirty_clean)]
+#[must_use]
 pub struct RustcDirtyClean {
     #[primary_span]
     pub span: Span,
@@ -553,6 +594,7 @@ pub struct NoMangle {
 
 #[derive(Diagnostic)]
 #[diag(passes_repr_ident, code = "E0565")]
+#[must_use]
 pub struct ReprIdent {
     #[primary_span]
     pub span: Span,
@@ -560,6 +602,7 @@ pub struct ReprIdent {
 
 #[derive(Diagnostic)]
 #[diag(passes_repr_conflicting, code = "E0566")]
+#[must_use]
 pub struct ReprConflicting {
     #[primary_span]
     pub hint_spans: Vec<Span>,
@@ -571,6 +614,7 @@ pub struct ReprConflictingLint;
 
 #[derive(Diagnostic)]
 #[diag(passes_used_static)]
+#[must_use]
 pub struct UsedStatic {
     #[primary_span]
     pub span: Span,
@@ -578,6 +622,7 @@ pub struct UsedStatic {
 
 #[derive(Diagnostic)]
 #[diag(passes_used_compiler_linker)]
+#[must_use]
 pub struct UsedCompilerLinker {
     #[primary_span]
     pub spans: Vec<Span>,
@@ -585,6 +630,7 @@ pub struct UsedCompilerLinker {
 
 #[derive(Diagnostic)]
 #[diag(passes_allow_internal_unstable)]
+#[must_use]
 pub struct AllowInternalUnstable {
     #[primary_span]
     pub attr_span: Span,
@@ -594,6 +640,7 @@ pub struct AllowInternalUnstable {
 
 #[derive(Diagnostic)]
 #[diag(passes_debug_visualizer_placement)]
+#[must_use]
 pub struct DebugVisualizerPlacement {
     #[primary_span]
     pub span: Span,
@@ -604,6 +651,7 @@ pub struct DebugVisualizerPlacement {
 #[note(passes_note_1)]
 #[note(passes_note_2)]
 #[note(passes_note_3)]
+#[must_use]
 pub struct DebugVisualizerInvalid {
     #[primary_span]
     pub span: Span,
@@ -611,6 +659,7 @@ pub struct DebugVisualizerInvalid {
 
 #[derive(Diagnostic)]
 #[diag(passes_debug_visualizer_unreadable)]
+#[must_use]
 pub struct DebugVisualizerUnreadable<'a> {
     #[primary_span]
     pub span: Span,
@@ -620,6 +669,7 @@ pub struct DebugVisualizerUnreadable<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_allow_const_fn_unstable)]
+#[must_use]
 pub struct RustcAllowConstFnUnstable {
     #[primary_span]
     pub attr_span: Span,
@@ -629,6 +679,7 @@ pub struct RustcAllowConstFnUnstable {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_safe_intrinsic)]
+#[must_use]
 pub struct RustcSafeIntrinsic {
     #[primary_span]
     pub attr_span: Span,
@@ -638,6 +689,7 @@ pub struct RustcSafeIntrinsic {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_std_internal_symbol)]
+#[must_use]
 pub struct RustcStdInternalSymbol {
     #[primary_span]
     pub attr_span: Span,
@@ -647,6 +699,7 @@ pub struct RustcStdInternalSymbol {
 
 #[derive(Diagnostic)]
 #[diag(passes_link_ordinal)]
+#[must_use]
 pub struct LinkOrdinal {
     #[primary_span]
     pub attr_span: Span,
@@ -654,6 +707,7 @@ pub struct LinkOrdinal {
 
 #[derive(Diagnostic)]
 #[diag(passes_confusables)]
+#[must_use]
 pub struct Confusables {
     #[primary_span]
     pub attr_span: Span,
@@ -661,6 +715,7 @@ pub struct Confusables {
 
 #[derive(Diagnostic)]
 #[diag(passes_empty_confusables)]
+#[must_use]
 pub(crate) struct EmptyConfusables {
     #[primary_span]
     pub span: Span,
@@ -668,6 +723,7 @@ pub(crate) struct EmptyConfusables {
 
 #[derive(Diagnostic)]
 #[diag(passes_incorrect_meta_item, code = "E0539")]
+#[must_use]
 pub(crate) struct IncorrectMetaItem {
     #[primary_span]
     pub span: Span,
@@ -686,6 +742,7 @@ pub(crate) struct IncorrectMetaItemSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(passes_stability_promotable)]
+#[must_use]
 pub struct StabilityPromotable {
     #[primary_span]
     pub attr_span: Span,
@@ -738,6 +795,7 @@ pub struct Unused {
 
 #[derive(Diagnostic)]
 #[diag(passes_non_exported_macro_invalid_attrs, code = "E0518")]
+#[must_use]
 pub struct NonExportedMacroInvalidAttrs {
     #[primary_span]
     #[label]
@@ -757,6 +815,7 @@ pub struct UnusedDuplicate {
 
 #[derive(Diagnostic)]
 #[diag(passes_unused_multiple)]
+#[must_use]
 pub struct UnusedMultiple {
     #[primary_span]
     #[suggestion(code = "", applicability = "machine-applicable")]
@@ -768,6 +827,7 @@ pub struct UnusedMultiple {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_lint_opt_ty)]
+#[must_use]
 pub struct RustcLintOptTy {
     #[primary_span]
     pub attr_span: Span,
@@ -777,6 +837,7 @@ pub struct RustcLintOptTy {
 
 #[derive(Diagnostic)]
 #[diag(passes_rustc_lint_opt_deny_field_access)]
+#[must_use]
 pub struct RustcLintOptDenyFieldAccess {
     #[primary_span]
     pub attr_span: Span,
@@ -786,6 +847,7 @@ pub struct RustcLintOptDenyFieldAccess {
 
 #[derive(Diagnostic)]
 #[diag(passes_collapse_debuginfo)]
+#[must_use]
 pub struct CollapseDebuginfo {
     #[primary_span]
     pub attr_span: Span,
@@ -802,6 +864,7 @@ pub struct DeprecatedAnnotationHasNoEffect {
 
 #[derive(Diagnostic)]
 #[diag(passes_unknown_external_lang_item, code = "E0264")]
+#[must_use]
 pub struct UnknownExternLangItem {
     #[primary_span]
     pub span: Span,
@@ -810,18 +873,21 @@ pub struct UnknownExternLangItem {
 
 #[derive(Diagnostic)]
 #[diag(passes_missing_panic_handler)]
+#[must_use]
 pub struct MissingPanicHandler;
 
 #[derive(Diagnostic)]
 #[diag(passes_missing_lang_item)]
 #[note]
 #[help]
+#[must_use]
 pub struct MissingLangItem {
     pub name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(passes_lang_item_fn_with_target_feature)]
+#[must_use]
 pub struct LangItemWithTargetFeature {
     #[primary_span]
     pub attr_span: Span,
@@ -832,6 +898,7 @@ pub struct LangItemWithTargetFeature {
 
 #[derive(Diagnostic)]
 #[diag(passes_lang_item_on_incorrect_target, code = "E0718")]
+#[must_use]
 pub struct LangItemOnIncorrectTarget {
     #[primary_span]
     #[label]
@@ -843,6 +910,7 @@ pub struct LangItemOnIncorrectTarget {
 
 #[derive(Diagnostic)]
 #[diag(passes_unknown_lang_item, code = "E0522")]
+#[must_use]
 pub struct UnknownLangItem {
     #[primary_span]
     #[label]
@@ -892,6 +960,7 @@ impl IntoDiagnostic<'_> for InvalidAttrAtCrateLevel {
 
 #[derive(Diagnostic)]
 #[diag(passes_duplicate_diagnostic_item_in_crate)]
+#[must_use]
 pub struct DuplicateDiagnosticItemInCrate {
     #[primary_span]
     pub duplicate_span: Option<Span>,
@@ -906,6 +975,7 @@ pub struct DuplicateDiagnosticItemInCrate {
 
 #[derive(Diagnostic)]
 #[diag(passes_layout_abi)]
+#[must_use]
 pub struct LayoutAbi {
     #[primary_span]
     pub span: Span,
@@ -914,6 +984,7 @@ pub struct LayoutAbi {
 
 #[derive(Diagnostic)]
 #[diag(passes_layout_align)]
+#[must_use]
 pub struct LayoutAlign {
     #[primary_span]
     pub span: Span,
@@ -922,6 +993,7 @@ pub struct LayoutAlign {
 
 #[derive(Diagnostic)]
 #[diag(passes_layout_size)]
+#[must_use]
 pub struct LayoutSize {
     #[primary_span]
     pub span: Span,
@@ -930,6 +1002,7 @@ pub struct LayoutSize {
 
 #[derive(Diagnostic)]
 #[diag(passes_layout_homogeneous_aggregate)]
+#[must_use]
 pub struct LayoutHomogeneousAggregate {
     #[primary_span]
     pub span: Span,
@@ -938,6 +1011,7 @@ pub struct LayoutHomogeneousAggregate {
 
 #[derive(Diagnostic)]
 #[diag(passes_layout_of)]
+#[must_use]
 pub struct LayoutOf {
     #[primary_span]
     pub span: Span,
@@ -947,6 +1021,7 @@ pub struct LayoutOf {
 
 #[derive(Diagnostic)]
 #[diag(passes_layout_invalid_attribute)]
+#[must_use]
 pub struct LayoutInvalidAttribute {
     #[primary_span]
     pub span: Span,
@@ -954,6 +1029,7 @@ pub struct LayoutInvalidAttribute {
 
 #[derive(Diagnostic)]
 #[diag(passes_abi_of)]
+#[must_use]
 pub struct AbiOf {
     #[primary_span]
     pub span: Span,
@@ -963,6 +1039,7 @@ pub struct AbiOf {
 
 #[derive(Diagnostic)]
 #[diag(passes_abi_ne)]
+#[must_use]
 pub struct AbiNe {
     #[primary_span]
     pub span: Span,
@@ -972,6 +1049,7 @@ pub struct AbiNe {
 
 #[derive(Diagnostic)]
 #[diag(passes_abi_invalid_attribute)]
+#[must_use]
 pub struct AbiInvalidAttribute {
     #[primary_span]
     pub span: Span,
@@ -979,6 +1057,7 @@ pub struct AbiInvalidAttribute {
 
 #[derive(Diagnostic)]
 #[diag(passes_unrecognized_field)]
+#[must_use]
 pub struct UnrecognizedField {
     #[primary_span]
     pub span: Span,
@@ -987,6 +1066,7 @@ pub struct UnrecognizedField {
 
 #[derive(Diagnostic)]
 #[diag(passes_feature_stable_twice, code = "E0711")]
+#[must_use]
 pub struct FeatureStableTwice {
     #[primary_span]
     pub span: Span,
@@ -997,6 +1077,7 @@ pub struct FeatureStableTwice {
 
 #[derive(Diagnostic)]
 #[diag(passes_feature_previously_declared, code = "E0711")]
+#[must_use]
 pub struct FeaturePreviouslyDeclared<'a, 'b> {
     #[primary_span]
     pub span: Span,
@@ -1065,6 +1146,7 @@ impl<'a> IntoDiagnostic<'_> for BreakNonLoop<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_continue_labeled_block, code = "E0696")]
+#[must_use]
 pub struct ContinueLabeledBlock {
     #[primary_span]
     #[label]
@@ -1075,6 +1157,7 @@ pub struct ContinueLabeledBlock {
 
 #[derive(Diagnostic)]
 #[diag(passes_break_inside_closure, code = "E0267")]
+#[must_use]
 pub struct BreakInsideClosure<'a> {
     #[primary_span]
     #[label]
@@ -1086,6 +1169,7 @@ pub struct BreakInsideClosure<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_break_inside_async_block, code = "E0267")]
+#[must_use]
 pub struct BreakInsideAsyncBlock<'a> {
     #[primary_span]
     #[label]
@@ -1097,6 +1181,7 @@ pub struct BreakInsideAsyncBlock<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_outside_loop, code = "E0268")]
+#[must_use]
 pub struct OutsideLoop<'a> {
     #[primary_span]
     #[label]
@@ -1117,6 +1202,7 @@ pub struct OutsideLoopSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(passes_unlabeled_in_labeled_block, code = "E0695")]
+#[must_use]
 pub struct UnlabeledInLabeledBlock<'a> {
     #[primary_span]
     #[label]
@@ -1126,6 +1212,7 @@ pub struct UnlabeledInLabeledBlock<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_unlabeled_cf_in_while_condition, code = "E0590")]
+#[must_use]
 pub struct UnlabeledCfInWhileCondition<'a> {
     #[primary_span]
     #[label]
@@ -1135,6 +1222,7 @@ pub struct UnlabeledCfInWhileCondition<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_cannot_inline_naked_function)]
+#[must_use]
 pub struct CannotInlineNakedFunction {
     #[primary_span]
     pub span: Span,
@@ -1146,6 +1234,7 @@ pub struct UndefinedNakedFunctionAbi;
 
 #[derive(Diagnostic)]
 #[diag(passes_no_patterns)]
+#[must_use]
 pub struct NoPatterns {
     #[primary_span]
     pub span: Span,
@@ -1154,6 +1243,7 @@ pub struct NoPatterns {
 #[derive(Diagnostic)]
 #[diag(passes_params_not_allowed)]
 #[help]
+#[must_use]
 pub struct ParamsNotAllowed {
     #[primary_span]
     pub span: Span,
@@ -1188,6 +1278,7 @@ impl IntoDiagnostic<'_> for NakedFunctionsAsmBlock {
 
 #[derive(Diagnostic)]
 #[diag(passes_naked_functions_operands, code = "E0787")]
+#[must_use]
 pub struct NakedFunctionsOperands {
     #[primary_span]
     pub unsupported_operands: Vec<Span>,
@@ -1195,6 +1286,7 @@ pub struct NakedFunctionsOperands {
 
 #[derive(Diagnostic)]
 #[diag(passes_naked_functions_asm_options, code = "E0787")]
+#[must_use]
 pub struct NakedFunctionsAsmOptions {
     #[primary_span]
     pub span: Span,
@@ -1203,6 +1295,7 @@ pub struct NakedFunctionsAsmOptions {
 
 #[derive(Diagnostic)]
 #[diag(passes_naked_functions_must_use_noreturn, code = "E0787")]
+#[must_use]
 pub struct NakedFunctionsMustUseNoreturn {
     #[primary_span]
     pub span: Span,
@@ -1212,6 +1305,7 @@ pub struct NakedFunctionsMustUseNoreturn {
 
 #[derive(Diagnostic)]
 #[diag(passes_attr_only_on_main)]
+#[must_use]
 pub struct AttrOnlyOnMain {
     #[primary_span]
     pub span: Span,
@@ -1220,6 +1314,7 @@ pub struct AttrOnlyOnMain {
 
 #[derive(Diagnostic)]
 #[diag(passes_attr_only_on_root_main)]
+#[must_use]
 pub struct AttrOnlyOnRootMain {
     #[primary_span]
     pub span: Span,
@@ -1228,6 +1323,7 @@ pub struct AttrOnlyOnRootMain {
 
 #[derive(Diagnostic)]
 #[diag(passes_attr_only_in_functions)]
+#[must_use]
 pub struct AttrOnlyInFunctions {
     #[primary_span]
     pub span: Span,
@@ -1236,6 +1332,7 @@ pub struct AttrOnlyInFunctions {
 
 #[derive(Diagnostic)]
 #[diag(passes_multiple_rustc_main, code = "E0137")]
+#[must_use]
 pub struct MultipleRustcMain {
     #[primary_span]
     pub span: Span,
@@ -1247,6 +1344,7 @@ pub struct MultipleRustcMain {
 
 #[derive(Diagnostic)]
 #[diag(passes_multiple_start_functions, code = "E0138")]
+#[must_use]
 pub struct MultipleStartFunctions {
     #[primary_span]
     pub span: Span,
@@ -1258,6 +1356,7 @@ pub struct MultipleStartFunctions {
 
 #[derive(Diagnostic)]
 #[diag(passes_extern_main)]
+#[must_use]
 pub struct ExternMain {
     #[primary_span]
     pub span: Span,
@@ -1265,6 +1364,7 @@ pub struct ExternMain {
 
 #[derive(Diagnostic)]
 #[diag(passes_unix_sigpipe_values)]
+#[must_use]
 pub struct UnixSigpipeValues {
     #[primary_span]
     pub span: Span,
@@ -1395,6 +1495,7 @@ impl IntoDiagnostic<'_> for DuplicateLangItem {
 
 #[derive(Diagnostic)]
 #[diag(passes_incorrect_target, code = "E0718")]
+#[must_use]
 pub struct IncorrectTarget<'a> {
     #[primary_span]
     pub span: Span,
@@ -1423,6 +1524,7 @@ pub struct OnlyHasEffectOn {
 
 #[derive(Diagnostic)]
 #[diag(passes_object_lifetime_err)]
+#[must_use]
 pub struct ObjectLifetimeErr {
     #[primary_span]
     pub span: Span,
@@ -1432,6 +1534,7 @@ pub struct ObjectLifetimeErr {
 #[derive(Diagnostic)]
 #[diag(passes_unrecognized_repr_hint, code = "E0552")]
 #[help]
+#[must_use]
 pub struct UnrecognizedReprHint {
     #[primary_span]
     pub span: Span,
@@ -1478,6 +1581,7 @@ pub enum AttrApplication {
 
 #[derive(Diagnostic)]
 #[diag(passes_transparent_incompatible, code = "E0692")]
+#[must_use]
 pub struct TransparentIncompatible {
     #[primary_span]
     pub hint_spans: Vec<Span>,
@@ -1486,6 +1590,7 @@ pub struct TransparentIncompatible {
 
 #[derive(Diagnostic)]
 #[diag(passes_deprecated_attribute, code = "E0549")]
+#[must_use]
 pub struct DeprecatedAttribute {
     #[primary_span]
     pub span: Span,
@@ -1493,6 +1598,7 @@ pub struct DeprecatedAttribute {
 
 #[derive(Diagnostic)]
 #[diag(passes_useless_stability)]
+#[must_use]
 pub struct UselessStability {
     #[primary_span]
     #[label]
@@ -1503,6 +1609,7 @@ pub struct UselessStability {
 
 #[derive(Diagnostic)]
 #[diag(passes_cannot_stabilize_deprecated)]
+#[must_use]
 pub struct CannotStabilizeDeprecated {
     #[primary_span]
     #[label]
@@ -1513,6 +1620,7 @@ pub struct CannotStabilizeDeprecated {
 
 #[derive(Diagnostic)]
 #[diag(passes_missing_stability_attr)]
+#[must_use]
 pub struct MissingStabilityAttr<'a> {
     #[primary_span]
     pub span: Span,
@@ -1521,6 +1629,7 @@ pub struct MissingStabilityAttr<'a> {
 
 #[derive(Diagnostic)]
 #[diag(passes_missing_const_stab_attr)]
+#[must_use]
 pub struct MissingConstStabAttr<'a> {
     #[primary_span]
     pub span: Span,
@@ -1530,6 +1639,7 @@ pub struct MissingConstStabAttr<'a> {
 #[derive(Diagnostic)]
 #[diag(passes_trait_impl_const_stable)]
 #[note]
+#[must_use]
 pub struct TraitImplConstStable {
     #[primary_span]
     pub span: Span,
@@ -1537,6 +1647,7 @@ pub struct TraitImplConstStable {
 
 #[derive(Diagnostic)]
 #[diag(passes_feature_only_on_nightly, code = "E0554")]
+#[must_use]
 pub struct FeatureOnlyOnNightly {
     #[primary_span]
     pub span: Span,
@@ -1545,6 +1656,7 @@ pub struct FeatureOnlyOnNightly {
 
 #[derive(Diagnostic)]
 #[diag(passes_unknown_feature, code = "E0635")]
+#[must_use]
 pub struct UnknownFeature {
     #[primary_span]
     pub span: Span,
@@ -1553,6 +1665,7 @@ pub struct UnknownFeature {
 
 #[derive(Diagnostic)]
 #[diag(passes_implied_feature_not_exist)]
+#[must_use]
 pub struct ImpliedFeatureNotExist {
     #[primary_span]
     pub span: Span,
@@ -1562,6 +1675,7 @@ pub struct ImpliedFeatureNotExist {
 
 #[derive(Diagnostic)]
 #[diag(passes_duplicate_feature_err, code = "E0636")]
+#[must_use]
 pub struct DuplicateFeatureErr {
     #[primary_span]
     pub span: Span,
@@ -1569,6 +1683,7 @@ pub struct DuplicateFeatureErr {
 }
 #[derive(Diagnostic)]
 #[diag(passes_missing_const_err)]
+#[must_use]
 pub struct MissingConstErr {
     #[primary_span]
     #[help]
@@ -1635,6 +1750,7 @@ pub struct ChangeFieldsToBeOfUnitType {
 
 #[derive(Diagnostic)]
 #[diag(passes_proc_macro_bad_sig)]
+#[must_use]
 pub(crate) struct ProcMacroBadSig {
     #[primary_span]
     pub span: Span,
@@ -1643,6 +1759,7 @@ pub(crate) struct ProcMacroBadSig {
 
 #[derive(Diagnostic)]
 #[diag(passes_skipping_const_checks)]
+#[must_use]
 pub struct SkippingConstChecks {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -4,6 +4,7 @@ use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(privacy_field_is_private, code = "E0451")]
+#[must_use]
 pub struct FieldIsPrivate {
     #[primary_span]
     pub span: Span,
@@ -31,6 +32,7 @@ pub enum FieldIsPrivateLabel {
 
 #[derive(Diagnostic)]
 #[diag(privacy_item_is_private)]
+#[must_use]
 pub struct ItemIsPrivate<'a> {
     #[primary_span]
     #[label]
@@ -41,6 +43,7 @@ pub struct ItemIsPrivate<'a> {
 
 #[derive(Diagnostic)]
 #[diag(privacy_unnamed_item_is_private)]
+#[must_use]
 pub struct UnnamedItemIsPrivate {
     #[primary_span]
     pub span: Span,
@@ -49,6 +52,7 @@ pub struct UnnamedItemIsPrivate {
 
 #[derive(Diagnostic)]
 #[diag(privacy_in_public_interface, code = "E0446")]
+#[must_use]
 pub struct InPublicInterface<'a> {
     #[primary_span]
     #[label]
@@ -62,6 +66,7 @@ pub struct InPublicInterface<'a> {
 
 #[derive(Diagnostic)]
 #[diag(privacy_report_effective_visibility)]
+#[must_use]
 pub struct ReportEffectiveVisibility {
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_query_system/src/error.rs
+++ b/compiler/rustc_query_system/src/error.rs
@@ -46,6 +46,7 @@ pub struct CycleUsage {
 
 #[derive(Diagnostic)]
 #[diag(query_system_cycle, code = "E0391")]
+#[must_use]
 pub struct Cycle {
     #[primary_span]
     pub span: Span,
@@ -64,6 +65,7 @@ pub struct Cycle {
 
 #[derive(Diagnostic)]
 #[diag(query_system_reentrant)]
+#[must_use]
 pub struct Reentrant;
 
 #[derive(Diagnostic)]
@@ -71,6 +73,7 @@ pub struct Reentrant;
 #[help]
 #[note(query_system_increment_compilation_note1)]
 #[note(query_system_increment_compilation_note2)]
+#[must_use]
 pub struct IncrementCompilation {
     pub run_cmd: String,
     pub dep_node: String,
@@ -79,6 +82,7 @@ pub struct IncrementCompilation {
 #[derive(Diagnostic)]
 #[help]
 #[diag(query_system_query_overflow)]
+#[must_use]
 pub struct QueryOverflow {
     #[primary_span]
     pub span: Option<Span>,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -8,32 +8,39 @@ use crate::{late::PatternSource, Res};
 
 #[derive(Diagnostic)]
 #[diag(resolve_parent_module_reset_for_binding, code = "E0637")]
+#[must_use]
 pub(crate) struct ParentModuleResetForBinding;
 
 #[derive(Diagnostic)]
 #[diag(resolve_ampersand_used_without_explicit_lifetime_name, code = "E0637")]
 #[note]
+#[must_use]
 pub(crate) struct AmpersandUsedWithoutExplicitLifetimeName(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_underscore_lifetime_name_cannot_be_used_here, code = "E0637")]
 #[note]
+#[must_use]
 pub(crate) struct UnderscoreLifetimeNameCannotBeUsedHere(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_crate_may_not_be_imported)]
+#[must_use]
 pub(crate) struct CrateMayNotBeImported(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_crate_root_imports_must_be_named_explicitly)]
+#[must_use]
 pub(crate) struct CrateRootNamesMustBeNamedExplicitly(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_crate_root_imports_must_be_named_explicitly)]
+#[must_use]
 pub(crate) struct ResolutionError(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_generic_params_from_outer_item, code = "E0401")]
+#[must_use]
 pub(crate) struct GenericParamsFromOuterItem {
     #[primary_span]
     #[label]
@@ -68,6 +75,7 @@ pub(crate) struct GenericParamsFromOuterItemSugg {
 
 #[derive(Diagnostic)]
 #[diag(resolve_name_is_already_used_as_generic_parameter, code = "E0403")]
+#[must_use]
 pub(crate) struct NameAlreadyUsedInParameterList {
     #[primary_span]
     #[label]
@@ -79,6 +87,7 @@ pub(crate) struct NameAlreadyUsedInParameterList {
 
 #[derive(Diagnostic)]
 #[diag(resolve_method_not_member_of_trait, code = "E0407")]
+#[must_use]
 pub(crate) struct MethodNotMemberOfTrait {
     #[primary_span]
     #[label]
@@ -103,6 +112,7 @@ pub(crate) struct AssociatedFnWithSimilarNameExists {
 
 #[derive(Diagnostic)]
 #[diag(resolve_type_not_member_of_trait, code = "E0437")]
+#[must_use]
 pub(crate) struct TypeNotMemberOfTrait {
     #[primary_span]
     #[label]
@@ -127,6 +137,7 @@ pub(crate) struct AssociatedTypeWithSimilarNameExists {
 
 #[derive(Diagnostic)]
 #[diag(resolve_const_not_member_of_trait, code = "E0438")]
+#[must_use]
 pub(crate) struct ConstNotMemberOfTrait {
     #[primary_span]
     #[label]
@@ -151,6 +162,7 @@ pub(crate) struct AssociatedConstWithSimilarNameExists {
 
 #[derive(Diagnostic)]
 #[diag(resolve_variable_bound_with_different_mode, code = "E0409")]
+#[must_use]
 pub(crate) struct VariableBoundWithDifferentMode {
     #[primary_span]
     #[label]
@@ -162,6 +174,7 @@ pub(crate) struct VariableBoundWithDifferentMode {
 
 #[derive(Diagnostic)]
 #[diag(resolve_ident_bound_more_than_once_in_parameter_list, code = "E0415")]
+#[must_use]
 pub(crate) struct IdentifierBoundMoreThanOnceInParameterList {
     #[primary_span]
     #[label]
@@ -171,6 +184,7 @@ pub(crate) struct IdentifierBoundMoreThanOnceInParameterList {
 
 #[derive(Diagnostic)]
 #[diag(resolve_ident_bound_more_than_once_in_same_pattern, code = "E0416")]
+#[must_use]
 pub(crate) struct IdentifierBoundMoreThanOnceInSamePattern {
     #[primary_span]
     #[label]
@@ -180,6 +194,7 @@ pub(crate) struct IdentifierBoundMoreThanOnceInSamePattern {
 
 #[derive(Diagnostic)]
 #[diag(resolve_undeclared_label, code = "E0426")]
+#[must_use]
 pub(crate) struct UndeclaredLabel {
     #[primary_span]
     #[label]
@@ -218,6 +233,7 @@ pub(crate) struct UnreachableLabelWithSimilarNameExists {
 
 #[derive(Diagnostic)]
 #[diag(resolve_self_import_can_only_appear_once_in_the_list, code = "E0430")]
+#[must_use]
 pub(crate) struct SelfImportCanOnlyAppearOnceInTheList {
     #[primary_span]
     #[label]
@@ -226,6 +242,7 @@ pub(crate) struct SelfImportCanOnlyAppearOnceInTheList {
 
 #[derive(Diagnostic)]
 #[diag(resolve_self_import_only_in_import_list_with_non_empty_prefix, code = "E0431")]
+#[must_use]
 pub(crate) struct SelfImportOnlyInImportListWithNonEmptyPrefix {
     #[primary_span]
     #[label]
@@ -235,6 +252,7 @@ pub(crate) struct SelfImportOnlyInImportListWithNonEmptyPrefix {
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_capture_dynamic_environment_in_fn_item, code = "E0434")]
 #[help]
+#[must_use]
 pub(crate) struct CannotCaptureDynamicEnvironmentInFnItem {
     #[primary_span]
     pub(crate) span: Span,
@@ -242,6 +260,7 @@ pub(crate) struct CannotCaptureDynamicEnvironmentInFnItem {
 
 #[derive(Diagnostic)]
 #[diag(resolve_attempt_to_use_non_constant_value_in_constant, code = "E0435")]
+#[must_use]
 pub(crate) struct AttemptToUseNonConstantValueInConstant<'a> {
     #[primary_span]
     pub(crate) span: Span,
@@ -284,6 +303,7 @@ pub(crate) struct AttemptToUseNonConstantValueInConstantWithoutSuggestion<'a> {
 
 #[derive(Diagnostic)]
 #[diag(resolve_self_imports_only_allowed_within, code = "E0429")]
+#[must_use]
 pub(crate) struct SelfImportsOnlyAllowedWithin {
     #[primary_span]
     pub(crate) span: Span,
@@ -318,6 +338,7 @@ pub(crate) struct SelfImportsOnlyAllowedWithinMultipartSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(resolve_binding_shadows_something_unacceptable, code = "E0530")]
+#[must_use]
 pub(crate) struct BindingShadowsSomethingUnacceptable<'a> {
     #[primary_span]
     #[label]
@@ -347,6 +368,7 @@ pub(crate) struct BindingShadowsSomethingUnacceptableSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(resolve_forward_declared_generic_param, code = "E0128")]
+#[must_use]
 pub(crate) struct ForwardDeclaredGenericParam {
     #[primary_span]
     #[label]
@@ -355,6 +377,7 @@ pub(crate) struct ForwardDeclaredGenericParam {
 
 #[derive(Diagnostic)]
 #[diag(resolve_param_in_ty_of_const_param, code = "E0770")]
+#[must_use]
 pub(crate) struct ParamInTyOfConstParam {
     #[primary_span]
     #[label]
@@ -377,6 +400,7 @@ pub(crate) enum ParamKindInTyOfConstParam {
 
 #[derive(Diagnostic)]
 #[diag(resolve_self_in_generic_param_default, code = "E0735")]
+#[must_use]
 pub(crate) struct SelfInGenericParamDefault {
     #[primary_span]
     #[label]
@@ -385,6 +409,7 @@ pub(crate) struct SelfInGenericParamDefault {
 
 #[derive(Diagnostic)]
 #[diag(resolve_param_in_non_trivial_anon_const)]
+#[must_use]
 pub(crate) struct ParamInNonTrivialAnonConst {
     #[primary_span]
     #[label]
@@ -414,6 +439,7 @@ pub(crate) enum ParamKindInNonTrivialAnonConst {
 #[derive(Diagnostic)]
 #[diag(resolve_unreachable_label, code = "E0767")]
 #[note]
+#[must_use]
 pub(crate) struct UnreachableLabel {
     #[primary_span]
     #[label]
@@ -457,6 +483,7 @@ pub(crate) struct UnreachableLabelSubLabelUnreachable {
 
 #[derive(Diagnostic)]
 #[diag(resolve_trait_impl_mismatch, code = "{code}")]
+#[must_use]
 pub(crate) struct TraitImplMismatch {
     #[primary_span]
     #[label]
@@ -472,6 +499,7 @@ pub(crate) struct TraitImplMismatch {
 #[derive(Diagnostic)]
 #[diag(resolve_invalid_asm_sym)]
 #[help]
+#[must_use]
 pub(crate) struct InvalidAsmSym {
     #[primary_span]
     #[label]
@@ -480,6 +508,7 @@ pub(crate) struct InvalidAsmSym {
 
 #[derive(Diagnostic)]
 #[diag(resolve_lowercase_self)]
+#[must_use]
 pub(crate) struct LowercaseSelf {
     #[primary_span]
     #[suggestion(code = "Self", applicability = "maybe-incorrect", style = "short")]
@@ -488,6 +517,7 @@ pub(crate) struct LowercaseSelf {
 
 #[derive(Diagnostic)]
 #[diag(resolve_trait_impl_duplicate, code = "E0201")]
+#[must_use]
 pub(crate) struct TraitImplDuplicate {
     #[primary_span]
     #[label]
@@ -501,6 +531,7 @@ pub(crate) struct TraitImplDuplicate {
 
 #[derive(Diagnostic)]
 #[diag(resolve_relative_2018)]
+#[must_use]
 pub(crate) struct Relative2018 {
     #[primary_span]
     pub(crate) span: Span,
@@ -511,10 +542,12 @@ pub(crate) struct Relative2018 {
 
 #[derive(Diagnostic)]
 #[diag(resolve_ancestor_only, code = "E0742")]
+#[must_use]
 pub(crate) struct AncestorOnly(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_expected_found, code = "E0577")]
+#[must_use]
 pub(crate) struct ExpectedFound {
     #[primary_span]
     #[label]
@@ -525,10 +558,12 @@ pub(crate) struct ExpectedFound {
 
 #[derive(Diagnostic)]
 #[diag(resolve_indeterminate, code = "E0578")]
+#[must_use]
 pub(crate) struct Indeterminate(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic)]
 #[diag(resolve_tool_module_imported)]
+#[must_use]
 pub(crate) struct ToolModuleImported {
     #[primary_span]
     pub(crate) span: Span,
@@ -538,10 +573,12 @@ pub(crate) struct ToolModuleImported {
 
 #[derive(Diagnostic)]
 #[diag(resolve_module_only)]
+#[must_use]
 pub(crate) struct ModuleOnly(#[primary_span] pub(crate) Span);
 
 #[derive(Diagnostic, Default)]
 #[diag(resolve_macro_expected_found)]
+#[must_use]
 pub(crate) struct MacroExpectedFound<'a> {
     #[primary_span]
     pub(crate) span: Span,
@@ -569,6 +606,7 @@ pub(crate) struct AddAsNonDerive<'a> {
 
 #[derive(Diagnostic)]
 #[diag(resolve_proc_macro_same_crate)]
+#[must_use]
 pub(crate) struct ProcMacroSameCrate {
     #[primary_span]
     pub(crate) span: Span,
@@ -578,6 +616,7 @@ pub(crate) struct ProcMacroSameCrate {
 
 #[derive(Diagnostic)]
 #[diag(resolve_imported_crate)]
+#[must_use]
 pub(crate) struct CrateImported {
     #[primary_span]
     pub(crate) span: Span,
@@ -585,6 +624,7 @@ pub(crate) struct CrateImported {
 
 #[derive(Diagnostic)]
 #[diag(resolve_macro_use_extern_crate_self)]
+#[must_use]
 pub(crate) struct MacroUseExternCrateSelf {
     #[primary_span]
     pub(crate) span: Span,
@@ -593,6 +633,7 @@ pub(crate) struct MacroUseExternCrateSelf {
 #[derive(Diagnostic)]
 #[diag(resolve_accessible_unsure)]
 #[note]
+#[must_use]
 pub(crate) struct CfgAccessibleUnsure {
     #[primary_span]
     pub(crate) span: Span,
@@ -601,6 +642,7 @@ pub(crate) struct CfgAccessibleUnsure {
 #[derive(Debug)]
 #[derive(Diagnostic)]
 #[diag(resolve_param_in_enum_discriminant)]
+#[must_use]
 pub(crate) struct ParamInEnumDiscriminant {
     #[primary_span]
     #[label]
@@ -642,6 +684,7 @@ pub(crate) struct ChangeImportBindingSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(resolve_imports_cannot_refer_to)]
+#[must_use]
 pub(crate) struct ImportsCannotReferTo<'a> {
     #[primary_span]
     pub(crate) span: Span,
@@ -650,6 +693,7 @@ pub(crate) struct ImportsCannotReferTo<'a> {
 
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_find_ident_in_this_scope)]
+#[must_use]
 pub(crate) struct CannotFindIdentInThisScope<'a> {
     #[primary_span]
     pub(crate) span: Span,
@@ -690,6 +734,7 @@ pub(crate) struct ConsiderAddingADerive {
 
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_determine_import_resolution)]
+#[must_use]
 pub(crate) struct CannotDetermineImportResolution {
     #[primary_span]
     pub(crate) span: Span,
@@ -698,6 +743,7 @@ pub(crate) struct CannotDetermineImportResolution {
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_determine_macro_resolution)]
 #[note]
+#[must_use]
 pub(crate) struct CannotDetermineMacroResolution {
     #[primary_span]
     pub(crate) span: Span,
@@ -707,6 +753,7 @@ pub(crate) struct CannotDetermineMacroResolution {
 
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_be_reexported_private, code = "E0364")]
+#[must_use]
 pub(crate) struct CannotBeReexportedPrivate {
     #[primary_span]
     pub(crate) span: Span,
@@ -715,6 +762,7 @@ pub(crate) struct CannotBeReexportedPrivate {
 
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_be_reexported_crate_public, code = "E0364")]
+#[must_use]
 pub(crate) struct CannotBeReexportedCratePublic {
     #[primary_span]
     pub(crate) span: Span,
@@ -724,6 +772,7 @@ pub(crate) struct CannotBeReexportedCratePublic {
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_be_reexported_private, code = "E0365")]
 #[note(resolve_consider_declaring_with_pub)]
+#[must_use]
 pub(crate) struct CannotBeReexportedPrivateNS {
     #[primary_span]
     #[label(resolve_reexport_of_private)]
@@ -734,6 +783,7 @@ pub(crate) struct CannotBeReexportedPrivateNS {
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_be_reexported_crate_public, code = "E0365")]
 #[note(resolve_consider_declaring_with_pub)]
+#[must_use]
 pub(crate) struct CannotBeReexportedCratePublicNS {
     #[primary_span]
     #[label(resolve_reexport_of_crate_public)]
@@ -758,6 +808,7 @@ pub(crate) struct ConsiderMarkingAsPub {
 
 #[derive(Diagnostic)]
 #[diag(resolve_cannot_glob_import_possible_crates)]
+#[must_use]
 pub(crate) struct CannotGlobImportAllCrates {
     #[primary_span]
     pub(crate) span: Span,
@@ -765,6 +816,7 @@ pub(crate) struct CannotGlobImportAllCrates {
 
 #[derive(Diagnostic)]
 #[diag(resolve_items_in_traits_are_not_importable)]
+#[must_use]
 pub(crate) struct ItemsInTraitsAreNotImportable {
     #[primary_span]
     pub(crate) span: Span,
@@ -772,6 +824,7 @@ pub(crate) struct ItemsInTraitsAreNotImportable {
 
 #[derive(Diagnostic)]
 #[diag(resolve_is_not_directly_importable, code = "E0253")]
+#[must_use]
 pub(crate) struct IsNotDirectlyImportable {
     #[primary_span]
     #[label]

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -28,66 +28,78 @@ impl<'a> IntoDiagnostic<'a> for FeatureGateError {
 
 #[derive(Subdiagnostic)]
 #[note(session_feature_diagnostic_for_issue)]
+#[must_use]
 pub struct FeatureDiagnosticForIssue {
     pub n: NonZeroU32,
 }
 
 #[derive(Subdiagnostic)]
 #[help(session_feature_diagnostic_help)]
+#[must_use]
 pub struct FeatureDiagnosticHelp {
     pub feature: Symbol,
 }
 
 #[derive(Subdiagnostic)]
 #[help(session_cli_feature_diagnostic_help)]
+#[must_use]
 pub struct CliFeatureDiagnosticHelp {
     pub feature: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_not_circumvent_feature)]
+#[must_use]
 pub struct NotCircumventFeature;
 
 #[derive(Diagnostic)]
 #[diag(session_linker_plugin_lto_windows_not_supported)]
+#[must_use]
 pub struct LinkerPluginToWindowsNotSupported;
 
 #[derive(Diagnostic)]
 #[diag(session_profile_use_file_does_not_exist)]
+#[must_use]
 pub struct ProfileUseFileDoesNotExist<'a> {
     pub path: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_profile_sample_use_file_does_not_exist)]
+#[must_use]
 pub struct ProfileSampleUseFileDoesNotExist<'a> {
     pub path: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_target_requires_unwind_tables)]
+#[must_use]
 pub struct TargetRequiresUnwindTables;
 
 #[derive(Diagnostic)]
 #[diag(session_instrumentation_not_supported)]
+#[must_use]
 pub struct InstrumentationNotSupported {
     pub us: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_not_supported)]
+#[must_use]
 pub struct SanitizerNotSupported {
     pub us: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizers_not_supported)]
+#[must_use]
 pub struct SanitizersNotSupported {
     pub us: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_cannot_mix_and_match_sanitizers)]
+#[must_use]
 pub struct CannotMixAndMatchSanitizers {
     pub first: String,
     pub second: String,
@@ -95,44 +107,54 @@ pub struct CannotMixAndMatchSanitizers {
 
 #[derive(Diagnostic)]
 #[diag(session_cannot_enable_crt_static_linux)]
+#[must_use]
 pub struct CannotEnableCrtStaticLinux;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_requires_lto)]
+#[must_use]
 pub struct SanitizerCfiRequiresLto;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_requires_single_codegen_unit)]
+#[must_use]
 pub struct SanitizerCfiRequiresSingleCodegenUnit;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_canonical_jump_tables_requires_cfi)]
+#[must_use]
 pub struct SanitizerCfiCanonicalJumpTablesRequiresCfi;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_generalize_pointers_requires_cfi)]
+#[must_use]
 pub struct SanitizerCfiGeneralizePointersRequiresCfi;
 
 #[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_normalize_integers_requires_cfi)]
+#[must_use]
 pub struct SanitizerCfiNormalizeIntegersRequiresCfi;
 
 #[derive(Diagnostic)]
 #[diag(session_split_lto_unit_requires_lto)]
+#[must_use]
 pub struct SplitLtoUnitRequiresLto;
 
 #[derive(Diagnostic)]
 #[diag(session_unstable_virtual_function_elimination)]
+#[must_use]
 pub struct UnstableVirtualFunctionElimination;
 
 #[derive(Diagnostic)]
 #[diag(session_unsupported_dwarf_version)]
+#[must_use]
 pub struct UnsupportedDwarfVersion {
     pub dwarf_version: u32,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_target_stack_protector_not_supported)]
+#[must_use]
 pub struct StackProtectorNotSupportedForTarget<'a> {
     pub stack_protector: StackProtector,
     pub target_triple: &'a TargetTriple,
@@ -140,22 +162,26 @@ pub struct StackProtectorNotSupportedForTarget<'a> {
 
 #[derive(Diagnostic)]
 #[diag(session_branch_protection_requires_aarch64)]
+#[must_use]
 pub(crate) struct BranchProtectionRequiresAArch64;
 
 #[derive(Diagnostic)]
 #[diag(session_split_debuginfo_unstable_platform)]
+#[must_use]
 pub struct SplitDebugInfoUnstablePlatform {
     pub debuginfo: SplitDebuginfo,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_file_is_not_writeable)]
+#[must_use]
 pub struct FileIsNotWriteable<'a> {
     pub file: &'a std::path::Path,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_file_write_fail)]
+#[must_use]
 pub(crate) struct FileWriteFail<'a> {
     pub path: &'a std::path::Path,
     pub err: String,
@@ -163,6 +189,7 @@ pub(crate) struct FileWriteFail<'a> {
 
 #[derive(Diagnostic)]
 #[diag(session_crate_name_does_not_match)]
+#[must_use]
 pub struct CrateNameDoesNotMatch {
     #[primary_span]
     pub span: Span,
@@ -172,12 +199,14 @@ pub struct CrateNameDoesNotMatch {
 
 #[derive(Diagnostic)]
 #[diag(session_crate_name_invalid)]
+#[must_use]
 pub struct CrateNameInvalid<'a> {
     pub s: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag(session_crate_name_empty)]
+#[must_use]
 pub struct CrateNameEmpty {
     #[primary_span]
     pub span: Option<Span>,
@@ -185,6 +214,7 @@ pub struct CrateNameEmpty {
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_character_in_create_name)]
+#[must_use]
 pub struct InvalidCharacterInCrateName {
     #[primary_span]
     pub span: Option<Span>,
@@ -217,6 +247,7 @@ impl ExprParenthesesNeeded {
 
 #[derive(Diagnostic)]
 #[diag(session_skipping_const_checks)]
+#[must_use]
 pub struct SkippingConstChecks {
     #[subdiagnostic]
     pub unleashed_features: Vec<UnleashedFeatureHelp>,
@@ -239,6 +270,7 @@ pub enum UnleashedFeatureHelp {
 
 #[derive(Diagnostic)]
 #[diag(session_invalid_literal_suffix)]
+#[must_use]
 pub(crate) struct InvalidLiteralSuffix<'a> {
     #[primary_span]
     #[label]
@@ -251,6 +283,7 @@ pub(crate) struct InvalidLiteralSuffix<'a> {
 #[derive(Diagnostic)]
 #[diag(session_invalid_int_literal_width)]
 #[help]
+#[must_use]
 pub(crate) struct InvalidIntLiteralWidth {
     #[primary_span]
     pub span: Span,
@@ -260,6 +293,7 @@ pub(crate) struct InvalidIntLiteralWidth {
 #[derive(Diagnostic)]
 #[diag(session_invalid_num_literal_base_prefix)]
 #[note]
+#[must_use]
 pub(crate) struct InvalidNumLiteralBasePrefix {
     #[primary_span]
     #[suggestion(applicability = "maybe-incorrect", code = "{fixed}")]
@@ -270,6 +304,7 @@ pub(crate) struct InvalidNumLiteralBasePrefix {
 #[derive(Diagnostic)]
 #[diag(session_invalid_num_literal_suffix)]
 #[help]
+#[must_use]
 pub(crate) struct InvalidNumLiteralSuffix {
     #[primary_span]
     #[label]
@@ -280,6 +315,7 @@ pub(crate) struct InvalidNumLiteralSuffix {
 #[derive(Diagnostic)]
 #[diag(session_invalid_float_literal_width)]
 #[help]
+#[must_use]
 pub(crate) struct InvalidFloatLiteralWidth {
     #[primary_span]
     pub span: Span,
@@ -289,6 +325,7 @@ pub(crate) struct InvalidFloatLiteralWidth {
 #[derive(Diagnostic)]
 #[diag(session_invalid_float_literal_suffix)]
 #[help]
+#[must_use]
 pub(crate) struct InvalidFloatLiteralSuffix {
     #[primary_span]
     #[label]
@@ -299,6 +336,7 @@ pub(crate) struct InvalidFloatLiteralSuffix {
 #[derive(Diagnostic)]
 #[diag(session_int_literal_too_large)]
 #[note]
+#[must_use]
 pub(crate) struct IntLiteralTooLarge {
     #[primary_span]
     pub span: Span,
@@ -307,6 +345,7 @@ pub(crate) struct IntLiteralTooLarge {
 
 #[derive(Diagnostic)]
 #[diag(session_hexadecimal_float_literal_not_supported)]
+#[must_use]
 pub(crate) struct HexadecimalFloatLiteralNotSupported {
     #[primary_span]
     #[label(session_not_supported)]
@@ -315,6 +354,7 @@ pub(crate) struct HexadecimalFloatLiteralNotSupported {
 
 #[derive(Diagnostic)]
 #[diag(session_octal_float_literal_not_supported)]
+#[must_use]
 pub(crate) struct OctalFloatLiteralNotSupported {
     #[primary_span]
     #[label(session_not_supported)]
@@ -323,6 +363,7 @@ pub(crate) struct OctalFloatLiteralNotSupported {
 
 #[derive(Diagnostic)]
 #[diag(session_binary_float_literal_not_supported)]
+#[must_use]
 pub(crate) struct BinaryFloatLiteralNotSupported {
     #[primary_span]
     #[label(session_not_supported)]
@@ -331,6 +372,7 @@ pub(crate) struct BinaryFloatLiteralNotSupported {
 
 #[derive(Diagnostic)]
 #[diag(session_nul_in_c_str)]
+#[must_use]
 pub(crate) struct NulInCStr {
     #[primary_span]
     pub span: Span,
@@ -425,6 +467,7 @@ pub fn report_lit_error(sess: &ParseSess, err: LitError, lit: token::Lit, span: 
 
 #[derive(Diagnostic)]
 #[diag(session_optimization_fuel_exhausted)]
+#[must_use]
 pub struct OptimisationFuelExhausted {
     pub msg: String,
 }
@@ -432,6 +475,7 @@ pub struct OptimisationFuelExhausted {
 #[derive(Diagnostic)]
 #[diag(session_incompatible_linker_flavor)]
 #[note]
+#[must_use]
 pub struct IncompatibleLinkerFlavor {
     pub flavor: &'static str,
     pub compatible_list: String,
@@ -439,14 +483,17 @@ pub struct IncompatibleLinkerFlavor {
 
 #[derive(Diagnostic)]
 #[diag(session_function_return_requires_x86_or_x86_64)]
+#[must_use]
 pub(crate) struct FunctionReturnRequiresX86OrX8664;
 
 #[derive(Diagnostic)]
 #[diag(session_function_return_thunk_extern_requires_non_large_code_model)]
+#[must_use]
 pub(crate) struct FunctionReturnThunkExternRequiresNonLargeCodeModel;
 
 #[derive(Diagnostic)]
 #[diag(session_failed_to_create_profiler)]
+#[must_use]
 pub struct FailedToCreateProfiler {
     pub err: String,
 }

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -9,6 +9,7 @@ use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(trait_selection_dump_vtable_entries)]
+#[must_use]
 pub struct DumpVTableEntries<'a> {
     #[primary_span]
     pub span: Span,
@@ -18,6 +19,7 @@ pub struct DumpVTableEntries<'a> {
 
 #[derive(Diagnostic)]
 #[diag(trait_selection_unable_to_construct_constant_value)]
+#[must_use]
 pub struct UnableToConstructConstantValue<'a> {
     #[primary_span]
     pub span: Span,
@@ -26,6 +28,7 @@ pub struct UnableToConstructConstantValue<'a> {
 
 #[derive(Diagnostic)]
 #[diag(trait_selection_empty_on_clause_in_rustc_on_unimplemented, code = "E0232")]
+#[must_use]
 pub struct EmptyOnClauseInOnUnimplemented {
     #[primary_span]
     #[label]
@@ -34,6 +37,7 @@ pub struct EmptyOnClauseInOnUnimplemented {
 
 #[derive(Diagnostic)]
 #[diag(trait_selection_invalid_on_clause_in_rustc_on_unimplemented, code = "E0232")]
+#[must_use]
 pub struct InvalidOnClauseInOnUnimplemented {
     #[primary_span]
     #[label]
@@ -43,6 +47,7 @@ pub struct InvalidOnClauseInOnUnimplemented {
 #[derive(Diagnostic)]
 #[diag(trait_selection_no_value_in_rustc_on_unimplemented, code = "E0232")]
 #[note]
+#[must_use]
 pub struct NoValueInOnUnimplemented {
     #[primary_span]
     #[label]
@@ -95,6 +100,7 @@ impl IntoDiagnostic<'_> for NegativePositiveConflict<'_> {
 
 #[derive(Diagnostic)]
 #[diag(trait_selection_inherent_projection_normalization_overflow)]
+#[must_use]
 pub struct InherentProjectionNormalizationOverflow {
     #[primary_span]
     pub span: Span,
@@ -134,6 +140,7 @@ impl AddToDiagnostic for AdjustSignatureBorrow {
 
 #[derive(Diagnostic)]
 #[diag(trait_selection_closure_kind_mismatch, code = "E0525")]
+#[must_use]
 pub struct ClosureKindMismatch {
     #[primary_span]
     #[label]

--- a/compiler/rustc_ty_utils/src/errors.rs
+++ b/compiler/rustc_ty_utils/src/errors.rs
@@ -6,6 +6,7 @@ use rustc_span::Span;
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_needs_drop_overflow)]
+#[must_use]
 pub struct NeedsDropOverflow<'tcx> {
     pub query_ty: Ty<'tcx>,
 }
@@ -13,6 +14,7 @@ pub struct NeedsDropOverflow<'tcx> {
 #[derive(Diagnostic)]
 #[diag(ty_utils_generic_constant_too_complex)]
 #[help]
+#[must_use]
 pub struct GenericConstantTooComplex {
     #[primary_span]
     pub span: Span,
@@ -70,6 +72,7 @@ pub enum GenericConstantTooComplexSub {
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_unexpected_fnptr_associated_item)]
+#[must_use]
 pub struct UnexpectedFnPtrAssociatedItem {
     #[primary_span]
     pub span: Span,
@@ -77,18 +80,21 @@ pub struct UnexpectedFnPtrAssociatedItem {
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_zero_length_simd_type)]
+#[must_use]
 pub struct ZeroLengthSimdType<'tcx> {
     pub ty: Ty<'tcx>,
 }
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_multiple_array_fields_simd_type)]
+#[must_use]
 pub struct MultipleArrayFieldsSimdType<'tcx> {
     pub ty: Ty<'tcx>,
 }
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_oversized_simd_type)]
+#[must_use]
 pub struct OversizedSimdType<'tcx> {
     pub ty: Ty<'tcx>,
     pub max_lanes: u64,
@@ -96,6 +102,7 @@ pub struct OversizedSimdType<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_non_primitive_simd_type)]
+#[must_use]
 pub struct NonPrimitiveSimdType<'tcx> {
     pub ty: Ty<'tcx>,
     pub e_ty: Ty<'tcx>,
@@ -103,6 +110,7 @@ pub struct NonPrimitiveSimdType<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_impl_trait_duplicate_arg)]
+#[must_use]
 pub struct DuplicateArg<'tcx> {
     pub arg: GenericArg<'tcx>,
     #[primary_span]
@@ -114,6 +122,7 @@ pub struct DuplicateArg<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(ty_utils_impl_trait_not_param, code = "E0792")]
+#[must_use]
 pub struct NotParam<'tcx> {
     pub arg: GenericArg<'tcx>,
     #[primary_span]

--- a/tests/ui-fulldeps/internal-lints/diagnostics.rs
+++ b/tests/ui-fulldeps/internal-lints/diagnostics.rs
@@ -23,6 +23,7 @@ rustc_fluent_macro::fluent_messages! { "./diagnostics.ftl" }
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct DeriveDiagnostic {
     #[primary_span]
     span: Span,

--- a/tests/ui-fulldeps/internal-lints/diagnostics.stderr
+++ b/tests/ui-fulldeps/internal-lints/diagnostics.stderr
@@ -1,5 +1,5 @@
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:42:13
+  --> $DIR/diagnostics.rs:43:13
    |
 LL |         dcx.struct_err("untranslatable diagnostic")
    |             ^^^^^^^^^^
@@ -11,13 +11,13 @@ LL | #![deny(rustc::untranslatable_diagnostic)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:62:14
+  --> $DIR/diagnostics.rs:63:14
    |
 LL |         diag.note("untranslatable diagnostic");
    |              ^^^^
 
 error: diagnostics should only be created in `IntoDiagnostic`/`AddToDiagnostic` impls
-  --> $DIR/diagnostics.rs:79:21
+  --> $DIR/diagnostics.rs:80:21
    |
 LL |     let _diag = dcx.struct_err(crate::fluent_generated::no_crate_example);
    |                     ^^^^^^^^^^
@@ -29,13 +29,13 @@ LL | #![deny(rustc::diagnostic_outside_of_impl)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostics should only be created in `IntoDiagnostic`/`AddToDiagnostic` impls
-  --> $DIR/diagnostics.rs:82:21
+  --> $DIR/diagnostics.rs:83:21
    |
 LL |     let _diag = dcx.struct_err("untranslatable diagnostic");
    |                     ^^^^^^^^^^
 
 error: diagnostics should be created using translatable messages
-  --> $DIR/diagnostics.rs:82:21
+  --> $DIR/diagnostics.rs:83:21
    |
 LL |     let _diag = dcx.struct_err("untranslatable diagnostic");
    |                     ^^^^^^^^^^

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.rs
@@ -29,6 +29,7 @@ struct NotIntoDiagnosticArg;
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct Test {
     #[primary_span]
     span: Span,

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive-doc-comment-field.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:36:10
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:37:10
    |
 LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call
@@ -13,7 +13,7 @@ note: required by a bound in `DiagnosticBuilder::<'a, G>::set_arg`
    = note: this error originates in the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotIntoDiagnosticArg: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive-doc-comment-field.rs:46:10
+  --> $DIR/diagnostic-derive-doc-comment-field.rs:47:10
    |
 LL | #[derive(Subdiagnostic)]
    |          ------------- required by a bound introduced by this call

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -33,10 +33,12 @@ rustc_fluent_macro::fluent_messages! { "./example.ftl" }
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct Hello {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct HelloWarn {}
 
 #[derive(Diagnostic)]
@@ -53,6 +55,7 @@ enum DiagnosticOnEnum {
 #[diag(no_crate_example, code = "E0123")]
 #[diag = "E0123"]
 //~^ ERROR failed to resolve: maybe a missing crate `core`
+#[must_use]
 struct WrongStructAttrStyle {}
 
 #[derive(Diagnostic)]
@@ -60,43 +63,51 @@ struct WrongStructAttrStyle {}
 //~^ ERROR `#[nonsense(...)]` is not a valid attribute
 //~^^ ERROR diagnostic slug not specified
 //~^^^ ERROR cannot find attribute `nonsense` in this scope
+#[must_use]
 struct InvalidStructAttr {}
 
 #[derive(Diagnostic)]
 #[diag("E0123")]
 //~^ ERROR diagnostic slug not specified
+#[must_use]
 struct InvalidLitNestedAttr {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense, code = "E0123")]
 //~^ ERROR cannot find value `nonsense` in module `crate::fluent_generated`
+#[must_use]
 struct InvalidNestedStructAttr {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense("foo"), code = "E0123", slug = "foo")]
 //~^ ERROR diagnostic slug must be the first argument
 //~| ERROR diagnostic slug not specified
+#[must_use]
 struct InvalidNestedStructAttr1 {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense = "...", code = "E0123", slug = "foo")]
 //~^ ERROR unknown argument
 //~| ERROR diagnostic slug not specified
+#[must_use]
 struct InvalidNestedStructAttr2 {}
 
 #[derive(Diagnostic)]
 #[diag(nonsense = 4, code = "E0123", slug = "foo")]
 //~^ ERROR unknown argument
 //~| ERROR diagnostic slug not specified
+#[must_use]
 struct InvalidNestedStructAttr3 {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123", slug = "foo")]
 //~^ ERROR unknown argument
+#[must_use]
 struct InvalidNestedStructAttr4 {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct WrongPlaceField {
     #[suggestion = "bar"]
     //~^ ERROR `#[suggestion = ...]` is not a valid attribute
@@ -108,32 +119,39 @@ struct WrongPlaceField {
 #[diag(no_crate_example, code = "E0456")]
 //~^ ERROR specified multiple times
 //~^^ ERROR specified multiple times
+#[must_use]
 struct DiagSpecifiedTwice {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0456", code = "E0457")]
 //~^ ERROR specified multiple times
+#[must_use]
 struct CodeSpecifiedTwice {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, no_crate::example, code = "E0456")]
 //~^ ERROR diagnostic slug must be the first argument
+#[must_use]
 struct SlugSpecifiedTwice {}
 
 #[derive(Diagnostic)]
-struct KindNotProvided {} //~ ERROR diagnostic slug not specified
+#[must_use] //~ ERROR diagnostic slug not specified
+struct KindNotProvided {}
 
 #[derive(Diagnostic)]
 #[diag(code = "E0456")]
 //~^ ERROR diagnostic slug not specified
+#[must_use]
 struct SlugNotProvided {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct CodeNotProvided {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct MessageWrongType {
     #[primary_span]
     //~^ ERROR `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
@@ -142,6 +160,7 @@ struct MessageWrongType {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct InvalidPathFieldAttr {
     #[nonsense]
     //~^ ERROR `#[nonsense]` is not a valid attribute
@@ -151,6 +170,7 @@ struct InvalidPathFieldAttr {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithField {
     name: String,
     #[label(no_crate_label)]
@@ -159,6 +179,7 @@ struct ErrorWithField {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithMessageAppliedToField {
     #[label(no_crate_label)]
     //~^ ERROR the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
@@ -167,6 +188,7 @@ struct ErrorWithMessageAppliedToField {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithNonexistentField {
     #[suggestion(no_crate_suggestion, code = "{name}")]
     //~^ ERROR `name` doesn't refer to a field on this type
@@ -176,6 +198,7 @@ struct ErrorWithNonexistentField {
 #[derive(Diagnostic)]
 //~^ ERROR invalid format string: expected `'}'`
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorMissingClosingBrace {
     #[suggestion(no_crate_suggestion, code = "{name")]
     suggestion: (Span, Applicability),
@@ -186,6 +209,7 @@ struct ErrorMissingClosingBrace {
 #[derive(Diagnostic)]
 //~^ ERROR invalid format string: unmatched `}`
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorMissingOpeningBrace {
     #[suggestion(no_crate_suggestion, code = "name}")]
     suggestion: (Span, Applicability),
@@ -195,6 +219,7 @@ struct ErrorMissingOpeningBrace {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct LabelOnSpan {
     #[label(no_crate_label)]
     sp: Span,
@@ -202,6 +227,7 @@ struct LabelOnSpan {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct LabelOnNonSpan {
     #[label(no_crate_label)]
     //~^ ERROR the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
@@ -210,6 +236,7 @@ struct LabelOnNonSpan {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct Suggest {
     #[suggestion(no_crate_suggestion, code = "This is the suggested code")]
     #[suggestion(no_crate_suggestion, code = "This is the suggested code", style = "normal")]
@@ -221,6 +248,7 @@ struct Suggest {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithoutCode {
     #[suggestion(no_crate_suggestion)]
     //~^ ERROR suggestion without `code = "..."`
@@ -229,6 +257,7 @@ struct SuggestWithoutCode {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithBadKey {
     #[suggestion(nonsense = "bar")]
     //~^ ERROR invalid nested attribute
@@ -238,6 +267,7 @@ struct SuggestWithBadKey {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithShorthandMsg {
     #[suggestion(msg = "bar")]
     //~^ ERROR invalid nested attribute
@@ -247,6 +277,7 @@ struct SuggestWithShorthandMsg {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithoutMsg {
     #[suggestion(code = "bar")]
     suggestion: (Span, Applicability),
@@ -254,6 +285,7 @@ struct SuggestWithoutMsg {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithTypesSwapped {
     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
     suggestion: (Applicability, Span),
@@ -261,6 +293,7 @@ struct SuggestWithTypesSwapped {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithWrongTypeApplicabilityOnly {
     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
     //~^ ERROR wrong field type for suggestion
@@ -269,6 +302,7 @@ struct SuggestWithWrongTypeApplicabilityOnly {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithSpanOnly {
     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
     suggestion: Span,
@@ -276,6 +310,7 @@ struct SuggestWithSpanOnly {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithDuplicateSpanAndApplicability {
     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
     suggestion: (Span, Span, Applicability),
@@ -284,6 +319,7 @@ struct SuggestWithDuplicateSpanAndApplicability {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct SuggestWithDuplicateApplicabilityAndSpan {
     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
     suggestion: (Applicability, Applicability, Span),
@@ -292,6 +328,7 @@ struct SuggestWithDuplicateApplicabilityAndSpan {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct WrongKindOfAnnotation {
     #[label = "bar"]
     //~^ ERROR `#[label = ...]` is not a valid attribute
@@ -300,6 +337,7 @@ struct WrongKindOfAnnotation {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct OptionsInErrors {
     #[label(no_crate_label)]
     label: Option<Span>,
@@ -309,6 +347,7 @@ struct OptionsInErrors {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0456")]
+#[must_use]
 struct MoveOutOfBorrowError<'tcx> {
     name: Ident,
     ty: Ty<'tcx>,
@@ -323,6 +362,7 @@ struct MoveOutOfBorrowError<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithLifetime<'a> {
     #[label(no_crate_label)]
     span: Span,
@@ -331,6 +371,7 @@ struct ErrorWithLifetime<'a> {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithDefaultLabelAttr<'a> {
     #[label]
     span: Span,
@@ -339,6 +380,7 @@ struct ErrorWithDefaultLabelAttr<'a> {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ArgFieldWithoutSkip {
     #[primary_span]
     span: Span,
@@ -348,6 +390,7 @@ struct ArgFieldWithoutSkip {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ArgFieldWithSkip {
     #[primary_span]
     span: Span,
@@ -359,6 +402,7 @@ struct ArgFieldWithSkip {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithSpannedNote {
     #[note]
     span: Span,
@@ -366,6 +410,7 @@ struct ErrorWithSpannedNote {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithSpannedNoteCustom {
     #[note(no_crate_note)]
     span: Span,
@@ -374,6 +419,7 @@ struct ErrorWithSpannedNoteCustom {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
 #[note]
+#[must_use]
 struct ErrorWithNote {
     val: String,
 }
@@ -381,12 +427,14 @@ struct ErrorWithNote {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
 #[note(no_crate_note)]
+#[must_use]
 struct ErrorWithNoteCustom {
     val: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithSpannedHelp {
     #[help]
     span: Span,
@@ -394,6 +442,7 @@ struct ErrorWithSpannedHelp {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithSpannedHelpCustom {
     #[help(no_crate_help)]
     span: Span,
@@ -402,6 +451,7 @@ struct ErrorWithSpannedHelpCustom {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
 #[help]
+#[must_use]
 struct ErrorWithHelp {
     val: String,
 }
@@ -409,6 +459,7 @@ struct ErrorWithHelp {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
 #[help(no_crate_help)]
+#[must_use]
 struct ErrorWithHelpCustom {
     val: String,
 }
@@ -416,6 +467,7 @@ struct ErrorWithHelpCustom {
 #[derive(Diagnostic)]
 #[help]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithHelpWrongOrder {
     val: String,
 }
@@ -423,6 +475,7 @@ struct ErrorWithHelpWrongOrder {
 #[derive(Diagnostic)]
 #[help(no_crate_help)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithHelpCustomWrongOrder {
     val: String,
 }
@@ -430,6 +483,7 @@ struct ErrorWithHelpCustomWrongOrder {
 #[derive(Diagnostic)]
 #[note]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithNoteWrongOrder {
     val: String,
 }
@@ -437,12 +491,14 @@ struct ErrorWithNoteWrongOrder {
 #[derive(Diagnostic)]
 #[note(no_crate_note)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithNoteCustomWrongOrder {
     val: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ApplicabilityInBoth {
     #[suggestion(no_crate_suggestion, code = "...", applicability = "maybe-incorrect")]
     //~^ ERROR specified multiple times
@@ -451,6 +507,7 @@ struct ApplicabilityInBoth {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct InvalidApplicability {
     #[suggestion(no_crate_suggestion, code = "...", applicability = "batman")]
     //~^ ERROR invalid applicability
@@ -459,6 +516,7 @@ struct InvalidApplicability {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ValidApplicability {
     #[suggestion(no_crate_suggestion, code = "...", applicability = "maybe-incorrect")]
     suggestion: Span,
@@ -466,6 +524,7 @@ struct ValidApplicability {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct NoApplicability {
     #[suggestion(no_crate_suggestion, code = "...")]
     suggestion: Span,
@@ -477,6 +536,7 @@ struct Note;
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct Subdiagnostic {
     #[subdiagnostic]
     note: Note,
@@ -484,6 +544,7 @@ struct Subdiagnostic {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct VecField {
     #[primary_span]
     #[label]
@@ -492,6 +553,7 @@ struct VecField {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct UnitField {
     #[primary_span]
     spans: Span,
@@ -503,6 +565,7 @@ struct UnitField {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct OptUnitField {
     #[primary_span]
     spans: Span,
@@ -514,6 +577,7 @@ struct OptUnitField {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct BoolField {
     #[primary_span]
     spans: Span,
@@ -527,6 +591,7 @@ struct BoolField {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct LabelWithTrailingPath {
     #[label(no_crate_label, foo)]
     //~^ ERROR a diagnostic slug must be the first argument to the attribute
@@ -535,6 +600,7 @@ struct LabelWithTrailingPath {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct LabelWithTrailingNameValue {
     #[label(no_crate_label, foo = "...")]
     //~^ ERROR only `no_span` is a valid nested attribute
@@ -543,6 +609,7 @@ struct LabelWithTrailingNameValue {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct LabelWithTrailingList {
     #[label(no_crate_label, foo("..."))]
     //~^ ERROR only `no_span` is a valid nested attribute
@@ -563,6 +630,7 @@ struct PrimarySpanOnLint {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct ErrorWithMultiSpan {
     #[primary_span]
     span: MultiSpan,
@@ -571,6 +639,7 @@ struct ErrorWithMultiSpan {
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
 #[warning]
+#[must_use]
 struct ErrorWithWarn {
     val: String,
 }
@@ -580,6 +649,7 @@ struct ErrorWithWarn {
 //~^ ERROR `#[error(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
 //~| ERROR cannot find attribute `error` in this scope
+#[must_use]
 struct ErrorAttribute {}
 
 #[derive(Diagnostic)]
@@ -587,6 +657,7 @@ struct ErrorAttribute {}
 //~^ ERROR `#[warn_(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
 //~| ERROR cannot find attribute `warn_` in this scope
+#[must_use]
 struct WarnAttribute {}
 
 #[derive(Diagnostic)]
@@ -594,6 +665,7 @@ struct WarnAttribute {}
 //~^ ERROR `#[lint(...)]` is not a valid attribute
 //~| ERROR diagnostic slug not specified
 //~| ERROR cannot find attribute `lint` in this scope
+#[must_use]
 struct LintAttributeOnSessionDiag {}
 
 #[derive(LintDiagnostic)]
@@ -606,6 +678,7 @@ struct LintAttributeOnLintDiag {}
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct DuplicatedSuggestionCode {
     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
     //~^ ERROR specified multiple times
@@ -614,6 +687,7 @@ struct DuplicatedSuggestionCode {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct InvalidTypeInSuggestionTuple {
     #[suggestion(no_crate_suggestion, code = "...")]
     suggestion: (Span, usize),
@@ -622,6 +696,7 @@ struct InvalidTypeInSuggestionTuple {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct MissingApplicabilityInSuggestionTuple {
     #[suggestion(no_crate_suggestion, code = "...")]
     suggestion: (Span,),
@@ -630,6 +705,7 @@ struct MissingApplicabilityInSuggestionTuple {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct MissingCodeInSuggestion {
     #[suggestion(no_crate_suggestion)]
     //~^ ERROR suggestion without `code = "..."`
@@ -644,6 +720,7 @@ struct MissingCodeInSuggestion {
 #[multipart_suggestion()]
 //~^ ERROR cannot find attribute `multipart_suggestion` in this scope
 //~| ERROR `#[multipart_suggestion(...)]` is not a valid attribute
+#[must_use]
 struct MultipartSuggestion {
     #[multipart_suggestion(no_crate_suggestion)]
     //~^ ERROR `#[multipart_suggestion(...)]` is not a valid attribute
@@ -655,6 +732,7 @@ struct MultipartSuggestion {
 #[diag(no_crate_example, code = "E0123")]
 #[suggestion(no_crate_suggestion, code = "...")]
 //~^ ERROR `#[suggestion(...)]` is not a valid attribute
+#[must_use]
 struct SuggestionOnStruct {
     #[primary_span]
     suggestion: Span,
@@ -664,6 +742,7 @@ struct SuggestionOnStruct {
 #[diag(no_crate_example, code = "E0123")]
 #[label]
 //~^ ERROR `#[label]` is not a valid attribute
+#[must_use]
 struct LabelOnStruct {
     #[primary_span]
     suggestion: Span,
@@ -689,12 +768,14 @@ enum ExampleEnum {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct RawIdentDiagnosticArg {
     pub r#type: String,
 }
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SubdiagnosticBad {
     #[subdiagnostic(bad)]
     //~^ ERROR `eager` is the only supported nested attribute for `subdiagnostic`
@@ -703,6 +784,7 @@ struct SubdiagnosticBad {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SubdiagnosticBadStr {
     #[subdiagnostic = "bad"]
     //~^ ERROR `#[subdiagnostic = ...]` is not a valid attribute
@@ -711,6 +793,7 @@ struct SubdiagnosticBadStr {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SubdiagnosticBadTwice {
     #[subdiagnostic(bad, bad)]
     //~^ ERROR `eager` is the only supported nested attribute for `subdiagnostic`
@@ -719,6 +802,7 @@ struct SubdiagnosticBadTwice {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SubdiagnosticBadLitStr {
     #[subdiagnostic("bad")]
     //~^ ERROR `eager` is the only supported nested attribute for `subdiagnostic`
@@ -735,6 +819,7 @@ struct SubdiagnosticEagerLint {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SubdiagnosticEagerCorrect {
     #[subdiagnostic(eager)]
     note: Note,
@@ -755,6 +840,7 @@ pub(crate) struct SubdiagnosticWithSuggestion {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SubdiagnosticEagerSuggestion {
     #[subdiagnostic(eager)]
     sub: SubdiagnosticWithSuggestion,
@@ -763,6 +849,7 @@ struct SubdiagnosticEagerSuggestion {
 /// with a doc comment on the type..
 #[derive(Diagnostic)]
 #[diag(no_crate_example, code = "E0123")]
+#[must_use]
 struct WithDocComment {
     /// ..and the field
     #[primary_span]
@@ -771,6 +858,7 @@ struct WithDocComment {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionsGood {
     #[suggestion(code("foo", "bar"))]
     sub: Span,
@@ -778,6 +866,7 @@ struct SuggestionsGood {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionsSingleItem {
     #[suggestion(code("foo"))]
     sub: Span,
@@ -785,6 +874,7 @@ struct SuggestionsSingleItem {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionsNoItem {
     #[suggestion(code())]
     //~^ ERROR expected at least one string literal for `code(...)`
@@ -793,6 +883,7 @@ struct SuggestionsNoItem {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionsInvalidItem {
     #[suggestion(code(foo))]
     //~^ ERROR `code(...)` must contain only string literals
@@ -802,6 +893,7 @@ struct SuggestionsInvalidItem {
 
 #[derive(Diagnostic)] //~ ERROR cannot find value `__code_34` in this scope
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionsInvalidLiteral {
     #[suggestion(code = 3)]
     //~^ ERROR failed to resolve: maybe a missing crate `core`
@@ -810,6 +902,7 @@ struct SuggestionsInvalidLiteral {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionStyleGood {
     #[suggestion(code = "", style = "hidden")]
     sub: Span,
@@ -817,6 +910,7 @@ struct SuggestionStyleGood {
 
 #[derive(Diagnostic)]
 #[diag(no_crate_example)]
+#[must_use]
 struct SuggestionOnVec {
     #[suggestion(no_crate_suggestion, code = "")]
     //~^ ERROR `#[suggestion(...)]` is not a valid attribute

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -916,3 +916,7 @@ struct SuggestionOnVec {
     //~^ ERROR `#[suggestion(...)]` is not a valid attribute
     sub: Vec<Span>,
 }
+
+#[derive(Diagnostic)]
+#[diag(no_crate_example)] //~ ERROR You must mark diagnostic structs with `#[must_use]`
+struct MissingMustUseAttr {}

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -1,11 +1,11 @@
 error: unsupported type attribute for diagnostic derive enum
-  --> $DIR/diagnostic-derive.rs:43:1
+  --> $DIR/diagnostic-derive.rs:45:1
    |
 LL | #[diag(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:46:5
+  --> $DIR/diagnostic-derive.rs:48:5
    |
 LL |     Foo,
    |     ^^^
@@ -13,7 +13,7 @@ LL |     Foo,
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:48:5
+  --> $DIR/diagnostic-derive.rs:50:5
    |
 LL |     Bar,
    |     ^^^
@@ -21,52 +21,55 @@ LL |     Bar,
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[nonsense(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:59:1
+  --> $DIR/diagnostic-derive.rs:62:1
    |
 LL | #[nonsense(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:59:1
+  --> $DIR/diagnostic-derive.rs:62:1
    |
 LL | / #[nonsense(no_crate_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct InvalidStructAttr {}
    | |___________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:66:1
+  --> $DIR/diagnostic-derive.rs:70:1
    |
 LL | / #[diag("E0123")]
 LL | |
+LL | | #[must_use]
 LL | | struct InvalidLitNestedAttr {}
    | |______________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: diagnostic slug must be the first argument
-  --> $DIR/diagnostic-derive.rs:76:16
+  --> $DIR/diagnostic-derive.rs:82:16
    |
 LL | #[diag(nonsense("foo"), code = "E0123", slug = "foo")]
    |                ^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:76:1
+  --> $DIR/diagnostic-derive.rs:82:1
    |
 LL | / #[diag(nonsense("foo"), code = "E0123", slug = "foo")]
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct InvalidNestedStructAttr1 {}
    | |__________________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: unknown argument
-  --> $DIR/diagnostic-derive.rs:82:8
+  --> $DIR/diagnostic-derive.rs:89:8
    |
 LL | #[diag(nonsense = "...", code = "E0123", slug = "foo")]
    |        ^^^^^^^^
@@ -74,18 +77,19 @@ LL | #[diag(nonsense = "...", code = "E0123", slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:82:1
+  --> $DIR/diagnostic-derive.rs:89:1
    |
 LL | / #[diag(nonsense = "...", code = "E0123", slug = "foo")]
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct InvalidNestedStructAttr2 {}
    | |__________________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: unknown argument
-  --> $DIR/diagnostic-derive.rs:88:8
+  --> $DIR/diagnostic-derive.rs:96:8
    |
 LL | #[diag(nonsense = 4, code = "E0123", slug = "foo")]
    |        ^^^^^^^^
@@ -93,18 +97,19 @@ LL | #[diag(nonsense = 4, code = "E0123", slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:88:1
+  --> $DIR/diagnostic-derive.rs:96:1
    |
 LL | / #[diag(nonsense = 4, code = "E0123", slug = "foo")]
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct InvalidNestedStructAttr3 {}
    | |__________________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: unknown argument
-  --> $DIR/diagnostic-derive.rs:94:42
+  --> $DIR/diagnostic-derive.rs:103:42
    |
 LL | #[diag(no_crate_example, code = "E0123", slug = "foo")]
    |                                          ^^^^
@@ -112,97 +117,99 @@ LL | #[diag(no_crate_example, code = "E0123", slug = "foo")]
    = note: only the `code` parameter is valid after the slug
 
 error: `#[suggestion = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:101:5
+  --> $DIR/diagnostic-derive.rs:112:5
    |
 LL |     #[suggestion = "bar"]
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:108:8
+  --> $DIR/diagnostic-derive.rs:119:8
    |
 LL | #[diag(no_crate_example, code = "E0456")]
    |        ^^^^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:107:8
+  --> $DIR/diagnostic-derive.rs:118:8
    |
 LL | #[diag(no_crate_example, code = "E0123")]
    |        ^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:108:26
+  --> $DIR/diagnostic-derive.rs:119:26
    |
 LL | #[diag(no_crate_example, code = "E0456")]
    |                          ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:107:26
+  --> $DIR/diagnostic-derive.rs:118:26
    |
 LL | #[diag(no_crate_example, code = "E0123")]
    |                          ^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:114:42
+  --> $DIR/diagnostic-derive.rs:126:42
    |
 LL | #[diag(no_crate_example, code = "E0456", code = "E0457")]
    |                                          ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:114:26
+  --> $DIR/diagnostic-derive.rs:126:26
    |
 LL | #[diag(no_crate_example, code = "E0456", code = "E0457")]
    |                          ^^^^
 
 error: diagnostic slug must be the first argument
-  --> $DIR/diagnostic-derive.rs:119:43
+  --> $DIR/diagnostic-derive.rs:132:43
    |
 LL | #[diag(no_crate_example, no_crate::example, code = "E0456")]
    |                                           ^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:124:1
+  --> $DIR/diagnostic-derive.rs:138:1
    |
-LL | struct KindNotProvided {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / #[must_use]
+LL | | struct KindNotProvided {}
+   | |_________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:127:1
+  --> $DIR/diagnostic-derive.rs:142:1
    |
 LL | / #[diag(code = "E0456")]
 LL | |
+LL | | #[must_use]
 LL | | struct SlugNotProvided {}
    | |_________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: the `#[primary_span]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:138:5
+  --> $DIR/diagnostic-derive.rs:156:5
    |
 LL |     #[primary_span]
    |     ^^^^^^^^^^^^^^^
 
 error: `#[nonsense]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:146:5
+  --> $DIR/diagnostic-derive.rs:165:5
    |
 LL |     #[nonsense]
    |     ^^^^^^^^^^^
 
 error: the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:163:5
+  --> $DIR/diagnostic-derive.rs:184:5
    |
 LL |     #[label(no_crate_label)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `name` doesn't refer to a field on this type
-  --> $DIR/diagnostic-derive.rs:171:46
+  --> $DIR/diagnostic-derive.rs:193:46
    |
 LL |     #[suggestion(no_crate_suggestion, code = "{name}")]
    |                                              ^^^^^^^^
 
 error: invalid format string: expected `'}'` but string was terminated
-  --> $DIR/diagnostic-derive.rs:176:10
+  --> $DIR/diagnostic-derive.rs:198:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ expected `'}'` in format string
@@ -211,7 +218,7 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
-  --> $DIR/diagnostic-derive.rs:186:10
+  --> $DIR/diagnostic-derive.rs:209:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ unmatched `}` in format string
@@ -220,19 +227,19 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `#[label(...)]` attribute can only be applied to fields of type `Span` or `MultiSpan`
-  --> $DIR/diagnostic-derive.rs:206:5
+  --> $DIR/diagnostic-derive.rs:232:5
    |
 LL |     #[label(no_crate_label)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:225:5
+  --> $DIR/diagnostic-derive.rs:253:5
    |
 LL |     #[suggestion(no_crate_suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid nested attribute
-  --> $DIR/diagnostic-derive.rs:233:18
+  --> $DIR/diagnostic-derive.rs:262:18
    |
 LL |     #[suggestion(nonsense = "bar")]
    |                  ^^^^^^^^
@@ -240,13 +247,13 @@ LL |     #[suggestion(nonsense = "bar")]
    = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:233:5
+  --> $DIR/diagnostic-derive.rs:262:5
    |
 LL |     #[suggestion(nonsense = "bar")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid nested attribute
-  --> $DIR/diagnostic-derive.rs:242:18
+  --> $DIR/diagnostic-derive.rs:272:18
    |
 LL |     #[suggestion(msg = "bar")]
    |                  ^^^
@@ -254,13 +261,13 @@ LL |     #[suggestion(msg = "bar")]
    = help: only `no_span`, `style`, `code` and `applicability` are valid nested attributes
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:242:5
+  --> $DIR/diagnostic-derive.rs:272:5
    |
 LL |     #[suggestion(msg = "bar")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: wrong field type for suggestion
-  --> $DIR/diagnostic-derive.rs:265:5
+  --> $DIR/diagnostic-derive.rs:298:5
    |
 LL | /     #[suggestion(no_crate_suggestion, code = "This is suggested code")]
 LL | |
@@ -270,79 +277,79 @@ LL | |     suggestion: Applicability,
    = help: `#[suggestion(...)]` should be applied to fields of type `Span` or `(Span, Applicability)`
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:281:24
+  --> $DIR/diagnostic-derive.rs:316:24
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                        ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:281:18
+  --> $DIR/diagnostic-derive.rs:316:18
    |
 LL |     suggestion: (Span, Span, Applicability),
    |                  ^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:289:33
+  --> $DIR/diagnostic-derive.rs:325:33
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                                 ^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:289:18
+  --> $DIR/diagnostic-derive.rs:325:18
    |
 LL |     suggestion: (Applicability, Applicability, Span),
    |                  ^^^^^^^^^^^^^
 
 error: `#[label = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:296:5
+  --> $DIR/diagnostic-derive.rs:333:5
    |
 LL |     #[label = "bar"]
    |     ^^^^^^^^^^^^^^^^
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:447:5
+  --> $DIR/diagnostic-derive.rs:503:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", applicability = "maybe-incorrect")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:449:24
+  --> $DIR/diagnostic-derive.rs:505:24
    |
 LL |     suggestion: (Span, Applicability),
    |                        ^^^^^^^^^^^^^
 
 error: invalid applicability
-  --> $DIR/diagnostic-derive.rs:455:69
+  --> $DIR/diagnostic-derive.rs:512:69
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", applicability = "batman")]
    |                                                                     ^^^^^^^^
 
 error: the `#[help(...)]` attribute can only be applied to fields of type `Span`, `MultiSpan`, `bool` or `()`
-  --> $DIR/diagnostic-derive.rs:522:5
+  --> $DIR/diagnostic-derive.rs:586:5
    |
 LL |     #[help(no_crate_help)]
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: a diagnostic slug must be the first argument to the attribute
-  --> $DIR/diagnostic-derive.rs:531:32
+  --> $DIR/diagnostic-derive.rs:596:32
    |
 LL |     #[label(no_crate_label, foo)]
    |                                ^
 
 error: only `no_span` is a valid nested attribute
-  --> $DIR/diagnostic-derive.rs:539:29
+  --> $DIR/diagnostic-derive.rs:605:29
    |
 LL |     #[label(no_crate_label, foo = "...")]
    |                             ^^^
 
 error: only `no_span` is a valid nested attribute
-  --> $DIR/diagnostic-derive.rs:547:29
+  --> $DIR/diagnostic-derive.rs:614:29
    |
 LL |     #[label(no_crate_label, foo("..."))]
    |                             ^^^
 
 error: `#[primary_span]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:559:5
+  --> $DIR/diagnostic-derive.rs:626:5
    |
 LL |     #[primary_span]
    |     ^^^^^^^^^^^^^^^
@@ -350,67 +357,70 @@ LL |     #[primary_span]
    = help: the `primary_span` field attribute is not valid for lint diagnostics
 
 error: `#[error(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:579:1
+  --> $DIR/diagnostic-derive.rs:648:1
    |
 LL | #[error(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:579:1
+  --> $DIR/diagnostic-derive.rs:648:1
    |
 LL | / #[error(no_crate_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct ErrorAttribute {}
    | |________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[warn_(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:586:1
+  --> $DIR/diagnostic-derive.rs:656:1
    |
 LL | #[warn_(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:586:1
+  --> $DIR/diagnostic-derive.rs:656:1
    |
 LL | / #[warn_(no_crate_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct WarnAttribute {}
    | |_______________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:593:1
+  --> $DIR/diagnostic-derive.rs:664:1
    |
 LL | #[lint(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:593:1
+  --> $DIR/diagnostic-derive.rs:664:1
    |
 LL | / #[lint(no_crate_example, code = "E0123")]
 LL | |
 LL | |
 LL | |
+LL | | #[must_use]
 LL | | struct LintAttributeOnSessionDiag {}
    | |____________________________________^
    |
    = help: specify the slug as the first argument to the `#[diag(...)]` attribute, such as `#[diag(hir_analysis_example_error)]`
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:600:1
+  --> $DIR/diagnostic-derive.rs:672:1
    |
 LL | #[lint(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[lint(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:600:1
+  --> $DIR/diagnostic-derive.rs:672:1
    |
 LL | #[lint(no_crate_example, code = "E0123")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -418,7 +428,7 @@ LL | #[lint(no_crate_example, code = "E0123")]
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: diagnostic slug not specified
-  --> $DIR/diagnostic-derive.rs:600:1
+  --> $DIR/diagnostic-derive.rs:672:1
    |
 LL | / #[lint(no_crate_example, code = "E0123")]
 LL | |
@@ -431,19 +441,19 @@ LL | | struct LintAttributeOnLintDiag {}
    = help: specify the slug as the first argument to the attribute, such as `#[diag(compiletest_example)]`
 
 error: specified multiple times
-  --> $DIR/diagnostic-derive.rs:610:53
+  --> $DIR/diagnostic-derive.rs:683:53
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
    |                                                     ^^^^
    |
 note: previously specified here
-  --> $DIR/diagnostic-derive.rs:610:39
+  --> $DIR/diagnostic-derive.rs:683:39
    |
 LL |     #[suggestion(no_crate_suggestion, code = "...", code = ",,,")]
    |                                       ^^^^
 
 error: wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:619:24
+  --> $DIR/diagnostic-derive.rs:693:24
    |
 LL |     suggestion: (Span, usize),
    |                        ^^^^^
@@ -451,7 +461,7 @@ LL |     suggestion: (Span, usize),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: wrong types for suggestion
-  --> $DIR/diagnostic-derive.rs:627:17
+  --> $DIR/diagnostic-derive.rs:702:17
    |
 LL |     suggestion: (Span,),
    |                 ^^^^^^^
@@ -459,13 +469,13 @@ LL |     suggestion: (Span,),
    = help: `#[suggestion(...)]` on a tuple field must be applied to fields of type `(Span, Applicability)`
 
 error: suggestion without `code = "..."`
-  --> $DIR/diagnostic-derive.rs:634:5
+  --> $DIR/diagnostic-derive.rs:710:5
    |
 LL |     #[suggestion(no_crate_suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:641:1
+  --> $DIR/diagnostic-derive.rs:717:1
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -473,7 +483,7 @@ LL | #[multipart_suggestion(no_crate_suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:644:1
+  --> $DIR/diagnostic-derive.rs:720:1
    |
 LL | #[multipart_suggestion()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -481,7 +491,7 @@ LL | #[multipart_suggestion()]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[multipart_suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:648:5
+  --> $DIR/diagnostic-derive.rs:725:5
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -489,7 +499,7 @@ LL |     #[multipart_suggestion(no_crate_suggestion)]
    = help: consider creating a `Subdiagnostic` instead
 
 error: `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:656:1
+  --> $DIR/diagnostic-derive.rs:733:1
    |
 LL | #[suggestion(no_crate_suggestion, code = "...")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -497,7 +507,7 @@ LL | #[suggestion(no_crate_suggestion, code = "...")]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: `#[label]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:665:1
+  --> $DIR/diagnostic-derive.rs:743:1
    |
 LL | #[label]
    | ^^^^^^^^
@@ -505,31 +515,31 @@ LL | #[label]
    = help: `#[label]` and `#[suggestion]` can only be applied to fields
 
 error: `eager` is the only supported nested attribute for `subdiagnostic`
-  --> $DIR/diagnostic-derive.rs:699:7
+  --> $DIR/diagnostic-derive.rs:780:7
    |
 LL |     #[subdiagnostic(bad)]
    |       ^^^^^^^^^^^^^^^^^^
 
 error: `#[subdiagnostic = ...]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:707:5
+  --> $DIR/diagnostic-derive.rs:789:5
    |
 LL |     #[subdiagnostic = "bad"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eager` is the only supported nested attribute for `subdiagnostic`
-  --> $DIR/diagnostic-derive.rs:715:7
+  --> $DIR/diagnostic-derive.rs:798:7
    |
 LL |     #[subdiagnostic(bad, bad)]
    |       ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eager` is the only supported nested attribute for `subdiagnostic`
-  --> $DIR/diagnostic-derive.rs:723:7
+  --> $DIR/diagnostic-derive.rs:807:7
    |
 LL |     #[subdiagnostic("bad")]
    |       ^^^^^^^^^^^^^^^^^^^^
 
 error: `#[subdiagnostic(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:731:5
+  --> $DIR/diagnostic-derive.rs:815:5
    |
 LL |     #[subdiagnostic(eager)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -537,19 +547,19 @@ LL |     #[subdiagnostic(eager)]
    = help: eager subdiagnostics are not supported on lints
 
 error: expected at least one string literal for `code(...)`
-  --> $DIR/diagnostic-derive.rs:789:23
+  --> $DIR/diagnostic-derive.rs:879:23
    |
 LL |     #[suggestion(code())]
    |                       ^
 
 error: `code(...)` must contain only string literals
-  --> $DIR/diagnostic-derive.rs:797:23
+  --> $DIR/diagnostic-derive.rs:888:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^
 
 error: `#[suggestion(...)]` is not a valid attribute
-  --> $DIR/diagnostic-derive.rs:821:5
+  --> $DIR/diagnostic-derive.rs:915:5
    |
 LL |     #[suggestion(no_crate_suggestion, code = "")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -559,85 +569,85 @@ LL |     #[suggestion(no_crate_suggestion, code = "")]
    = help: to show a variable set of suggestions, use a `Vec` of `Subdiagnostic`s annotated with `#[suggestion(...)]`
 
 error[E0433]: failed to resolve: maybe a missing crate `core`?
-  --> $DIR/diagnostic-derive.rs:54:8
+  --> $DIR/diagnostic-derive.rs:56:8
    |
 LL | #[diag = "E0123"]
    |        ^ maybe a missing crate `core`?
 
 error[E0433]: failed to resolve: maybe a missing crate `core`?
-  --> $DIR/diagnostic-derive.rs:797:23
+  --> $DIR/diagnostic-derive.rs:888:23
    |
 LL |     #[suggestion(code(foo))]
    |                       ^^^ maybe a missing crate `core`?
 
 error[E0433]: failed to resolve: maybe a missing crate `core`?
-  --> $DIR/diagnostic-derive.rs:806:25
+  --> $DIR/diagnostic-derive.rs:898:25
    |
 LL |     #[suggestion(code = 3)]
    |                         ^ maybe a missing crate `core`?
 
 error: cannot find attribute `nonsense` in this scope
-  --> $DIR/diagnostic-derive.rs:59:3
+  --> $DIR/diagnostic-derive.rs:62:3
    |
 LL | #[nonsense(no_crate_example, code = "E0123")]
    |   ^^^^^^^^
 
 error: cannot find attribute `nonsense` in this scope
-  --> $DIR/diagnostic-derive.rs:146:7
+  --> $DIR/diagnostic-derive.rs:165:7
    |
 LL |     #[nonsense]
    |       ^^^^^^^^
 
 error: cannot find attribute `error` in this scope
-  --> $DIR/diagnostic-derive.rs:579:3
+  --> $DIR/diagnostic-derive.rs:648:3
    |
 LL | #[error(no_crate_example, code = "E0123")]
    |   ^^^^^
 
 error: cannot find attribute `warn_` in this scope
-  --> $DIR/diagnostic-derive.rs:586:3
+  --> $DIR/diagnostic-derive.rs:656:3
    |
 LL | #[warn_(no_crate_example, code = "E0123")]
    |   ^^^^^ help: a built-in attribute with a similar name exists: `warn`
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:593:3
+  --> $DIR/diagnostic-derive.rs:664:3
    |
 LL | #[lint(no_crate_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `lint` in this scope
-  --> $DIR/diagnostic-derive.rs:600:3
+  --> $DIR/diagnostic-derive.rs:672:3
    |
 LL | #[lint(no_crate_example, code = "E0123")]
    |   ^^^^ help: a built-in attribute with a similar name exists: `link`
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:641:3
+  --> $DIR/diagnostic-derive.rs:717:3
    |
 LL | #[multipart_suggestion(no_crate_suggestion)]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:644:3
+  --> $DIR/diagnostic-derive.rs:720:3
    |
 LL | #[multipart_suggestion()]
    |   ^^^^^^^^^^^^^^^^^^^^
 
 error: cannot find attribute `multipart_suggestion` in this scope
-  --> $DIR/diagnostic-derive.rs:648:7
+  --> $DIR/diagnostic-derive.rs:725:7
    |
 LL |     #[multipart_suggestion(no_crate_suggestion)]
    |       ^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find value `nonsense` in module `crate::fluent_generated`
-  --> $DIR/diagnostic-derive.rs:71:8
+  --> $DIR/diagnostic-derive.rs:76:8
    |
 LL | #[diag(nonsense, code = "E0123")]
    |        ^^^^^^^^ not found in `crate::fluent_generated`
 
 error[E0425]: cannot find value `__code_34` in this scope
-  --> $DIR/diagnostic-derive.rs:803:10
+  --> $DIR/diagnostic-derive.rs:894:10
    |
 LL | #[derive(Diagnostic)]
    |          ^^^^^^^^^^ not found in this scope
@@ -645,7 +655,7 @@ LL | #[derive(Diagnostic)]
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Hello: IntoDiagnosticArg` is not satisfied
-  --> $DIR/diagnostic-derive.rs:345:12
+  --> $DIR/diagnostic-derive.rs:387:12
    |
 LL | #[derive(Diagnostic)]
    |          ---------- required by a bound introduced by this call

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -568,6 +568,13 @@ LL |     #[suggestion(no_crate_suggestion, code = "")]
    = help: to show a suggestion consisting of multiple parts, use a `Subdiagnostic` annotated with `#[multipart_suggestion(...)]`
    = help: to show a variable set of suggestions, use a `Vec` of `Subdiagnostic`s annotated with `#[suggestion(...)]`
 
+error: You must mark diagnostic structs with `#[must_use]`
+  --> $DIR/diagnostic-derive.rs:921:1
+   |
+LL | / #[diag(no_crate_example)]
+LL | | struct MissingMustUseAttr {}
+   | |____________________________^
+
 error[E0433]: failed to resolve: maybe a missing crate `core`?
   --> $DIR/diagnostic-derive.rs:56:8
    |
@@ -668,7 +675,7 @@ note: required by a bound in `DiagnosticBuilder::<'a, G>::set_arg`
   --> $COMPILER_DIR/rustc_errors/src/diagnostic_builder.rs:LL:CC
    = note: this error originates in the macro `forward` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 84 previous errors
+error: aborting due to 85 previous errors
 
 Some errors have detailed explanations: E0277, E0425, E0433.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui-fulldeps/session-diagnostic/enforce_slug_naming.rs
+++ b/tests/ui-fulldeps/session-diagnostic/enforce_slug_naming.rs
@@ -22,4 +22,5 @@ extern crate rustc_session;
 #[derive(Diagnostic)]
 #[diag(compiletest_example, code = "E0123")]
 //~^ ERROR diagnostic slug and crate name do not match
+#[must_use]
 struct Hello {}

--- a/tests/ui-fulldeps/session-diagnostic/invalid-variable.rs
+++ b/tests/ui-fulldeps/session-diagnostic/invalid-variable.rs
@@ -17,4 +17,5 @@ rustc_fluent_macro::fluent_messages! { "./example.ftl" }
 
 #[derive(Diagnostic)]
 #[diag(no_crate_bad_reference)]
+#[must_use]
 struct BadRef;


### PR DESCRIPTION
This will prevent bugs like https://github.com/rust-lang/rust/issues/118972 at compile time.

Also see https://github.com/rust-lang/rust/pull/118973 where this was originally discussed.

This PR handles
* `Diagnostic` structs 

We should also begin to require `#[must_use]` on

* `Diagnostic` enums
* `Subdiagnostic` structs
* `Subdiagnostic` enums

but let's wait with that until we know we want this at all.

r? @michaelwoerister (who maybe want to delegate this to someone else)

cc @rust-lang/wg-diagnostics 

Note: Review this PR commit-by-commit since one of the commits is repetitive but big...

## Alternatives

We could maybe turn the `Diagnostic` derive macro into an attribute macro so that it can add `#[must_use]` automatically behind the scenes. But I am personally not against the clarity of an explicit `#[must_use]` attribute.