### PR TITLE
Ask for rustc version in diagnostic reports, remind users to update their toolchain

### DIFF
--- a/.github/ISSUE_TEMPLATE/diagnostics.yaml
+++ b/.github/ISSUE_TEMPLATE/diagnostics.yaml
@@ -52,10 +52,23 @@ body:
       render: Rust
     validations:
       required: false
-  - type: markdown
+  - type: textarea
+    id: version
     attributes:
-      value: |
-        If you're using the stable version of the compiler, you should also check if the bug also exists in the beta or nightly versions. The output might also be different depending on the Edition.
+      label: Rust Version
+      description: Please provide the `rustc` version, `rustc --version --verbose`. Make sure that you're using the latest version of the compiler, and not an outdated stable or nightly release!
+      placeholder: |
+        $ rustc --version --verbose
+        rustc 1.XX.Y (SHORTHASH DATE)
+        binary: rustc
+        commit-hash: LONGHASHVALUE
+        commit-date: DATE
+        host: PLATFORMTRIPLE
+        release: 1.XX.Y
+        LLVM version: XX.YY.ZZ
+      render: Shell
+    validations:
+      required: true
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/ice.yaml
+++ b/.github/ISSUE_TEMPLATE/ice.yaml
@@ -40,7 +40,7 @@ body:
     id: version
     attributes:
       label: Rust Version
-      description: Please provide the `rustc` version, `rustc --version --verbose`
+      description: Please provide the `rustc` version, `rustc --version --verbose`. Make sure that you're using the latest version of the compiler, and not an outdated stable or nightly release!
       placeholder: |
         $ rustc --version --verbose
         rustc 1.XX.Y (SHORTHASH DATE)


### PR DESCRIPTION
IDK why we don't ask for rustc toolchain when filing diagnostic issues. Diagnostics are sometimes very dramatically affected by compiler version, and users may report old diagnostic issues that were fixed by subsequent rustc versions that they have yet to update to.

For example, #119678 was made a bit more difficult to triage due to the template not asking the issuer to report their rustc version.