### PR TITLE
Remove special-casing around `AliasKind::Opaque` when structurally resolving in new solver

### DIFF
--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> Iterator for Autoderef<'a, 'tcx> {
             // we have some type like `&<Ty as Trait>::Assoc`, since users of
             // autoderef expect this type to have been structurally normalized.
             if self.infcx.next_trait_solver()
-                && let ty::Alias(ty::Projection | ty::Inherent | ty::Weak, _) = ty.kind()
+                && let ty::Alias(..) = ty.kind()
             {
                 let (normalized_ty, obligations) = self.structurally_normalize(ty)?;
                 self.state.obligations.extend(obligations);

--- a/compiler/rustc_trait_selection/src/traits/structural_normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_normalize.rs
@@ -22,8 +22,7 @@ impl<'tcx> StructurallyNormalizeExt<'tcx> for At<'_, 'tcx> {
         assert!(!ty.is_ty_var(), "should have resolved vars before calling");
 
         if self.infcx.next_trait_solver() {
-            // FIXME(-Znext-solver): Should we resolve opaques here?
-            let ty::Alias(ty::Projection | ty::Inherent | ty::Weak, _) = *ty.kind() else {
+            let ty::Alias(..) = *ty.kind() else {
                 return Ok(ty);
             };
 

--- a/tests/ui/coroutine/clone-rpit.next.stderr
+++ b/tests/ui/coroutine/clone-rpit.next.stderr
@@ -1,0 +1,52 @@
+error[E0391]: cycle detected when type-checking `foo`
+  --> $DIR/clone-rpit.rs:12:1
+   |
+LL | pub fn foo<'a, 'b>() -> impl Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires coroutine witness types for `foo::{closure#0}`...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+note: ...which requires promoting constants in MIR for `foo::{closure#0}`...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+note: ...which requires preparing `foo::{closure#0}` for borrow checking...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+note: ...which requires checking if `foo::{closure#0}` contains FFI-unwind calls...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+note: ...which requires building MIR for `foo::{closure#0}`...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+note: ...which requires match-checking `foo::{closure#0}`...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+note: ...which requires type-checking `foo::{closure#0}`...
+  --> $DIR/clone-rpit.rs:13:5
+   |
+LL |     move |_: ()| {
+   |     ^^^^^^^^^^^^
+   = note: ...which again requires type-checking `foo`, completing the cycle
+note: cycle used when computing type of opaque `foo::{opaque#0}`
+  --> $DIR/clone-rpit.rs:12:25
+   |
+LL | pub fn foo<'a, 'b>() -> impl Clone {
+   |                         ^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/coroutine/clone-rpit.rs
+++ b/tests/ui/coroutine/clone-rpit.rs
@@ -1,6 +1,7 @@
 // revisions: current next
 //[next] compile-flags: -Znext-solver
-// check-pass
+//[current] check-pass
+//[next] known-bug: trait-system-refactor-initiative#82
 
 #![feature(coroutines, coroutine_trait, coroutine_clone)]
 

--- a/tests/ui/impl-trait/eagerly-reveal-in-local-body.rs
+++ b/tests/ui/impl-trait/eagerly-reveal-in-local-body.rs
@@ -1,0 +1,13 @@
+// check-pass
+// compile-flags: -Znext-solver
+
+#![feature(type_alias_impl_trait)]
+
+fn main() {
+    type Tait = impl Sized;
+    struct S {
+        i: i32,
+    }
+    let x: Tait = S { i: 0 };
+    println!("{}", x.i);
+}

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:6:5
+  --> $DIR/recursive-coroutine-indirect.rs:10:5
    |
 LL |     move || {
    |     ^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:6:5
+  --> $DIR/recursive-coroutine-indirect.rs:10:5
    |
 LL |     move || {
    |     ^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.rs
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.rs
@@ -1,5 +1,9 @@
 // revisions: current next
 //[next] compile-flags: -Znext-solver
+
+//[next] build-fail
+// Deeply normalizing writeback results of opaques makes this into a post-mono error :(
+
 #![feature(coroutines)]
 #![allow(unconditional_recursion)]
 fn coroutine_hold() -> impl Sized {

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
@@ -13,11 +13,8 @@ fn main() {
 }
 
 fn weird0() -> impl Sized + !Sized {}
-//~^ ERROR mismatched types
-//~| ERROR type mismatch resolving `() == impl !Sized + Sized`
+//~^ ERROR type mismatch resolving `() == impl !Sized + Sized`
 fn weird1() -> impl !Sized + Sized {}
-//~^ ERROR mismatched types
-//~| ERROR type mismatch resolving `() == impl !Sized + Sized`
+//~^ ERROR type mismatch resolving `() == impl !Sized + Sized`
 fn weird2() -> impl !Sized {}
-//~^ ERROR mismatched types
-//~| ERROR type mismatch resolving `() == impl !Sized`
+//~^ ERROR type mismatch resolving `() == impl !Sized`

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.stderr
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.stderr
@@ -1,50 +1,17 @@
-error[E0308]: mismatched types
-  --> $DIR/opaque-type-unsatisfied-bound.rs:15:36
-   |
-LL | fn weird0() -> impl Sized + !Sized {}
-   |                ------------------- ^^ types differ
-   |                |
-   |                the expected opaque type
-   |
-   = note: expected opaque type `impl !Sized + Sized`
-                found unit type `()`
-
 error[E0271]: type mismatch resolving `() == impl !Sized + Sized`
   --> $DIR/opaque-type-unsatisfied-bound.rs:15:16
    |
 LL | fn weird0() -> impl Sized + !Sized {}
    |                ^^^^^^^^^^^^^^^^^^^ types differ
 
-error[E0308]: mismatched types
-  --> $DIR/opaque-type-unsatisfied-bound.rs:18:36
-   |
-LL | fn weird1() -> impl !Sized + Sized {}
-   |                ------------------- ^^ types differ
-   |                |
-   |                the expected opaque type
-   |
-   = note: expected opaque type `impl !Sized + Sized`
-                found unit type `()`
-
 error[E0271]: type mismatch resolving `() == impl !Sized + Sized`
-  --> $DIR/opaque-type-unsatisfied-bound.rs:18:16
+  --> $DIR/opaque-type-unsatisfied-bound.rs:17:16
    |
 LL | fn weird1() -> impl !Sized + Sized {}
    |                ^^^^^^^^^^^^^^^^^^^ types differ
 
-error[E0308]: mismatched types
-  --> $DIR/opaque-type-unsatisfied-bound.rs:21:28
-   |
-LL | fn weird2() -> impl !Sized {}
-   |                ----------- ^^ types differ
-   |                |
-   |                the expected opaque type
-   |
-   = note: expected opaque type `impl !Sized`
-                found unit type `()`
-
 error[E0271]: type mismatch resolving `() == impl !Sized`
-  --> $DIR/opaque-type-unsatisfied-bound.rs:21:16
+  --> $DIR/opaque-type-unsatisfied-bound.rs:19:16
    |
 LL | fn weird2() -> impl !Sized {}
    |                ^^^^^^^^^^^ types differ
@@ -63,7 +30,7 @@ note: required by a bound in `consume`
 LL | fn consume(_: impl Trait) {}
    |                    ^^^^^ required by this bound in `consume`
 
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0271, E0277, E0308.
+Some errors have detailed explanations: E0271, E0277.
 For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
@@ -3,7 +3,6 @@
 #![feature(negative_bounds, unboxed_closures)]
 
 fn produce() -> impl !Fn<(u32,)> {}
-//~^ ERROR mismatched types
-//~| ERROR type mismatch resolving `() == impl !Fn<(u32,)>`
+//~^ ERROR type mismatch resolving `() == impl !Fn<(u32,)>`
 
 fn main() {}

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.stderr
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.stderr
@@ -1,21 +1,9 @@
-error[E0308]: mismatched types
-  --> $DIR/opaque-type-unsatisfied-fn-bound.rs:5:34
-   |
-LL | fn produce() -> impl !Fn<(u32,)> {}
-   |                 ---------------- ^^ types differ
-   |                 |
-   |                 the expected opaque type
-   |
-   = note: expected opaque type `impl !Fn<(u32,)>`
-                found unit type `()`
-
 error[E0271]: type mismatch resolving `() == impl !Fn<(u32,)>`
   --> $DIR/opaque-type-unsatisfied-fn-bound.rs:5:17
    |
 LL | fn produce() -> impl !Fn<(u32,)> {}
    |                 ^^^^^^^^^^^^^^^^ types differ
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0271, E0308.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/traits/next-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.rs
@@ -23,10 +23,10 @@ fn main() {
     let x = String::from("hello, world");
     drop(<() as Foo>::copy_me(&x));
     //~^ ERROR overflow evaluating the requirement `<() as Foo>::Item: Sized`
-    //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == _`
-    //~| ERROR overflow evaluating the requirement `<() as Foo>::Item well-formed`
     //~| ERROR overflow evaluating the requirement `String <: <() as Foo>::Item`
+    //~| ERROR overflow evaluating the requirement `<() as Foo>::Item well-formed`
     //~| ERROR overflow evaluating the requirement `&<() as Foo>::Item well-formed`
-    //~| ERROR overflow evaluating the requirement `<() as Foo>::Item normalizes-to _`
+    //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == _`
+    //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == _`
     println!("{x}");
 }

--- a/tests/ui/traits/next-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.stderr
@@ -52,13 +52,14 @@ LL |     drop(<() as Foo>::copy_me(&x));
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`alias_bound_unsound`)
 
-error[E0275]: overflow evaluating the requirement `<() as Foo>::Item normalizes-to _`
+error[E0275]: overflow evaluating the requirement `<() as Foo>::Item == _`
   --> $DIR/alias-bound-unsound.rs:24:10
    |
 LL |     drop(<() as Foo>::copy_me(&x));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`alias_bound_unsound`)
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.rs
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.rs
@@ -13,8 +13,10 @@ fn needs_bar<S: Bar>() {}
 
 fn test<T: Foo1<Assoc1 = <T as Foo2>::Assoc2> + Foo2<Assoc2 = <T as Foo1>::Assoc1>>() {
     needs_bar::<T::Assoc1>();
-    //~^ ERROR overflow evaluating the requirement `<T as Foo1>::Assoc1: Bar`
-    //~| ERROR overflow evaluating the requirement `<T as Foo2>::Assoc2`
+    //~^ ERROR overflow evaluating the requirement `<T as Foo1>::Assoc1 == _`
+    //~| ERROR overflow evaluating the requirement `<T as Foo1>::Assoc1 == _`
+    //~| ERROR overflow evaluating the requirement `<T as Foo1>::Assoc1 == _`
+    //~| ERROR overflow evaluating the requirement `<T as Foo1>::Assoc1: Bar`
 }
 
 fn main() {}

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.stderr
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `needs_bar`
 LL | fn needs_bar<S: Bar>() {}
    |                 ^^^ required by this bound in `needs_bar`
 
-error[E0275]: overflow evaluating the requirement `<T as Foo2>::Assoc2`
+error[E0275]: overflow evaluating the requirement `<T as Foo1>::Assoc1 == _`
   --> $DIR/recursive-self-normalization-2.rs:15:5
    |
 LL |     needs_bar::<T::Assoc1>();
@@ -19,6 +19,23 @@ LL |     needs_bar::<T::Assoc1>();
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization_2`)
 
-error: aborting due to 2 previous errors
+error[E0275]: overflow evaluating the requirement `<T as Foo1>::Assoc1 == _`
+  --> $DIR/recursive-self-normalization-2.rs:15:5
+   |
+LL |     needs_bar::<T::Assoc1>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization_2`)
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0275]: overflow evaluating the requirement `<T as Foo1>::Assoc1 == _`
+  --> $DIR/recursive-self-normalization-2.rs:15:17
+   |
+LL |     needs_bar::<T::Assoc1>();
+   |                 ^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization_2`)
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization.rs
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization.rs
@@ -9,8 +9,10 @@ fn needs_bar<S: Bar>() {}
 
 fn test<T: Foo<Assoc = <T as Foo>::Assoc>>() {
     needs_bar::<T::Assoc>();
-    //~^ ERROR overflow evaluating the requirement `<T as Foo>::Assoc: Bar`
-    //~| ERROR overflow evaluating the requirement `<T as Foo>::Assoc` [E0275]
+    //~^ ERROR overflow evaluating the requirement `<T as Foo>::Assoc == _`
+    //~| ERROR overflow evaluating the requirement `<T as Foo>::Assoc == _`
+    //~| ERROR overflow evaluating the requirement `<T as Foo>::Assoc == _`
+    //~| ERROR overflow evaluating the requirement `<T as Foo>::Assoc: Bar`
 }
 
 fn main() {}

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization.stderr
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `needs_bar`
 LL | fn needs_bar<S: Bar>() {}
    |                 ^^^ required by this bound in `needs_bar`
 
-error[E0275]: overflow evaluating the requirement `<T as Foo>::Assoc`
+error[E0275]: overflow evaluating the requirement `<T as Foo>::Assoc == _`
   --> $DIR/recursive-self-normalization.rs:11:5
    |
 LL |     needs_bar::<T::Assoc>();
@@ -19,6 +19,23 @@ LL |     needs_bar::<T::Assoc>();
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization`)
 
-error: aborting due to 2 previous errors
+error[E0275]: overflow evaluating the requirement `<T as Foo>::Assoc == _`
+  --> $DIR/recursive-self-normalization.rs:11:5
+   |
+LL |     needs_bar::<T::Assoc>();
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization`)
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0275]: overflow evaluating the requirement `<T as Foo>::Assoc == _`
+  --> $DIR/recursive-self-normalization.rs:11:17
+   |
+LL |     needs_bar::<T::Assoc>();
+   |                 ^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization`)
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
This fixes a few inconsistencies around where we don't eagerly resolve opaques to their (locally-defined) hidden types in the new solver. It essentially allows this code to work:
```rust
fn main() {
    type Tait = impl Sized;
    struct S {
        i: i32,
    }
    let x: Tait = S { i: 0 };
    println!("{}", x.i);
}
```

Since `Tait` is defined in `main`, we are able to poke through the type of `x` with deref.

r? lcnr