### PR TITLE
Tune the inlinability of `unwrap`

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1061,7 +1061,7 @@ impl<T, E> Result<T, E> {
     /// let x: Result<u32, &str> = Err("emergency failure");
     /// x.unwrap(); // panics with `emergency failure`
     /// ```
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap(self) -> T

--- a/tests/codegen/infallible-unwrap-in-opt-z.rs
+++ b/tests/codegen/infallible-unwrap-in-opt-z.rs
@@ -1,0 +1,26 @@
+// compile-flags: -C opt-level=z --edition=2021
+// ignore-debug
+
+#![crate_type = "lib"]
+
+// From <https://github.com/rust-lang/rust/issues/115463>
+
+// CHECK-LABEL: @read_up_to_8(
+#[no_mangle]
+pub fn read_up_to_8(buf: &[u8]) -> u64 {
+    // CHECK-NOT: unwrap_failed
+    if buf.len() < 4 {
+        // actual instance has more code.
+        return 0;
+    }
+    let lo = u32::from_le_bytes(buf[..4].try_into().unwrap()) as u64;
+    let hi = u32::from_le_bytes(buf[buf.len() - 4..][..4].try_into().unwrap()) as u64;
+    lo | (hi << 8 * (buf.len() as u64 - 4))
+}
+
+// CHECK-LABEL: @checking_unwrap_expectation(
+#[no_mangle]
+pub fn checking_unwrap_expectation(buf: &[u8]) -> &[u8; 4] {
+    // CHECK: call void @_ZN4core6result13unwrap_failed17h
+    buf.try_into().unwrap()
+}


### PR DESCRIPTION
Fixes #115463
cc @thomcc 

This tweaks `unwrap` on ~~`Option` &~~ `Result` to be two parts:
- `#[inline(always)]` for checking the discriminant
- `#[cold]` for actually panicking

The idea here is that checking the discriminant on a `Result` ~~or `Option`~~ should always be trivial enough to be worth inlining, even in `opt-level=z`, especially compared to passing it to a function.

As seen in the issue and codegen test, this will hopefully help particularly for things like `.try_into().unwrap()`s that are actually infallible, but in a way that's only visible with the inlining.

EDIT: I've restricted this to `Result` to avoid combining effects