### PR TITLE
rustdoc-search: reuse individual types in function signatures

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2717,8 +2717,24 @@ ${item.displayPath}<span class="${type}">${name}</span>\
      * @return {Array<FunctionSearchType>}
      */
     function buildItemSearchTypeAll(types, lowercasePaths) {
-        return types.map(type => buildItemSearchType(type, lowercasePaths));
+        return types.length > 0 ?
+            types.map(type => buildItemSearchType(type, lowercasePaths)) :
+            EMPTY_GENERICS_ARRAY;
     }
+
+    /**
+     * Empty, immutable map used in item search types with no bindings.
+     *
+     * @type {Map<integer, Array<Functiontype>>}
+     */
+    const EMPTY_BINDINGS_MAP = new Map();
+
+    /**
+     * Empty, immutable map used in item search types with no bindings.
+     *
+     * @type {Array<Functiontype>}
+     */
+    const EMPTY_GENERICS_ARRAY = [];
 
     /**
      * Converts a single type.
@@ -2732,15 +2748,15 @@ ${item.displayPath}<span class="${type}">${name}</span>\
         let pathIndex, generics, bindings;
         if (typeof type === "number") {
             pathIndex = type;
-            generics = [];
-            bindings = new Map();
+            generics = EMPTY_GENERICS_ARRAY;
+            bindings = EMPTY_BINDINGS_MAP;
         } else {
             pathIndex = type[PATH_INDEX_DATA];
             generics = buildItemSearchTypeAll(
                 type[GENERICS_DATA],
                 lowercasePaths
             );
-            if (type.length > BINDINGS_DATA) {
+            if (type.length > BINDINGS_DATA && type[BINDINGS_DATA].length > 0) {
                 bindings = new Map(type[BINDINGS_DATA].map(binding => {
                     const [assocType, constraints] = binding;
                     // Associated type constructors are represented sloppily in rustdoc's
@@ -2759,7 +2775,7 @@ ${item.displayPath}<span class="${type}">${name}</span>\
                     ];
                 }));
             } else {
-                bindings = new Map();
+                bindings = EMPTY_BINDINGS_MAP;
             }
         }
         if (pathIndex < 0) {


### PR DESCRIPTION
Because `search.js` never mutates the function signature after loading it,
they can be safely and easily reused across functions.

This change doesn't change the format of the search index.
It only changes `search.js`.

Profiler output: https://notriddle.com/rustdoc-html-demo-9/fn-signature-opti2/index.html

<table><tr><th>benchmark<th>before<th>after

<tr><th>arti<td>

```
user: 002.228 s
sys:  000.315 s
wall: 001.663 s
child_RSS_high:     315668 KiB
group_mem_high:     285948 KiB
```

<td>

```
user: 001.805 s
sys:  000.231 s
wall: 001.398 s
child_RSS_high:     235864 KiB
group_mem_high:     203056 KiB
```

<tr><th>cortex-m<td>

```
user: 000.143 s
sys:  000.035 s
wall: 000.140 s
child_RSS_high:      59168 KiB
group_mem_high:      23000 KiB
```

<td>

```
user: 000.138 s
sys:  000.031 s
wall: 000.133 s
child_RSS_high:      58944 KiB
group_mem_high:      22220 KiB
```

<tr><th>sqlx<td>

```
user: 000.792 s
sys:  000.115 s
wall: 000.536 s
child_RSS_high:     156716 KiB
group_mem_high:     122948 KiB
```

<td>

```
user: 000.824 s
sys:  000.084 s
wall: 000.535 s
child_RSS_high:     136668 KiB
group_mem_high:     101792 KiB
```

<tr><th>stm32f4<td>

```
user: 006.665 s
sys:  003.533 s
wall: 008.624 s
child_RSS_high:    1037660 KiB
group_mem_high:    1022516 KiB
```

<td>

```
user: 005.997 s
sys:  003.185 s
wall: 007.987 s
child_RSS_high:     832068 KiB
group_mem_high:     810908 KiB
```

<tr><th>stm32f4xx-hal<td>

```
user: 000.317 s
sys:  000.051 s
wall: 000.203 s
child_RSS_high:      77060 KiB
group_mem_high:      41776 KiB
```

<td>

```
user: 000.287 s
sys:  000.046 s
wall: 000.180 s
child_RSS_high:      75216 KiB
group_mem_high:      39200 KiB
```

<tr><th>ripgrep<td>

```
user: 000.463 s
sys:  000.063 s
wall: 000.295 s
child_RSS_high:     101288 KiB
group_mem_high:      66364 KiB
```

<td>

```
user: 000.472 s
sys:  000.036 s
wall: 000.247 s
child_RSS_high:      82708 KiB
group_mem_high:      47056 KiB
```

</tr></table>
