### PR TITLE
Fix `allow_internal_unstable` for `(min_)specialization`

### DIFF
--- a/compiler/rustc_index_macros/src/lib.rs
+++ b/compiler/rustc_index_macros/src/lib.rs
@@ -36,6 +36,9 @@ mod newtype;
     feature = "nightly",
     allow_internal_unstable(step_trait, rustc_attrs, trusted_step, spec_option_partial_eq)
 )]
+// FIXME: Remove the above comment about `min_specialization` once bootstrap is bumped,
+// and the corresponding one on SpecOptionPartialEq
+#[cfg_attr(all(feature = "nightly", not(bootstrap)), allow_internal_unstable(min_specialization))]
 pub fn newtype_index(input: TokenStream) -> TokenStream {
     newtype::newtype(input)
 }

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -142,23 +142,29 @@ pub fn translate_args_with_cause<'tcx>(
 pub(super) fn specializes(tcx: TyCtxt<'_>, (impl1_def_id, impl2_def_id): (DefId, DefId)) -> bool {
     // The feature gate should prevent introducing new specializations, but not
     // taking advantage of upstream ones.
+    // If specialization is enabled for this crate then no extra checks are needed.
+    // If it's not, and either of the `impl`s is local to this crate, then this definitely
+    // isn't specializing - unless specialization is enabled for the `impl` span,
+    // e.g. if it comes from an `allow_internal_unstable` macro
     let features = tcx.features();
     let specialization_enabled = features.specialization || features.min_specialization;
-    if !specialization_enabled && impl1_def_id.is_local() {
-        let span = tcx.def_span(impl1_def_id);
-        if !span.allows_unstable(sym::specialization)
-            && !span.allows_unstable(sym::min_specialization)
-        {
-            return false;
+    if !specialization_enabled {
+        if impl1_def_id.is_local() {
+            let span = tcx.def_span(impl1_def_id);
+            if !span.allows_unstable(sym::specialization)
+                && !span.allows_unstable(sym::min_specialization)
+            {
+                return false;
+            }
         }
-    }
 
-    if !specialization_enabled && impl2_def_id.is_local() {
-        let span = tcx.def_span(impl2_def_id);
-        if !span.allows_unstable(sym::specialization)
-            && !span.allows_unstable(sym::min_specialization)
-        {
-            return false;
+        if impl2_def_id.is_local() {
+            let span = tcx.def_span(impl2_def_id);
+            if !span.allows_unstable(sym::specialization)
+                && !span.allows_unstable(sym::min_specialization)
+            {
+                return false;
+            }
         }
     }
 

--- a/tests/ui/specialization/allow_internal_unstable.rs
+++ b/tests/ui/specialization/allow_internal_unstable.rs
@@ -1,0 +1,18 @@
+// check-pass
+// test for #119950
+// compile-flags: --crate-type lib
+
+#![allow(internal_features)]
+#![feature(allow_internal_unstable)]
+
+#[allow_internal_unstable(min_specialization)]
+macro_rules! test {
+    () => {
+        struct T<U>(U);
+        trait Tr {}
+        impl<U> Tr for T<U> {}
+        impl Tr for T<u8> {}
+    }
+}
+
+test! {}


### PR DESCRIPTION
Fixes #119950

Blocked on #119949 (comment doesn't make sense until that merges)

I'd like to follow this up and look for more instances of not properly checking spans for features but I wanted to fix the motivating issue.