### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -504,18 +504,10 @@ impl<'a> Parser<'a> {
     }
 
     fn ident_or_err(&mut self, recover: bool) -> PResult<'a, (Ident, /* is_raw */ bool)> {
-        let result = self.token.ident().ok_or_else(|| self.expected_ident_found(recover));
-
-        let (ident, is_raw) = match result {
-            Ok(ident) => ident,
-            Err(err) => match err {
-                // we recovered!
-                Ok(ident) => ident,
-                Err(err) => return Err(err),
-            },
-        };
-
-        Ok((ident, is_raw))
+        match self.token.ident() {
+            Some(ident) => Ok(ident),
+            None => self.expected_ident_found(recover),
+        }
     }
 
     /// Checks if the next token is `tok`, and returns `true` if so.

--- a/tests/rustdoc-js-std/asrawfd.js
+++ b/tests/rustdoc-js-std/asrawfd.js
@@ -7,7 +7,6 @@ const EXPECTED = {
         // Validate that type alias methods get the correct path.
         { 'path': 'std::os::fd::AsRawFd', 'name': 'as_raw_fd' },
         { 'path': 'std::os::fd::AsRawFd', 'name': 'as_raw_fd' },
-        { 'path': 'std::os::linux::process::PidFd', 'name': 'as_raw_fd' },
         { 'path': 'std::os::fd::RawFd', 'name': 'as_raw_fd' },
     ],
 };

--- a/tests/rustdoc-js-std/path-maxeditdistance.js
+++ b/tests/rustdoc-js-std/path-maxeditdistance.js
@@ -1,0 +1,42 @@
+// exact-check
+const FILTER_CRATE = "std";
+const EXPECTED = [
+    {
+        query: 'vec::intoiterator',
+        others: [
+            // trait std::iter::IntoIterator is not the first result
+            { 'path': 'std::vec', 'name': 'IntoIter' },
+            { 'path': 'std::vec::Vec', 'name': 'into_iter' },
+            { 'path': 'std::vec::Drain', 'name': 'into_iter' },
+            { 'path': 'std::vec::IntoIter', 'name': 'into_iter' },
+            { 'path': 'std::vec::ExtractIf', 'name': 'into_iter' },
+            { 'path': 'std::vec::Splice', 'name': 'into_iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'into_iter' },
+        ],
+    },
+    {
+        query: 'vec::iter',
+        others: [
+            // std::net::ToSocketAttrs::iter should not show up here
+            { 'path': 'std::vec', 'name': 'IntoIter' },
+            { 'path': 'std::vec::Vec', 'name': 'from_iter' },
+            { 'path': 'std::vec::Vec', 'name': 'into_iter' },
+            { 'path': 'std::vec::Drain', 'name': 'into_iter' },
+            { 'path': 'std::vec::IntoIter', 'name': 'into_iter' },
+            { 'path': 'std::vec::ExtractIf', 'name': 'into_iter' },
+            { 'path': 'std::vec::Splice', 'name': 'into_iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'iter_mut' },
+            { 'path': 'std::collections::VecDeque', 'name': 'from_iter' },
+            { 'path': 'std::collections::VecDeque', 'name': 'into_iter' },
+        ],
+    },
+    {
+        query: 'slice::itermut',
+        others: [
+            // std::collections::btree_map::itermut should not show up here
+            { 'path': 'std::slice', 'name': 'IterMut' },
+            { 'path': 'std::slice', 'name': 'iter_mut' },
+        ],
+    },
+];

--- a/tests/rustdoc-js-std/path-ordering.js
+++ b/tests/rustdoc-js-std/path-ordering.js
@@ -1,11 +1,20 @@
-const EXPECTED = {
-    query: 'hashset::insert',
-    others: [
-        // ensure hashset::insert comes first
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_with' },
-        { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_owned' },
-        { 'path': 'std::collections::hash_map::HashMap', 'name': 'insert' },
-    ],
-};
+const EXPECTED = [
+    {
+        query: 'hashset::insert',
+        others: [
+            // ensure hashset::insert comes first
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_with' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_owned' },
+        ],
+    },
+    {
+        query: 'hash::insert',
+        others: [
+            // ensure hashset/hashmap::insert come first
+            { 'path': 'std::collections::hash_map::HashMap', 'name': 'insert' },
+            { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/exact-match.js
+++ b/tests/rustdoc-js/exact-match.js
@@ -3,6 +3,5 @@ const EXPECTED = {
     'others': [
         { 'path': 'exact_match::Si', 'name': 'pc' },
         { 'path': 'exact_match::Psi', 'name': 'pc' },
-        { 'path': 'exact_match::Si', 'name': 'pa' },
     ],
 };

--- a/tests/rustdoc-js/module-substring.js
+++ b/tests/rustdoc-js/module-substring.js
@@ -1,7 +1,15 @@
-const EXPECTED = {
-    'query': 'ig::pc',
-    'others': [
-        { 'path': 'module_substring::Sig', 'name': 'pc' },
-        { 'path': 'module_substring::Si', 'name': 'pc' },
-    ],
-};
+const EXPECTED = [
+    {
+        'query': 'ig::pc',
+        'others': [
+            { 'path': 'module_substring::Sig', 'name': 'pc' },
+        ],
+    },
+    {
+        'query': 'si::pc',
+        'others': [
+            { 'path': 'module_substring::Si', 'name': 'pc' },
+            { 'path': 'module_substring::Sig', 'name': 'pc' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/path-maxeditdistance.js
+++ b/tests/rustdoc-js/path-maxeditdistance.js
@@ -1,0 +1,35 @@
+// exact-check
+
+const EXPECTED = [
+    {
+        'query': 'xxxxxxxxxxx::hocuspocusprestidigitation',
+        // do not match abracadabra::hocuspocusprestidigitation
+        'others': [],
+    },
+    {
+        // exact match
+        'query': 'abracadabra::hocuspocusprestidigitation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // swap br/rb; that's edit distance 2, where maxPathEditDistance = 3 (11 / 3)
+        'query': 'arbacadarba::hocuspocusprestidigitation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // truncate 5 chars, where maxEditDistance = 7 (21 / 3)
+        'query': 'abracadarba::hocusprestidigitation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // truncate 9 chars, where maxEditDistance = 5 (17 / 3)
+        'query': 'abracadarba::hprestidigitation',
+        'others': [],
+    },
+];

--- a/tests/rustdoc-js/path-maxeditdistance.rs
+++ b/tests/rustdoc-js/path-maxeditdistance.rs
@@ -1,0 +1,3 @@
+#![crate_name="abracadabra"]
+
+pub struct HocusPocusPrestidigitation;

--- a/tests/rustdoc-js/path-ordering.js
+++ b/tests/rustdoc-js/path-ordering.js
@@ -1,13 +1,13 @@
 // exact-check
 
 const EXPECTED = {
-    'query': 'b::ccccccc',
+    'query': 'bbbbbb::ccccccc',
     'others': [
         // `ccccccc` is an exact match for all three of these.
         // However `b` is a closer match for `bb` than for any
         // of the others, so it ought to go first.
-        { 'path': 'path_ordering::bb', 'name': 'Ccccccc' },
-        { 'path': 'path_ordering::aa', 'name': 'Ccccccc' },
-        { 'path': 'path_ordering::dd', 'name': 'Ccccccc' },
+        { 'path': 'path_ordering::bbbbbb', 'name': 'Ccccccc' },
+        { 'path': 'path_ordering::abbbbb', 'name': 'Ccccccc' },
+        { 'path': 'path_ordering::dbbbbb', 'name': 'Ccccccc' },
     ],
 };

--- a/tests/rustdoc-js/path-ordering.rs
+++ b/tests/rustdoc-js/path-ordering.rs
@@ -1,9 +1,9 @@
-pub mod dd {
+pub mod dbbbbb {
     pub struct Ccccccc;
 }
-pub mod aa {
+pub mod abbbbb {
     pub struct Ccccccc;
 }
-pub mod bb {
+pub mod bbbbbb {
     pub struct Ccccccc;
 }

--- a/tests/ui/half-open-range-patterns/range_pat_interactions1.rs
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions1.rs
@@ -17,7 +17,7 @@ fn main() {
         }
         match x as i32 {
             0..5+1 => errors_only.push(x),
-            //~^ error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `+`
+            //~^ error: expected one of `=>`, `if`, or `|`, found `+`
             1 | -3..0 => first_or.push(x),
             y @ (0..5 | 6) => or_two.push(y),
             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),

--- a/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `+`
+error: expected one of `=>`, `if`, or `|`, found `+`
   --> $DIR/range_pat_interactions1.rs:19:17
    |
 LL |             0..5+1 => errors_only.push(x),
-   |                 ^ expected one of `,`, `=>`, `if`, `|`, or `}`
+   |                 ^ expected one of `=>`, `if`, or `|`
 
 error[E0408]: variable `n` is not bound in all patterns
   --> $DIR/range_pat_interactions1.rs:10:25

--- a/tests/ui/half-open-range-patterns/range_pat_interactions2.rs
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions2.rs
@@ -9,7 +9,7 @@ fn main() {
         match x as i32 {
             0..=(5+1) => errors_only.push(x),
             //~^ error: inclusive range with no end
-            //~| error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `(`
+            //~| error: expected one of `=>`, `if`, or `|`, found `(`
             1 | -3..0 => first_or.push(x),
             y @ (0..5 | 6) => or_two.push(y),
             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),

--- a/tests/ui/half-open-range-patterns/range_pat_interactions2.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions2.stderr
@@ -6,11 +6,11 @@ LL |             0..=(5+1) => errors_only.push(x),
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
 
-error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `(`
+error: expected one of `=>`, `if`, or `|`, found `(`
   --> $DIR/range_pat_interactions2.rs:10:17
    |
 LL |             0..=(5+1) => errors_only.push(x),
-   |                 ^ expected one of `,`, `=>`, `if`, `|`, or `}`
+   |                 ^ expected one of `=>`, `if`, or `|`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/not_general_enough_regression_106630.rs
+++ b/tests/ui/impl-trait/not_general_enough_regression_106630.rs
@@ -1,0 +1,33 @@
+// edition:2018
+// run-pass
+
+use std::future::Future;
+
+trait AsyncCallback<'a> {
+    type Out;
+}
+
+impl<'a, Fut, T, F> AsyncCallback<'a> for F
+where
+    F: FnOnce(&'a mut ()) -> Fut,
+    Fut: Future<Output = T> + Send + 'a,
+{
+    type Out = T;
+}
+
+trait CallbackMarker {}
+
+impl<F, T> CallbackMarker for F
+where
+    T: 'static,
+    for<'a> F: AsyncCallback<'a, Out = T> + Send,
+{
+}
+
+fn do_sth<F: CallbackMarker>(_: F) {}
+
+async fn callback(_: &mut ()) -> impl Send {}
+
+fn main() {
+    do_sth(callback);
+}

--- a/tests/ui/parser/attribute/attr-stmt-expr-attr-bad.rs
+++ b/tests/ui/parser/attribute/attr-stmt-expr-attr-bad.rs
@@ -84,15 +84,15 @@ fn main() {}
 
 #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] 10 => () } }
 //~^ ERROR inclusive range with no end
-//~| ERROR expected one of `,`, `=>`, `if`, `|`, or `}`, found `#`
+//~| ERROR expected one of `=>`, `if`, or `|`, found `#`
 #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] -10 => () } }
 //~^ ERROR inclusive range with no end
-//~| ERROR expected one of `,`, `=>`, `if`, `|`, or `}`, found `#`
+//~| ERROR expected one of `=>`, `if`, or `|`, found `#`
 #[cfg(FALSE)] fn e() { match 0 { 0..=-#[attr] 10 => () } }
 //~^ ERROR unexpected token: `#`
 #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] FOO => () } }
 //~^ ERROR inclusive range with no end
-//~| ERROR expected one of `,`, `=>`, `if`, `|`, or `}`, found `#`
+//~| ERROR expected one of `=>`, `if`, or `|`, found `#`
 
 #[cfg(FALSE)] fn e() { let _ = x.#![attr]foo(); }
 //~^ ERROR unexpected token: `#`

--- a/tests/ui/parser/attribute/attr-stmt-expr-attr-bad.stderr
+++ b/tests/ui/parser/attribute/attr-stmt-expr-attr-bad.stderr
@@ -365,11 +365,11 @@ LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] 10 => () } }
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
 
-error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `#`
+error: expected one of `=>`, `if`, or `|`, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:85:38
    |
 LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] 10 => () } }
-   |                                      ^ expected one of `,`, `=>`, `if`, `|`, or `}`
+   |                                      ^ expected one of `=>`, `if`, or `|`
 
 error[E0586]: inclusive range with no end
   --> $DIR/attr-stmt-expr-attr-bad.rs:88:35
@@ -379,11 +379,11 @@ LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] -10 => () } }
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
 
-error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `#`
+error: expected one of `=>`, `if`, or `|`, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:88:38
    |
 LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] -10 => () } }
-   |                                      ^ expected one of `,`, `=>`, `if`, `|`, or `}`
+   |                                      ^ expected one of `=>`, `if`, or `|`
 
 error: unexpected token: `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:91:39
@@ -399,11 +399,11 @@ LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] FOO => () } }
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
 
-error: expected one of `,`, `=>`, `if`, `|`, or `}`, found `#`
+error: expected one of `=>`, `if`, or `|`, found `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:93:38
    |
 LL | #[cfg(FALSE)] fn e() { match 0 { 0..=#[attr] FOO => () } }
-   |                                      ^ expected one of `,`, `=>`, `if`, `|`, or `}`
+   |                                      ^ expected one of `=>`, `if`, or `|`
 
 error: unexpected token: `#`
   --> $DIR/attr-stmt-expr-attr-bad.rs:97:34

--- a/tests/ui/parser/issues/issue-24375.rs
+++ b/tests/ui/parser/issues/issue-24375.rs
@@ -3,7 +3,7 @@ static tmp : [&'static str; 2]  = ["hello", "he"];
 fn main() {
     let z = "hello";
     match z {
-        tmp[0] => {} //~ ERROR expected one of `,`, `=>`, `@`, `if`, `|`, or `}`, found `[`
+        tmp[0] => {} //~ ERROR expected one of `=>`, `@`, `if`, or `|`, found `[`
         _ => {}
     }
 }

--- a/tests/ui/parser/issues/issue-24375.stderr
+++ b/tests/ui/parser/issues/issue-24375.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,`, `=>`, `@`, `if`, `|`, or `}`, found `[`
+error: expected one of `=>`, `@`, `if`, or `|`, found `[`
   --> $DIR/issue-24375.rs:6:12
    |
 LL |         tmp[0] => {}
-   |            ^ expected one of `,`, `=>`, `@`, `if`, `|`, or `}`
+   |            ^ expected one of `=>`, `@`, `if`, or `|`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/match-arm-without-body.stderr
+++ b/tests/ui/parser/match-arm-without-body.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,`, `=>`, `if`, `|`, or `}`, found reserved identifier `_`
+error: expected one of `=>`, `if`, or `|`, found reserved identifier `_`
   --> $DIR/match-arm-without-body.rs:13:9
    |
 LL |         Some(_)
-   |                - expected one of `,`, `=>`, `if`, `|`, or `}`
+   |                - expected one of `=>`, `if`, or `|`
 LL |         _ => {}
    |         ^ unexpected token
 
@@ -44,11 +44,11 @@ LL +
 LL ~         _ => {}
    |
 
-error: expected one of `,`, `.`, `=>`, `?`, `}`, or an operator, found reserved identifier `_`
+error: expected one of `.`, `=>`, `?`, or an operator, found reserved identifier `_`
   --> $DIR/match-arm-without-body.rs:36:9
    |
 LL |         Some(_) if true
-   |                        - expected one of `,`, `.`, `=>`, `?`, `}`, or an operator
+   |                        - expected one of `.`, `=>`, `?`, or an operator
 LL |         _ => {}
    |         ^ unexpected token
 

--- a/tests/ui/parser/pat-lt-bracket-1.rs
+++ b/tests/ui/parser/pat-lt-bracket-1.rs
@@ -1,7 +1,7 @@
 fn main() {
   match 42 {
     x < 7 => (),
-   //~^ error: expected one of `,`, `=>`, `@`, `if`, `|`, or `}`, found `<`
+   //~^ error: expected one of `=>`, `@`, `if`, or `|`, found `<`
     _ => ()
   }
 }

--- a/tests/ui/parser/pat-lt-bracket-1.stderr
+++ b/tests/ui/parser/pat-lt-bracket-1.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,`, `=>`, `@`, `if`, `|`, or `}`, found `<`
+error: expected one of `=>`, `@`, `if`, or `|`, found `<`
   --> $DIR/pat-lt-bracket-1.rs:3:7
    |
 LL |     x < 7 => (),
-   |       ^ expected one of `,`, `=>`, `@`, `if`, `|`, or `}`
+   |       ^ expected one of `=>`, `@`, `if`, or `|`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - #119331 (rustdoc-search: count path edits with separate edit limit)
 - #119359 (Simplify Parser::ident_or_error)
 - #119376 (Add regression test for #106630)
 - #119379 (Update `parse_seq` doc)
 - #119380 (Don't suggest writing a bodyless arm if the pattern can never be a never pattern)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119331,119359,119376,119379,119380)
<!-- homu-ignore:end -->