### PR TITLE
never patterns: Check bindings wrt never patterns

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -36,6 +36,10 @@ resolve_attempt_to_use_non_constant_value_in_constant_with_suggestion =
 resolve_attempt_to_use_non_constant_value_in_constant_without_suggestion =
     this would need to be a `{$suggestion}`
 
+resolve_binding_in_never_pattern =
+    never patterns cannot contain variable bindings
+    .suggestion = use a wildcard `_` instead
+
 resolve_binding_shadows_something_unacceptable =
     {$shadowing_binding}s cannot shadow {$shadowed_binding}s
     .label = cannot be named the same as {$article} {$shadowed_binding}

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -960,6 +960,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 .create_err(errs::TraitImplDuplicate { span, name, trait_item_span, old_span }),
             ResolutionError::InvalidAsmSym => self.dcx().create_err(errs::InvalidAsmSym { span }),
             ResolutionError::LowercaseSelf => self.dcx().create_err(errs::LowercaseSelf { span }),
+            ResolutionError::BindingInNeverPattern => {
+                self.dcx().create_err(errs::BindingInNeverPattern { span })
+            }
         }
     }
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -486,6 +486,15 @@ pub(crate) struct LowercaseSelf {
     pub(crate) span: Span,
 }
 
+#[derive(Debug)]
+#[derive(Diagnostic)]
+#[diag(resolve_binding_in_never_pattern)]
+pub(crate) struct BindingInNeverPattern {
+    #[primary_span]
+    #[suggestion(code = "_", applicability = "machine-applicable", style = "short")]
+    pub(crate) span: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(resolve_trait_impl_duplicate, code = "E0201")]
 pub(crate) struct TraitImplDuplicate {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3324,7 +3324,17 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
 
     /// Check the consistency of bindings wrt or-patterns and never patterns.
     fn check_consistent_bindings(&mut self, pat: &'ast Pat) {
-        let _ = self.compute_and_check_binding_map(pat);
+        let mut is_or_or_never = false;
+        pat.walk(&mut |pat| match pat.kind {
+            PatKind::Or(..) | PatKind::Never => {
+                is_or_or_never = true;
+                false
+            }
+            _ => true,
+        });
+        if is_or_or_never {
+            let _ = self.compute_and_check_binding_map(pat);
+        }
     }
 
     fn resolve_arm(&mut self, arm: &'ast Arm) {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -265,6 +265,8 @@ enum ResolutionError<'a> {
     InvalidAsmSym,
     /// `self` used instead of `Self` in a generic parameter
     LowercaseSelf,
+    /// A never pattern has a binding.
+    BindingInNeverPattern,
 }
 
 enum VisResolutionError<'a> {

--- a/tests/ui/feature-gates/feature-gate-never_patterns.rs
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.rs
@@ -7,7 +7,6 @@ fn main() {
     let res: Result<u32, Void> = Ok(0);
     let (Ok(_x) | Err(&!)) = res.as_ref();
     //~^ ERROR `!` patterns are experimental
-    //~| ERROR: is not bound in all patterns
 
     unsafe {
         let ptr: *const Void = NonNull::dangling().as_ptr();

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -1,5 +1,5 @@
 error: unexpected `,` in pattern
-  --> $DIR/feature-gate-never_patterns.rs:34:16
+  --> $DIR/feature-gate-never_patterns.rs:33:16
    |
 LL |         Some(_),
    |                ^
@@ -13,14 +13,6 @@ help: ...or a vertical bar to match on multiple alternatives
 LL |         Some(_) |
    |
 
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/feature-gate-never_patterns.rs:8:19
-   |
-LL |     let (Ok(_x) | Err(&!)) = res.as_ref();
-   |             --    ^^^^^^^ pattern doesn't bind `_x`
-   |             |
-   |             variable not in all patterns
-
 error[E0658]: `!` patterns are experimental
   --> $DIR/feature-gate-never_patterns.rs:8:24
    |
@@ -31,7 +23,7 @@ LL |     let (Ok(_x) | Err(&!)) = res.as_ref();
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
 
 error[E0658]: `!` patterns are experimental
-  --> $DIR/feature-gate-never_patterns.rs:15:13
+  --> $DIR/feature-gate-never_patterns.rs:14:13
    |
 LL |             !
    |             ^
@@ -40,7 +32,7 @@ LL |             !
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
 
 error[E0658]: `!` patterns are experimental
-  --> $DIR/feature-gate-never_patterns.rs:21:13
+  --> $DIR/feature-gate-never_patterns.rs:20:13
    |
 LL |             !
    |             ^
@@ -49,7 +41,7 @@ LL |             !
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
 
 error[E0658]: `!` patterns are experimental
-  --> $DIR/feature-gate-never_patterns.rs:26:13
+  --> $DIR/feature-gate-never_patterns.rs:25:13
    |
 LL |             ! => {}
    |             ^
@@ -58,25 +50,25 @@ LL |             ! => {}
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
 
 error: `match` arm with no body
-  --> $DIR/feature-gate-never_patterns.rs:39:9
+  --> $DIR/feature-gate-never_patterns.rs:38:9
    |
 LL |         Some(_)
    |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
 
 error: `match` arm with no body
-  --> $DIR/feature-gate-never_patterns.rs:44:9
+  --> $DIR/feature-gate-never_patterns.rs:43:9
    |
 LL |         Some(_) if false,
    |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
 
 error: `match` arm with no body
-  --> $DIR/feature-gate-never_patterns.rs:46:9
+  --> $DIR/feature-gate-never_patterns.rs:45:9
    |
 LL |         Some(_) if false
    |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
 
 error[E0658]: `!` patterns are experimental
-  --> $DIR/feature-gate-never_patterns.rs:51:13
+  --> $DIR/feature-gate-never_patterns.rs:50:13
    |
 LL |         Err(!),
    |             ^
@@ -85,7 +77,7 @@ LL |         Err(!),
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
 
 error[E0658]: `!` patterns are experimental
-  --> $DIR/feature-gate-never_patterns.rs:55:13
+  --> $DIR/feature-gate-never_patterns.rs:54:13
    |
 LL |         Err(!) if false,
    |             ^
@@ -94,24 +86,23 @@ LL |         Err(!) if false,
    = help: add `#![feature(never_patterns)]` to the crate attributes to enable
 
 error: `match` arm with no body
-  --> $DIR/feature-gate-never_patterns.rs:65:9
+  --> $DIR/feature-gate-never_patterns.rs:64:9
    |
 LL |         Some(_)
    |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
 
 error: `match` arm with no body
-  --> $DIR/feature-gate-never_patterns.rs:71:9
+  --> $DIR/feature-gate-never_patterns.rs:70:9
    |
 LL |         Some(_) if false
    |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
 
 error: a guard on a never pattern will never be run
-  --> $DIR/feature-gate-never_patterns.rs:55:19
+  --> $DIR/feature-gate-never_patterns.rs:54:19
    |
 LL |         Err(!) if false,
    |                   ^^^^^ help: remove this guard
 
-error: aborting due to 14 previous errors
+error: aborting due to 13 previous errors
 
-Some errors have detailed explanations: E0408, E0658.
-For more information about an error, try `rustc --explain E0408`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/pattern/never_patterns.rs
+++ b/tests/ui/pattern/never_patterns.rs
@@ -74,26 +74,3 @@ fn never_pattern_location(void: Void) {
         Some(&(_, !)),
     }
 }
-
-fn never_and_bindings() {
-    let x: Result<bool, &(u32, Void)> = Ok(false);
-
-    // FIXME(never_patterns): Never patterns in or-patterns don't need to share the same bindings.
-    match x {
-        Ok(_x) | Err(&!) => {}
-        //~^ ERROR: is not bound in all patterns
-    }
-    let (Ok(_x) | Err(&!)) = x;
-    //~^ ERROR: is not bound in all patterns
-
-    // FIXME(never_patterns): A never pattern mustn't have bindings.
-    match x {
-        Ok(_) => {}
-        Err(&(_b, !)),
-    }
-    match x {
-        Ok(_a) | Err(&(_b, !)) => {}
-        //~^ ERROR: is not bound in all patterns
-        //~| ERROR: is not bound in all patterns
-    }
-}

--- a/tests/ui/pattern/never_patterns.rs
+++ b/tests/ui/pattern/never_patterns.rs
@@ -7,12 +7,9 @@ fn main() {}
 
 // The classic use for empty types.
 fn safe_unwrap_result<T>(res: Result<T, Void>) {
-    let Ok(_x) = res;
-    // FIXME(never_patterns): These should be allowed
+    let Ok(_x) = res; //~ ERROR refutable pattern in local binding
     let (Ok(_x) | Err(!)) = &res;
-    //~^ ERROR: is not bound in all patterns
     let (Ok(_x) | Err(&!)) = res.as_ref();
-    //~^ ERROR: is not bound in all patterns
 }
 
 // Check we only accept `!` where we want to.

--- a/tests/ui/pattern/never_patterns.stderr
+++ b/tests/ui/pattern/never_patterns.stderr
@@ -14,38 +14,6 @@ LL |     let (Ok(_x) | Err(&!)) = res.as_ref();
    |             |
    |             variable not in all patterns
 
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/never_patterns.rs:83:18
-   |
-LL |         Ok(_x) | Err(&!) => {}
-   |            --    ^^^^^^^ pattern doesn't bind `_x`
-   |            |
-   |            variable not in all patterns
-
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/never_patterns.rs:86:19
-   |
-LL |     let (Ok(_x) | Err(&!)) = x;
-   |             --    ^^^^^^^ pattern doesn't bind `_x`
-   |             |
-   |             variable not in all patterns
-
-error[E0408]: variable `_b` is not bound in all patterns
-  --> $DIR/never_patterns.rs:95:9
-   |
-LL |         Ok(_a) | Err(&(_b, !)) => {}
-   |         ^^^^^^         -- variable not in all patterns
-   |         |
-   |         pattern doesn't bind `_b`
-
-error[E0408]: variable `_a` is not bound in all patterns
-  --> $DIR/never_patterns.rs:95:18
-   |
-LL |         Ok(_a) | Err(&(_b, !)) => {}
-   |            --    ^^^^^^^^^^^^^ pattern doesn't bind `_a`
-   |            |
-   |            variable not in all patterns
-
-error: aborting due to 6 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0408`.

--- a/tests/ui/pattern/never_patterns.stderr
+++ b/tests/ui/pattern/never_patterns.stderr
@@ -1,19 +1,17 @@
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/never_patterns.rs:12:19
+error[E0005]: refutable pattern in local binding
+  --> $DIR/never_patterns.rs:10:9
    |
-LL |     let (Ok(_x) | Err(!)) = &res;
-   |             --    ^^^^^^ pattern doesn't bind `_x`
-   |             |
-   |             variable not in all patterns
-
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/never_patterns.rs:14:19
+LL |     let Ok(_x) = res;
+   |         ^^^^^^ pattern `Err(_)` not covered
    |
-LL |     let (Ok(_x) | Err(&!)) = res.as_ref();
-   |             --    ^^^^^^^ pattern doesn't bind `_x`
-   |             |
-   |             variable not in all patterns
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Result<T, Void>`
+help: you might want to use `let else` to handle the variant that isn't matched
+   |
+LL |     let Ok(_x) = res else { todo!() };
+   |                      ++++++++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0408`.
+For more information about this error, try `rustc --explain E0005`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
@@ -6,23 +6,20 @@ enum Void {}
 fn main() {
     let x: Result<bool, &(u32, u32, Void)> = Ok(false);
 
-    // FIXME(never_patterns): Never patterns in or-patterns don't need to share the same bindings.
     match x {
         Ok(_x) | Err(&!) => {}
-        //~^ ERROR: is not bound in all patterns
     }
     let (Ok(_x) | Err(&!)) = x;
-    //~^ ERROR: is not bound in all patterns
 
-    // FIXME(never_patterns): A never pattern mustn't have bindings.
     match x {
         Ok(_) => {}
         Err(&(_a, _b, !)),
+        //~^ ERROR: never patterns cannot contain variable bindings
+        //~| ERROR: never patterns cannot contain variable bindings
     }
     match x {
         Ok(_ok) | Err(&(_a, _b, !)) => {}
-        //~^ ERROR: is not bound in all patterns
-        //~| ERROR: is not bound in all patterns
-        //~| ERROR: is not bound in all patterns
+        //~^ ERROR: never patterns cannot contain variable bindings
+        //~| ERROR: never patterns cannot contain variable bindings
     }
 }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
@@ -23,3 +23,24 @@ fn main() {
         //~| ERROR: never patterns cannot contain variable bindings
     }
 }
+
+fn void(void: Void) {
+    let (_a | !) = void;
+    let (! | _a) = void;
+    let ((_a, _) | (_a, _ | !)) = (true, void);
+    let (_a | (! | !,)) = (void,);
+    let ((_a,) | (!,)) = (void,);
+
+    let (_a, (! | !)) = (true, void);
+    //~^ ERROR: never patterns cannot contain variable bindings
+    let (_a, (_b | !)) = (true, void);
+
+    let _a @ ! = void;
+    //~^ ERROR: never patterns cannot contain variable bindings
+    let _a @ (_b | !) = void;
+    let (_a @ (), !) = ((), void);
+    //~^ ERROR: never patterns cannot contain variable bindings
+    let (_a |
+            (_b @ (_, !))) = (true, void);
+    //~^ ERROR: never patterns cannot contain variable bindings
+}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
@@ -1,0 +1,28 @@
+#![feature(never_patterns)]
+#![allow(incomplete_features)]
+
+enum Void {}
+
+fn main() {
+    let x: Result<bool, &(u32, u32, Void)> = Ok(false);
+
+    // FIXME(never_patterns): Never patterns in or-patterns don't need to share the same bindings.
+    match x {
+        Ok(_x) | Err(&!) => {}
+        //~^ ERROR: is not bound in all patterns
+    }
+    let (Ok(_x) | Err(&!)) = x;
+    //~^ ERROR: is not bound in all patterns
+
+    // FIXME(never_patterns): A never pattern mustn't have bindings.
+    match x {
+        Ok(_) => {}
+        Err(&(_a, _b, !)),
+    }
+    match x {
+        Ok(_ok) | Err(&(_a, _b, !)) => {}
+        //~^ ERROR: is not bound in all patterns
+        //~| ERROR: is not bound in all patterns
+        //~| ERROR: is not bound in all patterns
+    }
+}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
@@ -1,0 +1,43 @@
+error[E0408]: variable `_x` is not bound in all patterns
+  --> $DIR/bindings.rs:11:18
+   |
+LL |         Ok(_x) | Err(&!) => {}
+   |            --    ^^^^^^^ pattern doesn't bind `_x`
+   |            |
+   |            variable not in all patterns
+
+error[E0408]: variable `_x` is not bound in all patterns
+  --> $DIR/bindings.rs:14:19
+   |
+LL |     let (Ok(_x) | Err(&!)) = x;
+   |             --    ^^^^^^^ pattern doesn't bind `_x`
+   |             |
+   |             variable not in all patterns
+
+error[E0408]: variable `_a` is not bound in all patterns
+  --> $DIR/bindings.rs:23:9
+   |
+LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
+   |         ^^^^^^^         -- variable not in all patterns
+   |         |
+   |         pattern doesn't bind `_a`
+
+error[E0408]: variable `_b` is not bound in all patterns
+  --> $DIR/bindings.rs:23:9
+   |
+LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
+   |         ^^^^^^^             -- variable not in all patterns
+   |         |
+   |         pattern doesn't bind `_b`
+
+error[E0408]: variable `_ok` is not bound in all patterns
+  --> $DIR/bindings.rs:23:19
+   |
+LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
+   |            ---    ^^^^^^^^^^^^^^^^^ pattern doesn't bind `_ok`
+   |            |
+   |            variable not in all patterns
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0408`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
@@ -1,43 +1,26 @@
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/bindings.rs:11:18
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:16:15
    |
-LL |         Ok(_x) | Err(&!) => {}
-   |            --    ^^^^^^^ pattern doesn't bind `_x`
-   |            |
-   |            variable not in all patterns
+LL |         Err(&(_a, _b, !)),
+   |               ^^ help: use a wildcard `_` instead
 
-error[E0408]: variable `_x` is not bound in all patterns
-  --> $DIR/bindings.rs:14:19
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:16:19
    |
-LL |     let (Ok(_x) | Err(&!)) = x;
-   |             --    ^^^^^^^ pattern doesn't bind `_x`
-   |             |
-   |             variable not in all patterns
+LL |         Err(&(_a, _b, !)),
+   |                   ^^ help: use a wildcard `_` instead
 
-error[E0408]: variable `_a` is not bound in all patterns
-  --> $DIR/bindings.rs:23:9
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:21:25
    |
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
-   |         ^^^^^^^         -- variable not in all patterns
-   |         |
-   |         pattern doesn't bind `_a`
+   |                         ^^ help: use a wildcard `_` instead
 
-error[E0408]: variable `_b` is not bound in all patterns
-  --> $DIR/bindings.rs:23:9
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:21:29
    |
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
-   |         ^^^^^^^             -- variable not in all patterns
-   |         |
-   |         pattern doesn't bind `_b`
+   |                             ^^ help: use a wildcard `_` instead
 
-error[E0408]: variable `_ok` is not bound in all patterns
-  --> $DIR/bindings.rs:23:19
-   |
-LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
-   |            ---    ^^^^^^^^^^^^^^^^^ pattern doesn't bind `_ok`
-   |            |
-   |            variable not in all patterns
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-For more information about this error, try `rustc --explain E0408`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
@@ -22,5 +22,29 @@ error: never patterns cannot contain variable bindings
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
    |                             ^^ help: use a wildcard `_` instead
 
-error: aborting due to 4 previous errors
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:34:10
+   |
+LL |     let (_a, (! | !)) = (true, void);
+   |          ^^ help: use a wildcard `_` instead
+
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:38:9
+   |
+LL |     let _a @ ! = void;
+   |         ^^ help: use a wildcard `_` instead
+
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:41:10
+   |
+LL |     let (_a @ (), !) = ((), void);
+   |          ^^ help: use a wildcard `_` instead
+
+error: never patterns cannot contain variable bindings
+  --> $DIR/bindings.rs:44:14
+   |
+LL |             (_b @ (_, !))) = (true, void);
+   |              ^^ help: use a wildcard `_` instead
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.rs
@@ -71,6 +71,7 @@ fn parse(x: Void) {
 
     let ! = x;
     let y @ ! = x;
+    //~^ ERROR: never patterns cannot contain variable bindings
 }
 
 fn foo(!: Void) {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -22,6 +22,12 @@ error: top-level or-patterns are not allowed in `let` bindings
 LL |     let Ok(_) | Err(!) = &res; // Disallowed; see #82048.
    |         ^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(Ok(_) | Err(!))`
 
+error: never patterns cannot contain variable bindings
+  --> $DIR/parse.rs:73:9
+   |
+LL |     let y @ ! = x;
+   |         ^ help: use a wildcard `_` instead
+
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:31:20
    |
@@ -40,5 +46,5 @@ error: a guard on a never pattern will never be run
 LL |         never!() if true,
    |                     ^^^^ help: remove this guard
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Never patterns:
- Shouldn't contain bindings since they never match anything;
- Don't count when checking that or-patterns have consistent bindings.

r? @compiler-errors 