### PR TITLE
Avoid using preorder traversals of MIR

### DIFF
--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -5,7 +5,6 @@ use crate::place_ext::PlaceExt;
 use crate::BorrowIndex;
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_index::bit_set::BitSet;
-use rustc_middle::mir::traversal;
 use rustc_middle::mir::visit::{MutatingUseContext, NonUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, Body, Local, Location};
 use rustc_middle::ty::{RegionVid, TyCtxt};
@@ -140,7 +139,8 @@ impl<'tcx> BorrowSet<'tcx> {
             ),
         };
 
-        for (block, block_data) in traversal::preorder(body) {
+        for &block in body.basic_blocks.reverse_postorder() {
+            let block_data = &body.basic_blocks[block];
             visitor.visit_basic_block_data(block, block_data);
         }
 

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -73,7 +73,7 @@ impl<'tcx> MirPass<'tcx> for Validator {
             tcx,
             mir_phase,
             unwind_edge_count: 0,
-            reachable_blocks: traversal::reachable_as_bitset(body),
+            reachable_blocks: body.basic_blocks.reachable_as_bitset(),
             value_cache: FxHashSet::default(),
             can_unwind,
         };
@@ -104,7 +104,7 @@ struct CfgChecker<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     mir_phase: MirPhase,
     unwind_edge_count: usize,
-    reachable_blocks: BitSet<BasicBlock>,
+    reachable_blocks: &'a BitSet<BasicBlock>,
     value_cache: FxHashSet<u128>,
     // If `false`, then the MIR must not contain `UnwindAction::Continue` or
     // `TerminatorKind::Resume`.

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -145,6 +145,19 @@ impl<T: Idx> BitSet<T> {
         result
     }
 
+    /// Creates a new bitset with a given `domain_size` using the given function to fill it.
+    #[inline]
+    pub fn from_fn_n(domain_size: usize, f: impl Fn(T) -> bool) -> BitSet<T> {
+        let mut result = BitSet::new_empty(domain_size);
+        for i in 0..domain_size {
+            let i = T::new(i);
+            if f(i) {
+                result.insert(i);
+            }
+        }
+        result
+    }
+
     /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -70,6 +70,13 @@ impl<'tcx> BasicBlocks<'tcx> {
         self.cache.reachable_as_bitset.get_or_init(|| reachable_as_bitset(&self.basic_blocks))
     }
 
+    /// Records reachable blocks in the cache.
+    #[inline]
+    pub fn assume_reachable_as_bitset(&self, reachable: BitSet<BasicBlock>) {
+        debug_assert_eq!(&reachable, self.reachable_as_bitset());
+        self.cache.reachable_as_bitset.get_or_init(|| reachable);
+    }
+
     /// Returns basic blocks in a reverse postorder.
     ///
     /// See [`traversal::reverse_postorder`]'s docs to learn what is preorder traversal.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1316,6 +1316,7 @@ impl<'tcx> BasicBlockData<'tcx> {
     }
 
     /// Does the block have no statements and an unreachable terminator?
+    #[inline]
     pub fn is_empty_unreachable(&self) -> bool {
         self.statements.is_empty() && matches!(self.terminator().kind, TerminatorKind::Unreachable)
     }

--- a/compiler/rustc_middle/src/mir/traversal.rs
+++ b/compiler/rustc_middle/src/mir/traversal.rs
@@ -44,16 +44,6 @@ impl<'a, 'tcx> Preorder<'a, 'tcx> {
     }
 }
 
-/// Preorder traversal of a graph.
-///
-/// This function creates an iterator over the `Body`'s basic blocks, that
-/// returns basic blocks in a preorder.
-///
-/// See [`Preorder`]'s docs to learn what is preorder traversal.
-pub fn preorder<'a, 'tcx>(body: &'a Body<'tcx>) -> Preorder<'a, 'tcx> {
-    Preorder::new(&body.basic_blocks, START_BLOCK)
-}
-
 impl<'a, 'tcx> Iterator for Preorder<'a, 'tcx> {
     type Item = (BasicBlock, &'a BasicBlockData<'tcx>);
 
@@ -235,25 +225,6 @@ pub fn postorder<'a, 'tcx>(
 ) -> impl Iterator<Item = (BasicBlock, &'a BasicBlockData<'tcx>)> + ExactSizeIterator + DoubleEndedIterator
 {
     reverse_postorder(body).rev()
-}
-
-/// Returns an iterator over all basic blocks reachable from the `START_BLOCK` in no particular
-/// order.
-///
-/// This is clearer than writing `preorder` in cases where the order doesn't matter.
-pub fn reachable<'a, 'tcx>(
-    body: &'a Body<'tcx>,
-) -> impl 'a + Iterator<Item = (BasicBlock, &'a BasicBlockData<'tcx>)> {
-    preorder(body)
-}
-
-/// Returns a `BitSet` containing all basic blocks reachable from the `START_BLOCK`.
-pub fn reachable_as_bitset(
-    basic_blocks: &IndexSlice<BasicBlock, BasicBlockData<'_>>,
-) -> BitSet<BasicBlock> {
-    let mut iter = Preorder::new(basic_blocks, START_BLOCK);
-    iter.by_ref().for_each(drop);
-    iter.visited
 }
 
 /// Reverse postorder traversal of a graph.

--- a/compiler/rustc_mir_dataflow/src/framework/cursor.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/cursor.rs
@@ -69,7 +69,7 @@ where
             pos: CursorPosition::block_entry(mir::START_BLOCK),
 
             #[cfg(debug_assertions)]
-            reachable_blocks: mir::traversal::reachable_as_bitset(body),
+            reachable_blocks: body.basic_blocks.reachable_as_bitset().clone(),
         }
     }
 

--- a/compiler/rustc_mir_dataflow/src/framework/engine.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/engine.rs
@@ -69,8 +69,8 @@ where
         body: &'mir mir::Body<'tcx>,
         vis: &mut impl ResultsVisitor<'mir, 'tcx, Self, FlowState = A::Domain>,
     ) {
-        let blocks = mir::traversal::reachable(body);
-        visit_results(body, blocks.map(|(bb, _)| bb), self, vis)
+        let blocks = body.basic_blocks.reverse_postorder();
+        visit_results(body, blocks.iter().copied(), self, vis)
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/graphviz.rs
@@ -36,7 +36,7 @@ where
     body: &'mir Body<'tcx>,
     results: RefCell<Option<Results<'tcx, A>>>,
     style: OutputStyle,
-    reachable: BitSet<BasicBlock>,
+    reachable: &'mir BitSet<BasicBlock>,
 }
 
 impl<'mir, 'tcx, A> Formatter<'mir, 'tcx, A>
@@ -48,7 +48,7 @@ where
         results: Results<'tcx, A>,
         style: OutputStyle,
     ) -> Self {
-        let reachable = mir::traversal::reachable_as_bitset(body);
+        let reachable = body.basic_blocks.reachable_as_bitset();
         Formatter { body, results: Some(results).into(), style, reachable }
     }
 

--- a/compiler/rustc_mir_dataflow/src/framework/visitor.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/visitor.rs
@@ -15,7 +15,7 @@ pub fn visit_results<'mir, 'tcx, F, R>(
     let mut state = results.new_flow_state(body);
 
     #[cfg(debug_assertions)]
-    let reachable_blocks = mir::traversal::reachable_as_bitset(body);
+    let reachable_blocks = body.basic_blocks.reachable_as_bitset();
 
     for block in blocks {
         #[cfg(debug_assertions)]

--- a/compiler/rustc_mir_transform/src/const_goto.rs
+++ b/compiler/rustc_mir_transform/src/const_goto.rs
@@ -51,7 +51,7 @@ impl<'tcx> MirPass<'tcx> for ConstGoto {
         // if we applied optimizations, we potentially have some cfg to cleanup to
         // make it easier for further passes
         if should_simplify {
-            simplify_cfg(tcx, body);
+            simplify_cfg(body);
             simplify_locals(body, tcx);
         }
     }

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -44,7 +44,8 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let mut call_operands_to_move = Vec::new();
     let mut patch = Vec::new();
 
-    for (bb, bb_data) in traversal::preorder(body) {
+    for &bb in body.basic_blocks.reverse_postorder() {
+        let bb_data = &body.basic_blocks[bb];
         if let TerminatorKind::Call { ref args, .. } = bb_data.terminator().kind {
             let loc = Location { block: bb, statement_index: bb_data.statements.len() };
 

--- a/compiler/rustc_mir_transform/src/deduplicate_blocks.rs
+++ b/compiler/rustc_mir_transform/src/deduplicate_blocks.rs
@@ -25,7 +25,7 @@ impl<'tcx> MirPass<'tcx> for DeduplicateBlocks {
         if has_opts_to_apply {
             let mut opt_applier = OptApplier { tcx, duplicates };
             opt_applier.visit_body(body);
-            simplify_cfg(tcx, body);
+            simplify_cfg(body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -138,8 +138,8 @@ use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
 use rustc_middle::mir::HasLocalDecls;
 use rustc_middle::mir::{dump_mir, PassWhere};
 use rustc_middle::mir::{
-    traversal, Body, InlineAsmOperand, Local, LocalKind, Location, Operand, Place, Rvalue,
-    Statement, StatementKind, TerminatorKind,
+    Body, InlineAsmOperand, Local, LocalKind, Location, Operand, Place, Rvalue, Statement,
+    StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::impls::MaybeLiveLocals;
@@ -470,7 +470,8 @@ impl<'a, 'body, 'alloc, 'tcx> FilterInformation<'a, 'body, 'alloc, 'tcx> {
     }
 
     fn internal_filter_liveness(&mut self) {
-        for (block, data) in traversal::preorder(self.body) {
+        for &block in self.body.basic_blocks.reverse_postorder() {
+            let data = &self.body.basic_blocks[block];
             self.at = Location { block, statement_index: data.statements.len() };
             self.live.seek_after_primary_effect(self.at);
             self.write_info.for_terminator(&data.terminator().kind);

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -804,10 +804,8 @@ fn dest_prop_mir_dump<'body, 'tcx>(
     live: &mut ResultsCursor<'body, 'tcx, MaybeLiveLocals>,
     round: usize,
 ) {
-    let mut reachable = None;
     dump_mir(tcx, false, "DestinationPropagation-dataflow", &round, body, |pass_where, w| {
-        let reachable = reachable.get_or_insert_with(|| traversal::reachable_as_bitset(body));
-
+        let reachable = body.basic_blocks.reachable_as_bitset();
         match pass_where {
             PassWhere::BeforeLocation(loc) if reachable.contains(loc.block) => {
                 live.seek_after_primary_effect(loc);

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -212,7 +212,7 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
         // Since this optimization adds new basic blocks and invalidates others,
         // clean up the cfg to make it nicer for other passes
         if should_cleanup {
-            simplify_cfg(tcx, body);
+            simplify_cfg(body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -15,7 +15,7 @@ use rustc_target::abi::FieldIdx;
 use rustc_target::spec::abi::Abi;
 
 use crate::cost_checker::CostChecker;
-use crate::simplify::{remove_dead_blocks, CfgSimplifier};
+use crate::simplify::simplify_cfg;
 use crate::util;
 use std::iter;
 use std::ops::{Range, RangeFrom};
@@ -56,8 +56,7 @@ impl<'tcx> MirPass<'tcx> for Inline {
         let _guard = span.enter();
         if inline(tcx, body) {
             debug!("running simplify cfg on {:?}", body.source);
-            CfgSimplifier::new(body).simplify();
-            remove_dead_blocks(body);
+            simplify_cfg(body);
             deref_finder(tcx, body);
         }
     }

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -769,7 +769,8 @@ fn loop_headers(body: &Body<'_>) -> BitSet<BasicBlock> {
     let mut loop_headers = BitSet::new_empty(body.basic_blocks.len());
     let dominators = body.basic_blocks.dominators();
     // Only visit reachable blocks.
-    for (bb, bbdata) in traversal::preorder(body) {
+    for &bb in body.basic_blocks.reverse_postorder() {
+        let bbdata = &body.basic_blocks[bb];
         for succ in bbdata.terminator().successors() {
             if dominators.dominates(succ, bb) {
                 loop_headers.insert(succ);

--- a/compiler/rustc_mir_transform/src/lint.rs
+++ b/compiler/rustc_mir_transform/src/lint.rs
@@ -34,7 +34,8 @@ pub fn lint_body<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, when: String) {
         maybe_storage_dead,
         places: Default::default(),
     };
-    for (bb, data) in traversal::reachable(body) {
+    for &bb in body.basic_blocks.reverse_postorder() {
+        let data = &body.basic_blocks[bb];
         lint.visit_basic_block_data(bb, data);
     }
 }

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -174,7 +174,7 @@ impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
         }
 
         if should_cleanup {
-            simplify_cfg(tcx, body);
+            simplify_cfg(body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -254,7 +254,7 @@ fn compute_replacement<'tcx>(
         can_perform_opt,
         allowed_replacements: FxHashSet::default(),
     };
-    let reachable_blocks = traversal::reachable_as_bitset(body);
+    let reachable_blocks = body.basic_blocks.reachable_as_bitset();
     for (bb, bbdata) in body.basic_blocks.iter_enumerated() {
         // Only visit reachable blocks as we rely on dataflow.
         if reachable_blocks.contains(bb) {

--- a/compiler/rustc_mir_transform/src/remove_unneeded_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_unneeded_drops.rs
@@ -38,7 +38,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUnneededDrops {
         // if we applied optimizations, we potentially have some cfg to cleanup to
         // make it easier for further passes
         if should_simplify {
-            simplify_cfg(tcx, body);
+            simplify_cfg(body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -50,11 +50,11 @@ impl<'tcx> MirPass<'tcx> for SeparateConstSwitch {
         sess.mir_opt_level() >= 2 && sess.opts.unstable_opts.unsound_mir_opts
     }
 
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+    fn run_pass(&self, _: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         // If execution did something, applying a simplification layer
         // helps later passes optimize the copy away.
         if separate_const_switch(body) > 0 {
-            super::simplify::simplify_cfg(tcx, body);
+            super::simplify::simplify_cfg(body);
         }
     }
 }

--- a/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
@@ -108,7 +108,7 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body@$DIR/async_await.rs:15:18: 18:2}>,
 
     bb0: {
         _39 = discriminant((*(_1.0: &mut {async fn body@$DIR/async_await.rs:15:18: 18:2})));
-        switchInt(move _39) -> [0: bb1, 1: bb29, 3: bb27, 4: bb28, otherwise: bb30];
+        switchInt(move _39) -> [0: bb1, 1: bb29, 3: bb27, 4: bb28, otherwise: bb9];
     }
 
     bb1: {
@@ -344,9 +344,5 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body@$DIR/async_await.rs:15:18: 18:2}>,
 
     bb29: {
         assert(const false, "`async fn` resumed after completion") -> [success: bb29, unwind unreachable];
-    }
-
-    bb30: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
@@ -56,7 +56,7 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb8, 1: bb6, otherwise: bb7];
+          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb2];
       }
   
       bb1: {
@@ -114,20 +114,16 @@
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
           StorageDead(_13);
 -         goto -> bb5;
-+         goto -> bb9;
++         goto -> bb8;
       }
   
       bb7: {
-          unreachable;
-      }
-  
-      bb8: {
           _11 = move ((_4 as Ok).0: i32);
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(move _11);
           goto -> bb5;
 +     }
 + 
-+     bb9: {
++     bb8: {
 +         StorageDead(_12);
 +         StorageDead(_11);
 +         StorageDead(_10);

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
@@ -56,7 +56,7 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb8, 1: bb6, otherwise: bb7];
+          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb2];
       }
   
       bb1: {
@@ -114,20 +114,16 @@
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
           StorageDead(_13);
 -         goto -> bb5;
-+         goto -> bb9;
++         goto -> bb8;
       }
   
       bb7: {
-          unreachable;
-      }
-  
-      bb8: {
           _11 = move ((_4 as Ok).0: i32);
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(move _11);
           goto -> bb5;
 +     }
 + 
-+     bb9: {
++     bb8: {
 +         StorageDead(_12);
 +         StorageDead(_11);
 +         StorageDead(_10);

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -50,7 +50,7 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK-LABEL: fn identity(
     // CHECK: bb0: {
     // CHECK:     [[x:_.*]] = _1;
-    // CHECK:     switchInt(move {{_.*}}) -> [0: bb8, 1: bb6, otherwise: bb7];
+    // CHECK:     switchInt(move {{_.*}}) -> [0: bb7, 1: bb6, otherwise: bb2];
     // CHECK: bb1: {
     // CHECK:     {{_.*}} = (([[controlflow:_.*]] as Continue).0: i32);
     // CHECK:     _0 = Result::<i32, i32>::Ok(
@@ -68,14 +68,12 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK: bb6: {
     // CHECK:     {{_.*}} = move (([[x]] as Err).0: i32);
     // CHECK:     [[controlflow]] = ControlFlow::<Result<Infallible, i32>, i32>::Break(
-    // CHECK:     goto -> bb9;
+    // CHECK:     goto -> bb8;
     // CHECK: bb7: {
-    // CHECK:     unreachable;
-    // CHECK: bb8: {
     // CHECK:     {{_.*}} = move (([[x]] as Ok).0: i32);
     // CHECK:     [[controlflow]] = ControlFlow::<Result<Infallible, i32>, i32>::Continue(
     // CHECK:     goto -> bb5;
-    // CHECK: bb9: {
+    // CHECK: bb8: {
     // CHECK:     goto -> bb3;
     Ok(x?)
 }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -56,9 +56,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb1, 1: bb3, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb1, 1: bb2, otherwise: bb6];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb1, 1: bb3, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb1, 1: bb2, otherwise: bb6];
       }
   
       bb1: {
@@ -66,10 +66,6 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum32) }};
           StorageDead(_10);
@@ -79,18 +75,18 @@
           StorageLive(_5);
           StorageLive(_6);
           _9 = const _;
--         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb4, unwind unreachable];
-+         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum32) }}, const false) -> [return: bb4, unwind unreachable];
+-         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb3, unwind unreachable];
++         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum32) }}, const false) -> [return: bb3, unwind unreachable];
       }
   
-      bb4: {
+      bb3: {
           StorageLive(_12);
           StorageLive(_15);
           _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb2];
+          switchInt(move _12) -> [0: bb5, 1: bb4, otherwise: bb6];
       }
   
-      bb5: {
+      bb4: {
           _15 = const "called `Result::unwrap()` on an `Err` value";
           StorageLive(_16);
           StorageLive(_17);
@@ -100,7 +96,7 @@
           _14 = result::unwrap_failed(move _15, move _16) -> unwind unreachable;
       }
   
-      bb6: {
+      bb5: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_15);
           StorageDead(_12);
@@ -114,6 +110,10 @@
           StorageDead(_4);
           StorageDead(_3);
           return;
+      }
+  
+      bb6: {
+          unreachable;
       }
   }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -41,9 +41,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb4, otherwise: bb3];
+-         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb5];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb4, otherwise: bb3];
++         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb5];
       }
   
       bb1: {
@@ -64,10 +64,6 @@
       }
   
       bb3: {
-          unreachable;
-      }
-  
-      bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum32) }};
           StorageDead(_10);
@@ -77,12 +73,16 @@
           StorageLive(_5);
           StorageLive(_6);
           _9 = const _;
--         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb5, unwind continue];
-+         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum32) }}, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb4, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum32) }}, const false) -> [return: bb4, unwind continue];
+      }
+  
+      bb4: {
+          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
       }
   
       bb5: {
-          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
+          unreachable;
       }
   }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -56,9 +56,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb1, 1: bb3, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb1, 1: bb2, otherwise: bb6];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb1, 1: bb3, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb1, 1: bb2, otherwise: bb6];
       }
   
       bb1: {
@@ -66,10 +66,6 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum64) }};
           StorageDead(_10);
@@ -79,18 +75,18 @@
           StorageLive(_5);
           StorageLive(_6);
           _9 = const _;
--         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb4, unwind unreachable];
-+         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum64) }}, const false) -> [return: bb4, unwind unreachable];
+-         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb3, unwind unreachable];
++         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum64) }}, const false) -> [return: bb3, unwind unreachable];
       }
   
-      bb4: {
+      bb3: {
           StorageLive(_12);
           StorageLive(_15);
           _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb2];
+          switchInt(move _12) -> [0: bb5, 1: bb4, otherwise: bb6];
       }
   
-      bb5: {
+      bb4: {
           _15 = const "called `Result::unwrap()` on an `Err` value";
           StorageLive(_16);
           StorageLive(_17);
@@ -100,7 +96,7 @@
           _14 = result::unwrap_failed(move _15, move _16) -> unwind unreachable;
       }
   
-      bb6: {
+      bb5: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_15);
           StorageDead(_12);
@@ -114,6 +110,10 @@
           StorageDead(_4);
           StorageDead(_3);
           return;
+      }
+  
+      bb6: {
+          unreachable;
       }
   }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -41,9 +41,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb4, otherwise: bb3];
+-         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb5];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb4, otherwise: bb3];
++         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb5];
       }
   
       bb1: {
@@ -64,10 +64,6 @@
       }
   
       bb3: {
-          unreachable;
-      }
-  
-      bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum64) }};
           StorageDead(_10);
@@ -77,12 +73,16 @@
           StorageLive(_5);
           StorageLive(_6);
           _9 = const _;
--         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb5, unwind continue];
-+         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum64) }}, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(_9, _1, const false) -> [return: bb4, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(const {ALLOC1<imm>: &std::alloc::Global}, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum64) }}, const false) -> [return: bb4, unwind continue];
+      }
+  
+      bb4: {
+          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
       }
   
       bb5: {
-          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
+          unreachable;
       }
   }
 + 

--- a/tests/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/tests/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -52,7 +52,7 @@
           StorageLive(_10);
           StorageLive(_11);
           _9 = discriminant(_1);
-          switchInt(move _9) -> [0: bb6, 1: bb5, otherwise: bb2];
+          switchInt(move _9) -> [0: bb5, 1: bb4, otherwise: bb6];
       }
   
       bb1: {
@@ -63,10 +63,6 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>);
           _13 = ((_6 as Err).0: i32);
           _0 = Result::<i32, i32>::Err(move _13);
@@ -74,27 +70,31 @@
           return;
       }
   
-      bb4: {
+      bb3: {
           StorageDead(_11);
           StorageDead(_10);
           StorageDead(_9);
           _5 = discriminant(_3);
-          switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2];
+          switchInt(move _5) -> [0: bb1, 1: bb2, otherwise: bb6];
       }
   
-      bb5: {
+      bb4: {
           _11 = ((_1 as Err).0: i32);
           StorageLive(_12);
           _12 = Result::<Infallible, i32>::Err(move _11);
           _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _12);
           StorageDead(_12);
-          goto -> bb4;
+          goto -> bb3;
+      }
+  
+      bb5: {
+          _10 = ((_1 as Ok).0: i32);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(move _10);
+          goto -> bb3;
       }
   
       bb6: {
-          _10 = ((_1 as Ok).0: i32);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(move _10);
-          goto -> bb4;
+          unreachable;
       }
   }
   

--- a/tests/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/tests/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -30,47 +30,47 @@
       bb0: {
           StorageLive(_2);
           _3 = discriminant(_1);
-          switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _3) -> [0: bb2, 1: bb1, otherwise: bb7];
       }
   
       bb1: {
           _6 = ((_1 as Err).0: usize);
           _2 = ControlFlow::<usize, i32>::Break(_6);
-          goto -> bb4;
+          goto -> bb3;
       }
   
       bb2: {
-          unreachable;
+          _4 = ((_1 as Ok).0: i32);
+          _2 = ControlFlow::<usize, i32>::Continue(_4);
+          goto -> bb3;
       }
   
       bb3: {
-          _4 = ((_1 as Ok).0: i32);
-          _2 = ControlFlow::<usize, i32>::Continue(_4);
-          goto -> bb4;
+          _8 = discriminant(_2);
+          switchInt(move _8) -> [0: bb5, 1: bb4, otherwise: bb7];
       }
   
       bb4: {
-          _8 = discriminant(_2);
-          switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb2];
-      }
-  
-      bb5: {
           StorageLive(_11);
           _11 = ((_2 as Break).0: usize);
           _0 = Option::<i32>::None;
           StorageDead(_11);
-          goto -> bb7;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _9 = ((_2 as Continue).0: i32);
+          _0 = Option::<i32>::Some(_9);
+          goto -> bb6;
       }
   
       bb6: {
-          _9 = ((_2 as Continue).0: i32);
-          _0 = Option::<i32>::Some(_9);
-          goto -> bb7;
+          StorageDead(_2);
+          return;
       }
   
       bb7: {
-          StorageDead(_2);
-          return;
+          unreachable;
       }
   }
   

--- a/tests/ui/borrowck/borrowck-mut-borrow-linear-errors.stderr
+++ b/tests/ui/borrowck/borrowck-mut-borrow-linear-errors.stderr
@@ -2,30 +2,31 @@ error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:10:30
    |
 LL |             1 => { addr.push(&mut x); }
-   |                              ^^^^^^ second mutable borrow occurs here
+   |                              ^^^^^^ `x` was mutably borrowed here in the previous iteration of the loop
 LL |             2 => { addr.push(&mut x); }
 LL |             _ => { addr.push(&mut x); }
-   |                    ----      ------ first mutable borrow occurs here
-   |                    |
-   |                    first borrow later used here
+   |                    ---- first borrow used here, in later iteration of loop
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:11:30
    |
+LL |             1 => { addr.push(&mut x); }
+   |                              ------ first mutable borrow occurs here
 LL |             2 => { addr.push(&mut x); }
    |                              ^^^^^^ second mutable borrow occurs here
 LL |             _ => { addr.push(&mut x); }
-   |                    ----      ------ first mutable borrow occurs here
-   |                    |
-   |                    first borrow later used here
+   |                    ---- first borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
   --> $DIR/borrowck-mut-borrow-linear-errors.rs:12:30
    |
+LL |             1 => { addr.push(&mut x); }
+   |                              ------ first mutable borrow occurs here
+LL |             2 => { addr.push(&mut x); }
 LL |             _ => { addr.push(&mut x); }
-   |                    ----      ^^^^^^ `x` was mutably borrowed here in the previous iteration of the loop
+   |                    ----      ^^^^^^ second mutable borrow occurs here
    |                    |
-   |                    first borrow used here, in later iteration of loop
+   |                    first borrow later used here
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
To use RPO instead as it is cached.

r? @ghost 