### PR TITLE
Check lint cap before entering `late_lint_mod`

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -142,9 +142,10 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn lint_mod(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    if !tcx.sess.opts.lint_cap.is_some_and(|cap| cap == Level::Allow) {
-        late_lint_mod(tcx, module_def_id, BuiltinCombinedModuleLateLintPass::new());
+    if let Some(lint_cap) = tcx.sess.opts.lint_cap && lint_cap == Level::Allow {
+        return;
     }
+    late_lint_mod(tcx, module_def_id, BuiltinCombinedModuleLateLintPass::new());
 }
 
 early_lint_methods!(

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -142,7 +142,9 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn lint_mod(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    late_lint_mod(tcx, module_def_id, BuiltinCombinedModuleLateLintPass::new());
+    if !tcx.sess.opts.lint_cap.is_some_and(|cap| cap == Level::Allow) {
+        late_lint_mod(tcx, module_def_id, BuiltinCombinedModuleLateLintPass::new());
+    }
 }
 
 early_lint_methods!(

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -142,7 +142,9 @@ pub fn provide(providers: &mut Providers) {
 }
 
 fn lint_mod(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    if let Some(lint_cap) = tcx.sess.opts.lint_cap && lint_cap == Level::Allow {
+    if let Some(lint_cap) = tcx.sess.opts.lint_cap
+        && lint_cap == Level::Allow
+    {
         return;
     }
     late_lint_mod(tcx, module_def_id, BuiltinCombinedModuleLateLintPass::new());


### PR DESCRIPTION
Before entering `late_lint_mod`, check that we're not on an allowed lint cap. Because of the lint cap, we won't even try to lint.

I'd love to have a perf run.