### PR TITLE
Implement `const_open_options` as an unstable feature

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -453,7 +453,8 @@ impl File {
     /// ```
     #[must_use]
     #[stable(feature = "with_options", since = "1.58.0")]
-    pub fn options() -> OpenOptions {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn options() -> OpenOptions {
         OpenOptions::new()
     }
 
@@ -911,9 +912,10 @@ impl OpenOptions {
     /// let mut options = OpenOptions::new();
     /// let file = options.read(true).open("foo.txt");
     /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    pub fn new() -> Self {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn new() -> Self {
         OpenOptions(fs_imp::OpenOptions::new())
     }
 
@@ -930,7 +932,8 @@ impl OpenOptions {
     /// let file = OpenOptions::new().read(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn read(&mut self, read: bool) -> &mut Self {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn read(&mut self, read: bool) -> &mut Self {
         self.0.read(read);
         self
     }
@@ -951,7 +954,8 @@ impl OpenOptions {
     /// let file = OpenOptions::new().write(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn write(&mut self, write: bool) -> &mut Self {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn write(&mut self, write: bool) -> &mut Self {
         self.0.write(write);
         self
     }
@@ -996,7 +1000,8 @@ impl OpenOptions {
     /// let file = OpenOptions::new().append(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn append(&mut self, append: bool) -> &mut Self {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn append(&mut self, append: bool) -> &mut Self {
         self.0.append(append);
         self
     }
@@ -1016,7 +1021,8 @@ impl OpenOptions {
     /// let file = OpenOptions::new().write(true).truncate(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn truncate(&mut self, truncate: bool) -> &mut Self {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn truncate(&mut self, truncate: bool) -> &mut Self {
         self.0.truncate(truncate);
         self
     }
@@ -1037,7 +1043,8 @@ impl OpenOptions {
     /// let file = OpenOptions::new().write(true).create(true).open("foo.txt");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn create(&mut self, create: bool) -> &mut Self {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn create(&mut self, create: bool) -> &mut Self {
         self.0.create(create);
         self
     }
@@ -1070,7 +1077,8 @@ impl OpenOptions {
     ///                              .open("foo.txt");
     /// ```
     #[stable(feature = "expand_open_options2", since = "1.9.0")]
-    pub fn create_new(&mut self, create_new: bool) -> &mut Self {
+    #[rustc_const_unstable(feature = "const_open_options", issue = "none")]
+    pub const fn create_new(&mut self, create_new: bool) -> &mut Self {
         self.0.create_new(create_new);
         self
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -397,6 +397,7 @@
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
 #![feature(const_maybe_uninit_uninit_array)]
+#![feature(const_open_options)]
 #![feature(const_waker)]
 #![feature(thread_local_internals)]
 // tidy-alphabetical-end

--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -192,7 +192,7 @@ impl DirEntry {
 }
 
 impl OpenOptions {
-    pub fn new() -> OpenOptions {
+    pub const fn new() -> OpenOptions {
         OpenOptions {
             // generic
             read: false,
@@ -206,22 +206,22 @@ impl OpenOptions {
         }
     }
 
-    pub fn read(&mut self, read: bool) {
+    pub const fn read(&mut self, read: bool) {
         self.read = read;
     }
-    pub fn write(&mut self, write: bool) {
+    pub const fn write(&mut self, write: bool) {
         self.write = write;
     }
-    pub fn append(&mut self, append: bool) {
+    pub const fn append(&mut self, append: bool) {
         self.append = append;
     }
-    pub fn truncate(&mut self, truncate: bool) {
+    pub const fn truncate(&mut self, truncate: bool) {
         self.truncate = truncate;
     }
-    pub fn create(&mut self, create: bool) {
+    pub const fn create(&mut self, create: bool) {
         self.create = create;
     }
-    pub fn create_new(&mut self, create_new: bool) {
+    pub const fn create_new(&mut self, create_new: bool) {
         self.create_new = create_new;
     }
 

--- a/library/std/src/sys/solid/fs.rs
+++ b/library/std/src/sys/solid/fs.rs
@@ -226,7 +226,7 @@ impl DirEntry {
 }
 
 impl OpenOptions {
-    pub fn new() -> OpenOptions {
+    pub const fn new() -> OpenOptions {
         OpenOptions {
             // generic
             read: false,
@@ -240,29 +240,29 @@ impl OpenOptions {
         }
     }
 
-    pub fn read(&mut self, read: bool) {
+    pub const fn read(&mut self, read: bool) {
         self.read = read;
     }
-    pub fn write(&mut self, write: bool) {
+    pub const fn write(&mut self, write: bool) {
         self.write = write;
     }
-    pub fn append(&mut self, append: bool) {
+    pub const fn append(&mut self, append: bool) {
         self.append = append;
     }
-    pub fn truncate(&mut self, truncate: bool) {
+    pub const fn truncate(&mut self, truncate: bool) {
         self.truncate = truncate;
     }
-    pub fn create(&mut self, create: bool) {
+    pub const fn create(&mut self, create: bool) {
         self.create = create;
     }
-    pub fn create_new(&mut self, create_new: bool) {
+    pub const fn create_new(&mut self, create_new: bool) {
         self.create_new = create_new;
     }
 
-    pub fn custom_flags(&mut self, flags: i32) {
+    pub const fn custom_flags(&mut self, flags: i32) {
         self.custom_flags = flags;
     }
-    pub fn mode(&mut self, _mode: u32) {}
+    pub const fn mode(&mut self, _mode: u32) {}
 
     fn get_access_mode(&self) -> io::Result<c_int> {
         match (self.read, self.write, self.append) {

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1039,7 +1039,7 @@ impl DirEntry {
 }
 
 impl OpenOptions {
-    pub fn new() -> OpenOptions {
+    pub const fn new() -> OpenOptions {
         OpenOptions {
             // generic
             read: false,
@@ -1054,29 +1054,29 @@ impl OpenOptions {
         }
     }
 
-    pub fn read(&mut self, read: bool) {
+    pub const fn read(&mut self, read: bool) {
         self.read = read;
     }
-    pub fn write(&mut self, write: bool) {
+    pub const fn write(&mut self, write: bool) {
         self.write = write;
     }
-    pub fn append(&mut self, append: bool) {
+    pub const fn append(&mut self, append: bool) {
         self.append = append;
     }
-    pub fn truncate(&mut self, truncate: bool) {
+    pub const fn truncate(&mut self, truncate: bool) {
         self.truncate = truncate;
     }
-    pub fn create(&mut self, create: bool) {
+    pub const fn create(&mut self, create: bool) {
         self.create = create;
     }
-    pub fn create_new(&mut self, create_new: bool) {
+    pub const fn create_new(&mut self, create_new: bool) {
         self.create_new = create_new;
     }
 
-    pub fn custom_flags(&mut self, flags: i32) {
+    pub const fn custom_flags(&mut self, flags: i32) {
         self.custom_flags = flags;
     }
-    pub fn mode(&mut self, mode: u32) {
+    pub const fn mode(&mut self, mode: u32) {
         self.mode = mode as mode_t;
     }
 

--- a/library/std/src/sys/unsupported/fs.rs
+++ b/library/std/src/sys/unsupported/fs.rs
@@ -169,16 +169,16 @@ impl DirEntry {
 }
 
 impl OpenOptions {
-    pub fn new() -> OpenOptions {
+    pub const fn new() -> OpenOptions {
         OpenOptions {}
     }
 
-    pub fn read(&mut self, _read: bool) {}
-    pub fn write(&mut self, _write: bool) {}
-    pub fn append(&mut self, _append: bool) {}
-    pub fn truncate(&mut self, _truncate: bool) {}
-    pub fn create(&mut self, _create: bool) {}
-    pub fn create_new(&mut self, _create_new: bool) {}
+    pub const fn read(&mut self, _read: bool) {}
+    pub const fn write(&mut self, _write: bool) {}
+    pub const fn append(&mut self, _append: bool) {}
+    pub const fn truncate(&mut self, _truncate: bool) {}
+    pub const fn create(&mut self, _create: bool) {}
+    pub const fn create_new(&mut self, _create_new: bool) {}
 }
 
 impl File {

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -265,38 +265,45 @@ impl DirEntry {
 }
 
 impl OpenOptions {
-    pub fn new() -> OpenOptions {
-        let mut base = OpenOptions::default();
-        base.dirflags = wasi::LOOKUPFLAGS_SYMLINK_FOLLOW;
-        return base;
+    pub const fn new() -> OpenOptions {
+        OpenOptions {
+            read: false,
+            write: false,
+            append: false,
+            dirflags: wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+            fdflags: 0,
+            oflags: 0,
+            rights_base: None,
+            rights_inheriting: None,
+        }
     }
 
-    pub fn read(&mut self, read: bool) {
+    pub const fn read(&mut self, read: bool) {
         self.read = read;
     }
 
-    pub fn write(&mut self, write: bool) {
+    pub const fn write(&mut self, write: bool) {
         self.write = write;
     }
 
-    pub fn truncate(&mut self, truncate: bool) {
+    pub const fn truncate(&mut self, truncate: bool) {
         self.oflag(wasi::OFLAGS_TRUNC, truncate);
     }
 
-    pub fn create(&mut self, create: bool) {
+    pub const fn create(&mut self, create: bool) {
         self.oflag(wasi::OFLAGS_CREAT, create);
     }
 
-    pub fn create_new(&mut self, create_new: bool) {
+    pub const fn create_new(&mut self, create_new: bool) {
         self.oflag(wasi::OFLAGS_EXCL, create_new);
         self.oflag(wasi::OFLAGS_CREAT, create_new);
     }
 
-    pub fn directory(&mut self, directory: bool) {
+    pub const fn directory(&mut self, directory: bool) {
         self.oflag(wasi::OFLAGS_DIRECTORY, directory);
     }
 
-    fn oflag(&mut self, bit: wasi::Oflags, set: bool) {
+    const fn oflag(&mut self, bit: wasi::Oflags, set: bool) {
         if set {
             self.oflags |= bit;
         } else {
@@ -304,28 +311,28 @@ impl OpenOptions {
         }
     }
 
-    pub fn append(&mut self, append: bool) {
+    pub const fn append(&mut self, append: bool) {
         self.append = append;
         self.fdflag(wasi::FDFLAGS_APPEND, append);
     }
 
-    pub fn dsync(&mut self, set: bool) {
+    pub const fn dsync(&mut self, set: bool) {
         self.fdflag(wasi::FDFLAGS_DSYNC, set);
     }
 
-    pub fn nonblock(&mut self, set: bool) {
+    pub const fn nonblock(&mut self, set: bool) {
         self.fdflag(wasi::FDFLAGS_NONBLOCK, set);
     }
 
-    pub fn rsync(&mut self, set: bool) {
+    pub const fn rsync(&mut self, set: bool) {
         self.fdflag(wasi::FDFLAGS_RSYNC, set);
     }
 
-    pub fn sync(&mut self, set: bool) {
+    pub const fn sync(&mut self, set: bool) {
         self.fdflag(wasi::FDFLAGS_SYNC, set);
     }
 
-    fn fdflag(&mut self, bit: wasi::Fdflags, set: bool) {
+    const fn fdflag(&mut self, bit: wasi::Fdflags, set: bool) {
         if set {
             self.fdflags |= bit;
         } else {
@@ -394,6 +401,12 @@ impl OpenOptions {
 
     pub fn lookup_flags(&mut self, flags: wasi::Lookupflags) {
         self.dirflags = flags;
+    }
+}
+
+impl Default for OpenOptions {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -175,7 +175,7 @@ impl DirEntry {
 }
 
 impl OpenOptions {
-    pub fn new() -> OpenOptions {
+    pub const fn new() -> OpenOptions {
         OpenOptions {
             // generic
             read: false,
@@ -194,43 +194,43 @@ impl OpenOptions {
         }
     }
 
-    pub fn read(&mut self, read: bool) {
+    pub const fn read(&mut self, read: bool) {
         self.read = read;
     }
-    pub fn write(&mut self, write: bool) {
+    pub const fn write(&mut self, write: bool) {
         self.write = write;
     }
-    pub fn append(&mut self, append: bool) {
+    pub const fn append(&mut self, append: bool) {
         self.append = append;
     }
-    pub fn truncate(&mut self, truncate: bool) {
+    pub const fn truncate(&mut self, truncate: bool) {
         self.truncate = truncate;
     }
-    pub fn create(&mut self, create: bool) {
+    pub const fn create(&mut self, create: bool) {
         self.create = create;
     }
-    pub fn create_new(&mut self, create_new: bool) {
+    pub const fn create_new(&mut self, create_new: bool) {
         self.create_new = create_new;
     }
 
-    pub fn custom_flags(&mut self, flags: u32) {
+    pub const fn custom_flags(&mut self, flags: u32) {
         self.custom_flags = flags;
     }
-    pub fn access_mode(&mut self, access_mode: u32) {
+    pub const fn access_mode(&mut self, access_mode: u32) {
         self.access_mode = Some(access_mode);
     }
-    pub fn share_mode(&mut self, share_mode: u32) {
+    pub const fn share_mode(&mut self, share_mode: u32) {
         self.share_mode = share_mode;
     }
-    pub fn attributes(&mut self, attrs: u32) {
+    pub const fn attributes(&mut self, attrs: u32) {
         self.attributes = attrs;
     }
-    pub fn security_qos_flags(&mut self, flags: u32) {
+    pub const fn security_qos_flags(&mut self, flags: u32) {
         // We have to set `SECURITY_SQOS_PRESENT` here, because one of the valid flags we can
         // receive is `SECURITY_ANONYMOUS = 0x0`, which we can't check for later on.
         self.security_qos_flags = flags | c::SECURITY_SQOS_PRESENT;
     }
-    pub fn security_attributes(&mut self, attrs: c::LPSECURITY_ATTRIBUTES) {
+    pub const fn security_attributes(&mut self, attrs: c::LPSECURITY_ATTRIBUTES) {
         self.security_attributes = attrs;
     }
 


### PR DESCRIPTION
This adds a feature gate for using `OpenOptions` methods in const contexts. `OpenOptions::new` is very trivial. All other functions will not be able to become stable until `const_mut_refs` lands (which I know @RalfJung says will be soon 😆 ).

This feature will be useful for saving a specific combination of options in a `const` and being able to easily reuse them.

There is no tracking issue yet, I will create one if this looks reasonable.

## New const-unstable API

```rust
// std::fs

impl File {
    pub const fn options() -> OpenOptions;
}

impl OpenOptions {
    pub const fn new() -> Self;
    pub const fn read(&mut self, read: bool) -> &mut Self;
    pub const fn write(&mut self, write: bool) -> &mut Self;
    pub const fn append(&mut self, append: bool) -> &mut Self;
    pub const fn truncate(&mut self, truncate: bool) -> &mut Self;
    pub const fn create(&mut self, create: bool) -> &mut Self;
    pub const fn create_new(&mut self, create_new: bool) -> &mut Self;
}
```

cc @rust-lang/wg-const-eval 
r? libs-api