### PR TITLE
Don't drop a hir node after lowering

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -555,7 +555,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     fn lower_arm(&mut self, arm: &Arm) -> hir::Arm<'hir> {
         let pat = self.lower_pat(&arm.pat);
-        let mut guard = arm.guard.as_ref().map(|cond| {
+        let guard = arm.guard.as_ref().map(|cond| {
             if let ExprKind::Let(pat, scrutinee, span, is_recovered) = &cond.kind {
                 hir::Guard::IfLet(self.arena.alloc(hir::Let {
                     hir_id: self.next_id(),
@@ -587,10 +587,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
             } else if let Some(body) = &arm.body {
                 self.dcx().emit_err(NeverPatternWithBody { span: body.span });
-                guard = None;
             } else if let Some(g) = &arm.guard {
                 self.dcx().emit_err(NeverPatternWithGuard { span: g.span });
-                guard = None;
             }
 
             // We add a fake `loop {}` arm body so that it typecks to `!`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.rs
@@ -1,0 +1,10 @@
+fn main() {}
+
+fn attr_in_guard() {
+    match None::<u32> {
+        Some(!) //~ ERROR `!` patterns are experimental
+            if #[deny(unused_mut)] //~ ERROR attributes on expressions are experimental
+            false //~ ERROR a guard on a never pattern will never be run
+    }
+    match false {}
+}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -1,0 +1,27 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:6:16
+   |
+LL |             if #[deny(unused_mut)]
+   |                ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: `!` patterns are experimental
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14
+   |
+LL |         Some(!)
+   |              ^
+   |
+   = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
+   = help: add `#![feature(never_patterns)]` to the crate attributes to enable
+
+error: a guard on a never pattern will never be run
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:7:13
+   |
+LL |             false
+   |             ^^^^^ help: remove this guard
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/119271.

It seems that all hir nodes that get allocated an id must be placed within the hir on pain of ICEs. In https://github.com/rust-lang/rust/pull/118527 I dropped guards on never patterns since they're not useful, which caused the ICE.