### PR TITLE
tests: fix overaligned-constant to not over-specify getelementptr instr

### DIFF
--- a/tests/codegen/overaligned-constant.rs
+++ b/tests/codegen/overaligned-constant.rs
@@ -17,7 +17,7 @@ fn main() {
     // CHECK: [[full:%_.*]] = alloca %SmallStruct, align 8
     // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[full]], ptr align 8 @0, i64 32, i1 false)
     // CHECK: %b.0 = load i32, ptr @0, align 4,
-    // CHECK: %b.1 = load i32, ptr getelementptr inbounds ({ i32, i32 }, ptr @0, i32 0, i32 1), align 4
+    // CHECK: %b.1 = load i32, ptr getelementptr inbounds ({{.*}}), align 4
     let mut s = S(1);
 
     s.0 = 3;


### PR DESCRIPTION
On LLVM 18 we get slightly different arguments here, so it's easier to just regex those away. The important details are all still asserted as I understand things.

Fixes #119193.

@rustbot label: +llvm-main