### PR TITLE
Allow building stage1+ std with `panic=abort`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -504,6 +504,9 @@
 # Defaults to rust.overflow-checks value
 #overflow-checks-std = rust.overflow-checks (boolean)
 
+# The panic strategy used for all compiler invocations
+#panic-strategy = "unwind"
+
 # Debuginfo level for most of Rust code, corresponds to the `-C debuginfo=N` option of `rustc`.
 # `0` - no debug info
 # `1` - line tables only - sufficient to generate backtraces that include line

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -2135,6 +2135,10 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTFLAGS", &rustc_args.join(" "));
         }
 
+        if matches!(self.config.rust_panic_strategy, crate::PanicStrategy::Abort) {
+            rustflags.arg("-Cpanic=abort");
+        }
+
         Cargo { command: cargo, rustflags, rustdocflags, hostflags, allow_features }
     }
 

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -105,6 +105,14 @@ impl Display for DebuginfoLevel {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PanicStrategy {
+    #[default]
+    Unwind,
+    Abort,
+}
+
 /// LLD in bootstrap works like this:
 /// - Self-contained lld: use `rust-lld` from the compiler's sysroot
 /// - External: use an external `lld` binary
@@ -272,6 +280,7 @@ pub struct Config {
     pub rust_profile_generate: Option<String>,
     pub rust_lto: RustcLto,
     pub rust_validate_mir_opts: Option<u32>,
+    pub rust_panic_strategy: PanicStrategy,
     pub llvm_profile_use: Option<String>,
     pub llvm_profile_generate: bool,
     pub llvm_libunwind_default: Option<LlvmLibunwind>,
@@ -1111,6 +1120,7 @@ define_config! {
         download_rustc: Option<StringOrBool> = "download-rustc",
         lto: Option<String> = "lto",
         validate_mir_opts: Option<u32> = "validate-mir-opts",
+        panic_strategy: Option<PanicStrategy> = "panic-strategy",
     }
 }
 
@@ -1562,6 +1572,7 @@ impl Config {
                 stack_protector,
                 strip,
                 lld_mode,
+                panic_strategy,
             } = rust;
 
             set(&mut config.channel, channel);
@@ -1594,6 +1605,7 @@ impl Config {
             debuginfo_level_std = debuginfo_level_std_toml;
             debuginfo_level_tools = debuginfo_level_tools_toml;
             debuginfo_level_tests = debuginfo_level_tests_toml;
+            set(&mut config.rust_panic_strategy, panic_strategy);
 
             config.rust_split_debuginfo = split_debuginfo
                 .as_deref()


### PR DESCRIPTION
Initial approach to #84766

This adds a `rust.panic-strategy-std` option to bootstrap, which controls how stage1+ std is built. I decided not to apply it to stage 0 std, otherwise I'd need to make the bootstrap compiler inject the correct panic runtime to build stage1 correctly.

Draft for now as this I'm not sure about the strategy, and only stage0 and 1 can be built with this option right now.

(All library changes are just fixing warnings that occur when building std with `panic_immediate_abort`)