### PR TITLE
Support encoding spans with relative offsets

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -68,7 +68,8 @@ pub const METADATA_HEADER: &[u8] = &[b'r', b'u', b's', b't', 0, 0, 0, METADATA_V
 
 #[derive(Encodable, Decodable)]
 enum SpanEncodingMode {
-    Shorthand(usize),
+    RelativeOffset(usize),
+    AbsoluteOffset(usize),
     Direct,
 }
 


### PR DESCRIPTION
The relative offset is often smaller than the absolute offset, and with
the LEB128 encoding, this ends up cutting the overall metadata size
considerably (~1.5 megabytes on libcore). We can support both relative
and absolute encodings essentially for free since we already take a full
byte to differentiate between direct and indirect encodings (so an extra
variant is quite cheap).