### PR TITLE
bootstrap: exclude link_jobs from `check_ci_llvm!` checks

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1776,7 +1776,6 @@ impl Config {
                 check_ci_llvm!(static_libstdcpp);
                 check_ci_llvm!(targets);
                 check_ci_llvm!(experimental_targets);
-                check_ci_llvm!(link_jobs);
                 check_ci_llvm!(clang_cl);
                 check_ci_llvm!(version_suffix);
                 check_ci_llvm!(cflags);


### PR DESCRIPTION
This option is largely there to help people to manage the memory usage on their systems during the LLVM build. The linking phase is as usual are the heaviest part of the build and if in an unlucky conincidence the circumstances align to kick off N_CORES links at the same time, not even hundreds of GiB of memory may suffice. It makes a lot of sense for developers to set&forget this option unconditionally based on how buff their development device is.

Not to mention, this option does not, in any way, affect the generated code (at least as far as I know.) It really doesn’t matter what option the CI build LLVM used here and/or if it matches with the user’s configuration.

Finally, 0 actual link jobs implied by `download-ci-llvm` is guaranteed to stay within the limits that are reasonable to set with this option.