### PR TITLE
Make some non-diagnostic-affecting `QPath::LangItem` into regular `QPath`s

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -639,7 +639,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             self.lower_span(span),
             Some(self.allow_gen_future.clone()),
         );
-        let resume_ty = hir::QPath::LangItem(hir::LangItem::ResumeTy, unstable_span);
+        let resume_ty = self.make_lang_item_qpath(hir::LangItem::ResumeTy, unstable_span);
         let input_ty = hir::Ty {
             hir_id: self.next_id(),
             kind: hir::TyKind::Path(resume_ty),
@@ -777,7 +777,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             self.lower_span(span),
             Some(self.allow_gen_future.clone()),
         );
-        let resume_ty = hir::QPath::LangItem(hir::LangItem::ResumeTy, unstable_span);
+        let resume_ty = self.make_lang_item_qpath(hir::LangItem::ResumeTy, unstable_span);
         let input_ty = hir::Ty {
             hir_id: self.next_id(),
             kind: hir::TyKind::Path(resume_ty),
@@ -2116,11 +2116,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
         lang_item: hir::LangItem,
         name: Symbol,
     ) -> hir::Expr<'hir> {
+        let qpath = self.make_lang_item_qpath(lang_item, self.lower_span(span));
         let path = hir::ExprKind::Path(hir::QPath::TypeRelative(
-            self.arena.alloc(self.ty(
-                span,
-                hir::TyKind::Path(hir::QPath::LangItem(lang_item, self.lower_span(span))),
-            )),
+            self.arena.alloc(self.ty(span, hir::TyKind::Path(qpath))),
             self.arena.alloc(hir::PathSegment::new(
                 Ident::new(name, span),
                 self.next_id(),

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -766,6 +766,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.resolver.get_import_res(id).present_items()
     }
 
+    fn make_lang_item_qpath(&mut self, lang_item: hir::LangItem, span: Span) -> hir::QPath<'hir> {
+        hir::QPath::Resolved(None, self.make_lang_item_path(lang_item, span, None))
+    }
+
     fn make_lang_item_path(
         &mut self,
         lang_item: hir::LangItem,
@@ -783,7 +787,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 hir_id: self.next_id(),
                 res,
                 args,
-                infer_args: false,
+                infer_args: args.is_none(),
             }]),
         })
     }

--- a/src/tools/clippy/tests/ui/author/macro_in_closure.stdout
+++ b/src/tools/clippy/tests/ui/author/macro_in_closure.stdout
@@ -12,6 +12,7 @@ if let StmtKind::Local(local) = stmt.kind
     && args.len() == 1
     && let ExprKind::Call(func1, args1) = args[0].kind
     && let ExprKind::Path(ref qpath1) = func1.kind
+    && match_qpath(qpath1, &["format_arguments", "new_v1"])
     && args1.len() == 2
     && let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, inner) = args1[0].kind
     && let ExprKind::Array(elements) = inner.kind
@@ -27,6 +28,7 @@ if let StmtKind::Local(local) = stmt.kind
     && elements1.len() == 1
     && let ExprKind::Call(func2, args2) = elements1[0].kind
     && let ExprKind::Path(ref qpath2) = func2.kind
+    && match_qpath(qpath2, &["format_argument", "new_display"])
     && args2.len() == 1
     && let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, inner2) = args2[0].kind
     && let ExprKind::Path(ref qpath3) = inner2.kind

--- a/src/tools/clippy/tests/ui/author/macro_in_loop.stdout
+++ b/src/tools/clippy/tests/ui/author/macro_in_loop.stdout
@@ -22,6 +22,7 @@ if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::Fo
     && args.len() == 1
     && let ExprKind::Call(func1, args1) = args[0].kind
     && let ExprKind::Path(ref qpath2) = func1.kind
+    && match_qpath(qpath2, &["format_arguments", "new_v1"])
     && args1.len() == 2
     && let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, inner) = args1[0].kind
     && let ExprKind::Array(elements) = inner.kind
@@ -37,6 +38,7 @@ if let Some(higher::ForLoop { pat: pat, arg: arg, body: body, .. }) = higher::Fo
     && elements1.len() == 1
     && let ExprKind::Call(func2, args2) = elements1[0].kind
     && let ExprKind::Path(ref qpath3) = func2.kind
+    && match_qpath(qpath3, &["format_argument", "new_display"])
     && args2.len() == 1
     && let ExprKind::AddrOf(BorrowKind::Ref, Mutability::Not, inner2) = args2[0].kind
     && let ExprKind::Path(ref qpath4) = inner2.kind

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -32,7 +32,7 @@ fn bar() ({
         ({
                 let res =
                     ((::alloc::fmt::format as
-                            for<'a> fn(Arguments<'a>) -> String {format})(((<#[lang = "format_arguments"]>::new_const
+                            for<'a> fn(Arguments<'a>) -> String {format})(((format_arguments::new_const
                                 as
                                 fn(&[&'static str]) -> Arguments<'_> {Arguments::<'_>::new_const})((&([("test"
                                             as &str)] as [&str; 1]) as &[&str; 1])) as Arguments<'_>))

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -9,8 +9,7 @@ fn main() {
         let x = 1;
         // Should flatten to println!("a 123 b {x} xyz\n"):
         {
-                ::std::io::_print(<#[lang = "format_arguments"]>::new_v1(&["a 123 b ",
-                                    " xyz\n"],
-                        &[<#[lang = "format_argument"]>::new_display(&x)]));
+                ::std::io::_print(format_arguments::new_v1(&["a 123 b ",
+                                    " xyz\n"], &[format_argument::new_display(&x)]));
             };
     }


### PR DESCRIPTION
The rest of 'em affect diagnostics, so leave them alone... for now.

cc #115178