### PR TITLE
Reorder early post-inlining passes.

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -565,17 +565,28 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         body,
         &[
             &check_alignment::CheckAlignment,
-            &lower_slice_len::LowerSliceLenCalls, // has to be done before inlining, otherwise actual call will be almost always inlined. Also simple, so can just do first
+            // Before inlining: trim down MIR with passes to reduce inlining work.
+
+            // Has to be done before inlining, otherwise actual call will be almost always inlined.
+            // Also simple, so can just do first
+            &lower_slice_len::LowerSliceLenCalls,
+            // Perform inlining, which may add a lot of code.
             &inline::Inline,
-            // Substitutions during inlining may introduce switch on enums with uninhabited branches.
+            // Code from other crates may have storage markers, so this needs to happen after inlining.
+            &remove_storage_markers::RemoveStorageMarkers,
+            // Inlining and substitution may introduce ZST and useless drops.
+            &remove_zsts::RemoveZsts,
+            &remove_unneeded_drops::RemoveUnneededDrops,
+            // Type substitution may create uninhabited enums.
             &uninhabited_enum_branching::UninhabitedEnumBranching,
             &unreachable_prop::UnreachablePropagation,
             &o1(simplify::SimplifyCfg::AfterUninhabitedEnumBranching),
-            &remove_storage_markers::RemoveStorageMarkers,
-            &remove_zsts::RemoveZsts,
-            &normalize_array_len::NormalizeArrayLen, // has to run after `slice::len` lowering
+            // Inlining may have introduced a lot of redundant code and a large move pattern.
+            // Now, we need to shrink the generated MIR.
+
+            // Has to run after `slice::len` lowering
+            &normalize_array_len::NormalizeArrayLen,
             &const_goto::ConstGoto,
-            &remove_unneeded_drops::RemoveUnneededDrops,
             &ref_prop::ReferencePropagation,
             &sroa::ScalarReplacementOfAggregates,
             &match_branches::MatchBranchSimplification,

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-abort.diff
@@ -61,7 +61,6 @@
 +         StorageDead(_10);
 +         StorageDead(_11);
 +         nop;
-          nop;
           StorageDead(_8);
           StorageDead(_3);
           StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-unwind.diff
@@ -61,7 +61,6 @@
 +         StorageDead(_10);
 +         StorageDead(_11);
 +         nop;
-          nop;
           StorageDead(_8);
           StorageDead(_3);
           StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-abort.diff
@@ -61,7 +61,6 @@
 +         StorageDead(_10);
 +         StorageDead(_11);
 +         nop;
-          nop;
           StorageDead(_8);
           StorageDead(_3);
           StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-unwind.diff
@@ -61,7 +61,6 @@
 +         StorageDead(_10);
 +         StorageDead(_11);
 +         nop;
-          nop;
           StorageDead(_8);
           StorageDead(_3);
           StorageDead(_1);

--- a/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-abort.diff
+++ b/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-abort.diff
@@ -6,8 +6,8 @@
       let _1: ();
   
       bb0: {
--         switchInt(const false) -> [0: bb3, otherwise: bb1];
-+         goto -> bb3;
+-         switchInt(const false) -> [0: bb2, otherwise: bb1];
++         goto -> bb2;
       }
   
       bb1: {
@@ -15,14 +15,6 @@
       }
   
       bb2: {
-          goto -> bb4;
-      }
-  
-      bb3: {
-          goto -> bb4;
-      }
-  
-      bb4: {
           return;
       }
   }

--- a/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
+++ b/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
@@ -6,8 +6,8 @@
       let _1: ();
   
       bb0: {
--         switchInt(const false) -> [0: bb3, otherwise: bb1];
-+         goto -> bb3;
+-         switchInt(const false) -> [0: bb2, otherwise: bb1];
++         goto -> bb2;
       }
   
       bb1: {
@@ -15,14 +15,6 @@
       }
   
       bb2: {
-          goto -> bb4;
-      }
-  
-      bb3: {
-          goto -> bb4;
-      }
-  
-      bb4: {
           return;
       }
   }

--- a/tests/mir-opt/simplify_match.main.GVN.panic-abort.diff
+++ b/tests/mir-opt/simplify_match.main.GVN.panic-abort.diff
@@ -11,19 +11,15 @@
   
       bb0: {
           _2 = const false;
--         switchInt(_2) -> [0: bb1, otherwise: bb2];
-+         switchInt(const false) -> [0: bb1, otherwise: bb2];
+-         switchInt(_2) -> [0: bb2, otherwise: bb1];
++         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-          goto -> bb3;
+          _0 = noop() -> [return: bb2, unwind unreachable];
       }
   
       bb2: {
-          _0 = noop() -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
           return;
       }
   }

--- a/tests/mir-opt/simplify_match.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/simplify_match.main.GVN.panic-unwind.diff
@@ -11,19 +11,15 @@
   
       bb0: {
           _2 = const false;
--         switchInt(_2) -> [0: bb1, otherwise: bb2];
-+         switchInt(const false) -> [0: bb1, otherwise: bb2];
+-         switchInt(_2) -> [0: bb2, otherwise: bb1];
++         switchInt(const false) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-          goto -> bb3;
+          _0 = noop() -> [return: bb2, unwind continue];
       }
   
       bb2: {
-          _0 = noop() -> [return: bb3, unwind continue];
-      }
-  
-      bb3: {
           return;
       }
   }


### PR DESCRIPTION
`RemoveZsts`, `RemoveUnneededDrops` and `UninhabitedEnumBranching` only depend on types, so they should be executed together early after MIR inlining introduces those types.

This does not change the end-result, but this makes the pipeline a bit more consistent.