### PR TITLE
Fix invalid check-cfg Cargo feature diagnostic help

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -804,8 +804,6 @@ pub trait LintContext {
                                 db.span_suggestion(value_span, "there is a expected value with a similar name", format!("\"{best_match}\""), Applicability::MaybeIncorrect);
 
                             }
-                        } else if name == sym::feature && is_from_cargo {
-                            db.help(format!("consider defining `{name}` as feature in `Cargo.toml`"));
                         } else if let &[first_possibility] = &possibilities[..] {
                             db.span_suggestion(name_span.shrink_to_hi(), "specify a config value", format!(" = \"{first_possibility}\""), Applicability::MaybeIncorrect);
                         }

--- a/tests/ui/check-cfg/cargo-feature.none.stderr
+++ b/tests/ui/check-cfg/cargo-feature.none.stderr
@@ -8,8 +8,17 @@ LL | #[cfg(feature = "serde")]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition name: `tokio_unstable`
+warning: unexpected `cfg` condition name: `feature`
   --> $DIR/cargo-feature.rs:18:7
+   |
+LL | #[cfg(feature)]
+   |       ^^^^^^^
+   |
+   = help: consider defining some features in `Cargo.toml`
+   = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
+
+warning: unexpected `cfg` condition name: `tokio_unstable`
+  --> $DIR/cargo-feature.rs:23:7
    |
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
@@ -19,7 +28,7 @@ LL | #[cfg(tokio_unstable)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `CONFIG_NVME`
-  --> $DIR/cargo-feature.rs:22:7
+  --> $DIR/cargo-feature.rs:27:7
    |
 LL | #[cfg(CONFIG_NVME = "m")]
    |       ^^^^^^^^^^^^^^^^^
@@ -27,5 +36,5 @@ LL | #[cfg(CONFIG_NVME = "m")]
    = help: consider using a Cargo feature instead or adding `println!("cargo:rustc-check-cfg=cfg(CONFIG_NVME, values(\"m\"))");` to the top of a `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
-warning: 3 warnings emitted
+warning: 4 warnings emitted
 

--- a/tests/ui/check-cfg/cargo-feature.rs
+++ b/tests/ui/check-cfg/cargo-feature.rs
@@ -15,6 +15,11 @@
 //[some]~^^ WARNING unexpected `cfg` condition value
 fn ser() {}
 
+#[cfg(feature)]
+//[none]~^ WARNING unexpected `cfg` condition name
+//[some]~^^ WARNING unexpected `cfg` condition value
+fn feat() {}
+
 #[cfg(tokio_unstable)]
 //~^ WARNING unexpected `cfg` condition name
 fn tokio() {}

--- a/tests/ui/check-cfg/cargo-feature.some.stderr
+++ b/tests/ui/check-cfg/cargo-feature.some.stderr
@@ -13,10 +13,9 @@ warning: unexpected `cfg` condition value: (none)
   --> $DIR/cargo-feature.rs:18:7
    |
 LL | #[cfg(feature)]
-   |       ^^^^^^^
+   |       ^^^^^^^- help: specify a config value: `= "bitcode"`
    |
    = note: expected values for `feature` are: `bitcode`
-   = help: consider defining `feature` as feature in `Cargo.toml`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition name: `tokio_unstable`

--- a/tests/ui/check-cfg/cargo-feature.some.stderr
+++ b/tests/ui/check-cfg/cargo-feature.some.stderr
@@ -9,8 +9,18 @@ LL | #[cfg(feature = "serde")]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
 
-warning: unexpected `cfg` condition name: `tokio_unstable`
+warning: unexpected `cfg` condition value: (none)
   --> $DIR/cargo-feature.rs:18:7
+   |
+LL | #[cfg(feature)]
+   |       ^^^^^^^
+   |
+   = note: expected values for `feature` are: `bitcode`
+   = help: consider defining `feature` as feature in `Cargo.toml`
+   = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
+
+warning: unexpected `cfg` condition name: `tokio_unstable`
+  --> $DIR/cargo-feature.rs:23:7
    |
 LL | #[cfg(tokio_unstable)]
    |       ^^^^^^^^^^^^^^
@@ -20,7 +30,7 @@ LL | #[cfg(tokio_unstable)]
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `m`
-  --> $DIR/cargo-feature.rs:22:7
+  --> $DIR/cargo-feature.rs:27:7
    |
 LL | #[cfg(CONFIG_NVME = "m")]
    |       ^^^^^^^^^^^^^^---
@@ -31,5 +41,5 @@ LL | #[cfg(CONFIG_NVME = "m")]
    = help: consider using a Cargo feature instead or adding `println!("cargo:rustc-check-cfg=cfg(CONFIG_NVME, values(\"m\"))");` to the top of a `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#check-cfg> for more information about checking conditional configuration
 
-warning: 3 warnings emitted
+warning: 4 warnings emitted
 


### PR DESCRIPTION
#118213 added specialized diagnostic for Cargo `feature` cfg. However when providing an empty `#[cfg(feature)]` condition the suggestion would suggest adding `feature` as a feature in `Cargo.toml` (wtf!).

This PR removes the invalid logic, which even brings a nice improvement.

```diff
   --> $DIR/cargo-feature.rs:18:7
    |
 LL | #[cfg(feature)]
-   |       ^^^^^^^
+   |       ^^^^^^^- help: specify a config value: `= "bitcode"`
    |
    = note: expected values for `feature` are: `bitcode`
-   = help: consider defining `feature` as feature in `Cargo.toml`
```

The first commit add a test showing the bug and the second commit fixes the bug.

@rustbot label +F-check-cfg