### PR TITLE
fix cyle error when suggesting to use associated function instead of constructor

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1755,11 +1755,8 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             .filter_map(|item| {
                 // Only assoc fns that return `Self`
                 let fn_sig = self.r.tcx.fn_sig(item.def_id).skip_binder();
-                let ret_ty = fn_sig.output();
-                let ret_ty = self
-                    .r
-                    .tcx
-                    .normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), ret_ty);
+                // Don't normalize the return type, because that can cause cycle errors.
+                let ret_ty = fn_sig.output().skip_binder();
                 let ty::Adt(def, _args) = ret_ty.kind() else {
                     return None;
                 };

--- a/tests/ui/resolve/auxiliary/suggest-constructor-cycle-error.rs
+++ b/tests/ui/resolve/auxiliary/suggest-constructor-cycle-error.rs
@@ -1,0 +1,12 @@
+mod m {
+    pub struct Uuid(());
+
+    impl Uuid {
+        pub fn encode_buffer() -> [u8; LENGTH] {
+            []
+        }
+    }
+    const LENGTH: usize = 0;
+}
+
+pub use m::Uuid;

--- a/tests/ui/resolve/suggest-constructor-cycle-error.rs
+++ b/tests/ui/resolve/suggest-constructor-cycle-error.rs
@@ -1,10 +1,10 @@
 // aux-build:suggest-constructor-cycle-error.rs
-//~^ cycle detected when getting the resolver for lowering [E0391]
 
 // Regression test for https://github.com/rust-lang/rust/issues/119625
 
 extern crate suggest_constructor_cycle_error as a;
 
 const CONST_NAME: a::Uuid = a::Uuid(());
+//~^ ERROR: cannot initialize a tuple struct which contains private fields [E0423]
 
 fn main() {}

--- a/tests/ui/resolve/suggest-constructor-cycle-error.rs
+++ b/tests/ui/resolve/suggest-constructor-cycle-error.rs
@@ -1,0 +1,10 @@
+// aux-build:suggest-constructor-cycle-error.rs
+//~^ cycle detected when getting the resolver for lowering [E0391]
+
+// Regression test for https://github.com/rust-lang/rust/issues/119625
+
+extern crate suggest_constructor_cycle_error as a;
+
+const CONST_NAME: a::Uuid = a::Uuid(());
+
+fn main() {}

--- a/tests/ui/resolve/suggest-constructor-cycle-error.stderr
+++ b/tests/ui/resolve/suggest-constructor-cycle-error.stderr
@@ -1,0 +1,15 @@
+error[E0391]: cycle detected when getting the resolver for lowering
+   |
+   = note: ...which requires normalizing `[u8; suggest_constructor_cycle_error::::m::{impl#0}::encode_buffer::{constant#0}]`...
+note: ...which requires resolving instance `suggest_constructor_cycle_error::m::Uuid::encode_buffer::{constant#0}`...
+  --> $DIR/auxiliary/suggest-constructor-cycle-error.rs:5:40
+   |
+LL |         pub fn encode_buffer() -> [u8; LENGTH] {
+   |                                        ^^^^^^
+   = note: ...which requires calculating the lang items map...
+   = note: ...which again requires getting the resolver for lowering, completing the cycle
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/resolve/suggest-constructor-cycle-error.stderr
+++ b/tests/ui/resolve/suggest-constructor-cycle-error.stderr
@@ -1,15 +1,15 @@
-error[E0391]: cycle detected when getting the resolver for lowering
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/suggest-constructor-cycle-error.rs:7:29
    |
-   = note: ...which requires normalizing `[u8; suggest_constructor_cycle_error::::m::{impl#0}::encode_buffer::{constant#0}]`...
-note: ...which requires resolving instance `suggest_constructor_cycle_error::m::Uuid::encode_buffer::{constant#0}`...
-  --> $DIR/auxiliary/suggest-constructor-cycle-error.rs:5:40
+LL | const CONST_NAME: a::Uuid = a::Uuid(());
+   |                             ^^^^^^^
    |
-LL |         pub fn encode_buffer() -> [u8; LENGTH] {
-   |                                        ^^^^^^
-   = note: ...which requires calculating the lang items map...
-   = note: ...which again requires getting the resolver for lowering, completing the cycle
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+note: constructor is not visible here due to private fields
+  --> $DIR/auxiliary/suggest-constructor-cycle-error.rs:2:21
+   |
+LL |     pub struct Uuid(());
+   |                     ^^ private field
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0391`.
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/119625.

The first commit fixes the infinite recursion and makes the cycle error actually show up. We do this by making the `Display` for `ty::Instance` impl  respect `with_no_queries` so that it can be used in query descriptions.

The second commit fixes the cycle error `resolver_for_lowering` -> `normalize` -> `resolve_instance` (for evaluating const) -> `lang_items` (for `drop_in_place`) -> `resolver_for_lowering` (for collecting lang items). We do this by simply skipping the suggestion when encountering an unnormalized type.