### PR TITLE
give const-err4 a more descriptive name

### DIFF
--- a/tests/ui/consts/const-err-enum-discriminant.rs
+++ b/tests/ui/consts/const-err-enum-discriminant.rs
@@ -1,4 +1,3 @@
-// stderr-per-bitwidth
 #[derive(Copy, Clone)]
 union Foo {
     a: isize,

--- a/tests/ui/consts/const-err-enum-discriminant.stderr
+++ b/tests/ui/consts/const-err-enum-discriminant.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-err4.rs:9:21
+  --> $DIR/const-err-enum-discriminant.rs:8:21
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
    |                     ^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory

--- a/tests/ui/consts/const-err4.64bit.stderr
+++ b/tests/ui/consts/const-err4.64bit.stderr
@@ -1,9 +1,0 @@
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-err4.rs:9:21
-   |
-LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-   |                     ^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Also, doesn't look like this still needs to be per-bitwidth

r? @oli-obk 