### PR TITLE
Suggest `=` to `==` in more cases, even in the face of reference mismatch

### DIFF
--- a/tests/ui/type/type-check/assignment-expected-bool.rs
+++ b/tests/ui/type/type-check/assignment-expected-bool.rs
@@ -31,4 +31,9 @@ fn main() {
     let _: usize = 0 = 0;
     //~^ ERROR mismatched types [E0308]
     //~| ERROR invalid left-hand side of assignment [E0070]
+
+    let foo = &String::new();
+    let bar = "";
+    if foo = bar {}
+    //~^ ERROR mismatched types [E0308]
 }

--- a/tests/ui/type/type-check/assignment-expected-bool.stderr
+++ b/tests/ui/type/type-check/assignment-expected-bool.stderr
@@ -135,7 +135,18 @@ LL |     let _: usize = 0 = 0;
    |            |
    |            expected due to this
 
-error: aborting due to 13 previous errors
+error[E0308]: mismatched types
+  --> $DIR/assignment-expected-bool.rs:37:8
+   |
+LL |     if foo = bar {}
+   |        ^^^^^^^^^ expected `bool`, found `()`
+   |
+help: you might have meant to compare for equality
+   |
+LL |     if foo == bar {}
+   |             +
+
+error: aborting due to 14 previous errors
 
 Some errors have detailed explanations: E0070, E0308.
 For more information about an error, try `rustc --explain E0070`.


### PR DESCRIPTION
Given `foo: &String` and `bar: str`, suggest `==` when given `if foo = bar {}`:

```
error[E0308]: mismatched types
  --> $DIR/assignment-expected-bool.rs:37:8
   |
LL |     if foo = bar {}
   |        ^^^^^^^^^ expected `bool`, found `()`
   |
help: you might have meant to compare for equality
   |
LL |     if foo == bar {}
   |             +
```