### PR TITLE
tests: Normalize `\r\n` to `\n` in some run-make tests

### DIFF
--- a/tests/run-make/raw-dylib-c/Makefile
+++ b/tests/run-make/raw-dylib-c/Makefile
@@ -17,7 +17,7 @@ else
 	$(CC) "$(TMPDIR)"/extern_1.obj -shared -o "$(TMPDIR)"/extern_1.dll
 	$(CC) "$(TMPDIR)"/extern_2.obj -shared -o "$(TMPDIR)"/extern_2.dll
 endif
-	"$(TMPDIR)"/driver > "$(TMPDIR)"/output.txt
+	"$(TMPDIR)"/driver | tr -d '\r' > "$(TMPDIR)"/output.txt
 	"$(TMPDIR)"/raw_dylib_test_bin > "$(TMPDIR)"/output_bin.txt
 
 ifdef RUSTC_BLESS_TEST

--- a/tests/run-make/raw-dylib-inline-cross-dylib/Makefile
+++ b/tests/run-make/raw-dylib-inline-cross-dylib/Makefile
@@ -26,5 +26,5 @@ else
 	$(CC) "$(TMPDIR)"/extern_1.obj -shared -o "$(TMPDIR)"/extern_1.dll
 	$(CC) "$(TMPDIR)"/extern_2.obj -shared -o "$(TMPDIR)"/extern_2.dll
 endif
-	$(call RUN,driver) > "$(TMPDIR)"/output.txt
+	$(call RUN,driver) | tr -d '\r' > "$(TMPDIR)"/output.txt
 	$(RUSTC_TEST_OP) "$(TMPDIR)"/output.txt output.txt

--- a/tests/run-make/raw-dylib-link-ordinal/Makefile
+++ b/tests/run-make/raw-dylib-link-ordinal/Makefile
@@ -13,5 +13,5 @@ ifdef IS_MSVC
 else
 	$(CC) "$(TMPDIR)"/exporter.obj exporter.def -shared -o "$(TMPDIR)"/exporter.dll
 endif
-	"$(TMPDIR)"/driver > "$(TMPDIR)"/output.txt
+	"$(TMPDIR)"/driver | tr -d '\r' > "$(TMPDIR)"/output.txt
 	$(RUSTC_TEST_OP) "$(TMPDIR)"/output.txt output.txt


### PR DESCRIPTION
The output is produced by printf from C code in these cases, and printf prints in text mode, which means `\n` will be printed as `\r\n` on Windows.

In --bless mode the new output with `\r\n` will replace expected output in `tests/run-make/raw-dylib-*\output.txt` files, which use \n, always resulting in dirty files in the repo.