### PR TITLE
Strip lld-wrapper binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,14 @@ gimli.debug = 0
 miniz_oxide.debug = 0
 object.debug = 0
 
+# These are very thin wrappers around executing lld with the right binary name.
+# Basically nothing within them can go wrong without having been explicitly logged anyway.
+# We ship these in every rustc tarball and even after compression they add up
+# to around 0.6MB of data every user needs to download (and 15MB on disk).
+[profile.release.package.lld-wrapper]
+debug = 0
+strip = true
+
 [patch.crates-io]
 # See comments in `library/rustc-std-workspace-core/README.md` for what's going on
 # here


### PR DESCRIPTION
This cuts down on the amount of data we need to ship and users need to keep on disk for each Rust toolchain. As noted in the added comment, there's not much going on in these executables, so the added benefit of symbols and debuginfo isn't large, while the cost is not insignificant.

This takes each of the binaries (we store 4 identical copies under different names) from 3.7MB to 384KB.