### PR TITLE
Don't validate / lint MIR before each pass

### DIFF
--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -129,12 +129,6 @@ fn run_passes_inner<'tcx>(
             if dump_enabled {
                 dump_mir_for_pass(tcx, body, name, false);
             }
-            if validate {
-                validate_body(tcx, body, format!("before pass {name}"));
-            }
-            if lint {
-                lint_body(tcx, body, format!("before pass {name}"));
-            }
 
             if let Some(prof_arg) = &prof_arg {
                 tcx.sess

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -1,4 +1,4 @@
-error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (before pass CheckPackedRef) at bb0[1]:
+error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH]::multiple_storage)) (after pass CheckPackedRef) at bb0[1]:
                                 StorageLive(_1) which already has storage here
   --> $DIR/storage-live.rs:22:13
    |


### PR DESCRIPTION
To avoid redundant work and verbose output in case of failures.