### PR TITLE
Fix: Properly set vendor in i686-win7-windows-msvc target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i686_win7_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_win7_windows_msvc.rs
@@ -4,6 +4,7 @@ pub fn target() -> Target {
     let mut base = base::windows_msvc::opts();
     base.cpu = "pentium4".into();
     base.max_atomic_width = Some(64);
+    base.vendor = "win7".into();
 
     base.add_pre_link_args(
         LinkerFlavor::Msvc(Lld::No),


### PR DESCRIPTION
In #118150 , setting the `vendor` field of the `i686-win7-windows-msvc` target was forgotten, preventing us from easily checking the target using `cfg(target_vendor)`.

With this PR, we set the target vendor to "win7".