### PR TITLE
std::net: bind update for using backlog as `-1` too.

### DIFF
--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -80,7 +80,12 @@ impl UnixListener {
                 target_os = "horizon"
             ))]
             const backlog: libc::c_int = 128;
-            #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd"))]
+            #[cfg(any(
+                target_os = "linux",
+                target_os = "freebsd",
+                target_os = "openbsd",
+                target_os = "macos"
+            ))]
             const backlog: libc::c_int = -1;
             #[cfg(not(any(
                 target_os = "windows",
@@ -88,6 +93,7 @@ impl UnixListener {
                 target_os = "linux",
                 target_os = "freebsd",
                 target_os = "openbsd",
+                target_os = "macos",
                 target_os = "espidf",
                 target_os = "horizon"
             )))]


### PR DESCRIPTION
Albeit not documented, macOs also support negative value for the backlog argument.

ref: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/kern/uipc_socket.c#L1061