### PR TITLE
Fix broken build for ESP IDF due to #119026

### DIFF
--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -73,7 +73,7 @@ impl UnixListener {
         unsafe {
             let inner = Socket::new_raw(libc::AF_UNIX, libc::SOCK_STREAM)?;
             let (addr, len) = sockaddr_un(path.as_ref())?;
-            #[cfg(any(target_os = "windows", target_os = "redox"))]
+            #[cfg(any(target_os = "windows", target_os = "redox", target_os = "espidf"))]
             const backlog: libc::c_int = 128;
             #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
             const backlog: libc::c_int = -1;
@@ -82,7 +82,8 @@ impl UnixListener {
                 target_os = "redox",
                 target_os = "linux",
                 target_os = "freebsd",
-                target_os = "openbsd"
+                target_os = "openbsd",
+                target_os = "espidf"
             )))]
             const backlog: libc::c_int = libc::SOMAXCONN;
 


### PR DESCRIPTION
`target_os = "espidf"` in `libc` lacks the `SOMAXCONN` constant, but that's probably irrelevant in this context, as `UnixListener` is not supported on ESP IDF - it being a single process "OS" only.

The PR just re-uses the `128` constant so that the code builds. Trying to use the listener on ESP IDF will fail with `ENOSYS`, which is fine.
 
*UPDATE* Might not fail with `ENOSYS` - need to test what error code would be returned, but that doesn`t change anything. 
