### PR TITLE
Relax IR checks in abi-main-signature-32bit-c-int.rs

### DIFF
--- a/tests/codegen/abi-main-signature-32bit-c-int.rs
+++ b/tests/codegen/abi-main-signature-32bit-c-int.rs
@@ -8,4 +8,4 @@
 fn main() {
 }
 
-// CHECK: define{{( hidden)?}} i32 @main(i32{{( %0)?}}, ptr{{( %1)?}})
+// CHECK: define{{.*}} i32 @main(i32{{( %0)?}}, ptr{{( %1)?}})


### PR DESCRIPTION
With https://github.com/llvm/llvm-project/pull/76553, we now infer
noundef on the return value of main in this test.
