### PR TITLE
rustc_span: More consistent span combination operations

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2489,7 +2489,7 @@ impl<'a> Parser<'a> {
                 }
                 ExprKind::Block(_, None) => {
                     this.dcx().emit_err(errors::IfExpressionMissingCondition {
-                        if_span: lo.shrink_to_hi(),
+                        if_span: lo.with_neighbor(cond.span).shrink_to_hi(),
                         block_span: self.sess.source_map().start_point(cond_span),
                     });
                     std::mem::replace(&mut cond, this.mk_expr_err(cond_span.shrink_to_hi()))

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3735,7 +3735,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn mk_expr(&self, span: Span, kind: ExprKind) -> P<Expr> {
-        P(Expr { kind, span, attrs: AttrVec::new(), id: DUMMY_NODE_ID, tokens: None })
+        self.mk_expr_with_attrs(span, kind, AttrVec::new())
     }
 
     pub(super) fn mk_expr_err(&self, span: Span) -> P<Expr> {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2118,7 +2118,7 @@ impl<'a> Parser<'a> {
                 Applicability::MaybeIncorrect,
             );
             err.span_suggestion(
-                span.shrink_to_hi(),
+                span.with_neighbor(self.token.span).shrink_to_hi(),
                 "add a semicolon",
                 ';',
                 Applicability::MaybeIncorrect,
@@ -2632,7 +2632,7 @@ impl<'a> Parser<'a> {
 
             let is_name_required = match this.token.kind {
                 token::DotDotDot => false,
-                _ => req_name(this.token.span.edition()),
+                _ => req_name(this.token.span.with_neighbor(this.prev_token.span).edition()),
             };
             let (pat, ty) = if is_name_required || this.is_named_param() {
                 debug!("parse_param_general parse_pat (is_name_required:{})", is_name_required);

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -850,21 +850,6 @@ impl fmt::Debug for SyntaxContext {
 }
 
 impl Span {
-    /// Creates a fresh expansion with given properties.
-    /// Expansions are normally created by macros, but in some cases expansions are created for
-    /// other compiler-generated code to set per-span properties like allowed unstable features.
-    /// The returned span belongs to the created expansion and has the new properties,
-    /// but its location is inherited from the current span.
-    pub fn fresh_expansion(self, expn_id: LocalExpnId) -> Span {
-        HygieneData::with(|data| {
-            self.with_ctxt(data.apply_mark(
-                self.ctxt(),
-                expn_id.to_expn_id(),
-                Transparency::Transparent,
-            ))
-        })
-    }
-
     /// Reuses the span but adds information like the kind of the desugaring and features that are
     /// allowed inside this span.
     pub fn mark_with_reason(
@@ -879,7 +864,7 @@ impl Span {
             ..ExpnData::default(ExpnKind::Desugaring(reason), self, edition, None, None)
         };
         let expn_id = LocalExpnId::fresh(expn_data, ctx);
-        self.fresh_expansion(expn_id)
+        self.apply_mark(expn_id.to_expn_id(), Transparency::Transparent)
     }
 }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -826,6 +826,39 @@ impl Span {
         )
     }
 
+    /// Prepare two spans to a combine operation like `to` or `between`.
+    /// FIXME: consider using declarative macro metavariable spans for the given spans if they are
+    /// better suitable for combining (#119412).
+    fn prepare_to_combine(
+        a_orig: Span,
+        b_orig: Span,
+    ) -> Result<(SpanData, SpanData, Option<LocalDefId>), Span> {
+        let (a, b) = (a_orig.data(), b_orig.data());
+
+        if a.ctxt != b.ctxt {
+            // Context mismatches usually happen when procedural macros combine spans copied from
+            // the macro input with spans produced by the macro (`Span::*_site`).
+            // In that case we consider the combined span to be produced by the macro and return
+            // the original macro-produced span as the result.
+            // Otherwise we just fall back to returning the first span.
+            // Combining locations typically doesn't make sense in case of context mismatches.
+            // `is_root` here is a fast path optimization.
+            let a_is_callsite = a.ctxt.is_root() || a.ctxt == b.span().source_callsite().ctxt();
+            return Err(if a_is_callsite { b_orig } else { a_orig });
+        }
+
+        let parent = if a.parent == b.parent { a.parent } else { None };
+        Ok((a, b, parent))
+    }
+
+    /// This span, but in a larger context, may switch to the metavariable span if suitable.
+    pub fn with_neighbor(self, neighbor: Span) -> Span {
+        match Span::prepare_to_combine(self, neighbor) {
+            Ok((this, ..)) => Span::new(this.lo, this.hi, this.ctxt, this.parent),
+            Err(_) => self,
+        }
+    }
+
     /// Returns a `Span` that would enclose both `self` and `end`.
     ///
     /// Note that this can also be used to extend the span "backwards":
@@ -837,26 +870,12 @@ impl Span {
     ///     ^^^^^^^^^^^^^^^^^^^^
     /// ```
     pub fn to(self, end: Span) -> Span {
-        let span_data = self.data();
-        let end_data = end.data();
-        // FIXME(jseyfried): `self.ctxt` should always equal `end.ctxt` here (cf. issue #23480).
-        // Return the macro span on its own to avoid weird diagnostic output. It is preferable to
-        // have an incomplete span than a completely nonsensical one.
-        if span_data.ctxt != end_data.ctxt {
-            if span_data.ctxt.is_root() {
-                return end;
-            } else if end_data.ctxt.is_root() {
-                return self;
+        match Span::prepare_to_combine(self, end) {
+            Ok((from, to, parent)) => {
+                Span::new(cmp::min(from.lo, to.lo), cmp::max(from.hi, to.hi), from.ctxt, parent)
             }
-            // Both spans fall within a macro.
-            // FIXME(estebank): check if it is the *same* macro.
+            Err(fallback) => fallback,
         }
-        Span::new(
-            cmp::min(span_data.lo, end_data.lo),
-            cmp::max(span_data.hi, end_data.hi),
-            if span_data.ctxt.is_root() { end_data.ctxt } else { span_data.ctxt },
-            if span_data.parent == end_data.parent { span_data.parent } else { None },
-        )
     }
 
     /// Returns a `Span` between the end of `self` to the beginning of `end`.
@@ -867,14 +886,12 @@ impl Span {
     ///         ^^^^^^^^^^^^^
     /// ```
     pub fn between(self, end: Span) -> Span {
-        let span = self.data();
-        let end = end.data();
-        Span::new(
-            span.hi,
-            end.lo,
-            if end.ctxt.is_root() { end.ctxt } else { span.ctxt },
-            if span.parent == end.parent { span.parent } else { None },
-        )
+        match Span::prepare_to_combine(self, end) {
+            Ok((from, to, parent)) => {
+                Span::new(cmp::min(from.hi, to.hi), cmp::max(from.lo, to.lo), from.ctxt, parent)
+            }
+            Err(fallback) => fallback,
+        }
     }
 
     /// Returns a `Span` from the beginning of `self` until the beginning of `end`.
@@ -885,31 +902,12 @@ impl Span {
     ///     ^^^^^^^^^^^^^^^^^
     /// ```
     pub fn until(self, end: Span) -> Span {
-        // Most of this function's body is copied from `to`.
-        // We can't just do `self.to(end.shrink_to_lo())`,
-        // because to also does some magic where it uses min/max so
-        // it can handle overlapping spans. Some advanced mis-use of
-        // `until` with different ctxts makes this visible.
-        let span_data = self.data();
-        let end_data = end.data();
-        // FIXME(jseyfried): `self.ctxt` should always equal `end.ctxt` here (cf. issue #23480).
-        // Return the macro span on its own to avoid weird diagnostic output. It is preferable to
-        // have an incomplete span than a completely nonsensical one.
-        if span_data.ctxt != end_data.ctxt {
-            if span_data.ctxt.is_root() {
-                return end;
-            } else if end_data.ctxt.is_root() {
-                return self;
+        match Span::prepare_to_combine(self, end) {
+            Ok((from, to, parent)) => {
+                Span::new(cmp::min(from.lo, to.lo), cmp::max(from.lo, to.lo), from.ctxt, parent)
             }
-            // Both spans fall within a macro.
-            // FIXME(estebank): check if it is the *same* macro.
+            Err(fallback) => fallback,
         }
-        Span::new(
-            span_data.lo,
-            end_data.lo,
-            if end_data.ctxt.is_root() { end_data.ctxt } else { span_data.ctxt },
-            if span_data.parent == end_data.parent { span_data.parent } else { None },
-        )
     }
 
     pub fn from_inner(self, inner: InnerSpan) -> Span {

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -65,6 +65,7 @@
 //! ```rust
 //! #![feature(core_intrinsics, custom_mir)]
 //! #![allow(internal_features)]
+//! #![allow(unused_assignments)]
 //!
 //! use core::intrinsics::mir::*;
 //!

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -8,7 +8,7 @@ use rustc_errors::{
 use rustc_parse::parse_stream_from_source_str;
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 use rustc_session::parse::ParseSess;
-use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId};
+use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId, Transparency};
 use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{FileName, InnerSpan, DUMMY_SP};
 
@@ -50,7 +50,7 @@ fn check_rust_syntax(
     let expn_data =
         ExpnData::default(ExpnKind::AstPass(AstPass::TestHarness), DUMMY_SP, edition, None, None);
     let expn_id = cx.tcx.with_stable_hashing_context(|hcx| LocalExpnId::fresh(expn_data, hcx));
-    let span = DUMMY_SP.fresh_expansion(expn_id);
+    let span = DUMMY_SP.apply_mark(expn_id.to_expn_id(), Transparency::Transparent);
 
     let is_empty = rustc_driver::catch_fatal_errors(|| {
         parse_stream_from_source_str(

--- a/tests/ui/anon-params/anon-params-edition-hygiene.rs
+++ b/tests/ui/anon-params/anon-params-edition-hygiene.rs
@@ -1,4 +1,3 @@
-// check-pass
 // edition:2018
 // aux-build:anon-params-edition-hygiene.rs
 
@@ -8,6 +7,8 @@
 #[macro_use]
 extern crate anon_params_edition_hygiene;
 
-generate_trait_2015!(u8);
+generate_trait_2015_ident!(u8);
+// FIXME: Edition hygiene doesn't work correctly with `tt`s in this case.
+generate_trait_2015_tt!(u8); //~ ERROR expected one of `:`, `@`, or `|`, found `)`
 
 fn main() {}

--- a/tests/ui/anon-params/anon-params-edition-hygiene.stderr
+++ b/tests/ui/anon-params/anon-params-edition-hygiene.stderr
@@ -1,0 +1,23 @@
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/anon-params-edition-hygiene.rs:12:1
+   |
+LL | generate_trait_2015_tt!(u8);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected one of `:`, `@`, or `|`
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+   = note: this error originates in the macro `generate_trait_2015_tt` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: if this is a `self` type, give it a parameter name
+   |
+LL | generate_trait_2015_tt!(self: u8);
+   |                         +++++
+help: if this is a parameter name, give it a type
+   |
+LL | generate_trait_2015_tt!(u8: TypeName);
+   |                           ++++++++++
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | generate_trait_2015_tt!(_: u8);
+   |                         ++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/anon-params/auxiliary/anon-params-edition-hygiene.rs
+++ b/tests/ui/anon-params/auxiliary/anon-params-edition-hygiene.rs
@@ -1,9 +1,18 @@
 // edition:2015
 
 #[macro_export]
-macro_rules! generate_trait_2015 {
+macro_rules! generate_trait_2015_ident {
     ($Type: ident) => {
-        trait Trait {
+        trait Trait1 {
+            fn method($Type) {}
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! generate_trait_2015_tt {
+    ($Type: tt) => {
+        trait Trait2 {
             fn method($Type) {}
         }
     };

--- a/tests/ui/editions/auxiliary/edition-kw-macro-2015.rs
+++ b/tests/ui/editions/auxiliary/edition-kw-macro-2015.rs
@@ -26,3 +26,8 @@ macro_rules! consumes_async_raw {
 macro_rules! passes_ident {
     ($i: ident) => ($i)
 }
+
+#[macro_export]
+macro_rules! passes_tt {
+    ($i: tt) => ($i)
+}

--- a/tests/ui/editions/auxiliary/edition-kw-macro-2018.rs
+++ b/tests/ui/editions/auxiliary/edition-kw-macro-2018.rs
@@ -26,3 +26,8 @@ macro_rules! consumes_async_raw {
 macro_rules! passes_ident {
     ($i: ident) => ($i)
 }
+
+#[macro_export]
+macro_rules! passes_tt {
+    ($i: tt) => ($i)
+}

--- a/tests/ui/editions/edition-keywords-2015-2015-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2015-2015-parsing.rs
@@ -19,6 +19,8 @@ pub fn check_async() {
 
     if passes_ident!(async) == 1 {} // OK
     if passes_ident!(r#async) == 1 {} // OK
+    if passes_tt!(async) == 1 {} // OK
+    if passes_tt!(r#async) == 1 {} // OK
     module::async(); // OK
     module::r#async(); // OK
 }

--- a/tests/ui/editions/edition-keywords-2015-2015.rs
+++ b/tests/ui/editions/edition-keywords-2015-2015.rs
@@ -20,6 +20,8 @@ pub fn check_async() {
 
     if passes_ident!(async) == 1 {} // OK
     if passes_ident!(r#async) == 1 {} // OK
+    if passes_tt!(async) == 1 {} // OK
+    if passes_tt!(r#async) == 1 {} // OK
     one_async::async(); // OK
     one_async::r#async(); // OK
     two_async::async(); // OK

--- a/tests/ui/editions/edition-keywords-2015-2018-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2015-2018-parsing.rs
@@ -19,6 +19,8 @@ pub fn check_async() {
 
     if passes_ident!(async) == 1 {} // OK
     if passes_ident!(r#async) == 1 {} // OK
+    if passes_tt!(async) == 1 {} // OK
+    if passes_tt!(r#async) == 1 {} // OK
     module::async(); // OK
     module::r#async(); // OK
 }

--- a/tests/ui/editions/edition-keywords-2015-2018.rs
+++ b/tests/ui/editions/edition-keywords-2015-2018.rs
@@ -20,6 +20,8 @@ pub fn check_async() {
 
     if passes_ident!(async) == 1 {} // OK
     if passes_ident!(r#async) == 1 {} // OK
+    if passes_tt!(async) == 1 {} // OK
+    if passes_tt!(r#async) == 1 {} // OK
     // one_async::async(); // ERROR, unresolved name
     // one_async::r#async(); // ERROR, unresolved name
     two_async::async(); // OK

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -21,8 +21,10 @@ pub fn check_async() {
     r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
     r#async = consumes_async_raw!(r#async); // OK
 
-    if passes_ident!(async) == 1 {}
+    if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
     if passes_ident!(r#async) == 1 {} // OK
+    if passes_tt!(async) == 1 {} //~ ERROR macro expansion ends with an incomplete expression
+    if passes_tt!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
 

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -10,7 +10,7 @@ LL |     let mut r#async = 1;
    |             ++
 
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:26:13
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:28:13
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
@@ -52,17 +52,23 @@ LL |     ($i: ident) => ($i)
    |
   ::: $DIR/edition-keywords-2018-2015-parsing.rs:24:8
    |
-LL |     if passes_ident!(async) == 1 {}
+LL |     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
    |        -------------------- in this macro invocation
 
+error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:26:24
+   |
+LL |     if passes_tt!(async) == 1 {}
+   |                        ^ expected one of `move`, `|`, or `||`
+
 error[E0308]: mismatched types
-  --> $DIR/edition-keywords-2018-2015-parsing.rs:29:33
+  --> $DIR/edition-keywords-2018-2015-parsing.rs:31:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer
    |                            |
    |                            expected due to this
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/editions/edition-keywords-2018-2015.rs
+++ b/tests/ui/editions/edition-keywords-2018-2015.rs
@@ -18,6 +18,8 @@ pub fn check_async() {
 
     // if passes_ident!(async) == 1 {} // ERROR, reserved
     if passes_ident!(r#async) == 1 {} // OK
+    // if passes_tt!(async) == 1 {} // ERROR, reserved
+    if passes_tt!(r#async) == 1 {} // OK
     // one_async::async(); // ERROR, reserved
     one_async::r#async(); // OK
     // two_async::async(); // ERROR, reserved

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -12,6 +12,13 @@ mod module {
     pub fn r#async() {}
 }
 
+macro_rules! local_passes_ident {
+    ($i: ident) => ($i) //~ ERROR macro expansion ends with an incomplete expression
+}
+macro_rules! local_passes_tt {
+    ($i: tt) => ($i) //~ ERROR macro expansion ends with an incomplete expression
+}
+
 pub fn check_async() {
     let mut async = 1; //~ ERROR expected identifier, found keyword `async`
     let mut r#async = 1; // OK
@@ -21,8 +28,14 @@ pub fn check_async() {
     r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
     r#async = consumes_async_raw!(r#async); // OK
 
-    if passes_ident!(async) == 1 {}
+    if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
     if passes_ident!(r#async) == 1 {} // OK
+    if passes_tt!(async) == 1 {} //~ ERROR macro expansion ends with an incomplete expression
+    if passes_tt!(r#async) == 1 {} // OK
+    if local_passes_ident!(async) == 1 {} // Error reported above in the macro
+    if local_passes_ident!(r#async) == 1 {} // OK
+    if local_passes_tt!(async) == 1 {} // Error reported above in the macro
+    if local_passes_tt!(r#async) == 1 {} // OK
     module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
 

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:16:13
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:23:13
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
@@ -10,7 +10,7 @@ LL |     let mut r#async = 1;
    |             ++
 
 error: expected identifier, found keyword `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:26:13
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:39:13
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
@@ -21,7 +21,7 @@ LL |     module::r#async();
    |             ++
 
 error: no rules expected the token `r#async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:20:31
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:27:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
@@ -33,7 +33,7 @@ LL |     (async) => (1)
    |      ^^^^^
 
 error: no rules expected the token `async`
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:21:35
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:28:35
    |
 LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
@@ -50,19 +50,37 @@ error: macro expansion ends with an incomplete expression: expected one of `move
 LL |     ($i: ident) => ($i)
    |                       ^ expected one of `move`, `|`, or `||`
    |
-  ::: $DIR/edition-keywords-2018-2018-parsing.rs:24:8
+  ::: $DIR/edition-keywords-2018-2018-parsing.rs:31:8
    |
-LL |     if passes_ident!(async) == 1 {}
+LL |     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved
    |        -------------------- in this macro invocation
 
+error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:33:24
+   |
+LL |     if passes_tt!(async) == 1 {}
+   |                        ^ expected one of `move`, `|`, or `||`
+
+error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:16:23
+   |
+LL |     ($i: ident) => ($i)
+   |                       ^ expected one of `move`, `|`, or `||`
+
+error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:19:20
+   |
+LL |     ($i: tt) => ($i)
+   |                    ^ expected one of `move`, `|`, or `||`
+
 error[E0308]: mismatched types
-  --> $DIR/edition-keywords-2018-2018-parsing.rs:29:33
+  --> $DIR/edition-keywords-2018-2018-parsing.rs:42:33
    |
 LL |     let _recovery_witness: () = 0;
    |                            --   ^ expected `()`, found integer
    |                            |
    |                            expected due to this
 
-error: aborting due to 6 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/editions/edition-keywords-2018-2018.rs
+++ b/tests/ui/editions/edition-keywords-2018-2018.rs
@@ -18,6 +18,8 @@ pub fn check_async() {
 
     // if passes_ident!(async) == 1 {} // ERROR, reserved
     if passes_ident!(r#async) == 1 {} // OK
+    // if passes_tt!(async) == 1 {} // ERROR, reserved
+    if passes_tt!(r#async) == 1 {} // OK
     // one_async::async(); // ERROR, reserved
     // one_async::r#async(); // ERROR, unresolved name
     // two_async::async(); // ERROR, reserved

--- a/tests/ui/lint/wide_pointer_comparisons.rs
+++ b/tests/ui/lint/wide_pointer_comparisons.rs
@@ -109,6 +109,15 @@ fn main() {
 
     {
         macro_rules! cmp {
+            ($a:tt, $b:tt) => { $a == $b }
+            //~^ WARN ambiguous wide pointer comparison
+        }
+
+        cmp!(a, b);
+    }
+
+    {
+        macro_rules! cmp {
             ($a:ident, $b:ident) => { $a == $b }
             //~^ WARN ambiguous wide pointer comparison
         }

--- a/tests/ui/lint/wide_pointer_comparisons.stderr
+++ b/tests/ui/lint/wide_pointer_comparisons.stderr
@@ -421,7 +421,18 @@ LL |         std::ptr::eq(*a, *b)
    |         ~~~~~~~~~~~~~  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:112:39
+  --> $DIR/wide_pointer_comparisons.rs:112:33
+   |
+LL |             ($a:tt, $b:tt) => { $a == $b }
+   |                                 ^^^^^^^^
+   |
+help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+   |
+LL |             ($a:tt, $b:tt) => { std::ptr::addr_eq($a, $b) }
+   |                                 ++++++++++++++++++  ~   +
+
+warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
+  --> $DIR/wide_pointer_comparisons.rs:121:39
    |
 LL |             ($a:ident, $b:ident) => { $a == $b }
    |                                       ^^^^^^^^
@@ -436,7 +447,7 @@ LL |             ($a:ident, $b:ident) => { std::ptr::addr_eq($a, $b) }
    |                                       ++++++++++++++++++  ~   +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
-  --> $DIR/wide_pointer_comparisons.rs:122:37
+  --> $DIR/wide_pointer_comparisons.rs:131:37
    |
 LL |             ($a:expr, $b:expr) => { $a == $b }
    |                                     ^^
@@ -448,5 +459,5 @@ LL |         cmp!(&a, &b);
    = help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    = note: this warning originates in the macro `cmp` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 37 warnings emitted
+warning: 38 warnings emitted
 

--- a/tests/ui/methods/method-on-ambiguous-numeric-type.rs
+++ b/tests/ui/methods/method-on-ambiguous-numeric-type.rs
@@ -5,6 +5,9 @@
 macro_rules! local_mac {
     ($ident:ident) => { let $ident = 42; }
 }
+macro_rules! local_mac_tt {
+    ($tt:tt) => { let $tt = 42; }
+}
 
 fn main() {
     let x = 2.0.neg();
@@ -22,6 +25,10 @@ fn main() {
 
     local_mac!(local_bar);
     local_bar.pow(2);
+    //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
+
+    local_mac_tt!(local_bar_tt);
+    local_bar_tt.pow(2);
     //~^ ERROR can't call method `pow` on ambiguous numeric type `{integer}`
 }
 

--- a/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
+++ b/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
@@ -1,5 +1,5 @@
 error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
-  --> $DIR/method-on-ambiguous-numeric-type.rs:10:17
+  --> $DIR/method-on-ambiguous-numeric-type.rs:13:17
    |
 LL |     let x = 2.0.neg();
    |                 ^^^
@@ -10,7 +10,7 @@ LL |     let x = 2.0_f32.neg();
    |             ~~~~~~~
 
 error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
-  --> $DIR/method-on-ambiguous-numeric-type.rs:14:15
+  --> $DIR/method-on-ambiguous-numeric-type.rs:17:15
    |
 LL |     let x = y.neg();
    |               ^^^
@@ -21,7 +21,7 @@ LL |     let y: f32 = 2.0;
    |          +++++
 
 error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
-  --> $DIR/method-on-ambiguous-numeric-type.rs:19:26
+  --> $DIR/method-on-ambiguous-numeric-type.rs:22:26
    |
 LL |     for i in 0..100 {
    |         - you must specify a type for this binding, like `i32`
@@ -29,7 +29,7 @@ LL |         println!("{}", i.pow(2));
    |                          ^^^
 
 error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
-  --> $DIR/method-on-ambiguous-numeric-type.rs:24:15
+  --> $DIR/method-on-ambiguous-numeric-type.rs:27:15
    |
 LL |     local_bar.pow(2);
    |               ^^^
@@ -40,7 +40,18 @@ LL |     ($ident:ident) => { let $ident: i32 = 42; }
    |                                   +++++
 
 error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
-  --> $DIR/method-on-ambiguous-numeric-type.rs:30:9
+  --> $DIR/method-on-ambiguous-numeric-type.rs:31:18
+   |
+LL |     local_bar_tt.pow(2);
+   |                  ^^^
+   |
+help: you must specify a type for this binding, like `i32`
+   |
+LL |     ($tt:tt) => { let $tt: i32 = 42; }
+   |                          +++++
+
+error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
+  --> $DIR/method-on-ambiguous-numeric-type.rs:37:9
    |
 LL |     bar.pow(2);
    |         ^^^
@@ -51,6 +62,6 @@ help: you must specify a type for this binding, like `i32`
 LL |     ($ident:ident) => { let $ident: i32 = 42; }
    |                                   +++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0689`.


### PR DESCRIPTION
Also add more tests for using `tt` in addition to `ident`, and some other minor tweaks, see individual commits.

This is a part of https://github.com/rust-lang/rust/pull/119412 that doesn't yet add side tables for metavariable spans.