### PR TITLE
Remove outdated references to librustc_middle

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -50,9 +50,7 @@ impl MachineStopType for ConstEvalErrKind {
     }
 }
 
-// The errors become `MachineStop` with plain strings when being raised.
-// `ConstEvalErr` (in `librustc_middle/mir/interpret/error.rs`) knows to
-// handle these.
+/// The errors become [`InterpError::MachineStop`] when being raised.
 impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalErrKind {
     fn into(self) -> InterpErrorInfo<'tcx> {
         err_machine_stop!(self).into()

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -147,7 +147,7 @@ pub fn make_display(f: impl Fn(&mut fmt::Formatter<'_>) -> fmt::Result) -> impl 
     Printer { f }
 }
 
-// See comments in src/librustc_middle/lib.rs
+// See comments in compiler/rustc_middle/src/tests.rs
 #[doc(hidden)]
 pub fn __noop_fix_for_27438() {}
 

--- a/compiler/rustc_error_codes/src/error_codes/E0264.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0264.md
@@ -13,7 +13,7 @@ extern "C" {
 ```
 
 A list of available external lang items is available in
-`src/librustc_middle/middle/weak_lang_items.rs`. Example:
+`compiler/rustc_hir/src/weak_lang_items.rs`. Example:
 
 ```
 #![feature(lang_items)]

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -639,7 +639,8 @@ impl DiagCtxt {
     }
 
     // This is here to not allow mutation of flags;
-    // as of this writing it's only used in tests in librustc_middle.
+    // as of this writing it's used in Session::consider_optimizing and
+    // in tests in rustc_interface.
     pub fn can_emit_warnings(&self) -> bool {
         self.inner.borrow_mut().flags.can_emit_warnings
     }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -72,7 +72,7 @@ use crate::nonstandard_style::{method_context, MethodLateContext};
 
 use std::fmt::Write;
 
-// hardwired lints from librustc_middle
+// hardwired lints from rustc_lint_defs
 pub use rustc_session::lint::builtin::*;
 
 declare_lint! {

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -94,7 +94,7 @@ macro_rules! arena_types {
 
             // Note that this deliberately duplicates items in the `rustc_hir::arena`,
             // since we need to allocate this type on both the `rustc_hir` arena
-            // (during lowering) and the `librustc_middle` arena (for decoding MIR)
+            // (during lowering) and the `rustc_middle` arena (for decoding MIR)
             [decode] asm_template: rustc_ast::InlineAsmTemplatePiece,
             [decode] used_trait_imports: rustc_data_structures::unord::UnordSet<rustc_hir::def_id::LocalDefId>,
             [decode] is_late_bound_map: rustc_data_structures::fx::FxIndexSet<rustc_hir::ItemLocalId>,

--- a/compiler/rustc_middle/src/tests.rs
+++ b/compiler/rustc_middle/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-// FIXME(#27438): right now the unit tests of librustc_middle don't refer to any actual
-//                functions generated in librustc_data_structures (all
+// FIXME(#27438): right now the unit tests of rustc_middle don't refer to any actual
+//                functions generated in rustc_data_structures (all
 //                references are through generic functions), but statics are
 //                referenced from time to time. Due to this bug we won't
 //                actually correctly link in the statics unless we also


### PR DESCRIPTION
The relevant comment is now in https://github.com/rust-lang/rust/blob/791a53f380d5cf800191f25941c94ace5099876e/compiler/rustc_middle/src/tests.rs#L3-L13