### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -779,8 +779,7 @@ pub enum PatKind {
     Ident(BindingAnnotation, Ident, Option<P<Pat>>),
 
     /// A struct or struct variant pattern (e.g., `Variant {x, y, ..}`).
-    /// The `bool` is `true` in the presence of a `..`.
-    Struct(Option<P<QSelf>>, Path, ThinVec<PatField>, /* recovered */ bool),
+    Struct(Option<P<QSelf>>, Path, ThinVec<PatField>, PatFieldsRest),
 
     /// A tuple struct/variant pattern (`Variant(x, y, .., z)`).
     TupleStruct(Option<P<QSelf>>, Path, ThinVec<P<Pat>>),
@@ -835,6 +834,15 @@ pub enum PatKind {
 
     /// A macro pattern; pre-expansion.
     MacCall(P<MacCall>),
+}
+
+/// Whether the `..` is present in a struct fields pattern.
+#[derive(Clone, Copy, Encodable, Decodable, Debug, PartialEq)]
+pub enum PatFieldsRest {
+    /// `module::StructName { field, ..}`
+    Rest,
+    /// `module::StructName { field }`
+    None,
 }
 
 /// The kind of borrow in an `AddrOf` expression,

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -82,7 +82,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                 span: self.lower_span(f.span),
                             }
                         }));
-                        break hir::PatKind::Struct(qpath, fs, *etc);
+                        break hir::PatKind::Struct(qpath, fs, *etc == ast::PatFieldsRest::Rest);
                     }
                     PatKind::Tuple(pats) => {
                         let (pats, ddpos) = self.lower_pat_tuple(pats, "tuple");

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1427,7 +1427,7 @@ impl<'a> State<'a> {
                 }
                 self.nbsp();
                 self.word("{");
-                let empty = fields.is_empty() && !etc;
+                let empty = fields.is_empty() && *etc == ast::PatFieldsRest::None;
                 if !empty {
                     self.space();
                 }
@@ -1445,7 +1445,7 @@ impl<'a> State<'a> {
                     },
                     |f| f.pat.span,
                 );
-                if *etc {
+                if *etc == ast::PatFieldsRest::Rest {
                     if !fields.is_empty() {
                         self.word_space(",");
                     }

--- a/compiler/rustc_error_codes/src/error_codes/E0640.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0640.md
@@ -1,1 +1,2 @@
 #### This error code is internal to the compiler and will not be emitted with normal Rust code.
+#### Note: this error code is no longer emitted by the compiler.

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -488,7 +488,7 @@ impl<'a> ExtCtxt<'a> {
         path: ast::Path,
         field_pats: ThinVec<ast::PatField>,
     ) -> P<ast::Pat> {
-        self.pat(span, PatKind::Struct(None, path, field_pats, false))
+        self.pat(span, PatKind::Struct(None, path, field_pats, ast::PatFieldsRest::None))
     }
     pub fn pat_tuple(&self, span: Span, pats: ThinVec<P<ast::Pat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::Tuple(pats))

--- a/compiler/rustc_hir_analysis/src/outlives/mod.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/mod.rs
@@ -4,7 +4,6 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::GenericArgKind;
 use rustc_middle::ty::{self, CratePredicatesMap, ToPredicate, TyCtxt};
-use rustc_span::symbol::sym;
 use rustc_span::Span;
 
 mod explicit;
@@ -48,25 +47,6 @@ fn inferred_outlives_of(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[(ty::Clau
 
                 let predicates =
                     crate_map.predicates.get(&item_def_id.to_def_id()).copied().unwrap_or(&[]);
-
-                if tcx.has_attr(item_def_id, sym::rustc_outlives) {
-                    let mut pred: Vec<String> = predicates
-                        .iter()
-                        .map(|(out_pred, _)| match out_pred.kind().skip_binder() {
-                            ty::ClauseKind::RegionOutlives(p) => p.to_string(),
-                            ty::ClauseKind::TypeOutlives(p) => p.to_string(),
-                            err => bug!("unexpected clause {:?}", err),
-                        })
-                        .collect();
-                    pred.sort();
-
-                    let span = tcx.def_span(item_def_id);
-                    let mut err = tcx.sess.struct_span_err(span, "rustc_outlives");
-                    for p in pred {
-                        err.note(p);
-                    }
-                    err.emit();
-                }
 
                 debug!("inferred_outlives_of({:?}) = {:?}", item_def_id, predicates);
 

--- a/compiler/rustc_hir_analysis/src/outlives/test.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/test.rs
@@ -1,5 +1,4 @@
-use rustc_errors::struct_span_err;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::symbol::sym;
 
 pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
@@ -7,15 +6,23 @@ pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
         // For unit testing: check for a special "rustc_outlives"
         // attribute and report an error with various results if found.
         if tcx.has_attr(id.owner_id, sym::rustc_outlives) {
-            let inferred_outlives_of = tcx.inferred_outlives_of(id.owner_id);
-            struct_span_err!(
-                tcx.sess,
-                tcx.def_span(id.owner_id),
-                E0640,
-                "{:?}",
-                inferred_outlives_of
-            )
-            .emit();
+            let predicates = tcx.inferred_outlives_of(id.owner_id);
+            let mut pred: Vec<String> = predicates
+                .iter()
+                .map(|(out_pred, _)| match out_pred.kind().skip_binder() {
+                    ty::ClauseKind::RegionOutlives(p) => p.to_string(),
+                    ty::ClauseKind::TypeOutlives(p) => p.to_string(),
+                    err => bug!("unexpected clause {:?}", err),
+                })
+                .collect();
+            pred.sort();
+
+            let span = tcx.def_span(id.owner_id);
+            let mut err = tcx.sess.struct_span_err(span, "rustc_outlives");
+            for p in pred {
+                err.note(p);
+            }
+            err.emit();
         }
     }
 }

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -15,7 +15,7 @@ use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Delimiter};
 use rustc_ast::{
     self as ast, AttrVec, BindingAnnotation, ByRef, Expr, ExprKind, MacCall, Mutability, Pat,
-    PatField, PatKind, Path, QSelf, RangeEnd, RangeSyntax,
+    PatField, PatFieldsRest, PatKind, Path, QSelf, RangeEnd, RangeSyntax,
 };
 use rustc_ast_pretty::pprust;
 use rustc_errors::{Applicability, DiagnosticBuilder, ErrorGuaranteed, IntoDiagnostic, PResult};
@@ -890,7 +890,8 @@ impl<'a> Parser<'a> {
             e.span_label(path.span, "while parsing the fields for this pattern");
             e.emit();
             self.recover_stmt();
-            (ThinVec::new(), true)
+            // When recovering, pretend we had `Foo { .. }`, to avoid cascading errors.
+            (ThinVec::new(), PatFieldsRest::Rest)
         });
         self.bump();
         Ok(PatKind::Struct(qself, path, fields, etc))
@@ -964,9 +965,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses the fields of a struct-like pattern.
-    fn parse_pat_fields(&mut self) -> PResult<'a, (ThinVec<PatField>, bool)> {
+    fn parse_pat_fields(&mut self) -> PResult<'a, (ThinVec<PatField>, PatFieldsRest)> {
         let mut fields = ThinVec::new();
-        let mut etc = false;
+        let mut etc = PatFieldsRest::None;
         let mut ate_comma = true;
         let mut delayed_err: Option<DiagnosticBuilder<'a, ErrorGuaranteed>> = None;
         let mut first_etc_and_maybe_comma_span = None;
@@ -1000,7 +1001,7 @@ impl<'a> Parser<'a> {
                 || self.check_noexpect(&token::DotDotDot)
                 || self.check_keyword(kw::Underscore)
             {
-                etc = true;
+                etc = PatFieldsRest::Rest;
                 let mut etc_sp = self.token.span;
                 if first_etc_and_maybe_comma_span.is_none() {
                     if let Some(comma_tok) = self

--- a/src/doc/rustc/src/platform-support/wasm32-wasi-preview1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasi-preview1-threads.md
@@ -90,7 +90,7 @@ The target intends to match the corresponding Clang target for its `"C"` ABI.
 
 ## Platform requirements
 
-The runtime should support the same set of APIs as any other supported wasi target for interacting with the host environment through the WASI standard. The runtime also should have implemetation of [wasi-threads proposal](https://github.com/WebAssembly/wasi-threads).
+The runtime should support the same set of APIs as any other supported wasi target for interacting with the host environment through the WASI standard. The runtime also should have implementation of [wasi-threads proposal](https://github.com/WebAssembly/wasi-threads).
 
 This target is not a stable target. This means that there are a few engines
 which implement the `wasi-threads` feature and if they do they're likely behind a

--- a/src/doc/rustdoc/src/how-to-write-documentation.md
+++ b/src/doc/rustdoc/src/how-to-write-documentation.md
@@ -267,6 +267,22 @@ you can wrap it like this:
 /// more documentation
 ```
 
+Please note that if you want to put markdown in the HTML tag and for it to
+be interpreted as such, you need to have an empty line between the HTML tags
+and your markdown content. For example if you want to use a link:
+
+```md
+/// documentation
+///
+/// <div class="warning">
+///
+/// Go to [this link](https://rust-lang.org)!
+///
+/// </div>
+///
+/// more documentation
+```
+
 [`backtrace`]: https://docs.rs/backtrace/0.3.50/backtrace/
 [commonmark markdown specification]: https://commonmark.org/
 [commonmark quick reference]: https://commonmark.org/help/

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -415,7 +415,7 @@ warning: 1 warning emitted
 
 ## `redundant_explicit_links`
 
-This lint is **warn-by-default**. It detects explicit links that are same
+This lint is **warn-by-default**. It detects explicit links that are the same
 as computed automatic links.
 This usually means the explicit links are removeable. For example:
 

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -415,9 +415,9 @@ warning: 1 warning emitted
 
 ## `redundant_explicit_links`
 
-This lint is **warned by default**. It detects explicit links that are same
+This lint is **warn-by-default**. It detects explicit links that are same
 as computed automatic links.
-This usually means the explicit links is removeable. For example:
+This usually means the explicit links are removeable. For example:
 
 ```rust
 #![warn(rustdoc::redundant_explicit_links)] // note: unnecessary - warns by default.

--- a/src/doc/unstable-book/src/compiler-flags/check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/check-cfg.md
@@ -107,7 +107,7 @@ fn poke_platypus() {}
 fn tame_lion() {}
 
 // This is UNEXPECTED, because 'windows' is a well known condition name,
-// and because 'windows' doens't take any values,
+// and because 'windows' doesn't take any values,
 // and will cause a compiler warning (by default).
 #[cfg(windows = "unix")]
 fn tame_windows() {}

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -186,8 +186,8 @@ declare_rustdoc_lint! {
 }
 
 declare_rustdoc_lint! {
-    /// This lint is **warned by default**. It detects explicit links that are same
-    /// as computed automatic links. This usually means the explicit links is removeable.
+    /// This lint is **warn-by-default**. It detects explicit links that are the same
+    /// as computed automatic links. This usually means the explicit links are removeable.
     /// This is a `rustdoc` only lint, see the documentation in the [rustdoc book].
     ///
     /// [rustdoc book]: ../../../rustdoc/lints.html#redundant_explicit_links

--- a/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
+++ b/src/tools/clippy/clippy_lints/src/unnested_or_patterns.rs
@@ -293,7 +293,7 @@ fn extend_with_struct_pat(
     qself1: &Option<P<ast::QSelf>>,
     path1: &ast::Path,
     fps1: &mut [ast::PatField],
-    rest1: bool,
+    rest1: ast::PatFieldsRest,
     start: usize,
     alternatives: &mut ThinVec<P<Pat>>,
 ) -> bool {

--- a/src/tools/rustfmt/src/patterns.rs
+++ b/src/tools/rustfmt/src/patterns.rs
@@ -259,9 +259,15 @@ impl Rewrite for Pat {
                 None,
                 None,
             ),
-            PatKind::Struct(ref qself, ref path, ref fields, ellipsis) => {
-                rewrite_struct_pat(qself, path, fields, ellipsis, self.span, context, shape)
-            }
+            PatKind::Struct(ref qself, ref path, ref fields, rest) => rewrite_struct_pat(
+                qself,
+                path,
+                fields,
+                rest == ast::PatFieldsRest::Rest,
+                self.span,
+                context,
+                shape,
+            ),
             PatKind::MacCall(ref mac) => {
                 rewrite_macro(mac, None, context, shape, MacroPosition::Pat)
             }

--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -27,7 +27,7 @@ const ERROR_DOCS_PATH: &str = "compiler/rustc_error_codes/src/error_codes/";
 const ERROR_TESTS_PATH: &str = "tests/ui/error-codes/";
 
 // Error codes that (for some reason) can't have a doctest in their explanation. Error codes are still expected to provide a code example, even if untested.
-const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E0640", "E0717"];
+const IGNORE_DOCTEST_CHECK: &[&str] = &["E0464", "E0570", "E0601", "E0602", "E0717"];
 
 // Error codes that don't yet have a UI test. This list will eventually be removed.
 const IGNORE_UI_TEST_CHECK: &[&str] =

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -494,7 +494,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             let mut err = |_| {
                 tidy_error!(bad, "{}: leading newline", file.display());
             };
-            suppressible_tidy_err!(err, skip_leading_newlines, "mising leading newline");
+            suppressible_tidy_err!(err, skip_leading_newlines, "missing leading newline");
         }
         let mut err = |msg: &str| {
             tidy_error!(bad, "{}: {}", file.display(), msg);

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -639,7 +639,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "oli-obk"]
+users_on_vacation = ["jyn514", "oli-obk", "spastorino"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Successful merges:

 - #119231 (Clairify `ast::PatKind::Struct` presese of `..` by using an enum instead of a bool)
 - #119232 (Fix doc typos)
 - #119245 (Improve documentation for using warning blocks in documentation)
 - #119248 (remove dead inferred outlives testing code)
 - #119249 (Add spastorino to users_on_vacation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119231,119232,119245,119248,119249)
<!-- homu-ignore:end -->