### PR TITLE
Make sure to instantiate placeholders correctly in old solver

### DIFF
--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.current.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.current.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unifying-placeholders-in-query-response-2.rs:5:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.next.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unifying-placeholders-in-query-response-2.rs:5:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.rs
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response-2.rs
@@ -1,0 +1,23 @@
+// revisions: current next
+//[next] compile-flags: -Znext-solver
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete
+
+trait Id {
+    type Output: ?Sized;
+}
+
+impl<T: ?Sized> Id for T {
+    type Output = T;
+}
+
+trait Everyone {}
+impl<T: ?Sized> Everyone for T {}
+
+fn hello() where for<T> <T as Id>::Output: Everyone {}
+
+fn main() {
+    hello();
+}

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.current.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.current.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unifying-placeholders-in-query-response.rs:5:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.next.stderr
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.next.stderr
@@ -1,0 +1,11 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unifying-placeholders-in-query-response.rs:5:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.rs
+++ b/tests/ui/traits/non_lifetime_binders/unifying-placeholders-in-query-response.rs
@@ -1,0 +1,27 @@
+// revisions: current next
+//[next] compile-flags: -Znext-solver
+// check-pass
+
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete
+
+pub trait Foo<T: ?Sized> {
+    type Bar<K: ?Sized>: ?Sized;
+}
+
+impl Foo<usize> for () {
+    type Bar<K: ?Sized> = K;
+}
+
+pub fn f<T1, T2>(a: T1, b: T2)
+where
+    T1: for<T> Foo<usize, Bar<T> = T>,
+    T2: for<T> Foo<usize, Bar<T> = <T1 as Foo<usize>>::Bar<T>>,
+{
+}
+
+fn it_works() {
+    f((), ());
+}
+
+fn main() {}


### PR DESCRIPTION
When creating the query substitution guess for an input placeholder type like `!1_T` (in universe 1), we were guessing the response substitution with something like `!0_T`. This failed to unify with `!1_T`, causing an ICE.

This PR reworks the query substitution guess code to work a bit more like the new solver. I'm *pretty* sure this is correct, though I'd really appreciate some scrutiny from someone (*cough* lcnr) who knows a bit more about query instantiation :)

Fixes #119941

r? lcnr