### PR TITLE
[rustdoc] Add `is_object_safe` information for traits in JSON output

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -648,10 +648,12 @@ impl FromWithTcx<clean::Trait> for Trait {
     fn from_tcx(trait_: clean::Trait, tcx: TyCtxt<'_>) -> Self {
         let is_auto = trait_.is_auto(tcx);
         let is_unsafe = trait_.unsafety(tcx) == rustc_hir::Unsafety::Unsafe;
+        let is_object_safe = trait_.is_object_safe(tcx);
         let clean::Trait { items, generics, bounds, .. } = trait_;
         Trait {
             is_auto,
             is_unsafe,
+            is_object_safe,
             items: ids(items, tcx),
             generics: generics.into_tcx(tcx),
             bounds: bounds.into_tcx(tcx),

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 27;
+pub const FORMAT_VERSION: u32 = 28;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -634,6 +634,7 @@ pub struct FnDecl {
 pub struct Trait {
     pub is_auto: bool,
     pub is_unsafe: bool,
+    pub is_object_safe: bool,
     pub items: Vec<Id>,
     pub generics: Generics,
     pub bounds: Vec<GenericBound>,

--- a/tests/rustdoc-json/traits/is_object_safe.rs
+++ b/tests/rustdoc-json/traits/is_object_safe.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+// @has "$.index[*][?(@.name=='FooUnsafe')]"
+// @is "$.index[*][?(@.name=='FooUnsafe')].inner.trait.is_object_safe" false
+pub trait FooUnsafe {
+    fn foo() -> Self;
+}
+
+// @has "$.index[*][?(@.name=='BarUnsafe')]"
+// @is "$.index[*][?(@.name=='BarUnsafe')].inner.trait.is_object_safe" false
+pub trait BarUnsafe<T> {
+    fn foo(i: T);
+}
+
+// @has "$.index[*][?(@.name=='FooSafe')]"
+// @is "$.index[*][?(@.name=='FooSafe')].inner.trait.is_object_safe" true
+pub trait FooSafe {
+    fn foo(&self);
+}

--- a/tests/rustdoc/trait-object-safe.rs
+++ b/tests/rustdoc/trait-object-safe.rs
@@ -22,6 +22,6 @@ pub trait Safe {
 }
 
 // @has 'foo/struct.Foo.html'
-// @!has - '//*[@class="object-safety-info"]' ''
-// @!has - '//*[@id="object-safety"]' ''
+// @count - '//*[@class="object-safety-info"]' 0
+// @count - '//*[@id="object-safety"]' 0
 pub struct Foo;


### PR DESCRIPTION
As asked by @obi1kenobi [here](https://github.com/rust-lang/rust/pull/113241#issuecomment-1868213677).

cc @aDotInTheVoid 
r? @notriddle 