### PR TITLE
Also walk bindings created by if-let guards

### DIFF
--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -1351,6 +1351,9 @@ impl<'a, 'tcx> Visitor<'tcx> for Liveness<'a, 'tcx> {
 
     fn visit_arm(&mut self, arm: &'tcx hir::Arm<'tcx>) {
         self.check_unused_vars_in_pat(arm.pat, None, None, |_, _, _, _| {});
+        if let Some(hir::Guard::IfLet(let_expr)) = arm.guard {
+            self.check_unused_vars_in_pat(let_expr.pat, None, None, |_, _, _, _| {});
+        }
         intravisit::walk_arm(self, arm);
     }
 }

--- a/tests/ui/lint/unused/issue-119383.rs
+++ b/tests/ui/lint/unused/issue-119383.rs
@@ -1,0 +1,9 @@
+#![feature(if_let_guard)]
+#![deny(unused_variables)]
+
+fn main() {
+    match () {
+        () if let Some(b) = Some(()) => {} //~ ERROR unused variable: `b`
+        _ => {}
+    }
+}

--- a/tests/ui/lint/unused/issue-119383.stderr
+++ b/tests/ui/lint/unused/issue-119383.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `b`
+  --> $DIR/issue-119383.rs:6:24
+   |
+LL |         () if let Some(b) = Some(()) => {}
+   |                        ^ help: if this is intentional, prefix it with an underscore: `_b`
+   |
+note: the lint level is defined here
+  --> $DIR/issue-119383.rs:2:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This change makes the `unused_variables` lint pick up unused bindings created by if-let guards.

Fixes #119383