### PR TITLE
Sort "the following types implement the trait" suggestion

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3081,6 +3081,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                         ))
                                     })
                                     .collect::<Vec<_>>();
+                                types.sort();
                                 let post = if types.len() > 9 {
                                     types.truncate(8);
                                     format!("\nand {} others", len - 8)


### PR DESCRIPTION
This should help external UI tests using `trybuild` by being less non-deterministic.

This is somewhat hard to reproduce, as it basically requires two different machines, but I've been consistently running into this for the past few months with the output from my CI differing from my local setup (example of a failed workflow in [here](https://github.com/madsmtm/objc2/actions/runs/7535570002/job/20511787869)).