### PR TITLE
Don't initialize stdout during io cleanup

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -623,13 +623,7 @@ pub fn stdout() -> Stdout {
 // by replacing the line writer by one with zero
 // buffering capacity.
 pub fn cleanup() {
-    let mut initialized = false;
-    let stdout = STDOUT.get_or_init(|| {
-        initialized = true;
-        ReentrantMutex::new(RefCell::new(LineWriter::with_capacity(0, stdout_raw())))
-    });
-
-    if !initialized {
+    if let Some(stdout) = STDOUT.get() {
         // The buffer was previously initialized, overwrite it here.
         // We use try_lock() instead of lock(), because someone
         // might have leaked a StdoutLock, which would

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -111,11 +111,11 @@ unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
 // NOTE: this is not guaranteed to run, for example when the program aborts.
 pub(crate) fn cleanup() {
     static CLEANUP: Once = Once::new();
-    CLEANUP.call_once(|| unsafe {
+    CLEANUP.call_once(|| {
         // Flush stdout and disable buffering.
         crate::io::cleanup();
         // SAFETY: Only called once during runtime cleanup.
-        sys::cleanup();
+        unsafe { sys::cleanup() };
     });
 }
 


### PR DESCRIPTION
Slightly simplify the `std::io::cleanup` code by using `OnceCell::get` instead of checking initialization manually with `get_or_init`.

This also has the consequence of not initializing stdout with an empty buffer if it hasn't been already, but I believe this is inconsequential given that this code only runs at process exit.