### PR TITLE
Add Lines::into_inner

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3092,6 +3092,37 @@ pub struct Lines<B> {
     buf: B,
 }
 
+impl<B> Lines<B> {
+    /// Consumes the `Lines`, returning the wrapped reader.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(lines_into_inner)]
+    ///
+    /// use std::io;
+    /// use std::io::{BufRead, BufReader};
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let foo_file = File::open("foo.txt")?;
+    ///     let foo_reader = BufReader::new(foo_file);
+    ///     let mut foo_lines = foo_reader.lines();
+    ///
+    ///     for line in &mut foo_lines {
+    ///         println!("{}", line?);
+    ///     }
+    ///
+    ///     let foo_file = foo_lines.into_inner().into_inner();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "lines_into_inner", issue = "none")]
+    pub fn into_inner(self) -> B {
+        self.buf
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: BufRead> Iterator for Lines<B> {
     type Item = Result<String>;

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -100,6 +100,9 @@ fn lines() {
     assert_eq!(s.next().unwrap().unwrap(), "12".to_string());
     assert_eq!(s.next().unwrap().unwrap(), "".to_string());
     assert!(s.next().is_none());
+
+    let buf = s.into_inner();
+    assert_eq!(buf.position(), 5);
 }
 
 #[test]


### PR DESCRIPTION
Add a simple function to unpack `std::io::Lines` into the underlying `BufRead` instance.