### PR TITLE
macro_rules: Eagerly mark spans of produced tokens

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_check.rs
+++ b/compiler/rustc_expand/src/mbe/macro_check.rs
@@ -242,7 +242,7 @@ fn check_binders(
         // the outer macro. See ui/macros/macro-of-higher-order.rs where $y:$fragment in the
         // LHS of the nested macro (and RHS of the outer macro) is parsed as MetaVar(y) Colon
         // MetaVar(fragment) and not as MetaVarDecl(y, fragment).
-        TokenTree::MetaVar(span, name) => {
+        TokenTree::MetaVar(span, name, _) => {
             if macros.is_empty() {
                 sess.dcx.span_bug(span, "unexpected MetaVar in lhs");
             }
@@ -342,7 +342,7 @@ fn check_occurrences(
         TokenTree::MetaVarDecl(span, _name, _kind) => {
             sess.dcx.span_bug(span, "unexpected MetaVarDecl in rhs")
         }
-        TokenTree::MetaVar(span, name) => {
+        TokenTree::MetaVar(span, name, _) => {
             let name = MacroRulesNormalizedIdent::new(name);
             check_ops_is_prefix(sess, node_id, macros, binders, ops, span, name);
         }

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -1378,7 +1378,7 @@ fn is_in_follow(tok: &mbe::TokenTree, kind: NonterminalKind) -> IsInFollow {
 fn quoted_tt_to_string(tt: &mbe::TokenTree) -> String {
     match tt {
         mbe::TokenTree::Token(token) => pprust::token_to_string(token).into(),
-        mbe::TokenTree::MetaVar(_, name) => format!("${name}"),
+        mbe::TokenTree::MetaVar(_, name, _) => format!("${name}"),
         mbe::TokenTree::MetaVarDecl(_, name, Some(kind)) => format!("${name}:{kind}"),
         mbe::TokenTree::MetaVarDecl(_, name, None) => format!("${name}:"),
         _ => panic!(

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -54,7 +54,7 @@ pub(super) fn parse(
         // parse out the matcher (i.e., in `$id:ident` this would parse the `:` and `ident`).
         let tree = parse_tree(tree, &mut trees, parsing_patterns, sess, node_id, features, edition);
         match tree {
-            TokenTree::MetaVar(start_sp, ident) if parsing_patterns => {
+            TokenTree::MetaVar(start_sp, ident, _) if parsing_patterns => {
                 let span = match trees.next() {
                     Some(&tokenstream::TokenTree::Token(Token { kind: token::Colon, span }, _)) => {
                         match trees.next() {
@@ -223,7 +223,7 @@ fn parse_tree<'a>(
                     if ident.name == kw::Crate && !is_raw {
                         TokenTree::token(token::Ident(kw::DollarCrate, is_raw), span)
                     } else {
-                        TokenTree::MetaVar(span, ident)
+                        TokenTree::MetaVar(span, ident, ident.span)
                     }
                 }
 
@@ -245,7 +245,8 @@ fn parse_tree<'a>(
                     let msg =
                         format!("expected identifier, found `{}`", pprust::token_to_string(token),);
                     sess.dcx.span_err(token.span, msg);
-                    TokenTree::MetaVar(token.span, Ident::empty())
+                    let ident = Ident::empty();
+                    TokenTree::MetaVar(token.span, ident, ident.span)
                 }
 
                 // There are no more tokens. Just return the `$` we already have.

--- a/tests/ui/macros/meta-variable-depth-outside-repeat.stderr
+++ b/tests/ui/macros/meta-variable-depth-outside-repeat.stderr
@@ -3,6 +3,11 @@ error: meta-variable expression `length` with depth parameter must be called ins
    |
 LL |         ${length(0)}
    |          ^^^^^^^^^^^
+...
+LL | const _: i32 = metavar!(0);
+   |                ----------- in this macro invocation
+   |
+   = note: this error originates in the macro `metavar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/out-of-bounds-arguments.stderr
@@ -3,18 +3,33 @@ error: depth parameter of meta-variable expression `count` must be less than 4
    |
 LL |             ${count($foo, 10)},
    |              ^^^^^^^^^^^^^^^^^
+...
+LL |     a!( { [ (a) ] [ (b c) ] } );
+   |     --------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: depth parameter of meta-variable expression `index` must be less than 3
   --> $DIR/out-of-bounds-arguments.rs:19:18
    |
 LL |                 ${index(10)},
    |                  ^^^^^^^^^^^
+...
+LL |     b!( { [ a b ] } );
+   |     ----------------- in this macro invocation
+   |
+   = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: depth parameter of meta-variable expression `length` must be less than 2
   --> $DIR/out-of-bounds-arguments.rs:32:18
    |
 LL |                 ${length(10)}
    |                  ^^^^^^^^^^^^
+...
+LL |     c!({ a });
+   |     --------- in this macro invocation
+   |
+   = note: this error originates in the macro `c` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -201,18 +201,33 @@ error: `count` can not be placed inside the inner-most repetition
    |
 LL |     ( $i:ident ) => { ${ count($i) } };
    |                        ^^^^^^^^^^^^^
+...
+LL |     curly__no_rhs_dollar__no_round!(a);
+   |     ---------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `curly__no_rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `count` can not be placed inside the inner-most repetition
   --> $DIR/syntax-errors.rs:17:24
    |
 LL |     ( $i:ident ) => { ${ count($i) } };
    |                        ^^^^^^^^^^^^^
+...
+LL |     curly__rhs_dollar__no_round!(a);
+   |     ------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `curly__rhs_dollar__no_round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: variable 'i' is still repeating at this depth
   --> $DIR/syntax-errors.rs:34:36
    |
 LL |     ( $( $i:ident ),* ) => { count($i) };
    |                                    ^^
+...
+LL |     no_curly__rhs_dollar__round!(a, b, c);
+   |     ------------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `no_curly__rhs_dollar__round` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found `$`
   --> $DIR/syntax-errors.rs:53:9

--- a/tests/ui/parser/macro/macro-repeat.stderr
+++ b/tests/ui/parser/macro/macro-repeat.stderr
@@ -3,14 +3,22 @@ error: variable 'v' is still repeating at this depth
    |
 LL |         $v
    |         ^^
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: variable 'v' is still repeating at this depth
   --> $DIR/macro-repeat.rs:3:9
    |
 LL |         $v
    |         ^^
+...
+LL |     mac!(1);
+   |     ------- in this macro invocation
    |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
When a declarative macro expands and produces tokens it marks their spans as coming from that specific macro expansion.
Marking is a relatively expensive operation - it needs to lock the global hygiene data.

Right now marking happens lazily, when a token is actually produced into the output.
But that means marking happens 100 times if `$($var)*` expands to a sequence of length 100 (span of `$var` is marked and outputted as a part of the resulting nonterminal token).

In this PR I'm trying to perform this marking eagerly and once.
- Pros (perf): tokens from sequences are marked once (1 time instead of N).
- Cons (perf): tokens that never end up in the output are still marked (1 time instead of 0).
- Cons (perf): cloning of the used macro arm's right hand side is required (`src` in `fn transcribe`).
- Cons (perf): metavariable tokens of the `tt` kind weren't previously marked but they are marked now (can't tell whether the variable is `tt` this early). However, for #119673 we'll need `tt` metavars marked anyway.
- Pros (diagnostics): Some erroneous tokens are now correctly reported as coming from a macro expansion.