### PR TITLE
Check yield terminator's resume type in borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -183,6 +183,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for LiveVariablesVisitor<'cx, 'tcx> {
         match ty_context {
             TyContext::ReturnTy(SourceInfo { span, .. })
             | TyContext::YieldTy(SourceInfo { span, .. })
+            | TyContext::ResumeTy(SourceInfo { span, .. })
             | TyContext::UserTy(span)
             | TyContext::LocalDecl { source_info: SourceInfo { span, .. }, .. } => {
                 span_bug!(span, "should not be visiting outside of the CFG: {:?}", ty_context);

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -76,6 +76,8 @@ pub struct UniversalRegions<'tcx> {
     pub unnormalized_input_tys: &'tcx [Ty<'tcx>],
 
     pub yield_ty: Option<Ty<'tcx>>,
+
+    pub resume_ty: Option<Ty<'tcx>>,
 }
 
 /// The "defining type" for this MIR. The key feature of the "defining
@@ -525,9 +527,12 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         debug!("build: extern regions = {}..{}", first_extern_index, first_local_index);
         debug!("build: local regions  = {}..{}", first_local_index, num_universals);
 
-        let yield_ty = match defining_ty {
-            DefiningTy::Coroutine(_, args) => Some(args.as_coroutine().yield_ty()),
-            _ => None,
+        let (resume_ty, yield_ty) = match defining_ty {
+            DefiningTy::Coroutine(_, args) => {
+                let tys = args.as_coroutine();
+                (Some(tys.resume_ty()), Some(tys.yield_ty()))
+            }
+            _ => (None, None),
         };
 
         UniversalRegions {
@@ -541,6 +546,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
             unnormalized_output_ty: *unnormalized_output_ty,
             unnormalized_input_tys,
             yield_ty,
+            resume_ty,
         }
     }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -250,6 +250,9 @@ pub struct CoroutineInfo<'tcx> {
     /// The yield type of the function, if it is a coroutine.
     pub yield_ty: Option<Ty<'tcx>>,
 
+    /// The resume type of the function, if it is a coroutine.
+    pub resume_ty: Option<Ty<'tcx>>,
+
     /// Coroutine drop glue.
     pub coroutine_drop: Option<Body<'tcx>>,
 
@@ -385,6 +388,7 @@ impl<'tcx> Body<'tcx> {
             coroutine: coroutine_kind.map(|coroutine_kind| {
                 Box::new(CoroutineInfo {
                     yield_ty: None,
+                    resume_ty: None,
                     coroutine_drop: None,
                     coroutine_layout: None,
                     coroutine_kind,
@@ -549,6 +553,11 @@ impl<'tcx> Body<'tcx> {
     #[inline]
     pub fn yield_ty(&self) -> Option<Ty<'tcx>> {
         self.coroutine.as_ref().and_then(|coroutine| coroutine.yield_ty)
+    }
+
+    #[inline]
+    pub fn resume_ty(&self) -> Option<Ty<'tcx>> {
+        self.coroutine.as_ref().and_then(|coroutine| coroutine.resume_ty)
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -996,6 +996,12 @@ macro_rules! super_body {
                     TyContext::YieldTy(SourceInfo::outermost(span))
                 );
             }
+            if let Some(resume_ty) = $(& $mutability)? gen.resume_ty {
+                $self.visit_ty(
+                    resume_ty,
+                    TyContext::ResumeTy(SourceInfo::outermost(span))
+                );
+            }
         }
 
         for (bb, data) in basic_blocks_iter!($body, $($mutability, $invalidate)?) {
@@ -1243,6 +1249,8 @@ pub enum TyContext {
     ReturnTy(SourceInfo),
 
     YieldTy(SourceInfo),
+
+    ResumeTy(SourceInfo),
 
     /// A type found at some location.
     Location(Location),

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1733,6 +1733,7 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
         }
 
         body.coroutine.as_mut().unwrap().yield_ty = None;
+        body.coroutine.as_mut().unwrap().resume_ty = None;
         body.coroutine.as_mut().unwrap().coroutine_layout = Some(layout);
 
         // Insert `drop(coroutine_struct)` which is used to drop upvars for coroutines in

--- a/tests/ui/coroutine/check-resume-ty-lifetimes-2.rs
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes-2.rs
@@ -1,0 +1,35 @@
+#![feature(coroutine_trait)]
+#![feature(coroutines)]
+
+use std::ops::Coroutine;
+
+struct Contravariant<'a>(fn(&'a ()));
+struct Covariant<'a>(fn() -> &'a ());
+
+fn bad1<'short, 'long: 'short>() -> impl Coroutine<Covariant<'short>> {
+    |_: Covariant<'short>| {
+        let a: Covariant<'long> = yield ();
+        //~^ ERROR lifetime may not live long enough
+    }
+}
+
+fn bad2<'short, 'long: 'short>() -> impl Coroutine<Contravariant<'long>> {
+    |_: Contravariant<'long>| {
+        let a: Contravariant<'short> = yield ();
+        //~^ ERROR lifetime may not live long enough
+    }
+}
+
+fn good1<'short, 'long: 'short>() -> impl Coroutine<Covariant<'long>> {
+    |_: Covariant<'long>| {
+        let a: Covariant<'short> = yield ();
+    }
+}
+
+fn good2<'short, 'long: 'short>() -> impl Coroutine<Contravariant<'short>> {
+    |_: Contravariant<'short>| {
+        let a: Contravariant<'long> = yield ();
+    }
+}
+
+fn main() {}

--- a/tests/ui/coroutine/check-resume-ty-lifetimes-2.stderr
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes-2.stderr
@@ -1,0 +1,36 @@
+error: lifetime may not live long enough
+  --> $DIR/check-resume-ty-lifetimes-2.rs:11:16
+   |
+LL | fn bad1<'short, 'long: 'short>() -> impl Coroutine<Covariant<'short>> {
+   |         ------  ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+LL |     |_: Covariant<'short>| {
+LL |         let a: Covariant<'long> = yield ();
+   |                ^^^^^^^^^^^^^^^^ type annotation requires that `'short` must outlive `'long`
+   |
+   = help: consider adding the following bound: `'short: 'long`
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |     move |_: Covariant<'short>| {
+   |     ++++
+
+error: lifetime may not live long enough
+  --> $DIR/check-resume-ty-lifetimes-2.rs:18:40
+   |
+LL | fn bad2<'short, 'long: 'short>() -> impl Coroutine<Contravariant<'long>> {
+   |         ------  ----- lifetime `'long` defined here
+   |         |
+   |         lifetime `'short` defined here
+LL |     |_: Contravariant<'long>| {
+LL |         let a: Contravariant<'short> = yield ();
+   |                                        ^^^^^^^^ yielding this value requires that `'short` must outlive `'long`
+   |
+   = help: consider adding the following bound: `'short: 'long`
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |     move |_: Contravariant<'long>| {
+   |     ++++
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/coroutine/check-resume-ty-lifetimes.rs
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes.rs
@@ -1,0 +1,27 @@
+#![feature(coroutine_trait)]
+#![feature(coroutines)]
+#![allow(unused)]
+
+use std::ops::Coroutine;
+use std::ops::CoroutineState;
+use std::pin::pin;
+
+fn mk_static(s: &str) -> &'static str {
+    let mut storage: Option<&'static str> = None;
+
+    let mut coroutine = pin!(|_: &str| {
+        let x: &'static str = yield ();
+        //~^ ERROR lifetime may not live long enough
+        storage = Some(x);
+    });
+
+    coroutine.as_mut().resume(s);
+    coroutine.as_mut().resume(s);
+
+    storage.unwrap()
+}
+
+fn main() {
+    let s = mk_static(&String::from("hello, world"));
+    println!("{s}");
+}

--- a/tests/ui/coroutine/check-resume-ty-lifetimes.stderr
+++ b/tests/ui/coroutine/check-resume-ty-lifetimes.stderr
@@ -1,0 +1,11 @@
+error: lifetime may not live long enough
+  --> $DIR/check-resume-ty-lifetimes.rs:13:16
+   |
+LL | fn mk_static(s: &str) -> &'static str {
+   |                 - let's call the lifetime of this reference `'1`
+...
+LL |         let x: &'static str = yield ();
+   |                ^^^^^^^^^^^^ type annotation requires that `'1` must outlive `'static`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
In borrowck, we didn't check that the lifetimes of the `TerminatorKind::Yield`'s `resume_place` were actually compatible with the coroutine's signature. That means that the lifetimes were totally going unchecked. Whoops!

This PR implements this checking.

Fixes #119564

r? types