### PR TITLE
Remove usage of `to_stable_hash_key` when stable hashing hash maps

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -506,14 +506,6 @@ unsafe impl StableOrd for String {
     const CAN_USE_UNSTABLE_SORT: bool = true;
 }
 
-impl<HCX> ToStableHashKey<HCX> for String {
-    type KeyType = String;
-    #[inline]
-    fn to_stable_hash_key(&self, _: &HCX) -> Self::KeyType {
-        self.clone()
-    }
-}
-
 impl<HCX, T1: ToStableHashKey<HCX>, T2: ToStableHashKey<HCX>> ToStableHashKey<HCX> for (T1, T2) {
     type KeyType = (T1::KeyType, T2::KeyType);
     #[inline]
@@ -647,14 +639,13 @@ impl_stable_traits_for_trivial_type!(::std::path::PathBuf);
 
 impl<K, V, R, HCX> HashStable<HCX> for ::std::collections::HashMap<K, V, R>
 where
-    K: ToStableHashKey<HCX> + Eq,
+    K: HashStable<HCX> + Eq,
     V: HashStable<HCX>,
     R: BuildHasher,
 {
     #[inline]
     fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         stable_hash_reduce(hcx, hasher, self.iter(), self.len(), |hasher, hcx, (key, value)| {
-            let key = key.to_stable_hash_key(hcx);
             key.hash_stable(hcx, hasher);
             value.hash_stable(hcx, hasher);
         });

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -4,7 +4,7 @@
 
 use rustc_arena::DroplessArena;
 use rustc_data_structures::fx::FxIndexSet;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lock;
 use rustc_macros::HashStable_Generic;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -2092,14 +2092,6 @@ impl<CTX> HashStable<CTX> for Symbol {
     #[inline]
     fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         self.as_str().hash_stable(hcx, hasher);
-    }
-}
-
-impl<CTX> ToStableHashKey<CTX> for Symbol {
-    type KeyType = String;
-    #[inline]
-    fn to_stable_hash_key(&self, _: &CTX) -> String {
-        self.as_str().to_string()
     }
 }
 


### PR DESCRIPTION
I tried to look for some types that had an expensive `to_stable_hash_key` implementation and move them to `HashStable` instead. Let's see if there's any perf. impact.