### PR TITLE
stop feed vis when cant access for trait item

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3076,7 +3076,16 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         }
 
         let feed_visibility = |this: &mut Self, def_id| {
-            let vis = this.r.tcx.visibility(def_id).expect_local();
+            let vis = this.r.tcx.visibility(def_id);
+            let vis = if vis.is_visible_locally() {
+                vis.expect_local()
+            } else {
+                this.r.dcx().span_delayed_bug(
+                    span,
+                    "error should be emitted when an unexpected trait item is used",
+                );
+                rustc_middle::ty::Visibility::Public
+            };
             this.r.feed_visibility(this.r.local_def_id(id), vis);
         };
 

--- a/tests/ui/privacy/auxiliary/issue-119463-extern.rs
+++ b/tests/ui/privacy/auxiliary/issue-119463-extern.rs
@@ -1,0 +1,3 @@
+trait PrivateTrait {
+    const FOO: usize;
+}

--- a/tests/ui/privacy/issue-119463.rs
+++ b/tests/ui/privacy/issue-119463.rs
@@ -1,0 +1,15 @@
+// aux-build:issue-119463-extern.rs
+
+extern crate issue_119463_extern;
+
+struct S;
+
+impl issue_119463_extern::PrivateTrait for S {
+    //~^ ERROR: trait `PrivateTrait` is private
+    const FOO: usize = 1;
+
+    fn nonexistent() {}
+    //~^ ERROR: method `nonexistent` is not a member of trait
+}
+
+fn main() {}

--- a/tests/ui/privacy/issue-119463.stderr
+++ b/tests/ui/privacy/issue-119463.stderr
@@ -1,0 +1,22 @@
+error[E0407]: method `nonexistent` is not a member of trait `issue_119463_extern::PrivateTrait`
+  --> $DIR/issue-119463.rs:11:5
+   |
+LL |     fn nonexistent() {}
+   |     ^^^^^^^^^^^^^^^^^^^ not a member of trait `issue_119463_extern::PrivateTrait`
+
+error[E0603]: trait `PrivateTrait` is private
+  --> $DIR/issue-119463.rs:7:27
+   |
+LL | impl issue_119463_extern::PrivateTrait for S {
+   |                           ^^^^^^^^^^^^ private trait
+   |
+note: the trait `PrivateTrait` is defined here
+  --> $DIR/auxiliary/issue-119463-extern.rs:1:1
+   |
+LL | trait PrivateTrait {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0407, E0603.
+For more information about an error, try `rustc --explain E0407`.


### PR DESCRIPTION
Fixes #119463 

It's not necessary to feed visibility when use a private trait.

r? @petrochenkov 