### PR TITLE
Pass DeadItem and lint as consistent group in dead-code.

### DIFF
--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(let_chains)]
 #![feature(map_try_insert)]
 #![feature(min_specialization)]
+#![feature(slice_group_by)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
 #![deny(rustc::untranslatable_diagnostic)]

--- a/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.rs
+++ b/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.rs
@@ -15,6 +15,10 @@ struct Bar {
     _h: usize,
 }
 
+// Issue 119267: this should not ICE.
+#[derive(Debug)]
+struct Foo(usize, #[allow(unused)] usize);
+
 fn main() {
     Bar {
         a: 1,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/119267