### PR TITLE
coverage: Prepare mappings separately from injecting statements

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -48,8 +48,13 @@ impl CoverageSpans {
         !self.bcb_to_spans[bcb].is_empty()
     }
 
-    pub(super) fn spans_for_bcb(&self, bcb: BasicCoverageBlock) -> &[Span] {
-        &self.bcb_to_spans[bcb]
+    pub(super) fn bcbs_with_coverage_spans(
+        &self,
+    ) -> impl Iterator<Item = (BasicCoverageBlock, &[Span])> {
+        self.bcb_to_spans.iter_enumerated().filter_map(|(bcb, spans)| {
+            // Only yield BCBs that have at least one coverage span.
+            (!spans.is_empty()).then_some((bcb, spans.as_slice()))
+        })
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -630,8 +630,10 @@ fn test_make_bcb_counters() {
         // coverage spans for BCBs 1 and 2. Now we skip that step and just tell
         // BCB counter construction that those BCBs have spans.
         let bcb_has_coverage_spans = |bcb: BasicCoverageBlock| (1..=2).contains(&bcb.as_usize());
-        let mut coverage_counters = counters::CoverageCounters::new(&basic_coverage_blocks);
-        coverage_counters.make_bcb_counters(&basic_coverage_blocks, bcb_has_coverage_spans);
+        let coverage_counters = counters::CoverageCounters::make_bcb_counters(
+            &basic_coverage_blocks,
+            bcb_has_coverage_spans,
+        );
         assert_eq!(coverage_counters.num_expressions(), 0);
 
         assert_eq!(


### PR DESCRIPTION
These two tasks historically needed to be interleaved, but after various recent changes (including #116046 and #116917) they can now be fully separated.

---

@rustbot label +A-code-coverage