### PR TITLE
Inline 2 functions that appear in dep-graph profiles.

### DIFF
--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -263,6 +263,7 @@ impl Parse for Newtype {
             impl std::ops::Add<usize> for #name {
                 type Output = Self;
 
+                #[inline]
                 fn add(self, other: usize) -> Self {
                     Self::from_usize(self.index() + other)
                 }

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -169,6 +169,7 @@ impl EdgeHeader {
     }
 }
 
+#[inline]
 fn mask(bits: usize) -> usize {
     usize::MAX >> ((std::mem::size_of::<usize>() * 8) - bits)
 }


### PR DESCRIPTION
Those functions are small enough not to deserve a dedicated symbol.