### PR TITLE
Don't ICE when noting GAT bounds in `report_no_match_method_error`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -825,11 +825,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             "auto trait is invoked with no method error, but no error reported?",
                         );
                     }
-                    Some(Node::Item(hir::Item {
-                        ident,
-                        kind: hir::ItemKind::Trait(..) | hir::ItemKind::TraitAlias(..),
-                        ..
-                    })) => {
+                    Some(
+                        Node::Item(hir::Item {
+                            ident,
+                            kind: hir::ItemKind::Trait(..) | hir::ItemKind::TraitAlias(..),
+                            ..
+                        })
+                        // We may also encounter unsatisfied GAT or method bounds
+                        | Node::TraitItem(hir::TraitItem { ident, .. })
+                        | Node::ImplItem(hir::ImplItem { ident, .. }),
+                    ) => {
                         skip_list.insert(p);
                         let entry = spanned_predicates.entry(ident.span);
                         let entry = entry.or_insert_with(|| {
@@ -840,7 +845,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         entry.1.insert((cause_span, "unsatisfied trait bound introduced here"));
                         entry.2.push(p);
                     }
-                    Some(node) => unreachable!("encountered `{node:?}`"),
+                    Some(node) => unreachable!("encountered `{node:?}` due to `{cause:#?}`"),
                     None => (),
                 }
             }

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs
@@ -1,0 +1,33 @@
+use std::ops::Deref;
+
+trait PointerFamily {
+    type Pointer<T>: Deref<Target = T>;
+}
+
+struct RcFamily;
+
+impl PointerFamily for RcFamily {
+    type Pointer<T> = dyn Deref<Target = T>;
+    //~^ ERROR the size for values of type `(dyn Deref<Target = T> + 'static)` cannot be known at compilation time
+}
+
+enum Node<T, P: PointerFamily> {
+    Cons(T, P::Pointer<Node<T, P>>),
+    Nil,
+}
+
+type RcNode<T> = Node<T, RcFamily>;
+
+impl<T, P: PointerFamily> Node<T, P>
+where
+    P::Pointer<Node<T, P>>: Sized,
+{
+    fn new() -> P::Pointer<Self> {
+        todo!()
+    }
+}
+
+fn main() {
+    let mut list = RcNode::<i32>::new();
+    //~^ ERROR the size for values of type `Node<i32, RcFamily>` cannot be known at compilation time
+}

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
@@ -1,0 +1,52 @@
+error[E0277]: the size for values of type `(dyn Deref<Target = T> + 'static)` cannot be known at compilation time
+  --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:10:23
+   |
+LL |     type Pointer<T> = dyn Deref<Target = T>;
+   |                       ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Deref<Target = T> + 'static)`
+note: required by a bound in `PointerFamily::Pointer`
+  --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:4:5
+   |
+LL |     type Pointer<T>: Deref<Target = T>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PointerFamily::Pointer`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Pointer<T>: Deref<Target = T> + ?Sized;
+   |                                        ++++++++
+
+error[E0599]: the size for values of type `Node<i32, RcFamily>` cannot be known at compilation time
+  --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:31:35
+   |
+LL | enum Node<T, P: PointerFamily> {
+   | ------------------------------
+   | |
+   | variant or associated item `new` not found for this enum
+   | doesn't satisfy `Node<i32, RcFamily>: Sized`
+...
+LL |     let mut list = RcNode::<i32>::new();
+   |                                   ^^^ doesn't have a size known at compile-time
+  --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
+   |
+   = note: doesn't satisfy `_: Sized`
+   |
+note: trait bound `Node<i32, RcFamily>: Sized` was not satisfied
+  --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:4:18
+   |
+LL |     type Pointer<T>: Deref<Target = T>;
+   |          ------- ^ unsatisfied trait bound introduced here
+note: trait bound `(dyn Deref<Target = Node<i32, RcFamily>> + 'static): Sized` was not satisfied
+  --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:23:29
+   |
+LL | impl<T, P: PointerFamily> Node<T, P>
+   |                           ----------
+LL | where
+LL |     P::Pointer<Node<T, P>>: Sized,
+   |                             ^^^^^ unsatisfied trait bound introduced here
+note: the trait `Sized` must be implemented
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
We can encounter `BindingObligation`s from GATs that we should handle in `report_no_match_method_error`. I assume we can encounter them from methods, though I didn't really feel like wasting my time creating a repro.

Fixes #119942