### PR TITLE
style-guide: When breaking binops handle multi-line first operand better

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -40,6 +40,8 @@ include:
   of a delimited expression, delimited expressions are generally combinable,
   regardless of the number of members. Previously only applied with exactly
   one member (except for closures with explicit blocks).
+- When line-breaking a binary operator, if the first operand spans multiple
+  lines, use the base indentation of the last line.
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -330,7 +330,7 @@ than at other binary operators.
 
 If line-breaking a binary operator (including assignment operators) where the
 first operand spans multiple lines, use the base indentation of the *last*
-line of the first , and indent relative to that:
+line of the first operand, and indent relative to that:
 
 ```rust
 impl SomeType {

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,6 +328,37 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
+If line-breaking a binary operator (including assignment operators) where the
+first operand spans multiple lines, use the base indentation of the *last*
+line of the first , and indent relative to that:
+
+```rust
+impl SomeType {
+    fn method(&mut self) {
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info =
+                long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
+
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info
+                + long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
+
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info = Some(ExtraInfo {
+                parent,
+                count: count as u16,
+                children: children.into_boxed_slice(),
+            });
+    }
+}
+```
+
 ### Casts (`as`)
 
 Format `as` casts like a binary operator. In particular, always include spaces

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,7 +328,7 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
-If line-breaking a binary operator (including assignment operators) where the
+If line-breaking at a binary operator (including assignment operators) where the
 first operand spans multiple lines, use the base indentation of the *last*
 line of the first operand, and indent relative to that:
 


### PR DESCRIPTION
Use the indentation of the *last* line of the first operand, not the first.

Fixes https://github.com/rust-lang/style-team/issues/189
