### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -97,7 +97,7 @@ Rustdoc
 - [Accept less invalid Rust in rustdoc.](https://github.com/rust-lang/rust/pull/117450/)
 - [Document lack of object safety on affected traits.](https://github.com/rust-lang/rust/pull/113241/)
 - [Hide `#[repr(transparent)]` if it isn't part of the public ABI.](https://github.com/rust-lang/rust/pull/115439/)
-- [Show enum discrimant if it is a C-like variant.](https://github.com/rust-lang/rust/pull/116142/)
+- [Show enum discriminant if it is a C-like variant.](https://github.com/rust-lang/rust/pull/116142/)
 
 <a id="1.75.0-Compatibility-Notes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@ Language
 
 - [Stabilize `async fn` and return-position `impl Trait` in traits.](https://github.com/rust-lang/rust/pull/115822/)
 - [Allow function pointer signatures containing `&mut T` in `const` contexts.](https://github.com/rust-lang/rust/pull/116015/)
+- [Match `usize`/`isize` exhaustively with half-open ranges.](https://github.com/rust-lang/rust/pull/116692/)
 - [Guarantee that `char` has the same size and alignment as `u32`.](https://github.com/rust-lang/rust/pull/116894/)
 - [Document that the null pointer has the 0 address.](https://github.com/rust-lang/rust/pull/116988/)
 - [Allow partially moved values in `match`.](https://github.com/rust-lang/rust/pull/103208/)
@@ -19,7 +20,6 @@ Language
 Compiler
 --------
 
-- [Match usize/isize exhaustively with half-open ranges.](https://github.com/rust-lang/rust/pull/116692/)
 - [Rework negative coherence to properly consider impls that only partly overlap.](https://github.com/rust-lang/rust/pull/112875/)
 - [Bump `COINDUCTIVE_OVERLAP_IN_COHERENCE` to deny, and warn in dependencies.](https://github.com/rust-lang/rust/pull/116493/)
 - [Consider alias bounds when computing liveness in NLL.](https://github.com/rust-lang/rust/pull/116733/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,7 @@ Compiler
 - [Bump `COINDUCTIVE_OVERLAP_IN_COHERENCE` to deny, and warn in dependencies.](https://github.com/rust-lang/rust/pull/116493/)
 - [Consider alias bounds when computing liveness in NLL.](https://github.com/rust-lang/rust/pull/116733/)
 - [Add the V (vector) extension to the `riscv64-linux-android` target spec.](https://github.com/rust-lang/rust/pull/116618/)
+- [Automatically enable cross-crate inlining for small functions](https://github.com/rust-lang/rust/pull/116505)
 - Add several new tier 3 targets:
     - [`csky-unknown-linux-gnuabiv2hf`](https://github.com/rust-lang/rust/pull/117049/)
     - [`i586-unknown-netbsd`](https://github.com/rust-lang/rust/pull/117170/)
@@ -43,7 +44,6 @@ Libraries
 - [Implement `Not, Bit{And,Or}{,Assign}` for IP addresses.](https://github.com/rust-lang/rust/pull/113747/)
 - [Implement `Default` for `ExitCode`.](https://github.com/rust-lang/rust/pull/114589/)
 - [Guarantee representation of None in NPO](https://github.com/rust-lang/rust/pull/115333/)
-- [Don't panic in `<BorrowedCursor as io::Write>::write`](https://github.com/rust-lang/rust/pull/115460/)
 - [Document when atomic loads are guaranteed read-only.](https://github.com/rust-lang/rust/pull/115577/)
 - [Broaden the consequences of recursive TLS initialization.](https://github.com/rust-lang/rust/pull/116172/)
 - [Windows: Support sub-millisecond sleep.](https://github.com/rust-lang/rust/pull/116461/)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -121,7 +121,7 @@ tools.
 
 - [Optimize `librustc_driver.so` with BOLT.](https://github.com/rust-lang/rust/pull/116352/)
 - [Enable parallel rustc front end in dev and nightly builds.](https://github.com/rust-lang/rust/pull/117435/)
-- [Distribute `rustc-codegen-cratelift` as rustup component on the nightly channel.](https://github.com/rust-lang/rust/pull/81746/)
+- [Distribute `rustc-codegen-cranelift` as rustup component on the nightly channel.](https://github.com/rust-lang/rust/pull/81746/)
 
 Version 1.74.1 (2023-12-07)
 ===========================

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,128 @@
+Version 1.75.0 (2023-12-28)
+==========================
+
+<a id="1.75.0-Language"></a>
+
+Language
+--------
+
+- [Stabilize `async fn` and return-position `impl Trait` in traits.](https://github.com/rust-lang/rust/pull/115822/)
+- [Allow function pointer signatures containing `&mut T` in `const` contexts.](https://github.com/rust-lang/rust/pull/116015/)
+- [Guarantee that `char` has the same size and alignment as `u32`.](https://github.com/rust-lang/rust/pull/116894/)
+- [Document that the null pointer has the 0 address.](https://github.com/rust-lang/rust/pull/116988/)
+- [Allow partially moved values in `match`.](https://github.com/rust-lang/rust/pull/103208/)
+- [Add notes about non-compliant FP behavior on 32bit x86 targets.](https://github.com/rust-lang/rust/pull/113053/)
+- [Stabilize ratified RISC-V target features.](https://github.com/rust-lang/rust/pull/116485/)
+
+<a id="1.75.0-Compiler"></a>
+
+Compiler
+--------
+
+- [Match usize/isize exhaustively with half-open ranges.](https://github.com/rust-lang/rust/pull/116692/)
+- [Rework negative coherence to properly consider impls that only partly overlap.](https://github.com/rust-lang/rust/pull/112875/)
+- [Bump `COINDUCTIVE_OVERLAP_IN_COHERENCE` to deny, and warn in dependencies.](https://github.com/rust-lang/rust/pull/116493/)
+- [Consider alias bounds when computing liveness in NLL.](https://github.com/rust-lang/rust/pull/116733/)
+- [Add the V (vector) extension to the `riscv64-linux-android` target spec.](https://github.com/rust-lang/rust/pull/116618/)
+- Add several new tier 3 targets:
+    - [`csky-unknown-linux-gnuabiv2hf`](https://github.com/rust-lang/rust/pull/117049/)
+    - [`i586-unknown-netbsd`](https://github.com/rust-lang/rust/pull/117170/)
+    - [`mipsel-unknown-netbsd`](https://github.com/rust-lang/rust/pull/117356/)
+
+Refer to Rust's [platform support page][platform-support-doc]
+for more information on Rust's tiered platform support.
+
+<a id="1.75.0-Libraries"></a>
+
+Libraries
+---------
+
+- [Override `Waker::clone_from` to avoid cloning `Waker`s unnecessarily.](https://github.com/rust-lang/rust/pull/96979/)
+- [Implement `BufRead` for `VecDeque<u8>`.](https://github.com/rust-lang/rust/pull/110604/)
+- [Implement `FusedIterator` for `DecodeUtf16` when the inner iterator does.](https://github.com/rust-lang/rust/pull/110729/)
+- [Implement `Not, Bit{And,Or}{,Assign}` for IP addresses.](https://github.com/rust-lang/rust/pull/113747/)
+- [Implement `Default` for `ExitCode`.](https://github.com/rust-lang/rust/pull/114589/)
+- [Guarantee representation of None in NPO](https://github.com/rust-lang/rust/pull/115333/)
+- [Don't panic in `<BorrowedCursor as io::Write>::write`](https://github.com/rust-lang/rust/pull/115460/)
+- [Document when atomic loads are guaranteed read-only.](https://github.com/rust-lang/rust/pull/115577/)
+- [Broaden the consequences of recursive TLS initialization.](https://github.com/rust-lang/rust/pull/116172/)
+- [Windows: Support sub-millisecond sleep.](https://github.com/rust-lang/rust/pull/116461/)
+- [Fix generic bound of `str::SplitInclusive`'s `DoubleEndedIterator` impl](https://github.com/rust-lang/rust/pull/100806/)
+- [Fix exit status / wait status on non-Unix `cfg(unix)` platforms.](https://github.com/rust-lang/rust/pull/115108/)
+
+<a id="1.75.0-Stabilized-APIs"></a>
+
+Stabilized APIs
+---------------
+
+- [`Atomic*::from_ptr`](https://doc.rust-lang.org/stable/core/sync/atomic/struct.AtomicUsize.html#method.from_ptr)
+- [`FileTimes`](https://doc.rust-lang.org/stable/std/fs/struct.FileTimes.html)
+- [`FileTimesExt`](https://doc.rust-lang.org/stable/std/os/windows/fs/trait.FileTimesExt.html)
+- [`File::set_modified`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_modified)
+- [`File::set_times`](https://doc.rust-lang.org/stable/std/fs/struct.File.html#method.set_times)
+- [`IpAddr::to_canonical`](https://doc.rust-lang.org/stable/core/net/enum.IpAddr.html#method.to_canonical)
+- [`Ipv6Addr::to_canonical`](https://doc.rust-lang.org/stable/core/net/struct.Ipv6Addr.html#method.to_canonical)
+- [`Option::as_slice`](https://doc.rust-lang.org/stable/core/option/enum.Option.html#method.as_slice)
+- [`Option::as_mut_slice`](https://doc.rust-lang.org/stable/core/option/enum.Option.html#method.as_mut_slice)
+- [`pointer::byte_add`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.byte_add)
+- [`pointer::byte_offset`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.byte_offset)
+- [`pointer::byte_offset_from`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.byte_offset_from)
+- [`pointer::byte_sub`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.byte_sub)
+- [`pointer::wrapping_byte_add`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.wrapping_byte_add)
+- [`pointer::wrapping_byte_offset`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.wrapping_byte_offset)
+- [`pointer::wrapping_byte_sub`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.wrapping_byte_sub)
+
+These APIs are now stable in const contexts:
+
+- [`Ipv6Addr::to_ipv4_mapped`](https://doc.rust-lang.org/stable/core/net/struct.Ipv6Addr.html#method.to_ipv4_mapped)
+- [`MaybeUninit::assume_init_read`](https://doc.rust-lang.org/stable/core/mem/union.MaybeUninit.html#method.assume_init_read)
+- [`MaybeUninit::zeroed`](https://doc.rust-lang.org/stable/core/mem/union.MaybeUninit.html#method.zeroed)
+- [`mem::discriminant`](https://doc.rust-lang.org/stable/core/mem/fn.discriminant.html)
+- [`mem::zeroed`](https://doc.rust-lang.org/stable/core/mem/fn.zeroed.html)
+
+<a id="1.75.0-Cargo"></a>
+
+Cargo
+-----
+
+- [Add new packages to `[workspace.members]` automatically.](https://github.com/rust-lang/cargo/pull/12779/)
+- [Allow version-less `Cargo.toml` manifests.](https://github.com/rust-lang/cargo/pull/12786/)
+- [Make browser links out of HTML file paths.](https://github.com/rust-lang/cargo/pull/12889)
+
+<a id="1.75.0-Rustdoc"></a>
+
+Rustdoc
+-------
+
+- [Accept less invalid Rust in rustdoc.](https://github.com/rust-lang/rust/pull/117450/)
+- [Document lack of object safety on affected traits.](https://github.com/rust-lang/rust/pull/113241/)
+- [Hide `#[repr(transparent)]` if it isn't part of the public ABI.](https://github.com/rust-lang/rust/pull/115439/)
+- [Show enum discrimant if it is a C-like variant.](https://github.com/rust-lang/rust/pull/116142/)
+
+<a id="1.75.0-Compatibility-Notes"></a>
+
+Compatibility Notes
+-------------------
+
+- [FreeBSD targets now require at least version 12.](https://github.com/rust-lang/rust/pull/114521/)
+- [Formally demote tier 2 MIPS targets to tier 3.](https://github.com/rust-lang/rust/pull/115238/)
+- [Make misalignment a hard error in `const` contexts.](https://github.com/rust-lang/rust/pull/115524/)
+- [Fix detecting references to packed unsized fields.](https://github.com/rust-lang/rust/pull/115583/)
+- [Remove support for compiler plugins.](https://github.com/rust-lang/rust/pull/116412/)
+
+<a id="1.75.0-Internal-Changes"></a>
+
+Internal Changes
+----------------
+
+These changes do not affect any public interfaces of Rust, but they represent
+significant improvements to the performance or internals of rustc and related
+tools.
+
+- [Optimize `librustc_driver.so` with BOLT.](https://github.com/rust-lang/rust/pull/116352/)
+- [Enable parallel rustc front end in dev and nightly builds.](https://github.com/rust-lang/rust/pull/117435/)
+- [Distribute `rustc-codegen-cratelift` as rustup component on the nightly channel.](https://github.com/rust-lang/rust/pull/81746/)
+
 Version 1.74.1 (2023-12-07)
 ===========================
 

--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -117,12 +117,12 @@ ast_passes_fn_without_body =
     free function without a body
     .suggestion = provide a definition for the function
 
+ast_passes_forbidden_bound =
+    bounds cannot be used in this context
+
 ast_passes_forbidden_default =
     `default` is only allowed on items in trait impls
     .label = `default` because of this
-
-ast_passes_forbidden_lifetime_bound =
-    lifetime bounds cannot be used in this context
 
 ast_passes_forbidden_non_lifetime_param =
     only lifetime parameters can be used in this context

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -52,8 +52,8 @@ pub struct TraitFnConst {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_forbidden_lifetime_bound)]
-pub struct ForbiddenLifetimeBound {
+#[diag(ast_passes_forbidden_bound)]
+pub struct ForbiddenBound {
     #[primary_span]
     pub spans: Vec<Span>,
 }

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -152,8 +152,8 @@ impl<'a> PostExpansionVisitor<'a> {
     }
 
     fn check_late_bound_lifetime_defs(&self, params: &[ast::GenericParam]) {
-        // Check only lifetime parameters are present and that the lifetime
-        // parameters that are present have no bounds.
+        // Check only lifetime parameters are present and that the
+        // generic parameters that are present have no bounds.
         let non_lt_param_spans = params.iter().filter_map(|param| match param.kind {
             ast::GenericParamKind::Lifetime { .. } => None,
             _ => Some(param.ident.span),
@@ -164,10 +164,11 @@ impl<'a> PostExpansionVisitor<'a> {
             non_lt_param_spans,
             crate::fluent_generated::ast_passes_forbidden_non_lifetime_param
         );
+
         for param in params {
             if !param.bounds.is_empty() {
                 let spans: Vec<_> = param.bounds.iter().map(|b| b.span()).collect();
-                self.sess.emit_err(errors::ForbiddenLifetimeBound { spans });
+                self.sess.emit_err(errors::ForbiddenBound { spans });
             }
         }
     }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_watchos.rs
@@ -4,7 +4,7 @@ use crate::spec::{Target, TargetOptions};
 pub fn target() -> Target {
     let base = opts("watchos", Arch::Arm64);
     Target {
-        llvm_target: "aarch-apple-watchos".into(),
+        llvm_target: "aarch64-apple-watchos".into(),
         pointer_width: 64,
         data_layout: "e-m:o-i64:64-i128:128-n32:64-S128".into(),
         arch: "aarch64".into(),

--- a/config.example.toml
+++ b/config.example.toml
@@ -323,6 +323,7 @@ change-id = 118703
 #    "rustdoc",
 #    "rustfmt",
 #    "rust-analyzer",
+#    "rust-analyzer-proc-macro-srv",
 #    "analysis",
 #    "src",
 #    "rust-demangler",  # if profiler = true

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opener"
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.26.7"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c375d5fd899e32847b8566e10598d6e9f1d9b55ec6de3cdf9e7da4bdc51371bc"
+checksum = "c68492e7268037de59ae153d7efb79546cf94a18a9548235420d3d8d2436b4b1"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -630,7 +630,7 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi",
+ "windows",
 ]
 
 [[package]]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -59,7 +59,7 @@ walkdir = "2"
 xz2 = "0.1"
 
 # Dependencies needed by the build-metrics feature
-sysinfo = { version = "0.26.0", optional = true }
+sysinfo = { version = "0.30.0", optional = true }
 
 # Solaris doesn't support flock() and thus fd-lock is not option now
 [target.'cfg(not(target_os = "solaris"))'.dependencies]

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -671,11 +671,14 @@ impl Step for RustAnalyzerProcMacroSrv {
         // Allow building `rust-analyzer-proc-macro-srv` both as part of the `rust-analyzer` and as a stand-alone tool.
         run.path("src/tools/rust-analyzer")
             .path("src/tools/rust-analyzer/crates/proc-macro-srv-cli")
-            .default_condition(builder.config.tools.as_ref().map_or(true, |tools| {
-                tools
-                    .iter()
-                    .any(|tool| tool == "rust-analyzer" || tool == "rust-analyzer-proc-macro-srv")
-            }))
+            .default_condition(
+                builder.config.extended
+                    && builder.config.tools.as_ref().map_or(true, |tools| {
+                        tools.iter().any(|tool| {
+                            tool == "rust-analyzer" || tool == "rust-analyzer-proc-macro-srv"
+                        })
+                    }),
+            )
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -289,6 +289,18 @@ impl PathSet {
     }
 }
 
+const PATH_REMAP: &[(&str, &str)] = &[("rust-analyzer-proc-macro-srv", "proc-macro-srv-cli")];
+
+fn remap_paths(paths: &mut Vec<&Path>) {
+    for path in paths.iter_mut() {
+        for &(search, replace) in PATH_REMAP {
+            if path.to_str() == Some(search) {
+                *path = Path::new(replace)
+            }
+        }
+    }
+}
+
 impl StepDescription {
     fn from<S: Step>(kind: Kind) -> StepDescription {
         StepDescription {
@@ -360,6 +372,8 @@ impl StepDescription {
         // strip CurDir prefix if present
         let mut paths: Vec<_> =
             paths.into_iter().map(|p| p.strip_prefix(".").unwrap_or(p)).collect();
+
+        remap_paths(&mut paths);
 
         // Handle all test suite paths.
         // (This is separate from the loop below to avoid having to handle multiple paths in `is_suite_path` somehow.)

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -96,4 +96,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Removed rust.run_dsymutil and dist.gpg_password_file config options, as they were unused.",
     },
+    ChangeInfo {
+        change_id: 119124,
+        severity: ChangeSeverity::Warning,
+        summary: "rust-analyzer-proc-macro-srv is no longer enabled by default. To build it, you must either enable it in the configuration or explicitly invoke it with x.py.",
+    },
 ];

--- a/src/bootstrap/src/utils/metrics.rs
+++ b/src/bootstrap/src/utils/metrics.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::fs::File;
 use std::io::BufWriter;
 use std::time::{Duration, Instant, SystemTime};
-use sysinfo::{CpuExt, System, SystemExt};
+use sysinfo::System;
 
 // Update this number whenever a breaking change is made to the build metrics.
 //

--- a/tests/rustdoc-ui/bounded-hr-lifetime.rs
+++ b/tests/rustdoc-ui/bounded-hr-lifetime.rs
@@ -4,6 +4,6 @@
 pub fn hrlt<'b, 'c>()
 where
     for<'a: 'b + 'c> &'a (): std::fmt::Debug,
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
 {
 }

--- a/tests/rustdoc-ui/bounded-hr-lifetime.stderr
+++ b/tests/rustdoc-ui/bounded-hr-lifetime.stderr
@@ -1,4 +1,4 @@
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/bounded-hr-lifetime.rs:6:13
    |
 LL |     for<'a: 'b + 'c> &'a (): std::fmt::Debug,

--- a/tests/ui/bounds-lifetime.rs
+++ b/tests/ui/bounds-lifetime.rs
@@ -1,6 +1,6 @@
-type A = for<'b, 'a: 'b> fn(); //~ ERROR lifetime bounds cannot be used in this context
-type B = for<'b, 'a: 'b,> fn(); //~ ERROR lifetime bounds cannot be used in this context
-type C = for<'b, 'a: 'b +> fn(); //~ ERROR lifetime bounds cannot be used in this context
+type A = for<'b, 'a: 'b> fn(); //~ ERROR bounds cannot be used in this context
+type B = for<'b, 'a: 'b,> fn(); //~ ERROR bounds cannot be used in this context
+type C = for<'b, 'a: 'b +> fn(); //~ ERROR bounds cannot be used in this context
 type D = for<'a, T> fn(); //~ ERROR only lifetime parameters can be used in this context
 type E = dyn for<T, U> Fn(); //~ ERROR only lifetime parameters can be used in this context
 

--- a/tests/ui/bounds-lifetime.stderr
+++ b/tests/ui/bounds-lifetime.stderr
@@ -1,16 +1,16 @@
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/bounds-lifetime.rs:1:22
    |
 LL | type A = for<'b, 'a: 'b> fn();
    |                      ^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/bounds-lifetime.rs:2:22
    |
 LL | type B = for<'b, 'a: 'b,> fn();
    |                      ^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/bounds-lifetime.rs:3:22
    |
 LL | type C = for<'b, 'a: 'b +> fn();

--- a/tests/ui/closures/binder/bounds-on-closure-type-binders.rs
+++ b/tests/ui/closures/binder/bounds-on-closure-type-binders.rs
@@ -1,0 +1,14 @@
+// check-fail
+
+#![allow(incomplete_features)]
+#![feature(non_lifetime_binders)]
+#![feature(closure_lifetime_binder)]
+
+trait Trait {}
+
+fn main() {
+    // Regression test for issue #119067
+    let _ = for<T: Trait> || -> () {};
+    //~^ ERROR bounds cannot be used in this context
+    //~| ERROR late-bound type parameter not allowed on closures
+}

--- a/tests/ui/closures/binder/bounds-on-closure-type-binders.stderr
+++ b/tests/ui/closures/binder/bounds-on-closure-type-binders.stderr
@@ -1,0 +1,14 @@
+error: bounds cannot be used in this context
+  --> $DIR/bounds-on-closure-type-binders.rs:11:20
+   |
+LL |     let _ = for<T: Trait> || -> () {};
+   |                    ^^^^^
+
+error: late-bound type parameter not allowed on closures
+  --> $DIR/bounds-on-closure-type-binders.rs:11:17
+   |
+LL |     let _ = for<T: Trait> || -> () {};
+   |                 ^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/higher-ranked/higher-lifetime-bounds.rs
+++ b/tests/ui/higher-ranked/higher-lifetime-bounds.rs
@@ -6,7 +6,7 @@ fn bar1<'a, 'b>(
     x: &'a i32,
     y: &'b i32,
     f: for<'xa, 'xb: 'xa+'xa> fn(&'xa i32, &'xb i32) -> &'xa i32)
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
 {
     // If the bound in f's type would matter, the call below would (have to)
     // be rejected.
@@ -14,7 +14,7 @@ fn bar1<'a, 'b>(
 }
 
 fn bar2<'a, 'b, F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>(
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
     x: &'a i32,
     y: &'b i32,
     f: F)
@@ -29,7 +29,7 @@ fn bar3<'a, 'b, F>(
     y: &'b i32,
     f: F)
     where F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
 {
     // If the bound in f's type would matter, the call below would (have to)
     // be rejected.
@@ -41,7 +41,7 @@ fn bar4<'a, 'b, F>(
     y: &'b i32,
     f: F)
     where for<'xa, 'xb: 'xa> F: Fn(&'xa i32, &'xb i32) -> &'xa i32
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
 {
     // If the bound in f's type would matter, the call below would (have to)
     // be rejected.
@@ -49,21 +49,21 @@ fn bar4<'a, 'b, F>(
 }
 
 struct S1<F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>(F);
-//~^ ERROR lifetime bounds cannot be used in this context
+//~^ ERROR bounds cannot be used in this context
 struct S2<F>(F) where F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32;
-//~^ ERROR lifetime bounds cannot be used in this context
+//~^ ERROR bounds cannot be used in this context
 struct S3<F>(F) where for<'xa, 'xb: 'xa> F: Fn(&'xa i32, &'xb i32) -> &'xa i32;
-//~^ ERROR lifetime bounds cannot be used in this context
+//~^ ERROR bounds cannot be used in this context
 
 struct S_fnty(for<'xa, 'xb: 'xa> fn(&'xa i32, &'xb i32) -> &'xa i32);
-//~^ ERROR lifetime bounds cannot be used in this context
+//~^ ERROR bounds cannot be used in this context
 
 type T1 = Box<dyn for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>;
-//~^ ERROR lifetime bounds cannot be used in this context
+//~^ ERROR bounds cannot be used in this context
 
 fn main() {
     let _ : Option<for<'xa, 'xb: 'xa> fn(&'xa i32, &'xb i32) -> &'xa i32> = None;
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
     let _ : Option<Box<dyn for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>> = None;
-    //~^ ERROR lifetime bounds cannot be used in this context
+    //~^ ERROR bounds cannot be used in this context
 }

--- a/tests/ui/higher-ranked/higher-lifetime-bounds.stderr
+++ b/tests/ui/higher-ranked/higher-lifetime-bounds.stderr
@@ -1,64 +1,64 @@
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:8:22
    |
 LL |     f: for<'xa, 'xb: 'xa+'xa> fn(&'xa i32, &'xb i32) -> &'xa i32)
    |                      ^^^ ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:16:34
    |
 LL | fn bar2<'a, 'b, F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>(
    |                                  ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:31:28
    |
 LL |     where F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32
    |                            ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:43:25
    |
 LL |     where for<'xa, 'xb: 'xa> F: Fn(&'xa i32, &'xb i32) -> &'xa i32
    |                         ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:51:28
    |
 LL | struct S1<F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>(F);
    |                            ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:53:40
    |
 LL | struct S2<F>(F) where F: for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32;
    |                                        ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:55:37
    |
 LL | struct S3<F>(F) where for<'xa, 'xb: 'xa> F: Fn(&'xa i32, &'xb i32) -> &'xa i32;
    |                                     ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:58:29
    |
 LL | struct S_fnty(for<'xa, 'xb: 'xa> fn(&'xa i32, &'xb i32) -> &'xa i32);
    |                             ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:61:33
    |
 LL | type T1 = Box<dyn for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>;
    |                                 ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:65:34
    |
 LL |     let _ : Option<for<'xa, 'xb: 'xa> fn(&'xa i32, &'xb i32) -> &'xa i32> = None;
    |                                  ^^^
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/higher-lifetime-bounds.rs:67:42
    |
 LL |     let _ : Option<Box<dyn for<'xa, 'xb: 'xa> Fn(&'xa i32, &'xb i32) -> &'xa i32>> = None;

--- a/tests/ui/parser/recover/recover-fn-ptr-with-generics.rs
+++ b/tests/ui/parser/recover/recover-fn-ptr-with-generics.rs
@@ -21,7 +21,7 @@ fn main() {
 
     let _: extern fn<'a: 'static>();
     //~^ ERROR function pointer types may not have generic parameters
-    //~| ERROR lifetime bounds cannot be used in this context
+    //~| ERROR bounds cannot be used in this context
 
     let _: for<'any> extern "C" fn<'u>();
     //~^ ERROR function pointer types may not have generic parameters

--- a/tests/ui/parser/recover/recover-fn-ptr-with-generics.stderr
+++ b/tests/ui/parser/recover/recover-fn-ptr-with-generics.stderr
@@ -100,7 +100,7 @@ error[E0412]: cannot find type `T` in this scope
 LL |     type Identity = fn<T>(T) -> T;
    |                                 ^ not found in this scope
 
-error: lifetime bounds cannot be used in this context
+error: bounds cannot be used in this context
   --> $DIR/recover-fn-ptr-with-generics.rs:22:26
    |
 LL |     let _: extern fn<'a: 'static>();

--- a/tests/ui/traits/non_lifetime_binders/bounds-on-type-binders.rs
+++ b/tests/ui/traits/non_lifetime_binders/bounds-on-type-binders.rs
@@ -1,0 +1,14 @@
+// check-fail
+
+#![allow(incomplete_features)]
+#![feature(non_lifetime_binders)]
+
+trait Trait {}
+
+trait Trait2
+where
+    for<T: Trait> ():,
+{ //~^ ERROR bounds cannot be used in this context
+}
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/bounds-on-type-binders.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bounds-on-type-binders.stderr
@@ -1,0 +1,8 @@
+error: bounds cannot be used in this context
+  --> $DIR/bounds-on-type-binders.rs:10:12
+   |
+LL |     for<T: Trait> ():,
+   |            ^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #118729 (Add release notes for 1.75.0)
 - #119124 (don't build `rust-analyzer-proc-macro-srv` on def config )
 - #119154 (Simple modification of `non_lifetime_binders`'s diagnostic information to adapt to type binders)
 - #119176 (Fix name error in aarch64_apple_watchos tier 3 target)
 - #119182 (Update sysinfo version to 0.30.0)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=118729,119124,119154,119176,119182)
<!-- homu-ignore:end -->