### PR TITLE
Add codegen test for RVO on MaybeUninit

### DIFF
--- a/tests/codegen/maybeuninit-rvo.rs
+++ b/tests/codegen/maybeuninit-rvo.rs
@@ -1,0 +1,33 @@
+// compile-flags: -O
+#![feature(c_unwind)]
+#![crate_type = "lib"]
+
+pub struct Foo([u8; 1000]);
+
+extern "C" {
+    fn init(p: *mut Foo);
+}
+
+pub fn new_from_uninit() -> Foo {
+    // CHECK-LABEL: new_from_uninit
+    // CHECK-NOT: call void @llvm.memcpy.
+    let mut x = std::mem::MaybeUninit::uninit();
+    unsafe {
+        init(x.as_mut_ptr());
+        x.assume_init()
+    }
+}
+
+extern "C-unwind" {
+    fn init_unwind(p: *mut Foo);
+}
+
+pub fn new_from_uninit_unwind() -> Foo {
+    // CHECK-LABEL: new_from_uninit
+    // CHECK: call void @llvm.memcpy.
+    let mut x = std::mem::MaybeUninit::uninit();
+    unsafe {
+        init_unwind(x.as_mut_ptr());
+        x.assume_init()
+    }
+}


### PR DESCRIPTION
Codegen test for https://github.com/rust-lang/rust/issues/90595. Currently, this only works with `-Cpanic=abort`, but hopefully in the [future](https://www.npopov.com/2024/01/01/This-year-in-LLVM-2023.html#writable-and-dead_on_unwind) it should also work in the presence of panics.

r? @nikic