### PR TITLE
[WIP] Linker flavors: next steps

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2284,6 +2284,10 @@ fn add_order_independent_options(
     out_filename: &Path,
     tmpdir: &Path,
 ) {
+    if flavor.uses_clang() && sess.target.linker_flavor != sess.host.linker_flavor {
+        cmd.arg(format!("--target={}", sess.target.llvm_target));
+    }
+
     // Take care of the flavors and CLI options requesting the `lld` linker.
     add_lld_args(cmd, sess, flavor, self_contained_components);
 
@@ -3053,29 +3057,4 @@ fn add_lld_args(
     // 2. Implement the "linker flavor" part of this feature by asking `cc` to use some kind of
     // `lld` as the linker.
     cmd.arg("-fuse-ld=lld");
-
-    if !flavor.is_gnu() {
-        // Tell clang to use a non-default LLD flavor.
-        // Gcc doesn't understand the target option, but we currently assume
-        // that gcc is not used for Apple and Wasm targets (#97402).
-        //
-        // Note that we don't want to do that by default on macOS: e.g. passing a
-        // 10.7 target to LLVM works, but not to recent versions of clang/macOS, as
-        // shown in issue #101653 and the discussion in PR #101792.
-        //
-        // It could be required in some cases of cross-compiling with
-        // LLD, but this is generally unspecified, and we don't know
-        // which specific versions of clang, macOS SDK, host and target OS
-        // combinations impact us here.
-        //
-        // So we do a simple first-approximation until we know more of what the
-        // Apple targets require (and which would be handled prior to hitting this
-        // LLD codepath anyway), but the expectation is that until then
-        // this should be manually passed if needed. We specify the target when
-        // targeting a different linker flavor on macOS, and that's also always
-        // the case when targeting WASM.
-        if sess.target.linker_flavor != sess.host.linker_flavor {
-            cmd.arg(format!("--target={}", sess.target.llvm_target));
-        }
-    }
 }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -788,7 +788,7 @@ fn link_natively<'a>(
         // then it should not default to linking executables as pie. Different
         // versions of gcc seem to use different quotes in the error message so
         // don't check for them.
-        if matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))
+        if matches!(flavor, LinkerFlavor::Gnu(Cc::Yes | Cc::Clang, _))
             && unknown_arg_regex.is_match(&out)
             && out.contains("-no-pie")
             && cmd.get_args().iter().any(|e| e.to_string_lossy() == "-no-pie")
@@ -806,7 +806,7 @@ fn link_natively<'a>(
 
         // Detect '-static-pie' used with an older version of gcc or clang not supporting it.
         // Fallback from '-static-pie' to '-static' in that case.
-        if matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))
+        if matches!(flavor, LinkerFlavor::Gnu(Cc::Yes | Cc::Clang, _))
             && unknown_arg_regex.is_match(&out)
             && (out.contains("-static-pie") || out.contains("--no-dynamic-linker"))
             && cmd.get_args().iter().any(|e| e.to_string_lossy() == "-static-pie")
@@ -1318,6 +1318,10 @@ pub fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                             "cc"
                         }
                     }
+                    LinkerFlavor::Gnu(Cc::Clang, _)
+                    | LinkerFlavor::Darwin(Cc::Clang, _)
+                    | LinkerFlavor::WasmLld(Cc::Clang)
+                    | LinkerFlavor::Unix(Cc::Clang) => "clang",
                     LinkerFlavor::Gnu(_, Lld::Yes)
                     | LinkerFlavor::Darwin(_, Lld::Yes)
                     | LinkerFlavor::WasmLld(..)
@@ -1778,7 +1782,9 @@ fn add_pre_link_objects(
     let empty = Default::default();
     let objects = if self_contained {
         &opts.pre_link_objects_self_contained
-    } else if !(sess.target.os == "fuchsia" && matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))) {
+    } else if !(sess.target.os == "fuchsia"
+        && matches!(flavor, LinkerFlavor::Gnu(Cc::Yes | Cc::Clang, _)))
+    {
         &opts.pre_link_objects
     } else {
         &empty
@@ -2287,7 +2293,7 @@ fn add_order_independent_options(
 
     if sess.target.os == "fuchsia"
         && crate_type == CrateType::Executable
-        && !matches!(flavor, LinkerFlavor::Gnu(Cc::Yes, _))
+        && !matches!(flavor, LinkerFlavor::Gnu(Cc::Yes | Cc::Clang, _))
     {
         let prefix = if sess.opts.unstable_opts.sanitizer.contains(SanitizerSet::ADDRESS) {
             "asan/"
@@ -2923,7 +2929,7 @@ fn add_apple_sdk(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
     };
 
     match flavor {
-        LinkerFlavor::Darwin(Cc::Yes, _) => {
+        LinkerFlavor::Darwin(Cc::Yes | Cc::Clang, _) => {
             cmd.args(&["-isysroot", &sdk_root, "-Wl,-syslibroot", &sdk_root]);
         }
         LinkerFlavor::Darwin(Cc::No, _) => {

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_unknown.rs
@@ -35,15 +35,7 @@ pub fn target() -> Target {
             "--no-entry",
         ],
     );
-    options.add_pre_link_args(
-        LinkerFlavor::WasmLld(Cc::Yes),
-        &[
-            // Make sure clang uses LLD as its linker and is configured appropriately
-            // otherwise
-            "--target=wasm32-unknown-unknown",
-            "-Wl,--no-entry",
-        ],
-    );
+    options.add_pre_link_args(LinkerFlavor::WasmLld(Cc::Yes), &["-Wl,--no-entry"]);
 
     Target {
         llvm_target: "wasm32-unknown-unknown".into(),

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasi.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasi.rs
@@ -74,13 +74,12 @@
 
 use crate::spec::crt_objects;
 use crate::spec::LinkSelfContainedDefault;
-use crate::spec::{base, Cc, LinkerFlavor, Target};
+use crate::spec::{base, Target};
 
 pub fn target() -> Target {
     let mut options = base::wasm::options();
 
     options.os = "wasi".into();
-    options.add_pre_link_args(LinkerFlavor::WasmLld(Cc::Yes), &["--target=wasm32-wasi"]);
 
     options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();
     options.post_link_objects_self_contained = crt_objects::post_wasi_self_contained();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasi_preview1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasi_preview1_threads.rs
@@ -85,12 +85,7 @@ pub fn target() -> Target {
     );
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::Yes),
-        &[
-            "--target=wasm32-wasi-threads",
-            "-Wl,--import-memory",
-            "-Wl,--export-memory,",
-            "-Wl,--shared-memory",
-        ],
+        &["-Wl,--import-memory", "-Wl,--export-memory,", "-Wl,--shared-memory"],
     );
 
     options.pre_link_objects_self_contained = crt_objects::pre_wasi_self_contained();

--- a/compiler/rustc_target/src/spec/targets/wasm64_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm64_unknown_unknown.rs
@@ -22,15 +22,7 @@ pub fn target() -> Target {
             "-mwasm64",
         ],
     );
-    options.add_pre_link_args(
-        LinkerFlavor::WasmLld(Cc::Yes),
-        &[
-            // Make sure clang uses LLD as its linker and is configured appropriately
-            // otherwise
-            "--target=wasm64-unknown-unknown",
-            "-Wl,--no-entry",
-        ],
-    );
+    options.add_pre_link_args(LinkerFlavor::WasmLld(Cc::Yes), &["-Wl,--no-entry"]);
 
     // Any engine that implements wasm64 will surely implement the rest of these
     // features since they were all merged into the official spec by the time

--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -73,15 +73,21 @@ impl Target {
                 };
 
                 match self.linker_flavor {
-                    LinkerFlavor::Gnu(Cc::Yes, lld) => check_noncc(LinkerFlavor::Gnu(Cc::No, lld)),
-                    LinkerFlavor::WasmLld(Cc::Yes) => check_noncc(LinkerFlavor::WasmLld(Cc::No)),
-                    LinkerFlavor::Unix(Cc::Yes) => check_noncc(LinkerFlavor::Unix(Cc::No)),
+                    LinkerFlavor::Gnu(Cc::Yes | Cc::Clang, lld) => {
+                        check_noncc(LinkerFlavor::Gnu(Cc::No, lld))
+                    }
+                    LinkerFlavor::WasmLld(Cc::Yes | Cc::Clang) => {
+                        check_noncc(LinkerFlavor::WasmLld(Cc::No))
+                    }
+                    LinkerFlavor::Unix(Cc::Yes | Cc::Clang) => {
+                        check_noncc(LinkerFlavor::Unix(Cc::No))
+                    }
                     _ => {}
                 }
             }
 
             // Check that link args for lld and non-lld versions of flavors are consistent.
-            for cc in [Cc::No, Cc::Yes] {
+            for cc in [Cc::No, Cc::Yes, Cc::Clang] {
                 assert_eq!(
                     args.get(&LinkerFlavor::Gnu(cc, Lld::No)),
                     args.get(&LinkerFlavor::Gnu(cc, Lld::Yes)),

--- a/tests/run-make/rust-lld/Makefile
+++ b/tests/run-make/rust-lld/Makefile
@@ -4,5 +4,5 @@ include ../tools.mk
 # needs-rust-lld
 # ignore-s390x lld does not yet support s390x as target
 all:
-	RUSTC_LOG=rustc_codegen_ssa::back::link=info $(RUSTC) -Clink-self-contained=+linker -Clinker-flavor=gnu-lld-cc -Zunstable-options -Clink-args=-Wl,-v main.rs 2> $(TMPDIR)/output.txt
+	RUSTC_LOG=rustc_codegen_ssa::back::link=info $(RUSTC) -Clink-self-contained=+linker -Clinker-flavor=*-lld-cc -Zunstable-options -Clink-args=-Wl,-v main.rs 2> $(TMPDIR)/output.txt
 	$(CGREP) -e "^LLD [0-9]+\.[0-9]+\.[0-9]+" < $(TMPDIR)/output.txt

--- a/tests/ui/linkage-attr/incompatible-flavor.stderr
+++ b/tests/ui/linkage-attr/incompatible-flavor.stderr
@@ -1,6 +1,6 @@
 error: linker flavor `msvc` is incompatible with the current target
    |
-   = note: compatible flavors are: gnu, gnu-lld, gnu-cc, gnu-lld-cc, gcc, ld, ld.lld
+   = note: compatible flavors are: gnu, gnu-lld, gnu-cc, gnu-lld-cc, gnu-clang, gnu-lld-clang, gcc, ld, ld.lld
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
TODO: detailed description.

Features that may affect the naming scheme for linker flavors (at least those I'm aware of):
- 1. Clang linker flavors - allow supporting cross-linking automatically by passing `--target`, something that is not supported by gcc-style compilers.
- 2. Generic linker flavors like in https://github.com/rust-lang/rust/commit/364f36d9450ab3a1c16883c0df34f25f4cfd6a78, portable between targets.
- 3. A flavor for linking LLVM bitcode through rustc. It can be supported for all targets, I think - https://github.com/rust-lang/rust/pull/117458#issuecomment-1889150208.
- 4. Linker flavors that deviate from the default target's flavor in the main component, like `LinkerFlavor::Gnu` for a `LinkerFlavor::Msvc`-based target - https://github.com/rust-lang/rust/pull/110869. Even if it requires some special logic, that would still be less heavy weight than providing whole [separate targets](https://github.com/rust-lang/rust/pull/110869#issuecomment-1525982048) with their own CI and distributed binaries.

r? @lqd 
cc @jschwe