### PR TITLE
Document `rustc_index::vec::IndexVec`

### DIFF
--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -17,27 +17,15 @@ use crate::{Idx, IndexSlice};
 /// While it's possible to use `u32` or `usize` directly for `I`,
 /// you almost certainly want to use a [`newtype_index!`]-generated type instead.
 ///
-/// This allows to index the IndexVec with the new index type:
+/// This allows to index the IndexVec with the new index type
 ///
-/// ```
-/// use crate as rustc_index;
-/// use rustc_index::{IndexVec, newtype_index};
-///
-/// newtype_index! {
-///   pub struct MyIdx {}
-/// }
-///
-/// let my_index_vec: IndexVec<MyIdx, u32> = IndexVec::from_raw(vec![0,1,2,3]);
-/// let idx: MyIdx = MyIdx::from_u32(2);
-/// assert_eq!(my_index_vec[idx], 2);
-/// ```
 ///
 /// [`newtype_index!`]: ../macro.newtype_index.html
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct IndexVec<I: Idx, T> {
     pub raw: Vec<T>,
-    _marker: PhantomData<fn(&I)>,
+    _marker: PhantomData<I>,
 }
 
 impl<I: Idx, T> IndexVec<I, T> {
@@ -77,7 +65,7 @@ impl<I: Idx, T> IndexVec<I, T> {
         IndexVec::from_raw(vec![elem; universe.len()])
     }
 
-    /// Creates a new `IndexVec` with n copies of `elem`
+    /// Creates a new IndexVec
     #[inline]
     pub fn from_elem_n(elem: T, n: usize) -> Self
     where

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -12,9 +12,25 @@ use std::vec;
 use crate::{Idx, IndexSlice};
 
 /// An owned contiguous collection of `T`s, indexed by `I` rather than by `usize`.
+/// Its purpose is to avoid mixing indexes.
 ///
 /// While it's possible to use `u32` or `usize` directly for `I`,
 /// you almost certainly want to use a [`newtype_index!`]-generated type instead.
+///
+/// This allows to index the IndexVec with the new index type:
+///
+/// ```
+/// use crate as rustc_index;
+/// use rustc_index::{IndexVec, newtype_index};
+///
+/// newtype_index! {
+///   pub struct MyIdx {}
+/// }
+///
+/// let my_index_vec: IndexVec<MyIdx, u32> = IndexVec::from_raw(vec![0,1,2,3]);
+/// let idx: MyIdx = MyIdx::from_u32(2);
+/// assert_eq!(my_index_vec[idx], 2);
+/// ```
 ///
 /// [`newtype_index!`]: ../macro.newtype_index.html
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -25,11 +41,13 @@ pub struct IndexVec<I: Idx, T> {
 }
 
 impl<I: Idx, T> IndexVec<I, T> {
+    /// Constructs a new, empty `IndexVec<I, T>`.
     #[inline]
     pub const fn new() -> Self {
         IndexVec::from_raw(Vec::new())
     }
 
+    /// Constructs a new `IndexVec<I, T>` from a `Vec<T>`
     #[inline]
     pub const fn from_raw(raw: Vec<T>) -> Self {
         IndexVec { raw, _marker: PhantomData }
@@ -59,6 +77,7 @@ impl<I: Idx, T> IndexVec<I, T> {
         IndexVec::from_raw(vec![elem; universe.len()])
     }
 
+    /// Creates a new `IndexVec` with n copies of `elem`
     #[inline]
     pub fn from_elem_n(elem: T, n: usize) -> Self
     where

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -17,15 +17,13 @@ use crate::{Idx, IndexSlice};
 /// While it's possible to use `u32` or `usize` directly for `I`,
 /// you almost certainly want to use a [`newtype_index!`]-generated type instead.
 ///
-/// This allows to index the IndexVec with the new index type
-///
-///
+/// This allows to index the IndexVec with the new index type.
 /// [`newtype_index!`]: ../macro.newtype_index.html
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct IndexVec<I: Idx, T> {
     pub raw: Vec<T>,
-    _marker: PhantomData<I>,
+    _marker: PhantomData<fn(&I)>,
 }
 
 impl<I: Idx, T> IndexVec<I, T> {
@@ -35,7 +33,7 @@ impl<I: Idx, T> IndexVec<I, T> {
         IndexVec::from_raw(Vec::new())
     }
 
-    /// Constructs a new `IndexVec<I, T>` from a `Vec<T>`
+    /// Constructs a new `IndexVec<I, T>` from a `Vec<T>`.
     #[inline]
     pub const fn from_raw(raw: Vec<T>) -> Self {
         IndexVec { raw, _marker: PhantomData }
@@ -65,7 +63,7 @@ impl<I: Idx, T> IndexVec<I, T> {
         IndexVec::from_raw(vec![elem; universe.len()])
     }
 
-    /// Creates a new IndexVec
+    /// Creates a new IndexVec with n copies of the `elem`.
     #[inline]
     pub fn from_elem_n(elem: T, n: usize) -> Self
     where
@@ -92,6 +90,7 @@ impl<I: Idx, T> IndexVec<I, T> {
         IndexSlice::from_raw_mut(&mut self.raw)
     }
 
+    /// Pushes an element to the array returning the index where it was pushed to.
     #[inline]
     pub fn push(&mut self, d: T) -> I {
         let idx = self.next_index();

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -18,6 +18,7 @@ use crate::{Idx, IndexSlice};
 /// you almost certainly want to use a [`newtype_index!`]-generated type instead.
 ///
 /// This allows to index the IndexVec with the new index type.
+///
 /// [`newtype_index!`]: ../macro.newtype_index.html
 #[derive(Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]


### PR DESCRIPTION
Document a few of the methods.

Part of https://github.com/rust-lang/rust/issues/93792.