### PR TITLE
[perf-only] rustdoc: cross-crate re-exports: eagerly clean default object lifetimes

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1908,7 +1908,7 @@ fn normalize<'tcx>(
 
 fn clean_trait_object_lifetime_bound<'tcx>(
     region: ty::Region<'tcx>,
-    container: Option<ContainerTy<'_, 'tcx>>,
+    container: Option<ObjectLifetimeDefault<'tcx>>,
     preds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     tcx: TyCtxt<'tcx>,
 ) -> Option<Lifetime> {
@@ -1937,7 +1937,7 @@ fn clean_trait_object_lifetime_bound<'tcx>(
 
 fn can_elide_trait_object_lifetime_bound<'tcx>(
     region: ty::Region<'tcx>,
-    container: Option<ContainerTy<'_, 'tcx>>,
+    default: Option<ObjectLifetimeDefault<'tcx>>,
     preds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     tcx: TyCtxt<'tcx>,
 ) -> bool {
@@ -1945,8 +1945,7 @@ fn can_elide_trait_object_lifetime_bound<'tcx>(
 
     // > If the trait object is used as a type argument of a generic type then the containing type is
     // > first used to try to infer a bound.
-    let default = container
-        .map_or(ObjectLifetimeDefault::Empty, |container| container.object_lifetime_default(tcx));
+    let default = default.unwrap_or(ObjectLifetimeDefault::Empty);
 
     // > If there is a unique bound from the containing type then that is the default
     // If there is a default object lifetime and the given region is lexically equal to it, elide it.
@@ -1983,54 +1982,6 @@ fn can_elide_trait_object_lifetime_bound<'tcx>(
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum ContainerTy<'a, 'tcx> {
-    Ref(ty::Region<'tcx>),
-    Regular {
-        ty: DefId,
-        /// The arguments *have* to contain an arg for the self type if the corresponding generics
-        /// contain a self type.
-        args: ty::Binder<'tcx, &'a [ty::GenericArg<'tcx>]>,
-        arg: usize,
-    },
-}
-
-impl<'tcx> ContainerTy<'_, 'tcx> {
-    fn object_lifetime_default(self, tcx: TyCtxt<'tcx>) -> ObjectLifetimeDefault<'tcx> {
-        match self {
-            Self::Ref(region) => ObjectLifetimeDefault::Arg(region),
-            Self::Regular { ty: container, args, arg: index } => {
-                let (DefKind::Struct
-                | DefKind::Union
-                | DefKind::Enum
-                | DefKind::TyAlias
-                | DefKind::Trait) = tcx.def_kind(container)
-                else {
-                    return ObjectLifetimeDefault::Empty;
-                };
-
-                let generics = tcx.generics_of(container);
-                debug_assert_eq!(generics.parent_count, 0);
-
-                let param = generics.params[index].def_id;
-                let default = tcx.object_lifetime_default(param);
-                match default {
-                    rbv::ObjectLifetimeDefault::Param(lifetime) => {
-                        // The index is relative to the parent generics but since we don't have any,
-                        // we don't need to translate it.
-                        let index = generics.param_def_id_to_index[&lifetime];
-                        let arg = args.skip_binder()[index as usize].expect_region();
-                        ObjectLifetimeDefault::Arg(arg)
-                    }
-                    rbv::ObjectLifetimeDefault::Empty => ObjectLifetimeDefault::Empty,
-                    rbv::ObjectLifetimeDefault::Static => ObjectLifetimeDefault::Static,
-                    rbv::ObjectLifetimeDefault::Ambiguous => ObjectLifetimeDefault::Ambiguous,
-                }
-            }
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ObjectLifetimeDefault<'tcx> {
     Empty,
@@ -2044,7 +1995,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
     bound_ty: ty::Binder<'tcx, Ty<'tcx>>,
     cx: &mut DocContext<'tcx>,
     parent_def_id: Option<DefId>,
-    container: Option<ContainerTy<'_, 'tcx>>,
+    container: Option<ObjectLifetimeDefault<'tcx>>,
 ) -> Type {
     let bound_ty = normalize(cx, bound_ty).unwrap_or(bound_ty);
     match *bound_ty.skip_binder().kind() {
@@ -2071,7 +2022,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
                 bound_ty.rebind(ty),
                 cx,
                 None,
-                Some(ContainerTy::Ref(r)),
+                Some(ObjectLifetimeDefault::Arg(r)),
             )),
         },
         ty::FnDef(..) | ty::FnPtr(_) => {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1908,7 +1908,7 @@ fn normalize<'tcx>(
 
 fn clean_trait_object_lifetime_bound<'tcx>(
     region: ty::Region<'tcx>,
-    container: Option<ContainerTy<'tcx>>,
+    container: Option<ContainerTy<'_, 'tcx>>,
     preds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     tcx: TyCtxt<'tcx>,
 ) -> Option<Lifetime> {
@@ -1937,7 +1937,7 @@ fn clean_trait_object_lifetime_bound<'tcx>(
 
 fn can_elide_trait_object_lifetime_bound<'tcx>(
     region: ty::Region<'tcx>,
-    container: Option<ContainerTy<'tcx>>,
+    container: Option<ContainerTy<'_, 'tcx>>,
     preds: &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     tcx: TyCtxt<'tcx>,
 ) -> bool {
@@ -1984,18 +1984,18 @@ fn can_elide_trait_object_lifetime_bound<'tcx>(
 }
 
 #[derive(Debug)]
-pub(crate) enum ContainerTy<'tcx> {
+pub(crate) enum ContainerTy<'a, 'tcx> {
     Ref(ty::Region<'tcx>),
     Regular {
         ty: DefId,
         /// The arguments *have* to contain an arg for the self type if the corresponding generics
         /// contain a self type.
-        args: ty::Binder<'tcx, &'tcx [ty::GenericArg<'tcx>]>,
+        args: ty::Binder<'tcx, &'a [ty::GenericArg<'tcx>]>,
         arg: usize,
     },
 }
 
-impl<'tcx> ContainerTy<'tcx> {
+impl<'tcx> ContainerTy<'_, 'tcx> {
     fn object_lifetime_default(self, tcx: TyCtxt<'tcx>) -> ObjectLifetimeDefault<'tcx> {
         match self {
             Self::Ref(region) => ObjectLifetimeDefault::Arg(region),
@@ -2044,7 +2044,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
     bound_ty: ty::Binder<'tcx, Ty<'tcx>>,
     cx: &mut DocContext<'tcx>,
     parent_def_id: Option<DefId>,
-    container: Option<ContainerTy<'tcx>>,
+    container: Option<ContainerTy<'_, 'tcx>>,
 ) -> Type {
     let bound_ty = normalize(cx, bound_ty).unwrap_or(bound_ty);
     match *bound_ty.skip_binder().kind() {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -36,7 +36,7 @@ use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi::Abi;
 
 use crate::clean::cfg::Cfg;
-use crate::clean::external_path;
+use crate::clean::clean_middle_path;
 use crate::clean::inline::{self, print_inlined_const};
 use crate::clean::utils::{is_literal_expr, print_evaluated_const};
 use crate::core::DocContext;
@@ -1258,7 +1258,7 @@ impl GenericBound {
     fn sized_with(cx: &mut DocContext<'_>, modifier: hir::TraitBoundModifier) -> GenericBound {
         let did = cx.tcx.require_lang_item(LangItem::Sized, None);
         let empty = ty::Binder::dummy(ty::GenericArgs::empty());
-        let path = external_path(cx, did, false, ThinVec::new(), empty);
+        let path = clean_middle_path(cx, did, false, ThinVec::new(), empty);
         inline::record_extern_fqn(cx, did, ItemType::Trait);
         GenericBound::TraitBound(PolyTrait { trait_: path, generic_params: Vec::new() }, modifier)
     }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -75,13 +75,13 @@ pub(crate) fn krate(cx: &mut DocContext<'_>) -> Crate {
     Crate { module, external_traits: cx.external_traits.clone() }
 }
 
-pub(crate) fn ty_args_to_args<'tcx>(
+pub(crate) fn clean_middle_generic_args<'tcx>(
     cx: &mut DocContext<'tcx>,
-    ty_args: ty::Binder<'tcx, &'tcx [ty::GenericArg<'tcx>]>,
+    args: ty::Binder<'tcx, &'tcx [ty::GenericArg<'tcx>]>,
     has_self: bool,
     owner: DefId,
 ) -> Vec<GenericArg> {
-    if ty_args.skip_binder().is_empty() {
+    if args.skip_binder().is_empty() {
         // Fast path which avoids executing the query `generics_of`.
         return Vec::new();
     }
@@ -90,9 +90,9 @@ pub(crate) fn ty_args_to_args<'tcx>(
     let mut elision_has_failed_once_before = false;
 
     let offset = if has_self { 1 } else { 0 };
-    let mut args = Vec::with_capacity(ty_args.skip_binder().len().saturating_sub(offset));
+    let mut clean_args = Vec::with_capacity(args.skip_binder().len().saturating_sub(offset));
 
-    let ty_arg_to_arg = |(index, arg): (usize, &ty::GenericArg<'tcx>)| match arg.unpack() {
+    let clean_middle_arg = |(index, arg): (usize, &ty::GenericArg<'tcx>)| match arg.unpack() {
         GenericArgKind::Lifetime(lt) => {
             Some(GenericArg::Lifetime(clean_middle_region(lt).unwrap_or(Lifetime::elided())))
         }
@@ -101,10 +101,9 @@ pub(crate) fn ty_args_to_args<'tcx>(
             if !elision_has_failed_once_before
                 && let Some(default) = params[index].default_value(cx.tcx)
             {
-                let default =
-                    ty_args.map_bound(|args| default.instantiate(cx.tcx, args).expect_ty());
+                let default = args.map_bound(|args| default.instantiate(cx.tcx, args).expect_ty());
 
-                if can_elide_generic_arg(ty_args.rebind(ty), default) {
+                if can_elide_generic_arg(args.rebind(ty), default) {
                     return None;
                 }
 
@@ -112,15 +111,10 @@ pub(crate) fn ty_args_to_args<'tcx>(
             }
 
             Some(GenericArg::Type(clean_middle_ty(
-                ty_args.rebind(ty),
+                args.rebind(ty),
                 cx,
                 None,
-                Some(crate::clean::ContainerTy::Regular {
-                    ty: owner,
-                    args: ty_args,
-                    has_self,
-                    arg: index,
-                }),
+                Some(crate::clean::ContainerTy::Regular { ty: owner, args, has_self, arg: index }),
             )))
         }
         GenericArgKind::Const(ct) => {
@@ -133,22 +127,22 @@ pub(crate) fn ty_args_to_args<'tcx>(
                 && let Some(default) = params[index].default_value(cx.tcx)
             {
                 let default =
-                    ty_args.map_bound(|args| default.instantiate(cx.tcx, args).expect_const());
+                    args.map_bound(|args| default.instantiate(cx.tcx, args).expect_const());
 
-                if can_elide_generic_arg(ty_args.rebind(ct), default) {
+                if can_elide_generic_arg(args.rebind(ct), default) {
                     return None;
                 }
 
                 elision_has_failed_once_before = true;
             }
 
-            Some(GenericArg::Const(Box::new(clean_middle_const(ty_args.rebind(ct), cx))))
+            Some(GenericArg::Const(Box::new(clean_middle_const(args.rebind(ct), cx))))
         }
     };
 
-    args.extend(ty_args.skip_binder().iter().enumerate().rev().filter_map(ty_arg_to_arg));
-    args.reverse();
-    args
+    clean_args.extend(args.skip_binder().iter().enumerate().rev().filter_map(clean_middle_arg));
+    clean_args.reverse();
+    clean_args
 }
 
 /// Check if the generic argument `actual` coincides with the `default` and can therefore be elided.
@@ -192,14 +186,14 @@ where
     actual.skip_binder() == default.skip_binder()
 }
 
-fn external_generic_args<'tcx>(
+fn clean_middle_generic_args_with_bindings<'tcx>(
     cx: &mut DocContext<'tcx>,
     did: DefId,
     has_self: bool,
     bindings: ThinVec<TypeBinding>,
     ty_args: ty::Binder<'tcx, GenericArgsRef<'tcx>>,
 ) -> GenericArgs {
-    let args = ty_args_to_args(cx, ty_args.map_bound(|args| &args[..]), has_self, did);
+    let args = clean_middle_generic_args(cx, ty_args.map_bound(|args| &args[..]), has_self, did);
 
     if cx.tcx.fn_trait_kind_from_def_id(did).is_some() {
         let ty = ty_args
@@ -225,7 +219,7 @@ fn external_generic_args<'tcx>(
     }
 }
 
-pub(super) fn external_path<'tcx>(
+pub(super) fn clean_middle_path<'tcx>(
     cx: &mut DocContext<'tcx>,
     did: DefId,
     has_self: bool,
@@ -238,7 +232,7 @@ pub(super) fn external_path<'tcx>(
         res: Res::Def(def_kind, did),
         segments: thin_vec![PathSegment {
             name,
-            args: external_generic_args(cx, did, has_self, bindings, args),
+            args: clean_middle_generic_args_with_bindings(cx, did, has_self, bindings, args),
         }],
     }
 }

--- a/tests/rustdoc/inline_cross/auxiliary/default-generic-args.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/default-generic-args.rs
@@ -40,6 +40,11 @@ pub struct Multi<A = u64, B = u64>(A, B);
 
 pub type M0 = Multi<u64, ()>;
 
-pub trait Trait<'a, T = &'a ()> {}
+pub trait Trait0<'a, T = &'a ()> {}
+pub type D0 = dyn for<'a> Trait0<'a>;
 
-pub type F = dyn for<'a> Trait<'a>;
+// Regression test for issue #119529.
+pub trait Trait1<T = (), const K: u32 = 0> {}
+pub type D1<T> = dyn Trait1<T>;
+pub type D2<const K: u32> = dyn Trait1<(), K>;
+pub type D3 = dyn Trait1;

--- a/tests/rustdoc/inline_cross/auxiliary/u_default_generic_args.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/u_default_generic_args.rs
@@ -1,0 +1,1 @@
+pub use default_generic_args::*;

--- a/tests/rustdoc/inline_cross/default-generic-args.rs
+++ b/tests/rustdoc/inline_cross/default-generic-args.rs
@@ -79,15 +79,14 @@ pub use default_generic_args::P1;
 pub use default_generic_args::P2;
 
 // @has user/type.A0.html
-// Ensure that we elide generic arguments that are alpha-equivalent to their respective
-// generic parameter (modulo substs) (#1):
-// @has - '//*[@class="rust item-decl"]//code' "Alpha"
+// @has - '//*[@class="rust item-decl"]//code' "Alpha;"
 pub use default_generic_args::A0;
 
 // @has user/type.A1.html
-// Ensure that we elide generic arguments that are alpha-equivalent to their respective
-// generic parameter (modulo substs) (#1):
-// @has - '//*[@class="rust item-decl"]//code' "Alpha"
+// Demonstrates that we currently don't elide generic arguments that are alpha-equivalent to their
+// respective generic parameter (after instantiation) for perf reasons (it would require us to
+// create an inference context).
+// @has - '//*[@class="rust item-decl"]//code' "Alpha<for<'arbitrary> fn(_: &'arbitrary ())>"
 pub use default_generic_args::A1;
 
 // @has user/type.M0.html
@@ -97,8 +96,19 @@ pub use default_generic_args::A1;
 // @has - '//*[@class="rust item-decl"]//code' "Multi<u64, ()>"
 pub use default_generic_args::M0;
 
-// @has user/type.F.html
-// FIXME: Ideally, we would elide `&'a ()` but `'a` is an escaping bound var which we can't reason
-//        about at the moment since we don't keep track of bound vars.
-// @has - '//*[@class="rust item-decl"]//code' "dyn for<'a> Trait<'a, &'a ()>"
-pub use default_generic_args::F;
+// @has user/type.D0.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn for<'a> Trait0<'a>"
+pub use default_generic_args::D0;
+
+// Regression test for issue #119529.
+// Check that we correctly elide def ty&const args inside trait object types.
+
+// @has user/type.D1.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn Trait1<T>"
+pub use default_generic_args::D1;
+// @has user/type.D2.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn Trait1<(), K>"
+pub use default_generic_args::D2;
+// @has user/type.D3.html
+// @has - '//*[@class="rust item-decl"]//code' "dyn Trait1;"
+pub use default_generic_args::D3;


### PR DESCRIPTION
Only the last commit is relevant. Let's see how bad eager cleaning actually is.
r? ghost