### PR TITLE
Apply clippy::perf fixes

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2791,11 +2791,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     )
                 })
                 .map(|mut field_path| {
+                    use std::fmt::Write;
+
                     field_path.pop();
-                    field_path
-                        .iter()
-                        .map(|id| format!("{}.", id.name.to_ident_string()))
-                        .collect::<String>()
+                    field_path.iter().fold(String::new(), |mut s, id| {
+                        write!(s, "{}.", id.name.to_ident_string()).unwrap();
+                        s
+                    })
                 })
                 .collect::<Vec<_>>();
             candidate_fields.sort();

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
+#![feature(lint_reasons)]
 #![feature(never_type)]
 #![feature(rustc_attrs)]
 #![recursion_limit = "256"]
@@ -145,6 +146,7 @@ fn maybe_source_file_to_parser(
 /// Given a session and a path and an optional span (for error reporting),
 /// add the path to the session's source_map and return the new source_file or
 /// error when a file can't be read.
+#[expect(clippy::result_large_err)]
 fn try_file_to_source_file(
     sess: &ParseSess,
     path: &Path,


### PR DESCRIPTION
Fixes `clippy::perf` lints in the compiler. I'm not sure if all of these are readability improvements... (I don't expect any perf impact, the code is just diagnostics and stable MIR).

r? @compiler-errors