### PR TITLE
Fix doc typos

### DIFF
--- a/src/doc/rustc/src/platform-support/wasm32-wasi-preview1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasi-preview1-threads.md
@@ -90,7 +90,7 @@ The target intends to match the corresponding Clang target for its `"C"` ABI.
 
 ## Platform requirements
 
-The runtime should support the same set of APIs as any other supported wasi target for interacting with the host environment through the WASI standard. The runtime also should have implemetation of [wasi-threads proposal](https://github.com/WebAssembly/wasi-threads).
+The runtime should support the same set of APIs as any other supported wasi target for interacting with the host environment through the WASI standard. The runtime also should have implementation of [wasi-threads proposal](https://github.com/WebAssembly/wasi-threads).
 
 This target is not a stable target. This means that there are a few engines
 which implement the `wasi-threads` feature and if they do they're likely behind a

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -415,7 +415,7 @@ warning: 1 warning emitted
 
 ## `redundant_explicit_links`
 
-This lint is **warn-by-default**. It detects explicit links that are same
+This lint is **warn-by-default**. It detects explicit links that are the same
 as computed automatic links.
 This usually means the explicit links are removeable. For example:
 

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -415,9 +415,9 @@ warning: 1 warning emitted
 
 ## `redundant_explicit_links`
 
-This lint is **warned by default**. It detects explicit links that are same
+This lint is **warn-by-default**. It detects explicit links that are same
 as computed automatic links.
-This usually means the explicit links is removeable. For example:
+This usually means the explicit links are removeable. For example:
 
 ```rust
 #![warn(rustdoc::redundant_explicit_links)] // note: unnecessary - warns by default.

--- a/src/doc/unstable-book/src/compiler-flags/check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/check-cfg.md
@@ -107,7 +107,7 @@ fn poke_platypus() {}
 fn tame_lion() {}
 
 // This is UNEXPECTED, because 'windows' is a well known condition name,
-// and because 'windows' doens't take any values,
+// and because 'windows' doesn't take any values,
 // and will cause a compiler warning (by default).
 #[cfg(windows = "unix")]
 fn tame_windows() {}

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -186,8 +186,8 @@ declare_rustdoc_lint! {
 }
 
 declare_rustdoc_lint! {
-    /// This lint is **warned by default**. It detects explicit links that are same
-    /// as computed automatic links. This usually means the explicit links is removeable.
+    /// This lint is **warn-by-default**. It detects explicit links that are the same
+    /// as computed automatic links. This usually means the explicit links are removeable.
     /// This is a `rustdoc` only lint, see the documentation in the [rustdoc book].
     ///
     /// [rustdoc book]: ../../../rustdoc/lints.html#redundant_explicit_links

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -494,7 +494,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             let mut err = |_| {
                 tidy_error!(bad, "{}: leading newline", file.display());
             };
-            suppressible_tidy_err!(err, skip_leading_newlines, "mising leading newline");
+            suppressible_tidy_err!(err, skip_leading_newlines, "missing leading newline");
         }
         let mut err = |msg: &str| {
             tidy_error!(bad, "{}: {}", file.display(), msg);


### PR DESCRIPTION
This PR fixes some typos I found while trawling through the rust source. 