### PR TITLE
Adding alignment to the cases to test for specific error messages.

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -893,7 +893,7 @@ impl<'a> Parser<'a> {
                 0,
                 ParseError {
                     description: "expected format parameter to occur after `:`".to_owned(),
-                    note: Some(format!("`{}` comes after `:`.", alignment)),
+                    note: None,
                     label: format!("expected `{}` to occur after `:`", alignment).to_owned(),
                     span: pos.to(pos),
                     secondary_label: None,

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -289,10 +289,10 @@ impl<'a> Iterator for Parser<'a> {
                             }
                         } else {
                             if let Some(&(_, maybe)) = self.cur.peek() {
-                                if maybe == '?' {
-                                    self.suggest_format();
-                                } else {
-                                    self.suggest_positional_arg_instead_of_captured_arg(arg);
+                                match maybe {
+                                    '?' => self.suggest_format_debug(),
+                                    '<' | '^' | '>' => self.suggest_format_align(maybe),
+                                    _ => self.suggest_positional_arg_instead_of_captured_arg(arg),
                                 }
                             }
                         }
@@ -868,10 +868,9 @@ impl<'a> Parser<'a> {
         found.then_some(cur)
     }
 
-    fn suggest_format(&mut self) {
+    fn suggest_format_debug(&mut self) {
         if let (Some(pos), Some(_)) = (self.consume_pos('?'), self.consume_pos(':')) {
             let word = self.word();
-            let _end = self.current_pos();
             let pos = self.to_span_index(pos);
             self.errors.insert(
                 0,
@@ -879,6 +878,23 @@ impl<'a> Parser<'a> {
                     description: "expected format parameter to occur after `:`".to_owned(),
                     note: Some(format!("`?` comes after `:`, try `{}:{}` instead", word, "?")),
                     label: "expected `?` to occur after `:`".to_owned(),
+                    span: pos.to(pos),
+                    secondary_label: None,
+                    suggestion: Suggestion::None,
+                },
+            );
+        }
+    }
+
+    fn suggest_format_align(&mut self, alignment: char) {
+        if let Some(pos) = self.consume_pos(alignment) {
+            let pos = self.to_span_index(pos);
+            self.errors.insert(
+                0,
+                ParseError {
+                    description: "expected format parameter to occur after `:`".to_owned(),
+                    note: Some(format!("`{}` comes after `:`.", alignment)),
+                    label: format!("expected `{}` to occur after `:`", alignment).to_owned(),
                     span: pos.to(pos),
                     secondary_label: None,
                     suggestion: Suggestion::None,

--- a/tests/ui/fmt/format-string-wrong-order.rs
+++ b/tests/ui/fmt/format-string-wrong-order.rs
@@ -12,4 +12,10 @@ fn main() {
     //~^ ERROR invalid format string: expected `'}'`, found `'?'`
     format!("{?:#?}", bar);
     //~^ ERROR invalid format string: expected format parameter to occur after `:`
+    format!("Hello {<5:}!", "x");
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
+    format!("Hello {^5:}!", "x");
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
+    format!("Hello {>5:}!", "x");
+    //~^ ERROR invalid format string: expected format parameter to occur after `:`
 }

--- a/tests/ui/fmt/format-string-wrong-order.stderr
+++ b/tests/ui/fmt/format-string-wrong-order.stderr
@@ -55,24 +55,18 @@ error: invalid format string: expected format parameter to occur after `:`
    |
 LL |     format!("Hello {<5:}!", "x");
    |                     ^ expected `<` to occur after `:` in format string
-   |
-   = note: `<` comes after `:`.
 
 error: invalid format string: expected format parameter to occur after `:`
   --> $DIR/format-string-wrong-order.rs:17:21
    |
 LL |     format!("Hello {^5:}!", "x");
    |                     ^ expected `^` to occur after `:` in format string
-   |
-   = note: `^` comes after `:`.
 
 error: invalid format string: expected format parameter to occur after `:`
   --> $DIR/format-string-wrong-order.rs:19:21
    |
 LL |     format!("Hello {>5:}!", "x");
    |                     ^ expected `>` to occur after `:` in format string
-   |
-   = note: `>` comes after `:`.
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/fmt/format-string-wrong-order.stderr
+++ b/tests/ui/fmt/format-string-wrong-order.stderr
@@ -50,5 +50,29 @@ LL |     format!("{?:#?}", bar);
    |
    = note: `?` comes after `:`, try `:?` instead
 
-error: aborting due to 6 previous errors
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:15:21
+   |
+LL |     format!("Hello {<5:}!", "x");
+   |                     ^ expected `<` to occur after `:` in format string
+   |
+   = note: `<` comes after `:`.
+
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:17:21
+   |
+LL |     format!("Hello {^5:}!", "x");
+   |                     ^ expected `^` to occur after `:` in format string
+   |
+   = note: `^` comes after `:`.
+
+error: invalid format string: expected format parameter to occur after `:`
+  --> $DIR/format-string-wrong-order.rs:19:21
+   |
+LL |     format!("Hello {>5:}!", "x");
+   |                     ^ expected `>` to occur after `:` in format string
+   |
+   = note: `>` comes after `:`.
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Adding alignment to the list of cases to test for specific error message. Covers `>`, `^` and `<`.

Pinging people who chimed in last time ( https://github.com/rust-lang/rust/pull/106805 ): @estebank , @compiler-errors and @Nilstrieb 