### PR TITLE
[beta] rustdoc ui: adjust tooltip z-index to be above sidebar

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1059,7 +1059,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	position: absolute;
 	top: 100%;
 	right: 0;
-	z-index: 2;
+	z-index: 101;
 	margin-top: 7px;
 	border-radius: 3px;
 	border: 1px solid var(--border-color);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -14,6 +14,7 @@
 	   and on the RUSTDOC_MOBILE_BREAKPOINT */
 	--desktop-sidebar-width: 200px;
 	--src-sidebar-width: 300px;
+	--desktop-sidebar-z-index: 100;
 }
 
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
@@ -396,7 +397,7 @@ img {
 	height: 100vh;
 	top: 0;
 	left: 0;
-	z-index: 100;
+	z-index: var(--desktop-sidebar-z-index);
 }
 
 .rustdoc.src .sidebar {
@@ -416,7 +417,7 @@ img {
 	touch-action: none;
 	width: 9px;
 	cursor: col-resize;
-	z-index: 200;
+	z-index: calc(var(--desktop-sidebar-z-index) + 1);
 	position: fixed;
 	height: 100%;
 	/* make sure there's a 1px gap between the scrollbar and resize handle */
@@ -448,7 +449,6 @@ img {
 
 .sidebar-resizing .sidebar {
 	position: fixed;
-	z-index: 100;
 }
 .sidebar-resizing > body {
 	padding-left: var(--resizing-sidebar-width);
@@ -1059,7 +1059,7 @@ so that we can apply CSS-filters to change the arrow color in themes */
 	position: absolute;
 	top: 100%;
 	right: 0;
-	z-index: 101;
+	z-index: calc(var(--desktop-sidebar-z-index) + 1);
 	margin-top: 7px;
 	border-radius: 3px;
 	border: 1px solid var(--border-color);

--- a/tests/rustdoc-gui/tooltip-over-sidebar.goml
+++ b/tests/rustdoc-gui/tooltip-over-sidebar.goml
@@ -1,0 +1,12 @@
+// Check that the doctest info tooltips are above the sidebar.
+go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
+move-cursor-to: ".example-wrap.ignore .tooltip"
+wait-for: ".tooltip.popover"
+
+// Move cursor to top left corner of the tooltip and check that it doesn't fade.
+move-cursor-to: ".tooltip.popover"
+wait-for: 100
+assert: ".tooltip.popover:not(.fade-out)"
+
+move-cursor-to: (0, 0)
+wait-for: ".tooltip.popover.fade-out"


### PR DESCRIPTION
Backport of https://github.com/rust-lang/rust/pull/119477.
Fixes https://github.com/rust-lang/rust/issues/119472.

range-diff:
```range-diff
446:  d796ad4209b =  11:  53637cdd8ed rustdoc ui: adjust tooltip z-index to be above sidebar
459:  b1853eb3bd5 !  12:  c4c4ff67fae use css variable for z-index of the sidebar
    @@ src/librustdoc/html/static/css/rustdoc.css: so that we can apply CSS-filters to
        margin-top: 7px;
        border-radius: 3px;
        border: 1px solid var(--border-color);
    -@@ src/librustdoc/html/static/css/rustdoc.css: a.tooltip:hover::after {
    - }
    - .src #sidebar-button {
    -   left: 8px;
    --  z-index: 101;
    -+  z-index: calc(var(--desktop-sidebar-z-index) + 1);
    - }
    - .hide-sidebar .src #sidebar-button {
    -   position: static;
```

The "show sidebar" button on the [source view page](https://doc.rust-lang.org/nightly/src/std/lib.rs.html) works differently on beta and nightly, but it is in fact above the sidebar in both versions.

beta button:
![beta button](https://github.com/rust-lang/rust/assets/26522220/24d7e86f-d19e-452f-bef2-6b6004b42255)

nightly button:
![nightly button](https://github.com/rust-lang/rust/assets/26522220/239dfdda-d9ca-4945-94dd-96254ed1c13f)

cc @Mark-Simulacrum 