### PR TITLE
remove dead inferred outlives testing code

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0640.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0640.md
@@ -1,1 +1,2 @@
 #### This error code is internal to the compiler and will not be emitted with normal Rust code.
+#### Note: this error code is no longer emitted by the compiler.

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -4,7 +4,6 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::GenericArgKind;
 use rustc_middle::ty::{self, CratePredicatesMap, ToPredicate, TyCtxt};
-use rustc_span::symbol::sym;
 use rustc_span::Span;
 
 mod explicit;
@@ -48,25 +47,6 @@ fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[(ty::Clau
 
                 let predicates =
                     crate_map.predicates.get(&item_def_id.to_def_id()).copied().unwrap_or(&[]);
-
-                if tcx.has_attr(item_def_id, sym::rustc_outlives) {
-                    let mut pred: Vec<String> = predicates
-                        .iter()
-                        .map(|(out_pred, _)| match out_pred.kind().skip_binder() {
-                            ty::ClauseKind::RegionOutlives(p) => p.to_string(),
-                            ty::ClauseKind::TypeOutlives(p) => p.to_string(),
-                            err => bug!("unexpected clause {:?}", err),
-                        })
-                        .collect();
-                    pred.sort();
-
-                    let span = tcx.def_span(item_def_id);
-                    let mut err = tcx.sess.struct_span_err(span, "rustc_outlives");
-                    for p in pred {
-                        err.note(p);
-                    }
-                    err.emit();
-                }
 
                 debug!("inferred_outlives_of({:?}) = {:?}", item_def_id, predicates);
 

--- a/compiler/rustc_hir_analysis/src/outlives/test.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/test.rs
@@ -1,5 +1,4 @@
-use rustc_errors::struct_span_err;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::symbol::sym;
 
 pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
@@ -7,15 +6,23 @@ pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
         // For unit testing: check for a special "rustc_outlives"
         // attribute and report an error with various results if found.
         if tcx.has_attr(id.owner_id, sym::rustc_outlives) {
-            let inferred_outlives_of = tcx.inferred_outlives_of(id.owner_id);
-            struct_span_err!(
-                tcx.sess,
-                tcx.def_span(id.owner_id),
-                E0640,
-                "{:?}",
-                inferred_outlives_of
-            )
-            .emit();
+            let predicates = tcx.inferred_outlives_of(id.owner_id);
+            let mut pred: Vec<String> = predicates
+                .iter()
+                .map(|(out_pred, _)| match out_pred.kind().skip_binder() {
+                    ty::ClauseKind::RegionOutlives(p) => p.to_string(),
+                    ty::ClauseKind::TypeOutlives(p) => p.to_string(),
+                    err => bug!("unexpected clause {:?}", err),
+                })
+                .collect();
+            pred.sort();
+
+            let span = tcx.def_span(id.owner_id);
+            let mut err = tcx.sess.struct_span_err(span, "rustc_outlives");
+            for p in pred {
+                err.note(p);
+            }
+            err.emit();
         }
     }
 }

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -27,7 +27,7 @@ const ERROR_DOCS_PATH: &str = "compiler/rustc_error_codes/src/error_codes/";
 const ERROR_TESTS_PATH: &str = "tests/ui/error-codes/";
 
 // Error codes that (for some reason) can't have a doctest in their explanation. Error codes are still expected to provide a code example, even if untested.
-const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E0640", "E0717"];
+const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E0717"];
 
 // Error codes that don't yet have a UI test. This list will eventually be removed.
 const IGNORE_UI_TEST_CHECK: &[&str] =


### PR DESCRIPTION
The `test_inferred_outlives` function was never run, because the code that's actually used for the tests was part of the `inferred_outlives_of` query, which ran before `test_inferred_outlives` during type collecting. This PR separates the test code from the query and moves it inside the dedicated function.