### PR TITLE
Fix representation when printing abstract consts

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.rs
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.rs
@@ -19,8 +19,8 @@ where
     //~^^ ERROR: unconstrained generic constant
     //~^^^ ERROR: function takes 1 generic argument but 2 generic arguments were supplied
     //~^^^^ ERROR: unconstrained generic constant
-    //~^^^^^ ERROR: unconstrained generic constant `{const expr}`
-    //~^^^^^^ ERROR: unconstrained generic constant `{const expr}`
+    //~^^^^^ ERROR: unconstrained generic constant `L + 1 + L`
+    //~^^^^^^ ERROR: unconstrained generic constant `L + 1`
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -52,19 +52,17 @@ LL | |         }
 LL | |     }],
    | |_____^ required by this bound in `foo`
 
-error: unconstrained generic constant `{const expr}`
+error: unconstrained generic constant `L + 1 + L`
   --> $DIR/issue_114151.rs:17:5
    |
 LL |     foo::<_, L>([(); L + 1 + L]);
    |     ^^^^^^^^^^^
 
-error: unconstrained generic constant `{const expr}`
+error: unconstrained generic constant `L + 1`
   --> $DIR/issue_114151.rs:17:5
    |
 LL |     foo::<_, L>([(); L + 1 + L]);
    |     ^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/transmute-fail.stderr
+++ b/tests/ui/const-generics/transmute-fail.stderr
@@ -4,8 +4,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     std::mem::transmute(v)
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `[[u32; H+1]; W]` (generic size {const expr})
-   = note: target type: `[[u32; W+1]; H]` (generic size {const expr})
+   = note: source type: `[[u32; H+1]; W]` (generic size (H + 1) * 4 * W)
+   = note: target type: `[[u32; W+1]; H]` (generic size (W + 1) * 4 * H)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fail.rs:16:5
@@ -22,8 +22,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     std::mem::transmute(v)
    |     ^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `[[u32; H]; W]` (generic size {const expr})
-   = note: target type: `[u32; W * H * H]` (generic size {const expr})
+   = note: source type: `[[u32; H]; W]` (generic size 4 * H * W)
+   = note: target type: `[u32; W * H * H]` (generic size 4 * H * H * W)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> $DIR/transmute-fail.rs:30:5


### PR DESCRIPTION
Previously, when printing a const generic expr, it would only display it as `{{const expr}}`. This allows for a more legible representation when printing these out.

I also zipped the types with their constants for abstract consts that contain function calls when using type annotations, eg: `foo(S: usize, true: bool) -> usize` insteaad of `foo(S, true): fn(usize, bool) -> usize` for conciseness.