### PR TITLE
Exhaustiveness: keep the original `thir::Pat` around

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -856,21 +856,21 @@ fn report_arm_reachability<'p, 'tcx>(
     for (arm, is_useful) in report.arm_usefulness.iter() {
         match is_useful {
             Usefulness::Redundant => {
-                report_unreachable_pattern(*arm.pat.data().unwrap(), arm.arm_data, catchall)
+                report_unreachable_pattern(arm.pat.data().unwrap().span, arm.arm_data, catchall)
             }
             Usefulness::Useful(redundant_subpats) if redundant_subpats.is_empty() => {}
             // The arm is reachable, but contains redundant subpatterns (from or-patterns).
             Usefulness::Useful(redundant_subpats) => {
                 let mut redundant_subpats = redundant_subpats.clone();
                 // Emit lints in the order in which they occur in the file.
-                redundant_subpats.sort_unstable_by_key(|pat| pat.data());
+                redundant_subpats.sort_unstable_by_key(|pat| pat.data().unwrap().span);
                 for pat in redundant_subpats {
-                    report_unreachable_pattern(*pat.data().unwrap(), arm.arm_data, None);
+                    report_unreachable_pattern(pat.data().unwrap().span, arm.arm_data, None);
                 }
             }
         }
         if !arm.has_guard && catchall.is_none() && pat_is_catchall(arm.pat) {
-            catchall = Some(*arm.pat.data().unwrap());
+            catchall = Some(arm.pat.data().unwrap().span);
         }
     }
 }

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -203,7 +203,7 @@ pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
                 };
 
                 use rustc_errors::DecorateLint;
-                let mut err = rcx.tcx.dcx().struct_span_warn(*arm.pat.data().unwrap(), "");
+                let mut err = rcx.tcx.dcx().struct_span_warn(arm.pat.data().unwrap().span, "");
                 err.set_primary_message(decorator.msg());
                 decorator.decorate_lint(&mut err);
                 err.emit();
@@ -254,7 +254,7 @@ pub(crate) fn lint_overlapping_range_endpoints<'a, 'p, 'tcx>(
                 // Iterate on patterns that contained `overlap`.
                 for pat in column.iter() {
                     let Constructor::IntRange(this_range) = pat.ctor() else { continue };
-                    let this_span = *pat.data().unwrap();
+                    let this_span = pat.data().unwrap().span;
                     if this_range.is_singleton() {
                         // Don't lint when one of the ranges is a singleton.
                         continue;

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -540,7 +540,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
                         // `Ref`), and has one field. That field has constructor `Str(value)` and no
                         // subfields.
                         // Note: `t` is `str`, not `&str`.
-                        let subpattern = DeconstructedPat::new(Str(*value), &[], *t, pat.span);
+                        let subpattern = DeconstructedPat::new(Str(*value), &[], *t, pat);
                         ctor = Ref;
                         fields = singleton(subpattern)
                     }
@@ -624,7 +624,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
                 fields = &[];
             }
         }
-        DeconstructedPat::new(ctor, fields, pat.ty, pat.span)
+        DeconstructedPat::new(ctor, fields, pat.ty, pat)
     }
 
     /// Convert back to a `thir::PatRangeBoundary` for diagnostic purposes.
@@ -894,7 +894,7 @@ impl<'p, 'tcx> TypeCx for RustcMatchCheckCtxt<'p, 'tcx> {
     type VariantIdx = VariantIdx;
     type StrLit = Const<'tcx>;
     type ArmData = HirId;
-    type PatData = Span;
+    type PatData = &'p Pat<'tcx>;
 
     fn is_exhaustive_patterns_feature_on(&self) -> bool {
         self.tcx.features().exhaustive_patterns


### PR DESCRIPTION
This PR makes it possible for exhaustiveness to look at the original `thir::Pat`, which I'll need at least for the [`small_gaps`](https://github.com/rust-lang/rust/pull/118879) lint (without that we can't distinguish inclusive and exclusive ranges within exhaustiveness). This PR is almost entirely lifetime-wrangling.