### PR TITLE
Remove crossbeam-channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,7 +3797,6 @@ dependencies = [
 name = "rustc_expand"
 version = "0.0.0"
 dependencies = [
- "crossbeam-channel",
  "rustc_ast",
  "rustc_ast_passes",
  "rustc_ast_pretty",

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 
 [dependencies]
 # tidy-alphabetical-start
-crossbeam-channel = "0.5.0"
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_passes = { path = "../rustc_ast_passes" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }


### PR DESCRIPTION
The standard library's std::sync::mpsc basically is a crossbeam channel, and for the use case here will definitely suffice. This drops this dependency from librustc_driver.