### PR TITLE
Don't ICE if TAIT-defining fn contains a closure with `_` in return type

### DIFF
--- a/tests/ui/type-alias-impl-trait/closure_infer.rs
+++ b/tests/ui/type-alias-impl-trait/closure_infer.rs
@@ -1,0 +1,35 @@
+// check-pass
+
+// Regression test for an ICE: https://github.com/rust-lang/rust/issues/119916
+
+#![feature(impl_trait_in_assoc_type)]
+#![feature(type_alias_impl_trait)]
+
+// `impl_trait_in_assoc_type` example from the bug report.
+pub trait StreamConsumer {
+    type BarrierStream;
+    fn execute() -> Self::BarrierStream;
+}
+
+pub struct DispatchExecutor;
+
+impl StreamConsumer for DispatchExecutor {
+    type BarrierStream = impl Sized;
+    fn execute() -> Self::BarrierStream {
+        || -> _ {}
+    }
+}
+
+// Functions that constrain TAITs can contain closures with an `_` in the return type.
+type Foo = impl Sized;
+fn foo() -> Foo {
+    || -> _ {}
+}
+
+// The `_` in the closure return type can also be the TAIT itself.
+type Bar = impl Sized;
+fn bar() -> impl FnOnce() -> Bar {
+    || -> _ {}
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -12,3 +12,8 @@ fn test() -> Pointer<_> {
 fn main() {
     test();
 }
+
+extern "Rust" {
+    fn bar() -> Pointer<_>;
+    //~^ ERROR: the placeholder `_` is not allowed within types
+}

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -7,6 +7,15 @@ LL | fn test() -> Pointer<_> {
    |              |       not allowed in type signatures
    |              help: replace with the correct return type: `Pointer<i32>`
 
-error: aborting due to 1 previous error
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/issue-77179.rs:17:25
+   |
+LL |     fn bar() -> Pointer<_>;
+   |                         ^
+   |                         |
+   |                         not allowed in type signatures
+   |                         help: use type parameters instead: `T`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
The `delay_span_bug` got added in https://github.com/rust-lang/rust/pull/119803/commits/0e82aaeb6799041991c54fb9ff37b5c20a5c6146 to reduce the amount of errors emitted for functions that have `_` in their return type, because inference doesn't apply to function items. But this logic shouldn't apply to closures, because their return types *can* be inferred.

Fixes https://github.com/rust-lang/rust/issues/119916.