### PR TITLE
Change return type of unstable `Waker::noop()` from `Waker` to `&Waker`.

### DIFF
--- a/library/core/tests/async_iter/mod.rs
+++ b/library/core/tests/async_iter/mod.rs
@@ -7,8 +7,7 @@ fn into_async_iter() {
     let async_iter = async_iter::from_iter(0..3);
     let mut async_iter = pin!(async_iter.into_async_iter());
 
-    let waker = core::task::Waker::noop();
-    let mut cx = &mut core::task::Context::from_waker(&waker);
+    let mut cx = &mut core::task::Context::from_waker(core::task::Waker::noop());
 
     assert_eq!(async_iter.as_mut().poll_next(&mut cx), Poll::Ready(Some(0)));
     assert_eq!(async_iter.as_mut().poll_next(&mut cx), Poll::Ready(Some(1)));

--- a/src/tools/miri/tests/pass/async-fn.rs
+++ b/src/tools/miri/tests/pass/async-fn.rs
@@ -76,8 +76,7 @@ async fn uninhabited_variant() {
 fn run_fut<T>(fut: impl Future<Output = T>) -> T {
     use std::task::{Context, Poll, Waker};
 
-    let waker = Waker::noop();
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
 
     let mut pinned = Box::pin(fut);
     loop {

--- a/src/tools/miri/tests/pass/dyn-star.rs
+++ b/src/tools/miri/tests/pass/dyn-star.rs
@@ -93,8 +93,7 @@ fn dispatch_on_pin_mut() {
     let mut fut = async_main();
 
     // Poll loop, just to test the future...
-    let waker = Waker::noop();
-    let ctx = &mut Context::from_waker(&waker);
+    let ctx = &mut Context::from_waker(Waker::noop());
 
     loop {
         match unsafe { Pin::new_unchecked(&mut fut).poll(ctx) } {

--- a/src/tools/miri/tests/pass/future-self-referential.rs
+++ b/src/tools/miri/tests/pass/future-self-referential.rs
@@ -77,8 +77,7 @@ impl Future for DoStuff {
 }
 
 fn run_fut<T>(fut: impl Future<Output = T>) -> T {
-    let waker = Waker::noop();
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
 
     let mut pinned = pin!(fut);
     loop {
@@ -90,8 +89,7 @@ fn run_fut<T>(fut: impl Future<Output = T>) -> T {
 }
 
 fn self_referential_box() {
-    let waker = Waker::noop();
-    let cx = &mut Context::from_waker(&waker);
+    let cx = &mut Context::from_waker(Waker::noop());
 
     async fn my_fut() -> i32 {
         let val = 10;

--- a/src/tools/miri/tests/pass/issues/issue-miri-2068.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-2068.rs
@@ -6,8 +6,7 @@ use std::task::{Context, Poll, Waker};
 
 pub fn fuzzing_block_on<O, F: Future<Output = O>>(fut: F) -> O {
     let mut fut = std::pin::pin!(fut);
-    let waker = Waker::noop();
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
     loop {
         match fut.as_mut().poll(&mut context) {
             Poll::Ready(v) => return v,

--- a/src/tools/miri/tests/pass/move-data-across-await-point.rs
+++ b/src/tools/miri/tests/pass/move-data-across-await-point.rs
@@ -56,8 +56,7 @@ fn data_moved() {
 fn run_fut<T>(fut: impl Future<Output = T>) -> T {
     use std::task::{Context, Poll, Waker};
 
-    let waker = Waker::noop();
-    let mut context = Context::from_waker(&waker);
+    let mut context = Context::from_waker(Waker::noop());
 
     let mut pinned = Box::pin(fut);
     loop {

--- a/tests/coverage/async.coverage
+++ b/tests/coverage/async.coverage
@@ -117,8 +117,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let waker = Waker::noop();
-   LL|       |        let mut context = Context::from_waker(&waker);
+   LL|       |        let mut context = Context::from_waker(Waker::noop());
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async.rs
+++ b/tests/coverage/async.rs
@@ -110,8 +110,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let waker = Waker::noop();
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async2.coverage
+++ b/tests/coverage/async2.coverage
@@ -41,8 +41,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let waker = Waker::noop();
-   LL|       |        let mut context = Context::from_waker(&waker);
+   LL|       |        let mut context = Context::from_waker(Waker::noop());
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async2.rs
+++ b/tests/coverage/async2.rs
@@ -39,8 +39,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let waker = Waker::noop();
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async_block.coverage
+++ b/tests/coverage/async_block.coverage
@@ -24,8 +24,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let waker = Waker::noop();
-   LL|       |        let mut context = Context::from_waker(&waker);
+   LL|       |        let mut context = Context::from_waker(Waker::noop());
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/async_block.rs
+++ b/tests/coverage/async_block.rs
@@ -23,8 +23,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let waker = Waker::noop();
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/closure_macro_async.coverage
+++ b/tests/coverage/closure_macro_async.coverage
@@ -54,8 +54,7 @@
    LL|       |    #[coverage(off)]
    LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
    LL|       |        let mut future = pin!(future);
-   LL|       |        let waker = Waker::noop();
-   LL|       |        let mut context = Context::from_waker(&waker);
+   LL|       |        let mut context = Context::from_waker(Waker::noop());
    LL|       |
    LL|       |        loop {
    LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/coverage/closure_macro_async.rs
+++ b/tests/coverage/closure_macro_async.rs
@@ -53,8 +53,7 @@ mod executor {
     #[coverage(off)]
     pub fn block_on<F: Future>(mut future: F) -> F::Output {
         let mut future = pin!(future);
-        let waker = Waker::noop();
-        let mut context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(Waker::noop());
 
         loop {
             if let Poll::Ready(val) = future.as_mut().poll(&mut context) {

--- a/tests/ui/async-await/for-await-passthrough.rs
+++ b/tests/ui/async-await/for-await-passthrough.rs
@@ -25,8 +25,7 @@ async fn real_main() {
 
 fn main() {
     let future = real_main();
-    let waker = std::task::Waker::noop();
-    let mut cx = &mut core::task::Context::from_waker(&waker);
+    let mut cx = &mut core::task::Context::from_waker(std::task::Waker::noop());
     let mut future = core::pin::pin!(future);
     while let core::task::Poll::Pending = future.as_mut().poll(&mut cx) {}
 }

--- a/tests/ui/async-await/for-await.rs
+++ b/tests/ui/async-await/for-await.rs
@@ -17,8 +17,7 @@ async fn real_main() {
 
 fn main() {
     let future = real_main();
-    let waker = std::task::Waker::noop();
-    let mut cx = &mut core::task::Context::from_waker(&waker);
+    let mut cx = &mut core::task::Context::from_waker(std::task::Waker::noop());
     let mut future = core::pin::pin!(future);
     while let core::task::Poll::Pending = future.as_mut().poll(&mut cx) {}
 }

--- a/tests/ui/async-await/in-trait/async-default-fn-overridden.rs
+++ b/tests/ui/async-await/in-trait/async-default-fn-overridden.rs
@@ -40,8 +40,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = Waker::noop();
-    let ctx = &mut Context::from_waker(&waker);
+    let ctx = &mut Context::from_waker(Waker::noop());
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
@@ -43,8 +43,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = Waker::noop();
-    let ctx = &mut Context::from_waker(&waker);
+    let ctx = &mut Context::from_waker(Waker::noop());
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
+++ b/tests/ui/async-await/in-trait/dont-project-to-specializable-projection.stderr
@@ -21,7 +21,7 @@ LL |     default async fn foo(_: T) -> &'static str {
    = note: specialization behaves in inconsistent and surprising ways with async functions in traits, and for now is disallowed
 
 error[E0599]: no method named `poll` found for struct `Pin<&mut impl Future<Output = ()>>` in the current scope
-  --> $DIR/dont-project-to-specializable-projection.rs:50:28
+  --> $DIR/dont-project-to-specializable-projection.rs:49:28
    |
 LL |         match fut.as_mut().poll(ctx) {
    |                            ^^^^ method not found in `Pin<&mut impl Future<Output = ()>>`

--- a/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
+++ b/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
@@ -11,7 +11,6 @@ async gen fn gen_fn() -> &'static str {
 
 pub fn main() {
     let async_iterator = pin!(gen_fn());
-    let waker = Waker::noop();
-    let ctx = &mut Context::from_waker(&waker);
+    let ctx = &mut Context::from_waker(Waker::noop());
     async_iterator.poll_next(ctx);
 }

--- a/tests/ui/coroutine/async_gen_fn_iter.rs
+++ b/tests/ui/coroutine/async_gen_fn_iter.rs
@@ -74,8 +74,7 @@ fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = Waker::noop();
-    let ctx = &mut Context::from_waker(&waker);
+    let ctx = &mut Context::from_waker(Waker::noop());
 
     loop {
         match fut.as_mut().poll(ctx) {

--- a/tests/ui/dyn-star/dispatch-on-pin-mut.rs
+++ b/tests/ui/dyn-star/dispatch-on-pin-mut.rs
@@ -19,15 +19,14 @@ async fn async_main() {
 // ------------------------------------------------------------------------- //
 // Implementation Details Below...
 
-use std::task::*;
 use std::pin::pin;
+use std::task::*;
 
 fn main() {
     let mut fut = pin!(async_main());
 
     // Poll loop, just to test the future...
-    let waker = Waker::noop();
-    let ctx = &mut Context::from_waker(&waker);
+    let ctx = &mut Context::from_waker(Waker::noop());
 
     loop {
         match fut.as_mut().poll(ctx) {


### PR DESCRIPTION
The advantage of this is that it does not need to be assigned to a variable to be used in a `Context` creation, which is the most common thing to want to do with a noop waker. It also avoids unnecessarily executing the dynamically dispatched drop function when the noop waker is dropped.

If an owned noop waker is desired, it can be created by cloning, but the reverse is harder to do since it requires declaring a constant. Alternatively, both versions could be provided, like `futures::task::noop_waker()` and `futures::task::noop_waker_ref()`, but that seems to me to be API clutter for a very small benefit, whereas having the `&'static` reference available is a large reduction in boilerplate.

[Previous discussion on the tracking issue starting here](https://github.com/rust-lang/rust/issues/98286#issuecomment-1862159766)