### PR TITLE
Pass LLVM error message back to pass wrapper.

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -787,7 +787,9 @@ LLVMRustOptimize(
     for (auto PluginPath: Plugins) {
       auto Plugin = PassPlugin::Load(PluginPath.str());
       if (!Plugin) {
-        LLVMRustSetLastError(("Failed to load pass plugin" + PluginPath.str()).c_str());
+        auto Err = Plugin.takeError();
+        auto ErrMsg = llvm::toString(std::move(Err));
+        LLVMRustSetLastError(ErrMsg.c_str());
         return LLVMRustResult::Failure;
       }
       Plugin->registerPassBuilderCallbacks(PB);


### PR DESCRIPTION
When rustc fails to load a plugin, it should provide more detailed error message. Before this PR, rustc prints:

```
error: failed to run LLVM passes: Failed to load pass pluginPLUGIN_NAME.so
```

This PR passes LLVM errors back to rustc. After this PR, rustc prints:

```
error: failed to run LLVM passes: Could not load library 'PLUGIN_NAME.so': PLUGIN_NAME.so: undefined symbol: _ZN4llvm9DebugFlagE
```

This PR only contains usability improvements and does not change any functionality. Thus, no new unit test is implemented.