### PR TITLE
coverage: Anonymize line numbers in branch views

### DIFF
--- a/src/tools/compiletest/src/runtest/tests.rs
+++ b/src/tools/compiletest/src/runtest/tests.rs
@@ -48,3 +48,75 @@ fn normalize_platform_differences() {
         r#"println!("test\ntest")"#,
     );
 }
+
+/// Test for anonymizing line numbers in coverage reports, especially for
+/// branch regions.
+///
+/// FIXME(#119681): This test can be removed when we have examples of branch
+/// coverage in the actual coverage test suite.
+#[test]
+fn anonymize_coverage_line_numbers() {
+    let anon = |coverage| TestCx::anonymize_coverage_line_numbers(coverage);
+
+    let input = r#"
+    6|      3|fn print_size<T>() {
+    7|      3|    if std::mem::size_of::<T>() > 4 {
+  ------------------
+  |  Branch (7:8): [True: 0, False: 1]
+  |  Branch (7:8): [True: 0, False: 1]
+  |  Branch (7:8): [True: 1, False: 0]
+  ------------------
+    8|      1|        println!("size > 4");
+"#;
+
+    let expected = r#"
+   LL|      3|fn print_size<T>() {
+   LL|      3|    if std::mem::size_of::<T>() > 4 {
+  ------------------
+  |  Branch (LL:8): [True: 0, False: 1]
+  |  Branch (LL:8): [True: 0, False: 1]
+  |  Branch (LL:8): [True: 1, False: 0]
+  ------------------
+   LL|      1|        println!("size > 4");
+"#;
+
+    assert_eq!(anon(input), expected);
+
+    //////////
+
+    let input = r#"
+   12|      3|}
+  ------------------
+  | branch_generics::print_size::<()>:
+  |    6|      1|fn print_size<T>() {
+  |    7|      1|    if std::mem::size_of::<T>() > 4 {
+  |  ------------------
+  |  |  Branch (7:8): [True: 0, False: 1]
+  |  ------------------
+  |    8|      0|        println!("size > 4");
+  |    9|      1|    } else {
+  |   10|      1|        println!("size <= 4");
+  |   11|      1|    }
+  |   12|      1|}
+  ------------------
+"#;
+
+    let expected = r#"
+   LL|      3|}
+  ------------------
+  | branch_generics::print_size::<()>:
+  |   LL|      1|fn print_size<T>() {
+  |   LL|      1|    if std::mem::size_of::<T>() > 4 {
+  |  ------------------
+  |  |  Branch (LL:8): [True: 0, False: 1]
+  |  ------------------
+  |   LL|      0|        println!("size > 4");
+  |   LL|      1|    } else {
+  |   LL|      1|        println!("size <= 4");
+  |   LL|      1|    }
+  |   LL|      1|}
+  ------------------
+"#;
+
+    assert_eq!(anon(input), expected);
+}


### PR DESCRIPTION
Extracted from #118305, as this is now the only part of that PR that needs to touch compiletest.

---

Coverage tests run the `llvm-cov` tool to generate a coverage report for a test program, and then compare the report against a known-good snapshot.

We use the `anonymize_coverage_line_numbers` function to replace line numbers in coverage reports with `LL`, so that they are less sensitive to lines being added or removed. This PR augments the existing code by making it also support the slightly different line number syntax used when reporting branch regions.

Currently the compiler never emits branch regions, so there is no way to write a coverage test that makes use of this new capability. Instead, I've added a unit test that checks against some sample reports taken from #118305. That unit test can be removed when some form of branch coverage support gets merged, and real branch coverage tests are added to the coverage test suite.

(I have also manually tested this change as part of my draft branch-coverage PR.)