### PR TITLE
Split out `option::unwrap_failed` like we have `result::unwrap_failed`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -921,14 +921,14 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.unwrap(), "air"); // fails
     /// ```
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     pub const fn unwrap(self) -> T {
         match self {
             Some(val) => val,
-            None => panic("called `Option::unwrap()` on a `None` value"),
+            None => unwrap_failed(),
         }
     }
 
@@ -1968,6 +1968,14 @@ impl<T, E> Option<Result<T, E>> {
             None => Ok(None),
         }
     }
+}
+
+#[cfg_attr(not(feature = "panic_immediate_abort"), inline(never))]
+#[cfg_attr(feature = "panic_immediate_abort", inline)]
+#[cold]
+#[track_caller]
+const fn unwrap_failed() -> ! {
+    panic("called `Option::unwrap()` on a `None` value")
 }
 
 // This is a separate function to reduce the code size of .expect() itself.

--- a/tests/codegen/debuginfo-inline-callsite-location.rs
+++ b/tests/codegen/debuginfo-inline-callsite-location.rs
@@ -4,9 +4,9 @@
 // can correctly merge the debug info if it merges the inlined code (e.g., for merging of tail
 // calls to panic.
 
-// CHECK:       tail call void @_ZN4core9panicking5panic17h{{([0-9a-z]{16})}}E
+// CHECK:       tail call void @_ZN4core6option13unwrap_failed17h{{([0-9a-z]{16})}}E
 // CHECK-SAME:  !dbg ![[#first_dbg:]]
-// CHECK:       tail call void @_ZN4core9panicking5panic17h{{([0-9a-z]{16})}}E
+// CHECK:       tail call void @_ZN4core6option13unwrap_failed17h{{([0-9a-z]{16})}}E
 // CHECK-SAME:  !dbg ![[#second_dbg:]]
 
 // CHECK-DAG:   ![[#func_dbg:]] = distinct !DISubprogram(name: "unwrap<i32>"

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
@@ -51,7 +51,7 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb4: {
-        _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind unreachable;
+        _7 = option::unwrap_failed() -> unwind unreachable;
     }
 
     bb5: {

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
@@ -51,7 +51,7 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb4: {
-        _7 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind continue;
+        _7 = option::unwrap_failed() -> unwind continue;
     }
 
     bb5: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -62,7 +62,7 @@
       }
   
       bb1: {
-          _11 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind unreachable;
+          _11 = option::unwrap_failed() -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -60,7 +60,7 @@
       }
   
       bb2: {
-          _11 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind continue;
+          _11 = option::unwrap_failed() -> unwind continue;
       }
   
       bb3: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -62,7 +62,7 @@
       }
   
       bb1: {
-          _11 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind unreachable;
+          _11 = option::unwrap_failed() -> unwind unreachable;
       }
   
       bb2: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -60,7 +60,7 @@
       }
   
       bb2: {
-          _11 = core::panicking::panic(const "called `Option::unwrap()` on a `None` value") -> unwind continue;
+          _11 = option::unwrap_failed() -> unwind continue;
       }
   
       bb3: {


### PR DESCRIPTION
...and like `option::expect_failed`