### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,6 +3877,7 @@ dependencies = [
  "rustc_feature",
  "rustc_fluent_macro",
  "rustc_hir",
+ "rustc_hir_pretty",
  "rustc_index",
  "rustc_infer",
  "rustc_lint_defs",

--- a/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
@@ -111,6 +111,9 @@ fn start<T: Termination + 'static>(
 }
 
 static mut NUM: u8 = 6 * 7;
+
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#[allow(static_mut_ref)]
 static NUM_REF: &'static u8 = unsafe { &NUM };
 
 unsafe fn zeroed<T>() -> T {

--- a/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
@@ -98,6 +98,9 @@ fn start<T: Termination + 'static>(
 }
 
 static mut NUM: u8 = 6 * 7;
+
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#[allow(static_mut_ref)]
 static NUM_REF: &'static u8 = unsafe { &NUM };
 
 macro_rules! assert {

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -515,6 +515,7 @@ E0792: include_str!("./error_codes/E0792.md"),
 E0793: include_str!("./error_codes/E0793.md"),
 E0794: include_str!("./error_codes/E0794.md"),
 E0795: include_str!("./error_codes/E0795.md"),
+E0796: include_str!("./error_codes/E0796.md"),
 }
 
 // Undocumented removed error codes. Note that many removed error codes are kept in the list above

--- a/compiler/rustc_error_codes/src/error_codes/E0796.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0796.md
@@ -1,0 +1,22 @@
+Reference of mutable static.
+
+Erroneous code example:
+
+```compile_fail,edition2024,E0796
+static mut X: i32 = 23;
+static mut Y: i32 = 24;
+
+unsafe {
+  let y = &X;
+  let ref x = X;
+  let (x, y) = (&X, &Y);
+  foo(&X);
+}
+
+fn foo<'a>(_x: &'a i32) {}
+```
+
+Mutable statics can be written to by multiple threads: aliasing violations or
+data races will cause undefined behavior.
+
+Reference of mutable static is a hard error from 2024 edition.

--- a/compiler/rustc_hir_analysis/Cargo.toml
+++ b/compiler/rustc_hir_analysis/Cargo.toml
@@ -17,6 +17,7 @@ rustc_errors = { path = "../rustc_errors" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }
 rustc_hir = { path = "../rustc_hir" }
+rustc_hir_pretty = { path = "../rustc_hir_pretty" }
 rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }
 rustc_lint_defs = { path = "../rustc_lint_defs" }

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -346,6 +346,20 @@ hir_analysis_start_not_target_feature = `#[start]` function is not allowed to ha
 hir_analysis_start_not_track_caller = `#[start]` function is not allowed to be `#[track_caller]`
     .label = `#[start]` function is not allowed to be `#[track_caller]`
 
+hir_analysis_static_mut_ref = reference of mutable static is disallowed
+    .label = reference of mutable static
+    .note = mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+    .suggestion = shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+    .suggestion_mut = mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+
+hir_analysis_static_mut_ref_lint = {$shared}reference of mutable static is discouraged
+    .label = shared reference of mutable static
+    .label_mut = mutable reference of mutable static
+    .suggestion = shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+    .suggestion_mut = mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+    .note = reference of mutable static is a hard error from 2024 edition
+    .why_note = mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+
 hir_analysis_static_specialize = cannot specialize on `'static` lifetime
 
 hir_analysis_substs_on_overridden_impl = could not resolve substs on overridden impl

--- a/compiler/rustc_hir_analysis/src/check/errs.rs
+++ b/compiler/rustc_hir_analysis/src/check/errs.rs
@@ -1,0 +1,78 @@
+use rustc_hir as hir;
+use rustc_hir_pretty::qpath_to_string;
+use rustc_lint_defs::builtin::STATIC_MUT_REF;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+use rustc_type_ir::Mutability;
+
+use crate::errors;
+
+/// Check for shared or mutable references of `static mut` inside expression
+pub fn maybe_expr_static_mut(tcx: TyCtxt<'_>, expr: hir::Expr<'_>) {
+    let span = expr.span;
+    let hir_id = expr.hir_id;
+    if let hir::ExprKind::AddrOf(borrow_kind, m, expr) = expr.kind
+        && matches!(borrow_kind, hir::BorrowKind::Ref)
+        && let Some(var) = is_path_static_mut(*expr)
+    {
+        handle_static_mut_ref(
+            tcx,
+            span,
+            var,
+            span.edition().at_least_rust_2024(),
+            matches!(m, Mutability::Mut),
+            hir_id,
+        );
+    }
+}
+
+fn is_path_static_mut(expr: hir::Expr<'_>) -> Option<String> {
+    if let hir::ExprKind::Path(qpath) = expr.kind
+        && let hir::QPath::Resolved(_, path) = qpath
+        && let hir::def::Res::Def(def_kind, _) = path.res
+        && let hir::def::DefKind::Static(mt) = def_kind
+        && matches!(mt, Mutability::Mut)
+    {
+        return Some(qpath_to_string(&qpath));
+    }
+    None
+}
+
+fn handle_static_mut_ref(
+    tcx: TyCtxt<'_>,
+    span: Span,
+    var: String,
+    e2024: bool,
+    mutable: bool,
+    hir_id: hir::HirId,
+) {
+    if e2024 {
+        let sugg = if mutable {
+            errors::StaticMutRefSugg::Mut { span, var }
+        } else {
+            errors::StaticMutRefSugg::Shared { span, var }
+        };
+        tcx.sess.parse_sess.dcx.emit_err(errors::StaticMutRef { span, sugg });
+        return;
+    }
+
+    let (label, sugg, shared) = if mutable {
+        (
+            errors::RefOfMutStaticLabel::Mut { span },
+            errors::RefOfMutStaticSugg::Mut { span, var },
+            "mutable ",
+        )
+    } else {
+        (
+            errors::RefOfMutStaticLabel::Shared { span },
+            errors::RefOfMutStaticSugg::Shared { span, var },
+            "shared ",
+        )
+    };
+    tcx.emit_spanned_lint(
+        STATIC_MUT_REF,
+        hir_id,
+        span,
+        errors::RefOfMutStatic { shared, why_note: (), label, sugg },
+    );
+}

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -66,6 +66,7 @@ mod check;
 mod compare_impl_item;
 pub mod dropck;
 mod entry;
+mod errs;
 pub mod intrinsic;
 pub mod intrinsicck;
 mod region;

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -18,7 +18,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::source_map;
 use rustc_span::Span;
 
-use super::errs::maybe_expr_static_mut;
+use super::errs::{maybe_expr_static_mut, maybe_stmt_static_mut};
 
 use std::mem;
 
@@ -215,6 +215,8 @@ fn resolve_pat<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, pat: &'tcx hir
 fn resolve_stmt<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, stmt: &'tcx hir::Stmt<'tcx>) {
     let stmt_id = stmt.hir_id.local_id;
     debug!("resolve_stmt(stmt.id={:?})", stmt_id);
+
+    maybe_stmt_static_mut(visitor.tcx, *stmt);
 
     // Every statement will clean up the temporaries created during
     // execution of that statement. Therefore each statement has an

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -18,6 +18,8 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::source_map;
 use rustc_span::Span;
 
+use super::errs::maybe_expr_static_mut;
+
 use std::mem;
 
 #[derive(Debug, Copy, Clone)]
@@ -231,6 +233,8 @@ fn resolve_stmt<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, stmt: &'tcx h
 
 fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
     debug!("resolve_expr - pre-increment {} expr = {:?}", visitor.expr_and_pat_count, expr);
+
+    maybe_expr_static_mut(visitor.tcx, *expr);
 
     let prev_cx = visitor.cx;
     visitor.enter_node_scope_with_dtor(expr.hir_id.local_id);

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1410,3 +1410,94 @@ pub struct OnlyCurrentTraitsPointerSugg<'a> {
     pub mut_key: &'a str,
     pub ptr_ty: Ty<'a>,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_static_mut_ref, code = "E0796")]
+#[note]
+pub struct StaticMutRef {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: StaticMutRefSugg,
+}
+
+#[derive(Subdiagnostic)]
+pub enum StaticMutRefSugg {
+    #[suggestion(
+        hir_analysis_suggestion,
+        style = "verbose",
+        code = "addr_of!({var})",
+        applicability = "maybe-incorrect"
+    )]
+    Shared {
+        #[primary_span]
+        span: Span,
+        var: String,
+    },
+    #[suggestion(
+        hir_analysis_suggestion_mut,
+        style = "verbose",
+        code = "addr_of_mut!({var})",
+        applicability = "maybe-incorrect"
+    )]
+    Mut {
+        #[primary_span]
+        span: Span,
+        var: String,
+    },
+}
+
+// STATIC_MUT_REF lint
+#[derive(LintDiagnostic)]
+#[diag(hir_analysis_static_mut_ref_lint)]
+#[note]
+pub struct RefOfMutStatic<'a> {
+    pub shared: &'a str,
+    #[note(hir_analysis_why_note)]
+    pub why_note: (),
+    #[subdiagnostic]
+    pub label: RefOfMutStaticLabel,
+    #[subdiagnostic]
+    pub sugg: RefOfMutStaticSugg,
+}
+
+#[derive(Subdiagnostic)]
+pub enum RefOfMutStaticLabel {
+    #[label(hir_analysis_label)]
+    Shared {
+        #[primary_span]
+        span: Span,
+    },
+    #[label(hir_analysis_label_mut)]
+    Mut {
+        #[primary_span]
+        span: Span,
+    },
+}
+
+#[derive(Subdiagnostic)]
+pub enum RefOfMutStaticSugg {
+    #[suggestion(
+        hir_analysis_suggestion,
+        style = "verbose",
+        code = "addr_of!({var})",
+        applicability = "maybe-incorrect"
+    )]
+    Shared {
+        #[primary_span]
+        span: Span,
+        var: String,
+    },
+    #[suggestion(
+        hir_analysis_suggestion_mut,
+        style = "verbose",
+        code = "addr_of_mut!({var})",
+        applicability = "maybe-incorrect"
+    )]
+    Mut {
+        #[primary_span]
+        span: Span,
+        var: String,
+    },
+}

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -166,12 +166,9 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
 
     // this ensures that later parts of type checking can assume that items
     // have valid types and not error
-    // FIXME(matthewjasper) We shouldn't need to use `track_errors`.
-    tcx.sess.track_errors(|| {
-        tcx.sess.time("type_collecting", || {
-            tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
-        });
-    })?;
+    tcx.sess.time("type_collecting", || {
+        tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
+    });
 
     if tcx.features().rustc_attrs {
         tcx.sess.track_errors(|| {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -89,6 +89,7 @@ declare_lint_pass! {
         SINGLE_USE_LIFETIMES,
         SOFT_UNSTABLE,
         STABLE_FEATURES,
+        STATIC_MUT_REF,
         SUSPICIOUS_AUTO_TRAIT_IMPLS,
         TEST_UNSTABLE_LINT,
         TEXT_DIRECTION_CODEPOINT_IN_COMMENT,
@@ -1786,6 +1787,57 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
         reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>",
+    };
+}
+
+declare_lint! {
+    /// The `static_mut_ref` lint checks for shared or mutable references
+    /// of mutable static inside `unsafe` blocks and `unsafe` functions.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,edition2021
+    /// fn main() {
+    ///     static mut X: i32 = 23;
+    ///     static mut Y: i32 = 24;
+    ///
+    ///     unsafe {
+    ///         let y = &X;
+    ///         let ref x = X;
+    ///         let (x, y) = (&X, &Y);
+    ///         foo(&X);
+    ///     }
+    /// }
+    ///
+    /// unsafe fn _foo() {
+    ///     static mut X: i32 = 23;
+    ///     static mut Y: i32 = 24;
+    ///
+    ///     let y = &X;
+    ///     let ref x = X;
+    ///     let (x, y) = (&X, &Y);
+    ///     foo(&X);
+    /// }
+    ///
+    /// fn foo<'a>(_x: &'a i32) {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Shared or mutable references of mutable static are almost always a mistake and
+    /// can lead to undefined behavior and various other problems in your code.
+    ///
+    /// This lint is "warn" by default on editions up to 2021, from 2024 there is
+    /// a hard error instead.
+    pub STATIC_MUT_REF,
+    Warn,
+    "shared references or mutable references of mutable static is discouraged",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
+        reference: "issue #114447 <https://github.com/rust-lang/rust/issues/114447>",
+        explain_reason: false,
     };
 }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1476,7 +1476,7 @@ pub fn reveal_opaque_types_in_bounds<'tcx>(
     val.fold_with(&mut visitor)
 }
 
-/// Determines whether an item is annotated with `doc(hidden)`.
+/// Determines whether an item is directly annotated with `doc(hidden)`.
 fn is_doc_hidden(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     tcx.get_attrs(def_id, sym::doc)
         .filter_map(|attr| attr.meta_item_list())

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2194,15 +2194,20 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
     fn find_module(&mut self, def_id: DefId) -> Option<(Module<'a>, ImportSuggestion)> {
         let mut result = None;
         let mut seen_modules = FxHashSet::default();
-        let mut worklist = vec![(self.r.graph_root, ThinVec::new())];
+        let root_did = self.r.graph_root.def_id();
+        let mut worklist = vec![(
+            self.r.graph_root,
+            ThinVec::new(),
+            root_did.is_local() || !self.r.tcx.is_doc_hidden(root_did),
+        )];
 
-        while let Some((in_module, path_segments)) = worklist.pop() {
+        while let Some((in_module, path_segments, doc_visible)) = worklist.pop() {
             // abort if the module is already found
             if result.is_some() {
                 break;
             }
 
-            in_module.for_each_child(self.r, |_, ident, _, name_binding| {
+            in_module.for_each_child(self.r, |r, ident, _, name_binding| {
                 // abort if the module is already found or if name_binding is private external
                 if result.is_some() || !name_binding.vis.is_visible_locally() {
                     return;
@@ -2212,6 +2217,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     let mut path_segments = path_segments.clone();
                     path_segments.push(ast::PathSegment::from_ident(ident));
                     let module_def_id = module.def_id();
+                    let doc_visible = doc_visible
+                        && (module_def_id.is_local() || !r.tcx.is_doc_hidden(module_def_id));
                     if module_def_id == def_id {
                         let path =
                             Path { span: name_binding.span, segments: path_segments, tokens: None };
@@ -2222,6 +2229,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                                 descr: "module",
                                 path,
                                 accessible: true,
+                                doc_visible,
                                 note: None,
                                 via_import: false,
                             },
@@ -2229,7 +2237,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     } else {
                         // add the module to the lookup
                         if seen_modules.insert(module_def_id) {
-                            worklist.push((module, path_segments));
+                            worklist.push((module, path_segments, doc_visible));
                         }
                     }
                 }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1274,7 +1274,10 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     // Cannot enable crt-static with sanitizers on Linux
-    if sess.crt_static(None) && !sess.opts.unstable_opts.sanitizer.is_empty() {
+    if sess.crt_static(None)
+        && !sess.opts.unstable_opts.sanitizer.is_empty()
+        && !sess.target.is_like_msvc
+    {
         sess.dcx().emit_err(errors::CannotEnableCrtStaticLinux);
     }
 

--- a/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_pc_windows_msvc.rs
@@ -1,9 +1,10 @@
-use crate::spec::{base, LinkerFlavor, Lld, Target};
+use crate::spec::{base, LinkerFlavor, Lld, SanitizerSet, Target};
 
 pub fn target() -> Target {
     let mut base = base::windows_msvc::opts();
     base.cpu = "pentium4".into();
     base.max_atomic_width = Some(64);
+    base.supported_sanitizers = SanitizerSet::ADDRESS;
 
     base.add_pre_link_args(
         LinkerFlavor::Msvc(Lld::No),

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_windows_msvc.rs
@@ -1,10 +1,11 @@
-use crate::spec::{base, Target};
+use crate::spec::{base, SanitizerSet, Target};
 
 pub fn target() -> Target {
     let mut base = base::windows_msvc::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
     base.max_atomic_width = Some(64);
+    base.supported_sanitizers = SanitizerSet::ADDRESS;
 
     Target {
         llvm_target: "x86_64-pc-windows-msvc".into(),

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -279,6 +279,12 @@ pub fn normalize_param_env_or_error<'tcx>(
                 }
 
                 fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
+                    // FIXME(return_type_notation): track binders in this normalizer, as
+                    // `ty::Const::normalize` can only work with properly preserved binders.
+
+                    if c.has_escaping_bound_vars() {
+                        return ty::Const::new_misc_error(self.0, c.ty());
+                    }
                     // While it is pretty sus to be evaluating things with an empty param env, it
                     // should actually be okay since without `feature(generic_const_exprs)` the only
                     // const arguments that have a non-empty param env are array repeat counts. These

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -261,6 +261,8 @@ cfg_if::cfg_if! {
    }
 }
 
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#[allow(static_mut_ref)]
 pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     use core::intrinsics::atomic_store_seqcst;
 
@@ -322,6 +324,8 @@ pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     _CxxThrowException(throw_ptr, &mut THROW_INFO as *mut _ as *mut _);
 }
 
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#[allow(static_mut_ref)]
 pub unsafe fn cleanup(payload: *mut u8) -> Box<dyn Any + Send> {
     // A null payload here means that we got here from the catch (...) of
     // __rust_try. This happens when a non-Rust foreign exception is caught.

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -73,8 +73,18 @@ impl UnixListener {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
             let (addr, len) = sockaddr_un(path.as_ref())?;
-            const backlog: libc::c_int =
-                if cfg!(any(target_os = "linux", target_os = "freebsd")) { -1 } else { 128 };
+            #[cfg(any(target_os = "windows", target_os = "redox"))]
+            const backlog: libc::c_int = 128;
+            #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
+            const backlog: libc::c_int = -1;
+            #[cfg(not(any(
+                target_os = "windows",
+                target_os = "redox",
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "openbsd"
+            )))]
+            const backlog: libc::c_int = libc::SOMAXCONN;
 
             cvt(libc::bind(inner.as_inner().as_raw_fd(), &addr as *const _ as *const _, len as _))?;
             cvt(libc::listen(inner.as_inner().as_raw_fd(), backlog))?;

--- a/library/std/src/sys/common/thread_local/fast_local.rs
+++ b/library/std/src/sys/common/thread_local/fast_local.rs
@@ -13,6 +13,8 @@ pub macro thread_local_inner {
     (@key $t:ty, const $init:expr) => {{
         #[inline]
         #[deny(unsafe_op_in_unsafe_fn)]
+        // FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+        #[cfg_attr(not(bootstrap), allow(static_mut_ref))]
         unsafe fn __getit(
             _init: $crate::option::Option<&mut $crate::option::Option<$t>>,
         ) -> $crate::option::Option<&'static $t> {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -274,7 +274,7 @@ fn copy_third_party_objects(
 ) -> Vec<(PathBuf, DependencyType)> {
     let mut target_deps = vec![];
 
-    if builder.config.sanitizers_enabled(target) && compiler.stage != 0 {
+    if builder.config.needs_sanitizer_runtime_built(target) && compiler.stage != 0 {
         // The sanitizers are only copied in stage1 or above,
         // to avoid creating dependency on LLVM.
         target_deps.extend(

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2180,8 +2180,15 @@ impl Config {
         self.target_config.get(&target).map(|t| t.sanitizers).flatten().unwrap_or(self.sanitizers)
     }
 
-    pub fn any_sanitizers_enabled(&self) -> bool {
-        self.target_config.values().any(|t| t.sanitizers == Some(true)) || self.sanitizers
+    pub fn needs_sanitizer_runtime_built(&self, target: TargetSelection) -> bool {
+        // MSVC uses the Microsoft-provided sanitizer runtime, but all other runtimes we build.
+        !target.is_msvc() && self.sanitizers_enabled(target)
+    }
+
+    pub fn any_sanitizers_to_build(&self) -> bool {
+        self.target_config
+            .iter()
+            .any(|(ts, t)| !ts.is_msvc() && t.sanitizers.unwrap_or(self.sanitizers))
     }
 
     pub fn profiler_path(&self, target: TargetSelection) -> Option<&str> {

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -96,7 +96,7 @@ pub fn check(build: &mut Build) {
             })
             .any(|build_llvm_ourselves| build_llvm_ourselves);
 
-    let need_cmake = building_llvm || build.config.any_sanitizers_enabled();
+    let need_cmake = building_llvm || build.config.any_sanitizers_to_build();
     if need_cmake && cmd_finder.maybe_have("cmake").is_none() {
         eprintln!(
             "

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -161,7 +161,9 @@ target | std | notes
 [`nvptx64-nvidia-cuda`](platform-support/nvptx64-nvidia-cuda.md) | * | --emit=asm generates PTX code that [runs on NVIDIA GPUs]
 [`riscv32imac-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * | Bare RISC-V (RV32IMAC ISA)
 [`riscv32i-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * | Bare RISC-V (RV32I ISA)
+[`riscv32im-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * |  | Bare RISC-V (RV32IM ISA)
 [`riscv32imc-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * | Bare RISC-V (RV32IMC ISA)
+[`riscv32imafc-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * | Bare RISC-V (RV32IMAFC ISA)
 `riscv64gc-unknown-none-elf` | * | Bare RISC-V (RV64IMAFDC ISA)
 `riscv64imac-unknown-none-elf` | * | Bare RISC-V (RV64IMAC ISA)
 `sparc64-unknown-linux-gnu` | ✓ | SPARC Linux (kernel 4.4, glibc 2.23)
@@ -315,8 +317,6 @@ target | std | host | notes
 [`powerpc64-ibm-aix`](platform-support/aix.md) | ? |  | 64-bit AIX (7.2 and newer)
 `riscv32gc-unknown-linux-gnu` |   |   | RISC-V Linux (kernel 5.4, glibc 2.33)
 `riscv32gc-unknown-linux-musl` |   |   | RISC-V Linux (kernel 5.4, musl + RISCV32 support patches)
-[`riscv32imafc-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * | Bare RISC-V (RV32IMAFC ISA)
-[`riscv32im-unknown-none-elf`](platform-support/riscv32imac-unknown-none-elf.md) | * |  | Bare RISC-V (RV32IM ISA)
 [`riscv32imac-unknown-xous-elf`](platform-support/riscv32imac-unknown-xous-elf.md) | ? |  | RISC-V Xous (RV32IMAC ISA)
 [`riscv32imc-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF
 [`riscv32imac-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF

--- a/src/doc/rustc/src/platform-support/riscv32imac-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv32imac-unknown-none-elf.md
@@ -1,6 +1,6 @@
 # `riscv32{i,im,imc,imac,imafc}-unknown-none-elf`
 
-**Tier: 2/3**
+**Tier: 2**
 
 Bare-metal target for RISC-V CPUs with the RV32I, RV32IM, RV32IMC, RV32IMAFC and RV32IMAC ISAs.
 
@@ -24,11 +24,11 @@ This target is included in Rust and can be installed via `rustup`.
 
 ## Testing
 
-This is a cross-compiled no-std target, which must be run either in a simulator
+This is a cross-compiled `no-std` target, which must be run either in a simulator
 or by programming them onto suitable hardware. It is not possible to run the
-Rust testsuite on this target.
+Rust test-suite on this target.
 
 ## Cross-compilation toolchains and C code
 
 This target supports C code. If interlinking with C or C++, you may need to use
-riscv64-unknown-elf-gcc as a linker instead of rust-lld.
+`riscv64-unknown-elf-gcc` as a linker instead of `rust-lld`.

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -8,8 +8,6 @@ help: consider importing one of these items
    |
 LL + use core::marker::PhantomData;
    |
-LL + use serde::__private::PhantomData;
-   |
 LL + use std::marker::PhantomData;
    |
 

--- a/src/tools/lint-docs/src/groups.rs
+++ b/src/tools/lint-docs/src/groups.rs
@@ -15,6 +15,7 @@ static GROUP_DESCRIPTIONS: &[(&str, &str)] = &[
     ("future-incompatible", "Lints that detect code that has future-compatibility problems"),
     ("rust-2018-compatibility", "Lints used to transition code from the 2015 edition to 2018"),
     ("rust-2021-compatibility", "Lints used to transition code from the 2018 edition to 2021"),
+    ("rust-2024-compatibility", "Lints used to transition code from the 2021 edition to 2024"),
 ];
 
 type LintGroups = BTreeMap<String, BTreeSet<String>>;

--- a/src/tools/miri/tests/fail/tls/tls_static_dealloc.rs
+++ b/src/tools/miri/tests/fail/tls/tls_static_dealloc.rs
@@ -1,6 +1,8 @@
 //! Ensure that thread-local statics get deallocated when the thread dies.
 
 #![feature(thread_local)]
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#![allow(static_mut_ref)]
 
 #[thread_local]
 static mut TLS: u8 = 0;

--- a/src/tools/miri/tests/pass/static_mut.rs
+++ b/src/tools/miri/tests/pass/static_mut.rs
@@ -1,4 +1,7 @@
 static mut FOO: i32 = 42;
+
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#[allow(static_mut_ref)]
 static BAR: Foo = Foo(unsafe { &FOO as *const _ });
 
 #[allow(dead_code)]

--- a/src/tools/miri/tests/pass/tls/tls_static.rs
+++ b/src/tools/miri/tests/pass/tls/tls_static.rs
@@ -8,6 +8,8 @@
 //! test, we also check that thread-locals act as per-thread statics.
 
 #![feature(thread_local)]
+// FIXME: Use `SyncUnsafeCell` instead of allowing `static_mut_ref` lint
+#![allow(static_mut_ref)]
 
 use std::thread;
 

--- a/tests/run-make/sanitizer-cdylib-link/Makefile
+++ b/tests/run-make/sanitizer-cdylib-link/Makefile
@@ -12,5 +12,5 @@ LOG := $(TMPDIR)/log.txt
 
 all:
 	$(RUSTC) -g -Z sanitizer=address --crate-type cdylib --target $(TARGET) library.rs
-	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) -llibrary program.rs
+	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) program.rs
 	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow

--- a/tests/run-make/sanitizer-cdylib-link/program.rs
+++ b/tests/run-make/sanitizer-cdylib-link/program.rs
@@ -1,3 +1,5 @@
+#[cfg_attr(windows, link(name = "library.dll.lib", modifiers = "+verbatim"))]
+#[cfg_attr(not(windows), link(name = "library"))]
 extern "C" {
     fn overflow();
 }

--- a/tests/run-make/sanitizer-dylib-link/Makefile
+++ b/tests/run-make/sanitizer-dylib-link/Makefile
@@ -12,5 +12,5 @@ LOG := $(TMPDIR)/log.txt
 
 all:
 	$(RUSTC) -g -Z sanitizer=address --crate-type dylib --target $(TARGET) library.rs
-	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) -llibrary program.rs
+	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) program.rs
 	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow

--- a/tests/run-make/sanitizer-dylib-link/program.rs
+++ b/tests/run-make/sanitizer-dylib-link/program.rs
@@ -1,3 +1,5 @@
+#[cfg_attr(windows, link(name = "library.dll.lib", modifiers = "+verbatim"))]
+#[cfg_attr(not(windows), link(name = "library"))]
 extern "C" {
     fn overflow();
 }

--- a/tests/run-make/sanitizer-staticlib-link/program.rs
+++ b/tests/run-make/sanitizer-staticlib-link/program.rs
@@ -1,4 +1,4 @@
-#[link(name = "library")]
+#[link(name = "library", kind = "static")]
 extern "C" {
     fn overflow();
 }

--- a/tests/ui/abi/statics/static-mut-foreign.rs
+++ b/tests/ui/abi/statics/static-mut-foreign.rs
@@ -33,7 +33,9 @@ unsafe fn run() {
     rust_dbg_static_mut = -3;
     assert_eq!(rust_dbg_static_mut, -3);
     static_bound(&rust_dbg_static_mut);
+    //~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
     static_bound_set(&mut rust_dbg_static_mut);
+    //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
 }
 
 pub fn main() {

--- a/tests/ui/abi/statics/static-mut-foreign.stderr
+++ b/tests/ui/abi/statics/static-mut-foreign.stderr
@@ -1,0 +1,31 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/static-mut-foreign.rs:35:18
+   |
+LL |     static_bound(&rust_dbg_static_mut);
+   |                  ^^^^^^^^^^^^^^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     static_bound(addr_of!(rust_dbg_static_mut));
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/static-mut-foreign.rs:37:22
+   |
+LL |     static_bound_set(&mut rust_dbg_static_mut);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     static_bound_set(addr_of_mut!(rust_dbg_static_mut));
+   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: 2 warnings emitted
+

--- a/tests/ui/asm/named-asm-labels.stderr
+++ b/tests/ui/asm/named-asm-labels.stderr
@@ -245,7 +245,88 @@ LL |             ab: nop // ab: does foo
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:124:14
+  --> $DIR/named-asm-labels.rs:132:19
+   |
+LL |             asm!("test_{}: nop", in(reg) 10);
+   |                   ^^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:134:15
+   |
+LL |         asm!("test_{}: nop", const 10);
+   |               ^^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:135:15
+   |
+LL |         asm!("test_{}: nop", sym main);
+   |               ^^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:136:15
+   |
+LL |         asm!("{}_test: nop", const 10);
+   |               ^^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:137:15
+   |
+LL |         asm!("test_{}_test: nop", const 10);
+   |               ^^^^^^^^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:138:15
+   |
+LL |         asm!("{}: nop", const 10);
+   |               ^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:140:15
+   |
+LL |         asm!("{uwu}: nop", uwu = const 10);
+   |               ^^^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:141:15
+   |
+LL |         asm!("{0}: nop", const 10);
+   |               ^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:142:15
+   |
+LL |         asm!("{1}: nop", "/* {0} */", const 10, const 20);
+   |               ^^^
+   |
+   = help: only local labels of the form `<number>:` should be used in inline asm
+   = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
+
+error: avoid using named labels in inline assembly
+  --> $DIR/named-asm-labels.rs:145:14
    |
 LL |         asm!(include_str!("named-asm-labels.s"));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -254,7 +335,7 @@ LL |         asm!(include_str!("named-asm-labels.s"));
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 warning: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:134:19
+  --> $DIR/named-asm-labels.rs:155:19
    |
 LL |             asm!("warned: nop");
    |                   ^^^^^^
@@ -262,13 +343,13 @@ LL |             asm!("warned: nop");
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 note: the lint level is defined here
-  --> $DIR/named-asm-labels.rs:132:16
+  --> $DIR/named-asm-labels.rs:153:16
    |
 LL |         #[warn(named_asm_labels)]
    |                ^^^^^^^^^^^^^^^^
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:143:20
+  --> $DIR/named-asm-labels.rs:164:20
    |
 LL |     unsafe { asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1, options(noreturn)) }
    |                    ^^^^^
@@ -277,7 +358,7 @@ LL |     unsafe { asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1, options(noret
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:149:20
+  --> $DIR/named-asm-labels.rs:170:20
    |
 LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noreturn)) }
    |                    ^^^^^
@@ -286,7 +367,7 @@ LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noret
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:157:20
+  --> $DIR/named-asm-labels.rs:178:20
    |
 LL |     unsafe { asm!(".Laaa: nop; ret;", options(noreturn)) }
    |                    ^^^^^
@@ -295,7 +376,7 @@ LL |     unsafe { asm!(".Laaa: nop; ret;", options(noreturn)) }
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:167:24
+  --> $DIR/named-asm-labels.rs:188:24
    |
 LL |         unsafe { asm!(".Lbbb: nop; ret;", options(noreturn)) }
    |                        ^^^^^
@@ -304,7 +385,7 @@ LL |         unsafe { asm!(".Lbbb: nop; ret;", options(noreturn)) }
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:176:15
+  --> $DIR/named-asm-labels.rs:197:15
    |
 LL |         asm!("closure1: nop");
    |               ^^^^^^^^
@@ -313,7 +394,7 @@ LL |         asm!("closure1: nop");
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:180:15
+  --> $DIR/named-asm-labels.rs:201:15
    |
 LL |         asm!("closure2: nop");
    |               ^^^^^^^^
@@ -322,7 +403,7 @@ LL |         asm!("closure2: nop");
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:190:19
+  --> $DIR/named-asm-labels.rs:211:19
    |
 LL |             asm!("closure3: nop");
    |                   ^^^^^^^^
@@ -330,5 +411,5 @@ LL |             asm!("closure3: nop");
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
-error: aborting due to 35 previous errors; 1 warning emitted
+error: aborting due to 44 previous errors; 1 warning emitted
 

--- a/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
@@ -13,7 +13,7 @@ LL | impl<T> Windows {
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/issue-109071.rs:5:8
    |
-LL | struct Windows<T> {}
+LL | struct Windows<T> { t: T }
    |        ^^^^^^^ -
 help: add missing generic argument
    |
@@ -30,7 +30,7 @@ LL |     type Item = &[T];
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
 error[E0223]: ambiguous associated type
-  --> $DIR/issue-109071.rs:15:22
+  --> $DIR/issue-109071.rs:16:22
    |
 LL |     fn T() -> Option<Self::Item> {}
    |                      ^^^^^^^^^^

--- a/tests/ui/associated-inherent-types/issue-109071.rs
+++ b/tests/ui/associated-inherent-types/issue-109071.rs
@@ -2,18 +2,20 @@
 #![cfg_attr(with_gate, feature(inherent_associated_types))]
 #![cfg_attr(with_gate, allow(incomplete_features))]
 
-struct Windows<T> {}
+struct Windows<T> { t: T }
 
 impl<T> Windows { //~ ERROR: missing generics for struct `Windows`
     type Item = &[T]; //~ ERROR: `&` without an explicit lifetime name cannot be used here
     //[no_gate]~^ ERROR: inherent associated types are unstable
 
     fn next() -> Option<Self::Item> {}
+    //[with_gate]~^ ERROR type annotations needed
 }
 
 impl<T> Windows<T> {
     fn T() -> Option<Self::Item> {}
     //[no_gate]~^ ERROR: ambiguous associated type
+    //[with_gate]~^^ ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.with_gate.stderr
@@ -13,14 +13,26 @@ LL | impl<T> Windows {
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/issue-109071.rs:5:8
    |
-LL | struct Windows<T> {}
+LL | struct Windows<T> { t: T }
    |        ^^^^^^^ -
 help: add missing generic argument
    |
 LL | impl<T> Windows<T> {
    |                +++
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/issue-109071.rs:11:18
+   |
+LL |     fn next() -> Option<Self::Item> {}
+   |                  ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
-Some errors have detailed explanations: E0107, E0637.
+error[E0282]: type annotations needed
+  --> $DIR/issue-109071.rs:16:15
+   |
+LL |     fn T() -> Option<Self::Item> {}
+   |               ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0282, E0637.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/associated-inherent-types/issue-109299-1.rs
+++ b/tests/ui/associated-inherent-types/issue-109299-1.rs
@@ -8,5 +8,6 @@ impl Lexer<i32> {
 }
 
 type X = impl for<T> Fn() -> Lexer<T>::Cursor; //~ ERROR associated type `Cursor` not found for `Lexer<T>` in the current scope
+//~^ ERROR: unconstrained opaque type
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109299-1.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299-1.stderr
@@ -10,6 +10,14 @@ LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
    = note: the associated type was found for
            - `Lexer<i32>`
 
-error: aborting due to 1 previous error
+error: unconstrained opaque type
+  --> $DIR/issue-109299-1.rs:10:10
+   |
+LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `X` must be used in combination with a concrete type within the same module
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0220`.

--- a/tests/ui/associated-inherent-types/issue-109768.rs
+++ b/tests/ui/associated-inherent-types/issue-109768.rs
@@ -8,5 +8,6 @@ impl<T> Local { //~ ERROR missing generics for struct `Local`
     type AssocType3 = T; //~ ERROR inherent associated types are unstable
 
     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
+    //~^ ERROR: this struct takes 1 argument but 0 arguments were supplied
 }
 //~^ ERROR `main` function not found

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -1,5 +1,5 @@
 error[E0601]: `main` function not found in crate `issue_109768`
-  --> $DIR/issue-109768.rs:11:2
+  --> $DIR/issue-109768.rs:12:2
    |
 LL | }
    |  ^ consider adding a `main` function to `$DIR/issue-109768.rs`
@@ -29,7 +29,23 @@ LL |     type AssocType3 = T;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0061]: this struct takes 1 argument but 0 arguments were supplied
+  --> $DIR/issue-109768.rs:10:56
+   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
+   |                                                        ^^^^^^^-- an argument is missing
+   |
+note: tuple struct defined here
+  --> $DIR/issue-109768.rs:3:8
+   |
+LL | struct Wrapper<T>(T);
+   |        ^^^^^^^
+help: provide the argument
+   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper(/* value */);
+   |                                                               ~~~~~~~~~~~~~
 
-Some errors have detailed explanations: E0107, E0601, E0658.
-For more information about an error, try `rustc --explain E0107`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0061, E0107, E0601, E0658.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/associated-type-bounds/duplicate.rs
+++ b/tests/ui/associated-type-bounds/duplicate.rs
@@ -134,14 +134,17 @@ where
 fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     iter::empty()
+    //~^ ERROR type annotations needed
 }
 fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
@@ -194,11 +197,14 @@ trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
 trait TRS1: Iterator<Item: Copy, Item: Send> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS2: Iterator<Item: Copy, Item: Copy> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRS3: Iterator<Item: 'static, Item: 'static> {}
 //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+//~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 trait TRW1<T>
 where
@@ -223,12 +229,14 @@ where
     Self: Iterator<Item: Copy, Item: Send>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRSW2
 where
     Self: Iterator<Item: Copy, Item: Copy>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
@@ -237,15 +245,19 @@ where
     Self: Iterator<Item: 'static, Item: 'static>,
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
     //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
 {
 }
 trait TRA1 {
     type A: Iterator<Item: Copy, Item: Send>;
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+    //~| ERROR the trait bound `<<Self as TRA1>::A as Iterator>::Item: Copy` is not satisfied
 }
 trait TRA2 {
     type A: Iterator<Item: Copy, Item: Copy>;
     //~^ ERROR the value of the associated type `Item` in trait `Iterator` is already specified [E0719]
+    //~| ERROR the trait bound `<<Self as TRA2>::A as Iterator>::Item: Copy` is not satisfied
 }
 trait TRA3 {
     type A: Iterator<Item: 'static, Item: 'static>;

--- a/tests/ui/associated-type-bounds/duplicate.stderr
+++ b/tests/ui/associated-type-bounds/duplicate.stderr
@@ -199,7 +199,7 @@ LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:138:42
+  --> $DIR/duplicate.rs:139:42
    |
 LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              ----------  ^^^^^^^^^^ re-bound here
@@ -207,7 +207,7 @@ LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:142:45
+  --> $DIR/duplicate.rs:144:45
    |
 LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              -------------  ^^^^^^^^^^^^^ re-bound here
@@ -215,7 +215,7 @@ LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:146:40
+  --> $DIR/duplicate.rs:149:40
    |
 LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -223,7 +223,7 @@ LL | fn FAPIT1(_: impl Iterator<Item: Copy, Item: Send>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:148:40
+  --> $DIR/duplicate.rs:151:40
    |
 LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -231,7 +231,7 @@ LL | fn FAPIT2(_: impl Iterator<Item: Copy, Item: Copy>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:150:43
+  --> $DIR/duplicate.rs:153:43
    |
 LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -239,7 +239,7 @@ LL | fn FAPIT3(_: impl Iterator<Item: 'static, Item: 'static>) {}
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:153:35
+  --> $DIR/duplicate.rs:156:35
    |
 LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       ----------  ^^^^^^^^^^ re-bound here
@@ -247,7 +247,7 @@ LL | type TAI1<T: Iterator<Item: Copy, Item: Send>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:155:35
+  --> $DIR/duplicate.rs:158:35
    |
 LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       ----------  ^^^^^^^^^^ re-bound here
@@ -255,7 +255,7 @@ LL | type TAI2<T: Iterator<Item: Copy, Item: Copy>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:157:38
+  --> $DIR/duplicate.rs:160:38
    |
 LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       -------------  ^^^^^^^^^^^^^ re-bound here
@@ -263,7 +263,7 @@ LL | type TAI3<T: Iterator<Item: 'static, Item: 'static>> = T;
    |                       `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:161:29
+  --> $DIR/duplicate.rs:164:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -271,7 +271,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:166:29
+  --> $DIR/duplicate.rs:169:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -279,7 +279,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:171:32
+  --> $DIR/duplicate.rs:174:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 -------------  ^^^^^^^^^^^^^ re-bound here
@@ -287,7 +287,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:175:36
+  --> $DIR/duplicate.rs:178:36
    |
 LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -295,7 +295,7 @@ LL | type ETAI1<T: Iterator<Item: Copy, Item: Send>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:177:36
+  --> $DIR/duplicate.rs:180:36
    |
 LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -303,7 +303,7 @@ LL | type ETAI2<T: Iterator<Item: Copy, Item: Copy>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:179:39
+  --> $DIR/duplicate.rs:182:39
    |
 LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        -------------  ^^^^^^^^^^^^^ re-bound here
@@ -311,7 +311,7 @@ LL | type ETAI3<T: Iterator<Item: 'static, Item: 'static>> = impl Copy;
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:181:40
+  --> $DIR/duplicate.rs:184:40
    |
 LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -319,7 +319,7 @@ LL | type ETAI4 = impl Iterator<Item: Copy, Item: Send>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:183:40
+  --> $DIR/duplicate.rs:186:40
    |
 LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -327,7 +327,7 @@ LL | type ETAI5 = impl Iterator<Item: Copy, Item: Copy>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:185:43
+  --> $DIR/duplicate.rs:188:43
    |
 LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -335,7 +335,7 @@ LL | type ETAI6 = impl Iterator<Item: 'static, Item: 'static>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:188:36
+  --> $DIR/duplicate.rs:191:36
    |
 LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -343,7 +343,7 @@ LL | trait TRI1<T: Iterator<Item: Copy, Item: Send>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:190:36
+  --> $DIR/duplicate.rs:193:36
    |
 LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        ----------  ^^^^^^^^^^ re-bound here
@@ -351,7 +351,7 @@ LL | trait TRI2<T: Iterator<Item: Copy, Item: Copy>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:192:39
+  --> $DIR/duplicate.rs:195:39
    |
 LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        -------------  ^^^^^^^^^^^^^ re-bound here
@@ -359,7 +359,7 @@ LL | trait TRI3<T: Iterator<Item: 'static, Item: 'static>> {}
    |                        `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:194:34
+  --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -367,7 +367,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:194:34
+  --> $DIR/duplicate.rs:197:34
    |
 LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -377,7 +377,7 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
+  --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -385,7 +385,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
+  --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -395,7 +395,7 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:200:37
+  --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
@@ -403,7 +403,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:200:37
+  --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
@@ -413,7 +413,7 @@ LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:205:29
+  --> $DIR/duplicate.rs:211:29
    |
 LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -421,7 +421,7 @@ LL |     T: Iterator<Item: Copy, Item: Send>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:211:29
+  --> $DIR/duplicate.rs:217:29
    |
 LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 ----------  ^^^^^^^^^^ re-bound here
@@ -429,7 +429,7 @@ LL |     T: Iterator<Item: Copy, Item: Copy>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:217:32
+  --> $DIR/duplicate.rs:223:32
    |
 LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 -------------  ^^^^^^^^^^^^^ re-bound here
@@ -437,7 +437,7 @@ LL |     T: Iterator<Item: 'static, Item: 'static>,
    |                 `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:223:32
+  --> $DIR/duplicate.rs:229:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -445,7 +445,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:223:32
+  --> $DIR/duplicate.rs:229:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Send>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -455,7 +455,7 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:230:32
+  --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -463,7 +463,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:230:32
+  --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
    |                    ----------  ^^^^^^^^^^ re-bound here
@@ -473,7 +473,7 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:35
+  --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
@@ -481,7 +481,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:35
+  --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
@@ -491,7 +491,7 @@ LL |     Self: Iterator<Item: 'static, Item: 'static>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:255:40
+  --> $DIR/duplicate.rs:267:40
    |
 LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            ----------  ^^^^^^^^^^ re-bound here
@@ -499,7 +499,7 @@ LL | type TADyn1 = dyn Iterator<Item: Copy, Item: Send>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:257:44
+  --> $DIR/duplicate.rs:269:44
    |
 LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                ----------  ^^^^^^^^^^ re-bound here
@@ -507,7 +507,7 @@ LL | type TADyn2 = Box<dyn Iterator<Item: Copy, Item: Copy>>;
    |                                `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:259:43
+  --> $DIR/duplicate.rs:271:43
    |
 LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                            -------------  ^^^^^^^^^^^^^ re-bound here
@@ -515,7 +515,7 @@ LL | type TADyn3 = dyn Iterator<Item: 'static, Item: 'static>;
    |                            `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:243:34
+  --> $DIR/duplicate.rs:252:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -523,7 +523,7 @@ LL |     type A: Iterator<Item: Copy, Item: Send>;
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:247:34
+  --> $DIR/duplicate.rs:258:34
    |
 LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      ----------  ^^^^^^^^^^ re-bound here
@@ -531,13 +531,141 @@ LL |     type A: Iterator<Item: Copy, Item: Copy>;
    |                      `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:251:37
+  --> $DIR/duplicate.rs:263:37
    |
 LL |     type A: Iterator<Item: 'static, Item: 'static>;
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
 
-error: aborting due to 66 previous errors
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:197:34
+   |
+LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-For more information about this error, try `rustc --explain E0719`.
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:201:34
+   |
+LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:205:37
+   |
+LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
+   |                      -------------  ^^^^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:229:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Send>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:237:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Copy>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:245:35
+   |
+LL |     Self: Iterator<Item: 'static, Item: 'static>,
+   |                    -------------  ^^^^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `<<Self as TRA1>::A as Iterator>::Item: Copy` is not satisfied
+  --> $DIR/duplicate.rs:252:28
+   |
+LL |     type A: Iterator<Item: Copy, Item: Send>;
+   |                            ^^^^ the trait `Copy` is not implemented for `<<Self as TRA1>::A as Iterator>::Item`
+   |
+help: consider further restricting the associated type
+   |
+LL | trait TRA1 where <<Self as TRA1>::A as Iterator>::Item: Copy {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+  --> $DIR/duplicate.rs:252:40
+   |
+LL |     type A: Iterator<Item: Copy, Item: Send>;
+   |                                        ^^^^ `<<Self as TRA1>::A as Iterator>::Item` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `<<Self as TRA1>::A as Iterator>::Item`
+help: consider further restricting the associated type
+   |
+LL | trait TRA1 where <<Self as TRA1>::A as Iterator>::Item: Send {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<<Self as TRA2>::A as Iterator>::Item: Copy` is not satisfied
+  --> $DIR/duplicate.rs:258:28
+   |
+LL |     type A: Iterator<Item: Copy, Item: Copy>;
+   |                            ^^^^ the trait `Copy` is not implemented for `<<Self as TRA2>::A as Iterator>::Item`
+   |
+help: consider further restricting the associated type
+   |
+LL | trait TRA2 where <<Self as TRA2>::A as Iterator>::Item: Copy {
+   |            +++++++++++++++++++++++++++++++++++++++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:136:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:141:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:146:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
+error: aborting due to 78 previous errors
+
+Some errors have detailed explanations: E0277, E0282, E0719.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.rs
+++ b/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.rs
@@ -25,7 +25,7 @@ fn c<C>(_: C::Color) where C : Vehicle, C : Box {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-struct D<X>;
+struct D<X>(X);
 impl<X> D<X> where X : Vehicle {
     fn d(&self, _: X::Color) where X : Box { }
     //~^ ERROR ambiguous associated type `Color` in bounds of `X`

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.rs
@@ -20,7 +20,7 @@ fn dent<C:BoxCar>(c: C, color: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
+fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
     //~^ ERROR ambiguous associated type
     //~| ERROR the value of the associated types
 }
@@ -29,7 +29,7 @@ fn paint<C:BoxCar>(c: C, d: C::Color) {
     //~^ ERROR ambiguous associated type `Color` in bounds of `C`
 }
 
-fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
     //~^ ERROR the value of the associated types
     //~| ERROR equality constraints are not yet supported in `where` clauses
 }

--- a/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/tests/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -1,8 +1,8 @@
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:46
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:47
    |
-LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
+LL | fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
@@ -28,7 +28,7 @@ LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
    |                                ~~~~~~~~~~~~
 
 error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:38
    |
 LL |     type Color;
    |     ---------- ambiguous `Color` from `Vehicle`
@@ -36,8 +36,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- ambiguous `Color` from `Box`
 ...
-LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                                     ^^^^^^^^^^^ ambiguous associated type `Color`
+LL | fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
+   |                                      ^^^^^^^^^^^ ambiguous associated type `Color`
    |
    = help: consider introducing a new type parameter `T` and adding `where` constraints:
                where
@@ -46,7 +46,7 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
                    T: Box::Color = COLOR
 
 error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:31
    |
 LL |     type Color;
    |     ---------- `Vehicle::Color` defined here
@@ -54,8 +54,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- `Box::Color` defined here
 ...
-LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
-   |                              ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+LL | fn dent_object<COLOR>(c: &dyn BoxCar<Color=COLOR>) {
+   |                               ^^^^^^^^^^^^^^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 
@@ -81,7 +81,7 @@ LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
    |                             ~~~~~~~~~~~~
 
 error[E0191]: the value of the associated types `Color` in `Box`, `Color` in `Vehicle` must be specified
-  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32
+  --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:33
    |
 LL |     type Color;
    |     ---------- `Vehicle::Color` defined here
@@ -89,8 +89,8 @@ LL |     type Color;
 LL |     type Color;
    |     ---------- `Box::Color` defined here
 ...
-LL | fn dent_object_2<COLOR>(c: dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
-   |                                ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
+LL | fn dent_object_2<COLOR>(c: &dyn BoxCar) where <dyn BoxCar as Vehicle>::Color = COLOR {
+   |                                 ^^^^^^ associated types `Color` (from trait `Vehicle`), `Color` (from trait `Box`) must be specified
    |
    = help: consider introducing a new type parameter, adding `where` constraints using the fully-qualified path to the associated types
 

--- a/tests/ui/associated-types/issue-23595-1.rs
+++ b/tests/ui/associated-types/issue-23595-1.rs
@@ -7,6 +7,7 @@ trait Hierarchy {
     type ChildKey;
     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
     //~^ ERROR: the value of the associated types
+    //~| ERROR: the size for values of type
 
     fn data(&self) -> Option<(Self::Value, Self::Children)>;
 }

--- a/tests/ui/associated-types/issue-23595-1.stderr
+++ b/tests/ui/associated-types/issue-23595-1.stderr
@@ -8,6 +8,20 @@ LL |     type ChildKey;
 LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
    |     ------------- `Children` defined here                ^^^^^^^^^ help: specify the associated types: `Hierarchy<Value = Type, ChildKey = Type, Children = Type>`
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `(dyn Index<<Self as Hierarchy>::ChildKey, Output = (dyn Hierarchy + 'static)> + 'static)` cannot be known at compilation time
+  --> $DIR/issue-23595-1.rs:8:21
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Index<<Self as Hierarchy>::ChildKey, Output = (dyn Hierarchy + 'static)> + 'static)`
+note: required by a bound in `Hierarchy::Children`
+  --> $DIR/issue-23595-1.rs:8:5
+   |
+LL |     type Children = dyn Index<Self::ChildKey, Output=dyn Hierarchy>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Hierarchy::Children`
 
-For more information about this error, try `rustc --explain E0191`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0191, E0277.
+For more information about an error, try `rustc --explain E0191`.

--- a/tests/ui/async-await/issues/issue-65159.rs
+++ b/tests/ui/async-await/issues/issue-65159.rs
@@ -5,7 +5,7 @@
 async fn copy() -> Result<()>
 //~^ ERROR enum takes 2 generic arguments
 {
-    Ok(())
+    Ok(()) //~ ERROR: type annotations needed
 }
 
 fn main() { }

--- a/tests/ui/async-await/issues/issue-65159.stderr
+++ b/tests/ui/async-await/issues/issue-65159.stderr
@@ -11,6 +11,18 @@ help: add missing generic argument
 LL | async fn copy() -> Result<(), E>
    |                             +++
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-65159.rs:8:5
+   |
+LL |     Ok(())
+   |     ^^ cannot infer type of the type parameter `E` declared on the enum `Result`
+   |
+help: consider specifying the generic arguments
+   |
+LL |     Ok::<(), E>(())
+   |       +++++++++
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.rs
@@ -9,5 +9,6 @@ trait Super1<'a> {
 
 impl Super1<'_, bar(): Send> for () {}
 //~^ ERROR associated type bindings are not allowed here
+//~| ERROR not all trait items implemented
 
 fn main() {}

--- a/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
+++ b/tests/ui/async-await/return-type-notation/rtn-in-impl-signature.stderr
@@ -13,6 +13,16 @@ error[E0229]: associated type bindings are not allowed here
 LL | impl Super1<'_, bar(): Send> for () {}
    |                 ^^^^^^^^^^^ associated type not allowed here
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0046]: not all trait items implemented, missing: `bar`
+  --> $DIR/rtn-in-impl-signature.rs:10:1
+   |
+LL |     fn bar<'b>() -> bool;
+   |     --------------------- `bar` from trait
+...
+LL | impl Super1<'_, bar(): Send> for () {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bar` in implementation
 
-For more information about this error, try `rustc --explain E0229`.
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0046, E0229.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.afn.stderr
@@ -26,7 +26,7 @@ LL |     let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:28:17
+  --> $DIR/async-closure-gate.rs:29:17
    |
 LL |         let _ = #[track_caller] || {
    |                 ^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |         let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:36:9
+  --> $DIR/async-closure-gate.rs:37:9
    |
 LL |         #[track_caller] || {
    |         ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:45:13
+  --> $DIR/async-closure-gate.rs:47:13
    |
 LL |             #[track_caller] || {
    |             ^^^^^^^^^^^^^^^
@@ -52,6 +52,40 @@ LL |             #[track_caller] || {
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:27:5
+   |
+LL |   fn foo3() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = #[track_caller] || {
+LL | |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:44:5
+   |
+LL |   fn foo5() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = || {
+LL | |             #[track_caller] || {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
+++ b/tests/ui/async-await/track-caller/async-closure-gate.nofeat.stderr
@@ -26,7 +26,7 @@ LL |     let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:28:17
+  --> $DIR/async-closure-gate.rs:29:17
    |
 LL |         let _ = #[track_caller] || {
    |                 ^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL |         let _ = #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:36:9
+  --> $DIR/async-closure-gate.rs:37:9
    |
 LL |         #[track_caller] || {
    |         ^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |         #[track_caller] || {
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
 error[E0658]: `#[track_caller]` on closures is currently unstable
-  --> $DIR/async-closure-gate.rs:45:13
+  --> $DIR/async-closure-gate.rs:47:13
    |
 LL |             #[track_caller] || {
    |             ^^^^^^^^^^^^^^^
@@ -52,6 +52,40 @@ LL |             #[track_caller] || {
    = note: see issue #87417 <https://github.com/rust-lang/rust/issues/87417> for more information
    = help: add `#![feature(closure_track_caller)]` to the crate attributes to enable
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:27:5
+   |
+LL |   fn foo3() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = #[track_caller] || {
+LL | |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:27:5: 32:6}`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0308]: mismatched types
+  --> $DIR/async-closure-gate.rs:44:5
+   |
+LL |   fn foo5() {
+   |            - help: a return type might be missing here: `-> _`
+LL | /     async {
+LL | |
+LL | |         let _ = || {
+LL | |             #[track_caller] || {
+...  |
+LL | |         };
+LL | |     }
+   | |_____^ expected `()`, found `async` block
+   |
+   = note:  expected unit type `()`
+           found `async` block `{async block@$DIR/async-closure-gate.rs:44:5: 51:6}`
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/async-await/track-caller/async-closure-gate.rs
+++ b/tests/ui/async-await/track-caller/async-closure-gate.rs
@@ -25,6 +25,7 @@ async fn foo2() {
 
 fn foo3() {
     async {
+        //~^ ERROR mismatched types
         let _ = #[track_caller] || {
             //~^ ERROR `#[track_caller]` on closures is currently unstable [E0658]
         };
@@ -41,6 +42,7 @@ async fn foo4() {
 
 fn foo5() {
     async {
+        //~^ ERROR mismatched types
         let _ = || {
             #[track_caller] || {
                 //~^ ERROR `#[track_caller]` on closures is currently unstable [E0658]

--- a/tests/ui/borrowck/borrowck-access-permissions.rs
+++ b/tests/ui/borrowck/borrowck-access-permissions.rs
@@ -1,21 +1,27 @@
-static static_x : i32 = 1;
-static mut static_x_mut : i32 = 1;
+static static_x: i32 = 1;
+static mut static_x_mut: i32 = 1;
 
 fn main() {
     let x = 1;
     let mut x_mut = 1;
 
-    { // borrow of local
+    {
+        // borrow of local
         let _y1 = &mut x; //~ ERROR [E0596]
         let _y2 = &mut x_mut; // No error
     }
 
-    { // borrow of static
+    {
+        // borrow of static
         let _y1 = &mut static_x; //~ ERROR [E0596]
-        unsafe { let _y2 = &mut static_x_mut; } // No error
+        unsafe {
+            let _y2 = &mut static_x_mut;
+            //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+        }
     }
 
-    { // borrow of deref to box
+    {
+        // borrow of deref to box
         let box_x = Box::new(1);
         let mut box_x_mut = Box::new(1);
 
@@ -23,7 +29,8 @@ fn main() {
         let _y2 = &mut *box_x_mut; // No error
     }
 
-    { // borrow of deref to reference
+    {
+        // borrow of deref to reference
         let ref_x = &x;
         let ref_x_mut = &mut x_mut;
 
@@ -31,9 +38,10 @@ fn main() {
         let _y2 = &mut *ref_x_mut; // No error
     }
 
-    { // borrow of deref to pointer
-        let ptr_x : *const _ = &x;
-        let ptr_mut_x : *mut _ = &mut x_mut;
+    {
+        // borrow of deref to pointer
+        let ptr_x: *const _ = &x;
+        let ptr_mut_x: *mut _ = &mut x_mut;
 
         unsafe {
             let _y1 = &mut *ptr_x; //~ ERROR [E0596]
@@ -41,8 +49,12 @@ fn main() {
         }
     }
 
-    { // borrowing mutably through an immutable reference
-        struct Foo<'a> { f: &'a mut i32, g: &'a i32 };
+    {
+        // borrowing mutably through an immutable reference
+        struct Foo<'a> {
+            f: &'a mut i32,
+            g: &'a i32,
+        };
         let mut foo = Foo { f: &mut x_mut, g: &x };
         let foo_ref = &foo;
         let _y = &mut *foo_ref.f; //~ ERROR [E0596]

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -1,5 +1,20 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/borrowck-access-permissions.rs:18:23
+   |
+LL |             let _y2 = &mut static_x_mut;
+   |                       ^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |             let _y2 = addr_of_mut!(static_x_mut);
+   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-access-permissions.rs:9:19
+  --> $DIR/borrowck-access-permissions.rs:10:19
    |
 LL |         let _y1 = &mut x;
    |                   ^^^^^^ cannot borrow as mutable
@@ -10,13 +25,13 @@ LL |     let mut x = 1;
    |         +++
 
 error[E0596]: cannot borrow immutable static item `static_x` as mutable
-  --> $DIR/borrowck-access-permissions.rs:14:19
+  --> $DIR/borrowck-access-permissions.rs:16:19
    |
 LL |         let _y1 = &mut static_x;
    |                   ^^^^^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `*box_x` as mutable, as `box_x` is not declared as mutable
-  --> $DIR/borrowck-access-permissions.rs:22:19
+  --> $DIR/borrowck-access-permissions.rs:28:19
    |
 LL |         let _y1 = &mut *box_x;
    |                   ^^^^^^^^^^^ cannot borrow as mutable
@@ -27,7 +42,7 @@ LL |         let mut box_x = Box::new(1);
    |             +++
 
 error[E0596]: cannot borrow `*ref_x` as mutable, as it is behind a `&` reference
-  --> $DIR/borrowck-access-permissions.rs:30:19
+  --> $DIR/borrowck-access-permissions.rs:37:19
    |
 LL |         let _y1 = &mut *ref_x;
    |                   ^^^^^^^^^^^ `ref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
@@ -38,18 +53,18 @@ LL |         let ref_x = &mut x;
    |                      +++
 
 error[E0596]: cannot borrow `*ptr_x` as mutable, as it is behind a `*const` pointer
-  --> $DIR/borrowck-access-permissions.rs:39:23
+  --> $DIR/borrowck-access-permissions.rs:47:23
    |
 LL |             let _y1 = &mut *ptr_x;
    |                       ^^^^^^^^^^^ `ptr_x` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
    |
 help: consider changing this to be a mutable pointer
    |
-LL |         let ptr_x : *const _ = &mut x;
-   |                                 +++
+LL |         let ptr_x: *const _ = &mut x;
+   |                                +++
 
 error[E0596]: cannot borrow `*foo_ref.f` as mutable, as it is behind a `&` reference
-  --> $DIR/borrowck-access-permissions.rs:48:18
+  --> $DIR/borrowck-access-permissions.rs:60:18
    |
 LL |         let _y = &mut *foo_ref.f;
    |                  ^^^^^^^^^^^^^^^ `foo_ref` is a `&` reference, so the data it refers to cannot be borrowed as mutable
@@ -59,6 +74,6 @@ help: consider changing this to be a mutable reference
 LL |         let foo_ref = &mut foo;
    |                        +++
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.rs
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.rs
@@ -2,17 +2,22 @@
 
 // Test file taken from issue 45129 (https://github.com/rust-lang/rust/issues/45129)
 
-struct Foo { x: [usize; 2] }
+struct Foo {
+    x: [usize; 2],
+}
 
 static mut SFOO: Foo = Foo { x: [23, 32] };
 
 impl Foo {
-    fn x(&mut self) -> &mut usize { &mut self.x[0] }
+    fn x(&mut self) -> &mut usize {
+        &mut self.x[0]
+    }
 }
 
 fn main() {
     unsafe {
         let sfoo: *mut Foo = &mut SFOO;
+        //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
         let x = (*sfoo).x();
         (*sfoo).x[1] += 1;
         *x += 1;

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
@@ -1,0 +1,17 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/borrowck-unsafe-static-mutable-borrows.rs:19:30
+   |
+LL |         let sfoo: *mut Foo = &mut SFOO;
+   |                              ^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |         let sfoo: *mut Foo = addr_of_mut!(SFOO);
+   |                              ~~~~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/borrowck/issue-20801.rs
+++ b/tests/ui/borrowck/issue-20801.rs
@@ -12,6 +12,7 @@ fn imm_ref() -> &'static T {
 
 fn mut_ref() -> &'static mut T {
     unsafe { &mut GLOBAL_MUT_T }
+    //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
 }
 
 fn mut_ptr() -> *mut T {

--- a/tests/ui/borrowck/issue-20801.stderr
+++ b/tests/ui/borrowck/issue-20801.stderr
@@ -1,5 +1,20 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/issue-20801.rs:14:14
+   |
+LL |     unsafe { &mut GLOBAL_MUT_T }
+   |              ^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     unsafe { addr_of_mut!(GLOBAL_MUT_T) }
+   |              ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/issue-20801.rs:26:22
+  --> $DIR/issue-20801.rs:27:22
    |
 LL |     let a = unsafe { *mut_ref() };
    |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
@@ -11,7 +26,7 @@ LL +     let a = unsafe { mut_ref() };
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/issue-20801.rs:29:22
+  --> $DIR/issue-20801.rs:30:22
    |
 LL |     let b = unsafe { *imm_ref() };
    |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
@@ -23,7 +38,7 @@ LL +     let b = unsafe { imm_ref() };
    |
 
 error[E0507]: cannot move out of a raw pointer
-  --> $DIR/issue-20801.rs:32:22
+  --> $DIR/issue-20801.rs:33:22
    |
 LL |     let c = unsafe { *mut_ptr() };
    |                      ^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
@@ -35,7 +50,7 @@ LL +     let c = unsafe { mut_ptr() };
    |
 
 error[E0507]: cannot move out of a raw pointer
-  --> $DIR/issue-20801.rs:35:22
+  --> $DIR/issue-20801.rs:36:22
    |
 LL |     let d = unsafe { *const_ptr() };
    |                      ^^^^^^^^^^^^ move occurs because value has type `T`, which does not implement the `Copy` trait
@@ -46,6 +61,6 @@ LL -     let d = unsafe { *const_ptr() };
 LL +     let d = unsafe { const_ptr() };
    |
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.rs
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.rs
@@ -8,7 +8,10 @@ mod borrowck_closures_unique {
         static mut Y: isize = 3;
         let mut c1 = |y: &'static mut isize| x = y;
         //~^ ERROR is not declared as mutable
-        unsafe { c1(&mut Y); }
+        unsafe {
+            c1(&mut Y);
+            //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+        }
     }
 }
 
@@ -17,36 +20,50 @@ mod borrowck_closures_unique_grandparent {
         static mut Z: isize = 3;
         let mut c1 = |z: &'static mut isize| {
             let mut c2 = |y: &'static mut isize| x = y;
-        //~^ ERROR is not declared as mutable
+            //~^ ERROR is not declared as mutable
             c2(z);
         };
-        unsafe { c1(&mut Z); }
+        unsafe {
+            c1(&mut Z);
+            //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+        }
     }
 }
 
 // adapted from mutability_errors.rs
 mod mutability_errors {
     pub fn capture_assign_whole(x: (i32,)) {
-        || { x = (1,); };
-        //~^ ERROR is not declared as mutable
+        || {
+            x = (1,);
+            //~^ ERROR is not declared as mutable
+        };
     }
     pub fn capture_assign_part(x: (i32,)) {
-        || { x.0 = 1; };
-        //~^ ERROR is not declared as mutable
+        || {
+            x.0 = 1;
+            //~^ ERROR is not declared as mutable
+        };
     }
     pub fn capture_reborrow_whole(x: (i32,)) {
-        || { &mut x; };
-        //~^ ERROR is not declared as mutable
+        || {
+            &mut x;
+            //~^ ERROR is not declared as mutable
+        };
     }
     pub fn capture_reborrow_part(x: (i32,)) {
-        || { &mut x.0; };
-        //~^ ERROR is not declared as mutable
+        || {
+            &mut x.0;
+            //~^ ERROR is not declared as mutable
+        };
     }
 }
 
 fn main() {
     static mut X: isize = 2;
-    unsafe { borrowck_closures_unique::e(&mut X); }
+    unsafe {
+        borrowck_closures_unique::e(&mut X);
+        //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+    }
 
     mutability_errors::capture_assign_whole((1000,));
     mutability_errors::capture_assign_part((2000,));

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
@@ -1,3 +1,46 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:12:16
+   |
+LL |             c1(&mut Y);
+   |                ^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |             c1(addr_of_mut!(Y));
+   |                ~~~~~~~~~~~~~~~
+
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:27:16
+   |
+LL |             c1(&mut Z);
+   |                ^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |             c1(addr_of_mut!(Z));
+   |                ~~~~~~~~~~~~~~~
+
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:64:37
+   |
+LL |         borrowck_closures_unique::e(&mut X);
+   |                                     ^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |         borrowck_closures_unique::e(addr_of_mut!(X));
+   |                                     ~~~~~~~~~~~~~~~
+
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:9:46
    |
@@ -8,7 +51,7 @@ LL |         let mut c1 = |y: &'static mut isize| x = y;
    |                                              ^^^^^ cannot assign
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:19:50
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:22:50
    |
 LL |     pub fn ee(x: &'static mut isize) {
    |               - help: consider changing this to be mutable: `mut x`
@@ -17,38 +60,42 @@ LL |             let mut c2 = |y: &'static mut isize| x = y;
    |                                                  ^^^^^ cannot assign
 
 error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:30:14
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:37:13
    |
 LL |     pub fn capture_assign_whole(x: (i32,)) {
    |                                 - help: consider changing this to be mutable: `mut x`
-LL |         || { x = (1,); };
-   |              ^^^^^^^^ cannot assign
+LL |         || {
+LL |             x = (1,);
+   |             ^^^^^^^^ cannot assign
 
 error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:34:14
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:43:13
    |
 LL |     pub fn capture_assign_part(x: (i32,)) {
    |                                - help: consider changing this to be mutable: `mut x`
-LL |         || { x.0 = 1; };
-   |              ^^^^^^^ cannot assign
+LL |         || {
+LL |             x.0 = 1;
+   |             ^^^^^^^ cannot assign
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:38:14
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:49:13
    |
 LL |     pub fn capture_reborrow_whole(x: (i32,)) {
    |                                   - help: consider changing this to be mutable: `mut x`
-LL |         || { &mut x; };
-   |              ^^^^^^ cannot borrow as mutable
+LL |         || {
+LL |             &mut x;
+   |             ^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:42:14
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:55:13
    |
 LL |     pub fn capture_reborrow_part(x: (i32,)) {
    |                                  - help: consider changing this to be mutable: `mut x`
-LL |         || { &mut x.0; };
-   |              ^^^^^^^^ cannot borrow as mutable
+LL |         || {
+LL |             &mut x.0;
+   |             ^^^^^^^^ cannot borrow as mutable
 
-error: aborting due to 6 previous errors
+error: aborting due to 6 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.rs
@@ -17,6 +17,7 @@ async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
     //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument was supplied
     //~^^ ERROR struct takes 1 generic argument but 0 generic arguments were supplied
     LockedMarket(coroutine.lock().unwrap().buy())
+    //~^ ERROR: cannot return value referencing temporary value
 }
 
 struct LockedMarket<T>(T);

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -7,7 +7,7 @@ LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> 
    |                                                           expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
-  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:22:8
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:23:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> 
    |                                                           ^^^^^^^^^^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:22:8
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:23:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^ -
@@ -28,6 +28,16 @@ help: add missing generic argument
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_, T> {
    |                                                                          +++
 
-error: aborting due to 2 previous errors
+error[E0515]: cannot return value referencing temporary value
+  --> $DIR/issue-82126-mismatched-subst-and-hir.rs:19:5
+   |
+LL |     LockedMarket(coroutine.lock().unwrap().buy())
+   |     ^^^^^^^^^^^^^-------------------------^^^^^^^
+   |     |            |
+   |     |            temporary value created here
+   |     returns a value referencing data owned by the current function
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0515.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.rs
@@ -9,9 +9,10 @@ pub trait Parse {
 }
 
 pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
-//~^ ERROR expected type, found variant
+//~^ ERROR expected constant, found type
 //~| ERROR expected constant, found type
 //~| ERROR expected constant, found type
+//~| ERROR expected type
 
 fn no_help() -> Mode::Cool {}
 //~^ ERROR expected type, found variant

--- a/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
+++ b/tests/ui/const-generics/assoc_const_eq_diagnostic.stderr
@@ -8,7 +8,7 @@ LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
    |                                   help: try using the variant's enum: `Mode`
 
 error[E0573]: expected type, found variant `Mode::Cool`
-  --> $DIR/assoc_const_eq_diagnostic.rs:16:17
+  --> $DIR/assoc_const_eq_diagnostic.rs:17:17
    |
 LL | fn no_help() -> Mode::Cool {}
    |                 ^^^^^^^^^^
@@ -53,6 +53,25 @@ help: consider adding braces here
 LL | pub trait CoolStuff: Parse<MODE = { Mode::Cool }> {}
    |                                   +            +
 
-error: aborting due to 4 previous errors
+error: expected constant, found type
+  --> $DIR/assoc_const_eq_diagnostic.rs:11:35
+   |
+LL | pub trait CoolStuff: Parse<MODE = Mode::Cool> {}
+   |                            ----   ^^^^^^^^^^ unexpected type
+   |                            |
+   |                            expected a constant because of this associated constant
+   |
+note: the associated constant is defined here
+  --> $DIR/assoc_const_eq_diagnostic.rs:8:5
+   |
+LL |     const MODE: Mode;
+   |     ^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider adding braces here
+   |
+LL | pub trait CoolStuff: Parse<MODE = { Mode::Cool }> {}
+   |                                   +            +
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0573`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
@@ -9,6 +9,11 @@ const _: () = {
     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
     //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
     //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+    //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+    //~| ERROR `X` cannot be made into an object
 };
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -28,6 +28,86 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
 
-error: aborting due to 2 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                                +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^--- help: remove these generics
+   |                              |
+   |                              expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                                +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/issue-102768.rs:9:30
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                              ^--- help: remove these generics
+   |                              |
+   |                              expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/issue-102768.rs:9:24
+   |
+LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+   |                        ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-102768.rs:5:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-105257.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105257.rs
@@ -3,6 +3,7 @@
 
 trait Trait<T> {
     fn fnc<const N: usize = "">(&self) {} //~ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+    //~^ ERROR: mismatched types
     fn foo<const N: usize = { std::mem::size_of::<T>() }>(&self) {} //~ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-105257.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-105257.stderr
@@ -5,10 +5,17 @@ LL |     fn fnc<const N: usize = "">(&self) {}
    |            ^^^^^^^^^^^^^^^^^^^
 
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/issue-105257.rs:6:12
+  --> $DIR/issue-105257.rs:7:12
    |
 LL |     fn foo<const N: usize = { std::mem::size_of::<T>() }>(&self) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-105257.rs:5:29
+   |
+LL |     fn fnc<const N: usize = "">(&self) {}
+   |                             ^^ expected `usize`, found `&str`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
+++ b/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
@@ -4,5 +4,14 @@ error: cannot capture late-bound lifetime in constant
 LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
    |        -- lifetime defined here                     ^^
 
-error: aborting due to 1 previous error
+error: overly complex generic constant
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.rs
@@ -14,6 +14,7 @@ impl<const N: usize> Marker<N> for Example<N> {}
 fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
   //~^ ERROR: type provided when a constant was expected
   Example::<gimme_a_const!(marker)>
+  //~^ ERROR: type provided when a constant was expected
 }
 
 fn from_marker(_: impl Marker<{
@@ -33,7 +34,9 @@ fn main() {
   }>;
 
   let _fail = Example::<external_macro!()>;
+  //~^ ERROR: type provided when a constant was expected
 
   let _fail = Example::<gimme_a_const!()>;
   //~^ ERROR unexpected end of macro invocation
+  //~| ERROR: type provided when a constant was expected
 }

--- a/tests/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/tests/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:28:27
+  --> $DIR/macro-fail.rs:29:27
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ----------------------
@@ -13,7 +13,7 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:28:27
+  --> $DIR/macro-fail.rs:29:27
    |
 LL |   Example::<gimme_a_const!(marker)>
    |             ----------------------
@@ -41,7 +41,7 @@ LL |   let _fail = Example::<external_macro!()>;
    = note: this error originates in the macro `external_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-  --> $DIR/macro-fail.rs:37:25
+  --> $DIR/macro-fail.rs:39:25
    |
 LL |     macro_rules! gimme_a_const {
    |     -------------------------- when calling this macro
@@ -50,7 +50,7 @@ LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
    |
 note: while trying to match meta-variable `$rusty:ident`
-  --> $DIR/macro-fail.rs:28:8
+  --> $DIR/macro-fail.rs:29:8
    |
 LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |        ^^^^^^^^^^^^^
@@ -61,6 +61,24 @@ error[E0747]: type provided when a constant was expected
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:16:13
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:36:25
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |                         ^^^^^^^^^^^^^^^^^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:39:25
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0747`.

--- a/tests/ui/consts/const_let_assign2.rs
+++ b/tests/ui/consts/const_let_assign2.rs
@@ -16,6 +16,7 @@ static mut BB: AA = AA::new();
 
 fn main() {
     let ptr = unsafe { &mut BB };
+    //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
     for a in ptr.data.iter() {
         println!("{}", a);
     }

--- a/tests/ui/consts/const_let_assign2.stderr
+++ b/tests/ui/consts/const_let_assign2.stderr
@@ -1,0 +1,17 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/const_let_assign2.rs:18:24
+   |
+LL |     let ptr = unsafe { &mut BB };
+   |                        ^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     let ptr = unsafe { addr_of_mut!(BB) };
+   |                        ~~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/consts/escaping-bound-var.rs
+++ b/tests/ui/consts/escaping-bound-var.rs
@@ -3,7 +3,7 @@
 
 fn test<'a>(
     _: &'a (),
-) -> [(); {
+) -> [(); { //~ ERROR: mismatched types
     let x: &'a ();
     //~^ ERROR cannot capture late-bound lifetime in constant
     1

--- a/tests/ui/consts/escaping-bound-var.stderr
+++ b/tests/ui/consts/escaping-bound-var.stderr
@@ -16,5 +16,23 @@ LL | fn test<'a>(
 LL |     let x: &'a ();
    |             ^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0308]: mismatched types
+  --> $DIR/escaping-bound-var.rs:6:6
+   |
+LL |   fn test<'a>(
+   |      ---- implicitly returns `()` as its body has no tail or `return` expression
+LL |       _: &'a (),
+LL |   ) -> [(); {
+   |  ______^
+LL | |     let x: &'a ();
+LL | |
+LL | |     1
+LL | | }] {
+   | |__^ expected `[(); {
+    let x: &'a ();
+    1
+}]`, found `()`
 
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-103790.rs
+++ b/tests/ui/consts/issue-103790.rs
@@ -6,5 +6,6 @@ struct S<const S: (), const S: S = { S }>;
 //~| ERROR missing generics for struct `S`
 //~| ERROR cycle detected when computing type of `S::S`
 //~| ERROR cycle detected when computing type of `S`
+//~| ERROR `()` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -61,7 +61,16 @@ LL | | fn main() {}
    | |____________^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 4 previous errors
+error: `()` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-103790.rs:4:19
+   |
+LL | struct S<const S: (), const S: S = { S }>;
+   |                   ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0107, E0391, E0403.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/consts/issue-17718-const-bad-values.rs
+++ b/tests/ui/consts/issue-17718-const-bad-values.rs
@@ -3,7 +3,8 @@ const C1: &'static mut [usize] = &mut [];
 
 static mut S: usize = 3;
 const C2: &'static mut usize = unsafe { &mut S };
-//~^ ERROR: constants cannot refer to statics
+//~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+//~^^ ERROR: constants cannot refer to statics
 //~| ERROR: constants cannot refer to statics
 
 fn main() {}

--- a/tests/ui/consts/issue-17718-const-bad-values.stderr
+++ b/tests/ui/consts/issue-17718-const-bad-values.stderr
@@ -1,3 +1,18 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/issue-17718-const-bad-values.rs:5:41
+   |
+LL | const C2: &'static mut usize = unsafe { &mut S };
+   |                                         ^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL | const C2: &'static mut usize = unsafe { addr_of_mut!(S) };
+   |                                         ~~~~~~~~~~~~~~~
+
 error[E0764]: mutable references are not allowed in the final value of constants
   --> $DIR/issue-17718-const-bad-values.rs:1:34
    |
@@ -21,7 +36,7 @@ LL | const C2: &'static mut usize = unsafe { &mut S };
    = help: consider extracting the value of the `static` to a `const`, and referring to that
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0013, E0764.
 For more information about an error, try `rustc --explain E0013`.

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
@@ -1,3 +1,18 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/const_refers_to_static_cross_crate.rs:13:14
+   |
+LL |     unsafe { &static_cross_crate::ZERO }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     unsafe { addr_of!(static_cross_crate::ZERO) }
+   |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:10:1
    |
@@ -10,13 +25,13 @@ LL | const SLICE_MUT: &[u8; 1] = {
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:34:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:42:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:15:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
    |
 LL | const U8_MUT: &u8 = {
    | ^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to a static variable in a constant
@@ -27,31 +42,31 @@ LL | const U8_MUT: &u8 = {
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:42:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:50:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:15
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:52:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:59:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:67:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
@@ -59,61 +74,61 @@ LL |         U8_MUT3 => true,
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:13:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:13:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:17
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:17
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors; 1 warning emitted
+error: aborting due to 8 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
@@ -1,3 +1,18 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/const_refers_to_static_cross_crate.rs:13:14
+   |
+LL |     unsafe { &static_cross_crate::ZERO }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     unsafe { addr_of!(static_cross_crate::ZERO) }
+   |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:10:1
    |
@@ -10,13 +25,13 @@ LL | const SLICE_MUT: &[u8; 1] = {
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:34:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:42:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:15:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
    |
 LL | const U8_MUT: &u8 = {
    | ^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to a static variable in a constant
@@ -27,31 +42,31 @@ LL | const U8_MUT: &u8 = {
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:42:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:50:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:15
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:52:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:59:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:67:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
@@ -59,61 +74,61 @@ LL |         U8_MUT3 => true,
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:13:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:13:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:20:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:22:17
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:17
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
-LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         match static_cross_crate::OPT_ZERO {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors; 1 warning emitted
+error: aborting due to 8 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -7,13 +7,16 @@ extern crate static_cross_crate;
 
 // Sneaky: reference to a mutable static.
 // Allowing this would be a disaster for pattern matching, we could violate exhaustiveness checking!
-const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior to use this value
-//~| encountered a reference pointing to a static variable
+const SLICE_MUT: &[u8; 1] = {
+    //~^ ERROR undefined behavior to use this value
+    //~| encountered a reference pointing to a static variable
     unsafe { &static_cross_crate::ZERO }
+    //~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
 };
 
-const U8_MUT: &u8 = { //~ ERROR undefined behavior to use this value
-//~| encountered a reference pointing to a static variable
+const U8_MUT: &u8 = {
+    //~^ ERROR undefined behavior to use this value
+    //~| encountered a reference pointing to a static variable
     unsafe { &static_cross_crate::ZERO[0] }
 };
 
@@ -24,9 +27,14 @@ const U8_MUT2: &u8 = {
     //~| constant accesses static
 };
 const U8_MUT3: &u8 = {
-    unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
-    //~^ ERROR evaluation of constant value failed
-    //~| constant accesses static
+    unsafe {
+        match static_cross_crate::OPT_ZERO {
+            //~^ ERROR evaluation of constant value failed
+            //~| constant accesses static
+            Some(ref u) => u,
+            None => panic!(),
+        }
+    }
 };
 
 pub fn test(x: &[u8; 1]) -> bool {

--- a/tests/ui/consts/static_mut_containing_mut_ref.rs
+++ b/tests/ui/consts/static_mut_containing_mut_ref.rs
@@ -3,5 +3,6 @@
 static mut STDERR_BUFFER_SPACE: [u8; 42] = [0u8; 42];
 
 pub static mut STDERR_BUFFER: *mut [u8] = unsafe { &mut STDERR_BUFFER_SPACE };
+//~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
 
 fn main() {}

--- a/tests/ui/consts/static_mut_containing_mut_ref.stderr
+++ b/tests/ui/consts/static_mut_containing_mut_ref.stderr
@@ -1,0 +1,17 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/static_mut_containing_mut_ref.rs:5:52
+   |
+LL | pub static mut STDERR_BUFFER: *mut [u8] = unsafe { &mut STDERR_BUFFER_SPACE };
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL | pub static mut STDERR_BUFFER: *mut [u8] = unsafe { addr_of_mut!(STDERR_BUFFER_SPACE) };
+   |                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/consts/static_mut_containing_mut_ref2.mut_refs.stderr
+++ b/tests/ui/consts/static_mut_containing_mut_ref2.mut_refs.stderr
@@ -1,9 +1,24 @@
-error[E0080]: could not evaluate static initializer
-  --> $DIR/static_mut_containing_mut_ref2.rs:7:45
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/static_mut_containing_mut_ref2.rs:8:6
    |
-LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ modifying a static's initial value from another static's initializer
+LL |     *(&mut STDERR_BUFFER_SPACE) = 42;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     *addr_of_mut!(STDERR_BUFFER_SPACE) = 42;
+   |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 1 previous error
+error[E0080]: could not evaluate static initializer
+  --> $DIR/static_mut_containing_mut_ref2.rs:8:5
+   |
+LL |     *(&mut STDERR_BUFFER_SPACE) = 42;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ modifying a static's initial value from another static's initializer
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/static_mut_containing_mut_ref2.rs
+++ b/tests/ui/consts/static_mut_containing_mut_ref2.rs
@@ -4,8 +4,12 @@
 
 static mut STDERR_BUFFER_SPACE: u8 = 0;
 
-pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-//[mut_refs]~^ ERROR could not evaluate static initializer
-//[stock]~^^ ERROR mutable references are not allowed in statics
+pub static mut STDERR_BUFFER: () = unsafe {
+    *(&mut STDERR_BUFFER_SPACE) = 42;
+    //[mut_refs]~^ ERROR could not evaluate static initializer
+    //[stock]~^^ ERROR mutable references are not allowed in statics
+    //[mut_refs]~^^^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+    //[stock]~^^^^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+};
 
 fn main() {}

--- a/tests/ui/consts/static_mut_containing_mut_ref2.stock.stderr
+++ b/tests/ui/consts/static_mut_containing_mut_ref2.stock.stderr
@@ -1,12 +1,27 @@
-error[E0658]: mutable references are not allowed in statics
-  --> $DIR/static_mut_containing_mut_ref2.rs:7:46
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/static_mut_containing_mut_ref2.rs:8:6
    |
-LL | pub static mut STDERR_BUFFER: () = unsafe { *(&mut STDERR_BUFFER_SPACE) = 42; };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     *(&mut STDERR_BUFFER_SPACE) = 42;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     *addr_of_mut!(STDERR_BUFFER_SPACE) = 42;
+   |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error[E0658]: mutable references are not allowed in statics
+  --> $DIR/static_mut_containing_mut_ref2.rs:8:6
+   |
+LL |     *(&mut STDERR_BUFFER_SPACE) = 42;
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error: aborting due to 1 previous error
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/derives/issue-97343.rs
+++ b/tests/ui/derives/issue-97343.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed on type parameter
+    //~^ ERROR `Irrelevant` must be used
     irrelevant: Irrelevant,
 }
 

--- a/tests/ui/derives/issue-97343.stderr
+++ b/tests/ui/derives/issue-97343.stderr
@@ -16,6 +16,16 @@ LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0210]: type parameter `Irrelevant` must be used as the type parameter for some local type (e.g., `MyStruct<Irrelevant>`)
+  --> $DIR/issue-97343.rs:4:23
+   |
+LL | pub struct Irrelevant<Irrelevant> {
+   |                       ^^^^^^^^^^ type parameter `Irrelevant` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
-For more information about this error, try `rustc --explain E0109`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0109, E0210.
+For more information about an error, try `rustc --explain E0109`.

--- a/tests/ui/did_you_mean/bad-assoc-ty.rs
+++ b/tests/ui/did_you_mean/bad-assoc-ty.rs
@@ -71,6 +71,7 @@ enum N<F> where F: Fn() -> _ {
 union O<F> where F: Fn() -> _ {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for unions
     foo: F,
+    //~^ ERROR must implement `Copy`
 }
 
 trait P<F> where F: Fn() -> _ {

--- a/tests/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.stderr
@@ -299,7 +299,7 @@ LL | union O<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:76:29
+  --> $DIR/bad-assoc-ty.rs:77:29
    |
 LL | trait P<F> where F: Fn() -> _ {
    |                             ^ not allowed in type signatures
@@ -310,7 +310,7 @@ LL | trait P<F, T> where F: Fn() -> T {
    |          +++                   ~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:81:38
+  --> $DIR/bad-assoc-ty.rs:82:38
    |
 LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
    |                                      ^ not allowed in type signatures
@@ -320,7 +320,19 @@ help: use type parameters instead
 LL |     fn foo<F, T>(_: F) where F: Fn() -> T {}
    |             +++                         ~
 
-error: aborting due to 28 previous errors; 1 warning emitted
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/bad-assoc-ty.rs:73:5
+   |
+LL |     foo: F,
+   |     ^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL |     foo: std::mem::ManuallyDrop<F>,
+   |          +++++++++++++++++++++++ +
 
-Some errors have detailed explanations: E0121, E0223.
+error: aborting due to 29 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0121, E0223, E0740.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.fixed
@@ -8,6 +8,7 @@ trait Foo<T>: Sized {
 impl Foo<usize> for () {
     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~| ERROR type annotations needed
         (1, 2)
     }
 }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.rs
@@ -8,6 +8,7 @@ trait Foo<T>: Sized {
 impl Foo<usize> for () {
     fn bar(i: _, t: _, s: _) -> _ {
         //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        //~| ERROR type annotations needed
         (1, 2)
     }
 }

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
@@ -13,6 +13,13 @@ help: try replacing `_` with the types in the corresponding trait method signatu
 LL |     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
    |               ~~~     ~~~~~     ~~~     ~~~~~~~~~~~~
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:12
+   |
+LL |     fn bar(i: _, t: _, s: _) -> _ {
+   |            ^ cannot infer type
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0121, E0282.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
@@ -13,38 +13,39 @@ pub fn main() {
     d::println("created empty log");
     test(&log);
 
-    assert_eq!(&log.borrow()[..],
-               [
-                   //                                    created empty log
-                   //    +-- Make D(da_0, 0)
-                   //    | +-- Make D(de_1, 1)
-                   //    | |                             calling foo
-                   //    | |                             entered foo
-                   //    | | +-- Make D(de_2, 2)
-                   //    | | | +-- Make D(da_1, 3)
-                   //    | | | | +-- Make D(de_3, 4)
-                   //    | | | | | +-- Make D(de_4, 5)
-                   3, // | | | +-- Drop D(da_1, 3)
-                   //    | | |   | |
-                   4, // | | |   +-- Drop D(de_3, 4)
-                   //    | | |     |
-                   //    | | |     |                     eval tail of foo
-                   //    | | | +-- Make D(de_5, 6)
-                   //    | | | | +-- Make D(de_6, 7)
-                   5, // | | | | | +-- Drop D(de_4, 5)
-                   //    | | | | |
-                   2, // | | +-- Drop D(de_2, 2)
-                   //    | |   | |
-                   6, // | |   +-- Drop D(de_5, 6)
-                   //    | |     |
-                   1, // | +-- Drop D(de_1, 1)
-                   //    |       |
-                   0, // +-- Drop D(da_0, 0)
-                   //            |
-                   //            |                       result D(de_6, 7)
-                   7 //          +-- Drop D(de_6, 7)
-
-                       ]);
+    assert_eq!(
+        &log.borrow()[..],
+        [
+            //                                    created empty log
+            //    +-- Make D(da_0, 0)
+            //    | +-- Make D(de_1, 1)
+            //    | |                             calling foo
+            //    | |                             entered foo
+            //    | | +-- Make D(de_2, 2)
+            //    | | | +-- Make D(da_1, 3)
+            //    | | | | +-- Make D(de_3, 4)
+            //    | | | | | +-- Make D(de_4, 5)
+            3, // | | | +-- Drop D(da_1, 3)
+            //    | | |   | |
+            4, // | | |   +-- Drop D(de_3, 4)
+            //    | | |     |
+            //    | | |     |                     eval tail of foo
+            //    | | | +-- Make D(de_5, 6)
+            //    | | | | +-- Make D(de_6, 7)
+            5, // | | | | | +-- Drop D(de_4, 5)
+            //    | | | | |
+            2, // | | +-- Drop D(de_2, 2)
+            //    | |   | |
+            6, // | |   +-- Drop D(de_5, 6)
+            //    | |     |
+            1, // | +-- Drop D(de_1, 1)
+            //    |       |
+            0, // +-- Drop D(da_0, 0)
+            //            |
+            //            |                       result D(de_6, 7)
+            7 //          +-- Drop D(de_6, 7)
+        ]
+    );
 }
 
 fn test<'a>(log: d::Log<'a>) {
@@ -57,13 +58,13 @@ fn test<'a>(log: d::Log<'a>) {
 
 fn foo<'a>(da0: D<'a>, de1: D<'a>) -> D<'a> {
     d::println("entered foo");
-    let de2 = de1.incr();      // creates D(de_2, 2)
+    let de2 = de1.incr(); // creates D(de_2, 2)
     let de4 = {
         let _da1 = da0.incr(); // creates D(da_1, 3)
-        de2.incr().incr()      // creates D(de_3, 4) and D(de_4, 5)
+        de2.incr().incr() // creates D(de_3, 4) and D(de_4, 5)
     };
     d::println("eval tail of foo");
-    de4.incr().incr()          // creates D(de_5, 6) and D(de_6, 7)
+    de4.incr().incr() // creates D(de_5, 6) and D(de_6, 7)
 }
 
 // This module provides simultaneous printouts of the dynamic extents
@@ -74,9 +75,9 @@ const PREF_INDENT: u32 = 16;
 
 pub mod d {
     #![allow(unused_parens)]
+    use std::cell::RefCell;
     use std::fmt;
     use std::mem;
-    use std::cell::RefCell;
 
     static mut counter: u32 = 0;
     static mut trails: u64 = 0;
@@ -89,7 +90,8 @@ pub mod d {
 
     pub fn max_width() -> u32 {
         unsafe {
-            (mem::size_of_val(&trails)*8) as u32
+            (mem::size_of_val(&trails) * 8) as u32
+            //~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
         }
     }
 
@@ -123,7 +125,11 @@ pub mod d {
     }
 
     pub struct D<'a> {
-        name: &'static str, i: u32, uid: u32, trail: u32, log: Log<'a>
+        name: &'static str,
+        i: u32,
+        uid: u32,
+        trail: u32,
+        log: Log<'a>,
     }
 
     impl<'a> fmt::Display for D<'a> {
@@ -139,9 +145,7 @@ pub mod d {
                 let ctr = counter;
                 counter += 1;
                 trails |= (1 << trail);
-                let ret = D {
-                    name: name, i: i, log: log, uid: ctr, trail: trail
-                };
+                let ret = D { name: name, i: i, log: log, uid: ctr, trail: trail };
                 indent_println(trail, &format!("+-- Make {}", ret));
                 ret
             }
@@ -153,7 +157,9 @@ pub mod d {
 
     impl<'a> Drop for D<'a> {
         fn drop(&mut self) {
-            unsafe { trails &= !(1 << self.trail); };
+            unsafe {
+                trails &= !(1 << self.trail);
+            };
             self.log.borrow_mut().push(self.uid);
             indent_println(self.trail, &format!("+-- Drop {}", self));
             indent_println(::PREF_INDENT, "");

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.stderr
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.stderr
@@ -1,0 +1,17 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/issue-23338-ensure-param-drop-order.rs:93:31
+   |
+LL |             (mem::size_of_val(&trails) * 8) as u32
+   |                               ^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |             (mem::size_of_val(addr_of!(trails)) * 8) as u32
+   |                               ~~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
@@ -4,6 +4,7 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
     let _x: &SomeTrait = todo!();
+    //~^ ERROR trait objects must include the `dyn` keyword
 }
 
 trait SomeTrait {}

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -20,6 +20,17 @@ help: add `dyn` keyword before this trait
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    |                                   +++
 
-error: aborting due to 2 previous errors
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/dyn-2021-edition-error.rs:6:14
+   |
+LL |     let _x: &SomeTrait = todo!();
+   |              ^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL |     let _x: &dyn SomeTrait = todo!();
+   |              +++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/error-codes/E0017.rs
+++ b/tests/ui/error-codes/E0017.rs
@@ -3,12 +3,16 @@ const C: i32 = 2;
 static mut M: i32 = 3;
 
 const CR: &'static mut i32 = &mut C; //~ ERROR mutable references are not allowed
-                                     //~| WARN taking a mutable
+//~| WARN taking a mutable
+
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0658
-                                              //~| ERROR cannot borrow
-                                              //~| ERROR mutable references are not allowed
+//~| ERROR cannot borrow
+//~| ERROR mutable references are not allowed
 
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR mutable references are not allowed
-                                              //~| WARN taking a mutable
+//~| WARN taking a mutable
+
 static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M }; //~ ERROR mutable references are not
+//~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+
 fn main() {}

--- a/tests/ui/error-codes/E0017.stderr
+++ b/tests/ui/error-codes/E0017.stderr
@@ -1,3 +1,18 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/E0017.rs:15:52
+   |
+LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
+   |                                                    ^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { addr_of_mut!(M) };
+   |                                                    ~~~~~~~~~~~~~~~
+
 warning: taking a mutable reference to a `const` item
   --> $DIR/E0017.rs:5:30
    |
@@ -20,7 +35,7 @@ LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^
 
 error[E0658]: mutation through a reference is not allowed in statics
-  --> $DIR/E0017.rs:7:39
+  --> $DIR/E0017.rs:8:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^
@@ -29,19 +44,19 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/E0017.rs:7:39
+  --> $DIR/E0017.rs:8:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
-  --> $DIR/E0017.rs:7:39
+  --> $DIR/E0017.rs:8:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
 warning: taking a mutable reference to a `const` item
-  --> $DIR/E0017.rs:11:38
+  --> $DIR/E0017.rs:12:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^
@@ -55,18 +70,18 @@ LL | const C: i32 = 2;
    | ^^^^^^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/E0017.rs:11:38
+  --> $DIR/E0017.rs:12:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/E0017.rs:13:52
+  --> $DIR/E0017.rs:15:52
    |
 LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
    |                                                    ^^^^^^
 
-error: aborting due to 6 previous errors; 2 warnings emitted
+error: aborting due to 6 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0596, E0658, E0764.
 For more information about an error, try `rustc --explain E0596`.

--- a/tests/ui/error-codes/E0227.rs
+++ b/tests/ui/error-codes/E0227.rs
@@ -6,6 +6,7 @@ trait FooBar<'foo, 'bar>: Foo<'foo> + Bar<'bar> {}
 struct Baz<'foo, 'bar> {
     baz: dyn FooBar<'foo, 'bar>,
     //~^ ERROR ambiguous lifetime bound, explicit lifetime bound required
+    //~| ERROR lifetime bound not satisfied
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0227.stderr
+++ b/tests/ui/error-codes/E0227.stderr
@@ -4,6 +4,24 @@ error[E0227]: ambiguous lifetime bound, explicit lifetime bound required
 LL |     baz: dyn FooBar<'foo, 'bar>,
    |          ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/E0227.rs:7:10
+   |
+LL |     baz: dyn FooBar<'foo, 'bar>,
+   |          ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lifetime parameter instantiated with the lifetime `'bar` as defined here
+  --> $DIR/E0227.rs:6:18
+   |
+LL | struct Baz<'foo, 'bar> {
+   |                  ^^^^
+note: but lifetime parameter must outlive the lifetime `'foo` as defined here
+  --> $DIR/E0227.rs:6:12
+   |
+LL | struct Baz<'foo, 'bar> {
+   |            ^^^^
 
-For more information about this error, try `rustc --explain E0227`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0227, E0478.
+For more information about an error, try `rustc --explain E0227`.

--- a/tests/ui/error-codes/E0229.rs
+++ b/tests/ui/error-codes/E0229.rs
@@ -12,6 +12,9 @@ impl Foo for isize {
 
 fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
 //~^ ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR associated type bindings are not allowed here [E0229]
+//~| ERROR the trait bound `I: Foo` is not satisfied
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -4,6 +4,34 @@ error[E0229]: associated type bindings are not allowed here
 LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
    |                         ^^^^^ associated type not allowed here
 
-error: aborting due to 1 previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/E0229.rs:13:25
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                         ^^^^^ associated type not allowed here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-For more information about this error, try `rustc --explain E0229`.
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/E0229.rs:13:25
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                         ^^^^^ associated type not allowed here
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the trait bound `I: Foo` is not satisfied
+  --> $DIR/E0229.rs:13:15
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |               ^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `I`
+   |
+help: consider restricting type parameter `I`
+   |
+LL | fn baz<I: Foo>(x: &<I as Foo<A=Bar>>::A) {}
+   |         +++++
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/error-codes/E0719.rs
+++ b/tests/ui/error-codes/E0719.rs
@@ -1,6 +1,7 @@
 trait Foo: Iterator<Item = i32, Item = i32> {}
 //~^ ERROR is already specified
 //~| ERROR is already specified
+//~| ERROR is already specified
 
 type Unit = ();
 
@@ -11,5 +12,6 @@ fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
 
 fn main() {
     let _: &dyn Iterator<Item = i32, Item = i32>;
+    //~^ ERROR already specified
     test();
 }

--- a/tests/ui/error-codes/E0719.stderr
+++ b/tests/ui/error-codes/E0719.stderr
@@ -17,13 +17,31 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/E0719.rs:7:42
+  --> $DIR/E0719.rs:8:42
    |
 LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
    |                               ---------  ^^^^^^^^^^^ re-bound here
    |                               |
    |                               `Item` bound here first
 
-error: aborting due to 3 previous errors
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:1:33
+   |
+LL | trait Foo: Iterator<Item = i32, Item = i32> {}
+   |                     ----------  ^^^^^^^^^^ re-bound here
+   |                     |
+   |                     `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:14:38
+   |
+LL |     let _: &dyn Iterator<Item = i32, Item = i32>;
+   |                          ----------  ^^^^^^^^^^ re-bound here
+   |                          |
+   |                          `Item` bound here first
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0719`.

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for () {
     type Bar = impl std::fmt::Debug;
     //~^ ERROR: `impl Trait` in associated types is unstable
+    //~| ERROR: unconstrained opaque type
 }
 
 struct Mop;
@@ -13,6 +14,7 @@ impl Mop {
     type Bop = impl std::fmt::Debug;
     //~^ ERROR: `impl Trait` in associated types is unstable
     //~| ERROR: inherent associated types are unstable
+    //~| ERROR: unconstrained opaque type
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
@@ -8,7 +8,7 @@ LL |     type Bar = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: `impl Trait` in associated types is unstable
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:16
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
    |
 LL |     type Bop = impl std::fmt::Debug;
    |                ^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     type Bop = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
 
 error[E0658]: inherent associated types are unstable
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:13:5
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:5
    |
 LL |     type Bop = impl std::fmt::Debug;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,6 +25,22 @@ LL |     type Bop = impl std::fmt::Debug;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16
+   |
+LL |     type Bar = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bar` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16
+   |
+LL |     type Bop = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bop` must be used in combination with a concrete type within the same impl
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.rs
@@ -7,29 +7,35 @@
 
 struct Foo;
 impl Fn<()> for Foo {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `Fn` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `Fn` are experimental
+    //~| ERROR expected a `FnMut()` closure, found `Foo`
     extern "rust-call" fn call(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
+    //~| ERROR `call` has an incompatible type for trait
 }
 struct Foo1;
 impl FnOnce() for Foo1 {
-//~^ ERROR associated type bindings are not allowed here
-//~| ERROR manual implementations of `FnOnce` are experimental
+    //~^ ERROR associated type bindings are not allowed here
+    //~| ERROR manual implementations of `FnOnce` are experimental
+    //~| ERROR not all trait items implemented
     extern "rust-call" fn call_once(self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }
 struct Bar;
 impl FnMut<()> for Bar {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `FnMut` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `FnMut` are experimental
+    //~| ERROR expected a `FnOnce()` closure, found `Bar`
     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
+    //~| ERROR incompatible type for trait
 }
 struct Baz;
 impl FnOnce<()> for Baz {
-//~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
-//~| ERROR manual implementations of `FnOnce` are experimental
+    //~^ ERROR the precise format of `Fn`-family traits' type parameters is subject to change
+    //~| ERROR manual implementations of `FnOnce` are experimental
+    //~| ERROR not all trait items implemented
     extern "rust-call" fn call_once(&self, args: ()) -> () {}
     //~^ ERROR rust-call ABI is subject to change
 }

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -1,5 +1,5 @@
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:12:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:12
    |
 LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:19:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:22:12
    |
 LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:12
    |
 LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:33:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:39:12
    |
 LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |            ^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL | impl Fn<()> for Foo {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ manual implementations of `FnOnce` are experimental
@@ -60,19 +60,19 @@ LL | impl FnOnce() for Foo1 {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^ associated type not allowed here
    |
 help: parenthesized trait syntax expands to `FnOnce<(), Output=()>`
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
    |
 LL | impl FnOnce() for Foo1 {
    |      ^^^^^^^^
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^
@@ -81,7 +81,7 @@ LL | impl FnMut<()> for Bar {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnMut` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^ manual implementations of `FnMut` are experimental
@@ -89,7 +89,7 @@ LL | impl FnMut<()> for Bar {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
    |
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^
@@ -98,14 +98,76 @@ LL | impl FnOnce<()> for Baz {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
    |
 LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 12 previous errors
+error[E0277]: expected a `FnMut()` closure, found `Foo`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:17
+   |
+LL | impl Fn<()> for Foo {
+   |                 ^^^ expected an `FnMut()` closure, found `Foo`
+   |
+   = help: the trait `FnMut<()>` is not implemented for `Foo`
+   = note: wrap the `Foo` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0229, E0658.
-For more information about an error, try `rustc --explain E0183`.
+error[E0277]: expected a `FnOnce()` closure, found `Bar`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:20
+   |
+LL | impl FnMut<()> for Bar {
+   |                    ^^^ expected an `FnOnce()` closure, found `Bar`
+   |
+   = help: the trait `FnOnce<()>` is not implemented for `Bar`
+   = note: wrap the `Bar` in a closure with no arguments: `|| { /* code */ }`
+note: required by a bound in `FnMut`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error[E0053]: method `call` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:13:32
+   |
+LL |     extern "rust-call" fn call(self, args: ()) -> () {}
+   |                                ^^^^
+   |                                |
+   |                                expected `&Foo`, found `Foo`
+   |                                help: change the self-receiver type to match the trait: `&self`
+   |
+   = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
+              found signature `extern "rust-call" fn(Foo, ())`
+
+error[E0046]: not all trait items implemented, missing: `Output`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:1
+   |
+LL | impl FnOnce() for Foo1 {
+   | ^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+
+error[E0053]: method `call_mut` has an incompatible type for trait
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:36
+   |
+LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
+   |                                    ^^^^^
+   |                                    |
+   |                                    types differ in mutability
+   |                                    help: change the self-receiver type to match the trait: `&mut self`
+   |
+   = note: expected signature `extern "rust-call" fn(&mut Bar, ()) -> _`
+              found signature `extern "rust-call" fn(&Bar, ())`
+
+error[E0046]: not all trait items implemented, missing: `Output`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:1
+   |
+LL | impl FnOnce<()> for Baz {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation
+   |
+   = help: implement the missing item: `type Output = /* Type */;`
+
+error: aborting due to 18 previous errors
+
+Some errors have detailed explanations: E0046, E0053, E0183, E0229, E0277, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/fn/issue-39259.rs
+++ b/tests/ui/fn/issue-39259.rs
@@ -4,8 +4,10 @@
 struct S;
 
 impl Fn(u32) -> u32 for S {
-//~^ ERROR associated type bindings are not allowed here [E0229]
+    //~^ ERROR associated type bindings are not allowed here [E0229]
+    //~| ERROR expected a `FnMut(u32)` closure, found `S`
     fn call(&self) -> u32 {
+        //~^ ERROR method `call` has 1 parameter but the declaration in trait `call` has 2
         5
     }
 }

--- a/tests/ui/fn/issue-39259.stderr
+++ b/tests/ui/fn/issue-39259.stderr
@@ -10,6 +10,25 @@ help: parenthesized trait syntax expands to `Fn<(u32,), Output=u32>`
 LL | impl Fn(u32) -> u32 for S {
    |      ^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: expected a `FnMut(u32)` closure, found `S`
+  --> $DIR/issue-39259.rs:6:25
+   |
+LL | impl Fn(u32) -> u32 for S {
+   |                         ^ expected an `FnMut(u32)` closure, found `S`
+   |
+   = help: the trait `FnMut<(u32,)>` is not implemented for `S`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0229`.
+error[E0050]: method `call` has 1 parameter but the declaration in trait `call` has 2
+  --> $DIR/issue-39259.rs:9:13
+   |
+LL |     fn call(&self) -> u32 {
+   |             ^^^^^ expected 2 parameters, found 1
+   |
+   = note: `call` from trait: `extern "rust-call" fn(&Self, Args) -> <Self as FnOnce<Args>>::Output`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0050, E0229, E0277.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
@@ -6,4 +6,7 @@ fn main() {
   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
     //~^ ERROR: use of undeclared lifetime name `'x`
     //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: binding for associated type `Y` references lifetime
+    //~| ERROR: the trait `X` cannot be made into an object
 }

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
@@ -20,7 +20,38 @@ error[E0582]: binding for associated type `Y` references lifetime `'a`, which do
 LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
    |                                 ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0582]: binding for associated type `Y` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:33
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-Some errors have detailed explanations: E0261, E0582.
-For more information about an error, try `rustc --explain E0261`.
+error[E0582]: binding for associated type `Y` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:33
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:19
+   |
+LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'x>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0038, E0261, E0582.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
@@ -4,10 +4,11 @@ trait X {
   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
 }
 
-impl<T> X for T {
+impl<T> X for T { //~ ERROR: not all trait items implemented
   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
     //~^ ERROR missing generics for associated type
     //~^^ ERROR missing generics for associated type
+    //~| ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
     t
   }
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -31,6 +31,27 @@ help: add missing lifetime argument
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
    |                     ++++
 
-error: aborting due to 2 previous errors
+error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/gat-trait-path-missing-lifetime.rs:8:10
+   |
+LL |   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
+   |          -- expected 0 type parameters
+...
+LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
+   |          ^^  ^^
+   |          |
+   |          found 1 type parameter
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0046]: not all trait items implemented, missing: `Y`
+  --> $DIR/gat-trait-path-missing-lifetime.rs:7:1
+   |
+LL |   type Y<'a>;
+   |   ---------- `Y` from trait
+...
+LL | impl<T> X for T {
+   | ^^^^^^^^^^^^^^^ missing `Y` in implementation
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0049, E0107.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
@@ -7,10 +7,19 @@ fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
   //~| ERROR: parenthesized generic arguments cannot be used
   //~| ERROR associated type takes 0 generic arguments but 1 generic argument
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR at least one trait is required
+  //~| ERROR: the trait `X` cannot be made into an object
 
 
 fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
   //~^ ERROR: parenthesized generic arguments cannot be used
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+  //~| ERROR: the trait `X` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -16,7 +16,7 @@ LL | fn foo<'a>(arg: Box<dyn X<Y<'a> = &'a ()>>) {}
    |                            ~  ~
 
 error: parenthesized generic arguments cannot be used in associated type constraints
-  --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                           ^--
@@ -54,7 +54,7 @@ LL |   type Y<'a>;
    |        ^
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/gat-trait-path-parenthesised-args.rs:12:27
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                           ^ expected 1 lifetime argument
@@ -69,6 +69,141 @@ help: add missing lifetime argument
 LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
    |                             ++
 
-error: aborting due to 6 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
+   |                             +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^---- help: remove these generics
+   |                           |
+   |                           expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('_, 'a) = &'a ()>>) {}
+   |                             +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                           ^---- help: remove these generics
+   |                           |
+   |                           expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:29
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                             ^^
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-trait-path-parenthesised-args.rs:5:21
+   |
+LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+   |                     ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'a>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:21
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                     ^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |   type Y<'a>;
+   |        ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0038, E0107, E0224.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-71176.rs
+++ b/tests/ui/generic-associated-types/issue-71176.rs
@@ -9,6 +9,9 @@ impl Provider for () {
 struct Holder<B> {
   inner: Box<dyn Provider<A = B>>,
   //~^ ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: missing generics for associated type
+  //~| ERROR: the trait `Provider` cannot be made into an object
 }
 
 fn main() {

--- a/tests/ui/generic-associated-types/issue-71176.stderr
+++ b/tests/ui/generic-associated-types/issue-71176.stderr
@@ -14,6 +14,57 @@ help: add missing lifetime argument
 LL |   inner: Box<dyn Provider<A<'a> = B>>,
    |                            ++++
 
-error: aborting due to 1 previous error
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:10:27
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   inner: Box<dyn Provider<A<'a> = B>>,
+   |                            ++++
+
+error[E0038]: the trait `Provider` cannot be made into an object
+  --> $DIR/issue-71176.rs:10:14
+   |
+LL |   inner: Box<dyn Provider<A = B>>,
+   |              ^^^^^^^^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-71176.rs:2:10
+   |
+LL | trait Provider {
+   |       -------- this trait cannot be made into an object...
+LL |     type A<'a>;
+   |          ^ ...because it contains the generic associated type `A`
+   = help: consider moving `A` to another trait
+   = help: only type `()` implements the trait, consider using it directly instead
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/issue-79636-1.rs
+++ b/tests/ui/generic-associated-types/issue-79636-1.rs
@@ -3,6 +3,7 @@ trait Monad {
     type Wrapped<B>;
 
     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+        //~^ ERROR: the size for values of type `Self` cannot be known
         todo!()
     }
 }
@@ -14,8 +15,10 @@ where
     //~^ ERROR: missing generics for associated type `Monad::Wrapped`
 {
     outer.bind(|inner| inner)
+    //~^ ERROR type annotations needed
 }
 
 fn main() {
     assert_eq!(join(Some(Some(true))), Some(true));
+    //~^ ERROR: `Option<Option<bool>>: Monad` is not satisfied
 }

--- a/tests/ui/generic-associated-types/issue-79636-1.stderr
+++ b/tests/ui/generic-associated-types/issue-79636-1.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for associated type `Monad::Wrapped`
-  --> $DIR/issue-79636-1.rs:13:34
+  --> $DIR/issue-79636-1.rs:14:34
    |
 LL |     MInner: Monad<Unwrapped = A, Wrapped = MOuter::Wrapped<A>>,
    |                                  ^^^^^^^ expected 1 generic argument
@@ -14,6 +14,56 @@ help: add missing generic argument
 LL |     MInner: Monad<Unwrapped = A, Wrapped<B> = MOuter::Wrapped<A>>,
    |                                         +++
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-79636-1.rs:5:19
+   |
+LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+   |                   ^^^^ doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider further restricting `Self`
+   |
+LL |     fn bind<B, F>(self, f: F) -> Self::Wrapped<B> where Self: Sized {
+   |                                                   +++++++++++++++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     fn bind<B, F>(&self, f: F) -> Self::Wrapped<B> {
+   |                   +
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0282]: type annotations needed
+  --> $DIR/issue-79636-1.rs:17:17
+   |
+LL |     outer.bind(|inner| inner)
+   |                 ^^^^^
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     outer.bind(|inner: /* Type */| inner)
+   |                      ++++++++++++
+
+error[E0277]: the trait bound `Option<Option<bool>>: Monad` is not satisfied
+  --> $DIR/issue-79636-1.rs:22:21
+   |
+LL |     assert_eq!(join(Some(Some(true))), Some(true));
+   |                ---- ^^^^^^^^^^^^^^^^ the trait `Monad` is not implemented for `Option<Option<bool>>`
+   |                |
+   |                required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/issue-79636-1.rs:1:1
+   |
+LL | trait Monad {
+   | ^^^^^^^^^^^
+note: required by a bound in `join`
+  --> $DIR/issue-79636-1.rs:13:13
+   |
+LL | fn join<MOuter, MInner, A>(outer: MOuter) -> MOuter::Wrapped<A>
+   |    ---- required by a bound in this function
+LL | where
+LL |     MOuter: Monad<Unwrapped = MInner>,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `join`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0277, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -4,7 +4,7 @@ struct E<T> {
 }
 
 trait TestMut {
-    type Output<'a>;
+    type Output<'a>; //~ ERROR missing required bound
     fn test_mut<'a>(&'a mut self) -> Self::Output<'a>;
 }
 

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -14,6 +14,17 @@ help: add missing lifetime argument
 LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output<'a> = &'a mut f32>)
    |                                                     ++++
 
-error: aborting due to 1 previous error
+error: missing required bound on `Output`
+  --> $DIR/issue-80433.rs:7:5
+   |
+LL |     type Output<'a>;
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/missing_lifetime_args.rs
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.rs
@@ -10,6 +10,9 @@ struct Foo<'a, 'b, 'c> {
 
 fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
 //~^ ERROR missing generics for associated type
+//~| ERROR missing generics for associated type
+//~| ERROR missing generics for associated type
+//~| ERROR the trait `X` cannot be made into an object
 
 fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
 //~^ ERROR struct takes 3 lifetime arguments but 2 lifetime

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -15,7 +15,7 @@ LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
    |                                 ++++++++
 
 error[E0107]: struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/missing_lifetime_args.rs:14:26
+  --> $DIR/missing_lifetime_args.rs:17:26
    |
 LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
    |                          ^^^ --  -- supplied 2 lifetime arguments
@@ -33,7 +33,7 @@ LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b, 'a>) {}
    |                                    ++++
 
 error[E0107]: struct takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing_lifetime_args.rs:17:16
+  --> $DIR/missing_lifetime_args.rs:20:16
    |
 LL | fn f<'a>(_arg: Foo<'a>) {}
    |                ^^^ -- supplied 1 lifetime argument
@@ -50,6 +50,56 @@ help: add missing lifetime arguments
 LL | fn f<'a>(_arg: Foo<'a, 'a, 'a>) {}
    |                      ++++++++
 
-error: aborting due to 3 previous errors
+error[E0107]: missing generics for associated type `X::Y`
+  --> $DIR/missing_lifetime_args.rs:11:32
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                                ^ expected 2 lifetime arguments
+   |
+note: associated type defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL |     type Y<'a, 'b>;
+   |          ^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime arguments
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
+   |                                 ++++++++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: missing generics for associated type `X::Y`
+  --> $DIR/missing_lifetime_args.rs:11:32
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                                ^ expected 2 lifetime arguments
+   |
+note: associated type defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL |     type Y<'a, 'b>;
+   |          ^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime arguments
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
+   |                                 ++++++++
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/missing_lifetime_args.rs:11:26
+   |
+LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/missing_lifetime_args.rs:2:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a, 'b>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
@@ -6,6 +6,11 @@ const _: () = {
   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
       //~^ ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
       //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
+      //~| ERROR associated type takes 0 generic arguments but 1 generic argument
+      //~| ERROR the trait `X` cannot be made into an object
 };
 
 fn main() {}

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -28,6 +28,86 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
 
-error: aborting due to 2 previous errors
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                               +++
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^--- help: remove these generics
+   |                             |
+   |                             expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<'_, 1> = &'a ()>>) {}
+   |                               +++
+
+error[E0107]: associated type takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:29
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                             ^--- help: remove these generics
+   |                             |
+   |                             expected 0 generic arguments
+   |
+note: associated type defined here, with 0 generic parameters
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL |     type Y<'a>;
+   |          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/trait-path-type-error-once-implemented.rs:6:23
+   |
+LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+   |                       ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/trait-path-type-error-once-implemented.rs:2:10
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     type Y<'a>;
+   |          ^ ...because it contains the generic associated type `Y`
+   = help: consider moving `Y` to another trait
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0038, E0107.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/type-param-defaults.rs
+++ b/tests/ui/generic-associated-types/type-param-defaults.rs
@@ -29,6 +29,8 @@ where
 fn main() {
     // errors
     foo::<()>();
+    //~^ ERROR type mismatch
+    //~| ERROR `u64: Other` is not satisfied
     // works
     foo::<u32>();
 }

--- a/tests/ui/generic-associated-types/type-param-defaults.stderr
+++ b/tests/ui/generic-associated-types/type-param-defaults.stderr
@@ -16,5 +16,43 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 LL |     type Assoc<T = u32> = T;
    |                ^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0271]: type mismatch resolving `<() as Trait>::Assoc == u32`
+  --> $DIR/type-param-defaults.rs:31:11
+   |
+LL |     foo::<()>();
+   |           ^^ type mismatch resolving `<() as Trait>::Assoc == u32`
+   |
+note: expected this to be `u32`
+  --> $DIR/type-param-defaults.rs:11:27
+   |
+LL |     type Assoc<T = u32> = u64;
+   |                           ^^^
+note: required by a bound in `foo`
+  --> $DIR/type-param-defaults.rs:25:14
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this function
+LL | where
+LL |     T: Trait<Assoc = u32>,
+   |              ^^^^^^^^^^^ required by this bound in `foo`
 
+error[E0277]: the trait bound `u64: Other` is not satisfied
+  --> $DIR/type-param-defaults.rs:31:11
+   |
+LL |     foo::<()>();
+   |           ^^ the trait `Other` is not implemented for `u64`
+   |
+   = help: the trait `Other` is implemented for `u32`
+note: required by a bound in `foo`
+  --> $DIR/type-param-defaults.rs:26:15
+   |
+LL | fn foo<T>()
+   |    --- required by a bound in this function
+...
+LL |     T::Assoc: Other {
+   |               ^^^^^ required by this bound in `foo`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/generic-const-items/parameter-defaults.rs
+++ b/tests/ui/generic-const-items/parameter-defaults.rs
@@ -11,4 +11,5 @@ const NONE<T = ()>: Option<T> = None::<T>; //~ ERROR defaults for type parameter
 
 fn main() {
     let _ = NONE;
+    //~^ ERROR type annotations needed
 }

--- a/tests/ui/generic-const-items/parameter-defaults.stderr
+++ b/tests/ui/generic-const-items/parameter-defaults.stderr
@@ -4,5 +4,17 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 LL | const NONE<T = ()>: Option<T> = None::<T>;
    |            ^^^^^^
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed for `Option<T>`
+  --> $DIR/parameter-defaults.rs:13:9
+   |
+LL |     let _ = NONE;
+   |         ^
+   |
+help: consider giving this pattern a type, where the type for type parameter `T` is specified
+   |
+LL |     let _: Option<T> = NONE;
+   |          +++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/generics/wrong-number-of-args.rs
+++ b/tests/ui/generics/wrong-number-of-args.rs
@@ -21,7 +21,7 @@ mod no_generics {
 }
 
 mod type_and_type {
-    struct Ty<A, B>;
+    struct Ty<A, B>(A, B);
 
     type A = Ty;
     //~^ ERROR missing generics for struct `type_and_type::Ty`
@@ -43,7 +43,7 @@ mod type_and_type {
 }
 
 mod lifetime_and_type {
-    struct Ty<'a, T>;
+    struct Ty<'a, T>(&'a T);
 
     type A = Ty;
     //~^ ERROR missing generics for struct
@@ -75,7 +75,7 @@ mod lifetime_and_type {
 }
 
 mod type_and_type_and_type {
-    struct Ty<A, B, C = &'static str>;
+    struct Ty<A, B, C = &'static str>(A, B, C);
 
     type A = Ty;
     //~^ ERROR missing generics for struct `type_and_type_and_type::Ty`

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -246,7 +246,7 @@ LL |     type A = Ty;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -264,7 +264,7 @@ LL |     type B = Ty<usize>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic argument
    |
@@ -282,7 +282,7 @@ LL |     type D = Ty<usize, String, char>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 
 error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
@@ -294,7 +294,7 @@ LL |     type E = Ty<>;
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
-LL |     struct Ty<A, B>;
+LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -310,7 +310,7 @@ LL |     type A = Ty;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -326,7 +326,7 @@ LL |     type B = Ty<'static>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -342,7 +342,7 @@ LL |     type E = Ty<>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 help: add missing generic argument
    |
@@ -360,7 +360,7 @@ LL |     type F = Ty<'static, usize, 'static, usize>;
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^ --
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
@@ -374,7 +374,7 @@ LL |     type F = Ty<'static, usize, 'static, usize>;
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
-LL |     struct Ty<'a, T>;
+LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
 
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
@@ -386,7 +386,7 @@ LL |     type A = Ty;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic arguments
    |
@@ -404,7 +404,7 @@ LL |     type B = Ty<usize>;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic argument
    |
@@ -422,7 +422,7 @@ LL |     type E = Ty<usize, String, char, f64>;
 note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -  ----------------
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
@@ -434,7 +434,7 @@ LL |     type F = Ty<>;
 note: struct defined here, with at least 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
-LL |     struct Ty<A, B, C = &'static str>;
+LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -
 help: add missing generic arguments
    |

--- a/tests/ui/impl-header-lifetime-elision/bare_type.rs
+++ b/tests/ui/impl-header-lifetime-elision/bare_type.rs
@@ -33,12 +33,11 @@ type TypeI<T,> = T;
 static STATIC: () = ();
 
 fn main() {
-
     // ensure token `>=` works fine
-    let _: TypeA<'static>= &STATIC;
-    let _: TypeA<'static,>= &STATIC;
+    let _: TypeA<'static> = &STATIC;
+    let _: TypeA<'static,> = &STATIC;
 
     // ensure token `>>=` works fine
-    let _: Box<TypeA<'static>>= Box::new(&STATIC);
-    let _: Box<TypeA<'static,>>= Box::new(&STATIC);
+    let _: Box<TypeA<'static>> = Box::new(&STATIC);
+    let _: Box<TypeA<'static,>> = Box::new(&STATIC);
 }

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied
+  --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:13
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not implemented for `()`
+
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:24
    |
@@ -9,6 +15,7 @@ help: add `dyn` keyword before this trait
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0782`.
+Some errors have detailed explanations: E0277, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
@@ -6,6 +6,7 @@
 fn ice() -> impl AsRef<Fn(&())> {
     //[edition2015]~^ ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     //[edition2021]~^^ ERROR: trait objects must include the `dyn` keyword [E0782]
+    //[edition2021]~| ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     todo!()
 }
 

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.rs
@@ -4,16 +4,19 @@ use std::fmt::Debug;
 fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn d() -> impl Fn() -> (impl Debug + '_) {

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-fn-hrtb-bounds.rs:19:38
+  --> $DIR/impl-fn-hrtb-bounds.rs:22:38
    |
 LL | fn d() -> impl Fn() -> (impl Debug + '_) {
    |                                      ^^ expected named lifetime parameter
@@ -23,29 +23,56 @@ LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
    |                   ^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:10:52
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:9:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:10:20
    |
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
+  --> $DIR/impl-fn-hrtb-bounds.rs:16:52
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                                                    ^^
    |
 note: lifetime declared here
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:20
+  --> $DIR/impl-fn-hrtb-bounds.rs:16:20
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                    ^^
 
-error: aborting due to 4 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:6:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:12:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:18:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.rs
@@ -5,6 +5,7 @@ fn a() -> impl Fn(&u8) -> impl Debug + '_ {
     //~^ ERROR ambiguous `+` in a type
     //~| ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     |x| x
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn b() -> impl Fn() -> impl Debug + Send {

--- a/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
+++ b/tests/ui/impl-trait/impl-fn-parsing-ambiguities.stderr
@@ -5,7 +5,7 @@ LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                           ^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + '_)`
 
 error: ambiguous `+` in a type
-  --> $DIR/impl-fn-parsing-ambiguities.rs:10:24
+  --> $DIR/impl-fn-parsing-ambiguities.rs:11:24
    |
 LL | fn b() -> impl Fn() -> impl Debug + Send {
    |                        ^^^^^^^^^^^^^^^^^ help: use parentheses to disambiguate: `(impl Debug + Send)`
@@ -22,5 +22,14 @@ note: lifetime declared here
 LL | fn a() -> impl Fn(&u8) -> impl Debug + '_ {
    |                   ^
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-parsing-ambiguities.rs:7:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/impl-trait/impl_trait_projections.rs
+++ b/tests/ui/impl-trait/impl_trait_projections.rs
@@ -15,7 +15,7 @@ fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
     x.next().unwrap()
 }
 
-fn projection_with_named_trait_is_disallowed(x: impl Iterator)
+fn projection_with_named_trait_is_disallowed(mut x: impl Iterator)
     -> <impl Iterator as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
 {
@@ -25,7 +25,9 @@ fn projection_with_named_trait_is_disallowed(x: impl Iterator)
 fn projection_with_named_trait_inside_path_is_disallowed()
     -> <::std::ops::Range<impl Debug> as Iterator>::Item
 //~^ ERROR `impl Trait` is not allowed in path parameters
+//~| ERROR `impl Debug: Step` is not satisfied
 {
+    //~^ ERROR `impl Debug: Step` is not satisfied
     (1i32..100).next().unwrap()
 }
 

--- a/tests/ui/impl-trait/impl_trait_projections.stderr
+++ b/tests/ui/impl-trait/impl_trait_projections.stderr
@@ -17,7 +17,7 @@ LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
    |                           ^^^^^^^^^^
 
 error[E0667]: `impl Trait` is not allowed in path parameters
-  --> $DIR/impl_trait_projections.rs:33:29
+  --> $DIR/impl_trait_projections.rs:35:29
    |
 LL |     -> <dyn Iterator<Item = impl Debug> as Iterator>::Item
    |                             ^^^^^^^^^^
@@ -28,6 +28,46 @@ error[E0667]: `impl Trait` is not allowed in path parameters
 LL | fn projection_is_disallowed(x: impl Iterator) -> <impl Iterator>::Item {
    |                                                   ^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0277]: the trait bound `impl Debug: Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:26:8
+   |
+LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Step` is not implemented for `impl Debug`
+   |
+   = help: the following other types implement trait `Step`:
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+           and 8 others
+   = note: required for `std::ops::Range<impl Debug>` to implement `Iterator`
 
-For more information about this error, try `rustc --explain E0667`.
+error[E0277]: the trait bound `impl Debug: Step` is not satisfied
+  --> $DIR/impl_trait_projections.rs:29:1
+   |
+LL | / {
+LL | |
+LL | |     (1i32..100).next().unwrap()
+LL | | }
+   | |_^ the trait `Step` is not implemented for `impl Debug`
+   |
+   = help: the following other types implement trait `Step`:
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
+             usize
+           and 8 others
+   = note: required for `std::ops::Range<impl Debug>` to implement `Iterator`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0667.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/implicit-capture-late.stderr
+++ b/tests/ui/impl-trait/implicit-capture-late.stderr
@@ -4,6 +4,12 @@ error[E0657]: `impl Trait` can only capture lifetimes bound at the fn or impl le
 LL | fn foo(x: Vec<i32>) -> Box<dyn for<'a> Deref<Target = impl ?Sized>> {
    |                                    ^^
 
-error: aborting due to 1 previous error
+error: [o]
+  --> $DIR/implicit-capture-late.rs:10:55
+   |
+LL | fn foo(x: Vec<i32>) -> Box<dyn for<'a> Deref<Target = impl ?Sized>> {
+   |                                                       ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0657`.

--- a/tests/ui/impl-trait/issues/issue-67830.rs
+++ b/tests/ui/impl-trait/issues/issue-67830.rs
@@ -21,6 +21,8 @@ struct A;
 fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     Wrap(|a| Some(a).into_iter())
+    //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR implementation of `FnOnce` is not general enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-67830.stderr
+++ b/tests/ui/impl-trait/issues/issue-67830.stderr
@@ -10,5 +10,24 @@ note: lifetime declared here
 LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
    |                       ^^
 
-error: aborting due to 1 previous error
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/issue-67830.rs:23:5
+   |
+LL |     Wrap(|a| Some(a).into_iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
+
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/issue-67830.rs:23:5
+   |
+LL |     Wrap(|a| Some(a).into_iter())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-88236-2.rs
+++ b/tests/ui/impl-trait/issues/issue-88236-2.rs
@@ -18,11 +18,16 @@ fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
 fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     &()
+    //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR implementation of `Hrtb` is not general enough
 }
 
 fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
     x
+    //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236-2.stderr
@@ -23,16 +23,70 @@ LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Sen
    |                                               ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/issue-88236-2.rs:23:78
+  --> $DIR/issue-88236-2.rs:25:78
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                                                              ^^
    |
 note: lifetime declared here
-  --> $DIR/issue-88236-2.rs:23:45
+  --> $DIR/issue-88236-2.rs:25:45
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                             ^^
 
-error: aborting due to 3 previous errors
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:20:5
+   |
+LL |     &()
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:20:5
+   |
+LL |     &()
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'a>` would have to be implemented for the type `&()`
+   = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                  -- lifetime `'b` defined here
+LL |
+LL |     x
+   |     ^ returning this value requires that `'b` must outlive `'static`
+   |
+help: to declare that `impl for<'a> Hrtb<'a, Assoc = impl Send + '_>` captures data from argument `x`, you can add an explicit `'b` lifetime bound
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> + 'b {
+   |                                                                                  ++++
+help: to declare that `impl Send + 'a` captures data from argument `x`, you can add an explicit `'b` lifetime bound
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a + 'b> {
+   |                                                                                 ++++
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL |     x
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
+
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:27:5
+   |
+LL |     x
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'a>` would have to be implemented for the type `&()`
+   = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/impl-trait/issues/issue-92305.rs
+++ b/tests/ui/impl-trait/issues/issue-92305.rs
@@ -5,6 +5,7 @@ use std::iter;
 fn f<T>(data: &[T]) -> impl Iterator<Item = Vec> {
     //~^ ERROR: missing generics for struct `Vec` [E0107]
     iter::empty()
+    //~^ ERROR: type annotations needed
 }
 
 fn g<T>(data: &[T], target: T) -> impl Iterator<Item = Vec<T>> {

--- a/tests/ui/impl-trait/issues/issue-92305.stderr
+++ b/tests/ui/impl-trait/issues/issue-92305.stderr
@@ -9,6 +9,18 @@ help: add missing generic argument
 LL | fn f<T>(data: &[T]) -> impl Iterator<Item = Vec<T>> {
    |                                                +++
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-92305.rs:7:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0282.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/nested-rpit-hrtb.rs
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.rs
@@ -31,9 +31,11 @@ fn one_hrtb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl Qux<'a>> {}
 
 fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
 //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+//~| ERROR implementation of `Bar` is not general enough
 
 fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
 //~^ ERROR higher kinded lifetime bounds on nested opaque types are not supported yet
+//~| ERROR: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param<'b>() -> impl for<'a> Foo<'a, Assoc = impl Qux<'b>> {}
@@ -43,9 +45,11 @@ fn one_hrtb_mention_fn_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl Sized
 
 // This should resolve.
 fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
+//~^ ERROR: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
 
 // This should resolve.
 fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+//~^ ERROR implementation of `Bar` is not general enough
 
 // This should resolve.
 fn two_htrb_trait_param() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Qux<'b>> {}
@@ -56,9 +60,11 @@ fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> 
 
 // This should resolve.
 fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
+//~^ ERROR: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
 
 // `'b` is not in scope for the outlives bound.
 fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
 //~^ ERROR use of undeclared lifetime name `'b` [E0261]
+//~| ERROR implementation of `Bar` is not general enough
 
 fn main() {}

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:54:77
+  --> $DIR/nested-rpit-hrtb.rs:58:77
    |
 LL | fn two_htrb_outlives() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                             ^^ undeclared lifetime
@@ -15,7 +15,7 @@ LL | fn two_htrb_outlives<'b>() -> impl for<'a> Foo<'a, Assoc = impl for<'b> Siz
    |                     ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/nested-rpit-hrtb.rs:61:82
+  --> $DIR/nested-rpit-hrtb.rs:66:82
    |
 LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
    |                                                                                  ^^ undeclared lifetime
@@ -66,17 +66,72 @@ LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a
    |                                         ^^
 
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/nested-rpit-hrtb.rs:35:73
+  --> $DIR/nested-rpit-hrtb.rs:36:73
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                                                         ^^
    |
 note: lifetime declared here
-  --> $DIR/nested-rpit-hrtb.rs:35:44
+  --> $DIR/nested-rpit-hrtb.rs:36:44
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
 
-error: aborting due to 6 previous errors
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:32:78
+   |
+LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
+   |                                                                              ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
-For more information about this error, try `rustc --explain E0261`.
+error[E0277]: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:36:64
+   |
+LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
+   |                                                                ^^^^^^^^^^^^ the trait `for<'a> Qux<'_>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:47:79
+   |
+LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
+   |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:51:93
+   |
+LL | fn one_hrtb_mention_fn_outlives_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'b> {}
+   |                                                                                             ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
+
+error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
+  --> $DIR/nested-rpit-hrtb.rs:62:64
+   |
+LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
+   |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
+   |
+   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: for that trait implementation, expected `()`, found `&'a ()`
+
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:66:86
+   |
+LL | fn two_htrb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Sized + 'b> {}
+   |                                                                                      ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0261, E0277.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/intrinsics/safe-intrinsic-mismatch.rs
+++ b/tests/ui/intrinsics/safe-intrinsic-mismatch.rs
@@ -3,9 +3,11 @@
 
 extern "rust-intrinsic" {
     fn size_of<T>() -> usize; //~ ERROR intrinsic safety mismatch
+    //~^ ERROR intrinsic safety mismatch
 
     #[rustc_safe_intrinsic]
     fn assume(b: bool); //~ ERROR intrinsic safety mismatch
+    //~^ ERROR intrinsic safety mismatch
 }
 
 fn main() {}

--- a/tests/ui/intrinsics/safe-intrinsic-mismatch.stderr
+++ b/tests/ui/intrinsics/safe-intrinsic-mismatch.stderr
@@ -5,10 +5,26 @@ LL |     fn size_of<T>() -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `assume`
-  --> $DIR/safe-intrinsic-mismatch.rs:8:5
+  --> $DIR/safe-intrinsic-mismatch.rs:9:5
    |
 LL |     fn assume(b: bool);
    |     ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `size_of`
+  --> $DIR/safe-intrinsic-mismatch.rs:5:5
+   |
+LL |     fn size_of<T>() -> usize;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: intrinsic safety mismatch between list of intrinsics within the compiler and core library intrinsics for intrinsic `assume`
+  --> $DIR/safe-intrinsic-mismatch.rs:9:5
+   |
+LL |     fn assume(b: bool);
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-23611-enum-swap-in-drop.stderr
+++ b/tests/ui/issues/issue-23611-enum-swap-in-drop.stderr
@@ -1,0 +1,17 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/issue-23611-enum-swap-in-drop.rs:189:31
+   |
+LL |             (mem::size_of_val(&trails) * 8) as u32
+   |                               ^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |             (mem::size_of_val(addr_of!(trails)) * 8) as u32
+   |                               ~~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-31910.rs
+++ b/tests/ui/issues/issue-31910.rs
@@ -1,4 +1,5 @@
 enum Enum<T: Trait> {
+    //~^ ERROR: `T` is never used
     X = Trait::Number,
     //~^ ERROR mismatched types
     //~| expected `isize`, found `i32`

--- a/tests/ui/issues/issue-31910.stderr
+++ b/tests/ui/issues/issue-31910.stderr
@@ -1,9 +1,18 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-31910.rs:2:9
+  --> $DIR/issue-31910.rs:3:9
    |
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected `isize`, found `i32`
 
-error: aborting due to 1 previous error
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-31910.rs:1:11
+   |
+LL | enum Enum<T: Trait> {
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0392.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/issues/issue-3214.rs
+++ b/tests/ui/issues/issue-3214.rs
@@ -5,6 +5,7 @@ fn foo<T>() {
 
     impl<T> Drop for Foo<T> {
         //~^ ERROR struct takes 0 generic arguments but 1 generic argument
+        //~| ERROR `T` is not constrained
         fn drop(&mut self) {}
     }
 }

--- a/tests/ui/issues/issue-3214.stderr
+++ b/tests/ui/issues/issue-3214.stderr
@@ -22,7 +22,13 @@ note: struct defined here, with 0 generic parameters
 LL |     struct Foo {
    |            ^^^
 
-error: aborting due to 2 previous errors
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-3214.rs:6:10
+   |
+LL |     impl<T> Drop for Foo<T> {
+   |          ^ unconstrained type parameter
 
-Some errors have detailed explanations: E0107, E0401.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0207, E0401.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/issues/issue-34373.rs
+++ b/tests/ui/issues/issue-34373.rs
@@ -5,6 +5,8 @@ trait Trait<T> {
 }
 
 pub struct Foo<T = Box<Trait<DefaultFoo>>>;  //~ ERROR cycle detected
+//~^ ERROR `T` is never used
+//~| ERROR `Trait` cannot be made into an object
 type DefaultFoo = Foo;
 
 fn main() {

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -5,7 +5,7 @@ LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
    |                              ^^^^^^^^^^
    |
 note: ...which requires expanding type alias `DefaultFoo`...
-  --> $DIR/issue-34373.rs:8:19
+  --> $DIR/issue-34373.rs:10:19
    |
 LL | type DefaultFoo = Foo;
    |                   ^^^
@@ -23,6 +23,38 @@ LL | | }
    | |_^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/issue-34373.rs:7:24
+   |
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   |                        ^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-34373.rs:4:8
+   |
+LL | trait Trait<T> {
+   |       ----- this trait cannot be made into an object...
+LL |     fn foo(_: T) {}
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self, _: T) {}
+   |            ++++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo(_: T) where Self: Sized {}
+   |                  +++++++++++++++++
 
-For more information about this error, try `rustc --explain E0391`.
+error[E0392]: parameter `T` is never used
+  --> $DIR/issue-34373.rs:7:16
+   |
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0391, E0392.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/lang-items/lang-item-generic-requirements.rs
+++ b/tests/ui/lang-items/lang-item-generic-requirements.rs
@@ -22,8 +22,8 @@ trait MyIndex<'a, T> {}
 #[lang = "phantom_data"]
 //~^ ERROR `phantom_data` language item must be applied to a struct with 1 generic argument
 struct MyPhantomData<T, U>;
-//~^ ERROR parameter `T` is never used
-//~| ERROR parameter `U` is never used
+//~^ ERROR `T` is never used
+//~| ERROR `U` is never used
 
 #[lang = "owned_box"]
 //~^ ERROR `owned_box` language item must be applied to a struct with at least 1 generic argument
@@ -41,8 +41,7 @@ fn ice() {
     // Use add
     let r = 5;
     let a = 6;
-    r + a;
-    //~^ ERROR cannot add `{integer}` to `{integer}`
+    r + a; //~ ERROR cannot add
 
     // Use drop in place
     my_ptr_drop();

--- a/tests/ui/lifetimes/issue-95023.rs
+++ b/tests/ui/lifetimes/issue-95023.rs
@@ -3,7 +3,9 @@ struct Error(ErrorKind);
 impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental [E0183]
     //~^^ ERROR associated type bindings are not allowed here [E0229]
-    fn foo<const N: usize>(&self) -> Self::B<{N}>;
+    //~| ERROR not all trait items implemented
+    //~| ERROR expected a `FnMut(&isize)` closure, found `Error`
+    fn foo<const N: usize>(&self) -> Self::B<{ N }>;
     //~^ ERROR associated function in `impl` without body
     //~^^ ERROR method `foo` is not a member of trait `Fn` [E0407]
     //~^^^ ERROR associated type `B` not found for `Self` [E0220]

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -1,16 +1,16 @@
 error: associated function in `impl` without body
-  --> $DIR/issue-95023.rs:6:5
+  --> $DIR/issue-95023.rs:8:5
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                                  |
-   |                                                  help: provide a definition for the function: `{ <body> }`
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                                    |
+   |                                                    help: provide a definition for the function: `{ <body> }`
 
 error[E0407]: method `foo` is not a member of trait `Fn`
-  --> $DIR/issue-95023.rs:6:5
+  --> $DIR/issue-95023.rs:8:5
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
 
 error[E0183]: manual implementations of `Fn` are experimental
   --> $DIR/issue-95023.rs:3:6
@@ -33,12 +33,30 @@ LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
 error[E0220]: associated type `B` not found for `Self`
-  --> $DIR/issue-95023.rs:6:44
+  --> $DIR/issue-95023.rs:8:44
    |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
    |                                            ^ help: `Self` has the following associated type: `Output`
 
-error: aborting due to 5 previous errors
+error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
+  --> $DIR/issue-95023.rs:3:21
+   |
+LL | impl Fn(&isize) for Error {
+   |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
+   |
+   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0220, E0229, E0407.
-For more information about an error, try `rustc --explain E0183`.
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-95023.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0046, E0183, E0220, E0229, E0277, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.rs
@@ -4,6 +4,7 @@ trait Trait<'a> {
     type Bar<'b>
     //~^ NOTE associated type defined here, with 1 lifetime parameter
     //~| NOTE
+    //~| NOTE
     where
         Self: 'b;
 }
@@ -13,6 +14,8 @@ struct Impl<'a>(&'a ());
 impl<'a> Trait<'a> for Impl<'a> {
     type Foo = &'a ();
     type Bar<'b> = &'b ();
+    //~^ ERROR: does not fulfill the required lifetime
+    //~| NOTE: type must outlive the lifetime `'b`
 }
 
 type A<'a> = Impl<'a>;

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-alias.rs:20:24
+  --> $DIR/missing-lifetime-in-alias.rs:23:24
    |
 LL | type B<'a> = <A<'a> as Trait>::Foo;
    |                        ^^^^^ expected named lifetime parameter
@@ -10,13 +10,13 @@ LL | type B<'a> = <A<'a> as Trait<'a>>::Foo;
    |                             ++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-in-alias.rs:24:28
+  --> $DIR/missing-lifetime-in-alias.rs:27:28
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |                            ^^^^^ expected named lifetime parameter
    |
 note: these named lifetimes are available to use
-  --> $DIR/missing-lifetime-in-alias.rs:24:8
+  --> $DIR/missing-lifetime-in-alias.rs:27:8
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |        ^^  ^^
@@ -26,7 +26,7 @@ LL | type C<'a, 'b> = <A<'a> as Trait<'lifetime>>::Bar;
    |                                 +++++++++++
 
 error[E0107]: missing generics for associated type `Trait::Bar`
-  --> $DIR/missing-lifetime-in-alias.rs:24:36
+  --> $DIR/missing-lifetime-in-alias.rs:27:36
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |                                    ^^^ expected 1 lifetime argument
@@ -41,7 +41,26 @@ help: add missing lifetime argument
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar<'a>;
    |                                       ++++
 
-error: aborting due to 3 previous errors
+error[E0477]: the type `Impl<'a>` does not fulfill the required lifetime
+  --> $DIR/missing-lifetime-in-alias.rs:16:20
+   |
+LL |     type Bar<'b>
+   |     ------------ definition of `Bar` from trait
+...
+LL |     type Bar<'b> = &'b ();
+   |                    ^^^^^^
+   |
+note: type must outlive the lifetime `'b` as defined here
+  --> $DIR/missing-lifetime-in-alias.rs:16:14
+   |
+LL |     type Bar<'b> = &'b ();
+   |              ^^
+help: copy the `where` clause predicates from the trait
+   |
+LL |     type Bar<'b> = &'b () where Self: 'b;
+   |                           ++++++++++++++
 
-Some errors have detailed explanations: E0106, E0107.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0107, E0477.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.rs
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.rs
@@ -14,9 +14,8 @@ struct S1 {
 
 impl S1 {
     fn new(_x: u64) -> S1 {
-        S1 {
-            a: unsafe { &mut X1 },
-        }
+        S1 { a: unsafe { &mut X1 } }
+        //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
     }
 }
 

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
@@ -1,0 +1,17 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/borrowck-thread-local-static-mut-borrow-outlives-fn.rs:17:26
+   |
+LL |         S1 { a: unsafe { &mut X1 } }
+   |                          ^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |         S1 { a: unsafe { addr_of_mut!(X1) } }
+   |                          ~~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.rs
@@ -15,6 +15,7 @@ fn is_static<T>(_: T) where T: 'static { }
 // code forces us into a conservative, hacky path.
 fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
 //~^ ERROR please supply an explicit bound
+//~| ERROR `(): Foo<'_>` is not satisfied
 
 fn main() {
     let s = format!("foo");

--- a/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-dyn-binding-nonstatic3.stderr
@@ -4,6 +4,20 @@ error[E0228]: the lifetime bound for this object type cannot be deduced from con
 LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
    |                                    ^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `(): Foo<'_>` is not satisfied
+  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:16:47
+   |
+LL | fn bar(x: &str) -> &dyn Foo<Item = dyn Bar> { &() }
+   |                                               ^^^ the trait `Foo<'_>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/object-lifetime-default-dyn-binding-nonstatic3.rs:4:1
+   |
+LL | trait Foo<'a> {
+   | ^^^^^^^^^^^^^
+   = note: required for the cast from `&()` to `&dyn Foo<'_, Item = dyn Bar>`
 
-For more information about this error, try `rustc --explain E0228`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0228, E0277.
+For more information about an error, try `rustc --explain E0228`.

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.rs
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.rs
@@ -6,6 +6,7 @@ trait Bar<T> {
 }
 
 trait Baz : Bar<Self> {
+    //~^ ERROR the size for values of type `Self` cannot be known
 }
 
 fn make_bar<T:Bar<u32>>(t: &T) -> &dyn Bar<u32> {

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Baz` cannot be made into an object
-  --> $DIR/object-safety-supertrait-mentions-Self.rs:15:31
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:16:31
    |
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ `Baz` cannot be made into an object
@@ -12,6 +12,27 @@ LL | trait Baz : Bar<Self> {
    |       |
    |       this trait cannot be made into an object...
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
+   |
+LL | trait Baz : Bar<Self> {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Bar`
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
+   |
+LL | trait Bar<T> {
+   |           ^ required by this bound in `Bar`
+help: consider further restricting `Self`
+   |
+LL | trait Baz : Bar<Self> + Sized {
+   |                       +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Bar<T: ?Sized> {
+   |            ++++++++
 
-For more information about this error, try `rustc --explain E0038`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
@@ -17,4 +17,5 @@ impl X {
     type W where Self: Eq;
     //~^ ERROR associated type in `impl` without body
     //~| ERROR inherent associated types are unstable
+    //~| ERROR duplicate definitions
 }

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -78,6 +78,16 @@ LL |     type W where Self: Eq;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 10 previous errors
+error[E0592]: duplicate definitions with name `W`
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
+   |
+LL |     type W: Ord where Self: Eq;
+   |     ------ other definition for `W`
+...
+LL |     type W where Self: Eq;
+   |     ^^^^^^ duplicate definitions for `W`
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0592, E0658.
+For more information about an error, try `rustc --explain E0592`.

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.rs
@@ -16,4 +16,5 @@ fn y<'a>(y: &mut 'a + Send) {
     //~| ERROR at least one trait is required for an object type
     let z = y as &mut 'a + Send;
     //~^ ERROR expected value, found trait `Send`
+    //~| ERROR at least one trait is required for an object type
 }

--- a/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
+++ b/tests/ui/parser/issues/issue-73568-lifetime-after-mut.stderr
@@ -33,7 +33,13 @@ error[E0224]: at least one trait is required for an object type
 LL | fn y<'a>(y: &mut 'a + Send) {
    |                  ^^
 
-error: aborting due to 5 previous errors
+error[E0224]: at least one trait is required for an object type
+  --> $DIR/issue-73568-lifetime-after-mut.rs:17:23
+   |
+LL |     let z = y as &mut 'a + Send;
+   |                       ^^
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0178, E0224, E0423.
 For more information about an error, try `rustc --explain E0178`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-impl-requires-const-trait.stderr
@@ -10,5 +10,15 @@ LL | impl const A for () {}
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
 
-error: aborting due to 1 previous error
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/const-impl-requires-const-trait.rs:8:6
+   |
+LL | impl const A for () {}
+   |      ^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-non-const-type.stderr
@@ -8,5 +8,11 @@ LL | #[derive_const(Default)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
@@ -23,6 +23,21 @@ LL | #[derive_const(Default, PartialEq)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/derive-const-use.rs:7:6
+   |
+LL | impl const Default for A {
+   |      ^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
 
-For more information about this error, try `rustc --explain E0635`.
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0207, E0635.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.rs
@@ -1,12 +1,14 @@
 #![feature(const_trait_impl, effects)]
 
 const fn test() -> impl ~const Fn() { //~ ERROR `~const` can only be applied to `#[const_trait]` traits
+    //~^ ERROR cycle detected
     const move || { //~ ERROR const closures are experimental
         let sl: &[u8] = b"foo";
 
         match sl {
             [first, remainder @ ..] => {
                 assert_eq!(first, &b'f');
+                //~^ ERROR can't compare `&u8` with `&u8`
             }
             [] => panic!(),
         }

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/ice-112822-expected-type-for-param.stderr
@@ -1,5 +1,5 @@
 error[E0658]: const closures are experimental
-  --> $DIR/ice-112822-expected-type-for-param.rs:4:5
+  --> $DIR/ice-112822-expected-type-for-param.rs:5:5
    |
 LL |     const move || {
    |     ^^^^^
@@ -13,6 +13,47 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn test() -> impl ~const Fn() {
    |                                ^^^^
 
-error: aborting due to 2 previous errors
+error[E0277]: can't compare `&u8` with `&u8`
+  --> $DIR/ice-112822-expected-type-for-param.rs:10:17
+   |
+LL |                 assert_eq!(first, &b'f');
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `&u8 == &u8`
+   |
+   = help: the trait `~const PartialEq<&u8>` is not implemented for `&u8`
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0391]: cycle detected when computing type of opaque `test::{opaque#0}`
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+   |
+LL | const fn test() -> impl ~const Fn() {
+   |                    ^^^^^^^^^^^^^^^^
+   |
+note: ...which requires borrow-checking `test`...
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:1
+   |
+LL | const fn test() -> impl ~const Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires promoting constants in MIR for `test`...
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:1
+   |
+LL | const fn test() -> impl ~const Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const checking `test`...
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:1
+   |
+LL | const fn test() -> impl ~const Fn() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing whether `test::{opaque#0}` is freeze...
+   = note: ...which requires evaluating trait selection obligation `test::{opaque#0}: core::marker::Freeze`...
+   = note: ...which again requires computing type of opaque `test::{opaque#0}`, completing the cycle
+note: cycle used when computing type of `test::{opaque#0}`
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:20
+   |
+LL | const fn test() -> impl ~const Fn() {
+   |                    ^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0391, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.nn.stderr
@@ -24,5 +24,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 3 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-2.rs:10:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.ny.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-2.rs:10:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.rs
@@ -10,7 +10,8 @@ trait Foo {
 trait Bar: ~const Foo {}
 //[ny,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
 //[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
-//[yn,nn]~^^^ ERROR: `~const` is not allowed here
+//[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
+//[yn,nn]~^^^^ ERROR: `~const` is not allowed here
 
 const fn foo<T: Bar>(x: &T) {
     x.a();

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
@@ -11,7 +11,7 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/super-traits-fail-2.rs:16:5
+  --> $DIR/super-traits-fail-2.rs:17:5
    |
 LL |     x.a();
    |     ^^^^^ expected `host`, found `true`

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/super-traits-fail-2.rs:16:5
+  --> $DIR/super-traits-fail-2.rs:17:5
    |
 LL |     x.a();
    |     ^^^^^ expected `host`, found `true`

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -25,10 +25,18 @@ LL | trait Bar: ~const Foo {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:17:24
+  --> $DIR/super-traits-fail-3.rs:18:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^
 
-error: aborting due to 4 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:12:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
@@ -12,5 +12,13 @@ LL | trait Bar: ~const Foo {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:12:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
@@ -12,11 +12,13 @@ trait Foo {
 trait Bar: ~const Foo {}
 //[ny,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
 //[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
-//[yn,nn]~^^^ ERROR: `~const` is not allowed here
+//[ny,nn]~| ERROR: `~const` can only be applied to `#[const_trait]`
+//[yn,nn]~^^^^ ERROR: `~const` is not allowed here
 
 const fn foo<T: ~const Bar>(x: &T) {
     //[yn,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
     x.a();
+    //[yn]~^ ERROR: mismatched types
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
@@ -11,10 +11,20 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:17:24
+  --> $DIR/super-traits-fail-3.rs:18:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/super-traits-fail-3.rs:20:5
+   |
+LL |     x.a();
+   |     ^^^^^ expected `host`, found `true`
+   |
+   = note: expected constant `host`
+              found constant `true`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.rs
@@ -9,10 +9,12 @@ fn non_const_function<T: ~const Trait>() {} //~ ERROR `~const` is not allowed
 struct Struct<T: ~const Trait> { field: T } //~ ERROR `~const` is not allowed here
 struct TupleStruct<T: ~const Trait>(T); //~ ERROR `~const` is not allowed here
 struct UnitStruct<T: ~const Trait>; //~ ERROR `~const` is not allowed here
+//~^ ERROR  parameter `T` is never used
 
 enum Enum<T: ~const Trait> { Variant(T) } //~ ERROR `~const` is not allowed here
 
 union Union<T: ~const Trait> { field: T } //~ ERROR `~const` is not allowed here
+//~^ ERROR field must implement `Copy`
 
 type Type<T: ~const Trait> = T; //~ ERROR `~const` is not allowed here
 
@@ -30,6 +32,7 @@ trait NonConstTrait {
 
 impl NonConstTrait for () {
     type Type<T: ~const Trait> = (); //~ ERROR `~const` is not allowed
+    //~^ ERROR overflow evaluating the requirement `(): Trait`
     fn non_const_function<T: ~const Trait>() {} //~ ERROR `~const` is not allowed
     const CONSTANT<T: ~const Trait>: () = (); //~ ERROR `~const` is not allowed
     //~^ ERROR generic const items are experimental

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -35,7 +35,7 @@ LL | struct UnitStruct<T: ~const Trait>;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:13:14
+  --> $DIR/tilde-const-invalid-places.rs:14:14
    |
 LL | enum Enum<T: ~const Trait> { Variant(T) }
    |              ^^^^^^
@@ -43,7 +43,7 @@ LL | enum Enum<T: ~const Trait> { Variant(T) }
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:15:16
+  --> $DIR/tilde-const-invalid-places.rs:16:16
    |
 LL | union Union<T: ~const Trait> { field: T }
    |                ^^^^^^
@@ -51,7 +51,7 @@ LL | union Union<T: ~const Trait> { field: T }
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:17:14
+  --> $DIR/tilde-const-invalid-places.rs:19:14
    |
 LL | type Type<T: ~const Trait> = T;
    |              ^^^^^^
@@ -59,7 +59,7 @@ LL | type Type<T: ~const Trait> = T;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:19:19
+  --> $DIR/tilde-const-invalid-places.rs:21:19
    |
 LL | const CONSTANT<T: ~const Trait>: () = ();
    |                   ^^^^^^
@@ -67,7 +67,7 @@ LL | const CONSTANT<T: ~const Trait>: () = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:23:18
+  --> $DIR/tilde-const-invalid-places.rs:25:18
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
    |                  ^^^^^^
@@ -75,7 +75,7 @@ LL |     type Type<T: ~const Trait>: ~const Trait;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:23:33
+  --> $DIR/tilde-const-invalid-places.rs:25:33
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
    |                                 ^^^^^^
@@ -83,19 +83,19 @@ LL |     type Type<T: ~const Trait>: ~const Trait;
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:26:30
+  --> $DIR/tilde-const-invalid-places.rs:28:30
    |
 LL |     fn non_const_function<T: ~const Trait>();
    |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:26:8
+  --> $DIR/tilde-const-invalid-places.rs:28:8
    |
 LL |     fn non_const_function<T: ~const Trait>();
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:27:23
+  --> $DIR/tilde-const-invalid-places.rs:29:23
    |
 LL |     const CONSTANT<T: ~const Trait>: ();
    |                       ^^^^^^
@@ -103,7 +103,7 @@ LL |     const CONSTANT<T: ~const Trait>: ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:32:18
+  --> $DIR/tilde-const-invalid-places.rs:34:18
    |
 LL |     type Type<T: ~const Trait> = ();
    |                  ^^^^^^
@@ -111,19 +111,19 @@ LL |     type Type<T: ~const Trait> = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:33:30
+  --> $DIR/tilde-const-invalid-places.rs:36:30
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:33:8
+  --> $DIR/tilde-const-invalid-places.rs:36:8
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:34:23
+  --> $DIR/tilde-const-invalid-places.rs:37:23
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                       ^^^^^^
@@ -131,7 +131,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:41:18
+  --> $DIR/tilde-const-invalid-places.rs:44:18
    |
 LL |     type Type<T: ~const Trait> = ();
    |                  ^^^^^^
@@ -139,19 +139,19 @@ LL |     type Type<T: ~const Trait> = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:43:30
+  --> $DIR/tilde-const-invalid-places.rs:46:30
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |                              ^^^^^^
    |
 note: this function is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:43:8
+  --> $DIR/tilde-const-invalid-places.rs:46:8
    |
 LL |     fn non_const_function<T: ~const Trait>() {}
    |        ^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:44:23
+  --> $DIR/tilde-const-invalid-places.rs:47:23
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                       ^^^^^^
@@ -159,55 +159,55 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = note: this item cannot have `~const` trait bounds
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:49:15
+  --> $DIR/tilde-const-invalid-places.rs:52:15
    |
 LL | trait Child0: ~const Trait {}
    |               ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:49:1
+  --> $DIR/tilde-const-invalid-places.rs:52:1
    |
 LL | trait Child0: ~const Trait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:50:26
+  --> $DIR/tilde-const-invalid-places.rs:53:26
    |
 LL | trait Child1 where Self: ~const Trait {}
    |                          ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:50:1
+  --> $DIR/tilde-const-invalid-places.rs:53:1
    |
 LL | trait Child1 where Self: ~const Trait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:53:9
+  --> $DIR/tilde-const-invalid-places.rs:56:9
    |
 LL | impl<T: ~const Trait> Trait for T {}
    |         ^^^^^^
    |
 note: this impl is not `const`, so it cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:53:1
+  --> $DIR/tilde-const-invalid-places.rs:56:1
    |
 LL | impl<T: ~const Trait> Trait for T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` is not allowed here
-  --> $DIR/tilde-const-invalid-places.rs:56:9
+  --> $DIR/tilde-const-invalid-places.rs:59:9
    |
 LL | impl<T: ~const Trait> Struct<T> {}
    |         ^^^^^^
    |
 note: inherent impls cannot have `~const` trait bounds
-  --> $DIR/tilde-const-invalid-places.rs:56:1
+  --> $DIR/tilde-const-invalid-places.rs:59:1
    |
 LL | impl<T: ~const Trait> Struct<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:19:15
+  --> $DIR/tilde-const-invalid-places.rs:21:15
    |
 LL | const CONSTANT<T: ~const Trait>: () = ();
    |               ^^^^^^^^^^^^^^^^^
@@ -216,7 +216,7 @@ LL | const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:27:19
+  --> $DIR/tilde-const-invalid-places.rs:29:19
    |
 LL |     const CONSTANT<T: ~const Trait>: ();
    |                   ^^^^^^^^^^^^^^^^^
@@ -225,7 +225,7 @@ LL |     const CONSTANT<T: ~const Trait>: ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:34:19
+  --> $DIR/tilde-const-invalid-places.rs:37:19
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                   ^^^^^^^^^^^^^^^^^
@@ -234,7 +234,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: generic const items are experimental
-  --> $DIR/tilde-const-invalid-places.rs:44:19
+  --> $DIR/tilde-const-invalid-places.rs:47:19
    |
 LL |     const CONSTANT<T: ~const Trait>: () = ();
    |                   ^^^^^^^^^^^^^^^^^
@@ -243,7 +243,7 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
 
 error[E0658]: inherent associated types are unstable
-  --> $DIR/tilde-const-invalid-places.rs:41:5
+  --> $DIR/tilde-const-invalid-places.rs:44:5
    |
 LL |     type Type<T: ~const Trait> = ();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -251,6 +251,39 @@ LL |     type Type<T: ~const Trait> = ();
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
 
-error: aborting due to 27 previous errors
+error[E0392]: parameter `T` is never used
+  --> $DIR/tilde-const-invalid-places.rs:11:19
+   |
+LL | struct UnitStruct<T: ~const Trait>;
+   |                   ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+  --> $DIR/tilde-const-invalid-places.rs:16:32
+   |
+LL | union Union<T: ~const Trait> { field: T }
+   |                                ^^^^^^^^
+   |
+   = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+   |
+LL | union Union<T: ~const Trait> { field: std::mem::ManuallyDrop<T> }
+   |                                       +++++++++++++++++++++++ +
+
+error[E0275]: overflow evaluating the requirement `(): Trait`
+  --> $DIR/tilde-const-invalid-places.rs:34:34
+   |
+LL |     type Type<T: ~const Trait> = ();
+   |                                  ^^
+   |
+note: required by a bound in `NonConstTrait::Type`
+  --> $DIR/tilde-const-invalid-places.rs:25:33
+   |
+LL |     type Type<T: ~const Trait>: ~const Trait;
+   |                                 ^^^^^^^^^^^^ required by this bound in `NonConstTrait::Type`
+
+error: aborting due to 30 previous errors
+
+Some errors have detailed explanations: E0275, E0392, E0658, E0740.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/sanitize/badfree.rs
+++ b/tests/ui/sanitize/badfree.rs
@@ -5,7 +5,7 @@
 // compile-flags: -Z sanitizer=address -O
 //
 // run-fail
-// error-pattern: AddressSanitizer: SEGV
+// regex-error-pattern: AddressSanitizer: (SEGV|attempting free on address which was not malloc)
 
 use std::ffi::c_void;
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.rs
+++ b/tests/ui/stability-attribute/generics-default-stability-where.rs
@@ -5,6 +5,7 @@ extern crate unstable_generic_param;
 use unstable_generic_param::*;
 
 impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature 'unstable_default'
+//~^ ERROR `T` must be used as the type parameter for some local type
     fn foo() -> usize { T::foo() }
 }
 

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -6,6 +6,16 @@ LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to 1 previous error
+error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+  --> $DIR/generics-default-stability-where.rs:7:6
+   |
+LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {
+   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
+   = note: only traits defined in the current crate can be implemented for a type parameter
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0210, E0658.
+For more information about an error, try `rustc --explain E0210`.

--- a/tests/ui/static/reference-of-mut-static-safe.e2021.stderr
+++ b/tests/ui/static/reference-of-mut-static-safe.e2021.stderr
@@ -1,0 +1,26 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static-safe.rs:9:14
+   |
+LL |     let _x = &X;
+   |              ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let _x = addr_of!(X);
+   |              ~~~~~~~~~~~
+
+error[E0133]: use of mutable static is unsafe and requires unsafe function or block
+  --> $DIR/reference-of-mut-static-safe.rs:9:14
+   |
+LL |     let _x = &X;
+   |              ^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/static/reference-of-mut-static-safe.e2024.stderr
+++ b/tests/ui/static/reference-of-mut-static-safe.e2024.stderr
@@ -1,0 +1,15 @@
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static-safe.rs:9:14
+   |
+LL |     let _x = &X;
+   |              ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let _x = addr_of!(X);
+   |              ~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0796`.

--- a/tests/ui/static/reference-of-mut-static-safe.rs
+++ b/tests/ui/static/reference-of-mut-static-safe.rs
@@ -1,0 +1,13 @@
+// revisions: e2021 e2024
+
+// [e2021] edition:2021
+// [e2024] compile-flags: --edition 2024 -Z unstable-options
+
+fn main() {
+    static mut X: i32 = 1;
+
+    let _x = &X;
+    //[e2024]~^ reference of mutable static is disallowed [E0796]
+    //[e2021]~^^ use of mutable static is unsafe and requires unsafe function or block [E0133]
+    //[e2021]~^^^ shared reference of mutable static is discouraged [static_mut_ref]
+}

--- a/tests/ui/static/reference-of-mut-static-unsafe-fn.rs
+++ b/tests/ui/static/reference-of-mut-static-unsafe-fn.rs
@@ -1,0 +1,23 @@
+// compile-flags: --edition 2024 -Z unstable-options
+
+fn main() {}
+
+unsafe fn _foo() {
+    static mut X: i32 = 1;
+    static mut Y: i32 = 1;
+
+    let _y = &X;
+    //~^ ERROR reference of mutable static is disallowed
+
+    let ref _a = X;
+    //~^ ERROR reference of mutable static is disallowed
+
+    let (_b, _c) = (&X, &Y);
+    //~^ ERROR reference of mutable static is disallowed
+    //~^^ ERROR reference of mutable static is disallowed
+
+    foo(&X);
+    //~^ ERROR reference of mutable static is disallowed
+}
+
+fn foo<'a>(_x: &'a i32) {}

--- a/tests/ui/static/reference-of-mut-static-unsafe-fn.stderr
+++ b/tests/ui/static/reference-of-mut-static-unsafe-fn.stderr
@@ -1,0 +1,63 @@
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static-unsafe-fn.rs:9:14
+   |
+LL |     let _y = &X;
+   |              ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let _y = addr_of!(X);
+   |              ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static-unsafe-fn.rs:12:18
+   |
+LL |     let ref _a = X;
+   |                  ^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let ref _a = addr_of!(X);
+   |                  ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static-unsafe-fn.rs:15:21
+   |
+LL |     let (_b, _c) = (&X, &Y);
+   |                     ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let (_b, _c) = (addr_of!(X), &Y);
+   |                     ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static-unsafe-fn.rs:15:25
+   |
+LL |     let (_b, _c) = (&X, &Y);
+   |                         ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let (_b, _c) = (&X, addr_of!(Y));
+   |                         ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static-unsafe-fn.rs:19:9
+   |
+LL |     foo(&X);
+   |         ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     foo(addr_of!(X));
+   |         ~~~~~~~~~~~
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0796`.

--- a/tests/ui/static/reference-of-mut-static.e2021.stderr
+++ b/tests/ui/static/reference-of-mut-static.e2021.stderr
@@ -1,0 +1,91 @@
+error: shared reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static.rs:16:18
+   |
+LL |         let _y = &X;
+   |                  ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+note: the lint level is defined here
+  --> $DIR/reference-of-mut-static.rs:6:9
+   |
+LL | #![deny(static_mut_ref)]
+   |         ^^^^^^^^^^^^^^
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let _y = addr_of!(X);
+   |                  ~~~~~~~~~~~
+
+error: mutable reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static.rs:20:18
+   |
+LL |         let _y = &mut X;
+   |                  ^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |         let _y = addr_of_mut!(X);
+   |                  ~~~~~~~~~~~~~~~
+
+error: shared reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static.rs:28:22
+   |
+LL |         let ref _a = X;
+   |                      ^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let ref _a = addr_of!(X);
+   |                      ~~~~~~~~~~~
+
+error: shared reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static.rs:32:25
+   |
+LL |         let (_b, _c) = (&X, &Y);
+   |                         ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let (_b, _c) = (addr_of!(X), &Y);
+   |                         ~~~~~~~~~~~
+
+error: shared reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static.rs:32:29
+   |
+LL |         let (_b, _c) = (&X, &Y);
+   |                             ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let (_b, _c) = (&X, addr_of!(Y));
+   |                             ~~~~~~~~~~~
+
+error: shared reference of mutable static is discouraged
+  --> $DIR/reference-of-mut-static.rs:38:13
+   |
+LL |         foo(&X);
+   |             ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         foo(addr_of!(X));
+   |             ~~~~~~~~~~~
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/static/reference-of-mut-static.e2024.stderr
+++ b/tests/ui/static/reference-of-mut-static.e2024.stderr
@@ -1,0 +1,75 @@
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static.rs:16:18
+   |
+LL |         let _y = &X;
+   |                  ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let _y = addr_of!(X);
+   |                  ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static.rs:20:18
+   |
+LL |         let _y = &mut X;
+   |                  ^^^^^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |         let _y = addr_of_mut!(X);
+   |                  ~~~~~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static.rs:28:22
+   |
+LL |         let ref _a = X;
+   |                      ^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let ref _a = addr_of!(X);
+   |                      ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static.rs:32:25
+   |
+LL |         let (_b, _c) = (&X, &Y);
+   |                         ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let (_b, _c) = (addr_of!(X), &Y);
+   |                         ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static.rs:32:29
+   |
+LL |         let (_b, _c) = (&X, &Y);
+   |                             ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         let (_b, _c) = (&X, addr_of!(Y));
+   |                             ~~~~~~~~~~~
+
+error[E0796]: reference of mutable static is disallowed
+  --> $DIR/reference-of-mut-static.rs:38:13
+   |
+LL |         foo(&X);
+   |             ^^ reference of mutable static
+   |
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |         foo(addr_of!(X));
+   |             ~~~~~~~~~~~
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0796`.

--- a/tests/ui/static/reference-of-mut-static.rs
+++ b/tests/ui/static/reference-of-mut-static.rs
@@ -1,0 +1,50 @@
+// revisions: e2021 e2024
+
+// [e2021] edition:2021
+// [e2024] compile-flags: --edition 2024 -Z unstable-options
+
+#![deny(static_mut_ref)]
+
+use std::ptr::{addr_of, addr_of_mut};
+
+fn main() {
+    static mut X: i32 = 1;
+
+    static mut Y: i32 = 1;
+
+    unsafe {
+        let _y = &X;
+        //[e2024]~^ ERROR reference of mutable static is disallowed
+        //[e2021]~^^ ERROR shared reference of mutable static is discouraged [static_mut_ref]
+
+        let _y = &mut X;
+        //[e2024]~^ ERROR reference of mutable static is disallowed
+        //[e2021]~^^ ERROR mutable reference of mutable static is discouraged [static_mut_ref]
+
+        let _z = addr_of_mut!(X);
+
+        let _p = addr_of!(X);
+
+        let ref _a = X;
+        //[e2024]~^ ERROR reference of mutable static is disallowed
+        //[e2021]~^^ ERROR shared reference of mutable static is discouraged [static_mut_ref]
+
+        let (_b, _c) = (&X, &Y);
+        //[e2024]~^ ERROR reference of mutable static is disallowed
+        //[e2021]~^^ ERROR shared reference of mutable static is discouraged [static_mut_ref]
+        //[e2024]~^^^ ERROR reference of mutable static is disallowed
+        //[e2021]~^^^^ ERROR shared reference of mutable static is discouraged [static_mut_ref]
+
+        foo(&X);
+        //[e2024]~^ ERROR reference of mutable static is disallowed
+        //[e2021]~^^ ERROR shared reference of mutable static is discouraged [static_mut_ref]
+
+        static mut Z: &[i32; 3] = &[0, 1, 2];
+
+        let _ = Z.len();
+        let _ = Z[0];
+        let _ = format!("{:?}", Z);
+    }
+}
+
+fn foo<'a>(_x: &'a i32) {}

--- a/tests/ui/static/safe-extern-statics-mut.mir.stderr
+++ b/tests/ui/static/safe-extern-statics-mut.mir.stderr
@@ -1,3 +1,32 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/safe-extern-statics-mut.rs:14:14
+   |
+LL |     let rb = &B;
+   |              ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let rb = addr_of!(B);
+   |              ~~~~~~~~~~~
+
+warning: shared reference of mutable static is discouraged
+  --> $DIR/safe-extern-statics-mut.rs:17:15
+   |
+LL |     let xrb = &XB;
+   |               ^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let xrb = addr_of!(XB);
+   |               ~~~~~~~~~~~~
+
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
   --> $DIR/safe-extern-statics-mut.rs:13:13
    |
@@ -15,7 +44,7 @@ LL |     let rb = &B;
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:15:14
+  --> $DIR/safe-extern-statics-mut.rs:16:14
    |
 LL |     let xb = XB;
    |              ^^ use of mutable static
@@ -23,13 +52,13 @@ LL |     let xb = XB;
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:16:15
+  --> $DIR/safe-extern-statics-mut.rs:17:15
    |
 LL |     let xrb = &XB;
    |               ^^^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/static/safe-extern-statics-mut.rs
+++ b/tests/ui/static/safe-extern-statics-mut.rs
@@ -12,6 +12,8 @@ extern "C" {
 fn main() {
     let b = B; //~ ERROR use of mutable static is unsafe
     let rb = &B; //~ ERROR use of mutable static is unsafe
+    //~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
     let xb = XB; //~ ERROR use of mutable static is unsafe
     let xrb = &XB; //~ ERROR use of mutable static is unsafe
+    //~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
 }

--- a/tests/ui/static/safe-extern-statics-mut.thir.stderr
+++ b/tests/ui/static/safe-extern-statics-mut.thir.stderr
@@ -1,3 +1,32 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/safe-extern-statics-mut.rs:14:14
+   |
+LL |     let rb = &B;
+   |              ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let rb = addr_of!(B);
+   |              ~~~~~~~~~~~
+
+warning: shared reference of mutable static is discouraged
+  --> $DIR/safe-extern-statics-mut.rs:17:15
+   |
+LL |     let xrb = &XB;
+   |               ^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     let xrb = addr_of!(XB);
+   |               ~~~~~~~~~~~~
+
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
   --> $DIR/safe-extern-statics-mut.rs:13:13
    |
@@ -15,7 +44,7 @@ LL |     let rb = &B;
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:15:14
+  --> $DIR/safe-extern-statics-mut.rs:16:14
    |
 LL |     let xb = XB;
    |              ^^ use of mutable static
@@ -23,13 +52,13 @@ LL |     let xb = XB;
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe function or block
-  --> $DIR/safe-extern-statics-mut.rs:16:16
+  --> $DIR/safe-extern-statics-mut.rs:17:16
    |
 LL |     let xrb = &XB;
    |                ^^ use of mutable static
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/statics/issue-15261.rs
+++ b/tests/ui/statics/issue-15261.rs
@@ -6,6 +6,7 @@
 
 static mut n_mut: usize = 0;
 
-static n: &'static usize = unsafe{ &n_mut };
+static n: &'static usize = unsafe { &n_mut };
+//~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
 
 fn main() {}

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -1,0 +1,17 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/issue-15261.rs:9:37
+   |
+LL | static n: &'static usize = unsafe { &n_mut };
+   |                                     ^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL | static n: &'static usize = unsafe { addr_of!(n_mut) };
+   |                                     ~~~~~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/statics/static-mut-xc.rs
+++ b/tests/ui/statics/static-mut-xc.rs
@@ -7,7 +7,6 @@
 
 // aux-build:static_mut_xc.rs
 
-
 extern crate static_mut_xc;
 
 unsafe fn static_bound(_: &'static isize) {}
@@ -27,7 +26,9 @@ unsafe fn run() {
     static_mut_xc::a = -3;
     assert_eq!(static_mut_xc::a, -3);
     static_bound(&static_mut_xc::a);
+    //~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
     static_bound_set(&mut static_mut_xc::a);
+    //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
 }
 
 pub fn main() {

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -1,0 +1,31 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/static-mut-xc.rs:28:18
+   |
+LL |     static_bound(&static_mut_xc::a);
+   |                  ^^^^^^^^^^^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     static_bound(addr_of!(static_mut_xc::a));
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/static-mut-xc.rs:30:22
+   |
+LL |     static_bound_set(&mut static_mut_xc::a);
+   |                      ^^^^^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     static_bound_set(addr_of_mut!(static_mut_xc::a));
+   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+warning: 2 warnings emitted
+

--- a/tests/ui/statics/static-recursive.rs
+++ b/tests/ui/statics/static-recursive.rs
@@ -1,36 +1,43 @@
 // run-pass
+
 static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
+//~^ WARN shared reference of mutable static is discouraged [static_mut_ref]
 
 struct StaticDoubleLinked {
     prev: &'static StaticDoubleLinked,
     next: &'static StaticDoubleLinked,
     data: i32,
-    head: bool
+    head: bool,
 }
 
-static L1: StaticDoubleLinked = StaticDoubleLinked{prev: &L3, next: &L2, data: 1, head: true};
-static L2: StaticDoubleLinked = StaticDoubleLinked{prev: &L1, next: &L3, data: 2, head: false};
-static L3: StaticDoubleLinked = StaticDoubleLinked{prev: &L2, next: &L1, data: 3, head: false};
-
+static L1: StaticDoubleLinked = StaticDoubleLinked { prev: &L3, next: &L2, data: 1, head: true };
+static L2: StaticDoubleLinked = StaticDoubleLinked { prev: &L1, next: &L3, data: 2, head: false };
+static L3: StaticDoubleLinked = StaticDoubleLinked { prev: &L2, next: &L1, data: 3, head: false };
 
 pub fn main() {
-    unsafe { assert_eq!(S, *(S as *const *const u8)); }
+    unsafe {
+        assert_eq!(S, *(S as *const *const u8));
+    }
 
     let mut test_vec = Vec::new();
     let mut cur = &L1;
     loop {
         test_vec.push(cur.data);
         cur = cur.next;
-        if cur.head { break }
+        if cur.head {
+            break;
+        }
     }
-    assert_eq!(&test_vec, &[1,2,3]);
+    assert_eq!(&test_vec, &[1, 2, 3]);
 
     let mut test_vec = Vec::new();
     let mut cur = &L1;
     loop {
         cur = cur.prev;
         test_vec.push(cur.data);
-        if cur.head { break }
+        if cur.head {
+            break;
+        }
     }
-    assert_eq!(&test_vec, &[3,2,1]);
+    assert_eq!(&test_vec, &[3, 2, 1]);
 }

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -1,0 +1,17 @@
+warning: shared reference of mutable static is discouraged
+  --> $DIR/static-recursive.rs:3:36
+   |
+LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
+   |                                    ^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL | static mut S: *const u8 = unsafe { addr_of!(S) as *const *const u8 as *const u8 };
+   |                                    ~~~~~~~~~~~
+
+warning: 1 warning emitted
+

--- a/tests/ui/suggestions/auxiliary/hidden-struct.rs
+++ b/tests/ui/suggestions/auxiliary/hidden-struct.rs
@@ -1,0 +1,17 @@
+#[doc(hidden)]
+pub mod hidden {
+    pub struct Foo;
+}
+
+pub mod hidden1 {
+    #[doc(hidden)]
+    pub struct Foo;
+}
+
+
+#[doc(hidden)]
+pub(crate) mod hidden2 {
+    pub struct Bar;
+}
+
+pub use hidden2::Bar;

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.rs
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.rs
@@ -5,6 +5,7 @@ trait Foo {
 impl Foo for () {
     fn bar(s: _) {}
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR has 1 parameter but the declaration in trait `Foo::bar` has 0
 }
 
 fn main() {}

--- a/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
+++ b/tests/ui/suggestions/bad-infer-in-trait-impl.stderr
@@ -9,6 +9,16 @@ help: use type parameters instead
 LL |     fn bar<T>(s: T) {}
    |           +++    ~
 
-error: aborting due to 1 previous error
+error[E0050]: method `bar` has 1 parameter but the declaration in trait `Foo::bar` has 0
+  --> $DIR/bad-infer-in-trait-impl.rs:6:15
+   |
+LL |     fn bar();
+   |     --------- trait requires 0 parameters
+...
+LL |     fn bar(s: _) {}
+   |               ^ expected 0 parameters, found 1
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0050, E0121.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.rs
@@ -1,0 +1,15 @@
+// aux-build:hidden-struct.rs
+// compile-flags: --crate-type lib
+
+extern crate hidden_struct;
+
+#[doc(hidden)]
+mod local {
+    pub struct Foo;
+}
+
+pub fn test(_: Foo) {}
+//~^ ERROR cannot find type `Foo` in this scope
+
+pub fn test2(_: Bar) {}
+//~^ ERROR cannot find type `Bar` in this scope

--- a/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
+++ b/tests/ui/suggestions/dont-suggest-foreign-doc-hidden.stderr
@@ -1,0 +1,25 @@
+error[E0412]: cannot find type `Foo` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:11:16
+   |
+LL | pub fn test(_: Foo) {}
+   |                ^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use local::Foo;
+   |
+
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/dont-suggest-foreign-doc-hidden.rs:14:17
+   |
+LL | pub fn test2(_: Bar) {}
+   |                 ^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use hidden_struct::Bar;
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/suggestions/fn-trait-notation.fixed
+++ b/tests/ui/suggestions/fn-trait-notation.fixed
@@ -2,6 +2,7 @@
 fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
 where
     F: Fn(i32) -> i32, //~ ERROR E0658
+    //~^ ERROR E0059
     G: Fn(i32, i32) -> (i32, i32), //~ ERROR E0658
     H: Fn(i32) -> i32, //~ ERROR E0658
 {

--- a/tests/ui/suggestions/fn-trait-notation.rs
+++ b/tests/ui/suggestions/fn-trait-notation.rs
@@ -2,6 +2,7 @@
 fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
 where
     F: Fn<i32, Output = i32>, //~ ERROR E0658
+    //~^ ERROR E0059
     G: Fn<(i32, i32, ), Output = (i32, i32)>, //~ ERROR E0658
     H: Fn<(i32,), Output = i32>, //~ ERROR E0658
 {

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -8,7 +8,7 @@ LL |     F: Fn<i32, Output = i32>,
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/fn-trait-notation.rs:5:8
+  --> $DIR/fn-trait-notation.rs:6:8
    |
 LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32, i32) -> (i32, i32)`
@@ -17,7 +17,7 @@ LL |     G: Fn<(i32, i32, ), Output = (i32, i32)>,
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/fn-trait-notation.rs:6:8
+  --> $DIR/fn-trait-notation.rs:7:8
    |
 LL |     H: Fn<(i32,), Output = i32>,
    |        ^^^^^^^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `Fn(i32) -> i32`
@@ -25,6 +25,16 @@ LL |     H: Fn<(i32,), Output = i32>,
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error[E0059]: type parameter to bare `Fn` trait must be a tuple
+  --> $DIR/fn-trait-notation.rs:4:8
+   |
+LL |     F: Fn<i32, Output = i32>,
+   |        ^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `i32`
+   |
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0059, E0658.
+For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
@@ -18,6 +18,7 @@ mod elided {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
     //~^ ERROR missing lifetime specifier
+    //~| ERROR lifetime may not live long enough
 }
 
 mod underscore {
@@ -36,6 +37,7 @@ mod underscore {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
     //~^ ERROR missing lifetime specifier
+    //~| ERROR lifetime may not live long enough
 }
 
 mod alone_in_path {
@@ -61,8 +63,8 @@ mod in_path {
 }
 
 // This must not err, as the `&` actually resolves to `'a`.
-fn resolved_anonymous<'a, T>(f: impl Fn(&'a str) -> &T) {
-    f("f")
+fn resolved_anonymous<'a, T: 'a>(f: impl Fn(&'a str) -> &T) {
+    f("f");
 }
 
 fn main() {}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -41,7 +41,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:58
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:58
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                          ^^ expected named lifetime parameter
@@ -62,7 +62,7 @@ LL +     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:64
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                                ^^ expected named lifetime parameter
@@ -83,7 +83,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next(
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:37
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                                     ^ expected named lifetime parameter
@@ -104,7 +104,7 @@ LL +     fn g(mut x: impl Foo) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:41
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:41
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                                         ^ expected named lifetime parameter
@@ -149,7 +149,7 @@ LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next()
    |         ++++                              ++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:24:35
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:25:35
    |
 LL |     fn f(_: impl Iterator<Item = &'_ ()>) {}
    |                                   ^^ expected named lifetime parameter
@@ -161,7 +161,7 @@ LL |     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
    |         ++++                          ~~
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:39
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:39
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                       ^^ expected named lifetime parameter
@@ -173,7 +173,7 @@ LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.nex
    |         ++++                              ~~
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:44:18
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:46:18
    |
 LL |     fn f(_: impl Foo) {}
    |                  ^^^ expected named lifetime parameter
@@ -185,7 +185,7 @@ LL |     fn f<'a>(_: impl Foo<'a>) {}
    |         ++++            ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:22
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                      ^^^ expected named lifetime parameter
@@ -197,7 +197,7 @@ LL |     fn g<'a>(mut x: impl Foo<'a>) -> Option<&()> { x.next() }
    |         ++++                ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:55:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:22
    |
 LL |     fn f(_: impl Foo<()>) {}
    |                      ^ expected named lifetime parameter
@@ -209,7 +209,7 @@ LL |     fn f<'a>(_: impl Foo<'a, ()>) {}
    |         ++++             +++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:26
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:26
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                          ^ expected named lifetime parameter
@@ -220,7 +220,23 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
    |         ++++                 +++
 
-error: aborting due to 14 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |     -----------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0106, E0658.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -42,10 +42,12 @@ thread_local! {
     //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR union takes 2 lifetime arguments but 1 lifetime argument was supplied
 }
 thread_local! {
     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR trait takes 2 lifetime arguments but 1 lifetime argument was supplied

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -107,7 +107,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -119,7 +119,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:47:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -228,7 +228,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -246,7 +246,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -265,7 +265,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -284,7 +284,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -303,7 +303,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
    |                                                        +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:47:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -321,7 +321,45 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error: aborting due to 20 previous errors
+error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
+   |
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
+   |
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       +++++++++
+
+error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:48:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        +++++++++
+
+error: aborting due to 22 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/tag-type-args.rs
+++ b/tests/ui/tag-type-args.rs
@@ -1,4 +1,5 @@
 enum Quux<T> { Bar }
+//~^ ERROR: parameter `T` is never used
 
 fn foo(c: Quux) { assert!((false)); } //~ ERROR missing generics for enum `Quux`
 

--- a/tests/ui/tag-type-args.stderr
+++ b/tests/ui/tag-type-args.stderr
@@ -1,5 +1,5 @@
 error[E0107]: missing generics for enum `Quux`
-  --> $DIR/tag-type-args.rs:3:11
+  --> $DIR/tag-type-args.rs:4:11
    |
 LL | fn foo(c: Quux) { assert!((false)); }
    |           ^^^^ expected 1 generic argument
@@ -14,6 +14,16 @@ help: add missing generic argument
 LL | fn foo(c: Quux<T>) { assert!((false)); }
    |               +++
 
-error: aborting due to 1 previous error
+error[E0392]: parameter `T` is never used
+  --> $DIR/tag-type-args.rs:1:11
+   |
+LL | enum Quux<T> { Bar }
+   |           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0392.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -86,6 +86,8 @@ static A: () = ();
 //~^ ERROR attribute should be applied to a function
 impl Quux for u8 {}
 //~^ NOTE not a function
+//~| NOTE missing `foo` in implementation
+//~| ERROR missing: `foo`
 
 #[target_feature(enable = "sse2")]
 //~^ ERROR attribute should be applied to a function
@@ -93,7 +95,7 @@ impl Foo {}
 //~^ NOTE not a function
 
 trait Quux {
-    fn foo();
+    fn foo(); //~ NOTE `foo` from trait
 }
 
 impl Quux for Foo {

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -117,7 +117,7 @@ LL | impl Quux for u8 {}
    | ------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:90:1
+  --> $DIR/invalid-attribute.rs:92:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL | impl Foo {}
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:108:5
+  --> $DIR/invalid-attribute.rs:110:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL | |     }
    | |_____- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:116:5
+  --> $DIR/invalid-attribute.rs:118:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +183,7 @@ LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:100:5
+  --> $DIR/invalid-attribute.rs:102:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -194,6 +194,16 @@ LL |     fn foo() {}
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
-error: aborting due to 22 previous errors
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/invalid-attribute.rs:87:1
+   |
+LL | impl Quux for u8 {}
+   | ^^^^^^^^^^^^^^^^ missing `foo` in implementation
+...
+LL |     fn foo();
+   |     --------- `foo` from trait
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 23 previous errors
+
+Some errors have detailed explanations: E0046, E0658.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/thread-local/thread-local-static.mir.stderr
+++ b/tests/ui/thread-local/thread-local-static.mir.stderr
@@ -1,3 +1,18 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/thread-local-static.rs:12:23
+   |
+LL |     std::mem::swap(x, &mut STATIC_VAR_2)
+   |                       ^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     std::mem::swap(x, addr_of_mut!(STATIC_VAR_2))
+   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/thread-local-static.rs:10:12
    |
@@ -38,7 +53,7 @@ LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0013, E0133, E0625, E0658.
 For more information about an error, try `rustc --explain E0013`.

--- a/tests/ui/thread-local/thread-local-static.rs
+++ b/tests/ui/thread-local/thread-local-static.rs
@@ -10,7 +10,8 @@ static mut STATIC_VAR_2: [u32; 8] = [4; 8];
 const fn g(x: &mut [u32; 8]) {
     //~^ ERROR mutable references are not allowed
     std::mem::swap(x, &mut STATIC_VAR_2)
-    //~^ ERROR thread-local statics cannot be accessed
+    //~^ WARN mutable reference of mutable static is discouraged [static_mut_ref]
+    //~^^ ERROR thread-local statics cannot be accessed
     //~| ERROR mutable references are not allowed
     //~| ERROR use of mutable static is unsafe
     //~| constant functions cannot refer to statics

--- a/tests/ui/thread-local/thread-local-static.thir.stderr
+++ b/tests/ui/thread-local/thread-local-static.thir.stderr
@@ -1,3 +1,18 @@
+warning: mutable reference of mutable static is discouraged
+  --> $DIR/thread-local-static.rs:12:23
+   |
+LL |     std::mem::swap(x, &mut STATIC_VAR_2)
+   |                       ^^^^^^^^^^^^^^^^^ mutable reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: mutable references are dangerous since if there's any other pointer or reference used for that static while the reference lives, that's UB; use `addr_of_mut!` instead to create a raw pointer
+   |
+LL |     std::mem::swap(x, addr_of_mut!(STATIC_VAR_2))
+   |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/thread-local-static.rs:10:12
    |
@@ -38,7 +53,7 @@ LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 5 previous errors
+error: aborting due to 5 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0013, E0133, E0625, E0658.
 For more information about an error, try `rustc --explain E0013`.

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
@@ -7,12 +7,14 @@ pub trait Trait<T> {
 }
 
 impl<T, S> Trait<T> for i32 {
+    //~^ ERROR `S` is not constrained
     type Assoc = String;
 }
 
 // Should not not trigger suggestion here...
 impl<T, S> Trait<T, S> for () {}
 //~^ ERROR trait takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR `S` is not constrained
 
 //... but should do so in all of the below cases except the last one
 fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
@@ -37,6 +39,7 @@ impl<T: Trait<u32, String>> Struct<T> {}
 trait YetAnotherTrait {}
 impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
 //~^ ERROR struct takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR `U` is not constrained
 
 
 fn main() {

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -1,5 +1,5 @@
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:14:12
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:12
    |
 LL | impl<T, S> Trait<T, S> for () {}
    |            ^^^^^ expected 1 generic argument
@@ -11,7 +11,7 @@ LL | pub trait Trait<T> {
    |           ^^^^^ -
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:18:12
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:12
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
    |            ^^^^^ expected 1 generic argument
@@ -27,7 +27,7 @@ LL | fn func<T: Trait<u32, Assoc = String>>(t: T) -> impl Trait<(), i32> {
    |                       +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:18:46
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:46
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
    |                                              ^^^^^ expected 1 generic argument
@@ -43,7 +43,7 @@ LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), Assoc = i32> {
    |                                                        +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:24:18
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:18
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |                  ^^^^^ expected 1 generic argument
@@ -59,7 +59,7 @@ LL | struct Struct<T: Trait<u32, Assoc = String>> {
    |                             +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:29:23
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:31:23
    |
 LL | trait AnotherTrait<T: Trait<T, i32>> {}
    |                       ^^^^^ expected 1 generic argument
@@ -75,7 +75,7 @@ LL | trait AnotherTrait<T: Trait<T, Assoc = i32>> {}
    |                                +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:32:9
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:34:9
    |
 LL | impl<T: Trait<u32, String>> Struct<T> {}
    |         ^^^^^ expected 1 generic argument
@@ -91,7 +91,7 @@ LL | impl<T: Trait<u32, Assoc = String>> Struct<T> {}
    |                    +++++++
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:38:58
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:58
    |
 LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          ^^^^^^    - help: remove this generic argument
@@ -99,11 +99,30 @@ LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:24:8
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:8
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
 
-error: aborting due to 7 previous errors
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
+   |
+LL | impl<T, S> Trait<T> for i32 {
+   |         ^ unconstrained type parameter
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:9
+   |
+LL | impl<T, S> Trait<T, S> for () {}
+   |         ^ unconstrained type parameter
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:35
+   |
+LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
+   |                                   ^ unconstrained type parameter
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0107, E0207.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/traits/issue-106072.rs
+++ b/tests/ui/traits/issue-106072.rs
@@ -1,4 +1,5 @@
 #[derive(Clone)] //~  trait objects must include the `dyn` keyword
+//~^ ERROR: the size for values of type `(dyn Foo + 'static)` cannot be known
 struct Foo;
 trait Foo {} //~ the name `Foo` is defined multiple times
 fn main() {}

--- a/tests/ui/traits/issue-106072.stderr
+++ b/tests/ui/traits/issue-106072.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/issue-106072.rs:3:1
+  --> $DIR/issue-106072.rs:4:1
    |
 LL | struct Foo;
    | ----------- previous definition of the type `Foo` here
@@ -7,6 +7,17 @@ LL | trait Foo {}
    | ^^^^^^^^^ `Foo` redefined here
    |
    = note: `Foo` must be defined only once in the type namespace of this module
+
+error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+  --> $DIR/issue-106072.rs:1:10
+   |
+LL | #[derive(Clone)]
+   |          ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+note: required by a bound in `Clone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-106072.rs:1:10
@@ -16,7 +27,7 @@ LL | #[derive(Clone)]
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0428, E0782.
-For more information about an error, try `rustc --explain E0428`.
+Some errors have detailed explanations: E0277, E0428, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-28576.rs
+++ b/tests/ui/traits/issue-28576.rs
@@ -3,6 +3,8 @@ pub trait Foo<RHS=Self> {
 }
 
 pub trait Bar: Foo<Assoc=()> {
+    //~^ ERROR: the size for values of type `Self` cannot be known
+    //~| ERROR: the size for values of type `Self` cannot be known
     fn new(&self, b: &
            dyn Bar //~ ERROR the trait `Bar` cannot be made into an object
               <Assoc=()>

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/issue-28576.rs:7:12
+  --> $DIR/issue-28576.rs:9:12
    |
 LL | /            dyn Bar
 LL | |               <Assoc=()>
@@ -15,6 +15,47 @@ LL | pub trait Bar: Foo<Assoc=()> {
    |           |    ...because it uses `Self` as a type parameter
    |           this trait cannot be made into an object...
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by this bound in `Foo`
+help: consider further restricting `Self`
+   |
+LL | pub trait Bar: Foo<Assoc=()> + Sized {
+   |                              +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS=Self: ?Sized> {
+   |                       ++++++++
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by this bound in `Foo`
+help: consider further restricting `Self`
+   |
+LL |     ) where Self: Sized;
+   |       +++++++++++++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS=Self: ?Sized> {
+   |                       ++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/issue-38404.rs
+++ b/tests/ui/traits/issue-38404.rs
@@ -1,7 +1,8 @@
 trait A<T>: std::ops::Add<Self> + Sized {}
 trait B<T>: A<T> {}
-trait C<T>: A<dyn B<T, Output=usize>> {}
+trait C<T>: A<dyn B<T, Output = usize>> {}
 //~^ ERROR the trait `B` cannot be made into an object
+//~| ERROR the trait `B` cannot be made into an object
 //~| ERROR the trait `B` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/traits/issue-38404.stderr
+++ b/tests/ui/traits/issue-38404.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
-LL | trait C<T>: A<dyn B<T, Output=usize>> {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
@@ -15,8 +15,8 @@ LL | trait B<T>: A<T> {}
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/issue-38404.rs:3:15
    |
-LL | trait C<T>: A<dyn B<T, Output=usize>> {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
@@ -27,6 +27,21 @@ LL | trait B<T>: A<T> {}
    |       - this trait cannot be made into an object...
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `B` cannot be made into an object
+  --> $DIR/issue-38404.rs:3:15
+   |
+LL | trait C<T>: A<dyn B<T, Output = usize>> {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-38404.rs:1:13
+   |
+LL | trait A<T>: std::ops::Add<Self> + Sized {}
+   |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
+LL | trait B<T>: A<T> {}
+   |       - this trait cannot be made into an object...
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/issue-87558.rs
+++ b/tests/ui/traits/issue-87558.rs
@@ -3,6 +3,8 @@ struct Error(ErrorKind);
 impl Fn(&isize) for Error {
     //~^ ERROR manual implementations of `Fn` are experimental
     //~| ERROR associated type bindings are not allowed here
+    //~| ERROR closure, found `Error`
+    //~| ERROR not all trait items implemented, missing: `call`
     fn from() {} //~ ERROR method `from` is not a member of trait `Fn`
 }
 

--- a/tests/ui/traits/issue-87558.stderr
+++ b/tests/ui/traits/issue-87558.stderr
@@ -1,5 +1,5 @@
 error[E0407]: method `from` is not a member of trait `Fn`
-  --> $DIR/issue-87558.rs:6:5
+  --> $DIR/issue-87558.rs:8:5
    |
 LL |     fn from() {}
    |     ^^^^^^^^^^^^ not a member of trait `Fn`
@@ -24,7 +24,25 @@ help: parenthesized trait syntax expands to `Fn<(&isize,), Output=()>`
 LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
+  --> $DIR/issue-87558.rs:3:21
+   |
+LL | impl Fn(&isize) for Error {
+   |                     ^^^^^ expected an `FnMut(&isize)` closure, found `Error`
+   |
+   = help: the trait `FnMut<(&isize,)>` is not implemented for `Error`
+note: required by a bound in `Fn`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-Some errors have detailed explanations: E0183, E0229, E0407.
-For more information about an error, try `rustc --explain E0183`.
+error[E0046]: not all trait items implemented, missing: `call`
+  --> $DIR/issue-87558.rs:3:1
+   |
+LL | impl Fn(&isize) for Error {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
+   |
+   = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0046, E0183, E0229, E0277, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/traits/non_lifetime_binders/late-bound-in-anon-ct.rs
+++ b/tests/ui/traits/non_lifetime_binders/late-bound-in-anon-ct.rs
@@ -6,6 +6,6 @@ fn foo() -> usize
 where
     for<T> [i32; { let _: T = todo!(); 0 }]:,
     //~^ ERROR cannot capture late-bound type parameter in constant
-{}
+{ 42 }
 
 fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.rs
@@ -3,5 +3,8 @@ trait Foo {
 }
 
 fn bar(x: &dyn Foo) {} //~ ERROR the trait `Foo` cannot be made into an object
+//~^ ERROR the trait `Foo` cannot be made into an object
+//~| ERROR the trait `Foo` cannot be made into an object
+//~| ERROR the trait `Foo` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
@@ -13,6 +13,53 @@ LL |     type Bar<T>;
    |          ^^^ ...because it contains the generic associated type `Bar`
    = help: consider moving `Bar` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:16
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |                ^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-unsafe-missing-assoc-type.rs:5:12
+   |
+LL | fn bar(x: &dyn Foo) {}
+   |            ^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type Bar<T>;
+   |          ^^^ ...because it contains the generic associated type `Bar`
+   = help: consider moving `Bar` to another trait
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -16,6 +16,7 @@ mod assert {
     >()
     where
         Dst: BikeshedIntrinsicFrom< //~ ERROR trait takes at most 3 generic arguments but 6 generic arguments were supplied
+        //~^ ERROR: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
             Src,
             Context,
             ASSUME_ALIGNMENT,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -9,6 +9,22 @@ LL | |             ASSUME_VALIDITY,
 LL | |             ASSUME_VISIBILITY,
    | |_____________________________- help: remove these generic arguments
 
-error: aborting due to 1 previous error
+error: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
+  --> $DIR/issue-101739-2.rs:18:14
+   |
+LL |           Dst: BikeshedIntrinsicFrom<
+   |  ______________^
+LL | |
+LL | |             Src,
+LL | |             Context,
+...  |
+LL | |             ASSUME_VISIBILITY,
+LL | |         >,
+   | |_________^ expected `Assume`, found `bool`
+   |
+note: required by a bound in `BikeshedIntrinsicFrom`
+  --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -1,4 +1,4 @@
-// Regression test for #77179.
+// Regression test for the ICE in #77179.
 
 #![feature(type_alias_impl_trait)]
 
@@ -6,7 +6,9 @@ type Pointer<T> = impl std::ops::Deref<Target = T>;
 
 fn test() -> Pointer<_> {
     //~^ ERROR: the placeholder `_` is not allowed within types
+    //~| ERROR: non-defining opaque type use in defining scope
     Box::new(1)
+    //~^ ERROR expected generic type parameter, found `i32`
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -7,6 +7,28 @@ LL | fn test() -> Pointer<_> {
    |              |       not allowed in type signatures
    |              help: replace with the correct return type: `Pointer<i32>`
 
-error: aborting due to 1 previous error
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/issue-77179.rs:7:14
+   |
+LL | fn test() -> Pointer<_> {
+   |              ^^^^^^^^^^ argument `i32` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/issue-77179.rs:5:19
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0792]: expected generic type parameter, found `i32`
+  --> $DIR/issue-77179.rs:10:5
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |              - this generic parameter must be used with a generic type parameter
+...
+LL |     Box::new(1)
+   |     ^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0121, E0792.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.rs
+++ b/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.rs
@@ -1,8 +1,8 @@
 #![feature(type_alias_impl_trait)]
 
-pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
+pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
 //~^ ERROR use of undeclared lifetime name `'db`
-//~| ERROR cannot find type `Key` in this scope
+//~| ERROR cannot find type `LocalKey` in this scope
 //~| ERROR unconstrained opaque type
 //~| ERROR unconstrained opaque type
 

--- a/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-impl-trait-in-tait.stderr
@@ -1,43 +1,43 @@
 error[E0261]: use of undeclared lifetime name `'db`
   --> $DIR/nested-impl-trait-in-tait.rs:3:40
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |                                        ^^^ undeclared lifetime
    |
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the bound lifetime-generic with a new `'db` lifetime
    |
-LL | pub type Tait = impl for<'db> Iterator<Item = (&'db Key, impl Iterator)>;
+LL | pub type Tait = impl for<'db> Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |                      ++++++++
 help: consider introducing lifetime `'db` here
    |
-LL | pub type Tait<'db> = impl Iterator<Item = (&'db Key, impl Iterator)>;
+LL | pub type Tait<'db> = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
    |              +++++
 
-error[E0412]: cannot find type `Key` in this scope
+error[E0412]: cannot find type `LocalKey` in this scope
   --> $DIR/nested-impl-trait-in-tait.rs:3:44
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
-   |                                            ^^^ not found in this scope
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
+   |                                            ^^^^^^^^ not found in this scope
    |
 help: consider importing this struct
    |
-LL + use std::thread::local_impl::Key;
+LL + use std::thread::LocalKey;
    |
 
 error: unconstrained opaque type
   --> $DIR/nested-impl-trait-in-tait.rs:3:17
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Tait` must be used in combination with a concrete type within the same module
 
 error: unconstrained opaque type
-  --> $DIR/nested-impl-trait-in-tait.rs:3:49
+  --> $DIR/nested-impl-trait-in-tait.rs:3:54
    |
-LL | pub type Tait = impl Iterator<Item = (&'db Key, impl Iterator)>;
-   |                                                 ^^^^^^^^^^^^^
+LL | pub type Tait = impl Iterator<Item = (&'db LocalKey, impl Iterator)>;
+   |                                                      ^^^^^^^^^^^^^
    |
    = note: `Tait` must be used in combination with a concrete type within the same module
 

--- a/tests/ui/typeck/escaping_bound_vars.rs
+++ b/tests/ui/typeck/escaping_bound_vars.rs
@@ -10,6 +10,10 @@ pub fn test()
 where
     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
     //~^ ERROR cannot capture late-bound lifetime in constant
+    //~| ERROR associated type bindings are not allowed here
+    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
+    //~| ERROR the trait bound `(): Elide<(&(),)>` is not satisfied
+    //~| ERROR cannot add
 {
 }
 

--- a/tests/ui/typeck/escaping_bound_vars.stderr
+++ b/tests/ui/typeck/escaping_bound_vars.stderr
@@ -6,5 +6,55 @@ LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
    |                                  |
    |                                  lifetime defined here
 
-error: aborting due to 1 previous error
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/escaping_bound_vars.rs:11:28
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                            ^^^^^^^^^^ associated type not allowed here
 
+error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
+  --> $DIR/escaping_bound_vars.rs:11:22
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                      ^^ the trait `Elide<(&(),)>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/escaping_bound_vars.rs:5:1
+   |
+LL | trait Elide<T> {
+   | ^^^^^^^^^^^^^^
+
+error[E0277]: cannot add `fn() {<() as Elide<(&(),)>>::call}` to `{integer}`
+  --> $DIR/escaping_bound_vars.rs:11:18
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                  ^ no implementation for `{integer} + fn() {<() as Elide<(&(),)>>::call}`
+   |
+   = help: the trait `Add<fn() {<() as Elide<(&(),)>>::call}>` is not implemented for `{integer}`
+   = help: the following other types implement trait `Add<Rhs>`:
+             <isize as Add>
+             <isize as Add<&isize>>
+             <i8 as Add>
+             <i8 as Add<&i8>>
+             <i16 as Add>
+             <i16 as Add<&i16>>
+             <i32 as Add>
+             <i32 as Add<&i32>>
+           and 48 others
+
+error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
+  --> $DIR/escaping_bound_vars.rs:11:18
+   |
+LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
+   |                  ^ the trait `Elide<(&(),)>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/escaping_bound_vars.rs:5:1
+   |
+LL | trait Elide<T> {
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0229, E0277.
+For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/typeck/issue-110052.rs
+++ b/tests/ui/typeck/issue-110052.rs
@@ -1,7 +1,7 @@
 // Makes sure we deal with escaping lifetimes *above* INNERMOST when
 // suggesting trait for ambiguous associated type.
 
-impl<I, V> Validator<I> for ()
+impl<I> Validator<I> for ()
 where
     for<'iter> dyn Validator<<&'iter I>::Item>:,
     //~^ ERROR ambiguous associated type

--- a/tests/ui/typeck/issue-79040.rs
+++ b/tests/ui/typeck/issue-79040.rs
@@ -1,5 +1,6 @@
 fn main() {
     const FOO = "hello" + 1; //~ ERROR cannot add `{integer}` to `&str`
     //~^ missing type for `const` item
+    //~| ERROR cannot add `{integer}` to `&str`
     println!("{}", FOO);
 }

--- a/tests/ui/typeck/issue-79040.stderr
+++ b/tests/ui/typeck/issue-79040.stderr
@@ -12,6 +12,16 @@ error: missing type for `const` item
 LL |     const FOO = "hello" + 1;
    |              ^ help: provide a type for the item: `: <type>`
 
-error: aborting due to 2 previous errors
+error[E0369]: cannot add `{integer}` to `&str`
+  --> $DIR/issue-79040.rs:2:25
+   |
+LL |     const FOO = "hello" + 1;
+   |                 ------- ^ - {integer}
+   |                 |
+   |                 &str
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.rs
@@ -4,11 +4,12 @@ fn foo1<T:Copy<U>, U>(x: T) {}
 trait Trait: Copy<dyn Send> {}
 //~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 //~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
-struct MyStruct1<T: Copy<T>>;
+struct MyStruct1<T: Copy<T>>(T);
 //~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
 
-struct MyStruct2<'a, T: Copy<'a>>;
+struct MyStruct2<'a, T: Copy<'a>>(&'a T);
 //~^ ERROR trait takes 0 lifetime arguments but 1 lifetime argument was supplied
 
 fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -25,23 +25,23 @@ LL | trait Trait: Copy<dyn Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:8:21
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:9:21
    |
-LL | struct MyStruct1<T: Copy<T>>;
+LL | struct MyStruct1<T: Copy<T>>(T);
    |                     ^^^^--- help: remove these generics
    |                     |
    |                     expected 0 generic arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:11:25
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:12:25
    |
-LL | struct MyStruct2<'a, T: Copy<'a>>;
+LL | struct MyStruct2<'a, T: Copy<'a>>(&'a T);
    |                         ^^^^---- help: remove these generics
    |                         |
    |                         expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:14:15
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^ -- help: remove this lifetime argument
@@ -49,13 +49,23 @@ LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:14:15
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^     - help: remove this generic argument
    |               |
    |               expected 0 generic arguments
 
-error: aborting due to 7 previous errors
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
+   |
+LL | trait Trait: Copy<dyn Send> {}
+   |              ^^^^---------- help: remove these generics
+   |              |
+   |              expected 0 generic arguments
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -198,6 +198,7 @@ trait Qux {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
+    //~^ ERROR: not all trait items implemented, missing: `F`
     type A = _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
     type B = _;

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -29,7 +29,7 @@ LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:205:5
+  --> $DIR/typeck_type_placeholder_item.rs:206:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -411,7 +411,7 @@ LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:216:31
+  --> $DIR/typeck_type_placeholder_item.rs:217:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -420,7 +420,7 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:221:10
+  --> $DIR/typeck_type_placeholder_item.rs:222:10
    |
 LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
@@ -429,7 +429,7 @@ LL | const _: Option<_> = map(value);
    |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:224:31
+  --> $DIR/typeck_type_placeholder_item.rs:225:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -438,13 +438,13 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:229:10
+  --> $DIR/typeck_type_placeholder_item.rs:230:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:229:29}>, {closure@typeck_type_placeholder_item.rs:229:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:229:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:230:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -631,25 +631,25 @@ LL |         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
    |                                         ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:201:14
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
    |
 LL |     type A = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:203:14
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:208:14
+  --> $DIR/typeck_type_placeholder_item.rs:209:14
    |
 LL |     const D: _ = 42;
    |              ^
@@ -657,7 +657,16 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error: aborting due to 71 previous errors
+error[E0046]: not all trait items implemented, missing: `F`
+  --> $DIR/typeck_type_placeholder_item.rs:200:1
+   |
+LL |     type F: std::ops::Fn(_);
+   |     ----------------------- `F` from trait
+...
+LL | impl Qux for Struct {
+   | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
-Some errors have detailed explanations: E0121, E0282, E0403.
-For more information about an error, try `rustc --explain E0121`.
+error: aborting due to 72 previous errors
+
+Some errors have detailed explanations: E0046, E0121, E0282, E0403.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -27,7 +27,7 @@ impl Test6 {
 }
 
 pub fn main() {
-    let _: Option<usize> = test1();
-    let _: f64 = test1();
+    let _: Option<usize> = test1(); //~ ERROR mismatched types
+    let _: f64 = test1(); //~ ERROR mismatched types
     let _: Option<i32> = test1();
 }

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -55,6 +55,29 @@ LL |     const TEST6: _ = 13;
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
-error: aborting due to 7 previous errors
+error[E0308]: mismatched types
+  --> $DIR/typeck_type_placeholder_item_help.rs:30:28
+   |
+LL |     let _: Option<usize> = test1();
+   |            -------------   ^^^^^^^ expected `Option<usize>`, found `Option<i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected enum `Option<usize>`
+              found enum `Option<i32>`
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0308]: mismatched types
+  --> $DIR/typeck_type_placeholder_item_help.rs:31:18
+   |
+LL |     let _: f64 = test1();
+   |            ---   ^^^^^^^ expected `f64`, found `Option<i32>`
+   |            |
+   |            expected due to this
+   |
+   = note: expected type `f64`
+              found enum `Option<i32>`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0121, E0308.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -21,10 +21,12 @@ fn same_type<A,B:Eq<A>>(a: A, b: B) { }
 fn test<'a,'b>() {
     // Parens are equivalent to omitting default in angle.
     eq::< dyn Foo<(isize,),Output=()>,               dyn Foo(isize)                      >();
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
 
     // Here we specify 'static explicitly in angle-bracket version.
     // Parenthesized winds up getting inferred.
     eq::< dyn Foo<'static, (isize,),Output=()>,      dyn Foo(isize)                      >();
+    //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
 }
 
 fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -1,5 +1,5 @@
 error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/unboxed-closure-sugar-region.rs:30:51
+  --> $DIR/unboxed-closure-sugar-region.rs:32:51
    |
 LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
    |                                                   ^^^ expected 1 lifetime argument
@@ -10,6 +10,30 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL | trait Foo<'a,T> {
    |       ^^^ --
 
-error: aborting due to 1 previous error
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unboxed-closure-sugar-region.rs:23:58
+   |
+LL |     eq::< dyn Foo<(isize,),Output=()>,               dyn Foo(isize)                      >();
+   |                                                          ^^^ expected 1 lifetime argument
+   |
+note: trait defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/unboxed-closure-sugar-region.rs:10:7
+   |
+LL | trait Foo<'a,T> {
+   |       ^^^ --
+
+error[E0107]: trait takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unboxed-closure-sugar-region.rs:28:58
+   |
+LL |     eq::< dyn Foo<'static, (isize,),Output=()>,      dyn Foo(isize)                      >();
+   |                                                          ^^^ expected 1 lifetime argument
+   |
+note: trait defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/unboxed-closure-sugar-region.rs:10:7
+   |
+LL | trait Foo<'a,T> {
+   |       ^^^ --
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.rs
@@ -2,25 +2,25 @@
 
 trait Zero { fn dummy(&self); }
 
-fn foo1(_: dyn Zero()) {
+fn foo1(_: &dyn Zero()) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
-fn foo2(_: dyn Zero<usize>) {
+fn foo2(_: &dyn Zero<usize>) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
-fn foo3(_: dyn Zero <   usize   >) {
+fn foo3(_: &dyn Zero <   usize   >) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
 }
 
-fn foo4(_: dyn Zero(usize)) {
+fn foo4(_: &dyn Zero(usize)) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }
 
-fn foo5(_: dyn Zero (   usize   )) {
+fn foo5(_: &dyn Zero (   usize   )) {
     //~^ ERROR trait takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type `Output` not found for `Zero`
 }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -1,58 +1,10 @@
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
-LL | fn foo1(_: dyn Zero()) {
-   |                ^^^^-- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:16
-   |
-LL | fn foo1(_: dyn Zero()) {
-   |                ^^^^^^ associated type `Output` not found
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:16
-   |
-LL | fn foo2(_: dyn Zero<usize>) {
-   |                ^^^^------- help: remove these generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:16
-   |
-LL | fn foo3(_: dyn Zero <   usize   >) {
-   |                ^^^^-------------- help: remove these generics
-   |                |
-   |                expected 0 generic arguments
-   |
-note: trait defined here, with 0 generic parameters
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
-   |
-LL | trait Zero { fn dummy(&self); }
-   |       ^^^^
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
-   |
-LL | fn foo4(_: dyn Zero(usize)) {
-   |                ^^^^------- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
+LL | fn foo1(_: &dyn Zero()) {
+   |                 ^^^^-- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
@@ -61,18 +13,46 @@ LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
-LL | fn foo4(_: dyn Zero(usize)) {
-   |                ^^^^^^^^^^^ associated type `Output` not found
+LL | fn foo1(_: &dyn Zero()) {
+   |                 ^^^^^^ associated type `Output` not found
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:17
    |
-LL | fn foo5(_: dyn Zero (   usize   )) {
-   |                ^^^^-------------- help: remove these parenthetical generics
-   |                |
-   |                expected 0 generic arguments
+LL | fn foo2(_: &dyn Zero<usize>) {
+   |                 ^^^^------- help: remove these generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:17
+   |
+LL | fn foo3(_: &dyn Zero <   usize   >) {
+   |                 ^^^^-------------- help: remove these generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
+   |
+LL | fn foo4(_: &dyn Zero(usize)) {
+   |                 ^^^^------- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
@@ -81,10 +61,30 @@ LL | trait Zero { fn dummy(&self); }
    |       ^^^^
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:16
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
    |
-LL | fn foo5(_: dyn Zero (   usize   )) {
-   |                ^^^^^^^^^^^^^^^^^^ associated type `Output` not found
+LL | fn foo4(_: &dyn Zero(usize)) {
+   |                 ^^^^^^^^^^^ associated type `Output` not found
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
+   |
+LL | fn foo5(_: &dyn Zero (   usize   )) {
+   |                 ^^^^-------------- help: remove these parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
+   |
+LL | trait Zero { fn dummy(&self); }
+   |       ^^^^
+
+error[E0220]: associated type `Output` not found for `Zero`
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
+   |
+LL | fn foo5(_: &dyn Zero (   usize   )) {
+   |                 ^^^^^^^^^^^^^^^^^^ associated type `Output` not found
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #117449 (Avoid silencing relevant follow-up errors)
 - #117556 (Disallow reference to `static mut` and adding `static_mut_ref` lint)
 - #118521 (Enable address sanitizer for MSVC targets using INFERASANLIBS linker flag)
 - #118704 (Promote `riscv32{im|imafc}` targets to tier 2)
 - #119026 (std::net::bind using -1 for openbsd which in turn sets it to somaxconn.)
 - #119151 (Hide foreign `#[doc(hidden)]` paths in import suggestions)
 - #119195 (Make named_asm_labels lint not trigger on unicode and trigger on format args)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117449,117556,118521,118704,119026,119151,119195)
<!-- homu-ignore:end -->