### PR TITLE
library: Fix warnings in rtstartup

### DIFF
--- a/library/rtstartup/rsbegin.rs
+++ b/library/rtstartup/rsbegin.rs
@@ -18,6 +18,7 @@
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(non_camel_case_types)]
+#![allow(internal_features)]
 
 #[lang = "sized"]
 trait Sized {}

--- a/library/rtstartup/rsend.rs
+++ b/library/rtstartup/rsend.rs
@@ -5,6 +5,7 @@
 #![feature(auto_traits)]
 #![crate_type = "rlib"]
 #![no_core]
+#![allow(internal_features)]
 
 #[lang = "sized"]
 trait Sized {}


### PR DESCRIPTION
Not sure why global `deny(warnings)` in bootstrap doesn't apply to this code, it did in the past.