### PR TITLE
[beta] Clippy (early) beta backport

### DIFF
--- a/src/tools/clippy/clippy_lints/src/uninhabited_references.rs
+++ b/src/tools/clippy/clippy_lints/src/uninhabited_references.rs
@@ -32,7 +32,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.76.0"]
     pub UNINHABITED_REFERENCES,
-    suspicious,
+    nursery,
     "reference to uninhabited type"
 }
 


### PR DESCRIPTION
Early backport of
- https://github.com/rust-lang/rust-clippy/pull/11997

This is causing some major issues for Clippy beta-users. As those are the ones that help testing new lints early, we want to fix their issues ASAP.

r? @Mark-Simulacrum 

cc @Manishearth 