### PR TITLE
rustdoc: treat query string `+` as space

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -279,7 +279,8 @@ function preLoadCss(cssUrl) {
             const params = {};
             window.location.search.substring(1).split("&").
                 map(s => {
-                    const pair = s.split("=");
+                    // https://github.com/rust-lang/rust/issues/119219
+                    const pair = s.split("=").map(x => x.replace(/\+/g, " "));
                     params[decodeURIComponent(pair[0])] =
                         typeof pair[1] === "undefined" ? null : decodeURIComponent(pair[1]);
                 });

--- a/tests/rustdoc-gui/search-form-elements.goml
+++ b/tests/rustdoc-gui/search-form-elements.goml
@@ -137,3 +137,12 @@ call-function: (
         "menu_a_color": "#3873ad",
     }
 )
+
+// Check that search input correctly decodes form encoding.
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=a+b"
+wait-for: "#search-tabs" // Waiting for the search.js to load.
+assert-property: (".search-input", { "value": "a b" })
+// Check that literal + is not treated as space.
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html?search=a%2Bb"
+wait-for: "#search-tabs" // Waiting for the search.js to load.
+assert-property: (".search-input", { "value": "a+b" })


### PR DESCRIPTION
Fixes #119219