### PR TITLE
Return the delimiter from slice::split_once

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2484,8 +2484,8 @@ impl<T> [T] {
     /// predicate.
     ///
     /// If any matching elements are present in the slice, returns the prefix
-    /// before the match and suffix after. The matching element itself is not
-    /// included. If no elements match, returns `None`.
+    /// before the match, the matching element, and the suffix after the match.
+    /// If no elements match, returns `None`.
     ///
     /// # Examples
     ///
@@ -2494,26 +2494,27 @@ impl<T> [T] {
     /// let s = [1, 2, 3, 2, 4];
     /// assert_eq!(s.split_once(|&x| x == 2), Some((
     ///     &[1][..],
+    ///     &2,
     ///     &[3, 2, 4][..]
     /// )));
     /// assert_eq!(s.split_once(|&x| x == 0), None);
     /// ```
     #[unstable(feature = "slice_split_once", reason = "newly added", issue = "112811")]
     #[inline]
-    pub fn split_once<F>(&self, pred: F) -> Option<(&[T], &[T])>
+    pub fn split_once<F>(&self, pred: F) -> Option<(&[T], &T, &[T])>
     where
         F: FnMut(&T) -> bool,
     {
         let index = self.iter().position(pred)?;
-        Some((&self[..index], &self[index + 1..]))
+        Some((&self[..index], &self[index], &self[index + 1..]))
     }
 
     /// Splits the slice on the last element that matches the specified
     /// predicate.
     ///
     /// If any matching elements are present in the slice, returns the prefix
-    /// before the match and suffix after. The matching element itself is not
-    /// included. If no elements match, returns `None`.
+    /// before the match, the matching element, and the suffix after the match.
+    /// If no elements match, returns `None`.
     ///
     /// # Examples
     ///
@@ -2522,18 +2523,19 @@ impl<T> [T] {
     /// let s = [1, 2, 3, 2, 4];
     /// assert_eq!(s.rsplit_once(|&x| x == 2), Some((
     ///     &[1, 2, 3][..],
+    ///     &2,
     ///     &[4][..]
     /// )));
     /// assert_eq!(s.rsplit_once(|&x| x == 0), None);
     /// ```
     #[unstable(feature = "slice_split_once", reason = "newly added", issue = "112811")]
     #[inline]
-    pub fn rsplit_once<F>(&self, pred: F) -> Option<(&[T], &[T])>
+    pub fn rsplit_once<F>(&self, pred: F) -> Option<(&[T], &T, &[T])>
     where
         F: FnMut(&T) -> bool,
     {
         let index = self.iter().rposition(pred)?;
-        Some((&self[..index], &self[index + 1..]))
+        Some((&self[..index], &self[index], &self[index + 1..]))
     }
 
     /// Returns `true` if the slice contains an element with the given value.

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2479,9 +2479,9 @@ fn slice_rsplit_array_mut_out_of_bounds() {
 fn slice_split_once() {
     let v = &[1, 2, 3, 2, 4][..];
 
-    assert_eq!(v.split_once(|&x| x == 2), Some((&[1][..], &[3, 2, 4][..])));
-    assert_eq!(v.split_once(|&x| x == 1), Some((&[][..], &[2, 3, 2, 4][..])));
-    assert_eq!(v.split_once(|&x| x == 4), Some((&[1, 2, 3, 2][..], &[][..])));
+    assert_eq!(v.split_once(|&x| x == 2), Some((&[1][..], &2, &[3, 2, 4][..])));
+    assert_eq!(v.split_once(|&x| x == 1), Some((&[][..], &1, &[2, 3, 2, 4][..])));
+    assert_eq!(v.split_once(|&x| x == 4), Some((&[1, 2, 3, 2][..], &4, &[][..])));
     assert_eq!(v.split_once(|&x| x == 0), None);
 }
 
@@ -2489,9 +2489,9 @@ fn slice_split_once() {
 fn slice_rsplit_once() {
     let v = &[1, 2, 3, 2, 4][..];
 
-    assert_eq!(v.rsplit_once(|&x| x == 2), Some((&[1, 2, 3][..], &[4][..])));
-    assert_eq!(v.rsplit_once(|&x| x == 1), Some((&[][..], &[2, 3, 2, 4][..])));
-    assert_eq!(v.rsplit_once(|&x| x == 4), Some((&[1, 2, 3, 2][..], &[][..])));
+    assert_eq!(v.rsplit_once(|&x| x == 2), Some((&[1, 2, 3][..], &2, &[4][..])));
+    assert_eq!(v.rsplit_once(|&x| x == 1), Some((&[][..], &1, &[2, 3, 2, 4][..])));
+    assert_eq!(v.rsplit_once(|&x| x == 4), Some((&[1, 2, 3, 2][..], &4, &[][..])));
     assert_eq!(v.rsplit_once(|&x| x == 0), None);
 }
 


### PR DESCRIPTION
This is a breaking change to the unstable `slice_split_once` feature. It was originally proposed in https://github.com/rust-lang/rust/issues/112811#issuecomment-1774865715.

This would be a departure from the `str::split_once` API that the `slice_split_once` methods were based on. The justification is that for arbitrary `T`, the split element and be complex and the relationship between the split element and the predicate can be more indirect than with typical str patterns.