### PR TITLE
rustfmt.toml: don't ignore just any tests path, only root one

### DIFF
--- a/compiler/rustc_errors/src/markdown/tests/term.rs
+++ b/compiler/rustc_errors/src/markdown/tests/term.rs
@@ -5,7 +5,8 @@ use termcolor::{BufferWriter, ColorChoice};
 use super::*;
 
 const INPUT: &str = include_str!("input.md");
-const OUTPUT_PATH: &[&str] = &[env!("CARGO_MANIFEST_DIR"), "src","markdown","tests","output.stdout"];
+const OUTPUT_PATH: &[&str] =
+    &[env!("CARGO_MANIFEST_DIR"), "src", "markdown", "tests", "output.stdout"];
 
 const TEST_WIDTH: usize = 80;
 
@@ -34,7 +35,7 @@ quis dolor non venenatis. Aliquam ut. ";
 fn test_wrapping_write() {
     WIDTH.with(|w| w.set(TEST_WIDTH));
     let mut buf = BufWriter::new(Vec::new());
-    let txt = TXT.replace("-\n","-").replace("_\n","_").replace('\n', " ").replace("    ", "");
+    let txt = TXT.replace("-\n", "-").replace("_\n", "_").replace('\n', " ").replace("    ", "");
     write_wrapping(&mut buf, &txt, 0, None).unwrap();
     write_wrapping(&mut buf, &txt, 4, None).unwrap();
     write_wrapping(

--- a/library/alloc/tests/autotraits.rs
+++ b/library/alloc/tests/autotraits.rs
@@ -55,12 +55,7 @@ fn test_btree_map() {
 
     require_send_sync(async {
         let _v = None::<
-            alloc::collections::btree_map::ExtractIf<
-                '_,
-                &u32,
-                &u32,
-                fn(&&u32, &mut &u32) -> bool,
-            >,
+            alloc::collections::btree_map::ExtractIf<'_, &u32, &u32, fn(&&u32, &mut &u32) -> bool>,
         >;
         async {}.await;
     });

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1,7 +1,7 @@
 use core::alloc::{Allocator, Layout};
-use core::{assert_eq, assert_ne};
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
+use core::{assert_eq, assert_ne};
 use std::alloc::System;
 use std::assert_matches::assert_matches;
 use std::borrow::Cow;
@@ -1212,7 +1212,7 @@ fn test_in_place_specialization_step_up_down() {
     assert_eq!(sink.len(), 2);
 
     let mut src: Vec<[u8; 3]> = Vec::with_capacity(17);
-    src.resize( 8, [0; 3]);
+    src.resize(8, [0; 3]);
     let iter = src.into_iter().map(|[a, b, _]| [a, b]);
     assert_in_place_trait(&iter);
     let sink: Vec<[u8; 2]> = iter.collect();
@@ -1221,11 +1221,7 @@ fn test_in_place_specialization_step_up_down() {
 
     let src = vec![[0u8; 4]; 256];
     let srcptr = src.as_ptr();
-    let iter = src
-        .into_iter()
-        .flat_map(|a| {
-            a.into_iter().map(|b| b.wrapping_add(1))
-        });
+    let iter = src.into_iter().flat_map(|a| a.into_iter().map(|b| b.wrapping_add(1)));
     assert_in_place_trait(&iter);
     let sink = iter.collect::<Vec<_>>();
     assert_eq!(srcptr as *const u8, sink.as_ptr());

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -1,6 +1,6 @@
-use core::{array, assert_eq};
 use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicUsize, Ordering};
+use core::{array, assert_eq};
 
 #[test]
 fn array_from_ref() {

--- a/library/core/tests/cell.rs
+++ b/library/core/tests/cell.rs
@@ -466,14 +466,14 @@ fn const_cells() {
     const CELL: Cell<i32> = Cell::new(3);
     const _: i32 = CELL.into_inner();
 
-/* FIXME(#110395)
-    const UNSAFE_CELL_FROM: UnsafeCell<i32> = UnsafeCell::from(3);
-    const _: i32 = UNSAFE_CELL.into_inner();
+    /* FIXME(#110395)
+        const UNSAFE_CELL_FROM: UnsafeCell<i32> = UnsafeCell::from(3);
+        const _: i32 = UNSAFE_CELL.into_inner();
 
-    const REF_CELL_FROM: RefCell<i32> = RefCell::from(3);
-    const _: i32 = REF_CELL.into_inner();
+        const REF_CELL_FROM: RefCell<i32> = RefCell::from(3);
+        const _: i32 = REF_CELL.into_inner();
 
-    const CELL_FROM: Cell<i32> = Cell::from(3);
-    const _: i32 = CELL.into_inner();
-*/
+        const CELL_FROM: Cell<i32> = Cell::from(3);
+        const _: i32 = CELL.into_inner();
+    */
 }

--- a/library/core/tests/error.rs
+++ b/library/core/tests/error.rs
@@ -1,4 +1,4 @@
-use core::error::{request_value, request_ref, Request};
+use core::error::{request_ref, request_value, Request};
 
 // Test the `Request` API.
 #[derive(Debug)]

--- a/library/core/tests/fmt/mod.rs
+++ b/library/core/tests/fmt/mod.rs
@@ -22,11 +22,11 @@ fn test_pointer_formats_data_pointer() {
 #[test]
 fn test_estimated_capacity() {
     assert_eq!(format_args!("").estimated_capacity(), 0);
-    assert_eq!(format_args!("{}", {""}).estimated_capacity(), 0);
+    assert_eq!(format_args!("{}", { "" }).estimated_capacity(), 0);
     assert_eq!(format_args!("Hello").estimated_capacity(), 5);
-    assert_eq!(format_args!("Hello, {}!", {""}).estimated_capacity(), 16);
-    assert_eq!(format_args!("{}, hello!", {"World"}).estimated_capacity(), 0);
-    assert_eq!(format_args!("{}. 16-bytes piece", {"World"}).estimated_capacity(), 32);
+    assert_eq!(format_args!("Hello, {}!", { "" }).estimated_capacity(), 16);
+    assert_eq!(format_args!("{}, hello!", { "World" }).estimated_capacity(), 0);
+    assert_eq!(format_args!("{}. 16-bytes piece", { "World" }).estimated_capacity(), 32);
 }
 
 #[test]

--- a/library/core/tests/hash/mod.rs
+++ b/library/core/tests/hash/mod.rs
@@ -35,7 +35,8 @@ impl Hasher for MyHasher {
 #[test]
 fn test_writer_hasher() {
     // FIXME(#110395)
-    /* const */ fn hash<T: Hash>(t: &T) -> u64 {
+    /* const */
+    fn hash<T: Hash>(t: &T) -> u64 {
         let mut s = MyHasher { hash: 0 };
         t.hash(&mut s);
         s.finish()
@@ -140,7 +141,8 @@ impl Hash for Custom {
 #[test]
 fn test_custom_state() {
     // FIXME(#110395)
-    /* const */ fn hash<T: Hash>(t: &T) -> u64 {
+    /* const */
+    fn hash<T: Hash>(t: &T) -> u64 {
         let mut c = CustomHasher { output: 0 };
         t.hash(&mut c);
         c.finish()

--- a/library/core/tests/iter/adapters/chain.rs
+++ b/library/core/tests/iter/adapters/chain.rs
@@ -42,7 +42,10 @@ fn test_iterator_chain_advance_by() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
             assert_eq!(iter.advance_by(xs.len() + i), Ok(()));
             assert_eq!(iter.next(), Some(&ys[i]));
-            assert_eq!(iter.advance_by(100), Err(NonZeroUsize::new(100 - (ys.len() - i - 1)).unwrap()));
+            assert_eq!(
+                iter.advance_by(100),
+                Err(NonZeroUsize::new(100 - (ys.len() - i - 1)).unwrap())
+            );
             assert_eq!(iter.advance_by(0), Ok(()));
         }
 
@@ -71,7 +74,10 @@ fn test_iterator_chain_advance_back_by() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
             assert_eq!(iter.advance_back_by(i), Ok(()));
             assert_eq!(iter.next_back(), Some(&ys[ys.len() - i - 1]));
-            assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (len - i - 1)).unwrap()));
+            assert_eq!(
+                iter.advance_back_by(100),
+                Err(NonZeroUsize::new(100 - (len - i - 1)).unwrap())
+            );
             assert_eq!(iter.advance_back_by(0), Ok(()));
         }
 
@@ -79,7 +85,10 @@ fn test_iterator_chain_advance_back_by() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
             assert_eq!(iter.advance_back_by(ys.len() + i), Ok(()));
             assert_eq!(iter.next_back(), Some(&xs[xs.len() - i - 1]));
-            assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (xs.len() - i - 1)).unwrap()));
+            assert_eq!(
+                iter.advance_back_by(100),
+                Err(NonZeroUsize::new(100 - (xs.len() - i - 1)).unwrap())
+            );
             assert_eq!(iter.advance_back_by(0), Ok(()));
         }
 

--- a/library/core/tests/iter/adapters/flatten.rs
+++ b/library/core/tests/iter/adapters/flatten.rs
@@ -1,5 +1,5 @@
-use core::assert_eq;
 use super::*;
+use core::assert_eq;
 use core::iter::*;
 use core::num::NonZeroUsize;
 

--- a/library/core/tests/iter/adapters/step_by.rs
+++ b/library/core/tests/iter/adapters/step_by.rs
@@ -245,7 +245,6 @@ fn test_step_by_skip() {
     assert_eq!((200..=255u8).step_by(10).nth(3), Some(230));
 }
 
-
 struct DeOpt<I: Iterator>(I);
 
 impl<I: Iterator> Iterator for DeOpt<I> {
@@ -265,17 +264,15 @@ impl<I: DoubleEndedIterator> DoubleEndedIterator for DeOpt<I> {
 #[test]
 fn test_step_by_fold_range_specialization() {
     macro_rules! t {
-        ($range:expr, $var: ident, $body:tt) => {
-            {
-                // run the same tests for the non-optimized version
-                let mut $var = DeOpt($range);
-                $body
-            }
-            {
-                let mut $var = $range;
-                $body
-            }
+        ($range:expr, $var: ident, $body:tt) => {{
+            // run the same tests for the non-optimized version
+            let mut $var = DeOpt($range);
+            $body
         }
+        {
+            let mut $var = $range;
+            $body
+        }};
     }
 
     t!((1usize..5).step_by(1), r, {
@@ -288,13 +285,12 @@ fn test_step_by_fold_range_specialization() {
         assert_eq!(r.sum::<usize>(), 2);
     });
 
-
     t!((0usize..5).step_by(2), r, {
         assert_eq!(r.next(), Some(0));
         assert_eq!(r.sum::<usize>(), 6);
     });
 
-    t!((usize::MAX - 6 .. usize::MAX).step_by(5), r, {
+    t!((usize::MAX - 6..usize::MAX).step_by(5), r, {
         assert_eq!(r.next(), Some(usize::MAX - 6));
         assert_eq!(r.sum::<usize>(), usize::MAX - 1);
     });

--- a/library/core/tests/iter/adapters/take.rs
+++ b/library/core/tests/iter/adapters/take.rs
@@ -93,7 +93,10 @@ fn test_take_advance_by() {
     assert_eq!((0..2).take(1).advance_back_by(10), Err(NonZeroUsize::new(9).unwrap()));
     assert_eq!((0..0).take(1).advance_back_by(1), Err(NonZeroUsize::new(1).unwrap()));
     assert_eq!((0..0).take(1).advance_back_by(0), Ok(()));
-    assert_eq!((0..usize::MAX).take(100).advance_back_by(usize::MAX), Err(NonZeroUsize::new(usize::MAX - 100).unwrap()));
+    assert_eq!(
+        (0..usize::MAX).take(100).advance_back_by(usize::MAX),
+        Err(NonZeroUsize::new(usize::MAX - 100).unwrap())
+    );
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -184,7 +184,7 @@ fn test_zip_nested_sideffectful() {
         let it = xs.iter_mut().map(|x| *x = 1).enumerate().zip(&ys);
         it.count();
     }
-    let length_aware =  &xs == &[1, 1, 1, 1, 0, 0];
+    let length_aware = &xs == &[1, 1, 1, 1, 0, 0];
     let probe_first = &xs == &[1, 1, 1, 1, 1, 0];
 
     // either implementation is valid according to zip documentation

--- a/library/core/tests/iter/traits/iterator.rs
+++ b/library/core/tests/iter/traits/iterator.rs
@@ -168,7 +168,10 @@ fn test_iterator_advance_back_by() {
         let mut iter = v.iter();
         assert_eq!(iter.advance_back_by(i), Ok(()));
         assert_eq!(iter.next_back().unwrap(), &v[v.len() - 1 - i]);
-        assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap()));
+        assert_eq!(
+            iter.advance_back_by(100),
+            Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap())
+        );
     }
 
     assert_eq!(v.iter().advance_back_by(v.len()), Ok(()));
@@ -183,7 +186,10 @@ fn test_iterator_rev_advance_back_by() {
         let mut iter = v.iter().rev();
         assert_eq!(iter.advance_back_by(i), Ok(()));
         assert_eq!(iter.next_back().unwrap(), &v[i]);
-        assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap()));
+        assert_eq!(
+            iter.advance_back_by(100),
+            Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap())
+        );
     }
 
     assert_eq!(v.iter().rev().advance_back_by(v.len()), Ok(()));

--- a/library/core/tests/net/ip_addr.rs
+++ b/library/core/tests/net/ip_addr.rs
@@ -664,7 +664,11 @@ fn ipv6_properties() {
         &[0x20, 1, 0, 0x20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         global | unicast_global
     );
-    check!("2001:30::", &[0x20, 1, 0, 0x30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], global | unicast_global);
+    check!(
+        "2001:30::",
+        &[0x20, 1, 0, 0x30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        global | unicast_global
+    );
     check!("2001:40::", &[0x20, 1, 0, 0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], unicast_global);
 
     check!(

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -178,19 +178,19 @@ fn test_or_else() {
     assert_eq!(x.or_else(two), Some(2));
     assert_eq!(x.or_else(none), None);
 
-/* FIXME(#110395)
-    const FOO: Option<isize> = Some(1);
-    const A: Option<isize> = FOO.or_else(two);
-    const B: Option<isize> = FOO.or_else(none);
-    assert_eq!(A, Some(1));
-    assert_eq!(B, Some(1));
+    /* FIXME(#110395)
+        const FOO: Option<isize> = Some(1);
+        const A: Option<isize> = FOO.or_else(two);
+        const B: Option<isize> = FOO.or_else(none);
+        assert_eq!(A, Some(1));
+        assert_eq!(B, Some(1));
 
-    const BAR: Option<isize> = None;
-    const C: Option<isize> = BAR.or_else(two);
-    const D: Option<isize> = BAR.or_else(none);
-    assert_eq!(C, Some(2));
-    assert_eq!(D, None);
-*/
+        const BAR: Option<isize> = None;
+        const C: Option<isize> = BAR.or_else(two);
+        const D: Option<isize> = BAR.or_else(none);
+        assert_eq!(C, Some(2));
+        assert_eq!(D, None);
+    */
 }
 
 #[test]
@@ -486,15 +486,15 @@ const fn option_const_mut() {
             None => unreachable!(),
         }
     }
-/* FIXME(const-hack)
-    {
-        let as_mut: Option<&mut usize> = Option::from(&mut option);
-        match as_mut {
-            Some(v) => *v = 42,
-            None => unreachable!(),
+    /* FIXME(const-hack)
+        {
+            let as_mut: Option<&mut usize> = Option::from(&mut option);
+            match as_mut {
+                Some(v) => *v = 42,
+                None => unreachable!(),
+            }
         }
-    }
-*/
+    */
 }
 
 #[test]

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -478,7 +478,11 @@ fn align_offset_various_strides() {
                 x |= test_stride::<A9>(ptr::invalid::<A9>(ptr), align);
 
                 #[repr(packed)]
-                struct A10(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u16);
+                struct A10(
+                    #[allow(dead_code)] u32,
+                    #[allow(dead_code)] u32,
+                    #[allow(dead_code)] u16,
+                );
                 x |= test_stride::<A10>(ptr::invalid::<A10>(ptr), align);
 
                 x |= test_stride::<u32>(ptr::invalid::<u32>(ptr), align);
@@ -532,7 +536,11 @@ fn align_offset_various_strides_const() {
                     test_stride::<A6>(ptr::invalid::<A6>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A7(#[allow(dead_code)] u32, #[allow(dead_code)] u16, #[allow(dead_code)] u8);
+                    struct A7(
+                        #[allow(dead_code)] u32,
+                        #[allow(dead_code)] u16,
+                        #[allow(dead_code)] u8,
+                    );
                     test_stride::<A7>(ptr::invalid::<A7>(ptr), ptr, align);
 
                     #[repr(packed)]
@@ -540,11 +548,19 @@ fn align_offset_various_strides_const() {
                     test_stride::<A8>(ptr::invalid::<A8>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A9(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u8);
+                    struct A9(
+                        #[allow(dead_code)] u32,
+                        #[allow(dead_code)] u32,
+                        #[allow(dead_code)] u8,
+                    );
                     test_stride::<A9>(ptr::invalid::<A9>(ptr), ptr, align);
 
                     #[repr(packed)]
-                    struct A10(#[allow(dead_code)] u32, #[allow(dead_code)] u32, #[allow(dead_code)] u16);
+                    struct A10(
+                        #[allow(dead_code)] u32,
+                        #[allow(dead_code)] u32,
+                        #[allow(dead_code)] u16,
+                    );
                     test_stride::<A10>(ptr::invalid::<A10>(ptr), ptr, align);
 
                     test_stride::<u32>(ptr::invalid::<u32>(ptr), ptr, align);

--- a/library/core/tests/time.rs
+++ b/library/core/tests/time.rs
@@ -479,22 +479,22 @@ fn duration_const() {
     const CHECKED_MUL: Option<Duration> = Duration::SECOND.checked_mul(1);
     assert_eq!(CHECKED_MUL, Some(Duration::SECOND));
 
-/*  FIXME(#110395)
-    const MUL_F32: Duration = Duration::SECOND.mul_f32(1.0);
-    assert_eq!(MUL_F32, Duration::SECOND);
+    /*  FIXME(#110395)
+        const MUL_F32: Duration = Duration::SECOND.mul_f32(1.0);
+        assert_eq!(MUL_F32, Duration::SECOND);
 
-    const MUL_F64: Duration = Duration::SECOND.mul_f64(1.0);
-    assert_eq!(MUL_F64, Duration::SECOND);
+        const MUL_F64: Duration = Duration::SECOND.mul_f64(1.0);
+        assert_eq!(MUL_F64, Duration::SECOND);
 
-    const CHECKED_DIV: Option<Duration> = Duration::SECOND.checked_div(1);
-    assert_eq!(CHECKED_DIV, Some(Duration::SECOND));
+        const CHECKED_DIV: Option<Duration> = Duration::SECOND.checked_div(1);
+        assert_eq!(CHECKED_DIV, Some(Duration::SECOND));
 
-    const DIV_F32: Duration = Duration::SECOND.div_f32(1.0);
-    assert_eq!(DIV_F32, Duration::SECOND);
+        const DIV_F32: Duration = Duration::SECOND.div_f32(1.0);
+        assert_eq!(DIV_F32, Duration::SECOND);
 
-    const DIV_F64: Duration = Duration::SECOND.div_f64(1.0);
-    assert_eq!(DIV_F64, Duration::SECOND);
-*/
+        const DIV_F64: Duration = Duration::SECOND.div_f64(1.0);
+        assert_eq!(DIV_F64, Duration::SECOND);
+    */
 
     const DIV_DURATION_F32: f32 = Duration::SECOND.div_duration_f32(Duration::SECOND);
     assert_eq!(DIV_DURATION_F32, 1.0);

--- a/library/std/tests/process_spawning.rs
+++ b/library/std/tests/process_spawning.rs
@@ -1,4 +1,4 @@
-#![cfg(not(target_env="sgx"))]
+#![cfg(not(target_env = "sgx"))]
 
 use std::env;
 use std::fs;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -13,7 +13,7 @@ ignore = [
 
     # tests for now are not formatted, as they are sometimes pretty-printing constrained
     # (and generally rustfmt can move around comments in UI-testing incompatible ways)
-    "tests",
+    "/tests/",
 
     # do not format submodules
     # FIXME: sync submodule list with tidy/bootstrap/etc

--- a/src/bootstrap/src/tests/config.rs
+++ b/src/bootstrap/src/tests/config.rs
@@ -32,9 +32,12 @@ fn download_ci_llvm() {
     assert_eq!(parse_llvm("rust.channel = \"dev\""), if_unchanged);
     assert!(!parse_llvm("rust.channel = \"stable\""));
     assert_eq!(parse_llvm("build.build = \"x86_64-unknown-linux-gnu\""), if_unchanged);
-    assert_eq!(parse_llvm(
-        "llvm.assertions = true \r\n build.build = \"x86_64-unknown-linux-gnu\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
-    ), if_unchanged);
+    assert_eq!(
+        parse_llvm(
+            "llvm.assertions = true \r\n build.build = \"x86_64-unknown-linux-gnu\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
+        ),
+        if_unchanged
+    );
     assert!(!parse_llvm(
         "llvm.assertions = true \r\n build.build = \"aarch64-apple-darwin\" \r\n llvm.download-ci-llvm = \"if-unchanged\""
     ));

--- a/src/bootstrap/src/tests/helpers.rs
+++ b/src/bootstrap/src/tests/helpers.rs
@@ -1,4 +1,4 @@
-use crate::utils::helpers::{extract_beta_rev, hex_encode, make, check_cfg_arg};
+use crate::utils::helpers::{check_cfg_arg, extract_beta_rev, hex_encode, make};
 use std::path::PathBuf;
 
 #[test]


### PR DESCRIPTION
Previously ignored any `tests` path, now only /tests at repo root.

For reference, https://git-scm.com/docs/gitignore#_pattern_format