### PR TITLE
Rename `--env` option flag to `--env-set`

### DIFF
--- a/compiler/rustc_builtin_macros/src/env.rs
+++ b/compiler/rustc_builtin_macros/src/env.rs
@@ -18,7 +18,7 @@ fn lookup_env<'cx>(cx: &'cx ExtCtxt<'_>, var: Symbol) -> Option<Symbol> {
     if let Some(value) = cx.sess.opts.logical_env.get(var) {
         return Some(Symbol::intern(value));
     }
-    // If the environment variable was not defined with the `--env` option, we try to retrieve it
+    // If the environment variable was not defined with the `--env-set` option, we try to retrieve it
     // from rustc's environment.
     env::var(var).ok().as_deref().map(Symbol::intern)
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1823,7 +1823,7 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
             "Remap source names in all output (compiler messages and output files)",
             "FROM=TO",
         ),
-        opt::multi("", "env", "Inject an environment variable", "VAR=VALUE"),
+        opt::multi("", "env-set", "Inject an environment variable", "VAR=VALUE"),
     ]);
     opts
 }
@@ -2599,11 +2599,11 @@ fn parse_logical_env(
 ) -> FxIndexMap<String, String> {
     let mut vars = FxIndexMap::default();
 
-    for arg in matches.opt_strs("env") {
+    for arg in matches.opt_strs("env-set") {
         if let Some((name, val)) = arg.split_once('=') {
             vars.insert(name.to_string(), val.to_string());
         } else {
-            early_dcx.early_fatal(format!("`--env`: specify value for variable `{arg}`"));
+            early_dcx.early_fatal(format!("`--env-set`: specify value for variable `{arg}`"));
         }
     }
 

--- a/src/doc/unstable-book/src/compiler-flags/env-set.md
+++ b/src/doc/unstable-book/src/compiler-flags/env-set.md
@@ -1,4 +1,4 @@
-# `env`
+# `env-set`
 
 The tracking issue for this feature is: [#118372](https://github.com/rust-lang/rust/issues/118372).
 
@@ -11,11 +11,11 @@ from the `proc_macro` crate.
 This information will be stored in the dep-info files. For more information about
 dep-info files, take a look [here](https://doc.rust-lang.org/cargo/guide/build-cache.html#dep-info-files).
 
-When retrieving an environment variable value, the one specified by `--env` will take
+When retrieving an environment variable value, the one specified by `--env-set` will take
 precedence. For example, if you want have `PATH=a` in your environment and pass:
 
 ```bash
-rustc --env PATH=env
+rustc --env-set PATH=env
 ```
 
 Then you will have:
@@ -24,17 +24,17 @@ Then you will have:
 assert_eq!(env!("PATH"), "env");
 ```
 
-It will trigger a new compilation if any of the `--env` argument value is different.
+It will trigger a new compilation if any of the `--env-set` argument value is different.
 So if you first passed:
 
 ```bash
---env A=B --env X=12
+--env-set A=B --env X=12
 ```
 
 and then on next compilation:
 
 ```bash
---env A=B
+--env-set A=B
 ```
 
 `X` value is different (not set) so the code will be re-compiled.
@@ -42,4 +42,4 @@ and then on next compilation:
 Please note that on Windows, environment variables are case insensitive but case
 preserving whereas `rustc`'s environment variables are case sensitive. For example,
 having `Path` in your environment (case insensitive) is different than using
-`rustc --env Path=...` (case sensitive).
+`rustc --env-set Path=...` (case sensitive).

--- a/tests/ui/extenv/extenv-env-overload.rs
+++ b/tests/ui/extenv/extenv-env-overload.rs
@@ -1,6 +1,6 @@
 // run-pass
 // rustc-env:MY_VAR=tadam
-// compile-flags: --env MY_VAR=123abc -Zunstable-options
+// compile-flags: --env-set MY_VAR=123abc -Zunstable-options
 
 // This test ensures that variables provided with `--env` take precedence over
 // variables from environment.

--- a/tests/ui/extenv/extenv-env.rs
+++ b/tests/ui/extenv/extenv-env.rs
@@ -1,4 +1,4 @@
-// compile-flags: --env FOO=123abc -Zunstable-options
+// compile-flags: --env-set FOO=123abc -Zunstable-options
 // run-pass
 fn main() {
     assert_eq!(env!("FOO"), "123abc");

--- a/tests/ui/extenv/extenv-not-env.rs
+++ b/tests/ui/extenv/extenv-not-env.rs
@@ -1,6 +1,6 @@
 // run-pass
 // rustc-env:MY_ENV=/
-// Ensures that variables not defined through `--env` are still available.
+// Ensures that variables not defined through `--env-set` are still available.
 
 fn main() {
     assert!(!env!("MY_ENV").is_empty());

--- a/tests/ui/feature-gates/env-flag.rs
+++ b/tests/ui/feature-gates/env-flag.rs
@@ -1,3 +1,3 @@
-// compile-flags: --env A=B
+// compile-flags: --env-set A=B
 
 fn main() {}

--- a/tests/ui/feature-gates/env-flag.stderr
+++ b/tests/ui/feature-gates/env-flag.stderr
@@ -1,2 +1,2 @@
-error: the `-Z unstable-options` flag must also be passed to enable the flag `env`
+error: the `-Z unstable-options` flag must also be passed to enable the flag `env-set`
 

--- a/tests/ui/proc-macro/env.rs
+++ b/tests/ui/proc-macro/env.rs
@@ -1,7 +1,7 @@
 // aux-build:env.rs
 // run-pass
 // rustc-env: THE_CONST=1
-// compile-flags: -Zunstable-options --env THE_CONST=12 --env ANOTHER=4
+// compile-flags: -Zunstable-options --env-set THE_CONST=12 --env-set ANOTHER=4
 
 #![crate_name = "foo"]
 


### PR DESCRIPTION
As discussed [on zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Stabilizing.20.60--env.60.20option.20flag.3F). We rename `--env` to not conflicting names with the [RFC](https://github.com/rust-lang/rfcs/pull/2794).

Part of https://github.com/rust-lang/rust/issues/118372 and of #80792.

r? @davidtwco 