### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -628,11 +628,3 @@ impl<'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for MakeSuggestableFolder<'tcx> {
         c.try_super_fold_with(self)
     }
 }
-
-#[derive(Diagnostic)]
-#[diag(middle_const_not_used_in_type_alias)]
-pub(super) struct ConstNotUsedTraitAlias {
-    pub ct: String,
-    #[primary_span]
-    pub span: Span,
-}

--- a/compiler/rustc_target/src/spec/aarch64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_illumos.rs
@@ -1,0 +1,19 @@
+use crate::spec::{Cc, LinkerFlavor, SanitizerSet, Target};
+
+pub fn target() -> Target {
+    let mut base = super::illumos_base::opts();
+    base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-std=c99"]);
+    base.cpu = "aarch64".into();
+    base.max_atomic_width = Some(128);
+    base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;
+
+    Target {
+        // LLVM does not currently have a separate illumos target,
+        // so we still pass Solaris to it
+        llvm_target: "aarch64-unknown-solaris2.11".into(),
+        pointer_width: 64,
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".into(),
+        arch: "aarch64".into(),
+        options: base,
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1586,6 +1586,7 @@ supported_targets! {
     ("sparcv9-sun-solaris", sparcv9_sun_solaris),
 
     ("x86_64-unknown-illumos", x86_64_unknown_illumos),
+    ("aarch64-unknown-illumos", aarch64_unknown_illumos),
 
     ("x86_64-pc-windows-gnu", x86_64_pc_windows_gnu),
     ("i686-pc-windows-gnu", i686_pc_windows_gnu),

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
@@ -1,7 +1,7 @@
-use crate::spec::{Cc, LinkerFlavor, SanitizerSet, Target};
+use crate::spec::{base, Cc, LinkerFlavor, SanitizerSet, Target};
 
 pub fn target() -> Target {
-    let mut base = super::illumos_base::opts();
+    let mut base = base::illumos::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-std=c99"]);
     base.cpu = "aarch64".into();
     base.max_atomic_width = Some(128);

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_illumos.rs
@@ -3,9 +3,9 @@ use crate::spec::{base, Cc, LinkerFlavor, SanitizerSet, Target};
 pub fn target() -> Target {
     let mut base = base::illumos::opts();
     base.add_pre_link_args(LinkerFlavor::Unix(Cc::Yes), &["-std=c99"]);
-    base.cpu = "aarch64".into();
     base.max_atomic_width = Some(128);
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI;
+    base.features = "+v8a".into();
 
     Target {
         // LLVM does not currently have a separate illumos target,

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -411,8 +411,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(file_create_new)]
-    ///
     /// use std::fs::File;
     /// use std::io::Write;
     ///
@@ -422,7 +420,7 @@ impl File {
     ///     Ok(())
     /// }
     /// ```
-    #[unstable(feature = "file_create_new", issue = "105135")]
+    #[stable(feature = "file_create_new", since = "CURRENT_RUSTC_VERSION")]
     pub fn create_new<P: AsRef<Path>>(path: P) -> io::Result<File> {
         OpenOptions::new().read(true).write(true).create_new(true).open(path.as_ref())
     }

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -229,6 +229,7 @@ target | std | host | notes
 [`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS |
 `aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit
+`aarch64-unknown-illumos` | ✓ | ✓ | ARM64 illumos
 `aarch64-unknown-linux-gnu_ilp32` | ✓ | ✓ | ARM64 Linux (ILP32 ABI)
 [`aarch64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | ARM64 NetBSD
 [`aarch64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | ARM64 OpenBSD

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -648,10 +648,12 @@ impl FromWithTcx<clean::Trait> for Trait {
     fn from_tcx(trait_: clean::Trait, tcx: TyCtxt<'_>) -> Self {
         let is_auto = trait_.is_auto(tcx);
         let is_unsafe = trait_.unsafety(tcx) == rustc_hir::Unsafety::Unsafe;
+        let is_object_safe = trait_.is_object_safe(tcx);
         let clean::Trait { items, generics, bounds, .. } = trait_;
         Trait {
             is_auto,
             is_unsafe,
+            is_object_safe,
             items: ids(items, tcx),
             generics: generics.into_tcx(tcx),
             bounds: bounds.into_tcx(tcx),

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 27;
+pub const FORMAT_VERSION: u32 = 28;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -634,6 +634,7 @@ pub struct FnDecl {
 pub struct Trait {
     pub is_auto: bool,
     pub is_unsafe: bool,
+    pub is_object_safe: bool,
     pub items: Vec<Id>,
     pub generics: Generics,
     pub bounds: Vec<GenericBound>,

--- a/tests/rustdoc-json/traits/is_object_safe.rs
+++ b/tests/rustdoc-json/traits/is_object_safe.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+// @has "$.index[*][?(@.name=='FooUnsafe')]"
+// @is "$.index[*][?(@.name=='FooUnsafe')].inner.trait.is_object_safe" false
+pub trait FooUnsafe {
+    fn foo() -> Self;
+}
+
+// @has "$.index[*][?(@.name=='BarUnsafe')]"
+// @is "$.index[*][?(@.name=='BarUnsafe')].inner.trait.is_object_safe" false
+pub trait BarUnsafe<T> {
+    fn foo(i: T);
+}
+
+// @has "$.index[*][?(@.name=='FooSafe')]"
+// @is "$.index[*][?(@.name=='FooSafe')].inner.trait.is_object_safe" true
+pub trait FooSafe {
+    fn foo(&self);
+}

--- a/tests/rustdoc/trait-object-safe.rs
+++ b/tests/rustdoc/trait-object-safe.rs
@@ -22,6 +22,6 @@ pub trait Safe {
 }
 
 // @has 'foo/struct.Foo.html'
-// @!has - '//*[@class="object-safety-info"]' ''
-// @!has - '//*[@id="object-safety"]' ''
+// @count - '//*[@class="object-safety-info"]' 0
+// @count - '//*[@id="object-safety"]' 0
 pub struct Foo;

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.rs
@@ -1,0 +1,16 @@
+#![feature(const_trait_impl, effects)]
+
+const fn test() -> impl ~const Fn() { //~ ERROR ~const can only be applied to `#[const_trait]` traits
+    const move || { //~ ERROR const closures are experimental
+        let sl: &[u8] = b"foo";
+
+        match sl {
+            [first, remainder @ ..] => {
+                assert_eq!(first, &b'f');
+            }
+            [] => panic!(),
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
@@ -1,0 +1,18 @@
+error[E0658]: const closures are experimental
+  --> $DIR/ice-112822-expected-type-for-param.rs:4:5
+   |
+LL |     const move || {
+   |     ^^^^^
+   |
+   = note: see issue #106003 <https://github.com/rust-lang/rust/issues/106003> for more information
+   = help: add `#![feature(const_closures)]` to the crate attributes to enable
+
+error: ~const can only be applied to `#[const_trait]` traits
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:32
+   |
+LL | const fn test() -> impl ~const Fn() {
+   |                                ^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - #112936 (Add illumos aarch64 target for rust.)
 - #119153 (stabilize `file_create_new`)
 - #119246 ([rustdoc] Add `is_object_safe` information for traits in JSON output)
 - #119254 (Remove an unused diagnostic struct)
 - #119255 (add a test for ICE #112822)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=112936,119153,119246,119254,119255)
<!-- homu-ignore:end -->