### PR TITLE
Exhaustiveness: use an `Option` instead of allocating fictitious patterns

### DIFF
--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -88,9 +88,8 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
             (0..arity).map(|_| Self { patterns: Vec::new() }).collect();
         let relevant_patterns =
             self.patterns.iter().filter(|pat| ctor.is_covered_by(pcx, pat.ctor()));
-        let ctor_sub_tys = pcx.ctor_sub_tys(ctor);
         for pat in relevant_patterns {
-            let specialized = pat.specialize(pcx, ctor, ctor_sub_tys);
+            let specialized = pat.specialize(ctor, arity);
             for (subpat, column) in specialized.into_iter().zip(&mut specialized_columns) {
                 column.expand_and_push(subpat);
             }

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -94,12 +94,6 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
                 column.expand_and_push(subpat);
             }
         }
-
-        assert!(
-            !specialized_columns[0].is_empty(),
-            "ctor {ctor:?} was listed as present but isn't;
-            there is an inconsistency between `Constructor::is_covered_by` and `ConstructorSet::split`"
-        );
         specialized_columns
     }
 }

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -72,11 +72,10 @@ impl<'p, Cx: TypeCx> DeconstructedPat<'p, Cx> {
     /// `other_ctor` can be different from `self.ctor`, but must be covered by it.
     pub(crate) fn specialize(
         &self,
-        _pcx: &PlaceCtxt<'_, 'p, Cx>,
         other_ctor: &Constructor<Cx>,
-        ctor_sub_tys: &[Cx::Ty],
+        ctor_arity: usize,
     ) -> SmallVec<[PatOrWild<'p, Cx>; 2]> {
-        let wildcard_sub_tys = || ctor_sub_tys.iter().map(|_| Wild).collect();
+        let wildcard_sub_tys = || (0..ctor_arity).map(|_| Wild).collect();
         match (&self.ctor, other_ctor) {
             // Return a wildcard for each field of `other_ctor`.
             (Wildcard, _) => wildcard_sub_tys(),
@@ -195,13 +194,12 @@ impl<'p, Cx: TypeCx> PatOrWild<'p, Cx> {
     /// `other_ctor` can be different from `self.ctor`, but must be covered by it.
     pub(crate) fn specialize(
         &self,
-        pcx: &PlaceCtxt<'_, 'p, Cx>,
         other_ctor: &Constructor<Cx>,
-        ctor_sub_tys: &[Cx::Ty],
+        ctor_arity: usize,
     ) -> SmallVec<[PatOrWild<'p, Cx>; 2]> {
         match self {
-            Wild => ctor_sub_tys.iter().map(|_| Wild).collect(),
-            Pat(pat) => pat.specialize(pcx, other_ctor, ctor_sub_tys),
+            Wild => (0..ctor_arity).map(|_| Wild).collect(),
+            Pat(pat) => pat.specialize(other_ctor, ctor_arity),
         }
     }
 


### PR DESCRIPTION
In the process of exhaustiveness checking, `Matrix` stores a 2D array of patterns. Those are subpatterns of the patterns we were provided as input, _except_ sometimes we allocate some extra wildcard patterns to fill a hole during specialization.

Morally though, we could store `Option<&'p DeconstructedPat>` in the matrix, where `None` signifies a wildcard. That way we'd only have "real" patterns in the matrix and we wouldn't need the arena to allocate these wildcards. This is what this PR does.

This is part of me splitting up https://github.com/rust-lang/rust/pull/119581 for ease of review.

r? @compiler-errors