### PR TITLE
fix minor mistake in comments describing VecDeque resizing

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -491,12 +491,12 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // A [o o o o o o o . . . . . . . . . ]
         //        L H
         //   [o o o o o o o o ]
-        //          H           L
-        // B [. . . o o o o o o o . . . . . . ]
+        //          H             L
+        // B [. . . o o o o o o o o . . . . . ]
         //              L H
         //   [o o o o o o o o ]
-        //            L                   H
-        // C [o o o o o . . . . . . . . . o o ]
+        //              L                 H
+        // C [o o o o o o . . . . . . . . o o ]
 
         // can't use is_contiguous() because the capacity is already updated.
         if self.head <= old_capacity - self.len {


### PR DESCRIPTION
Avoiding confusion where one of the items in the deque seems to disappear in two of the three cases