### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -576,25 +576,19 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         match self.expr_ty.kind() {
             ty::Ref(_, _, mt) => {
                 let mtstr = mt.prefix_str();
-                if self.cast_ty.is_trait() {
-                    match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
-                        Ok(s) => {
-                            err.span_suggestion(
-                                self.cast_span,
-                                "try casting to a reference instead",
-                                format!("&{mtstr}{s}"),
-                                Applicability::MachineApplicable,
-                            );
-                        }
-                        Err(_) => {
-                            let msg = format!("did you mean `&{mtstr}{tstr}`?");
-                            err.span_help(self.cast_span, msg);
-                        }
+                match fcx.tcx.sess.source_map().span_to_snippet(self.cast_span) {
+                    Ok(s) => {
+                        err.span_suggestion(
+                            self.cast_span,
+                            "try casting to a reference instead",
+                            format!("&{mtstr}{s}"),
+                            Applicability::MachineApplicable,
+                        );
                     }
-                } else {
-                    let msg =
-                        format!("consider using an implicit coercion to `&{mtstr}{tstr}` instead");
-                    err.span_help(self.span, msg);
+                    Err(_) => {
+                        let msg = format!("did you mean `&{mtstr}{tstr}`?");
+                        err.span_help(self.cast_span, msg);
+                    }
                 }
             }
             ty::Adt(def, ..) if def.is_box() => {

--- a/compiler/rustc_infer/src/infer/relate/combine.rs
+++ b/compiler/rustc_infer/src/infer/relate/combine.rs
@@ -335,7 +335,7 @@ impl<'tcx> InferCtxt<'tcx> {
         // constants and generic expressions are not yet handled correctly.
         let Generalization { value_may_be_infer: value, needs_wf: _ } = generalize::generalize(
             self,
-            &mut CombineDelegate { infcx: self, span, param_env },
+            &mut CombineDelegate { infcx: self, span },
             ct,
             target_vid,
             ty::Variance::Invariant,
@@ -454,11 +454,7 @@ impl<'infcx, 'tcx> CombineFields<'infcx, 'tcx> {
         // adding constraints like `'x: '?2` and `?1 <: ?3`.)
         let Generalization { value_may_be_infer: b_ty, needs_wf } = generalize::generalize(
             self.infcx,
-            &mut CombineDelegate {
-                infcx: self.infcx,
-                param_env: self.param_env,
-                span: self.trace.span(),
-            },
+            &mut CombineDelegate { infcx: self.infcx, span: self.trace.span() },
             a_ty,
             b_vid,
             ambient_variance,

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -55,8 +55,6 @@ pub fn generalize<'tcx, D: GeneralizerDelegate<'tcx>, T: Into<Term<'tcx>> + Rela
 /// Abstracts the handling of region vars between HIR and MIR/NLL typechecking
 /// in the generalizer code.
 pub trait GeneralizerDelegate<'tcx> {
-    fn param_env(&self) -> ty::ParamEnv<'tcx>;
-
     fn forbid_inference_vars() -> bool;
 
     fn span(&self) -> Span;
@@ -66,15 +64,10 @@ pub trait GeneralizerDelegate<'tcx> {
 
 pub struct CombineDelegate<'cx, 'tcx> {
     pub infcx: &'cx InferCtxt<'tcx>,
-    pub param_env: ty::ParamEnv<'tcx>,
     pub span: Span,
 }
 
 impl<'tcx> GeneralizerDelegate<'tcx> for CombineDelegate<'_, 'tcx> {
-    fn param_env(&self) -> ty::ParamEnv<'tcx> {
-        self.param_env
-    }
-
     fn forbid_inference_vars() -> bool {
         false
     }
@@ -95,10 +88,6 @@ impl<'tcx, T> GeneralizerDelegate<'tcx> for T
 where
     T: TypeRelatingDelegate<'tcx>,
 {
-    fn param_env(&self) -> ty::ParamEnv<'tcx> {
-        <Self as TypeRelatingDelegate<'tcx>>::param_env(self)
-    }
-
     fn forbid_inference_vars() -> bool {
         <Self as TypeRelatingDelegate<'tcx>>::forbid_inference_vars()
     }

--- a/tests/ui/cast/cast-to-slice.rs
+++ b/tests/ui/cast/cast-to-slice.rs
@@ -1,0 +1,8 @@
+fn main() {
+    "example".as_bytes() as [char];
+    //~^ ERROR cast to unsized type
+
+    let arr: &[u8] = &[0, 2, 3];
+    arr as [char];
+    //~^ ERROR cast to unsized type
+}

--- a/tests/ui/cast/cast-to-slice.stderr
+++ b/tests/ui/cast/cast-to-slice.stderr
@@ -1,0 +1,19 @@
+error[E0620]: cast to unsized type: `&[u8]` as `[char]`
+  --> $DIR/cast-to-slice.rs:2:5
+   |
+LL |     "example".as_bytes() as [char]; 
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^------
+   |                             |
+   |                             help: try casting to a reference instead: `&[char]`
+
+error[E0620]: cast to unsized type: `&[u8]` as `[char]`
+  --> $DIR/cast-to-slice.rs:6:5
+   |
+LL |     arr as [char];
+   |     ^^^^^^^------
+   |            |
+   |            help: try casting to a reference instead: `&[char]`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0620`.

--- a/tests/ui/cast/cast-to-slice.stderr
+++ b/tests/ui/cast/cast-to-slice.stderr
@@ -1,7 +1,7 @@
 error[E0620]: cast to unsized type: `&[u8]` as `[char]`
   --> $DIR/cast-to-slice.rs:2:5
    |
-LL |     "example".as_bytes() as [char]; 
+LL |     "example".as_bytes() as [char];
    |     ^^^^^^^^^^^^^^^^^^^^^^^^------
    |                             |
    |                             help: try casting to a reference instead: `&[char]`

--- a/tests/ui/error-codes/E0620.stderr
+++ b/tests/ui/error-codes/E0620.stderr
@@ -2,13 +2,9 @@ error[E0620]: cast to unsized type: `&[usize; 2]` as `[usize]`
   --> $DIR/E0620.rs:2:16
    |
 LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using an implicit coercion to `&[usize]` instead
-  --> $DIR/E0620.rs:2:16
-   |
-LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^-------
+   |                                 |
+   |                                 help: try casting to a reference instead: `&[usize]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-17441.stderr
+++ b/tests/ui/issues/issue-17441.stderr
@@ -2,13 +2,9 @@ error[E0620]: cast to unsized type: `&[usize; 2]` as `[usize]`
   --> $DIR/issue-17441.rs:2:16
    |
 LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider using an implicit coercion to `&[usize]` instead
-  --> $DIR/issue-17441.rs:2:16
-   |
-LL |     let _foo = &[1_usize, 2] as [usize];
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^-------
+   |                                 |
+   |                                 help: try casting to a reference instead: `&[usize]`
 
 error[E0620]: cast to unsized type: `Box<usize>` as `dyn Debug`
   --> $DIR/issue-17441.rs:5:16


### PR DESCRIPTION
Successful merges:

 - #119175 (fix: diagnostic for casting reference to slice)
 - #119337 (Remove dead codes)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119175,119337)
<!-- homu-ignore:end -->