### PR TITLE
Taint `_` placeholder types in trait impl method signatures

### DIFF
--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -2543,7 +2543,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         self.suggest_trait_fn_ty_for_impl_fn_infer(hir_id, Some(i))
                     {
                         infer_replacements.push((a.span, suggested_ty.to_string()));
-                        return suggested_ty;
+                        return Ty::new_error_with_message(
+                            self.tcx(),
+                            a.span,
+                            suggested_ty.to_string(),
+                        );
                     }
                 }
 
@@ -2561,7 +2565,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         self.suggest_trait_fn_ty_for_impl_fn_infer(hir_id, None)
                 {
                     infer_replacements.push((output.span, suggested_ty.to_string()));
-                    suggested_ty
+                    Ty::new_error_with_message(self.tcx(), output.span, suggested_ty.to_string())
                 } else {
                     visitor.visit_ty(output);
                     self.ast_ty_to_ty(output)

--- a/tests/ui/traits/method-argument-mismatch-variance-ice-119867.rs
+++ b/tests/ui/traits/method-argument-mismatch-variance-ice-119867.rs
@@ -1,0 +1,13 @@
+trait Deserialize {
+    fn deserialize(&self);
+}
+
+struct ArchivedVec<T>(T);
+
+impl<T> Deserialize for ArchivedVec<T> {
+    fn deserialize(s: _) {}
+    //~^ ERROR: `_` is not allowed within types on item signatures
+    //~| ERROR: has a `&self` declaration in the trait, but not in the impl
+}
+
+fn main() {}

--- a/tests/ui/traits/method-argument-mismatch-variance-ice-119867.stderr
+++ b/tests/ui/traits/method-argument-mismatch-variance-ice-119867.stderr
@@ -1,0 +1,24 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/method-argument-mismatch-variance-ice-119867.rs:8:23
+   |
+LL |     fn deserialize(s: _) {}
+   |                       ^ not allowed in type signatures
+   |
+help: try replacing `_` with the type in the corresponding trait method signature
+   |
+LL |     fn deserialize(s: &ArchivedVec<T>) {}
+   |                       ~~~~~~~~~~~~~~~
+
+error[E0186]: method `deserialize` has a `&self` declaration in the trait, but not in the impl
+  --> $DIR/method-argument-mismatch-variance-ice-119867.rs:8:5
+   |
+LL |     fn deserialize(&self);
+   |     ---------------------- `&self` used in trait
+...
+LL |     fn deserialize(s: _) {}
+   |     ^^^^^^^^^^^^^^^^^^^^ expected `&self` in impl
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0121, E0186.
+For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
We report an error right below for them, but that kind of broken type can cause subsequent ICEs.

fixes #119867