### PR TITLE
Remove ignore-stage1 that was added when changing error count msg

### DIFF
--- a/tests/ui-fulldeps/dropck-tarena-cycle-checked.rs
+++ b/tests/ui-fulldeps/dropck-tarena-cycle-checked.rs
@@ -1,5 +1,3 @@
-// ignore-stage1
-
 // Reject mixing cyclic structure and Drop when using TypedArena.
 //
 // (Compare against dropck-vec-cycle-checked.rs)

--- a/tests/ui-fulldeps/dropck-tarena-cycle-checked.stderr
+++ b/tests/ui-fulldeps/dropck-tarena-cycle-checked.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `arena` does not live long enough
-  --> $DIR/dropck-tarena-cycle-checked.rs:118:7
+  --> $DIR/dropck-tarena-cycle-checked.rs:116:7
    |
 LL |     let arena = TypedArena::default();
    |         ----- binding `arena` declared here

--- a/tests/ui-fulldeps/dropck-tarena-unsound-drop.rs
+++ b/tests/ui-fulldeps/dropck-tarena-unsound-drop.rs
@@ -1,5 +1,3 @@
-// ignore-stage1
-
 // Check that an arena (TypedArena) cannot carry elements whose drop
 // methods might access borrowed data of lifetime that does not
 // strictly outlive the arena itself.

--- a/tests/ui-fulldeps/dropck-tarena-unsound-drop.stderr
+++ b/tests/ui-fulldeps/dropck-tarena-unsound-drop.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `arena` does not live long enough
-  --> $DIR/dropck-tarena-unsound-drop.rs:43:7
+  --> $DIR/dropck-tarena-unsound-drop.rs:41:7
    |
 LL |     let arena: TypedArena<C> = TypedArena::default();
    |         ----- binding `arena` declared here

--- a/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.rs
+++ b/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.rs
@@ -1,6 +1,5 @@
 // Test the `rustc::span_use_eq_ctxt` internal lint
 // compile-flags: -Z unstable-options
-// ignore-stage1
 
 #![feature(rustc_private)]
 #![deny(rustc::span_use_eq_ctxt)]

--- a/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.stderr
+++ b/tests/ui-fulldeps/internal-lints/span_use_eq_ctxt.stderr
@@ -1,11 +1,11 @@
 error: use `.eq_ctxt()` instead of `.ctxt() == .ctxt()`
-  --> $DIR/span_use_eq_ctxt.rs:13:5
+  --> $DIR/span_use_eq_ctxt.rs:12:5
    |
 LL |     s.ctxt() == t.ctxt()
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/span_use_eq_ctxt.rs:6:9
+  --> $DIR/span_use_eq_ctxt.rs:5:9
    |
 LL | #![deny(rustc::span_use_eq_ctxt)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui-fulldeps/pathless-extern-unstable.rs
+++ b/tests/ui-fulldeps/pathless-extern-unstable.rs
@@ -1,6 +1,5 @@
 // edition:2018
 // compile-flags:--extern rustc_middle
-// ignore-stage1
 
 // Test that `--extern rustc_middle` fails with `rustc_private`.
 

--- a/tests/ui-fulldeps/pathless-extern-unstable.stderr
+++ b/tests/ui-fulldeps/pathless-extern-unstable.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/pathless-extern-unstable.rs:7:9
+  --> $DIR/pathless-extern-unstable.rs:6:9
    |
 LL | pub use rustc_middle;
    |         ^^^^^^^^^^^^

--- a/tests/ui-fulldeps/session-diagnostic/enforce_slug_naming.rs
+++ b/tests/ui-fulldeps/session-diagnostic/enforce_slug_naming.rs
@@ -1,5 +1,4 @@
 // rustc-env:CARGO_CRATE_NAME=rustc_dummy
-// ignore-stage1
 
 #![feature(rustc_private)]
 #![crate_type = "lib"]

--- a/tests/ui-fulldeps/session-diagnostic/enforce_slug_naming.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/enforce_slug_naming.stderr
@@ -1,5 +1,5 @@
 error: diagnostic slug and crate name do not match
-  --> $DIR/enforce_slug_naming.rs:23:8
+  --> $DIR/enforce_slug_naming.rs:22:8
    |
 LL | #[diag(compiletest_example, code = "E0123")]
    |        ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The bootstrap bump has happened, so the bootstrap compiler now contains the new diagnostic.

this was added in #118138