### PR TITLE
Exhaustiveness: abort on type error

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -430,7 +430,10 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         }
 
         let scrut_ty = scrut.ty;
-        let report = analyze_match(&cx, &tarms, scrut_ty);
+        let Ok(report) = analyze_match(&cx, &tarms, scrut_ty).map_err(|err| self.error = Err(err))
+        else {
+            return;
+        };
 
         match source {
             // Don't report arm reachability of desugared `match $iter.into_iter() { iter => .. }`
@@ -544,7 +547,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         let cx = self.new_cx(refutability, None, scrut, pat.span);
         let pat = self.lower_pattern(&cx, pat)?;
         let arms = [MatchArm { pat, arm_data: self.lint_level, has_guard: false }];
-        let report = analyze_match(&cx, &arms, pat.ty().inner());
+        let report = analyze_match(&cx, &arms, pat.ty().inner())?;
         Ok((cx, report))
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -430,9 +430,12 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         }
 
         let scrut_ty = scrut.ty;
-        let Ok(report) = analyze_match(&cx, &tarms, scrut_ty).map_err(|err| self.error = Err(err))
-        else {
-            return;
+        let report = match analyze_match(&cx, &tarms, scrut_ty) {
+            Ok(report) => report,
+            Err(err) => {
+                self.error = Err(err);
+                return;
+            }
         };
 
         match source {

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -77,7 +77,7 @@ pub trait TypeCx: Sized + fmt::Debug {
     /// The set of all the constructors for `ty`.
     ///
     /// This must follow the invariants of `ConstructorSet`
-    fn ctors_for_ty(&self, ty: Self::Ty) -> ConstructorSet<Self>;
+    fn ctors_for_ty(&self, ty: Self::Ty) -> Result<ConstructorSet<Self>, Self::Error>;
 
     /// Best-effort `Debug` implementation.
     fn debug_pat(f: &mut fmt::Formatter<'_>, pat: &DeconstructedPat<'_, Self>) -> fmt::Result;

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -24,6 +24,8 @@ use std::fmt;
 use rustc_index::Idx;
 #[cfg(feature = "rustc")]
 use rustc_middle::ty::Ty;
+#[cfg(feature = "rustc")]
+use rustc_span::ErrorGuaranteed;
 
 use crate::constructor::{Constructor, ConstructorSet};
 #[cfg(feature = "rustc")]
@@ -52,6 +54,8 @@ impl<'a, T: ?Sized> Captures<'a> for T {}
 pub trait TypeCx: Sized + fmt::Debug {
     /// The type of a pattern.
     type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
+    /// Errors that can abort analysis.
+    type Error: fmt::Debug;
     /// The index of an enum variant.
     type VariantIdx: Clone + Idx;
     /// A string literal
@@ -109,25 +113,25 @@ pub fn analyze_match<'p, 'tcx>(
     tycx: &RustcMatchCheckCtxt<'p, 'tcx>,
     arms: &[rustc::MatchArm<'p, 'tcx>],
     scrut_ty: Ty<'tcx>,
-) -> rustc::UsefulnessReport<'p, 'tcx> {
+) -> Result<rustc::UsefulnessReport<'p, 'tcx>, ErrorGuaranteed> {
     // Arena to store the extra wildcards we construct during analysis.
     let wildcard_arena = tycx.pattern_arena;
     let scrut_ty = tycx.reveal_opaque_ty(scrut_ty);
     let scrut_validity = ValidityConstraint::from_bool(tycx.known_valid_scrutinee);
     let cx = MatchCtxt { tycx, wildcard_arena };
 
-    let report = compute_match_usefulness(cx, arms, scrut_ty, scrut_validity);
+    let report = compute_match_usefulness(cx, arms, scrut_ty, scrut_validity)?;
 
     let pat_column = PatternColumn::new(arms);
 
     // Lint on ranges that overlap on their endpoints, which is likely a mistake.
-    lint_overlapping_range_endpoints(cx, &pat_column);
+    lint_overlapping_range_endpoints(cx, &pat_column)?;
 
     // Run the non_exhaustive_omitted_patterns lint. Only run on refutable patterns to avoid hitting
     // `if let`s. Only run if the match is exhaustive otherwise the error is redundant.
     if tycx.refutable && report.non_exhaustiveness_witnesses.is_empty() {
-        lint_nonexhaustive_missing_variants(cx, arms, &pat_column, scrut_ty)
+        lint_nonexhaustive_missing_variants(cx, arms, &pat_column, scrut_ty)?;
     }
 
-    report
+    Ok(report)
 }

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::captures::Captures;
 use rustc_middle::ty;
 use rustc_session::lint;
 use rustc_session::lint::builtin::NON_EXHAUSTIVE_OMITTED_PATTERNS;
-use rustc_span::Span;
+use rustc_span::{ErrorGuaranteed, Span};
 
 use crate::constructor::{IntRange, MaybeInfiniteInt};
 use crate::errors::{
@@ -110,9 +110,9 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
 fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
     cx: MatchCtxt<'a, 'p, 'tcx>,
     column: &PatternColumn<'p, 'tcx>,
-) -> Vec<WitnessPat<'p, 'tcx>> {
+) -> Result<Vec<WitnessPat<'p, 'tcx>>, ErrorGuaranteed> {
     let Some(ty) = column.head_ty() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let pcx = &PlaceCtxt::new_dummy(cx, ty);
 
@@ -121,7 +121,7 @@ fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
         // We can't consistently handle the case where no constructors are present (since this would
         // require digging deep through any type in case there's a non_exhaustive enum somewhere),
         // so for consistency we refuse to handle the top-level case, where we could handle it.
-        return vec![];
+        return Ok(Vec::new());
     }
 
     let mut witnesses = Vec::new();
@@ -141,7 +141,7 @@ fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
         let wild_pat = WitnessPat::wild_from_ctor(pcx, ctor);
         for (i, col_i) in specialized_columns.iter().enumerate() {
             // Compute witnesses for each column.
-            let wits_for_col_i = collect_nonexhaustive_missing_variants(cx, col_i);
+            let wits_for_col_i = collect_nonexhaustive_missing_variants(cx, col_i)?;
             // For each witness, we build a new pattern in the shape of `ctor(_, _, wit, _, _)`,
             // adding enough wildcards to match `arity`.
             for wit in wits_for_col_i {
@@ -151,7 +151,7 @@ fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
             }
         }
     }
-    witnesses
+    Ok(witnesses)
 }
 
 pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
@@ -159,13 +159,13 @@ pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
     arms: &[MatchArm<'p, 'tcx>],
     pat_column: &PatternColumn<'p, 'tcx>,
     scrut_ty: RevealedTy<'tcx>,
-) {
+) -> Result<(), ErrorGuaranteed> {
     let rcx: &RustcMatchCheckCtxt<'_, '_> = cx.tycx;
     if !matches!(
         rcx.tcx.lint_level_at_node(NON_EXHAUSTIVE_OMITTED_PATTERNS, rcx.match_lint_level).0,
         rustc_session::lint::Level::Allow
     ) {
-        let witnesses = collect_nonexhaustive_missing_variants(cx, pat_column);
+        let witnesses = collect_nonexhaustive_missing_variants(cx, pat_column)?;
         if !witnesses.is_empty() {
             // Report that a match of a `non_exhaustive` enum marked with `non_exhaustive_omitted_patterns`
             // is not exhaustive enough.
@@ -204,6 +204,7 @@ pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
             }
         }
     }
+    Ok(())
 }
 
 /// Traverse the patterns to warn the user about ranges that overlap on their endpoints.
@@ -211,9 +212,9 @@ pub(crate) fn lint_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
 pub(crate) fn lint_overlapping_range_endpoints<'a, 'p, 'tcx>(
     cx: MatchCtxt<'a, 'p, 'tcx>,
     column: &PatternColumn<'p, 'tcx>,
-) {
+) -> Result<(), ErrorGuaranteed> {
     let Some(ty) = column.head_ty() else {
-        return;
+        return Ok(());
     };
     let pcx = &PlaceCtxt::new_dummy(cx, ty);
     let rcx: &RustcMatchCheckCtxt<'_, '_> = cx.tycx;
@@ -275,8 +276,9 @@ pub(crate) fn lint_overlapping_range_endpoints<'a, 'p, 'tcx>(
         // Recurse into the fields.
         for ctor in set.present {
             for col in column.specialize(pcx, &ctor) {
-                lint_overlapping_range_endpoints(cx, &col);
+                lint_overlapping_range_endpoints(cx, &col)?;
             }
         }
     }
+    Ok(())
 }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -13,6 +13,7 @@ use rustc_middle::mir::{self, Const};
 use rustc_middle::thir::{FieldPat, Pat, PatKind, PatRange, PatRangeBoundary};
 use rustc_middle::ty::layout::IntegerExt;
 use rustc_middle::ty::{self, OpaqueTypeKey, Ty, TyCtxt, VariantDef};
+use rustc_span::ErrorGuaranteed;
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{FieldIdx, Integer, VariantIdx, FIRST_VARIANT};
 use smallvec::SmallVec;
@@ -944,6 +945,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
 
 impl<'p, 'tcx> TypeCx for RustcMatchCheckCtxt<'p, 'tcx> {
     type Ty = RevealedTy<'tcx>;
+    type Error = ErrorGuaranteed;
     type VariantIdx = VariantIdx;
     type StrLit = Const<'tcx>;
     type ArmData = HirId;

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -753,7 +753,7 @@ impl<'a, 'p, Cx: TypeCx> PlaceCtxt<'a, 'p, Cx> {
     pub(crate) fn ctor_sub_tys(&self, ctor: &Constructor<Cx>) -> &[Cx::Ty] {
         self.mcx.tycx.ctor_sub_tys(ctor, self.ty)
     }
-    pub(crate) fn ctors_for_ty(&self) -> ConstructorSet<Cx> {
+    pub(crate) fn ctors_for_ty(&self) -> Result<ConstructorSet<Cx>, Cx::Error> {
         self.mcx.tycx.ctors_for_ty(self.ty)
     }
 }
@@ -1383,7 +1383,7 @@ fn compute_exhaustiveness_and_usefulness<'a, 'p, Cx: TypeCx>(
 
     // Analyze the constructors present in this column.
     let ctors = matrix.heads().map(|p| p.ctor());
-    let ctors_for_ty = pcx.ctors_for_ty();
+    let ctors_for_ty = pcx.ctors_for_ty()?;
     let is_integers = matches!(ctors_for_ty, ConstructorSet::Integers { .. }); // For diagnostics.
     let split_set = ctors_for_ty.split(pcx, ctors);
     let all_missing = split_set.present.is_empty();

--- a/tests/ui/pattern/usefulness/issue-119493-type-error-ice.rs
+++ b/tests/ui/pattern/usefulness/issue-119493-type-error-ice.rs
@@ -1,0 +1,13 @@
+fn main() {}
+
+fn foo() {
+    #[derive(Copy, Clone)]
+    struct Foo(NonExistent);
+    //~^ ERROR cannot find type
+    //~| ERROR cannot find type
+
+    type U = impl Copy;
+    //~^ ERROR `impl Trait` in type aliases is unstable
+    let foo: U = Foo(());
+    let Foo(()) = foo;
+}

--- a/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
+++ b/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
@@ -1,0 +1,30 @@
+error[E0412]: cannot find type `NonExistent` in this scope
+  --> $DIR/issue-119493-type-error-ice.rs:5:16
+   |
+LL |     struct Foo(NonExistent);
+   |                ^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `NonExistent` in this scope
+  --> $DIR/issue-119493-type-error-ice.rs:5:16
+   |
+LL |     struct Foo(NonExistent);
+   |                ^^^^^^^^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL |     struct Foo<NonExistent>(NonExistent);
+   |               +++++++++++++
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/issue-119493-type-error-ice.rs:9:14
+   |
+LL |     type U = impl Copy;
+   |              ^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0658.
+For more information about an error, try `rustc --explain E0412`.

--- a/tests/ui/pattern/usefulness/issue-119778-type-error-ice.rs
+++ b/tests/ui/pattern/usefulness/issue-119778-type-error-ice.rs
@@ -1,0 +1,13 @@
+fn main() {}
+
+fn foo() {
+    #[derive(Copy, Clone)]
+    struct Foo([u8; S]);
+    //~^ ERROR cannot find value `S`
+    //~| ERROR cannot find value `S`
+
+    type U = impl Copy;
+    //~^ ERROR `impl Trait` in type aliases is unstable
+    let foo: U = Foo(());
+    let Foo(()) = foo;
+}

--- a/tests/ui/pattern/usefulness/issue-119778-type-error-ice.stderr
+++ b/tests/ui/pattern/usefulness/issue-119778-type-error-ice.stderr
@@ -1,0 +1,35 @@
+error[E0425]: cannot find value `S` in this scope
+  --> $DIR/issue-119778-type-error-ice.rs:5:21
+   |
+LL |     struct Foo([u8; S]);
+   |                     ^ not found in this scope
+   |
+help: you might be missing a const parameter
+   |
+LL |     struct Foo<const S: /* Type */>([u8; S]);
+   |               +++++++++++++++++++++
+
+error[E0425]: cannot find value `S` in this scope
+  --> $DIR/issue-119778-type-error-ice.rs:5:21
+   |
+LL |     struct Foo([u8; S]);
+   |                     ^ not found in this scope
+   |
+help: you might be missing a const parameter
+   |
+LL |     struct Foo<const S: /* Type */>([u8; S]);
+   |               +++++++++++++++++++++
+
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/issue-119778-type-error-ice.rs:9:14
+   |
+LL |     type U = impl Copy;
+   |              ^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0425, E0658.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
This adds an error path to exhaustiveness checking so that we abort instead of ICEing when encountering a stray `ty::Error`.

Fixes https://github.com/rust-lang/rust/issues/119493
Fixes https://github.com/rust-lang/rust/issues/119778

r? @compiler-errors 