### PR TITLE
Add debug info for macOS CI actions

### DIFF
--- a/src/ci/scripts/dump-environment.sh
+++ b/src/ci/scripts/dump-environment.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This script dumps information about the build environment to stdout.
 
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -17,3 +19,17 @@ set +o pipefail
 du . | sort -nr | head -n100
 set -o pipefail
 echo
+
+if isMacOS
+then
+    # Debugging information that might be helpful for diagnosing macOS
+    # performance issues.
+    # SIP
+    csrutil status
+    # Gatekeeper
+    spctl --status
+    # Authorization policy
+    DevToolsSecurity -status
+    # Spotlight status
+    mdutil -avs
+fi


### PR DESCRIPTION
This adds some debugging information to the CI logs about the macOS runners to potentially help diagnose performance issues. I think this is unlikely to help, since I think the most likely issue is over-provisioning, but I figured it might be a worthy shot in the dark. The macos-12 runners definitely have issues with SIP randomly being enabled, but I have not seen evidence of that for macos-13.
