### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -491,12 +491,12 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // A [o o o o o o o . . . . . . . . . ]
         //        L H
         //   [o o o o o o o o ]
-        //          H           L
-        // B [. . . o o o o o o o . . . . . . ]
+        //          H             L
+        // B [. . . o o o o o o o o . . . . . ]
         //              L H
         //   [o o o o o o o o ]
-        //            L                   H
-        // C [o o o o o . . . . . . . . . o o ]
+        //              L                 H
+        // C [o o o o o o . . . . . . . . o o ]
 
         // can't use is_contiguous() because the capacity is already updated.
         if self.head <= old_capacity - self.len {

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -36,6 +36,11 @@ root_dir="`dirname $src_dir`"
 objdir=$root_dir/obj
 dist=$objdir/build/dist
 
+
+if [ -d "$root_dir/.git" ]; then
+    IS_GIT_SOURCE=1
+fi
+
 source "$ci_dir/shared.sh"
 
 CACHE_DOMAIN="${CACHE_DOMAIN:-ci-caches.rust-lang.org}"
@@ -249,9 +254,13 @@ if [ "$dev" = "1" ]
 then
   # Interactive + TTY
   args="$args -it"
-  command="/bin/bash"
+  if [ $IS_GIT_SOURCE -eq 1 ]; then
+    command=(/bin/bash -c 'git config --global --add safe.directory /checkout;bash')
+  else
+    command=(/bin/bash)
+  fi
 else
-  command="/checkout/src/ci/run.sh"
+  command=(/checkout/src/ci/run.sh)
 fi
 
 if [ "$CI" != "" ]; then
@@ -301,7 +310,7 @@ docker \
   --init \
   --rm \
   rust-ci \
-  $command
+  "${command[@]}"
 
 cat $objdir/${SUMMARY_FILE} >> "${GITHUB_STEP_SUMMARY}"
 

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -199,6 +199,14 @@ else
     args="$args --env SCCACHE_DIR=/sccache --volume $HOME/.cache/sccache:/sccache"
 fi
 
+# By default, container volumes are bound as read-only; therefore doing experimental work
+# or debugging within the container environment (such as fetching submodules and
+# building them) is not possible. Setting READ_ONLY_SRC to 0 enables this capability by
+# binding the volumes in read-write mode.
+if [ "$READ_ONLY_SRC" != "0" ]; then
+    SRC_MOUNT_OPTION=":ro"
+fi
+
 # Run containers as privileged as it should give them access to some more
 # syscalls such as ptrace and whatnot. In the upgrade to LLVM 5.0 it was
 # discovered that the leak sanitizer apparently needs these syscalls nowadays so
@@ -233,7 +241,7 @@ if [ -f /.dockerenv ]; then
   docker cp . checkout:/checkout
   args="$args --volumes-from checkout"
 else
-  args="$args --volume $root_dir:/checkout:ro"
+  args="$args --volume $root_dir:/checkout$SRC_MOUNT_OPTION"
   args="$args --volume $objdir:/checkout/obj"
   args="$args --volume $HOME/.cargo:/cargo"
   args="$args --volume $HOME/rustsrc:$HOME/rustsrc"


### PR DESCRIPTION
Successful merges:

 - #119165 (improve container runner script)
 - #119205 (fix minor mistake in comments describing VecDeque resizing)
 - #119257 (interpret/memory: explain why we check is_thread_local_static)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119165,119205,119257)
<!-- homu-ignore:end -->