### PR TITLE
Use the current target instead of iterating over all targets

### DIFF
--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -204,15 +204,13 @@ install!((self, builder, _config),
         install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
     };
     Std, path = "library/std", true, only_hosts: false, {
-        for target in &builder.targets {
-            // `expect` should be safe, only None when host != build, but this
-            // only runs when host == build
-            let tarball = builder.ensure(dist::Std {
-                compiler: self.compiler,
-                target: *target
-            }).expect("missing std");
-            install_sh(builder, "std", self.compiler.stage, Some(*target), &tarball);
-        }
+        // `expect` should be safe, only None when host != build, but this
+        // only runs when host == build
+        let tarball = builder.ensure(dist::Std {
+            compiler: self.compiler,
+            target: self.target
+        }).expect("missing std");
+        install_sh(builder, "std", self.compiler.stage, Some(self.target), &tarball);
     };
     Cargo, alias = "cargo", Self::should_build(_config), only_hosts: true, {
         let tarball = builder


### PR DESCRIPTION
Since we already iterate through targets in StepDescription::maybe_run, there is no need to iterate targets again in the install step for std.

Compared the results before and after applying the changes to install step of std, and there were no differences.

```sh

  ~/devspace/.other/rustc-builds  $ sha256sum ./old/usr/local/lib/rustlib/manifest-rust-std-x86_64-*
c2ea86fc25ffac87b0b135f31ba9644ad97549da4c050c3921b437d1e18285fd  ./old/usr/local/lib/rustlib/manifest-rust-std-x86_64-pc-windows-gnu
d2f1081a779962e2cbc27f53191783d13428abd0964465547af78ce34c7251dd  ./old/usr/local/lib/rustlib/manifest-rust-std-x86_64-unknown-linux-gnu

  ~/devspace/.other/rustc-builds  $ sha256sum ./new/usr/local/lib/rustlib/manifest-rust-std-x86_64-*
c2ea86fc25ffac87b0b135f31ba9644ad97549da4c050c3921b437d1e18285fd  ./new/usr/local/lib/rustlib/manifest-rust-std-x86_64-pc-windows-gnu
d2f1081a779962e2cbc27f53191783d13428abd0964465547af78ce34c7251dd  ./new/usr/local/lib/rustlib/manifest-rust-std-x86_64-unknown-linux-gnu

```

Fixes #119533