### PR TITLE
rustdoc: offset generic args of cross-crate trait object types when cleaning

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1908,7 +1908,7 @@ fn normalize<'tcx>(
 
 fn clean_trait_object_lifetime_bound<'tcx>(
     region: ty::Region<'tcx>,
-    container: Option<ContainerTy<'tcx>>,
+    container: Option<ContainerTy<'_, 'tcx>>,
     preds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     tcx: TyCtxt<'tcx>,
 ) -> Option<Lifetime> {
@@ -1937,7 +1937,7 @@ fn clean_trait_object_lifetime_bound<'tcx>(
 
 fn can_elide_trait_object_lifetime_bound<'tcx>(
     region: ty::Region<'tcx>,
-    container: Option<ContainerTy<'tcx>>,
+    container: Option<ContainerTy<'_, 'tcx>>,
     preds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     tcx: TyCtxt<'tcx>,
 ) -> bool {
@@ -1984,18 +1984,18 @@ fn can_elide_trait_object_lifetime_bound<'tcx>(
 }
 
 #[derive(Debug)]
-pub(crate) enum ContainerTy<'tcx> {
+pub(crate) enum ContainerTy<'a, 'tcx> {
     Ref(ty::Region<'tcx>),
     Regular {
         ty: DefId,
         /// The arguments *have* to contain an arg for the self type if the corresponding generics
         /// contain a self type.
-        args: ty::Binder<'tcx, &'tcx [ty::GenericArg<'tcx>]>,
+        args: ty::Binder<'tcx, &'a [ty::GenericArg<'tcx>]>,
         arg: usize,
     },
 }
 
-impl<'tcx> ContainerTy<'tcx> {
+impl<'tcx> ContainerTy<'_, 'tcx> {
     fn object_lifetime_default(self, tcx: TyCtxt<'tcx>) -> ObjectLifetimeDefault<'tcx> {
         match self {
             Self::Ref(region) => ObjectLifetimeDefault::Arg(region),
@@ -2044,7 +2044,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
     bound_ty: ty::Binder<'tcx, Ty<'tcx>>,
     cx: &mut DocContext<'tcx>,
     parent_def_id: Option<DefId>,
-    container: Option<ContainerTy<'tcx>>,
+    container: Option<ContainerTy<'_, 'tcx>>,
 ) -> Type {
     let bound_ty = normalize(cx, bound_ty).unwrap_or(bound_ty);
     match *bound_ty.skip_binder().kind() {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -36,7 +36,7 @@ use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi::Abi;
 
 use crate::clean::cfg::Cfg;
-use crate::clean::external_path;
+use crate::clean::clean_middle_path;
 use crate::clean::inline::{self, print_inlined_const};
 use crate::clean::utils::{is_literal_expr, print_evaluated_const};
 use crate::core::DocContext;
@@ -1258,7 +1258,7 @@ impl GenericBound {
     fn sized_with(cx: &mut DocContext<'_>, modifier: hir::TraitBoundModifier) -> GenericBound {
         let did = cx.tcx.require_lang_item(LangItem::Sized, None);
         let empty = ty::Binder::dummy(ty::GenericArgs::empty());
-        let path = external_path(cx, did, false, ThinVec::new(), empty);
+        let path = clean_middle_path(cx, did, false, ThinVec::new(), empty);
         inline::record_extern_fqn(cx, did, ItemType::Trait);
         GenericBound::TraitBound(PolyTrait { trait_: path, generic_params: Vec::new() }, modifier)
     }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -81,7 +81,8 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
     mut has_self: bool,
     owner: DefId,
 ) -> Vec<GenericArg> {
-    if args.skip_binder().is_empty() {
+    let (args, bound_vars) = (args.skip_binder(), args.bound_vars());
+    if args.is_empty() {
         // Fast path which avoids executing the query `generics_of`.
         return Vec::new();
     }
@@ -90,7 +91,7 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
     let mut elision_has_failed_once_before = false;
 
     let offset = if has_self { 1 } else { 0 };
-    let mut clean_args = Vec::with_capacity(args.skip_binder().len().saturating_sub(offset));
+    let mut clean_args = Vec::with_capacity(args.len().saturating_sub(offset));
 
     // If the container is a trait object type, the arguments won't contain the self type but the
     // generics of the corresponding trait will. In such a case, prepend a dummy self type in order
@@ -98,16 +99,13 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
     // instantiate the generic parameter default later.
     let args = if !has_self && generics.parent.is_none() && generics.has_self {
         has_self = true;
-        // FIXME(fmease): Don't arena-allocate the args (blocked on further refactorings)!
-        args.map_bound(|args| {
-            &*cx.tcx.arena.alloc_from_iter(
-                [cx.tcx.types.trait_object_dummy_self.into()]
-                    .into_iter()
-                    .chain(args.iter().copied()),
-            )
-        })
+        [cx.tcx.types.trait_object_dummy_self.into()]
+            .into_iter()
+            .chain(args.iter().copied())
+            .collect::<Vec<_>>()
+            .into()
     } else {
-        args
+        std::borrow::Cow::from(args)
     };
 
     let clean_arg = |(index, arg): (usize, &ty::GenericArg<'tcx>)| match arg.unpack() {
@@ -116,12 +114,13 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
         }
         GenericArgKind::Type(_) if has_self && index == 0 => None,
         GenericArgKind::Type(ty) => {
+            let ty = ty::Binder::bind_with_vars(ty, bound_vars);
+
             if !elision_has_failed_once_before
                 && let Some(default) = generics.param_at(index, cx.tcx).default_value(cx.tcx)
             {
-                let default = args.map_bound(|args| default.instantiate(cx.tcx, args).expect_ty());
-
-                if can_elide_generic_arg(args.rebind(ty), default) {
+                let default = default.instantiate(cx.tcx, args.as_ref()).expect_ty();
+                if can_elide_generic_arg(ty, ty.rebind(default)) {
                     return None;
                 }
 
@@ -129,10 +128,14 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
             }
 
             Some(GenericArg::Type(clean_middle_ty(
-                args.rebind(ty),
+                ty,
                 cx,
                 None,
-                Some(crate::clean::ContainerTy::Regular { ty: owner, args, arg: index }),
+                Some(crate::clean::ContainerTy::Regular {
+                    ty: owner,
+                    args: ty.rebind(args.as_ref()),
+                    arg: index,
+                }),
             )))
         }
         GenericArgKind::Const(ct) => {
@@ -142,24 +145,24 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
                 return None;
             }
 
+            let ct = ty::Binder::bind_with_vars(ct, bound_vars);
+
             if !elision_has_failed_once_before
                 && let Some(default) = generics.param_at(index, cx.tcx).default_value(cx.tcx)
             {
-                let default =
-                    args.map_bound(|args| default.instantiate(cx.tcx, args).expect_const());
-
-                if can_elide_generic_arg(args.rebind(ct), default) {
+                let default = default.instantiate(cx.tcx, args.as_ref()).expect_const();
+                if can_elide_generic_arg(ct, ct.rebind(default)) {
                     return None;
                 }
 
                 elision_has_failed_once_before = true;
             }
 
-            Some(GenericArg::Const(Box::new(clean_middle_const(args.rebind(ct), cx))))
+            Some(GenericArg::Const(Box::new(clean_middle_const(ct, cx))))
         }
     };
 
-    clean_args.extend(args.skip_binder().iter().enumerate().rev().filter_map(clean_arg));
+    clean_args.extend(args.iter().enumerate().rev().filter_map(clean_arg));
     clean_args.reverse();
     clean_args
 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -78,7 +78,7 @@ pub(crate) fn krate(cx: &mut DocContext<'_>) -> Crate {
 pub(crate) fn clean_middle_generic_args<'tcx>(
     cx: &mut DocContext<'tcx>,
     args: ty::Binder<'tcx, &'tcx [ty::GenericArg<'tcx>]>,
-    has_self: bool,
+    mut has_self: bool,
     owner: DefId,
 ) -> Vec<GenericArg> {
     if args.skip_binder().is_empty() {
@@ -86,11 +86,29 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
         return Vec::new();
     }
 
-    let params = &cx.tcx.generics_of(owner).params;
+    let generics = cx.tcx.generics_of(owner);
     let mut elision_has_failed_once_before = false;
 
     let offset = if has_self { 1 } else { 0 };
     let mut clean_args = Vec::with_capacity(args.skip_binder().len().saturating_sub(offset));
+
+    // If the container is a trait object type, the arguments won't contain the self type but the
+    // generics of the corresponding trait will. In such a case, prepend a dummy self type in order
+    // to align the arguments and parameters for the iteration below and to enable us to correctly
+    // instantiate the generic parameter default later.
+    let args = if !has_self && generics.parent.is_none() && generics.has_self {
+        has_self = true;
+        // FIXME(fmease): Don't arena-allocate the args (blocked on further refactorings)!
+        args.map_bound(|args| {
+            &*cx.tcx.arena.alloc_from_iter(
+                [cx.tcx.types.trait_object_dummy_self.into()]
+                    .into_iter()
+                    .chain(args.iter().copied()),
+            )
+        })
+    } else {
+        args
+    };
 
     let clean_arg = |(index, arg): (usize, &ty::GenericArg<'tcx>)| match arg.unpack() {
         GenericArgKind::Lifetime(lt) => {
@@ -99,7 +117,7 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
         GenericArgKind::Type(_) if has_self && index == 0 => None,
         GenericArgKind::Type(ty) => {
             if !elision_has_failed_once_before
-                && let Some(default) = params[index].default_value(cx.tcx)
+                && let Some(default) = generics.param_at(index, cx.tcx).default_value(cx.tcx)
             {
                 let default = args.map_bound(|args| default.instantiate(cx.tcx, args).expect_ty());
 
@@ -114,17 +132,18 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
                 args.rebind(ty),
                 cx,
                 None,
-                Some(crate::clean::ContainerTy::Regular { ty: owner, args, has_self, arg: index }),
+                Some(crate::clean::ContainerTy::Regular { ty: owner, args, arg: index }),
             )))
         }
         GenericArgKind::Const(ct) => {
-            if let ty::GenericParamDefKind::Const { is_host_effect: true, .. } = params[index].kind
+            if let ty::GenericParamDefKind::Const { is_host_effect: true, .. } =
+                generics.param_at(index, cx.tcx).kind
             {
                 return None;
             }
 
             if !elision_has_failed_once_before
-                && let Some(default) = params[index].default_value(cx.tcx)
+                && let Some(default) = generics.param_at(index, cx.tcx).default_value(cx.tcx)
             {
                 let default =
                     args.map_bound(|args| default.instantiate(cx.tcx, args).expect_const());

--- a/tests/rustdoc/inline_cross/auxiliary/default-generic-args.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/default-generic-args.rs
@@ -40,6 +40,11 @@ pub struct Multi<A = u64, B = u64>(A, B);
 
 pub type M0 = Multi<u64, ()>;
 
-pub trait Trait<'a, T = &'a ()> {}
+pub trait Trait0<'a, T = &'a ()> {}
+pub type D0 = dyn for<'a> Trait0<'a>;
 
-pub type F = dyn for<'a> Trait<'a>;
+// Regression test for issue #119529.
+pub trait Trait1<T = (), const K: u32 = 0> {}
+pub type D1<T> = dyn Trait1<T>;
+pub type D2<const K: u32> = dyn Trait1<(), K>;
+pub type D3 = dyn Trait1;

--- a/tests/rustdoc/inline_cross/auxiliary/u_default_generic_args.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/u_default_generic_args.rs
@@ -1,0 +1,1 @@
+pub use default_generic_args::*;

--- a/tests/rustdoc/inline_cross/default-generic-args.rs
+++ b/tests/rustdoc/inline_cross/default-generic-args.rs
@@ -79,15 +79,14 @@ pub use default_generic_args::P1;
 pub use default_generic_args::P2;
 
 // @has user/type.A0.html
-// Ensure that we elide generic arguments that are alpha-equivalent to their respective
-// generic parameter (modulo substs) (#1):
-// @has - '//*[@class="rust item-decl"]//code' "Alpha"
+// @has - '//*[@class="rust item-decl"]//code' "Alpha;"
 pub use default_generic_args::A0;
 
 // @has user/type.A1.html
-// Ensure that we elide generic arguments that are alpha-equivalent to their respective
-// generic parameter (modulo substs) (#1):
-// @has - '//*[@class="rust item-decl"]//code' "Alpha"
+// Demonstrates that we currently don't elide generic arguments that are alpha-equivalent to their
+// respective generic parameter (after instantiation) for perf reasons (it would require us to
+// create an inference context).
+// @has - '//*[@class="rust item-decl"]//code' "Alpha<for<'arbitrary> fn(_: &'arbitrary ())>"
 pub use default_generic_args::A1;
 
 // @has user/type.M0.html
@@ -97,8 +96,19 @@ pub use default_generic_args::A1;
 // @has - '//*[@class="rust item-decl"]//code' "Multi<u64, ()>"
 pub use default_generic_args::M0;
 
-// @has user/type.F.html
-// FIXME: Ideally, we would elide `&'a ()` but `'a` is an escaping bound var which we can't reason
-//        about at the moment since we don't keep track of bound vars.
-// @has - '//*[@class="rust item-decl"]//code' "dyn for<'a> Trait<'a, &'a ()>"
-pub use default_generic_args::F;
+// @has user/type.D0.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn for<'a> Trait0<'a>"
+pub use default_generic_args::D0;
+
+// Regression test for issue #119529.
+// Check that we correctly elide def ty&const args inside trait object types.
+
+// @has user/type.D1.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn Trait1<T>"
+pub use default_generic_args::D1;
+// @has user/type.D2.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn Trait1<(), K>"
+pub use default_generic_args::D2;
+// @has user/type.D3.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn Trait1;"
+pub use default_generic_args::D3;


### PR DESCRIPTION
Fixes #119529.

This PR contains several refactorings apart from the bug fix.
Best reviewed commit by commit.
r? GuillaumeGomez