### PR TITLE
[meta] Clarify prioritization alert

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -383,7 +383,7 @@ message_on_add = """\
 - Priority?
 - Regression?
 - Notify people/groups?
-- Needs `I-nominated`?
+- Needs `I-{team}-nominated`?
 """
 message_on_remove = "Issue #{number}'s prioritization request has been removed."
 message_on_close = "Issue #{number} has been closed while requested for prioritization."


### PR DESCRIPTION
Apparently, there used to exist the label <kbd>I-nominated</kbd> judging from this entry:

https://github.com/rust-lang/rust/blob/8847bda592d940ae1f34d87d8cacdc09a9f787fa/triagebot.toml#L393

Since it was replaced with individual team labels, I think it makes sense to update the prioritization alert. Of course, it's not super important since the members of WG-prioritization already know that. This is just cleanup.

r? apiraino or wg-prioritization