### PR TITLE
Make `Barrier::new()` const

### DIFF
--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -81,8 +81,10 @@ impl Barrier {
     /// let barrier = Barrier::new(10);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "const_barrier", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
-    pub fn new(n: usize) -> Barrier {
+    #[inline]
+    pub const fn new(n: usize) -> Barrier {
         Barrier {
             lock: Mutex::new(BarrierState { count: 0, generation_id: 0 }),
             cvar: Condvar::new(),


### PR DESCRIPTION
I guess this was just missed in #97791?

@rustbot label T-libs-api -T-libs