### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/diagnostics.yaml
+++ b/.github/ISSUE_TEMPLATE/diagnostics.yaml
@@ -52,10 +52,23 @@ body:
       render: Rust
     validations:
       required: false
-  - type: markdown
+  - type: textarea
+    id: version
     attributes:
-      value: |
-        If you're using the stable version of the compiler, you should also check if the bug also exists in the beta or nightly versions. The output might also be different depending on the Edition.
+      label: Rust Version
+      description: Please provide the `rustc` version, `rustc --version --verbose`. Make sure that you're using the latest version of the compiler, and not an outdated stable or nightly release!
+      placeholder: |
+        $ rustc --version --verbose
+        rustc 1.XX.Y (SHORTHASH DATE)
+        binary: rustc
+        commit-hash: LONGHASHVALUE
+        commit-date: DATE
+        host: PLATFORMTRIPLE
+        release: 1.XX.Y
+        LLVM version: XX.YY.ZZ
+      render: Shell
+    validations:
+      required: true
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/ice.yaml
+++ b/.github/ISSUE_TEMPLATE/ice.yaml
@@ -40,7 +40,7 @@ body:
     id: version
     attributes:
       label: Rust Version
-      description: Please provide the `rustc` version, `rustc --version --verbose`
+      description: Please provide the `rustc` version, `rustc --version --verbose`. Make sure that you're using the latest version of the compiler, and not an outdated stable or nightly release!
       placeholder: |
         $ rustc --version --verbose
         rustc 1.XX.Y (SHORTHASH DATE)

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -969,7 +969,7 @@ pub fn promote_candidates<'tcx>(
             0,
             vec![],
             body.span,
-            body.coroutine_kind(),
+            None,
             body.tainted_by_errors,
         );
         promoted.phase = MirPhase::Analysis(AnalysisPhase::Initial);

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -86,8 +86,6 @@ macro_rules! thir_with_elements {
     }
 }
 
-pub const UPVAR_ENV_PARAM: ParamId = ParamId::from_u32(0);
-
 thir_with_elements! {
     body_type: BodyTy<'tcx>,
 

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -670,6 +670,8 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
         // This loop can get very hot for some bodies: it check each local in each bb.
         // To avoid this quadratic behaviour, we only clear the locals that were modified inside
         // the current block.
+        // The order in which we remove consts does not matter.
+        #[allow(rustc::potential_query_instability)]
         for local in written_only_inside_own_block_locals.drain() {
             debug_assert_eq!(
                 self.ecx.machine.can_const_prop[local],

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(rustc::potential_query_instability)]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
 #![feature(box_patterns)]

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -54,6 +54,8 @@ impl MirPass<'_> for UnreachablePropagation {
         patch.apply(body);
 
         // We do want do keep some unreachable blocks, but make them empty.
+        // The order in which we clear bb statements does not matter.
+        #[allow(rustc::potential_query_instability)]
         for bb in unreachable_blocks {
             body.basic_blocks_mut()[bb].statements.clear();
         }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1783,27 +1783,33 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn truncf64(x: f64) -> f64;
 
-    /// Returns the nearest integer to an `f32`. May raise an inexact floating-point exception
-    /// if the argument is not an integer.
+    /// Returns the nearest integer to an `f32`. Changing the rounding mode is not possible in Rust,
+    /// so this rounds half-way cases to the number with an even least significant digit.
+    ///
+    /// May raise an inexact floating-point exception if the argument is not an integer.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f32::round_ties_even`](../../std/primitive.f32.html#method.round_ties_even)
     #[rustc_nounwind]
     pub fn rintf32(x: f32) -> f32;
-    /// Returns the nearest integer to an `f64`. May raise an inexact floating-point exception
-    /// if the argument is not an integer.
+    /// Returns the nearest integer to an `f64`. Changing the rounding mode is not possible in Rust,
+    /// so this rounds half-way cases to the number with an even least significant digit.
+    ///
+    /// May raise an inexact floating-point exception if the argument is not an integer.
     ///
     /// The stabilized version of this intrinsic is
     /// [`f64::round_ties_even`](../../std/primitive.f64.html#method.round_ties_even)
     #[rustc_nounwind]
     pub fn rintf64(x: f64) -> f64;
 
-    /// Returns the nearest integer to an `f32`.
+    /// Returns the nearest integer to an `f32`. Changing the rounding mode is not possible in Rust,
+    /// so this rounds half-way cases to the number with an even least significant digit.
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_nounwind]
     pub fn nearbyintf32(x: f32) -> f32;
-    /// Returns the nearest integer to an `f64`.
+    /// Returns the nearest integer to an `f64`. Changing the rounding mode is not possible in Rust,
+    /// so this rounds half-way cases to the number with an even least significant digit.
     ///
     /// This intrinsic does not have a stable counterpart.
     #[rustc_nounwind]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2483,7 +2483,7 @@ impl<T> [T] {
     /// Splits the slice on the first element that matches the specified
     /// predicate.
     ///
-    /// If any matching elements are resent in the slice, returns the prefix
+    /// If any matching elements are present in the slice, returns the prefix
     /// before the match and suffix after. The matching element itself is not
     /// included. If no elements match, returns `None`.
     ///
@@ -2511,7 +2511,7 @@ impl<T> [T] {
     /// Splits the slice on the last element that matches the specified
     /// predicate.
     ///
-    /// If any matching elements are resent in the slice, returns the prefix
+    /// If any matching elements are present in the slice, returns the prefix
     /// before the match and suffix after. The matching element itself is not
     /// included. If no elements match, returns `None`.
     ///

--- a/src/bootstrap/src/core/build_steps/install.rs
+++ b/src/bootstrap/src/core/build_steps/install.rs
@@ -204,15 +204,13 @@ install!((self, builder, _config),
         install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
     };
     Std, path = "library/std", true, only_hosts: false, {
-        for target in &builder.targets {
-            // `expect` should be safe, only None when host != build, but this
-            // only runs when host == build
-            let tarball = builder.ensure(dist::Std {
-                compiler: self.compiler,
-                target: *target
-            }).expect("missing std");
-            install_sh(builder, "std", self.compiler.stage, Some(*target), &tarball);
-        }
+        // `expect` should be safe, only None when host != build, but this
+        // only runs when host == build
+        let tarball = builder.ensure(dist::Std {
+            compiler: self.compiler,
+            target: self.target
+        }).expect("missing std");
+        install_sh(builder, "std", self.compiler.stage, Some(self.target), &tarball);
     };
     Cargo, alias = "cargo", Self::should_build(_config), only_hosts: true, {
         let tarball = builder


### PR DESCRIPTION
Successful merges:

 - #119252 (rustc_mir_transform: Enforce `rustc::potential_query_instability` lint)
 - #119548 (Use the current target instead of iterating over all targets)
 - #119656 (document rounding behavior of rint/nearbyint for ties)
 - #119657 (Fix typo in docs for slice::split_once, slice::rsplit_once)
 - #119666 (Populate `yield` and `resume` types in MIR body while body is being initialized)
 - #119679 (Ask for rustc version in diagnostic reports, remind users to update their toolchain)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119252,119548,119656,119657,119666,119679)
<!-- homu-ignore:end -->