### PR TITLE
Only store StableCrateId once in DefPathTable.

### DIFF
--- a/compiler/rustc_data_structures/src/hashes.rs
+++ b/compiler/rustc_data_structures/src/hashes.rs
@@ -25,7 +25,7 @@ impl Hash64 {
     pub const ZERO: Hash64 = Hash64 { inner: 0 };
 
     #[inline]
-    pub(crate) fn new(n: u64) -> Self {
+    pub fn new(n: u64) -> Self {
         Self { inner: n }
     }
 

--- a/compiler/rustc_hir/src/def_path_hash_map.rs
+++ b/compiler/rustc_hir/src/def_path_hash_map.rs
@@ -1,21 +1,22 @@
-use rustc_data_structures::fingerprint::Fingerprint;
-use rustc_span::def_id::{DefIndex, DefPathHash};
+use rustc_data_structures::stable_hasher::Hash64;
+use rustc_span::def_id::DefIndex;
 
 #[derive(Clone, Default)]
 pub struct Config;
 
 impl odht::Config for Config {
-    type Key = DefPathHash;
+    // This hash-map is single-crate, so we only need to key by the local hash.
+    type Key = Hash64;
     type Value = DefIndex;
 
-    type EncodedKey = [u8; 16];
+    type EncodedKey = [u8; 8];
     type EncodedValue = [u8; 4];
 
     type H = odht::UnHashFn;
 
     #[inline]
-    fn encode_key(k: &DefPathHash) -> [u8; 16] {
-        k.0.to_le_bytes()
+    fn encode_key(k: &Hash64) -> [u8; 8] {
+        k.as_u64().to_le_bytes()
     }
 
     #[inline]
@@ -24,8 +25,8 @@ impl odht::Config for Config {
     }
 
     #[inline]
-    fn decode_key(k: &[u8; 16]) -> DefPathHash {
-        DefPathHash(Fingerprint::from_le_bytes(*k))
+    fn decode_key(k: &[u8; 8]) -> Hash64 {
+        Hash64::new(u64::from_le_bytes(*k))
     }
 
     #[inline]

--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -103,9 +103,6 @@ impl DefPathTable {
 pub struct Definitions {
     table: DefPathTable,
     next_disambiguator: UnordMap<(LocalDefId, DefPathData), u32>,
-
-    /// The [StableCrateId] of the local crate.
-    stable_crate_id: StableCrateId,
 }
 
 /// A unique identifier that we can use to lookup a definition
@@ -340,7 +337,7 @@ impl Definitions {
         let root = LocalDefId { local_def_index: table.allocate(key, def_path_hash) };
         assert_eq!(root.local_def_index, CRATE_DEF_INDEX);
 
-        Definitions { table, next_disambiguator: Default::default(), stable_crate_id }
+        Definitions { table, next_disambiguator: Default::default() }
     }
 
     /// Adds a definition with a parent definition.
@@ -382,7 +379,7 @@ impl Definitions {
         hash: DefPathHash,
         err: &mut dyn FnMut() -> !,
     ) -> LocalDefId {
-        debug_assert!(hash.stable_crate_id() == self.stable_crate_id);
+        debug_assert!(hash.stable_crate_id() == self.table.stable_crate_id);
         self.table
             .def_path_hash_to_index
             .get(&hash)

--- a/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
+++ b/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
@@ -19,7 +19,9 @@ impl DefPathHashMapRef<'_> {
     #[inline]
     pub fn def_path_hash_to_def_index(&self, def_path_hash: &DefPathHash) -> DefIndex {
         match *self {
-            DefPathHashMapRef::OwnedFromMetadata(ref map) => map.get(def_path_hash).unwrap(),
+            DefPathHashMapRef::OwnedFromMetadata(ref map) => {
+                map.get(&def_path_hash.local_hash()).unwrap()
+            }
             DefPathHashMapRef::BorrowedFromTcx(_) => {
                 panic!("DefPathHashMap::BorrowedFromTcx variant only exists for serialization")
             }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/119238 made me think of this.

cc @Mark-Simulacrum 