### PR TITLE
Ternary operation macro for Rust

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1540,6 +1540,48 @@ pub(crate) mod builtin {
         ($cond:expr, $($arg:tt)+) => {{ /* compiler built-in */ }};
     }
 
+    /// Recursive ternary operation for terse if-else statements.
+    ///
+    /// # Uses
+    ///
+    /// Provides brief if-else statement syntax similar to other languages.
+    ///
+    /// Reducing the lines-of-code (LOC) of chained if-else conditional
+    /// statements while improving the overall readability.
+    ///
+    /// Other use-cases of `ifelse!` include providing natural recursion of chained
+    /// conditional branches.
+    ///
+    /// If only a value is entered, that value is returned. This is necessary to
+    /// capture false statement remainders.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // A single if-else statement.
+    /// ifelse!(1 < 0, true, false);
+    ///
+    /// // Chained if-else statements.
+    /// ifelse!(1 < 0, true, 1 > 0, true, false);
+    /// ifelse!(1 < 0, true, 0 > 1, true, false);
+    /// ifelse!(1 < 0, true, 0 > 1, false, 0 != 0, 1, 0);
+    ///
+    /// // A single input returns itself.
+    /// assert!(ifelse!(false), false);
+    /// ```
+    #[rustc_builtin_macro]
+    #[macro_export]
+    macro_rules! ifelse {
+        ($cond:expr , $true_expr:expr , $($arg:tt)*) => {
+            if $cond {
+                $true_expr
+            } else {
+                ifelse!($($arg)*)
+            }
+        };
+        ($false_expr:expr) => ($false_expr);
+    }
+
     /// Prints passed tokens into the standard output.
     #[unstable(
         feature = "log_syntax",


### PR DESCRIPTION
There have been multiple community requests for a ternary operator in Rust.

This pull request provides a simple 10-line ternary operation macro defined using `macro_rules!`. It does not extend the Rust syntax and provides built-in support for recursion without additional macro calls.

Unlike other solutions out there, such as [terny](https://github.com/KaitlynEthylia/terny), [tern](https://github.com/lmburns/tern), [iffy](https://github.com/zfzackfrost/iffy-rs) and [ternop](https://github.com/spacekookie/ternop.rs), the provided solution is simpler and more closely matches a ternary operator design pattern.

Example usage:

```rust
// A single if-else statement.
ifelse!(1 < 0, true, false);

// Chained if-else statements.
ifelse!(1 < 0, true, 1 > 0, true, false);
ifelse!(1 < 0, true, 0 > 1, true, false);
ifelse!(1 < 0, true, 0 > 1, false, 0 != 0, 1, 0);

// A single input returns itself.
assert!(ifelse!(false), false);
```

The `ifelse!` macro is so useful for developer productivity that I propose making it a built-in macro.