### PR TITLE
Drop panic hook after running tests

### DIFF
--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -140,7 +140,10 @@ pub fn test_main(args: &[String], tests: Vec<TestDescAndFn>, options: Option<Opt
             });
             panic::set_hook(hook);
         }
-        match console::run_tests_console(&opts, tests) {
+        let res = console::run_tests_console(&opts, tests);
+        // Prevent Valgrind from reporting reachable blocks in users' unit tests.
+        drop(panic::take_hook());
+        match res {
             Ok(true) => {}
             Ok(false) => process::exit(ERROR_EXIT_CODE),
             Err(e) => {


### PR DESCRIPTION
Issue: https://github.com/rust-lang/rust/issues/119223
Previously we left the panic hook we allocated
on main termination. Doing so makes Valgrind
report it as a reachable unfreed block.
In order to fix that use `panic::take_hook()` before examining test results.

Example backtrace:
```
==146594== 16 bytes in 1 blocks are still reachable in loss record 1 of 1
==146594==    at 0x4A390C5: malloc (vg_replace_malloc.c:442)
==146594==    by 0x151336: alloc (alloc.rs:98)
==146594==    by 0x151336: alloc_impl (alloc.rs:181)
==146594==    by 0x151336: allocate (alloc.rs:241)
==146594==    by 0x151336: exchange_malloc (alloc.rs:330)
==146594==    by 0x151336: new<test::test_main::{closure_env#0}> (boxed.rs:217)
==146594==    by 0x151336: test::test_main (lib.rs:124)
==146594==    by 0x1522F9: test::test_main_static (lib.rs:160)
==146594==    by 0x11E102: reachable_block_with_cargo_test::main (lib.rs:1)
==146594==    by 0x11EABA: core::ops::function::FnOnce::call_once (function.rs:250)
==146594==    by 0x11E76D: std::sys_common::backtrace::__rust_begin_short_backtrace (backtrace.rs:154)
==146594==    by 0x11DFC0: std::rt::lang_start::{{closure}} (rt.rs:166)
==146594==    by 0x177D3A: call_once<(), (dyn core::ops::function::Fn<(), Output=i32> + core::marker::Sync + core::panic::unwind_safe::RefUnwindSafe)> (function.rs:284)
==146594==    by 0x177D3A: do_call<&(dyn core::ops::function::Fn<(), Output=i32> + core::marker::Sync + core::panic::unwind_safe::RefUnwindSafe), i32> (panicking.rs:504)
==146594==    by 0x177D3A: try<i32, &(dyn core::ops::function::Fn<(), Output=i32> + core::marker::Sync + core::panic::unwind_safe::RefUnwindSafe)> (panicking.rs:468)
==146594==    by 0x177D3A: catch_unwind<&(dyn core::ops::function::Fn<(), Output=i32> + core::marker::Sync + core::panic::unwind_safe::RefUnwindSafe), i32> (panic.rs:142)
==146594==    by 0x177D3A: {closure#2} (rt.rs:148)
==146594==    by 0x177D3A: do_call<std::rt::lang_start_internal::{closure_env#2}, isize> (panicking.rs:504)
==146594==    by 0x177D3A: try<isize, std::rt::lang_start_internal::{closure_env#2}> (panicking.rs:468)
==146594==    by 0x177D3A: catch_unwind<std::rt::lang_start_internal::{closure_env#2}, isize> (panic.rs:142)
==146594==    by 0x177D3A: std::rt::lang_start_internal (rt.rs:148)
==146594==    by 0x11DF99: std::rt::lang_start (rt.rs:165)
```