### PR TITLE
Fix typo in docs for slice::split_once, slice::rsplit_once

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2483,7 +2483,7 @@ impl<T> [T] {
     /// Splits the slice on the first element that matches the specified
     /// predicate.
     ///
-    /// If any matching elements are resent in the slice, returns the prefix
+    /// If any matching elements are present in the slice, returns the prefix
     /// before the match and suffix after. The matching element itself is not
     /// included. If no elements match, returns `None`.
     ///
@@ -2511,7 +2511,7 @@ impl<T> [T] {
     /// Splits the slice on the last element that matches the specified
     /// predicate.
     ///
-    /// If any matching elements are resent in the slice, returns the prefix
+    /// If any matching elements are present in the slice, returns the prefix
     /// before the match and suffix after. The matching element itself is not
     /// included. If no elements match, returns `None`.
     ///


### PR DESCRIPTION
This fixes a typo in the doc comments for these methods, which I tripped over while reading the docs: "If any matching elements are **resent** in the slice [...]", which is presumably meant to read **present**.

I mentioned this in #112811, the tracking issue for `slice_split_once`, and was encouraged to open a PR.