### PR TITLE
Unions are not `PointerLike`

### DIFF
--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -120,11 +120,11 @@ impl<'a> Layout<'a> {
     /// Whether the layout is from a type that implements [`std::marker::PointerLike`].
     ///
     /// Currently, that means that the type is pointer-sized, pointer-aligned,
-    /// and has a scalar ABI.
+    /// and has a initialized (non-union), scalar ABI.
     pub fn is_pointer_like(self, data_layout: &TargetDataLayout) -> bool {
         self.size() == data_layout.pointer_size
             && self.align().abi == data_layout.pointer_align.abi
-            && matches!(self.abi(), Abi::Scalar(..))
+            && matches!(self.abi(), Abi::Scalar(Scalar::Initialized { .. }))
     }
 }
 

--- a/tests/ui/dyn-star/union.rs
+++ b/tests/ui/dyn-star/union.rs
@@ -1,0 +1,16 @@
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+
+union Union {
+    x: usize,
+}
+
+trait Trait {}
+impl Trait for Union {}
+
+fn bar(_: dyn* Trait) {}
+
+fn main() {
+    bar(Union { x: 0usize });
+    //~^ ERROR `Union` needs to have the same ABI as a pointer
+}

--- a/tests/ui/dyn-star/union.stderr
+++ b/tests/ui/dyn-star/union.stderr
@@ -1,0 +1,20 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/union.rs:1:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: `Union` needs to have the same ABI as a pointer
+  --> $DIR/union.rs:14:9
+   |
+LL |     bar(Union { x: 0usize });
+   |         ^^^^^^^^^^^^^^^^^^^ `Union` needs to be a pointer-like type
+   |
+   = help: the trait `PointerLike` is not implemented for `Union`
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
I introduced the `PointerLike` trait to enforce `dyn*` coercions only from types that share the same ABI as a pointer. On top of needing to be scalar, they also should not be unions, since CTFE chokes on scalar reads for union types.

Fixes #119695