### PR TITLE
coverage: Don't show coverage for code paths that must panic/diverge

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -52,19 +52,18 @@ impl CoverageGraph {
             }
         }
 
-        let mut basic_coverage_blocks =
-            Self { bcbs, bb_to_bcb, successors, predecessors, dominators: None };
-        let dominators = dominators::dominators(&basic_coverage_blocks);
-        basic_coverage_blocks.dominators = Some(dominators);
+        let mut this = Self { bcbs, bb_to_bcb, successors, predecessors, dominators: None };
+
+        this.dominators = Some(dominators::dominators(&this));
 
         // The coverage graph's entry-point node (bcb0) always starts with bb0,
         // which never has predecessors. Any other blocks merged into bcb0 can't
         // have multiple (coverage-relevant) predecessors, so bcb0 always has
         // zero in-edges.
-        assert!(basic_coverage_blocks[START_BCB].leader_bb() == mir::START_BLOCK);
-        assert!(basic_coverage_blocks.predecessors[START_BCB].is_empty());
+        assert!(this[START_BCB].leader_bb() == mir::START_BLOCK);
+        assert!(this.predecessors[START_BCB].is_empty());
 
-        basic_coverage_blocks
+        this
     }
 
     fn compute_basic_coverage_blocks(

--- a/tests/coverage/abort.cov-map
+++ b/tests/coverage/abort.cov-map
@@ -44,14 +44,13 @@ Number of file 0 mappings: 13
 - Code(Counter(3)) at (prev + 2, 5) to (start + 1, 2)
 
 Function name: abort::might_abort
-Raw bytes (21): 0x[01, 01, 01, 01, 05, 03, 01, 04, 01, 01, 14, 05, 02, 09, 01, 24, 02, 02, 0c, 03, 02]
+Raw bytes (16): 0x[01, 01, 01, 01, 05, 02, 01, 04, 01, 01, 14, 02, 04, 0c, 03, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 3
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 4, 1) to (start + 1, 20)
-- Code(Counter(1)) at (prev + 2, 9) to (start + 1, 36)
-- Code(Expression(0, Sub)) at (prev + 2, 12) to (start + 3, 2)
+- Code(Expression(0, Sub)) at (prev + 4, 12) to (start + 3, 2)
     = (c0 - c1)
 

--- a/tests/coverage/abort.coverage
+++ b/tests/coverage/abort.coverage
@@ -3,8 +3,8 @@
    LL|       |
    LL|     12|extern "C" fn might_abort(should_abort: bool) {
    LL|     12|    if should_abort {
-   LL|      0|        println!("aborting...");
-   LL|      0|        panic!("panics and aborts");
+   LL|       |        println!("aborting...");
+   LL|       |        panic!("panics and aborts");
    LL|     12|    } else {
    LL|     12|        println!("Don't Panic");
    LL|     12|    }

--- a/tests/coverage/assert.cov-map
+++ b/tests/coverage/assert.cov-map
@@ -27,14 +27,11 @@ Number of file 0 mappings: 9
 - Code(Counter(4)) at (prev + 2, 5) to (start + 1, 2)
 
 Function name: assert::might_fail_assert
-Raw bytes (21): 0x[01, 01, 01, 01, 05, 03, 01, 04, 01, 02, 0f, 02, 02, 25, 00, 3d, 05, 01, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 04, 01, 02, 0f, 05, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 1
-- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 3
+Number of expressions: 0
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 4, 1) to (start + 2, 15)
-- Code(Expression(0, Sub)) at (prev + 2, 37) to (start + 0, 61)
-    = (c0 - c1)
-- Code(Counter(1)) at (prev + 1, 1) to (start + 0, 2)
+- Code(Counter(1)) at (prev + 3, 1) to (start + 0, 2)
 

--- a/tests/coverage/assert.coverage
+++ b/tests/coverage/assert.coverage
@@ -4,7 +4,6 @@
    LL|      4|fn might_fail_assert(one_plus_one: u32) {
    LL|      4|    println!("does 1 + 1 = {}?", one_plus_one);
    LL|      4|    assert_eq!(1 + 1, one_plus_one, "the argument was wrong");
-                                                  ^1
    LL|      3|}
    LL|       |
    LL|      1|fn main() -> Result<(), u8> {

--- a/tests/coverage/bad_counter_ids.cov-map
+++ b/tests/coverage/bad_counter_ids.cov-map
@@ -8,16 +8,13 @@ Number of file 0 mappings: 2
 - Code(Zero) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::eq_bad_message
-Raw bytes (21): 0x[01, 01, 01, 01, 00, 03, 01, 29, 01, 02, 0f, 02, 02, 20, 00, 2b, 00, 01, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 29, 01, 02, 0f, 00, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 1
-- expression 0 operands: lhs = Counter(0), rhs = Zero
-Number of file 0 mappings: 3
+Number of expressions: 0
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 41, 1) to (start + 2, 15)
-- Code(Expression(0, Sub)) at (prev + 2, 32) to (start + 0, 43)
-    = (c0 - Zero)
-- Code(Zero) at (prev + 1, 1) to (start + 0, 2)
+- Code(Zero) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::eq_good
 Raw bytes (14): 0x[01, 01, 00, 02, 01, 10, 01, 02, 1f, 05, 03, 01, 00, 02]
@@ -29,14 +26,13 @@ Number of file 0 mappings: 2
 - Code(Counter(1)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::eq_good_message
-Raw bytes (19): 0x[01, 01, 00, 03, 01, 15, 01, 02, 0f, 00, 02, 20, 00, 2b, 05, 01, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 15, 01, 02, 0f, 05, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 3
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 21, 1) to (start + 2, 15)
-- Code(Zero) at (prev + 2, 32) to (start + 0, 43)
-- Code(Counter(1)) at (prev + 1, 1) to (start + 0, 2)
+- Code(Counter(1)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::ne_bad
 Raw bytes (14): 0x[01, 01, 00, 02, 01, 2e, 01, 02, 1f, 00, 03, 01, 00, 02]
@@ -48,14 +44,13 @@ Number of file 0 mappings: 2
 - Code(Zero) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::ne_bad_message
-Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 02, 0f, 05, 02, 20, 00, 2b, 00, 01, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 33, 01, 02, 0f, 00, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
-Number of file 0 mappings: 3
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 51, 1) to (start + 2, 15)
-- Code(Counter(1)) at (prev + 2, 32) to (start + 0, 43)
-- Code(Zero) at (prev + 1, 1) to (start + 0, 2)
+- Code(Zero) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::ne_good
 Raw bytes (16): 0x[01, 01, 01, 01, 00, 02, 01, 1a, 01, 02, 1f, 02, 03, 01, 00, 02]
@@ -69,14 +64,13 @@ Number of file 0 mappings: 2
     = (c0 - Zero)
 
 Function name: bad_counter_ids::ne_good_message
-Raw bytes (21): 0x[01, 01, 01, 01, 00, 03, 01, 1f, 01, 02, 0f, 00, 02, 20, 00, 2b, 02, 01, 01, 00, 02]
+Raw bytes (16): 0x[01, 01, 01, 01, 00, 02, 01, 1f, 01, 02, 0f, 02, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Zero
-Number of file 0 mappings: 3
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 31, 1) to (start + 2, 15)
-- Code(Zero) at (prev + 2, 32) to (start + 0, 43)
-- Code(Expression(0, Sub)) at (prev + 1, 1) to (start + 0, 2)
+- Code(Expression(0, Sub)) at (prev + 3, 1) to (start + 0, 2)
     = (c0 - Zero)
 

--- a/tests/coverage/bad_counter_ids.coverage
+++ b/tests/coverage/bad_counter_ids.coverage
@@ -21,7 +21,6 @@
    LL|      1|fn eq_good_message() {
    LL|      1|    println!("b");
    LL|      1|    assert_eq!(Foo(1), Foo(1), "message b");
-                                             ^0
    LL|      1|}
    LL|       |
    LL|      1|fn ne_good() {
@@ -32,7 +31,6 @@
    LL|      1|fn ne_good_message() {
    LL|      1|    println!("d");
    LL|      1|    assert_ne!(Foo(1), Foo(3), "message d");
-                                             ^0
    LL|      1|}
    LL|       |
    LL|      1|fn eq_bad() {

--- a/tests/coverage/coroutine.cov-map
+++ b/tests/coverage/coroutine.cov-map
@@ -14,33 +14,20 @@ Number of file 0 mappings: 4
     = (c1 + (c0 - c1))
 
 Function name: coroutine::main
-Raw bytes (65): 0x[01, 01, 08, 07, 0d, 05, 09, 11, 15, 1e, 19, 11, 15, 15, 19, 1e, 19, 11, 15, 09, 01, 13, 01, 02, 16, 01, 07, 0b, 00, 2e, 11, 01, 2b, 00, 2d, 03, 01, 0e, 00, 35, 11, 02, 0b, 00, 2e, 1e, 01, 22, 00, 27, 1a, 00, 2c, 00, 2e, 17, 01, 0e, 00, 35, 1a, 02, 01, 00, 02]
+Raw bytes (41): 0x[01, 01, 01, 09, 0d, 07, 01, 13, 01, 02, 16, 01, 07, 0b, 00, 2e, 09, 01, 2b, 00, 2d, 09, 03, 0b, 00, 2e, 02, 01, 22, 00, 27, 11, 00, 2c, 00, 2e, 11, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 8
-- expression 0 operands: lhs = Expression(1, Add), rhs = Counter(3)
-- expression 1 operands: lhs = Counter(1), rhs = Counter(2)
-- expression 2 operands: lhs = Counter(4), rhs = Counter(5)
-- expression 3 operands: lhs = Expression(7, Sub), rhs = Counter(6)
-- expression 4 operands: lhs = Counter(4), rhs = Counter(5)
-- expression 5 operands: lhs = Counter(5), rhs = Counter(6)
-- expression 6 operands: lhs = Expression(7, Sub), rhs = Counter(6)
-- expression 7 operands: lhs = Counter(4), rhs = Counter(5)
-Number of file 0 mappings: 9
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(2), rhs = Counter(3)
+Number of file 0 mappings: 7
 - Code(Counter(0)) at (prev + 19, 1) to (start + 2, 22)
 - Code(Counter(0)) at (prev + 7, 11) to (start + 0, 46)
-- Code(Counter(4)) at (prev + 1, 43) to (start + 0, 45)
-- Code(Expression(0, Add)) at (prev + 1, 14) to (start + 0, 53)
-    = ((c1 + c2) + c3)
-- Code(Counter(4)) at (prev + 2, 11) to (start + 0, 46)
-- Code(Expression(7, Sub)) at (prev + 1, 34) to (start + 0, 39)
-    = (c4 - c5)
-- Code(Expression(6, Sub)) at (prev + 0, 44) to (start + 0, 46)
-    = ((c4 - c5) - c6)
-- Code(Expression(5, Add)) at (prev + 1, 14) to (start + 0, 53)
-    = (c5 + c6)
-- Code(Expression(6, Sub)) at (prev + 2, 1) to (start + 0, 2)
-    = ((c4 - c5) - c6)
+- Code(Counter(2)) at (prev + 1, 43) to (start + 0, 45)
+- Code(Counter(2)) at (prev + 3, 11) to (start + 0, 46)
+- Code(Expression(0, Sub)) at (prev + 1, 34) to (start + 0, 39)
+    = (c2 - c3)
+- Code(Counter(4)) at (prev + 0, 44) to (start + 0, 46)
+- Code(Counter(4)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: coroutine::main::{closure#0}
 Raw bytes (14): 0x[01, 01, 00, 02, 01, 15, 1c, 01, 1f, 05, 02, 10, 01, 06]

--- a/tests/coverage/coroutine.coverage
+++ b/tests/coverage/coroutine.coverage
@@ -25,11 +25,11 @@
    LL|       |
    LL|      1|    match Pin::new(&mut coroutine).resume(()) {
    LL|      1|        CoroutineState::Yielded(Ok(1)) => {}
-   LL|      0|        _ => panic!("unexpected return from resume"),
+   LL|       |        _ => panic!("unexpected return from resume"),
    LL|       |    }
    LL|      1|    match Pin::new(&mut coroutine).resume(()) {
    LL|      1|        CoroutineState::Complete("foo") => {}
-   LL|      0|        _ => panic!("unexpected return from resume"),
+   LL|       |        _ => panic!("unexpected return from resume"),
    LL|       |    }
    LL|      1|}
 

--- a/tests/coverage/inline.cov-map
+++ b/tests/coverage/inline.cov-map
@@ -14,14 +14,6 @@ Number of file 0 mappings: 5
 - Code(Expression(1, Sub)) at (prev + 3, 5) to (start + 1, 2)
     = ((c0 + c1) - c1)
 
-Function name: inline::error
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 31, 01, 01, 14]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 49, 1) to (start + 1, 20)
-
 Function name: inline::length::<char>
 Raw bytes (9): 0x[01, 01, 00, 01, 01, 1e, 01, 02, 02]
 Number of files: 1

--- a/tests/coverage/inline.coverage
+++ b/tests/coverage/inline.coverage
@@ -48,7 +48,7 @@
    LL|      6|}
    LL|       |
    LL|       |#[inline(always)]
-   LL|      0|fn error() {
-   LL|      0|    panic!("error");
+   LL|       |fn error() {
+   LL|       |    panic!("error");
    LL|       |}
 

--- a/tests/coverage/issue-84561.cov-map
+++ b/tests/coverage/issue-84561.cov-map
@@ -77,10 +77,10 @@ Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 167, 9) to (start + 2, 10)
 
 Function name: issue_84561::test3
-Raw bytes (436): 0x[01, 01, 41, 05, 09, 0d, 00, 15, 19, 12, 00, 15, 19, 21, 00, 1e, 00, 21, 00, 31, 00, 3d, 41, 2e, 45, 3d, 41, 42, 49, 45, 00, 3f, 51, 42, 49, 45, 00, 5d, 8a, 01, 8f, 01, 5d, 92, 01, 55, 51, 00, 92, 01, 55, 51, 00, 8f, 01, 5d, 92, 01, 55, 51, 00, 87, 01, 61, 5d, 8a, 01, 8f, 01, 5d, 92, 01, 55, 51, 00, 82, 01, 65, 87, 01, 61, 5d, 8a, 01, 8f, 01, 5d, 92, 01, 55, 51, 00, 75, f6, 01, fb, 01, 79, 00, fe, 01, 82, 02, 00, 69, 6d, 00, fe, 01, 82, 02, 00, 69, 6d, 69, 6d, 82, 02, 00, 69, 6d, fb, 01, 79, 00, fe, 01, 82, 02, 00, 69, 6d, f3, 01, 7d, 75, f6, 01, fb, 01, 79, 00, fe, 01, 82, 02, 00, 69, 6d, ee, 01, 00, f3, 01, 7d, 75, f6, 01, fb, 01, 79, 00, fe, 01, 82, 02, 00, 69, 6d, 33, 01, 08, 01, 03, 1c, 05, 04, 09, 01, 1c, 02, 02, 05, 04, 1f, 0d, 05, 05, 00, 1f, 06, 01, 05, 00, 1f, 15, 01, 09, 01, 1c, 12, 02, 05, 00, 1f, 0e, 01, 05, 00, 0f, 00, 00, 20, 00, 30, 21, 01, 05, 03, 0f, 00, 03, 20, 00, 30, 00, 00, 33, 00, 41, 00, 00, 4b, 00, 5a, 1e, 01, 05, 00, 0f, 00, 05, 09, 03, 10, 00, 05, 0d, 00, 1b, 00, 02, 0d, 00, 1c, 1a, 04, 09, 05, 06, 31, 06, 05, 03, 06, 22, 04, 05, 03, 06, 3d, 04, 09, 04, 06, 2e, 05, 08, 00, 0f, 45, 01, 09, 03, 0a, 2a, 05, 09, 03, 0a, 3f, 05, 08, 00, 0f, 51, 01, 09, 00, 13, 00, 03, 0d, 00, 1d, 3a, 03, 09, 00, 13, 00, 03, 0d, 00, 1d, 87, 01, 03, 05, 00, 0f, 8f, 01, 01, 0c, 00, 13, 5d, 01, 0d, 00, 13, 8a, 01, 02, 0d, 00, 13, 82, 01, 04, 05, 02, 13, 65, 03, 0d, 00, 13, 7e, 02, 0d, 00, 13, f3, 01, 03, 05, 00, 0f, 69, 01, 0c, 00, 13, 6d, 01, 0d, 03, 0e, 75, 04, 0d, 00, 13, fb, 01, 02, 0d, 00, 17, 82, 02, 01, 14, 00, 1b, 00, 01, 15, 00, 1b, fe, 01, 02, 15, 00, 1b, f6, 01, 04, 0d, 00, 13, 7d, 03, 09, 00, 19, ee, 01, 02, 05, 00, 0f, ea, 01, 03, 09, 00, 22, 00, 02, 05, 00, 0f, 00, 03, 09, 00, 2c, 00, 02, 01, 00, 02]
+Raw bytes (355): 0x[01, 01, 3a, 05, 09, 0d, 00, 15, 19, 12, 00, 15, 19, 21, 00, 1e, 00, 21, 00, 2d, 00, 35, 39, 2e, 3d, 35, 39, 42, 41, 3d, 00, 3f, 49, 42, 41, 3d, 00, 55, 8a, 01, 8f, 01, 55, 92, 01, 4d, 49, 00, 92, 01, 4d, 49, 00, 8f, 01, 55, 92, 01, 4d, 49, 00, 87, 01, 59, 55, 8a, 01, 8f, 01, 55, 92, 01, 4d, 49, 00, 82, 01, 5d, 87, 01, 59, 55, 8a, 01, 8f, 01, 55, 92, 01, 4d, 49, 00, 6d, da, 01, df, 01, 71, 00, e2, 01, e6, 01, 00, 61, 65, 00, e2, 01, e6, 01, 00, 61, 65, 61, 65, e6, 01, 00, 61, 65, df, 01, 71, 00, e2, 01, e6, 01, 00, 61, 65, d7, 01, 75, 6d, da, 01, df, 01, 71, 00, e2, 01, e6, 01, 00, 61, 65, 27, 01, 08, 01, 03, 1c, 05, 04, 09, 01, 1c, 02, 02, 05, 04, 1f, 0d, 05, 05, 00, 1f, 06, 01, 05, 00, 1f, 15, 01, 09, 01, 1c, 12, 02, 05, 00, 1f, 0e, 01, 05, 00, 0f, 21, 01, 05, 03, 0f, 1e, 04, 05, 00, 0f, 1a, 10, 09, 05, 06, 2d, 06, 05, 03, 06, 22, 04, 05, 03, 06, 35, 04, 09, 04, 06, 2e, 05, 08, 00, 0f, 3d, 01, 09, 03, 0a, 2a, 05, 09, 03, 0a, 3f, 05, 08, 00, 0f, 49, 01, 09, 00, 13, 3a, 06, 09, 00, 13, 87, 01, 06, 05, 00, 0f, 8f, 01, 01, 0c, 00, 13, 55, 01, 0d, 00, 13, 8a, 01, 02, 0d, 00, 13, 82, 01, 04, 05, 02, 13, 5d, 03, 0d, 00, 13, 7e, 02, 0d, 00, 13, d7, 01, 03, 05, 00, 0f, 61, 01, 0c, 00, 13, 65, 01, 0d, 03, 0e, 6d, 04, 0d, 00, 13, df, 01, 02, 0d, 00, 17, e6, 01, 01, 14, 00, 1b, 00, 01, 15, 00, 1b, e2, 01, 02, 15, 00, 1b, da, 01, 04, 0d, 00, 13, d2, 01, 05, 05, 00, 0f, 00, 05, 05, 00, 0f, 00, 05, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 65
+Number of expressions: 58
 - expression 0 operands: lhs = Counter(1), rhs = Counter(2)
 - expression 1 operands: lhs = Counter(3), rhs = Zero
 - expression 2 operands: lhs = Counter(5), rhs = Counter(6)
@@ -89,64 +89,57 @@ Number of expressions: 65
 - expression 5 operands: lhs = Counter(8), rhs = Zero
 - expression 6 operands: lhs = Expression(7, Sub), rhs = Zero
 - expression 7 operands: lhs = Counter(8), rhs = Zero
-- expression 8 operands: lhs = Counter(12), rhs = Zero
-- expression 9 operands: lhs = Counter(15), rhs = Counter(16)
-- expression 10 operands: lhs = Expression(11, Sub), rhs = Counter(17)
-- expression 11 operands: lhs = Counter(15), rhs = Counter(16)
-- expression 12 operands: lhs = Expression(16, Sub), rhs = Counter(18)
-- expression 13 operands: lhs = Counter(17), rhs = Zero
-- expression 14 operands: lhs = Expression(15, Add), rhs = Counter(20)
-- expression 15 operands: lhs = Expression(16, Sub), rhs = Counter(18)
-- expression 16 operands: lhs = Counter(17), rhs = Zero
-- expression 17 operands: lhs = Counter(23), rhs = Expression(34, Sub)
-- expression 18 operands: lhs = Expression(35, Add), rhs = Counter(23)
-- expression 19 operands: lhs = Expression(36, Sub), rhs = Counter(21)
-- expression 20 operands: lhs = Counter(20), rhs = Zero
-- expression 21 operands: lhs = Expression(36, Sub), rhs = Counter(21)
-- expression 22 operands: lhs = Counter(20), rhs = Zero
-- expression 23 operands: lhs = Expression(35, Add), rhs = Counter(23)
-- expression 24 operands: lhs = Expression(36, Sub), rhs = Counter(21)
-- expression 25 operands: lhs = Counter(20), rhs = Zero
-- expression 26 operands: lhs = Expression(33, Add), rhs = Counter(24)
-- expression 27 operands: lhs = Counter(23), rhs = Expression(34, Sub)
-- expression 28 operands: lhs = Expression(35, Add), rhs = Counter(23)
-- expression 29 operands: lhs = Expression(36, Sub), rhs = Counter(21)
-- expression 30 operands: lhs = Counter(20), rhs = Zero
-- expression 31 operands: lhs = Expression(32, Sub), rhs = Counter(25)
-- expression 32 operands: lhs = Expression(33, Add), rhs = Counter(24)
-- expression 33 operands: lhs = Counter(23), rhs = Expression(34, Sub)
-- expression 34 operands: lhs = Expression(35, Add), rhs = Counter(23)
-- expression 35 operands: lhs = Expression(36, Sub), rhs = Counter(21)
-- expression 36 operands: lhs = Counter(20), rhs = Zero
-- expression 37 operands: lhs = Counter(29), rhs = Expression(61, Sub)
-- expression 38 operands: lhs = Expression(62, Add), rhs = Counter(30)
-- expression 39 operands: lhs = Zero, rhs = Expression(63, Sub)
-- expression 40 operands: lhs = Expression(64, Sub), rhs = Zero
-- expression 41 operands: lhs = Counter(26), rhs = Counter(27)
-- expression 42 operands: lhs = Zero, rhs = Expression(63, Sub)
-- expression 43 operands: lhs = Expression(64, Sub), rhs = Zero
-- expression 44 operands: lhs = Counter(26), rhs = Counter(27)
-- expression 45 operands: lhs = Counter(26), rhs = Counter(27)
-- expression 46 operands: lhs = Expression(64, Sub), rhs = Zero
-- expression 47 operands: lhs = Counter(26), rhs = Counter(27)
-- expression 48 operands: lhs = Expression(62, Add), rhs = Counter(30)
-- expression 49 operands: lhs = Zero, rhs = Expression(63, Sub)
-- expression 50 operands: lhs = Expression(64, Sub), rhs = Zero
-- expression 51 operands: lhs = Counter(26), rhs = Counter(27)
-- expression 52 operands: lhs = Expression(60, Add), rhs = Counter(31)
-- expression 53 operands: lhs = Counter(29), rhs = Expression(61, Sub)
-- expression 54 operands: lhs = Expression(62, Add), rhs = Counter(30)
-- expression 55 operands: lhs = Zero, rhs = Expression(63, Sub)
-- expression 56 operands: lhs = Expression(64, Sub), rhs = Zero
-- expression 57 operands: lhs = Counter(26), rhs = Counter(27)
-- expression 58 operands: lhs = Expression(59, Sub), rhs = Zero
-- expression 59 operands: lhs = Expression(60, Add), rhs = Counter(31)
-- expression 60 operands: lhs = Counter(29), rhs = Expression(61, Sub)
-- expression 61 operands: lhs = Expression(62, Add), rhs = Counter(30)
-- expression 62 operands: lhs = Zero, rhs = Expression(63, Sub)
-- expression 63 operands: lhs = Expression(64, Sub), rhs = Zero
-- expression 64 operands: lhs = Counter(26), rhs = Counter(27)
-Number of file 0 mappings: 51
+- expression 8 operands: lhs = Counter(11), rhs = Zero
+- expression 9 operands: lhs = Counter(13), rhs = Counter(14)
+- expression 10 operands: lhs = Expression(11, Sub), rhs = Counter(15)
+- expression 11 operands: lhs = Counter(13), rhs = Counter(14)
+- expression 12 operands: lhs = Expression(16, Sub), rhs = Counter(16)
+- expression 13 operands: lhs = Counter(15), rhs = Zero
+- expression 14 operands: lhs = Expression(15, Add), rhs = Counter(18)
+- expression 15 operands: lhs = Expression(16, Sub), rhs = Counter(16)
+- expression 16 operands: lhs = Counter(15), rhs = Zero
+- expression 17 operands: lhs = Counter(21), rhs = Expression(34, Sub)
+- expression 18 operands: lhs = Expression(35, Add), rhs = Counter(21)
+- expression 19 operands: lhs = Expression(36, Sub), rhs = Counter(19)
+- expression 20 operands: lhs = Counter(18), rhs = Zero
+- expression 21 operands: lhs = Expression(36, Sub), rhs = Counter(19)
+- expression 22 operands: lhs = Counter(18), rhs = Zero
+- expression 23 operands: lhs = Expression(35, Add), rhs = Counter(21)
+- expression 24 operands: lhs = Expression(36, Sub), rhs = Counter(19)
+- expression 25 operands: lhs = Counter(18), rhs = Zero
+- expression 26 operands: lhs = Expression(33, Add), rhs = Counter(22)
+- expression 27 operands: lhs = Counter(21), rhs = Expression(34, Sub)
+- expression 28 operands: lhs = Expression(35, Add), rhs = Counter(21)
+- expression 29 operands: lhs = Expression(36, Sub), rhs = Counter(19)
+- expression 30 operands: lhs = Counter(18), rhs = Zero
+- expression 31 operands: lhs = Expression(32, Sub), rhs = Counter(23)
+- expression 32 operands: lhs = Expression(33, Add), rhs = Counter(22)
+- expression 33 operands: lhs = Counter(21), rhs = Expression(34, Sub)
+- expression 34 operands: lhs = Expression(35, Add), rhs = Counter(21)
+- expression 35 operands: lhs = Expression(36, Sub), rhs = Counter(19)
+- expression 36 operands: lhs = Counter(18), rhs = Zero
+- expression 37 operands: lhs = Counter(27), rhs = Expression(54, Sub)
+- expression 38 operands: lhs = Expression(55, Add), rhs = Counter(28)
+- expression 39 operands: lhs = Zero, rhs = Expression(56, Sub)
+- expression 40 operands: lhs = Expression(57, Sub), rhs = Zero
+- expression 41 operands: lhs = Counter(24), rhs = Counter(25)
+- expression 42 operands: lhs = Zero, rhs = Expression(56, Sub)
+- expression 43 operands: lhs = Expression(57, Sub), rhs = Zero
+- expression 44 operands: lhs = Counter(24), rhs = Counter(25)
+- expression 45 operands: lhs = Counter(24), rhs = Counter(25)
+- expression 46 operands: lhs = Expression(57, Sub), rhs = Zero
+- expression 47 operands: lhs = Counter(24), rhs = Counter(25)
+- expression 48 operands: lhs = Expression(55, Add), rhs = Counter(28)
+- expression 49 operands: lhs = Zero, rhs = Expression(56, Sub)
+- expression 50 operands: lhs = Expression(57, Sub), rhs = Zero
+- expression 51 operands: lhs = Counter(24), rhs = Counter(25)
+- expression 52 operands: lhs = Expression(53, Add), rhs = Counter(29)
+- expression 53 operands: lhs = Counter(27), rhs = Expression(54, Sub)
+- expression 54 operands: lhs = Expression(55, Add), rhs = Counter(28)
+- expression 55 operands: lhs = Zero, rhs = Expression(56, Sub)
+- expression 56 operands: lhs = Expression(57, Sub), rhs = Zero
+- expression 57 operands: lhs = Counter(24), rhs = Counter(25)
+Number of file 0 mappings: 39
 - Code(Counter(0)) at (prev + 8, 1) to (start + 3, 28)
 - Code(Counter(1)) at (prev + 4, 9) to (start + 1, 28)
 - Code(Expression(0, Sub)) at (prev + 2, 5) to (start + 4, 31)
@@ -159,66 +152,53 @@ Number of file 0 mappings: 51
     = (c5 - c6)
 - Code(Expression(3, Sub)) at (prev + 1, 5) to (start + 0, 15)
     = ((c5 - c6) - Zero)
-- Code(Zero) at (prev + 0, 32) to (start + 0, 48)
 - Code(Counter(8)) at (prev + 1, 5) to (start + 3, 15)
-- Code(Zero) at (prev + 3, 32) to (start + 0, 48)
-- Code(Zero) at (prev + 0, 51) to (start + 0, 65)
-- Code(Zero) at (prev + 0, 75) to (start + 0, 90)
-- Code(Expression(7, Sub)) at (prev + 1, 5) to (start + 0, 15)
+- Code(Expression(7, Sub)) at (prev + 4, 5) to (start + 0, 15)
     = (c8 - Zero)
-- Code(Zero) at (prev + 5, 9) to (start + 3, 16)
-- Code(Zero) at (prev + 5, 13) to (start + 0, 27)
-- Code(Zero) at (prev + 2, 13) to (start + 0, 28)
-- Code(Expression(6, Sub)) at (prev + 4, 9) to (start + 5, 6)
+- Code(Expression(6, Sub)) at (prev + 16, 9) to (start + 5, 6)
     = ((c8 - Zero) - Zero)
-- Code(Counter(12)) at (prev + 6, 5) to (start + 3, 6)
+- Code(Counter(11)) at (prev + 6, 5) to (start + 3, 6)
 - Code(Expression(8, Sub)) at (prev + 4, 5) to (start + 3, 6)
-    = (c12 - Zero)
-- Code(Counter(15)) at (prev + 4, 9) to (start + 4, 6)
+    = (c11 - Zero)
+- Code(Counter(13)) at (prev + 4, 9) to (start + 4, 6)
 - Code(Expression(11, Sub)) at (prev + 5, 8) to (start + 0, 15)
-    = (c15 - c16)
-- Code(Counter(17)) at (prev + 1, 9) to (start + 3, 10)
+    = (c13 - c14)
+- Code(Counter(15)) at (prev + 1, 9) to (start + 3, 10)
 - Code(Expression(10, Sub)) at (prev + 5, 9) to (start + 3, 10)
-    = ((c15 - c16) - c17)
+    = ((c13 - c14) - c15)
 - Code(Expression(15, Add)) at (prev + 5, 8) to (start + 0, 15)
-    = ((c17 - Zero) + c18)
-- Code(Counter(20)) at (prev + 1, 9) to (start + 0, 19)
-- Code(Zero) at (prev + 3, 13) to (start + 0, 29)
-- Code(Expression(14, Sub)) at (prev + 3, 9) to (start + 0, 19)
-    = (((c17 - Zero) + c18) - c20)
-- Code(Zero) at (prev + 3, 13) to (start + 0, 29)
-- Code(Expression(33, Add)) at (prev + 3, 5) to (start + 0, 15)
-    = (c23 + (((c20 - Zero) + c21) - c23))
+    = ((c15 - Zero) + c16)
+- Code(Counter(18)) at (prev + 1, 9) to (start + 0, 19)
+- Code(Expression(14, Sub)) at (prev + 6, 9) to (start + 0, 19)
+    = (((c15 - Zero) + c16) - c18)
+- Code(Expression(33, Add)) at (prev + 6, 5) to (start + 0, 15)
+    = (c21 + (((c18 - Zero) + c19) - c21))
 - Code(Expression(35, Add)) at (prev + 1, 12) to (start + 0, 19)
-    = ((c20 - Zero) + c21)
-- Code(Counter(23)) at (prev + 1, 13) to (start + 0, 19)
+    = ((c18 - Zero) + c19)
+- Code(Counter(21)) at (prev + 1, 13) to (start + 0, 19)
 - Code(Expression(34, Sub)) at (prev + 2, 13) to (start + 0, 19)
-    = (((c20 - Zero) + c21) - c23)
+    = (((c18 - Zero) + c19) - c21)
 - Code(Expression(32, Sub)) at (prev + 4, 5) to (start + 2, 19)
-    = ((c23 + (((c20 - Zero) + c21) - c23)) - c24)
-- Code(Counter(25)) at (prev + 3, 13) to (start + 0, 19)
+    = ((c21 + (((c18 - Zero) + c19) - c21)) - c22)
+- Code(Counter(23)) at (prev + 3, 13) to (start + 0, 19)
 - Code(Expression(31, Sub)) at (prev + 2, 13) to (start + 0, 19)
-    = (((c23 + (((c20 - Zero) + c21) - c23)) - c24) - c25)
-- Code(Expression(60, Add)) at (prev + 3, 5) to (start + 0, 15)
-    = (c29 + ((Zero + ((c26 - c27) - Zero)) - c30))
-- Code(Counter(26)) at (prev + 1, 12) to (start + 0, 19)
-- Code(Counter(27)) at (prev + 1, 13) to (start + 3, 14)
-- Code(Counter(29)) at (prev + 4, 13) to (start + 0, 19)
-- Code(Expression(62, Add)) at (prev + 2, 13) to (start + 0, 23)
-    = (Zero + ((c26 - c27) - Zero))
-- Code(Expression(64, Sub)) at (prev + 1, 20) to (start + 0, 27)
-    = (c26 - c27)
+    = (((c21 + (((c18 - Zero) + c19) - c21)) - c22) - c23)
+- Code(Expression(53, Add)) at (prev + 3, 5) to (start + 0, 15)
+    = (c27 + ((Zero + ((c24 - c25) - Zero)) - c28))
+- Code(Counter(24)) at (prev + 1, 12) to (start + 0, 19)
+- Code(Counter(25)) at (prev + 1, 13) to (start + 3, 14)
+- Code(Counter(27)) at (prev + 4, 13) to (start + 0, 19)
+- Code(Expression(55, Add)) at (prev + 2, 13) to (start + 0, 23)
+    = (Zero + ((c24 - c25) - Zero))
+- Code(Expression(57, Sub)) at (prev + 1, 20) to (start + 0, 27)
+    = (c24 - c25)
 - Code(Zero) at (prev + 1, 21) to (start + 0, 27)
-- Code(Expression(63, Sub)) at (prev + 2, 21) to (start + 0, 27)
-    = ((c26 - c27) - Zero)
-- Code(Expression(61, Sub)) at (prev + 4, 13) to (start + 0, 19)
-    = ((Zero + ((c26 - c27) - Zero)) - c30)
-- Code(Counter(31)) at (prev + 3, 9) to (start + 0, 25)
-- Code(Expression(59, Sub)) at (prev + 2, 5) to (start + 0, 15)
-    = ((c29 + ((Zero + ((c26 - c27) - Zero)) - c30)) - c31)
-- Code(Expression(58, Sub)) at (prev + 3, 9) to (start + 0, 34)
-    = (((c29 + ((Zero + ((c26 - c27) - Zero)) - c30)) - c31) - Zero)
-- Code(Zero) at (prev + 2, 5) to (start + 0, 15)
-- Code(Zero) at (prev + 3, 9) to (start + 0, 44)
-- Code(Zero) at (prev + 2, 1) to (start + 0, 2)
+- Code(Expression(56, Sub)) at (prev + 2, 21) to (start + 0, 27)
+    = ((c24 - c25) - Zero)
+- Code(Expression(54, Sub)) at (prev + 4, 13) to (start + 0, 19)
+    = ((Zero + ((c24 - c25) - Zero)) - c28)
+- Code(Expression(52, Sub)) at (prev + 5, 5) to (start + 0, 15)
+    = ((c27 + ((Zero + ((c24 - c25) - Zero)) - c28)) - c29)
+- Code(Zero) at (prev + 5, 5) to (start + 0, 15)
+- Code(Zero) at (prev + 5, 1) to (start + 0, 2)
 

--- a/tests/coverage/issue-84561.coverage
+++ b/tests/coverage/issue-84561.coverage
@@ -22,25 +22,23 @@
    LL|      1|    assert_ne!(bar, Foo(3));
    LL|      1|    assert_ne!(Foo(0), Foo(4));
    LL|      1|    assert_eq!(Foo(3), Foo(3), "with a message");
-                                             ^0
    LL|      1|    println!("{:?}", bar);
    LL|      1|    println!("{:?}", Foo(1));
    LL|      1|
    LL|      1|    assert_ne!(Foo(0), Foo(5), "{}", if is_true { "true message" } else { "false message" });
-                                             ^0                 ^0                      ^0
    LL|      1|    assert_ne!(
    LL|       |        Foo(0)
    LL|       |        ,
    LL|       |        Foo(5)
    LL|       |        ,
-   LL|      0|        "{}"
-   LL|      0|        ,
-   LL|      0|        if
-   LL|      0|        is_true
+   LL|       |        "{}"
+   LL|       |        ,
+   LL|       |        if
+   LL|       |        is_true
    LL|       |        {
-   LL|      0|            "true message"
+   LL|       |            "true message"
    LL|       |        } else {
-   LL|      0|            "false message"
+   LL|       |            "false message"
    LL|       |        }
    LL|       |    );
    LL|       |
@@ -78,13 +76,13 @@
    LL|      1|        assert_ne!(
    LL|       |            Foo(0),
    LL|       |            Foo(4),
-   LL|      0|            "with a message"
+   LL|       |            "with a message"
    LL|       |        );
    LL|       |    } else {
    LL|      0|        assert_eq!(
    LL|       |            Foo(3),
    LL|       |            Foo(3),
-   LL|      0|            "with a message"
+   LL|       |            "with a message"
    LL|       |        );
    LL|       |    }
    LL|      1|    assert_ne!(
@@ -122,17 +120,17 @@
    LL|      0|            Foo(1)
    LL|       |        },
    LL|       |        Foo(5),
-   LL|      0|        "with a message"
+   LL|       |        "with a message"
    LL|       |    );
    LL|      1|    assert_eq!(
    LL|       |        Foo(1),
    LL|       |        Foo(3),
-   LL|      1|        "this assert should fail"
+   LL|       |        "this assert should fail"
    LL|       |    );
    LL|      0|    assert_eq!(
    LL|       |        Foo(3),
    LL|       |        Foo(3),
-   LL|      0|        "this assert should not be reached"
+   LL|       |        "this assert should not be reached"
    LL|       |    );
    LL|      0|}
    LL|       |

--- a/tests/coverage/panic_unwind.cov-map
+++ b/tests/coverage/panic_unwind.cov-map
@@ -27,14 +27,13 @@ Number of file 0 mappings: 9
 - Code(Counter(4)) at (prev + 2, 5) to (start + 1, 2)
 
 Function name: panic_unwind::might_panic
-Raw bytes (21): 0x[01, 01, 01, 01, 05, 03, 01, 04, 01, 01, 14, 05, 02, 09, 01, 19, 02, 02, 0c, 03, 02]
+Raw bytes (16): 0x[01, 01, 01, 01, 05, 02, 01, 04, 01, 01, 14, 02, 04, 0c, 03, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
-Number of file 0 mappings: 3
+Number of file 0 mappings: 2
 - Code(Counter(0)) at (prev + 4, 1) to (start + 1, 20)
-- Code(Counter(1)) at (prev + 2, 9) to (start + 1, 25)
-- Code(Expression(0, Sub)) at (prev + 2, 12) to (start + 3, 2)
+- Code(Expression(0, Sub)) at (prev + 4, 12) to (start + 3, 2)
     = (c0 - c1)
 

--- a/tests/coverage/panic_unwind.coverage
+++ b/tests/coverage/panic_unwind.coverage
@@ -3,8 +3,8 @@
    LL|       |
    LL|      4|fn might_panic(should_panic: bool) {
    LL|      4|    if should_panic {
-   LL|      1|        println!("panicking...");
-   LL|      1|        panic!("panics");
+   LL|       |        println!("panicking...");
+   LL|       |        panic!("panics");
    LL|      3|    } else {
    LL|      3|        println!("Don't Panic");
    LL|      3|    }

--- a/tests/coverage/unreachable.cov-map
+++ b/tests/coverage/unreachable.cov-map
@@ -1,24 +1,39 @@
-Function name: unreachable::UNREACHABLE_CLOSURE::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 0f, 27, 00, 47]
+Function name: unreachable::main
+Raw bytes (86): 0x[01, 01, 10, 01, 05, 05, 02, 3f, 09, 05, 02, 09, 3a, 3f, 09, 05, 02, 37, 0d, 09, 3a, 3f, 09, 05, 02, 0d, 32, 37, 0d, 09, 3a, 3f, 09, 05, 02, 0a, 01, 19, 01, 01, 18, 05, 01, 19, 02, 06, 02, 02, 06, 00, 07, 3f, 01, 08, 00, 18, 09, 00, 19, 02, 06, 3a, 02, 06, 00, 07, 37, 01, 08, 00, 18, 0d, 00, 19, 02, 06, 32, 02, 06, 00, 07, 2f, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 15, 39) to (start + 0, 71)
-
-Function name: unreachable::unreachable_function
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 11, 01, 01, 25]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 17, 1) to (start + 1, 37)
-
-Function name: unreachable::unreachable_intrinsic
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 16, 01, 01, 2c]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 22, 1) to (start + 1, 44)
+Number of expressions: 16
+- expression 0 operands: lhs = Counter(0), rhs = Counter(1)
+- expression 1 operands: lhs = Counter(1), rhs = Expression(0, Sub)
+- expression 2 operands: lhs = Expression(15, Add), rhs = Counter(2)
+- expression 3 operands: lhs = Counter(1), rhs = Expression(0, Sub)
+- expression 4 operands: lhs = Counter(2), rhs = Expression(14, Sub)
+- expression 5 operands: lhs = Expression(15, Add), rhs = Counter(2)
+- expression 6 operands: lhs = Counter(1), rhs = Expression(0, Sub)
+- expression 7 operands: lhs = Expression(13, Add), rhs = Counter(3)
+- expression 8 operands: lhs = Counter(2), rhs = Expression(14, Sub)
+- expression 9 operands: lhs = Expression(15, Add), rhs = Counter(2)
+- expression 10 operands: lhs = Counter(1), rhs = Expression(0, Sub)
+- expression 11 operands: lhs = Counter(3), rhs = Expression(12, Sub)
+- expression 12 operands: lhs = Expression(13, Add), rhs = Counter(3)
+- expression 13 operands: lhs = Counter(2), rhs = Expression(14, Sub)
+- expression 14 operands: lhs = Expression(15, Add), rhs = Counter(2)
+- expression 15 operands: lhs = Counter(1), rhs = Expression(0, Sub)
+Number of file 0 mappings: 10
+- Code(Counter(0)) at (prev + 25, 1) to (start + 1, 24)
+- Code(Counter(1)) at (prev + 1, 25) to (start + 2, 6)
+- Code(Expression(0, Sub)) at (prev + 2, 6) to (start + 0, 7)
+    = (c0 - c1)
+- Code(Expression(15, Add)) at (prev + 1, 8) to (start + 0, 24)
+    = (c1 + (c0 - c1))
+- Code(Counter(2)) at (prev + 0, 25) to (start + 2, 6)
+- Code(Expression(14, Sub)) at (prev + 2, 6) to (start + 0, 7)
+    = ((c1 + (c0 - c1)) - c2)
+- Code(Expression(13, Add)) at (prev + 1, 8) to (start + 0, 24)
+    = (c2 + ((c1 + (c0 - c1)) - c2))
+- Code(Counter(3)) at (prev + 0, 25) to (start + 2, 6)
+- Code(Expression(12, Sub)) at (prev + 2, 6) to (start + 0, 7)
+    = ((c2 + ((c1 + (c0 - c1)) - c2)) - c3)
+- Code(Expression(11, Add)) at (prev + 1, 1) to (start + 0, 2)
+    = (c3 + ((c2 + ((c1 + (c0 - c1)) - c2)) - c3))
 

--- a/tests/coverage/unreachable.coverage
+++ b/tests/coverage/unreachable.coverage
@@ -1,5 +1,4 @@
    LL|       |#![feature(core_intrinsics)]
-   LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
    LL|       |
    LL|       |// <https://github.com/rust-lang/rust/issues/116171>
@@ -12,27 +11,26 @@
    LL|       |
    LL|       |use std::hint::{black_box, unreachable_unchecked};
    LL|       |
-   LL|      0|static UNREACHABLE_CLOSURE: fn() = || unsafe { unreachable_unchecked() };
+   LL|       |static UNREACHABLE_CLOSURE: fn() = || unsafe { unreachable_unchecked() };
    LL|       |
-   LL|      0|fn unreachable_function() {
-   LL|      0|    unsafe { unreachable_unchecked() }
+   LL|       |fn unreachable_function() {
+   LL|       |    unsafe { unreachable_unchecked() }
    LL|       |}
    LL|       |
    LL|       |// Use an intrinsic to more reliably trigger unreachable-propagation.
-   LL|      0|fn unreachable_intrinsic() {
-   LL|      0|    unsafe { std::intrinsics::unreachable() }
+   LL|       |fn unreachable_intrinsic() {
+   LL|       |    unsafe { std::intrinsics::unreachable() }
    LL|       |}
    LL|       |
-   LL|       |#[coverage(off)]
-   LL|       |fn main() {
-   LL|       |    if black_box(false) {
-   LL|       |        UNREACHABLE_CLOSURE();
-   LL|       |    }
-   LL|       |    if black_box(false) {
-   LL|       |        unreachable_function();
-   LL|       |    }
-   LL|       |    if black_box(false) {
-   LL|       |        unreachable_intrinsic();
-   LL|       |    }
-   LL|       |}
+   LL|      1|fn main() {
+   LL|      1|    if black_box(false) {
+   LL|      0|        UNREACHABLE_CLOSURE();
+   LL|      1|    }
+   LL|      1|    if black_box(false) {
+   LL|      0|        unreachable_function();
+   LL|      1|    }
+   LL|      1|    if black_box(false) {
+   LL|      0|        unreachable_intrinsic();
+   LL|      1|    }
+   LL|      1|}
 

--- a/tests/coverage/unreachable.rs
+++ b/tests/coverage/unreachable.rs
@@ -1,5 +1,4 @@
 #![feature(core_intrinsics)]
-#![feature(coverage_attribute)]
 //@ edition: 2021
 
 // <https://github.com/rust-lang/rust/issues/116171>
@@ -23,7 +22,6 @@ fn unreachable_intrinsic() {
     unsafe { std::intrinsics::unreachable() }
 }
 
-#[coverage(off)]
 fn main() {
     if black_box(false) {
         UNREACHABLE_CLOSURE();

--- a/tests/coverage/yield.cov-map
+++ b/tests/coverage/yield.cov-map
@@ -1,44 +1,23 @@
 Function name: yield::main
-Raw bytes (106): 0x[01, 01, 0b, 05, 00, 0d, 11, 22, 15, 0d, 11, 11, 15, 22, 15, 0d, 11, 22, 15, 0d, 11, 19, 1d, 25, 29, 10, 01, 07, 01, 01, 16, 01, 06, 0b, 00, 2e, 0d, 01, 27, 00, 29, 03, 01, 0e, 00, 34, 0d, 02, 0b, 00, 2e, 22, 01, 22, 00, 27, 1e, 00, 2c, 00, 2e, 13, 01, 0e, 00, 34, 1e, 03, 09, 00, 16, 1e, 07, 0b, 00, 2e, 21, 01, 27, 00, 29, 27, 01, 0e, 00, 34, 21, 02, 0b, 00, 2e, 2d, 01, 27, 00, 29, 2b, 01, 0e, 00, 34, 2d, 02, 01, 00, 02]
+Raw bytes (66): 0x[01, 01, 01, 09, 0d, 0c, 01, 07, 01, 01, 16, 01, 06, 0b, 00, 2e, 09, 01, 27, 00, 29, 09, 03, 0b, 00, 2e, 02, 01, 22, 00, 27, 11, 00, 2c, 00, 2e, 11, 04, 09, 00, 16, 11, 07, 0b, 00, 2e, 19, 01, 27, 00, 29, 19, 03, 0b, 00, 2e, 21, 01, 27, 00, 29, 21, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
-Number of expressions: 11
-- expression 0 operands: lhs = Counter(1), rhs = Zero
-- expression 1 operands: lhs = Counter(3), rhs = Counter(4)
-- expression 2 operands: lhs = Expression(8, Sub), rhs = Counter(5)
-- expression 3 operands: lhs = Counter(3), rhs = Counter(4)
-- expression 4 operands: lhs = Counter(4), rhs = Counter(5)
-- expression 5 operands: lhs = Expression(8, Sub), rhs = Counter(5)
-- expression 6 operands: lhs = Counter(3), rhs = Counter(4)
-- expression 7 operands: lhs = Expression(8, Sub), rhs = Counter(5)
-- expression 8 operands: lhs = Counter(3), rhs = Counter(4)
-- expression 9 operands: lhs = Counter(6), rhs = Counter(7)
-- expression 10 operands: lhs = Counter(9), rhs = Counter(10)
-Number of file 0 mappings: 16
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(2), rhs = Counter(3)
+Number of file 0 mappings: 12
 - Code(Counter(0)) at (prev + 7, 1) to (start + 1, 22)
 - Code(Counter(0)) at (prev + 6, 11) to (start + 0, 46)
-- Code(Counter(3)) at (prev + 1, 39) to (start + 0, 41)
-- Code(Expression(0, Add)) at (prev + 1, 14) to (start + 0, 52)
-    = (c1 + Zero)
-- Code(Counter(3)) at (prev + 2, 11) to (start + 0, 46)
-- Code(Expression(8, Sub)) at (prev + 1, 34) to (start + 0, 39)
-    = (c3 - c4)
-- Code(Expression(7, Sub)) at (prev + 0, 44) to (start + 0, 46)
-    = ((c3 - c4) - c5)
-- Code(Expression(4, Add)) at (prev + 1, 14) to (start + 0, 52)
-    = (c4 + c5)
-- Code(Expression(7, Sub)) at (prev + 3, 9) to (start + 0, 22)
-    = ((c3 - c4) - c5)
-- Code(Expression(7, Sub)) at (prev + 7, 11) to (start + 0, 46)
-    = ((c3 - c4) - c5)
+- Code(Counter(2)) at (prev + 1, 39) to (start + 0, 41)
+- Code(Counter(2)) at (prev + 3, 11) to (start + 0, 46)
+- Code(Expression(0, Sub)) at (prev + 1, 34) to (start + 0, 39)
+    = (c2 - c3)
+- Code(Counter(4)) at (prev + 0, 44) to (start + 0, 46)
+- Code(Counter(4)) at (prev + 4, 9) to (start + 0, 22)
+- Code(Counter(4)) at (prev + 7, 11) to (start + 0, 46)
+- Code(Counter(6)) at (prev + 1, 39) to (start + 0, 41)
+- Code(Counter(6)) at (prev + 3, 11) to (start + 0, 46)
 - Code(Counter(8)) at (prev + 1, 39) to (start + 0, 41)
-- Code(Expression(9, Add)) at (prev + 1, 14) to (start + 0, 52)
-    = (c6 + c7)
-- Code(Counter(8)) at (prev + 2, 11) to (start + 0, 46)
-- Code(Counter(11)) at (prev + 1, 39) to (start + 0, 41)
-- Code(Expression(10, Add)) at (prev + 1, 14) to (start + 0, 52)
-    = (c9 + c10)
-- Code(Counter(11)) at (prev + 2, 1) to (start + 0, 2)
+- Code(Counter(8)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: yield::main::{closure#0}
 Raw bytes (14): 0x[01, 01, 00, 02, 01, 08, 1c, 01, 10, 05, 02, 10, 01, 06]

--- a/tests/coverage/yield.coverage
+++ b/tests/coverage/yield.coverage
@@ -12,11 +12,11 @@
    LL|       |
    LL|      1|    match Pin::new(&mut coroutine).resume(()) {
    LL|      1|        CoroutineState::Yielded(1) => {}
-   LL|      0|        _ => panic!("unexpected value from resume"),
+   LL|       |        _ => panic!("unexpected value from resume"),
    LL|       |    }
    LL|      1|    match Pin::new(&mut coroutine).resume(()) {
    LL|      1|        CoroutineState::Complete("foo") => {}
-   LL|      0|        _ => panic!("unexpected value from resume"),
+   LL|       |        _ => panic!("unexpected value from resume"),
    LL|       |    }
    LL|       |
    LL|      1|    let mut coroutine = || {
@@ -28,11 +28,11 @@
    LL|       |
    LL|      1|    match Pin::new(&mut coroutine).resume(()) {
    LL|      1|        CoroutineState::Yielded(1) => {}
-   LL|      0|        _ => panic!("unexpected value from resume"),
+   LL|       |        _ => panic!("unexpected value from resume"),
    LL|       |    }
    LL|      1|    match Pin::new(&mut coroutine).resume(()) {
    LL|      1|        CoroutineState::Yielded(2) => {}
-   LL|      0|        _ => panic!("unexpected value from resume"),
+   LL|       |        _ => panic!("unexpected value from resume"),
    LL|       |    }
    LL|      1|}
 


### PR DESCRIPTION
One of the limitations of coverage instrumentation at the moment is that there's no good way to exclude “unreachable” code paths from coverage reports (e.g. see #80549).

However, as I noted in <https://github.com/rust-lang/rust/issues/80549#issuecomment-1837389747>, there is potentially a way around this in some cases. Coverage instrumentation already assumes that panics don't occur, so if we can detect code paths that *must* panic/diverge (e.g. because they call `panic!` or `unreachable!`), we can potentially exclude their spans from the coverage mappings.

Doing so seems to give quite pleasing results in some previously-troublesome cases.

---

Marking this as draft for now because it's a big user-visible change, and while I like it overall, I'm not fully convinced that it's the right thing to do.

r? @ghost
@rustbot label +A-code-coverage