### PR TITLE
never patterns: Document behavior of never patterns with macros-by-example

### DIFF
--- a/tests/ui/rfcs/rfc-0000-never_patterns/macros.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/macros.rs
@@ -1,0 +1,49 @@
+// check-pass
+// revisions: e2018 e2021
+//[e2018] edition:2018
+//[e2021] edition:2021
+#![feature(never_patterns)]
+#![allow(incomplete_features)]
+
+#[derive(Debug, PartialEq, Eq)]
+struct Pattern;
+#[derive(Debug, PartialEq, Eq)]
+struct Never;
+#[derive(Debug, PartialEq, Eq)]
+struct Other;
+
+macro_rules! detect_pat {
+    ($p:pat) => {
+        Pattern
+    };
+    (!) => {
+        Never
+    };
+    ($($x:tt)*) => {
+        Other
+    };
+}
+
+// For backwards-compatibility, all the cases that parse as `Pattern` under the feature gate must
+// have been parse errors before.
+fn main() {
+    // For backwards compatibility this does not match `$p:pat`.
+    assert_eq!(detect_pat!(!), Never);
+
+    // Edition 2018 parses both of these cases as `Other`. Both editions have been parsing the
+    // first case as `Other` before, so we mustn't change that.
+    assert_eq!(detect_pat!(! | true), Other);
+    #[cfg(e2018)]
+    assert_eq!(detect_pat!(true | !), Other);
+    #[cfg(e2021)]
+    assert_eq!(detect_pat!(true | !), Pattern);
+
+    // These are never patterns; they take no body when they're in a match arm.
+    assert_eq!(detect_pat!((!)), Pattern);
+    assert_eq!(detect_pat!((true, !)), Pattern);
+    assert_eq!(detect_pat!(Some(!)), Pattern);
+
+    // These count as normal patterns.
+    assert_eq!(detect_pat!((! | true)), Pattern);
+    assert_eq!(detect_pat!((Ok(x) | Err(&!))), Pattern);
+}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.rs
@@ -68,4 +68,9 @@ fn parse(x: Void) {
     //~^ ERROR top-level or-patterns are not allowed in `let` bindings
     let (Ok(_) | Err(!)) = &res;
     let (Ok(_) | Err(&!)) = res.as_ref();
+
+    let ! = x;
+    let y @ ! = x;
 }
+
+fn foo(!: Void) {}


### PR DESCRIPTION
`never_patterns` makes `!` parse as a pattern so I was worried about breaking macros-by-example matching. Turns out we're fine because the cases that now match `$p:pat` used to error in the past. The only tricky case is `!` by itself, which backwards-compatibly doesn't match `$p:pat`. I have no idea why tho, I didn't think of that when I was implementing parsing :sweat_smile:.

This adds tests so we don't regress the current behavior.

r? @compiler-errors 