### PR TITLE
Add `-Zerror-metrics=PATH` to save diagnostic metadata to disk

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -514,7 +514,7 @@ fn default_track_diagnostic(d: &mut Diagnostic, f: &mut dyn FnMut(&mut Diagnosti
 pub static TRACK_DIAGNOSTICS: AtomicRef<fn(&mut Diagnostic, &mut dyn FnMut(&mut Diagnostic))> =
     AtomicRef::new(&(default_track_diagnostic as _));
 
-#[derive(Copy, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct DiagCtxtFlags {
     /// If false, warning-level lints are suppressed.
     /// (rustc: see `--allow warnings` and `--cap-lints`)
@@ -535,6 +535,8 @@ pub struct DiagCtxtFlags {
     pub deduplicate_diagnostics: bool,
     /// Track where errors are created. Enabled with `-Ztrack-diagnostics`.
     pub track_diagnostics: bool,
+    /// Track whether error metrics are stored. Enabled with `-Zerror-metrics=path`.
+    pub metrics: Option<PathBuf>,
 }
 
 impl Drop for DiagCtxtInner {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1165,6 +1165,7 @@ impl UnstableOptions {
             macro_backtrace: self.macro_backtrace,
             deduplicate_diagnostics: self.deduplicate_diagnostics,
             track_diagnostics: self.track_diagnostics,
+            metrics: self.error_metrics.clone(),
         }
     }
 }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1621,6 +1621,8 @@ options! {
         "emit a section containing stack size metadata (default: no)"),
     emit_thin_lto: bool = (true, parse_bool, [TRACKED],
         "emit the bc module with thin LTO info (default: yes)"),
+    error_metrics: Option<PathBuf> = (None, parse_opt_pathbuf, [UNTRACKED],
+        "stores metrics about the errors being emitted by rustc to disk"),
     export_executable_symbols: bool = (false, parse_bool, [TRACKED],
         "export symbols from executables, as if they were dynamic libraries"),
     extra_const_ub_checks: bool = (false, parse_bool, [TRACKED],


### PR DESCRIPTION
Add nightly only flag to store information about encountered errors to disk. The information being tracked is:

 - Error code
 - Path to error being emitted
 - Number of subdiagnostics
 - Number of structured suggestions