### PR TITLE
rustdoc ui: adjust tooltip z-index to be above sidebar

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1046,7 +1046,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	position: absolute;
 	top: 100%;
 	right: 0;
-	z-index: 2;
+	z-index: 101;
 	margin-top: 7px;
 	border-radius: 3px;
 	border: 1px solid var(--border-color);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -14,6 +14,7 @@
 	   and on the RUSTDOC_MOBILE_BREAKPOINT */
 	--desktop-sidebar-width: 200px;
 	--src-sidebar-width: 300px;
+	--desktop-sidebar-z-index: 100;
 }
 
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
@@ -386,7 +387,7 @@ img {
 	height: 100vh;
 	top: 0;
 	left: 0;
-	z-index: 100;
+	z-index: var(--desktop-sidebar-z-index);
 }
 
 .rustdoc.src .sidebar {
@@ -407,7 +408,7 @@ img {
 	touch-action: none;
 	width: 9px;
 	cursor: col-resize;
-	z-index: 200;
+	z-index: calc(var(--desktop-sidebar-z-index) + 1);
 	position: fixed;
 	height: 100%;
 	/* make sure there's a 1px gap between the scrollbar and resize handle */
@@ -439,7 +440,6 @@ img {
 
 .sidebar-resizing .sidebar {
 	position: fixed;
-	z-index: 100;
 }
 .sidebar-resizing > body {
 	padding-left: var(--resizing-sidebar-width);
@@ -1046,7 +1046,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	position: absolute;
 	top: 100%;
 	right: 0;
-	z-index: 101;
+	z-index: calc(var(--desktop-sidebar-z-index) + 1);
 	margin-top: 7px;
 	border-radius: 3px;
 	border: 1px solid var(--border-color);
@@ -1561,7 +1561,7 @@ a.tooltip:hover::after {
 }
 .src #sidebar-button {
 	left: 8px;
-	z-index: 101;
+	z-index: calc(var(--desktop-sidebar-z-index) + 1);
 }
 .hide-sidebar .src #sidebar-button {
 	position: static;

--- a/tests/rustdoc-gui/tooltip-over-sidebar.goml
+++ b/tests/rustdoc-gui/tooltip-over-sidebar.goml
@@ -1,0 +1,12 @@
+// Check that the doctest info tooltips are above the sidebar.
+go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
+move-cursor-to: ".example-wrap.ignore .tooltip"
+wait-for: ".tooltip.popover"
+
+// Move cursor to top left corner of the tooltip and check that it doesn't fade.
+move-cursor-to: ".tooltip.popover"
+wait-for: 100
+assert: ".tooltip.popover:not(.fade-out)"
+
+move-cursor-to: (0, 0)
+wait-for: ".tooltip.popover.fade-out"


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/115660 the sidebar's z-index was changed to 100. This PR changes the tooltip's z-index to 101 to be above the sidebar again.

Fixes [after beta-backport] https://github.com/rust-lang/rust/issues/119472.