### PR TITLE
style-guide: Format single associated type `where` clauses on the same line

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -43,6 +43,7 @@ include:
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".
+- Format single associated type `where` clauses on the same line if they fit.
 
 ## Rust 2015/2018/2021 style edition
 

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -296,7 +296,7 @@ Prefer to use single-letter names for generic parameters.
 These rules apply for `where` clauses on any item.
 
 If a where clause is short, and appears on a short one-line function
-declaration with no body or a short associated type with no `=`, format it on
+declaration with no body or on a short type with no `=`, format it on
 the same line as the declaration:
 
 ```rust

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -347,7 +347,7 @@ where
 ```
 
 If a `where` clause is very short, prefer using an inline bound on the type
-parameter.
+parameter if possible.
 
 If a component of a `where` clause does not fit and contains `+`, break it
 before each `+` and block-indent the continuation lines. Put each bound on its

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -421,8 +421,19 @@ Format associated types like type aliases. Where an associated type has a
 bound, put a space after the colon but not before:
 
 ```rust
-pub type Foo: Bar;
+type Foo: Bar;
 ```
+
+If an associated type has no `=`, and has a `where` clause with only one entry,
+format the entire type declaration including the `where` clause on the same
+line if it fits:
+
+```rust
+type Item<'a> where Self: 'a;
+```
+
+If the associated type has a `=`, or if the `where` clause contains multiple
+entries, format it across multiple lines as with a type alias.
 
 ## extern items
 

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -295,8 +295,18 @@ Prefer to use single-letter names for generic parameters.
 
 These rules apply for `where` clauses on any item.
 
-If immediately following a closing bracket of any kind, write the keyword
-`where` on the same line, with a space before it.
+If a where clause is short, and appears on a short one-line function
+declaration with no body or a short associated type with no `=`, format it on
+the same line as the declaration:
+
+```rust
+fn new(&self) -> Self where Self: Sized;
+
+type Item<'a>: SomeTrait where Self: 'a;
+```
+
+Otherwise, if immediately following a closing bracket of any kind, write the
+keyword `where` on the same line, with a space before it.
 
 Otherwise, put `where` on a new line at the same indentation level. Put each
 component of a `where` clause on its own line, block-indented. Use a trailing
@@ -424,9 +434,9 @@ bound, put a space after the colon but not before:
 type Foo: Bar;
 ```
 
-If an associated type has no `=`, and has a `where` clause with only one entry,
-format the entire type declaration including the `where` clause on the same
-line if it fits:
+If an associated type is short, has no `=`, and has a `where` clause with only
+one entry, format the entire type declaration including the `where` clause on
+the same line if it fits:
 
 ```rust
 type Item<'a> where Self: 'a;

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -430,6 +430,7 @@ line if it fits:
 
 ```rust
 type Item<'a> where Self: 'a;
+type Item<'a>: PartialEq + Send where Self: 'a;
 ```
 
 If the associated type has a `=`, or if the `where` clause contains multiple


### PR DESCRIPTION
In particular, lifetime-generic associated types often have a
`where Self: 'a` bound, which we can format on the same line.
