### PR TITLE
show linker output even if the linker succeeds

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -183,6 +183,8 @@ codegen_ssa_linker_file_stem = couldn't extract file stem from specified linker
 codegen_ssa_linker_not_found = linker `{$linker_path}` not found
     .note = {$error}
 
+codegen_ssa_linker_output = {$inner}
+
 codegen_ssa_linker_unsupported_modifier = `as-needed` modifier not supported for current linker
 
 codegen_ssa_linking_failed = linking with `{$linker_path}` failed: {$exit_status}

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1040,6 +1040,11 @@ fn link_natively(
                 sess.dcx().abort_if_errors();
             }
 
+            let stderr = escape_string(&prog.stderr);
+            let stdout = escape_string(&prog.stdout);
+            info!("linker stderr:\n{}", &stderr);
+            info!("linker stdout:\n{}", &stdout);
+
             let (level, src) = codegen_results.crate_info.lint_levels.linker_messages;
             let lint = |msg| {
                 lint_level(sess, LINKER_MESSAGES, level, src, None, |diag| {
@@ -1049,16 +1054,14 @@ fn link_natively(
 
             if !prog.stderr.is_empty() {
                 // We already print `warning:` at the start of the diagnostic. Remove it from the linker output if present.
-                let stderr = escape_string(&prog.stderr);
-                debug!("original stderr: {stderr}");
                 let stderr = stderr
                     .strip_prefix("warning: ")
                     .unwrap_or(&stderr)
                     .replace(": warning: ", ": ");
                 lint(format!("linker stderr: {stderr}"));
             }
-            if !prog.stdout.is_empty() && sess.opts.verbose {
-                lint(format!("linker stdout: {}", escape_string(&prog.stdout)))
+            if !prog.stdout.is_empty() {
+                lint(format!("linker stdout: {}", stdout))
             }
         }
         Err(e) => {

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -44,7 +44,8 @@ use crate::mir::operand::OperandValue;
 use crate::mir::place::PlaceRef;
 use crate::traits::*;
 use crate::{
-    CachedModuleCodegen, CompiledModule, CrateInfo, ModuleCodegen, ModuleKind, errors, meth, mir,
+    CachedModuleCodegen, CodegenLintLevels, CompiledModule, CrateInfo, ModuleCodegen, ModuleKind,
+    errors, meth, mir,
 };
 
 pub(crate) fn bin_op_to_icmp_predicate(op: BinOp, signed: bool) -> IntPredicate {
@@ -927,6 +928,7 @@ impl CrateInfo {
             dependency_formats: Lrc::clone(tcx.dependency_formats(())),
             windows_subsystem,
             natvis_debugger_visualizers: Default::default(),
+            lint_levels: CodegenLintLevels::from_tcx(tcx),
         };
 
         info.native_libraries.reserve(n_crates);

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -200,6 +200,7 @@ pub struct CrateInfo {
     pub dependency_formats: Lrc<Dependencies>,
     pub windows_subsystem: Option<String>,
     pub natvis_debugger_visualizers: BTreeSet<DebuggerVisualizerFile>,
+    pub lint_levels: CodegenLintLevels,
 }
 
 #[derive(Encodable, Decodable)]

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -29,18 +29,23 @@ use rustc_ast as ast;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::unord::UnordMap;
+use rustc_hir::CRATE_HIR_ID;
 use rustc_hir::def_id::CrateNum;
 use rustc_macros::{Decodable, Encodable, HashStable};
 use rustc_middle::dep_graph::WorkProduct;
+use rustc_middle::lint::LintLevelSource;
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
 use rustc_middle::middle::dependency_format::Dependencies;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
+use rustc_middle::ty::TyCtxt;
 use rustc_middle::util::Providers;
 use rustc_serialize::opaque::{FileEncoder, MemDecoder};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_session::Session;
 use rustc_session::config::{CrateType, OutputFilenames, OutputType, RUST_CGU_EXT};
 use rustc_session::cstore::{self, CrateSource};
+use rustc_session::lint::Level;
+use rustc_session::lint::builtin::LINKER_MESSAGES;
 use rustc_session::utils::NativeLibKind;
 use rustc_span::Symbol;
 
@@ -301,5 +306,21 @@ impl CodegenResults {
         let codegen_results = CodegenResults::decode(&mut decoder);
         let outputs = OutputFilenames::decode(&mut decoder);
         Ok((codegen_results, outputs))
+    }
+}
+
+/// A list of lint levels used in codegen.
+///
+/// When using `-Z link-only`, we don't have access to the tcx and must work
+/// solely from the `.rlink` file. `Lint`s are defined too early to be encodeable.
+/// Instead, encode exactly the information we need.
+#[derive(Copy, Clone, Debug, Encodable, Decodable)]
+pub struct CodegenLintLevels {
+    linker_messages: (Level, LintLevelSource),
+}
+
+impl CodegenLintLevels {
+    pub fn from_tcx(tcx: TyCtxt<'_>) -> Self {
+        Self { linker_messages: tcx.lint_level_at_node(LINKER_MESSAGES, CRATE_HIR_ID) }
     }
 }

--- a/compiler/rustc_errors/src/json/tests.rs
+++ b/compiler/rustc_errors/src/json/tests.rs
@@ -47,7 +47,7 @@ fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
         let output = Arc::new(Mutex::new(Vec::new()));
         let je = JsonEmitter::new(
             Box::new(Shared { data: output.clone() }),
-            sm,
+            Some(sm),
             fallback_bundle,
             true, // pretty
             HumanReadableErrorType::Short,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -60,6 +60,7 @@ declare_lint_pass! {
         LARGE_ASSIGNMENTS,
         LATE_BOUND_LIFETIME_ARGUMENTS,
         LEGACY_DERIVE_HELPERS,
+        LINKER_MESSAGES,
         LONG_RUNNING_CONST_EVAL,
         LOSSY_PROVENANCE_CASTS,
         MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
@@ -4083,6 +4084,39 @@ declare_lint! {
     pub FFI_UNWIND_CALLS,
     Allow,
     "call to foreign functions or function pointers with FFI-unwind ABI"
+}
+
+declare_lint! {
+    /// The `linker_messages` lint forwards warnings from the linker.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (needs CLI args, platform-specific)
+    /// extern "C" {
+    ///   fn foo();
+    /// }
+    /// fn main () { unsafe { foo(); } }
+    /// ```
+    ///
+    /// On Linux, using `gcc -Wl,--warn-unresolved-symbols` as a linker, this will produce
+    ///
+    /// ```text
+    /// warning: linker stderr: rust-lld: undefined symbol: foo
+    ///          >>> referenced by rust_out.69edbd30df4ae57d-cgu.0
+    ///          >>>               rust_out.rust_out.69edbd30df4ae57d-cgu.0.rcgu.o:(rust_out::main::h3a90094b06757803)
+    ///   |
+    ///   = note: `#[warn(linker_messages)]` on by default
+    ///
+    /// warning: 1 warning emitted
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// Linkers emit platform-specific and program-specific warnings that cannot be predicted in advance by the rust compiler.
+    /// They are forwarded by default, but can be disabled by adding `#![allow(linker_messages)]` at the crate root.
+    pub LINKER_MESSAGES,
+    Warn,
+    "warnings emitted at runtime by the target-specific linker program"
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -161,7 +161,19 @@ impl<HCX: rustc_hir::HashStableContext> ToStableHashKey<HCX> for LintExpectation
 /// Setting for how to handle a lint.
 ///
 /// See: <https://doc.rust-lang.org/rustc/lints/levels.html>
-#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash, HashStable_Generic)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Ord,
+    Debug,
+    Hash,
+    Encodable,
+    Decodable,
+    HashStable_Generic
+)]
 pub enum Level {
     /// The `allow` level will not issue any message.
     Allow,

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_errors::{Diag, MultiSpan};
 use rustc_hir::{HirId, ItemLocalId};
-use rustc_macros::HashStable;
+use rustc_macros::{Decodable, Encodable, HashStable};
 use rustc_session::Session;
 use rustc_session::lint::builtin::{self, FORBIDDEN_LINT_GROUPS};
 use rustc_session::lint::{FutureIncompatibilityReason, Level, Lint, LintExpectationId, LintId};
@@ -15,7 +15,7 @@ use tracing::instrument;
 use crate::ty::TyCtxt;
 
 /// How a lint level was set.
-#[derive(Clone, Copy, PartialEq, Eq, HashStable, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Encodable, Decodable, HashStable, Debug)]
 pub enum LintLevelSource {
     /// Lint is at the default level as declared in rustc.
     Default,
@@ -173,7 +173,7 @@ impl TyCtxt<'_> {
 /// This struct represents a lint expectation and holds all required information
 /// to emit the `unfulfilled_lint_expectations` lint if it is unfulfilled after
 /// the `LateLintPass` has completed.
-#[derive(Clone, Debug, HashStable)]
+#[derive(Clone, Debug, Encodable, Decodable, HashStable)]
 pub struct LintExpectation {
     /// The reason for this expectation that can optionally be added as part of
     /// the attribute. It will be displayed as part of the lint message.

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -817,6 +817,9 @@ passes_unused_duplicate =
 passes_unused_empty_lints_note =
     attribute `{$name}` with an empty list has no effect
 
+passes_unused_linker_warnings_note =
+    the `linker_warnings` lint can only be controlled at the root of a crate that needs to be linked
+
 passes_unused_multiple =
     multiple `{$name}` attributes
     .suggestion = remove this attribute

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2338,11 +2338,20 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             })
         {
             if hir_id != CRATE_HIR_ID {
-                let err = match attr.style {
-                    ast::AttrStyle::Outer => errors::OuterCrateLevelAttr,
-                    ast::AttrStyle::Inner => errors::OuterCrateLevelAttr,
+                match attr.style {
+                    ast::AttrStyle::Outer => self.tcx.emit_node_span_lint(
+                        UNUSED_ATTRIBUTES,
+                        hir_id,
+                        attr.span,
+                        errors::OuterCrateLevelAttr,
+                    ),
+                    ast::AttrStyle::Inner => self.tcx.emit_node_span_lint(
+                        UNUSED_ATTRIBUTES,
+                        hir_id,
+                        attr.span,
+                        errors::InnerCrateLevelAttr,
+                    ),
                 };
-                self.tcx.emit_node_span_lint(UNUSED_ATTRIBUTES, hir_id, attr.span, err);
                 return;
             } else {
                 let never_needs_link = self

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -25,6 +25,7 @@ use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{self, TyCtxt, TypingMode};
 use rustc_middle::{bug, span_bug};
+use rustc_session::config::CrateType;
 use rustc_session::lint::builtin::{
     CONFLICTING_REPR_HINTS, INVALID_DOC_ATTRIBUTES, INVALID_MACRO_EXPORT_ARGUMENTS,
     UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES, UNUSED_ATTRIBUTES,
@@ -2328,6 +2329,33 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             && item.path == sym::reason
         {
             errors::UnusedNote::NoLints { name: attr.name_or_empty() }
+        } else if matches!(
+            attr.name_or_empty(),
+            sym::allow | sym::warn | sym::deny | sym::forbid | sym::expect
+        ) && let Some(meta) = attr.meta_item_list()
+            && meta.iter().any(|meta| {
+                meta.meta_item().map_or(false, |item| item.path == sym::linker_messages)
+            })
+        {
+            if hir_id != CRATE_HIR_ID {
+                let err = match attr.style {
+                    ast::AttrStyle::Outer => errors::OuterCrateLevelAttr,
+                    ast::AttrStyle::Inner => errors::OuterCrateLevelAttr,
+                };
+                self.tcx.emit_node_span_lint(UNUSED_ATTRIBUTES, hir_id, attr.span, err);
+                return;
+            } else {
+                let never_needs_link = self
+                    .tcx
+                    .crate_types()
+                    .iter()
+                    .all(|kind| matches!(kind, CrateType::Rlib | CrateType::Staticlib));
+                if never_needs_link {
+                    errors::UnusedNote::LinkerWarningsBinaryCrateOnly
+                } else {
+                    return;
+                }
+            }
         } else if attr.name_or_empty() == sym::default_method_body_is_const {
             errors::UnusedNote::DefaultMethodBodyConst
         } else {

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -802,6 +802,8 @@ pub(crate) enum UnusedNote {
     NoLints { name: Symbol },
     #[note(passes_unused_default_method_body_const_note)]
     DefaultMethodBodyConst,
+    #[note(passes_unused_linker_warnings_note)]
+    LinkerWarningsBinaryCrateOnly,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -895,13 +895,16 @@ fn default_emitter(
         }
         t => t,
     };
+
+    let source_map = if sopts.unstable_opts.link_only { None } else { Some(source_map) };
+
     match sopts.error_format {
         config::ErrorOutputType::HumanReadable(kind, color_config) => {
             let short = kind.short();
 
             if let HumanReadableErrorType::AnnotateSnippet = kind {
                 let emitter = AnnotateSnippetEmitter::new(
-                    Some(source_map),
+                    source_map,
                     bundle,
                     fallback_bundle,
                     short,
@@ -911,7 +914,7 @@ fn default_emitter(
             } else {
                 let emitter = HumanEmitter::new(stderr_destination(color_config), fallback_bundle)
                     .fluent_bundle(bundle)
-                    .sm(Some(source_map))
+                    .sm(source_map)
                     .short_message(short)
                     .teach(sopts.unstable_opts.teach)
                     .diagnostic_width(sopts.diagnostic_width)
@@ -1442,7 +1445,7 @@ fn mk_emitter(output: ErrorOutputType) -> Box<DynEmitter> {
         config::ErrorOutputType::Json { pretty, json_rendered, color_config } => {
             Box::new(JsonEmitter::new(
                 Box::new(io::BufWriter::new(io::stderr())),
-                Lrc::new(SourceMap::new(FilePathMapping::empty())),
+                Some(Lrc::new(SourceMap::new(FilePathMapping::empty()))),
                 fallback_bundle,
                 pretty,
                 json_rendered,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1189,6 +1189,7 @@ symbols! {
         link_section,
         linkage,
         linker,
+        linker_messages,
         lint_reasons,
         literal,
         load,

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3577,6 +3577,8 @@ impl Step for CodegenGCC {
         let mut cargo = build_cargo();
 
         cargo
+            // cg_gcc's build system ignores RUSTFLAGS. pass some flags through CG_RUSTFLAGS instead.
+            .env("CG_RUSTFLAGS", "-Alinker-messages")
             .arg("--")
             .arg("test")
             .arg("--use-system-gcc")

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1862,12 +1862,19 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         let mut hostflags = flags.clone();
         hostflags.push(format!("-Lnative={}", builder.test_helpers_out(compiler.host).display()));
         hostflags.extend(linker_flags(builder, compiler.host, LldThreads::No));
-        for flag in hostflags {
-            cmd.arg("--host-rustcflags").arg(flag);
-        }
 
         let mut targetflags = flags;
         targetflags.push(format!("-Lnative={}", builder.test_helpers_out(target).display()));
+
+        // FIXME: on macOS, we get linker warnings about duplicate `-lm` flags. We should investigate why this happens.
+        if suite == "ui-fulldeps" && target.ends_with("darwin") {
+            hostflags.push("-Alinker_messages".into());
+            targetflags.push("-Alinker_messages".into());
+        }
+
+        for flag in hostflags {
+            cmd.arg("--host-rustcflags").arg(flag);
+        }
         for flag in targetflags {
             cmd.arg("--target-rustcflags").arg(flag);
         }

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -269,6 +269,13 @@ impl Cargo {
             self.rustflags.arg("-Clink-arg=-gz");
         }
 
+        // Ignore linker warnings for now. These are complicated to fix and don't affect the build.
+        // FIXME: we should really investigate these...
+        // cfg(bootstrap)
+        if compiler.stage != 0 {
+            self.rustflags.arg("-Alinker-messages");
+        }
+
         // Throughout the build Cargo can execute a number of build scripts
         // compiling C/C++ code and we need to pass compilers, archivers, flags, etc
         // obtained previously to those build scripts.

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -178,7 +178,7 @@ pub(crate) fn new_dcx(
             Box::new(
                 JsonEmitter::new(
                     Box::new(io::BufWriter::new(io::stderr())),
-                    source_map,
+                    Some(source_map),
                     fallback_bundle,
                     pretty,
                     json_rendered,

--- a/tests/run-make/linker-warning/fake-linker.sh
+++ b/tests/run-make/linker-warning/fake-linker.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+code=0
+while ! [ $# = 0 ]; do
+    case "$1" in
+        run_make_info) echo "foo"
+            ;;
+        run_make_warn) echo "warning: bar" >&2
+            ;;
+        run_make_error) echo "error: baz" >&2; code=1
+            ;;
+        *) ;;   # rustc passes lots of args we don't care about
+    esac
+    shift
+done
+
+exit $code

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -44,4 +44,33 @@ fn main() {
         .assert_stderr_contains("object files omitted")
         .assert_stderr_contains_regex(r"\{")
         .assert_stderr_not_contains_regex(r"lib(/|\\\\)libstd");
+
+    // Make sure we show linker warnings even across `-Z no-link`
+    rustc()
+        .arg("-Zno-link")
+        .input("-")
+        .stdin_buf("#![deny(linker_messages)] \n fn main() {}")
+        .run()
+        .assert_stderr_equals("");
+    rustc()
+        .arg("-Zlink-only")
+        .arg("rust_out.rlink")
+        .linker("./fake-linker")
+        .link_arg("run_make_warn")
+        .run_fail()
+        // NOTE: the error message here is quite bad (we don't have a source
+        // span, but still try to print the lint source). But `-Z link-only` is
+        // unstable and this still shows the linker warning itself so this is
+        // probably good enough.
+        .assert_stderr_contains("linker stderr: bar");
+
+    // Same thing, but with json output.
+    rustc()
+        .error_format("json")
+        .arg("-Zlink-only")
+        .arg("rust_out.rlink")
+        .linker("./fake-linker")
+        .link_arg("run_make_warn")
+        .run_fail()
+        .assert_stderr_contains(r#""$message_type":"diagnostic""#);
 }

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -10,6 +10,25 @@ fn main() {
     // first, compile our linker
     rustc().arg("fake-linker.rs").output("fake-linker").run();
 
+    // Run rustc with our fake linker, and make sure it shows warnings
+    let warnings = run_rustc().link_arg("run_make_warn").run();
+    warnings.assert_stderr_contains("warning: linker stderr: bar");
+
+    // Make sure it shows stdout, but only when --verbose is passed
+    run_rustc()
+        .link_arg("run_make_info")
+        .verbose()
+        .run()
+        .assert_stderr_contains("warning: linker stdout: foo");
+    run_rustc()
+        .link_arg("run_make_info")
+        .run()
+        .assert_stderr_not_contains("warning: linker stdout: foo");
+
+    // Make sure we short-circuit this new path if the linker exits with an error
+    // (so the diagnostic is less verbose)
+    run_rustc().link_arg("run_make_error").run_fail().assert_stderr_contains("note: error: baz");
+
     // Make sure we don't show the linker args unless `--verbose` is passed
     run_rustc()
         .link_arg("run_make_error")

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -14,16 +14,11 @@ fn main() {
     let warnings = run_rustc().link_arg("run_make_warn").run();
     warnings.assert_stderr_contains("warning: linker stderr: bar");
 
-    // Make sure it shows stdout, but only when --verbose is passed
+    // Make sure it shows stdout
     run_rustc()
         .link_arg("run_make_info")
-        .verbose()
         .run()
         .assert_stderr_contains("warning: linker stdout: foo");
-    run_rustc()
-        .link_arg("run_make_info")
-        .run()
-        .assert_stderr_not_contains("warning: linker stdout: foo");
 
     // Make sure we short-circuit this new path if the linker exits with an error
     // (so the diagnostic is less verbose)

--- a/tests/run-make/rust-lld-by-default-beta-stable/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-beta-stable/rmake.rs
@@ -12,11 +12,7 @@ use run_make_support::rustc;
 fn main() {
     // A regular compilation should not use rust-lld by default. We'll check that by asking the
     // linker to display its version number with a link-arg.
-    let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
-        .link_arg("-Wl,-v")
-        .input("main.rs")
-        .run();
+    let output = rustc().verbose().link_arg("-Wl,-v").input("main.rs").run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",

--- a/tests/run-make/rust-lld-by-default-beta-stable/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-beta-stable/rmake.rs
@@ -12,7 +12,7 @@ use run_make_support::rustc;
 fn main() {
     // A regular compilation should not use rust-lld by default. We'll check that by asking the
     // linker to display its version number with a link-arg.
-    let output = rustc().verbose().link_arg("-Wl,-v").input("main.rs").run();
+    let output = rustc().link_arg("-Wl,-v").input("main.rs").run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
@@ -21,6 +21,7 @@ fn main() {
 }
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
-    let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+    let lld_version_re =
+        Regex::new(r"^warning: linker stdout: LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rust-lld-by-default-nightly/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-nightly/rmake.rs
@@ -12,11 +12,7 @@ use run_make_support::rustc;
 fn main() {
     // A regular compilation should use rust-lld by default. We'll check that by asking the linker
     // to display its version number with a link-arg.
-    let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
-        .link_arg("-Wl,-v")
-        .input("main.rs")
-        .run();
+    let output = rustc().verbose().link_arg("-Wl,-v").input("main.rs").run();
     assert!(
         find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
@@ -24,12 +20,8 @@ fn main() {
     );
 
     // But it can still be disabled by turning the linker feature off.
-    let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
-        .link_arg("-Wl,-v")
-        .arg("-Zlinker-features=-lld")
-        .input("main.rs")
-        .run();
+    let output =
+        rustc().verbose().link_arg("-Wl,-v").arg("-Zlinker-features=-lld").input("main.rs").run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
@@ -38,6 +30,7 @@ fn main() {
 }
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
-    let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+    let lld_version_re =
+        Regex::new(r"^warning: linker stdout: LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rust-lld-by-default-nightly/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-nightly/rmake.rs
@@ -12,7 +12,7 @@ use run_make_support::rustc;
 fn main() {
     // A regular compilation should use rust-lld by default. We'll check that by asking the linker
     // to display its version number with a link-arg.
-    let output = rustc().verbose().link_arg("-Wl,-v").input("main.rs").run();
+    let output = rustc().link_arg("-Wl,-v").input("main.rs").run();
     assert!(
         find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
@@ -20,8 +20,7 @@ fn main() {
     );
 
     // But it can still be disabled by turning the linker feature off.
-    let output =
-        rustc().verbose().link_arg("-Wl,-v").arg("-Zlinker-features=-lld").input("main.rs").run();
+    let output = rustc().link_arg("-Wl,-v").arg("-Zlinker-features=-lld").input("main.rs").run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -15,7 +15,6 @@ fn main() {
     // Compile to a custom target spec with rust-lld enabled by default. We'll check that by asking
     // the linker to display its version number with a link-arg.
     let output = rustc()
-        .verbose()
         .crate_type("cdylib")
         .target("custom-target.json")
         .link_arg("-Wl,-v")
@@ -29,7 +28,6 @@ fn main() {
 
     // But it can also be disabled via linker features.
     let output = rustc()
-        .verbose()
         .crate_type("cdylib")
         .target("custom-target.json")
         .arg("-Zlinker-features=-lld")

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -15,7 +15,7 @@ fn main() {
     // Compile to a custom target spec with rust-lld enabled by default. We'll check that by asking
     // the linker to display its version number with a link-arg.
     let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
+        .verbose()
         .crate_type("cdylib")
         .target("custom-target.json")
         .link_arg("-Wl,-v")
@@ -29,7 +29,7 @@ fn main() {
 
     // But it can also be disabled via linker features.
     let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
+        .verbose()
         .crate_type("cdylib")
         .target("custom-target.json")
         .arg("-Zlinker-features=-lld")
@@ -44,6 +44,7 @@ fn main() {
 }
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
-    let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+    let lld_version_re =
+        Regex::new(r"^warning: linker stdout: LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -14,10 +14,10 @@ fn main() {
     // Opt-in to lld and the self-contained linker, to link with rust-lld. We'll check that by
     // asking the linker to display its version number with a link-arg.
     let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
         .arg("-Zlinker-features=+lld")
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
+        .verbose()
         .link_arg(linker_version_flag)
         .input("main.rs")
         .run();
@@ -29,8 +29,8 @@ fn main() {
 
     // It should not be used when we explicitly opt-out of lld.
     let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
         .link_arg(linker_version_flag)
+        .verbose()
         .arg("-Zlinker-features=-lld")
         .input("main.rs")
         .run();
@@ -43,8 +43,8 @@ fn main() {
     // While we're here, also check that the last linker feature flag "wins" when passed multiple
     // times to rustc.
     let output = rustc()
-        .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
         .link_arg(linker_version_flag)
+        .verbose()
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
         .arg("-Zlinker-features=-lld")
@@ -60,6 +60,7 @@ fn main() {
 }
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
-    let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+    let lld_version_re =
+        Regex::new(r"^warning: linker stdout: LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -17,7 +17,6 @@ fn main() {
         .arg("-Zlinker-features=+lld")
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
-        .verbose()
         .link_arg(linker_version_flag)
         .input("main.rs")
         .run();
@@ -28,12 +27,8 @@ fn main() {
     );
 
     // It should not be used when we explicitly opt-out of lld.
-    let output = rustc()
-        .link_arg(linker_version_flag)
-        .verbose()
-        .arg("-Zlinker-features=-lld")
-        .input("main.rs")
-        .run();
+    let output =
+        rustc().link_arg(linker_version_flag).arg("-Zlinker-features=-lld").input("main.rs").run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
@@ -44,7 +39,6 @@ fn main() {
     // times to rustc.
     let output = rustc()
         .link_arg(linker_version_flag)
-        .verbose()
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
         .arg("-Zlinker-features=-lld")

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -55,6 +55,6 @@ fn main() {
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
     let lld_version_re =
-        Regex::new(r"^warning: linker stdout: LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+        Regex::new(r"^warning: linker std(out|err): LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/ui/lint/linker-warning-bin.rs
+++ b/tests/ui/lint/linker-warning-bin.rs
@@ -1,0 +1,6 @@
+//@ build-pass
+#![crate_type = "bin"]
+#![warn(unused_attributes)]
+#![allow(linker_messages)]
+
+fn main() {}

--- a/tests/ui/lint/linker-warning.rs
+++ b/tests/ui/lint/linker-warning.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+#![crate_type = "lib"]
+#![warn(unused_attributes)]
+#![allow(linker_messages)]
+//~^ WARNING unused attribute
+
+#[allow(linker_messages)]
+//~^ WARNING should be an inner attribute
+fn foo() {}

--- a/tests/ui/lint/linker-warning.stderr
+++ b/tests/ui/lint/linker-warning.stderr
@@ -1,0 +1,22 @@
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
+  --> $DIR/linker-warning.rs:7:1
+   |
+LL | #[allow(linker_messages)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/linker-warning.rs:3:9
+   |
+LL | #![warn(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+warning: unused attribute
+  --> $DIR/linker-warning.rs:4:1
+   |
+LL | #![allow(linker_messages)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: the `linker_warnings` lint can only be controlled at the root of a crate that needs to be linked
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Show stderr and stderr by default, controlled by a new `linker_messages` lint.

fixes https://github.com/rust-lang/rust/issues/83436. fixes https://github.com/rust-lang/rust/issues/38206. cc https://rust-lang.zulipchat.com/#narrow/stream/233931-t-compiler.2Fmajor-changes/topic/uplift.20some.20-Zverbose.20calls.20and.20rename.20to.E2.80.A6.20compiler-team.23706/near/408986134

<!-- try-job: dist-x86_64-msvc -->
try-job: aarch64-apple

r? @bjorn3