### PR TITLE
fix `./configure --set change-id`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -30,7 +30,7 @@
 #
 # If `change-id` does not match the version that is currently running,
 # `x.py` will inform you about the changes made on bootstrap.
-# change-id = <latest change id in src/bootstrap/src/utils/change_tracker.rs>
+#change-id = <latest change id in src/bootstrap/src/utils/change_tracker.rs>
 
 # =============================================================================
 # Tweaking how LLVM is compiled


### PR DESCRIPTION
the logic for this is kinda hacky and treats whitespace as significant https://github.com/rust-lang/rust/blob/d1e26401bc70a58e6daf1816d542be4573bbab84/src/bootstrap/configure.py#L485-L491

r? @onur-ozkan