### PR TITLE
Consistently unset RUSTC_BOOTSTRAP when compiling bootstrap

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -917,6 +917,19 @@ class RustBuild(object):
             if toml_val is not None:
                 env["{}_{}".format(var_name, host_triple_sanitized)] = toml_val
 
+        # In src/etc/rust_analyzer_settings.json, we configure rust-analyzer to
+        # pass RUSTC_BOOTSTRAP=1 to all cargo invocations because the standard
+        # library uses unstable Cargo features. Without RUSTC_BOOTSTRAP,
+        # rust-analyzer would fail to fetch workspace layout when the system's
+        # default toolchain is not nightly.
+        #
+        # But that setting has the collateral effect of rust-analyzer also
+        # passing RUSTC_BOOTSTRAP=1 to all x.py invocations too (the various
+        # overrideCommand). For compiling bootstrap, that is unwanted and can
+        # cause spurious rebuilding of bootstrap when rust-analyzer x.py
+        # invocations are interleaved with handwritten ones on the command line.
+        env.pop("RUSTC_BOOTSTRAP", None)
+
         # preserve existing RUSTFLAGS
         env.setdefault("RUSTFLAGS", "")
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/113906, all x.py invocations performed by rust-analyzer have RUSTC_BOOTSTRAP=1 set. This was to fix https://github.com/rust-lang/rust/issues/112391#issuecomment-1597224941 &mdash; rust-analyzer uses some default cargo from the system when fetching workspace layout, and the standard library uses some unstable cargo feature, so x.py would previously fail if the system toolchain wasn't nightly.

https://github.com/rust-lang/rust/blob/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/Cargo.toml#L1

This PR changes x.py to cancel out this RUSTC_BOOTSTRAP=1 when compiling bootstrap. It will only remain set when running the compiled bootstrap executable. This fixes spurious bootstrap rebuilds in the event that a rust-analyzer x.py invocation is alternated with someone running x.py themself on the command line, if any dependency of bootstrap looks at `option_env!("RUSTC_BOOTSTRAP")`, which is the case since https://github.com/rust-lang/rust/pull/119654.

**Before:**

```console
$ RUSTC_BOOTSTRAP=1 ./x.py check library/core
Building bootstrap
   Compiling proc-macro2 v1.0.76
   Compiling quote v1.0.35
   Compiling syn v2.0.48
   Compiling clap_derive v4.4.7
   Compiling serde_derive v1.0.195
   Compiling clap v4.4.13
   Compiling clap_complete v4.4.6
   Compiling build_helper v0.1.0
   Compiling bootstrap v0.0.0
    Finished dev [unoptimized] target(s) in 6.31s
Checking stage0 library artifacts {core} (x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 0.23s
Build completed successfully in 0:00:07

$ ./x.py check library/core
Building bootstrap
   Compiling proc-macro2 v1.0.76
   Compiling quote v1.0.35
   Compiling syn v2.0.48
   Compiling clap_derive v4.4.7
   Compiling serde_derive v1.0.195
   Compiling clap v4.4.13
   Compiling clap_complete v4.4.6
   Compiling build_helper v0.1.0
   Compiling bootstrap v0.0.0
    Finished dev [unoptimized] target(s) in 5.30s
Checking stage0 library artifacts {core} (x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 0.25s
Build completed successfully in 0:00:06
```

**After:**

```console
$ RUSTC_BOOTSTRAP=1 ./x.py check library/core
Building bootstrap
    Finished dev [unoptimized] target(s) in 0.06s
Checking stage0 library artifacts {core} (x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 0.14s
Build completed successfully in 0:00:01

$ ./x.py check library/core
Building bootstrap
    Finished dev [unoptimized] target(s) in 0.04s
Checking stage0 library artifacts {core} (x86_64-unknown-linux-gnu)
    Finished release [optimized] target(s) in 0.13s
Build completed successfully in 0:00:01
```