### PR TITLE
llvm: Allow `noundef` in codegen tests

### DIFF
--- a/tests/codegen/abi-main-signature-32bit-c-int.rs
+++ b/tests/codegen/abi-main-signature-32bit-c-int.rs
@@ -8,4 +8,4 @@
 fn main() {
 }
 
-// CHECK: define{{( hidden)?}} i32 @main(i32{{( %0)?}}, ptr{{( %1)?}})
+// CHECK: define{{( hidden| noundef)*}} i32 @main(i32{{( %0)?}}, ptr{{( %1)?}})

--- a/tests/codegen/sparc-struct-abi.rs
+++ b/tests/codegen/sparc-struct-abi.rs
@@ -18,7 +18,7 @@ pub struct Bool {
     b: bool,
 }
 
-// CHECK: define i64 @structbool()
+// CHECK: define{{.*}} i64 @structbool()
 // CHECK-NEXT: start:
 // CHECK-NEXT: ret i64 72057594037927936
 #[no_mangle]


### PR DESCRIPTION
LLVM 18 will automatically infer `noundef` in some situations. Adjust codegen tests to accept this.

See llvm/llvm-project#76553 for why `noundef` is being generated now.

@rustbot label:+llvm-main