### PR TITLE
Gate PR CI on clippy correctness lints

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -40,13 +40,9 @@ COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
 ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 
-# Run clippy just to make sure it doesn't error out; we don't actually want to gate on the warnings
-# though.
-# Ideally we'd use stage 1, but that ICEs: https://github.com/rust-lang/rust-clippy/issues/11230
-
 ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
            python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
-           python3 ../x.py clippy --stage 0 -Awarnings && \
+           python3 ../x.py clippy compiler -Aclippy::all -Dclippy::correctness && \
            python3 ../x.py build --stage 0 src/tools/build-manifest && \
            python3 ../x.py test --stage 0 src/tools/compiletest && \
            python3 ../x.py test --stage 0 core alloc std test proc_macro && \


### PR DESCRIPTION
Implements part of https://github.com/rust-lang/compiler-team/issues/709.

Note that `x.py clippy compiler` also checks the standard library, because it needs to be checked before the compiler. This happens even with `x.py clippy --stage 0`.