### PR TITLE
tidy: reduce allocs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,9 +2543,6 @@ dependencies = [
 [[package]]
 name = "miropt-test-tools"
 version = "0.1.0"
-dependencies = [
- "regex",
-]
 
 [[package]]
 name = "native-tls"

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -6,6 +6,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use once_cell::sync::Lazy;
 use regex::Regex;
 use tracing::*;
 
@@ -829,7 +830,8 @@ fn iter_header_extra(
     let mut ln = String::new();
     let mut line_number = 0;
 
-    let revision_magic_comment = Regex::new("//(\\[.*\\])?~.*").unwrap();
+    static REVISION_MAGIC_COMMENT_RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new("//(\\[.*\\])?~.*").unwrap());
 
     loop {
         line_number += 1;
@@ -849,7 +851,7 @@ fn iter_header_extra(
         // First try to accept `ui_test` style comments
         } else if let Some((lncfg, ln)) = line_directive(comment, ln) {
             it(lncfg, orig_ln, ln, line_number);
-        } else if mode == Mode::Ui && suite == "ui" && !revision_magic_comment.is_match(ln) {
+        } else if mode == Mode::Ui && suite == "ui" && !REVISION_MAGIC_COMMENT_RE.is_match(ln) {
             let Some((_, rest)) = line_directive("//", ln) else {
                 continue;
             };

--- a/src/tools/miropt-test-tools/Cargo.toml
+++ b/src/tools/miropt-test-tools/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-regex = "1.0"

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -130,16 +130,20 @@ fn should_ignore(line: &str) -> bool {
     // Matches test annotations like `//~ ERROR text`.
     // This mirrors the regex in src/tools/compiletest/src/runtest.rs, please
     // update both if either are changed.
-    let re = Regex::new("\\s*//(\\[.*\\])?~.*").unwrap();
+    lazy_static::lazy_static! {
+        static ref ANNOTATION_RE: Regex = Regex::new("\\s*//(\\[.*\\])?~.*").unwrap();
+    }
     // For `ui_test`-style UI test directives, also ignore
     // - `//@[rev] compile-flags`
     // - `//@[rev] normalize-stderr-test`
-    let ui_test_long_directives =
+    lazy_static::lazy_static! {
+        static ref UI_TEST_LONG_DIRECTIVES_RE: Regex =
         Regex::new("\\s*//@(\\[.*\\]) (compile-flags|normalize-stderr-test|error-pattern).*")
             .unwrap();
-    re.is_match(line)
+    }
+    ANNOTATION_RE.is_match(line)
         || ANNOTATIONS_TO_IGNORE.iter().any(|a| line.contains(a))
-        || ui_test_long_directives.is_match(line)
+        || UI_TEST_LONG_DIRECTIVES_RE.is_match(line)
 }
 
 /// Returns `true` if `line` is allowed to be longer than the normal limit.


### PR DESCRIPTION
this reduces allocs in tidy from (dhat output)

```
==31349== Total:     1,365,199,543 bytes in 4,774,213 blocks
==31349== At t-gmax: 10,975,708 bytes in 66,093 blocks
==31349== At t-end:  2,880,947 bytes in 12,332 blocks
==31349== Reads:     5,210,008,956 bytes
==31349== Writes:    1,280,920,127 bytes
```
to
```
==66633== Total:     791,565,538 bytes in 3,503,144 blocks
==66633== At t-gmax: 10,914,511 bytes in 65,997 blocks
==66633== At t-end:  395,531 bytes in 941 blocks
==66633== Reads:     4,249,388,949 bytes
==66633== Writes:    814,119,580 bytes
```

<del>by wrapping regex and updating `ignore` (effect probably not only from `ignore`, didn't measured)</del>

also moves one more regex into `Lazy` to reduce regex rebuilds.