### PR TITLE
Add note on SpecOptionPartialEq to `newtype_index`

### DIFF
--- a/compiler/rustc_index_macros/src/lib.rs
+++ b/compiler/rustc_index_macros/src/lib.rs
@@ -31,6 +31,9 @@ mod newtype;
 /// - `#[max = 0xFFFF_FFFD]`: specifies the max value, which allows niche
 ///   optimizations. The default max value is 0xFFFF_FF00.
 /// - `#[gate_rustc_only]`: makes parts of the generated code nightly-only.
+///
+/// `SpecOptionPartialEq` is specialized by this macro, so using it requires enabling
+/// `#![feature(min_specialization)]` for the crate.
 #[proc_macro]
 #[cfg_attr(
     feature = "nightly",

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2147,6 +2147,7 @@ impl<T: PartialEq> PartialEq for Option<T> {
 ///
 /// Once that's fixed, `Option` should go back to deriving `PartialEq`, as
 /// it used to do before <https://github.com/rust-lang/rust/pull/103556>.
+/// The comment regarding this trait on the `newtype_index` macro should be removed if this is done.
 #[unstable(feature = "spec_option_partial_eq", issue = "none", reason = "exposed only for rustc")]
 #[doc(hidden)]
 pub trait SpecOptionPartialEq: Sized {


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.60SpecOptionPartialEq.60.20error

r? @nnethercote 