### PR TITLE
mir-opt and custom target fixes

### DIFF
--- a/src/bootstrap/src/core/build_steps/synthetic_targets.rs
+++ b/src/bootstrap/src/core/build_steps/synthetic_targets.rs
@@ -59,6 +59,11 @@ fn create_synthetic_target(
     let mut cmd = Command::new(builder.rustc(compiler));
     cmd.arg("--target").arg(base.rustc_target_arg());
     cmd.args(["-Zunstable-options", "--print", "target-spec-json"]);
+
+    // If `rust.channel` is set to either beta or stable, rustc will complain that
+    // we cannot use nightly features. So `RUSTC_BOOTSTRAP` is needed here.
+    cmd.env("RUSTC_BOOTSTRAP", "1");
+
     cmd.stdout(Stdio::piped());
 
     let output = cmd.spawn().unwrap().wait_with_output().unwrap();

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1596,8 +1596,13 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         // NOTE: Only stage 1 is special cased because we need the rustc_private artifacts to match the
         // running compiler in stage 2 when plugins run.
         let stage_id = if suite == "ui-fulldeps" && compiler.stage == 1 {
-            compiler = builder.compiler(compiler.stage - 1, target);
-            format!("stage{}-{}", compiler.stage + 1, target)
+            // At stage 0 (stage - 1) we are using the beta compiler. Using `self.target` can lead finding
+            // an incorrect compiler path on cross-targets, as the stage 0 beta compiler is always equal
+            // to `build.build` in the configuration.
+            let build = builder.build.build;
+
+            compiler = builder.compiler(compiler.stage - 1, build);
+            format!("stage{}-{}", compiler.stage + 1, build)
         } else {
             format!("stage{}-{}", compiler.stage, target)
         };

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -479,6 +479,7 @@ impl TargetCfgs {
         let mut targets: HashMap<String, TargetCfg> = serde_json::from_str(&rustc_output(
             config,
             &["--print=all-target-specs-json", "-Zunstable-options"],
+            Default::default(),
         ))
         .unwrap();
 
@@ -491,16 +492,33 @@ impl TargetCfgs {
         let mut all_families = HashSet::new();
         let mut all_pointer_widths = HashSet::new();
 
-        // Handle custom target specs, which are not included in `--print=all-target-specs-json`.
-        if config.target.ends_with(".json") {
-            targets.insert(
-                config.target.clone(),
-                serde_json::from_str(&rustc_output(
-                    config,
-                    &["--print=target-spec-json", "-Zunstable-options", "--target", &config.target],
-                ))
-                .unwrap(),
-            );
+        // If current target is not included in the `--print=all-target-specs-json` output,
+        // we check whether it is a custom target from the user or a synthetic target from bootstrap.
+        if !targets.contains_key(&config.target) {
+            let mut envs: HashMap<String, String> = HashMap::new();
+
+            if let Ok(t) = std::env::var("RUST_TARGET_PATH") {
+                envs.insert("RUST_TARGET_PATH".into(), t);
+            }
+
+            // This returns false only when the target is neither a synthetic target
+            // nor a custom target from the user, indicating it is most likely invalid.
+            if config.target.ends_with(".json") || !envs.is_empty() {
+                targets.insert(
+                    config.target.clone(),
+                    serde_json::from_str(&rustc_output(
+                        config,
+                        &[
+                            "--print=target-spec-json",
+                            "-Zunstable-options",
+                            "--target",
+                            &config.target,
+                        ],
+                        envs,
+                    ))
+                    .unwrap(),
+                );
+            }
         }
 
         for (target, cfg) in targets.iter() {
@@ -545,7 +563,9 @@ impl TargetCfgs {
         // code below extracts them from `--print=cfg`: make sure to only override fields that can
         // actually be changed with `-C` flags.
         for config in
-            rustc_output(config, &["--print=cfg", "--target", &config.target]).trim().lines()
+            rustc_output(config, &["--print=cfg", "--target", &config.target], Default::default())
+                .trim()
+                .lines()
         {
             let (name, value) = config
                 .split_once("=\"")
@@ -624,11 +644,12 @@ pub enum Endian {
     Big,
 }
 
-fn rustc_output(config: &Config, args: &[&str]) -> String {
+fn rustc_output(config: &Config, args: &[&str], envs: HashMap<String, String>) -> String {
     let mut command = Command::new(&config.rustc_path);
     add_dylib_path(&mut command, iter::once(&config.compile_lib_path));
     command.args(&config.target_rustcflags).args(args);
     command.env("RUSTC_BOOTSTRAP", "1");
+    command.envs(envs);
 
     let output = match command.output() {
         Ok(output) => output,


### PR DESCRIPTION
From https://github.com/rust-lang/rust/issues/115642#issuecomment-1879589022

> > Could you please test the last two commits from https://github.com/onur-ozkan/rust/commits/panic-abort-mir-opt when you have the time? The first commit should resolve the error of using the nightly flag with a stable compiler, and the second one should resolve the custom target issue.

> I tested with the two commits and the errors of using nightly flag and custom target specs were not seen.
Testing was completed for the test suites like ui, run-pass-valgrind, coverage, mir-opt, codegen, assembly, incremental.

Fixes #115642