### PR TITLE
dump-ice-to-disk/check.sh: convert needless bashism in a /bin/sh script.

### DIFF
--- a/tests/run-make/dump-ice-to-disk/check.sh
+++ b/tests/run-make/dump-ice-to-disk/check.sh
@@ -53,8 +53,8 @@ echo $should_be_empty_tmp
 if [ $short -eq $default_set ] &&
     #[ $default -eq $short ] &&
     [ $default_set -eq $full ] &&
-    [[ $content == *"thread 'rustc' panicked at "* ]] &&
-    [[ $content == *"stack backtrace:"* ]] &&
+    [ "${content%%*"thread 'rustc' panicked at "*} != "$content" ] &&
+    [ "${content%%*"stack backtrace:"*}" != "$content" ] &&
     #[ $default -gt 0 ] &&
     [ $should_be_empty_dot -eq 0 ] &&
     [ $should_be_empty_tmp -eq 0 ]; then

--- a/tests/run-make/dump-ice-to-disk/check.sh
+++ b/tests/run-make/dump-ice-to-disk/check.sh
@@ -53,7 +53,7 @@ echo $should_be_empty_tmp
 if [ $short -eq $default_set ] &&
     #[ $default -eq $short ] &&
     [ $default_set -eq $full ] &&
-    [ "${content%%*"thread 'rustc' panicked at "*} != "$content" ] &&
+    [ "${content%%*"thread 'rustc' panicked at "*}" != "$content" ] &&
     [ "${content%%*"stack backtrace:"*}" != "$content" ] &&
     #[ $default -gt 0 ] &&
     [ $should_be_empty_dot -eq 0 ] &&


### PR DESCRIPTION
This script is marked with `#! /bin/sh`, but uses Bash-only constructs ("bashisms").
In this case there is a corresponding portable POSIX shell construct, and this
change converts to use that, instead of insisting that `/bin/sh` must be Bash.
