### PR TITLE
Fix tty detection for msys2's `/dev/ptmx`

### DIFF
--- a/library/std/src/sys/pal/windows/io.rs
+++ b/library/std/src/sys/pal/windows/io.rs
@@ -97,20 +97,6 @@ unsafe fn handle_is_console(handle: BorrowedHandle<'_>) -> bool {
         return true;
     }
 
-    // At this point, we *could* have a false negative. We can determine that this is a true
-    // negative if we can detect the presence of a console on any of the standard I/O streams. If
-    // another stream has a console, then we know we're in a Windows console and can therefore
-    // trust the negative.
-    for std_handle in [c::STD_INPUT_HANDLE, c::STD_OUTPUT_HANDLE, c::STD_ERROR_HANDLE] {
-        let std_handle = c::GetStdHandle(std_handle);
-        if !std_handle.is_null()
-            && std_handle != handle
-            && c::GetConsoleMode(std_handle, &mut out) != 0
-        {
-            return false;
-        }
-    }
-
     // Otherwise, we fall back to an msys hack to see if we can detect the presence of a pty.
     msys_tty_on(handle)
 }


### PR DESCRIPTION
Our "true negative" detection assumes that if at least one std handle is a Windows console then no other handle will be a msys2 tty pipe. This turns out to be a faulty assumption in the case of redirection to  `/dev/ptmx` in an msys2 shell. Maybe this is an msys2 bug but in any case we should try to make it work.

An alternative to this would be to replace the "true negative" detection with an attempt to detect if we're in an msys environment (e.g. by sniffing environment variables) but that seems like it'd be flaky too.

Fixes #119658