### PR TITLE
Stabilize ip_in_core feature

### DIFF
--- a/library/core/src/net/mod.rs
+++ b/library/core/src/net/mod.rs
@@ -9,7 +9,7 @@
 //! * [`SocketAddr`] represents socket addresses of either IPv4 or IPv6; [`SocketAddrV4`]
 //!   and [`SocketAddrV6`] are respectively IPv4 and IPv6 socket addresses
 
-#![unstable(feature = "ip_in_core", issue = "108443")]
+#![stable(feature = "ip_in_core", since = "CURRENT_RUSTC_VERSION")]
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::ip_addr::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -71,7 +71,6 @@
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
 #![feature(ip)]
-#![feature(ip_in_core)]
 #![feature(iter_advance_by)]
 #![feature(iter_array_chunks)]
 #![feature(iter_collect_into)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -325,7 +325,6 @@
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]
 #![feature(ip)]
-#![feature(ip_in_core)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_write_slice)]


### PR DESCRIPTION
Finally the last stage of https://github.com/rust-lang/rfcs/pull/2832. Since the FCP was [just completed with disposition *merge*](https://github.com/rust-lang/rust/issues/108443#issuecomment-1867864920), I create the stabilization PR for the `ip_in_core` feature. Allowing usage of `core::net` on stable Rust.

The error type `core::net::AddrParseError` itself becomes stable with this PR. However, `core::error::Error` is still unstable, so the `Error` impl for this type is not available on stable rust. Simply because `error_in_core` is not stable yet, but that should be fine!