### PR TITLE
Allow unauthorized users to use the has-merge-commits label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -21,6 +21,7 @@ allow-unauthenticated = [
     "perf-*",
     "AsyncAwait-OnDeck",
     "needs-triage",
+    "has-merge-commits",
 ]
 
 [glacier]


### PR DESCRIPTION
So they can remove it after they've removed the merge commit.