### PR TITLE
Removed redundant bounds checking at Split's next and next_back methods

### DIFF
--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -458,8 +458,8 @@ where
         match self.v.iter().position(|x| (self.pred)(x)) {
             None => self.finish(),
             Some(idx) => {
-                let ret = Some(&self.v[..idx]);
-                self.v = &self.v[idx + 1..];
+                let ret = Some(unsafe { self.v.get_unchecked(..idx) });
+                self.v = unsafe { self.v.get_unchecked(idx + 1..) };
                 ret
             }
         }
@@ -491,8 +491,8 @@ where
         match self.v.iter().rposition(|x| (self.pred)(x)) {
             None => self.finish(),
             Some(idx) => {
-                let ret = Some(&self.v[idx + 1..]);
-                self.v = &self.v[..idx];
+                let ret = Some(unsafe { self.v.get_unchecked(idx + 1..) });
+                self.v = unsafe { self.v.get_unchecked(..idx) };
                 ret
             }
         }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -458,8 +458,12 @@ where
         match self.v.iter().position(|x| (self.pred)(x)) {
             None => self.finish(),
             Some(idx) => {
-                let ret = Some(unsafe { self.v.get_unchecked(..idx) });
-                self.v = unsafe { self.v.get_unchecked(idx + 1..) };
+                let (left, right) =
+                    // SAFETY: if v.iter().position returns Some(idx), that
+                    // idx is definitely a valid index for v
+                    unsafe { (self.v.get_unchecked(..idx), self.v.get_unchecked(idx + 1..)) };
+                let ret = Some(left);
+                self.v = right;
                 ret
             }
         }
@@ -491,8 +495,12 @@ where
         match self.v.iter().rposition(|x| (self.pred)(x)) {
             None => self.finish(),
             Some(idx) => {
-                let ret = Some(unsafe { self.v.get_unchecked(idx + 1..) });
-                self.v = unsafe { self.v.get_unchecked(..idx) };
+                let (left, right) =
+                    // SAFETY: if v.iter().rposition returns Some(idx), then
+                    // idx is definitely a valid index for v
+                    unsafe { (self.v.get_unchecked(..idx), self.v.get_unchecked(idx + 1..)) };
+                let ret = Some(right);
+                self.v = left;
                 ret
             }
         }


### PR DESCRIPTION
Since these methods are using `Iterator::rposition`, which always returns a valid index, then there is no point in regular indexing with bounds checking