### PR TITLE
rustdoc-search: count path edits with separate edit limit

### DIFF
--- a/tests/rustdoc-js-std/asrawfd.js
+++ b/tests/rustdoc-js-std/asrawfd.js
@@ -7,7 +7,6 @@ const EXPECTED = {
         // Validate that type alias methods get the correct path.
         { 'path': 'std::os::fd::AsRawFd', 'name': 'as_raw_fd' },
         { 'path': 'std::os::fd::AsRawFd', 'name': 'as_raw_fd' },
-        { 'path': 'std::os::linux::process::PidFd', 'name': 'as_raw_fd' },
         { 'path': 'std::os::fd::RawFd', 'name': 'as_raw_fd' },
     ],
 };

--- a/tests/rustdoc-js-std/path-maxeditdistance.js
+++ b/tests/rustdoc-js-std/path-maxeditdistance.js
@@ -1,0 +1,42 @@
+// exact-check
+const FILTER_CRATE = "std";
+const EXPECTED = [
+    {
+        query: 'vec::intoiterator',
+        others: [
+            // trait std::iter::IntoIterator is not the first result
+            { 'path': 'std::vec', 'name': 'IntoIter' },
+            { 'path': 'std::vec::Vec', 'name': 'into_iter' },
+            { 'path': 'std::vec::Drain', 'name': 'into_iter' },
+            { 'path': 'std::vec::IntoIter', 'name': 'into_iter' },
+            { 'path': 'std::vec::ExtractIf', 'name': 'into_iter' },
+            { 'path': 'std::vec::Splice', 'name': 'into_iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'into_iter' },
+        ],
+    },
+    {
+        query: 'vec::iter',
+        others: [
+            // std::net::ToSocketAttrs::iter should not show up here
+            { 'path': 'std::vec', 'name': 'IntoIter' },
+            { 'path': 'std::vec::Vec', 'name': 'from_iter' },
+            { 'path': 'std::vec::Vec', 'name': 'into_iter' },
+            { 'path': 'std::vec::Drain', 'name': 'into_iter' },
+            { 'path': 'std::vec::IntoIter', 'name': 'into_iter' },
+            { 'path': 'std::vec::ExtractIf', 'name': 'into_iter' },
+            { 'path': 'std::vec::Splice', 'name': 'into_iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'iter_mut' },
+            { 'path': 'std::collections::VecDeque', 'name': 'from_iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'into_iter' },
+        ],
+    },
+    {
+        query: 'slice::itermut',
+        others: [
+            // std::collections::btree_map::itermut should not show up here
+            { 'path': 'std::slice', 'name': 'IterMut' },
+            { 'path': 'std::slice', 'name': 'iter_mut' },
+        ],
+    },
+];

--- a/tests/rustdoc-js-std/path-ordering.js
+++ b/tests/rustdoc-js-std/path-ordering.js
@@ -1,11 +1,20 @@
-const EXPECTED = {
-    query: 'hashset::insert',
-    others: [
-        // ensure hashset::insert comes first
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_with' },
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_owned' },
-        { 'path': 'std::collections::hash_map::HashMap', 'name': 'insert' },
-    ],
-};
+const EXPECTED = [
+    {
+        query: 'hashset::insert',
+        others: [
+            // ensure hashset::insert comes first
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_with' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_owned' },
+        ],
+    },
+    {
+        query: 'hash::insert',
+        others: [
+            // ensure hashset/hashmap::insert come first
+            { 'path': 'std::collections::hash_map::HashMap', 'name': 'insert' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/exact-match.js
+++ b/tests/rustdoc-js/exact-match.js
@@ -3,6 +3,5 @@ const EXPECTED = {
     'others': [
         { 'path': 'exact_match::Si', 'name': 'pc' },
         { 'path': 'exact_match::Psi', 'name': 'pc' },
-        { 'path': 'exact_match::Si', 'name': 'pa' },
     ],
 };

--- a/tests/rustdoc-js/module-substring.js
+++ b/tests/rustdoc-js/module-substring.js
@@ -1,7 +1,15 @@
-const EXPECTED = {
-    'query': 'ig::pc',
-    'others': [
-        { 'path': 'module_substring::Sig', 'name': 'pc' },
-        { 'path': 'module_substring::Si', 'name': 'pc' },
-    ],
-};
+const EXPECTED = [
+    {
+        'query': 'ig::pc',
+        'others': [
+            { 'path': 'module_substring::Sig', 'name': 'pc' },
+        ],
+    },
+    {
+        'query': 'si::pc',
+        'others': [
+            { 'path': 'module_substring::Si', 'name': 'pc' },
+            { 'path': 'module_substring::Sig', 'name': 'pc' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/path-maxeditdistance.js
+++ b/tests/rustdoc-js/path-maxeditdistance.js
@@ -1,0 +1,35 @@
+// exact-check
+
+const EXPECTED = [
+    {
+        'query': 'xxxxxxxxxxx::hocuspocusprestidigitation',
+        // do not match abracadabra::hocuspocusprestidigitation
+        'others': [],
+    },
+    {
+        // exact match
+        'query': 'abracadabra::hocuspocusprestidigitation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // swap br/rb; that's edit distance 2, where maxPathEditDistance = 3 (11 / 3)
+        'query': 'arbacadarba::hocuspocusprestidigitation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // truncate 5 chars, where maxEditDistance = 7 (21 / 3)
+        'query': 'abracadarba::hocusprestidigitation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // truncate 9 chars, where maxEditDistance = 5 (17 / 3)
+        'query': 'abracadarba::hprestidigitation',
+        'others': [],
+    },
+];

--- a/tests/rustdoc-js/path-maxeditdistance.rs
+++ b/tests/rustdoc-js/path-maxeditdistance.rs
@@ -1,0 +1,3 @@
+#![crate_name="abracadabra"]
+
+pub struct HocusPocusPrestidigitation;

--- a/tests/rustdoc-js/path-ordering.js
+++ b/tests/rustdoc-js/path-ordering.js
@@ -1,13 +1,13 @@
 // exact-check
 
 const EXPECTED = {
-    'query': 'b::ccccccc',
+    'query': 'bbbbbb::ccccccc',
     'others': [
         // `ccccccc` is an exact match for all three of these.
         // However `b` is a closer match for `bb` than for any
         // of the others, so it ought to go first.
-        { 'path': 'path_ordering::bb', 'name': 'Ccccccc' },
-        { 'path': 'path_ordering::aa', 'name': 'Ccccccc' },
-        { 'path': 'path_ordering::dd', 'name': 'Ccccccc' },
+        { 'path': 'path_ordering::bbbbbb', 'name': 'Ccccccc' },
+        { 'path': 'path_ordering::abbbbb', 'name': 'Ccccccc' },
+        { 'path': 'path_ordering::dbbbbb', 'name': 'Ccccccc' },
     ],
 };

--- a/tests/rustdoc-js/path-ordering.rs
+++ b/tests/rustdoc-js/path-ordering.rs
@@ -1,9 +1,9 @@
-pub mod dd {
+pub mod dbbbbb {
     pub struct Ccccccc;
 }
-pub mod aa {
+pub mod abbbbb {
     pub struct Ccccccc;
 }
-pub mod bb {
+pub mod bbbbbb {
     pub struct Ccccccc;
 }


### PR DESCRIPTION
Avoids strange-looking results like this one, where the path component seems to be ignored:

![image](https://github.com/rust-lang/rust/assets/1593513/f0ef077a-6e09-4d67-a29d-8cabc1495f66)

Since the two are counted separately elsewhere, they should get their own limits, too. The biggest problem with combining them is that paths are loosely checked by not requiring every component to match, which means that if they are short and matched loosely, they can easily find "drunk typist" matches that make no sense, like this old result:

    std::collections::btree_map::itermut matching slice::itermut
    maxEditDistance = ("slice::itermut".length) / 3 = 14 / 3 = 4
    editDistance("std", "slice") = 4
    editDistance("itermut", "itermut") = 0
        4 + 0 <= 4 PASS

Of course, `slice::itermut` should not match stuff from btreemap. `slice` should not match `std`.

The new result counts them separately:

    maxPathEditDistance = "slice".length / 3 = 5 / 3 = 1
    maxEditDistance = "itermut".length / 3 = 7 / 3 = 2
    editDistance("std", "slice") = 4
        4 <= 1 FAIL

Effectively, this makes path queries less "typo-resistant". It's not zero, but it means `vec` won't match the `v1` prelude.

This commit also adds substring matching to paths. It's stricter than the substring matching in the main part, but loose enough that what I expect to match does.

Queries without parent paths are unchanged.