### PR TITLE
Set `c_str_literals` stabilization version back to `CURRENT_RUSTC_VERSION`

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -77,7 +77,7 @@ declare_features! (
     /// Allows empty structs and enum variants with braces.
     (accepted, braced_empty_structs, "1.8.0", Some(29720)),
     /// Allows `c"foo"` literals.
-    (accepted, c_str_literals, "1.76.0", Some(105723)),
+    (accepted, c_str_literals, "CURRENT_RUSTC_VERSION", Some(105723)),
     /// Allows `#[cfg_attr(predicate, multiple, attributes, here)]`.
     (accepted, cfg_attr_multi, "1.33.0", Some(54881)),
     /// Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests.


### PR DESCRIPTION
 `c_str_literals`'s stabilization has been delayed to 1.77 (https://github.com/rust-lang/rust/pull/119528).
