### PR TITLE
bootstrap: handle vendored sources when remapping crate paths

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1799,15 +1799,20 @@ impl<'a> Builder<'a> {
         }
 
         if self.config.rust_remap_debuginfo {
-            // FIXME: handle vendored sources
-            let registry_src = t!(home::cargo_home()).join("registry").join("src");
             let mut env_var = OsString::new();
-            for entry in t!(std::fs::read_dir(registry_src)) {
-                if !env_var.is_empty() {
-                    env_var.push("\t");
-                }
-                env_var.push(t!(entry).path());
+            if self.config.vendor {
+                let vendor = self.build.src.join("vendor");
+                env_var.push(vendor);
                 env_var.push("=/rust/deps");
+            } else {
+                let registry_src = t!(home::cargo_home()).join("registry").join("src");
+                for entry in t!(std::fs::read_dir(registry_src)) {
+                    if !env_var.is_empty() {
+                        env_var.push("\t");
+                    }
+                    env_var.push(t!(entry).path());
+                    env_var.push("=/rust/deps");
+                }
             }
             cargo.env("RUSTC_CARGO_REGISTRY_SRC_TO_REMAP", env_var);
         }


### PR DESCRIPTION
#115872 introduced a feature to add path remapping for crate dependencies, but only when they came from Cargo's registry cache, not a vendor directory.

This caused builds that used remapped debuginfo and vendor directories to fail with:
```
std::fs::read_dir(registry_src) failed with No such file or directory (os error 2)
```
or (if the `registry/src` directory exists but is empty)
```
error: --remap-path-prefix must contain '=' between FROM and TO
```

Fixes #117885 by explicitly supporting the `vendor` directory and adding it to `RUSTC_CARGO_REGISTRY_SRC_TO_REMAP`. 

Note that `bootstrap.py` already assumes that `./vendor` within the rust repo is the only supported vendoring location.

r? @pietroalbini 