### PR TITLE
Run fuchsia tests only on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,8 +289,9 @@ jobs:
             os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-integration
+            env:
+              CI_ONLY_WHEN_CHANNEL: nightly
             os: ubuntu-20.04-16core-64gb
-            env: {}
           - name: x86_64-gnu-debug
             os: ubuntu-20.04-8core-32gb
             env: {}

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -471,6 +471,11 @@ jobs:
             <<: *job-linux-4c
 
           - name: x86_64-gnu-integration
+            env:
+              # Only run this job on the nightly channel. Fuchsia requires
+              # nightly features to compile, and this job would fail if
+              # executed on beta and stable.
+              CI_ONLY_WHEN_CHANNEL: nightly
             <<: *job-linux-16c
 
           - name: x86_64-gnu-debug


### PR DESCRIPTION
We discovered in https://github.com/rust-lang/rust/pull/119187 that the Fuchsia tests only work on nightly, and so we cannot have the `x86_64-gnu-integration` job run on beta and stable. This PR gates the job to only run in the nightly channel.

r? @tmandry 