### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,8 +289,9 @@ jobs:
             os: ubuntu-20.04-4core-16gb
             env: {}
           - name: x86_64-gnu-integration
+            env:
+              CI_ONLY_WHEN_CHANNEL: nightly
             os: ubuntu-20.04-16core-64gb
-            env: {}
           - name: x86_64-gnu-debug
             os: ubuntu-20.04-8core-32gb
             env: {}

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -5,7 +5,6 @@ use crate::pprust::state::{AnnNode, PrintState, State, INDENT_UNIT};
 use ast::StaticItem;
 use itertools::{Itertools, Position};
 use rustc_ast as ast;
-use rustc_ast::GenericBound;
 use rustc_ast::ModKind;
 use rustc_span::symbol::Ident;
 
@@ -338,21 +337,9 @@ impl<'a> State<'a> {
                 self.word_nbsp("trait");
                 self.print_ident(item.ident);
                 self.print_generic_params(&generics.params);
-                let mut real_bounds = Vec::with_capacity(bounds.len());
-                for bound in bounds.iter() {
-                    if let GenericBound::Trait(ptr, modifiers) = bound
-                        && let ast::BoundPolarity::Maybe(_) = modifiers.polarity
-                    {
-                        self.space();
-                        self.word_space("for ?");
-                        self.print_trait_ref(&ptr.trait_ref);
-                    } else {
-                        real_bounds.push(bound.clone());
-                    }
-                }
-                if !real_bounds.is_empty() {
+                if !bounds.is_empty() {
                     self.word_nbsp(":");
-                    self.print_type_bounds(&real_bounds);
+                    self.print_type_bounds(bounds);
                 }
                 self.print_where_clause(&generics.where_clause);
                 self.word(" ");

--- a/compiler/rustc_hir_analysis/src/check/entry.rs
+++ b/compiler/rustc_hir_analysis/src/check/entry.rs
@@ -124,7 +124,10 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
     if let Some(term_did) = tcx.lang_items().termination() {
         let return_ty = main_fnsig.output();
         let return_ty_span = main_fn_return_type_span(tcx, main_def_id).unwrap_or(main_span);
-        let return_ty = return_ty.skip_binder();
+        let Some(return_ty) = return_ty.no_bound_vars() else {
+            tcx.sess.emit_err(errors::MainFunctionReturnTypeGeneric { span: return_ty_span });
+            return;
+        };
         let infcx = tcx.infer_ctxt().build();
         let cause = traits::ObligationCause::new(
             return_ty_span,

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -553,17 +553,7 @@ impl<'a> State<'a> {
             }
             hir::ItemKind::OpaqueTy(opaque_ty) => {
                 self.print_item_type(item, opaque_ty.generics, |state| {
-                    let mut real_bounds = Vec::with_capacity(opaque_ty.bounds.len());
-                    for b in opaque_ty.bounds {
-                        if let GenericBound::Trait(ptr, hir::TraitBoundModifier::Maybe) = b {
-                            state.space();
-                            state.word_space("for ?");
-                            state.print_trait_ref(&ptr.trait_ref);
-                        } else {
-                            real_bounds.push(b);
-                        }
-                    }
-                    state.print_bounds("= impl", real_bounds);
+                    state.print_bounds("= impl", opaque_ty.bounds)
                 });
             }
             hir::ItemKind::Enum(ref enum_definition, params) => {
@@ -625,17 +615,7 @@ impl<'a> State<'a> {
                 self.word_nbsp("trait");
                 self.print_ident(item.ident);
                 self.print_generic_params(generics.params);
-                let mut real_bounds = Vec::with_capacity(bounds.len());
-                for b in bounds {
-                    if let GenericBound::Trait(ptr, hir::TraitBoundModifier::Maybe) = b {
-                        self.space();
-                        self.word_space("for ?");
-                        self.print_trait_ref(&ptr.trait_ref);
-                    } else {
-                        real_bounds.push(b);
-                    }
-                }
-                self.print_bounds(":", real_bounds);
+                self.print_bounds(":", bounds);
                 self.print_where_clause(generics);
                 self.word(" ");
                 self.bopen();

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1493,6 +1493,7 @@ supported_targets! {
     ("mips64-unknown-linux-muslabi64", mips64_unknown_linux_muslabi64),
     ("mips64el-unknown-linux-muslabi64", mips64el_unknown_linux_muslabi64),
     ("hexagon-unknown-linux-musl", hexagon_unknown_linux_musl),
+    ("hexagon-unknown-none-elf", hexagon_unknown_none_elf),
 
     ("mips-unknown-linux-uclibc", mips_unknown_linux_uclibc),
     ("mipsel-unknown-linux-uclibc", mipsel_unknown_linux_uclibc),

--- a/compiler/rustc_target/src/spec/targets/hexagon_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/hexagon_unknown_none_elf.rs
@@ -1,0 +1,27 @@
+use crate::spec::{PanicStrategy, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "hexagon-unknown-none-elf".into(),
+        pointer_width: 32,
+        data_layout: concat!(
+            "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32",
+            ":32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32",
+            ":32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048",
+            ":2048:2048"
+        )
+        .into(),
+        arch: "hexagon".into(),
+
+        options: TargetOptions {
+            cpu: "hexagonv60".into(),
+            panic_strategy: PanicStrategy::Abort,
+            dynamic_linking: true,
+            features: "-small-data,+hvx-length128b".into(),
+            max_atomic_width: Some(32),
+            emit_debug_gdb_scripts: false,
+            c_enum_min_bits: Some(8),
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -116,7 +116,8 @@ impl Target {
 
         // Check dynamic linking stuff
         // BPF: when targeting user space vms (like rbpf), those can load dynamic libraries.
-        if self.os == "none" && self.arch != "bpf" {
+        // hexagon: when targeting QuRT, that OS can load dynamic libraries.
+        if self.os == "none" && (self.arch != "bpf" && self.arch != "hexagon") {
             assert!(!self.dynamic_linking);
         }
         if self.only_cdylib

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -471,6 +471,11 @@ jobs:
             <<: *job-linux-4c
 
           - name: x86_64-gnu-integration
+            env:
+              # Only run this job on the nightly channel. Fuchsia requires
+              # nightly features to compile, and this job would fail if
+              # executed on beta and stable.
+              CI_ONLY_WHEN_CHANNEL: nightly
             <<: *job-linux-16c
 
           - name: x86_64-gnu-debug

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -38,6 +38,7 @@
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-kmc-solid_\*](platform-support/kmc-solid.md)
     - [csky-unknown-linux-gnuabiv2\*](platform-support/csky-unknown-linux-gnuabiv2.md)
+    - [hexagon-unknown-none-elf](platform-support/hexagon-unknown-none-elf.md)
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)
     - [loongarch\*-unknown-none\*](platform-support/loongarch-none.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -265,6 +265,7 @@ target | std | host | notes
 `bpfel-unknown-none` | * |  | BPF (little endian)
 `csky-unknown-linux-gnuabiv2` | ✓ |  | C-SKY abiv2 Linux (little endian)
 `csky-unknown-linux-gnuabiv2hf` | ✓ |  | C-SKY abiv2 Linux, hardfloat (little endian)
+[`hexagon-unknown-none-elf`](platform-support/hexagon-unknown-none-elf.md)| * | Bare Hexagon (v60+, HVX)
 `hexagon-unknown-linux-musl` | ? |  |
 `i386-apple-ios` | ✓ |  | 32-bit x86 iOS [^x86_32-floats-return-ABI]
 [`i586-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX Neutrino 7.0 RTOS  [^x86_32-floats-return-ABI]

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
@@ -1,0 +1,266 @@
+# `hexagon-unknown-none-elf`
+
+**Tier: 3**
+
+Rust for baremetal Hexagon DSPs.
+
+| Target                   | Descriptions                              |
+| ------------------------ | ----------------------------------------- |
+| hexagon-unknown-none-elf | Hexagon 32-bit (freestanding, hardfloat)  |
+
+## Target maintainers
+
+- [Brian Cain](https://github.com/androm3da), `bcain@quicinc.com`
+
+## Requirements
+
+This target is cross-compiled.  There is no support for `std`. There is no
+default allocator, but it's possible to use `alloc` by supplying an allocator.
+
+By default, code generated with this target should run on Hexagon DSP hardware.
+
+- `-Ctarget-cpu=hexagonv73` adds support for instructions defined up to Hexagon V73.
+
+Functions marked `extern "C"` use the [Hexagon architecture calling convention](https://lists.llvm.org/pipermail/llvm-dev/attachments/20190916/21516a52/attachment-0001.pdf).
+
+This target generates PIC ELF binaries.
+
+## Building the target
+
+You can build Rust with support for the target by adding it to the `target`
+list in `config.toml`:
+
+```toml
+[build]
+build-stage = 1
+host = ["<target for your host>"]
+target = ["<target for your host>", "hexagon-unknown-none-elf"]
+
+[target.hexagon-unknown-none-elf]
+
+cc = "hexagon-unknown-none-elf-clang"
+cxx = "hexagon-unknown-none-elf-clang++"
+linker = "hexagon-unknown-none-elf-clang"
+llvm-libunwind = 'in-tree'
+```
+
+Replace `<target for your host>` with `x86_64-unknown-linux-gnu` or whatever
+else is appropriate for your host machine.
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will either need to build Rust with the target enabled (see
+"Building the target" above), or build your own copy of `core` by using
+`build-std` or similar.
+
+## Testing
+
+Since `hexagon-unknown-none-elf` supports a variety of different environments and
+does not support `std`, this target does not support running the Rust test suite.
+
+## Cross-compilation toolchains and C code
+
+This target has been tested using `qemu-system-hexagon`.
+
+A common use case for `hexagon-unknown-none-elf` is building libraries that
+link against C code and can be used in emulation or on a device with a
+Hexagon DSP.
+
+The Hexagon SDK has libraries which are useful to link against when running
+on a device.
+
+
+# Standalone OS
+
+The script below will build an executable against "hexagon standalone OS"
+which is suitable for emulation or bare-metal on-device testing.
+
+First, run `cargo new --bin demo1_hexagon` then add the source below as
+`src/main.rs`.  This program demonstrates the console output via semihosting.
+
+```rust,ignore (platform-specific,eh-personality-is-unstable)
+#![no_std]
+#![no_main]
+
+extern "C" {
+    fn putchar(ch: i32);
+    fn _exit(code: i32) -> !;
+}
+
+#[no_mangle]
+extern "C" fn main() -> i32 {
+    let message = "Hello, this is Rust!";
+    for b in message.bytes() {
+        unsafe {
+            putchar(b as i32);
+        }
+    }
+    0
+}
+
+#[panic_handler]
+fn panic(_panic: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        _exit(1);
+    }
+}
+
+```
+
+Next, save the script below as `build.sh` and edit it to suit your
+environment.
+
+* `hex_toolchain` below refers to the [hexagon toolchain using exclusively
+public open source repos](https://github.com/quic/toolchain_for_hexagon/releases).
+* `cc` below refers to clang.  You can use `clang` from your distribution, as
+long as it's at least `clang-17`.  Or you can use
+`hexagon-unknown-none-elf-clang` from one of the [hexagon open source toolchain
+releases](https://github.com/quic/toolchain_for_hexagon/releases).
+
+```sh
+# Hexagon SDK, required for target libraries:
+hex_sdk_root=/local/mnt/workspace/Qualcomm/Hexagon_SDK/5.3.0.0
+hex_sdk_toolchain=${hex_sdk_root}/tools/HEXAGON_Tools/8.6.06
+
+sdk_libs=${hex_sdk_toolchain}/Tools/target/hexagon/lib
+q6_arch=v65
+g0_lib_path=${sdk_libs}/${q6_arch}/G0
+pic_lib_path=${sdk_libs}/${q6_arch}/G0/pic
+
+cargo build --target=hexagon-unknown-none-elf -Zbuild-std
+
+# Builds an executable against "hexagon standalone OS" suitable for emulation:
+${cc} --target=hexagon-unknown-none-elf -o testit \
+    -fuse-ld=lld \
+    -m${q6_arch} \
+    -nodefaultlibs \
+    -nostartfiles \
+    ${g0_lib_path}/crt0_standalone.o \
+    ${g0_lib_path}/crt0.o \
+    ${g0_lib_path}/init.o \
+    -L${sdk_libs}/${q6_arch}/ \
+    -L${sdk_libs}/ \
+    testit.c \
+    target/hexagon-unknown-none-elf/debug/libmin_ex_lib_lin.rlib \
+    target/hexagon-unknown-none-elf/debug/deps/libcore-*.rlib \
+    target/hexagon-unknown-none-elf/debug/deps/libcompiler_builtins-*.rlib \
+    -Wl,--start-group \
+    -Wl,--defsym,_SDA_BASE_=0,--defsym,__sbss_start=0,--defsym,__sbss_end=0 \
+    -lstandalone \
+    ${g0_lib_path}/libc.a \
+    -lgcc \
+    -lc_eh \
+    -Wl,--end-group \
+    ${g0_lib_path}/fini.o \
+
+${hex_toolchain}/x86_64-linux-gnu/bin/qemu-system-hexagon -monitor none -display none -kernel ./testit
+```
+
+# QuRT OS
+
+First, run `cargo new --lib demo2_hexagon` then add the source below as
+`src/lib.rs`.  This program demonstrates inline assembly and console output
+via semihosting.
+
+```rust,ignore (platform-specific,eh-personality-is-unstable)
+#![no_std]
+#![no_main]
+#![feature(lang_items)]
+#![feature(asm_experimental_arch)]
+
+use core::arch::asm;
+
+extern "C" {
+    fn putchar(ch: i32);
+    fn _exit(code: i32) -> !;
+}
+
+fn hexagon_specific() {
+    let mut buffer = [0_u8; 128];
+
+    unsafe {
+        let mut x = &buffer;
+        asm!(
+                "{{\n\t",
+                "  v0=vmem({addr}+#0)\n\t",
+                "  {tmp} = and({tmp}, #1)\n\t",
+                "}}\n\t",
+                addr = in(reg) x,
+                tmp = out(reg) _,
+            );
+    }
+}
+
+#[no_mangle]
+extern "C" fn hello() -> i32 {
+    let message = "Hello, this is Rust!\n";
+    for b in message.bytes() {
+        unsafe {
+            putchar(b as i32);
+        }
+    }
+    hexagon_specific();
+    0
+}
+
+#[panic_handler]
+fn panic(_panic: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        _exit(1);
+    }
+}
+
+#[lang = "eh_personality"]
+fn rust_eh_personality() {}
+
+```
+
+Next, save the script below as `build.sh` and edit it to suit your
+environment.  The script below will build a shared object against the QuRT
+RTOS which is suitable for emulation or on-device testing when loaded via
+the fastrpc-shell.
+
+
+```sh
+# Hexagon SDK, required for target libraries:
+hex_sdk_root=/local/mnt/workspace/Qualcomm/Hexagon_SDK/5.3.0.0
+hex_sdk_toolchain=${hex_sdk_root}/tools/HEXAGON_Tools/8.6.06
+
+sdk_libs=${hex_sdk_toolchain}/Tools/target/hexagon/lib
+q6_arch=v65
+g0_lib_path=${sdk_libs}/${q6_arch}/G0
+pic_lib_path=${sdk_libs}/${q6_arch}/G0/pic
+runelf=${hex_sdk_root}/rtos/qurt/computev65/sdksim_bin/runelf.pbn
+rmohs=${hex_sdk_root}/libs/run_main_on_hexagon/ship/hexagon_toolv86_${q6_arch}/run_main_on_hexagon_sim
+
+# Builds a library suitable for loading into "run_main_on_hexagon_sim" for
+# emulation or frpc shell on real target:
+${cc} --target=hexagon-unknown-none-elf -o testit.so \
+    -fuse-ld=lld \
+    -fPIC -shared \
+    -nostdlib \
+    -Wl,-Bsymbolic \
+      -Wl,--wrap=malloc \
+      -Wl,--wrap=calloc \
+      -Wl,--wrap=free \
+      -Wl,--wrap=realloc \
+      -Wl,--wrap=memalign \
+    -m${q6_arch} \
+    testit.c \
+    target/hexagon-unknown-none-elf/debug/libmin_ex_lib_lin.rlib \
+    target/hexagon-unknown-none-elf/debug/deps/libcore-*.rlib \
+    target/hexagon-unknown-none-elf/debug/deps/libcompiler_builtins-*.rlib \
+    -Wl,-soname=testit \
+    ${pic_lib_path}/libc.so
+
+# -Bsymbolic above for memory alloc funcs is necessary to access the heap on
+# target, but otherwise not required.
+
+# multi-stage loader: runelf => run_main_on_hexagon_sim => testit.so{`main`}
+${hex_toolchain}/x86_64-linux-gnu/bin/qemu-system-hexagon \
+    -monitor none \
+    -display none \
+    -kernel ${runelf} \
+    -append "${rmohs} -- ./testit.so"
+```

--- a/tests/codegen/overaligned-constant.rs
+++ b/tests/codegen/overaligned-constant.rs
@@ -17,7 +17,7 @@ fn main() {
     // CHECK: [[full:%_.*]] = alloca %SmallStruct, align 8
     // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[full]], ptr align 8 @0, i64 32, i1 false)
     // CHECK: %b.0 = load i32, ptr @0, align 4,
-    // CHECK: %b.1 = load i32, ptr getelementptr inbounds ({ i32, i32 }, ptr @0, i32 0, i32 1), align 4
+    // CHECK: %b.1 = load i32, ptr getelementptr inbounds ({{.*}}), align 4
     let mut s = S(1);
 
     s.0 = 3;

--- a/tests/ui/entry-point/return-ty-has-bound-vars.rs
+++ b/tests/ui/entry-point/return-ty-has-bound-vars.rs
@@ -1,5 +1,3 @@
 // issue-119209
 
-type Foo<'a> = impl PartialEq; //~ERROR `impl Trait` in type aliases is unstable
-
-fn main<'a>(_: &'a i32) -> Foo<'a> {} //~ERROR `main` function return type is not allowed to have generic parameters
+fn main<'a>(_: &'a i32) -> &'a () { &() } //~ERROR `main` function return type is not allowed to have generic parameters

--- a/tests/ui/entry-point/return-ty-has-bound-vars.rs
+++ b/tests/ui/entry-point/return-ty-has-bound-vars.rs
@@ -1,0 +1,5 @@
+// issue-119209
+
+type Foo<'a> = impl PartialEq; //~ERROR `impl Trait` in type aliases is unstable
+
+fn main<'a>(_: &'a i32) -> Foo<'a> {} //~ERROR `main` function return type is not allowed to have generic parameters

--- a/tests/ui/entry-point/return-ty-has-bound-vars.stderr
+++ b/tests/ui/entry-point/return-ty-has-bound-vars.stderr
@@ -1,0 +1,19 @@
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/return-ty-has-bound-vars.rs:3:16
+   |
+LL | type Foo<'a> = impl PartialEq;
+   |                ^^^^^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error[E0131]: `main` function return type is not allowed to have generic parameters
+  --> $DIR/return-ty-has-bound-vars.rs:5:28
+   |
+LL | fn main<'a>(_: &'a i32) -> Foo<'a> {}
+   |                            ^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0131, E0658.
+For more information about an error, try `rustc --explain E0131`.

--- a/tests/ui/entry-point/return-ty-has-bound-vars.stderr
+++ b/tests/ui/entry-point/return-ty-has-bound-vars.stderr
@@ -1,19 +1,9 @@
-error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/return-ty-has-bound-vars.rs:3:16
-   |
-LL | type Foo<'a> = impl PartialEq;
-   |                ^^^^^^^^^^^^^^
-   |
-   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
-   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
-
 error[E0131]: `main` function return type is not allowed to have generic parameters
-  --> $DIR/return-ty-has-bound-vars.rs:5:28
+  --> $DIR/return-ty-has-bound-vars.rs:3:28
    |
-LL | fn main<'a>(_: &'a i32) -> Foo<'a> {}
-   |                            ^^^^^^^
+LL | fn main<'a>(_: &'a i32) -> &'a () { &() }
+   |                            ^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0131, E0658.
-For more information about an error, try `rustc --explain E0131`.
+For more information about this error, try `rustc --explain E0131`.


### PR DESCRIPTION
Successful merges:

 - #117601 (Add support for hexagon-unknown-none-elf as target)
 - #119169 (Rid the AST & HIR pretty printer of cruft)
 - #119194 (Run fuchsia tests only on nightly)
 - #119201 (tests: fix overaligned-constant to not over-specify getelementptr instr)
 - #119215 (Emits error if has bound regions)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117601,119169,119194,119201,119215)
<!-- homu-ignore:end -->