### PR TITLE
bootstrap: use same make flags with rustdoc

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1221,11 +1221,6 @@ impl<'a> Builder<'a> {
             cmd.arg("-Dwarnings");
         }
         cmd.arg("-Znormalize-docs");
-
-        // Remove make-related flags that can cause jobserver problems.
-        cmd.env_remove("MAKEFLAGS");
-        cmd.env_remove("MFLAGS");
-
         cmd.args(linker_args(self, compiler.host, LldThreads::Yes));
         cmd
     }


### PR DESCRIPTION
Keeping same `MAKEFLAGS` and `MFLAGS` for rustdoc should allow rustdoc to use the same jobserver.