### PR TITLE
Primitive docs: fix confusing `Send` in `&T`'s list

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1348,7 +1348,6 @@ mod prim_usize {}
 /// * [`Fn`] \(in addition, `&T` references get [`FnMut`] and [`FnOnce`] if `T: Fn`)
 /// * [`Hash`]
 /// * [`ToSocketAddrs`]
-/// * [`Send`] \(`&T` references also require <code>T: [Sync]</code>)
 /// * [`Sync`]
 ///
 /// [`std::fmt`]: fmt
@@ -1366,6 +1365,7 @@ mod prim_usize {}
 /// * [`ExactSizeIterator`]
 /// * [`FusedIterator`]
 /// * [`TrustedLen`]
+/// * [`Send`]
 /// * [`io::Write`]
 /// * [`Read`]
 /// * [`Seek`]
@@ -1377,6 +1377,8 @@ mod prim_usize {}
 /// [`BufRead`]: ../std/io/trait.BufRead.html
 /// [`Read`]: ../std/io/trait.Read.html
 /// [`io::Write`]: ../std/io/trait.Write.html
+///
+/// In addition, `&T` references implement [`Send`] if and only if `T` implements [`Sync`].
 ///
 /// Note that due to method call deref coercion, simply calling a trait method will act like they
 /// work on references as well as they do on owned values! The implementations described here are


### PR DESCRIPTION
The two lists in this document describe what traits are implemented on references when their underlying `T` also implements them. However, while it is true that `T: Send + Sync` implies `&T: Send` (which is what the sentence is trying to explain), it is confusing to have `Send` in the list because `T: Send` is not needed for that. In particular, the "also require" part may be interpreted as "both `T: Send` and `T: Sync` are required".

Instead, move `Send` back to where it was before commit 7a477869b72e ("Makes docs for references a little less confusing"), i.e. to the `&mut` list (where no extra nota is needed, i.e. it fits naturally) and move the `Sync` definition/note to the bottom as something independent.