### PR TITLE
[meta] Remove Zulip rustdoc nomination alert

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -389,15 +389,6 @@ message_on_remove = "Issue #{number}'s prioritization request has been removed."
 message_on_close = "Issue #{number} has been closed while requested for prioritization."
 message_on_reopen = "Issue #{number} has been reopened."
 
-[notify-zulip."T-rustdoc"]
-required_labels = ["I-nominated"]
-zulip_stream = 266220 # #rustdoc
-topic = "nominated: #{number}"
-message_on_add = """\
-@*T-rustdoc* issue #{number} "{title}" has been nominated for `T-rustdoc` discussion.
-"""
-message_on_remove = "Issue #{number}'s nomination request has been removed."
-
 [notify-zulip."I-types-nominated"]
 zulip_stream = 326866 # #T-types/nominated
 topic = "#{number}: {title}"


### PR DESCRIPTION
There no longer exists the label <kbd>I-nominated</kbd>, it's no longer possible to trigger the Zulip nomination alert. Nowadays, there are separate <kbd>I-{team}-nominated</kbd> labels one for each team that makes use of such a nomination system.

Since t-rustdoc has never really used this nomination system, I figured I should remove it outright.

However, instead of that, I could also create the label <kbd>I-rustdoc-nominated</kbd> and adjust the triagebot entry. Whatever you prefer.

r? GuillaumeGomez or rustdoc