### PR TITLE
Simplify bootstrap `--check-cfg` arguments

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -21,7 +21,7 @@ use crate::core::config::{DryRun, SplitDebuginfo, TargetSelection};
 use crate::prepare_behaviour_dump_dir;
 use crate::utils::cache::{Cache, Interned, INTERNER};
 use crate::utils::helpers::{self, add_dylib_path, add_link_lib_path, exe, linker_args};
-use crate::utils::helpers::{libdir, linker_flags, output, t, LldThreads};
+use crate::utils::helpers::{check_cfg_arg, libdir, linker_flags, output, t, LldThreads};
 use crate::EXTRA_CHECK_CFGS;
 use crate::{Build, CLang, Crate, DocTests, GitRepo, Mode};
 
@@ -1467,23 +1467,7 @@ impl<'a> Builder<'a> {
         rustflags.arg("-Zunstable-options");
         for (restricted_mode, name, values) in EXTRA_CHECK_CFGS {
             if *restricted_mode == None || *restricted_mode == Some(mode) {
-                // Creating a string of the values by concatenating each value:
-                // ',values("tvos","watchos")' or '' (nothing) when there are no values.
-                let next = match values {
-                    Some(values) => {
-                        let mut tmp = values
-                            .iter()
-                            .map(|val| [",", "\"", val, "\""])
-                            .flatten()
-                            .collect::<String>();
-
-                        tmp.insert_str(1, "values(");
-                        tmp.push_str(")");
-                        tmp
-                    }
-                    None => "".to_string(),
-                };
-                rustflags.arg(&format!("--check-cfg=cfg({name}{next})"));
+                rustflags.arg(&check_cfg_arg(name, *values));
             }
         }
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1468,17 +1468,22 @@ impl<'a> Builder<'a> {
         for (restricted_mode, name, values) in EXTRA_CHECK_CFGS {
             if *restricted_mode == None || *restricted_mode == Some(mode) {
                 // Creating a string of the values by concatenating each value:
-                // ',"tvos","watchos"' or '' (nothing) when there are no values
-                let values = match values {
-                    Some(values) => values
-                        .iter()
-                        .map(|val| [",", "\"", val, "\""])
-                        .flatten()
-                        .collect::<String>(),
-                    None => String::new(),
+                // ',values("tvos","watchos")' or '' (nothing) when there are no values.
+                let next = match values {
+                    Some(values) => {
+                        let mut tmp = values
+                            .iter()
+                            .map(|val| [",", "\"", val, "\""])
+                            .flatten()
+                            .collect::<String>();
+
+                        tmp.insert_str(1, "values(");
+                        tmp.push_str(")");
+                        tmp
+                    }
+                    None => "".to_string(),
                 };
-                let values = values.strip_prefix(",").unwrap_or(&values); // remove the first `,`
-                rustflags.arg(&format!("--check-cfg=cfg({name},values({values}))"));
+                rustflags.arg(&format!("--check-cfg=cfg({name}{next})"));
             }
         }
 

--- a/src/bootstrap/src/tests/helpers.rs
+++ b/src/bootstrap/src/tests/helpers.rs
@@ -1,4 +1,4 @@
-use crate::utils::helpers::{extract_beta_rev, hex_encode, make};
+use crate::utils::helpers::{extract_beta_rev, hex_encode, make, check_cfg_arg};
 use std::path::PathBuf;
 
 #[test]
@@ -56,4 +56,17 @@ fn test_string_to_hex_encode() {
     let input_string = "Hello, World!";
     let hex_string = hex_encode(input_string);
     assert_eq!(hex_string, "48656c6c6f2c20576f726c6421");
+}
+
+#[test]
+fn test_check_cfg_arg() {
+    assert_eq!(check_cfg_arg("bootstrap", None), "--check-cfg=cfg(bootstrap)");
+    assert_eq!(
+        check_cfg_arg("target_arch", Some(&["s360"])),
+        "--check-cfg=cfg(target_arch,values(\"s360\"))"
+    );
+    assert_eq!(
+        check_cfg_arg("target_os", Some(&["nixos", "nix2"])),
+        "--check-cfg=cfg(target_os,values(\"nixos\",\"nix2\"))"
+    );
 }

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -552,3 +552,22 @@ where
 {
     input.as_ref().iter().map(|x| format!("{:02x}", x)).collect()
 }
+
+/// Create a `--check-cfg` argument invocation for a given name
+/// and it's values.
+pub fn check_cfg_arg(name: &str, values: Option<&[&str]>) -> String {
+    // Creating a string of the values by concatenating each value:
+    // ',values("tvos","watchos")' or '' (nothing) when there are no values.
+    let next = match values {
+        Some(values) => {
+            let mut tmp =
+                values.iter().map(|val| [",", "\"", val, "\""]).flatten().collect::<String>();
+
+            tmp.insert_str(1, "values(");
+            tmp.push_str(")");
+            tmp
+        }
+        None => "".to_string(),
+    };
+    format!("--check-cfg=cfg({name}{next})")
+}


### PR DESCRIPTION
This PR simplifies the generated check-cfg arguments generated for the no-values case.

For the `bootstrap` cfg:

```diff
- --check-cfg=cfg(bootstrap,values())
+ --check-cfg=cfg(bootstrap)
```

Those are equivalent, so there isn't any semantic difference; but the invocation is shorter and less distracting.

@rustbot label +F-check-cfg