### PR TITLE
Exhaustiveness: Reveal empty opaques in depth

### DIFF
--- a/tests/ui/pattern/usefulness/impl-trait.rs
+++ b/tests/ui/pattern/usefulness/impl-trait.rs
@@ -46,9 +46,7 @@ fn option_never(x: Void) -> Option<impl Copy> {
         }
         match option_never(x) {
             None => {}
-            // FIXME: Unreachable not detected because `is_uninhabited` does not look into opaque
-            // types.
-            _ => {}
+            _ => {} //~ ERROR unreachable
         }
     }
     Some(x)
@@ -137,10 +135,21 @@ fn nested_empty_opaque(x: Void) -> X {
         let opaque_void = nested_empty_opaque(x);
         let secretely_void = SecretelyVoid(opaque_void);
         match secretely_void {
-            // FIXME: Unreachable not detected because `is_uninhabited` does not look into opaque
-            // types.
-            _ => {}
+            _ => {} //~ ERROR unreachable
         }
     }
     x
+}
+
+type Y = (impl Copy, impl Copy);
+struct SecretelyDoubleVoid(Y);
+fn super_nested_empty_opaque(x: Void) -> Y {
+    if false {
+        let opaque_void = super_nested_empty_opaque(x);
+        let secretely_void = SecretelyDoubleVoid(opaque_void);
+        match secretely_void {
+            _ => {} //~ ERROR unreachable
+        }
+    }
+    (x, x)
 }

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -23,25 +23,31 @@ LL |             Some(_) => {}
    |             ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:61:13
-   |
-LL |             Some(_) => {}
-   |             ^^^^^^^
-
-error: unreachable pattern
-  --> $DIR/impl-trait.rs:65:13
+  --> $DIR/impl-trait.rs:49:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:78:9
+  --> $DIR/impl-trait.rs:59:13
+   |
+LL |             Some(_) => {}
+   |             ^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:63:13
+   |
+LL |             _ => {}
+   |             ^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:76:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:88:9
+  --> $DIR/impl-trait.rs:86:9
    |
 LL |         _ => {}
    |         - matches any value
@@ -49,24 +55,36 @@ LL |         Some((a, b)) => {}
    |         ^^^^^^^^^^^^ unreachable pattern
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:96:13
+  --> $DIR/impl-trait.rs:94:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:107:9
+  --> $DIR/impl-trait.rs:105:9
    |
 LL |         Some((mut x, mut y)) => {
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:126:13
+  --> $DIR/impl-trait.rs:124:13
    |
 LL |             _ => {}
    |             - matches any value
 LL |             Rec { n: 0, w: Some(Rec { n: 0, w: _ }) } => {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:138:13
+   |
+LL |             _ => {}
+   |             ^
+
+error: unreachable pattern
+  --> $DIR/impl-trait.rs:151:13
+   |
+LL |             _ => {}
+   |             ^
 
 error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty
   --> $DIR/impl-trait.rs:23:11
@@ -96,6 +114,6 @@ LL +         _ => todo!(),
 LL +     }
    |
 
-error: aborting due to 12 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/116821. As noted [there](https://github.com/rust-lang/rust/pull/116821#discussion_r1376673420), the current implementation doesn't detect emptiness of opaques when the opaque is nested inside a type. This doesn't matter for stable behavior (which ignores nested empty types anyway) but does matter for the [`exhaustive_patterns`](https://github.com/rust-lang/rust/issues/51085)/[`min_exhaustive_patterns`](https://github.com/rust-lang/rust/pull/118803) features.

This PR fixes this behavior by adding `InhabitedPredicate::apply_reveal_opaque` that considers opaque types when determining inhabitedness.

r? @compiler-errors 