### PR TITLE
Overhaul `-Ztreat-err-as-bug`

### DIFF
--- a/tests/ui/impl-trait/equality-in-canonical-query.clone.stderr
+++ b/tests/ui/impl-trait/equality-in-canonical-query.clone.stderr
@@ -1,4 +1,6 @@
-error: internal compiler error: no errors encountered even though `span_delayed_bug` issued
+note: no errors encountered even though `span_delayed_bug` issued
+
+note: those delayed bugs will now be shown as internal compiler errors
 
 error: internal compiler error: {OpaqueTypeKey { def_id: DefId(rpit::{opaque#0}), args: [] }: OpaqueTypeDecl { hidden_type: OpaqueHiddenType { span: no-location (#0), ty: Alias(Opaque, AliasTy { args: [], def_id: DefId(foo::{opaque#0}) }) } }}
    |
@@ -6,24 +8,18 @@ error: internal compiler error: {OpaqueTypeKey { def_id: DefId(rpit::{opaque#0})
            
 
 error: internal compiler error: error performing ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: UserFacing }, value: ProvePredicate { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [FnDef(DefId(rpit), []), ()], def_id: DefId(ops::function::FnOnce::Output) }, Term::Ty(Alias(Opaque, AliasTy { args: [], def_id: DefId(foo::{opaque#0}) }))), bound_vars: [] } } }
-  --> $DIR/equality-in-canonical-query.rs:19:5
+  --> $DIR/equality-in-canonical-query.rs:21:5
    |
 LL |     same_output(foo, rpit);
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 
-  --> $DIR/equality-in-canonical-query.rs:19:5
+  --> $DIR/equality-in-canonical-query.rs:21:5
    |
 LL |     same_output(foo, rpit);
    |     ^^^^^^^^^^^^^^^^^^^^^^
-
-
-
-
-
-
 
 query stack during panic:
 end of query stack
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/equality-in-canonical-query.rs
+++ b/tests/ui/impl-trait/equality-in-canonical-query.rs
@@ -1,11 +1,13 @@
 // issue: #116877
 // revisions: sized clone
 //[sized] check-pass
-
 //[clone] known-bug: #108498
 //[clone] failure-status: 101
 //[clone] normalize-stderr-test: "DefId\(.*?\]::" -> "DefId("
-//[clone] normalize-stderr-test: "(?m)note: .*$" -> ""
+//[clone] normalize-stderr-test: "(?m)note: we would appreciate a bug report.*\n\n" -> ""
+//[clone] normalize-stderr-test: "(?m)note: rustc.*running on.*\n\n" -> ""
+//[clone] normalize-stderr-test: "(?m)note: compiler flags.*\n\n" -> ""
+//[clone] normalize-stderr-test: "(?m)note: delayed at.*$" -> ""
 //[clone] normalize-stderr-test: "(?m)^ *\d+: .*\n" -> ""
 //[clone] normalize-stderr-test: "(?m)^ *at .*\n" -> ""
 

--- a/tests/ui/mir/lint/storage-live.stderr
+++ b/tests/ui/mir/lint/storage-live.stderr
@@ -4,11 +4,15 @@ error: internal compiler error: broken MIR in Item(DefId(0:8 ~ storage_live[HASH
    |
 LL |             StorageLive(a);
    |             ^^^^^^^^^^^^^^
+   |
+note: delayed at compiler/rustc_mir_transform/src/lint.rs:97:26 - disabled backtrace
+  --> $DIR/storage-live.rs:22:13
+   |
+LL |             StorageLive(a);
+   |             ^^^^^^^^^^^^^^
 
 aborting due to `-Z treat-err-as-bug=1`
 error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
-#0 [mir_const] preparing `multiple_storage` for borrow checking
-#1 [mir_promoted] promoting constants in MIR for `multiple_storage`
 end of query stack

--- a/tests/ui/mir/lint/storage-return.rs
+++ b/tests/ui/mir/lint/storage-return.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zlint-mir -Ztreat-err-as-bug
+// compile-flags: -Zlint-mir -Ztreat-err-as-bug -Zeagerly-emit-delayed-bugs
 // failure-status: 101
 // dont-check-compiler-stderr
 // error-pattern: has storage when returning

--- a/tests/ui/treat-err-as-bug/span_delayed_bug.rs
+++ b/tests/ui/treat-err-as-bug/span_delayed_bug.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Ztreat-err-as-bug
+// compile-flags: -Ztreat-err-as-bug -Zeagerly-emit-delayed-bugs
 // failure-status: 101
 // error-pattern: aborting due to `-Z treat-err-as-bug=1`
 // error-pattern: [trigger_span_delayed_bug] triggering a span delayed bug for testing incremental

--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
@@ -1,4 +1,6 @@
-error: internal compiler error: no errors encountered even though `span_delayed_bug` issued
+note: no errors encountered even though `span_delayed_bug` issued
+
+note: those delayed bugs will now be shown as internal compiler errors
 
 error: internal compiler error: {OpaqueTypeKey { def_id: DefId(get_rpit::{opaque#0}), args: [] }: OpaqueTypeDecl { hidden_type: OpaqueHiddenType { span: no-location (#0), ty: Alias(Opaque, AliasTy { args: [], def_id: DefId(Opaque::{opaque#0}) }) } }}
    |
@@ -6,24 +8,18 @@ error: internal compiler error: {OpaqueTypeKey { def_id: DefId(get_rpit::{opaque
            
 
 error: internal compiler error: error performing ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: UserFacing }, value: ProvePredicate { predicate: Binder { value: ProjectionPredicate(AliasTy { args: [FnDef(DefId(get_rpit), []), ()], def_id: DefId(ops::function::FnOnce::Output) }, Term::Ty(Alias(Opaque, AliasTy { args: [], def_id: DefId(Opaque::{opaque#0}) }))), bound_vars: [] } } }
-  --> $DIR/rpit_tait_equality_in_canonical_query.rs:28:5
+  --> $DIR/rpit_tait_equality_in_canonical_query.rs:31:5
    |
 LL |     query(get_rpit);
    |     ^^^^^^^^^^^^^^^
    |
 
-  --> $DIR/rpit_tait_equality_in_canonical_query.rs:28:5
+  --> $DIR/rpit_tait_equality_in_canonical_query.rs:31:5
    |
 LL |     query(get_rpit);
    |     ^^^^^^^^^^^^^^^
-
-
-
-
-
-
 
 query stack during panic:
 end of query stack
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.rs
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.rs
@@ -12,7 +12,10 @@
 //[current] known-bug: #108498
 //[current] failure-status: 101
 //[current] normalize-stderr-test: "DefId\(.*?\]::" -> "DefId("
-//[current] normalize-stderr-test: "(?m)note: .*$" -> ""
+//[current] normalize-stderr-test: "(?m)note: we would appreciate a bug report.*\n\n" -> ""
+//[current] normalize-stderr-test: "(?m)note: rustc.*running on.*\n\n" -> ""
+//[current] normalize-stderr-test: "(?m)note: compiler flags.*\n\n" -> ""
+//[current] normalize-stderr-test: "(?m)note: delayed at.*$" -> ""
 //[current] normalize-stderr-test: "(?m)^ *\d+: .*\n" -> ""
 //[current] normalize-stderr-test: "(?m)^ *at .*\n" -> ""
 


### PR DESCRIPTION
It's current behaviour is surprising, in a bad way. This also makes the implementation more complex than it needs to be.

r? @oli-obk 