### PR TITLE
[beta] Prepare 1.76 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,8 +289,9 @@ jobs:
             os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-integration
+            env:
+              CI_ONLY_WHEN_CHANNEL: nightly
             os: ubuntu-20.04-16core-64gb
-            env: {}
           - name: x86_64-gnu-debug
             os: ubuntu-20.04-8core-32gb
             env: {}

--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -77,7 +77,7 @@ declare_features! (
     /// Allows empty structs and enum variants with braces.
     (accepted, braced_empty_structs, "1.8.0", Some(29720)),
     /// Allows `c"foo"` literals.
-    (accepted, c_str_literals, "CURRENT_RUSTC_VERSION", Some(105723)),
+    (accepted, c_str_literals, "1.76.0", Some(105723)),
     /// Allows `#[cfg_attr(predicate, multiple, attributes, here)]`.
     (accepted, cfg_attr_multi, "1.33.0", Some(54881)),
     /// Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests.
@@ -341,7 +341,7 @@ declare_features! (
     (accepted, track_caller, "1.46.0", Some(47809)),
     /// Allows dyn upcasting trait objects via supertraits.
     /// Dyn upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
-    (accepted, trait_upcasting, "CURRENT_RUSTC_VERSION", Some(65991)),
+    (accepted, trait_upcasting, "1.76.0", Some(65991)),
     /// Allows #[repr(transparent)] on univariant enums (RFC 2645).
     (accepted, transparent_enums, "1.42.0", Some(60405)),
     /// Allows indexing tuples.

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -177,7 +177,7 @@ declare_features! (
     /// Allows using the `#[register_attr]` attribute.
     (removed, register_attr, "1.65.0", Some(66080),
      Some("removed in favor of `#![register_tool]`")),
-    (removed, rust_2018_preview, "CURRENT_RUSTC_VERSION", None,
+    (removed, rust_2018_preview, "1.76.0", None,
      Some("2018 Edition preview is no longer relevant")),
     /// Allows using the macros:
     /// + `__diagnostic_used`

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -204,7 +204,7 @@ declare_features! (
     /// Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.
     (internal, lang_items, "1.0.0", None),
     /// Changes `impl Trait` to capture all lifetimes in scope.
-    (unstable, lifetime_capture_rules_2024, "CURRENT_RUSTC_VERSION", None),
+    (unstable, lifetime_capture_rules_2024, "1.76.0", None),
     /// Allows `#[link(..., cfg(..))]`; perma-unstable per #37406
     (unstable, link_cfg, "1.14.0", None),
     /// Allows the `multiple_supertrait_upcastable` lint.
@@ -468,7 +468,7 @@ declare_features! (
     /// Allows using `#[repr(align(...))]` on function items
     (unstable, fn_align, "1.53.0", Some(82232)),
     /// Support delegating implementation of functions to other already implemented functions.
-    (incomplete, fn_delegation, "CURRENT_RUSTC_VERSION", Some(118212)),
+    (incomplete, fn_delegation, "1.76.0", Some(118212)),
     /// Allows defining gen blocks and `gen fn`.
     (unstable, gen_blocks, "1.75.0", Some(117078)),
     /// Infer generic args for both consts and types.
@@ -505,7 +505,7 @@ declare_features! (
     (unstable, let_chains, "1.37.0", Some(53667)),
     /// Allows using `#[link(kind = "link-arg", name = "...")]`
     /// to pass custom arguments to the linker.
-    (unstable, link_arg_attribute, "CURRENT_RUSTC_VERSION", Some(99427)),
+    (unstable, link_arg_attribute, "1.76.0", Some(99427)),
     /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.
     (unstable, lint_reasons, "1.31.0", Some(54503)),
     /// Give access to additional metadata about declarative macro meta-variables.
@@ -527,7 +527,7 @@ declare_features! (
     /// Allow negative trait implementations.
     (unstable, negative_impls, "1.44.0", Some(68318)),
     /// Allows the `!` pattern.
-    (incomplete, never_patterns, "CURRENT_RUSTC_VERSION", Some(118155)),
+    (incomplete, never_patterns, "1.76.0", Some(118155)),
     /// Allows the `!` type. Does not imply 'exhaustive_patterns' (below) any more.
     (unstable, never_type, "1.13.0", Some(35121)),
     /// Allows diverging expressions to fall back to `!` rather than `()`.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1768,7 +1768,7 @@ impl<T: Clone, A: Allocator + Clone> Rc<T, A> {
     /// assert!(ptr::eq(ptr, inner.as_ptr()));
     /// ```
     #[inline]
-    #[stable(feature = "arc_unwrap_or_clone", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "arc_unwrap_or_clone", since = "1.76.0")]
     pub fn unwrap_or_clone(this: Self) -> T {
         Rc::try_unwrap(this).unwrap_or_else(|rc| (*rc).clone())
     }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2194,7 +2194,7 @@ impl<T: Clone, A: Allocator + Clone> Arc<T, A> {
     /// assert!(ptr::eq(ptr, inner.as_ptr()));
     /// ```
     #[inline]
-    #[stable(feature = "arc_unwrap_or_clone", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "arc_unwrap_or_clone", since = "1.76.0")]
     pub fn unwrap_or_clone(this: Self) -> T {
         Arc::try_unwrap(this).unwrap_or_else(|arc| (*arc).clone())
     }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -729,7 +729,7 @@ pub const fn type_name<T: ?Sized>() -> &'static str {
 /// assert!(type_name_of_val(&y).contains("f32"));
 /// ```
 #[must_use]
-#[stable(feature = "type_name_of_val", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "type_name_of_val", since = "1.76.0")]
 #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
 pub const fn type_name_of_val<T: ?Sized>(_val: &T) -> &'static str {
     type_name::<T>()

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1088,7 +1088,7 @@ impl<T> Option<T> {
     /// let x: Option<&usize> = v.get(5).inspect(|x| println!("got: {x}"));
     /// ```
     #[inline]
-    #[stable(feature = "result_option_inspect", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "result_option_inspect", since = "1.76.0")]
     pub fn inspect<F: FnOnce(&T)>(self, f: F) -> Self {
         if let Some(ref x) = self {
             f(x);

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -720,8 +720,8 @@ where
 /// type or mutability, in particular if the code is refactored.
 #[inline(always)]
 #[must_use]
-#[stable(feature = "ptr_from_ref", since = "CURRENT_RUSTC_VERSION")]
-#[rustc_const_stable(feature = "ptr_from_ref", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "ptr_from_ref", since = "1.76.0")]
+#[rustc_const_stable(feature = "ptr_from_ref", since = "1.76.0")]
 #[rustc_never_returns_null_ptr]
 #[rustc_diagnostic_item = "ptr_from_ref"]
 pub const fn from_ref<T: ?Sized>(r: &T) -> *const T {
@@ -734,8 +734,8 @@ pub const fn from_ref<T: ?Sized>(r: &T) -> *const T {
 /// type or mutability, in particular if the code is refactored.
 #[inline(always)]
 #[must_use]
-#[stable(feature = "ptr_from_ref", since = "CURRENT_RUSTC_VERSION")]
-#[rustc_const_stable(feature = "ptr_from_ref", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "ptr_from_ref", since = "1.76.0")]
+#[rustc_const_stable(feature = "ptr_from_ref", since = "1.76.0")]
 #[rustc_allow_const_fn_unstable(const_mut_refs)]
 #[rustc_never_returns_null_ptr]
 pub const fn from_mut<T: ?Sized>(r: &mut T) -> *mut T {
@@ -1922,7 +1922,7 @@ pub fn eq<T: ?Sized>(a: *const T, b: *const T) -> bool {
 /// assert!(ptr::addr_eq(whole, first));
 /// assert!(!ptr::eq::<dyn std::fmt::Debug>(whole, first));
 /// ```
-#[stable(feature = "ptr_addr_eq", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "ptr_addr_eq", since = "1.76.0")]
 #[inline(always)]
 #[must_use = "pointer comparison produces a value"]
 pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -842,7 +842,7 @@ impl<T, E> Result<T, E> {
     ///     .expect("failed to parse number");
     /// ```
     #[inline]
-    #[stable(feature = "result_option_inspect", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "result_option_inspect", since = "1.76.0")]
     pub fn inspect<F: FnOnce(&T)>(self, f: F) -> Self {
         if let Ok(ref t) = self {
             f(t);
@@ -864,7 +864,7 @@ impl<T, E> Result<T, E> {
     /// }
     /// ```
     #[inline]
-    #[stable(feature = "result_option_inspect", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "result_option_inspect", since = "1.76.0")]
     pub fn inspect_err<F: FnOnce(&E)>(self, f: F) -> Self {
         if let Err(ref e) = self {
             f(e);

--- a/library/std/src/hash/mod.rs
+++ b/library/std/src/hash/mod.rs
@@ -87,5 +87,5 @@ pub(crate) mod random;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::hash::*;
 
-#[stable(feature = "std_hash_exports", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "std_hash_exports", since = "1.76.0")]
 pub use self::random::{DefaultHasher, RandomState};

--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,1 +1,1 @@
-nightly
+beta

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -471,6 +471,11 @@ jobs:
             <<: *job-linux-4c
 
           - name: x86_64-gnu-integration
+            env:
+              # Only run this job on the nightly channel. Fuchsia requires
+              # nightly features to compile, and this job would fail if
+              # executed on beta and stable.
+              CI_ONLY_WHEN_CHANNEL: nightly
             <<: *job-linux-16c
 
           - name: x86_64-gnu-debug


### PR DESCRIPTION
This PR bumps the channel to beta and updates the version placeholders for stabilizations.

r? @ghost