### PR TITLE
Remove libtest's dylib

### DIFF
--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -3,9 +3,6 @@ name = "test"
 version = "0.0.0"
 edition = "2021"
 
-[lib]
-crate-type = ["dylib", "rlib"]
-
 [dependencies]
 getopts = { version = "0.2.21", features = ['rustc-dep-of-std'] }
 std = { path = "../std" }


### PR DESCRIPTION
libtest.so is only used by rustdoc, and tests seem to pass locally with this change. I suppose if this is broken, the only way to find out is to make a PR.