### PR TITLE
Update `slice::Iter::rfold` to match `slice::Iter::fold`

### DIFF
--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -13,6 +13,7 @@ use crate::iter::{
 use crate::marker::PhantomData;
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZeroUsize;
+use crate::ops::IndexRange;
 use crate::ptr::{self, invalid, invalid_mut, NonNull};
 
 use super::{from_raw_parts, from_raw_parts_mut};

--- a/tests/codegen/slice-iter-fold.rs
+++ b/tests/codegen/slice-iter-fold.rs
@@ -2,7 +2,10 @@
 // compile-flags: -O
 #![crate_type = "lib"]
 
-// CHECK-LABEL: @slice_fold_to_last
+// CHECK-LABEL: @slice_for_each_to_last =
+// CHECK-SAME: alias{{.*}}@slice_fold_to_last
+
+// CHECK-LABEL: @slice_fold_to_last(
 #[no_mangle]
 pub fn slice_fold_to_last(slice: &[i32]) -> Option<&i32> {
     // CHECK-NOT: loop
@@ -10,4 +13,21 @@ pub fn slice_fold_to_last(slice: &[i32]) -> Option<&i32> {
     // CHECK-NOT: call
     // CHECK: ret
     slice.iter().fold(None, |_, i| Some(i))
+}
+
+#[no_mangle]
+pub fn slice_for_each_to_last(slice: &[i32]) -> Option<&i32> {
+    let mut last = None;
+    slice.iter().for_each(|i| last = Some(i));
+    last
+}
+
+// CHECK-LABEL: @slice_rfold_to_first(
+#[no_mangle]
+pub fn slice_rfold_to_first(slice: &[i32]) -> Option<&i32> {
+    // CHECK-NOT: loop
+    // CHECK-NOT: br
+    // CHECK-NOT: call
+    // CHECK: ret
+    slice.iter().rfold(None, |_, i| Some(i))
 }


### PR DESCRIPTION
Adds a new codegen test for `rfold`, like the one from #106343, and makes a similar fix, updating `rfold` to work via indices too.