### PR TITLE
Add non-regression test for ATPIT ICE #114325

### DIFF
--- a/tests/ui/impl-trait/associated-impl-trait-type-issue-114325.rs
+++ b/tests/ui/impl-trait/associated-impl-trait-type-issue-114325.rs
@@ -1,0 +1,55 @@
+// This is a non-regression test for issue #114325: an "unexpected unsized tail" ICE happened during
+// codegen, and was fixed by MIR drop tracking #107421.
+
+// edition: 2021
+// build-pass: ICEd during codegen.
+
+#![feature(impl_trait_in_assoc_type)]
+
+use std::future::Future;
+
+fn main() {
+    RuntimeRef::spawn_local(actor_fn(http_actor));
+}
+
+async fn http_actor() {
+    async fn respond(body: impl Body) {
+        body.write_message().await;
+    }
+
+    respond(&()).await;
+}
+
+trait Body {
+    type WriteFuture: Future;
+
+    fn write_message(self) -> Self::WriteFuture;
+}
+
+impl Body for &'static () {
+    type WriteFuture = impl Future<Output = ()>;
+
+    fn write_message(self) -> Self::WriteFuture {
+        async {}
+    }
+}
+
+trait NewActor {
+    type RuntimeAccess;
+}
+
+fn actor_fn<T, A>(_d: T) -> (T, A) {
+    loop {}
+}
+
+impl<F: FnMut() -> A, A> NewActor for (F, A) {
+    type RuntimeAccess = RuntimeRef;
+}
+struct RuntimeRef(Vec<()>);
+
+impl RuntimeRef {
+    fn spawn_local<NA: NewActor<RuntimeAccess = RuntimeRef>>(_f: NA) {
+        struct ActorFuture<NA: NewActor>(NA::RuntimeAccess);
+        (ActorFuture::<NA>(RuntimeRef(vec![])), _f);
+    }
+}


### PR DESCRIPTION
ATPIT issue #114325 had been unknowingly fixed by https://github.com/rust-lang/rust/pull/107421, so this PR adds its [MCVE](https://github.com/rust-lang/rust/issues/114325#issuecomment-1721561552) as a non-regression test.

Closes #114325.

