### PR TITLE
Remove `next_root_ty_var`

### DIFF
--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -71,7 +71,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let parent_args =
             GenericArgs::identity_for_item(tcx, tcx.typeck_root_def_id(expr_def_id.to_def_id()));
 
-        let tupled_upvars_ty = self.next_root_ty_var(TypeVariableOrigin {
+        let tupled_upvars_ty = self.next_ty_var(TypeVariableOrigin {
             kind: TypeVariableOriginKind::ClosureSynthetic,
             span: expr_span,
         });
@@ -101,7 +101,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                     // Create a type variable (for now) to represent the closure kind.
                     // It will be unified during the upvar inference phase (`upvar.rs`)
-                    None => self.next_root_ty_var(TypeVariableOrigin {
+                    None => self.next_ty_var(TypeVariableOrigin {
                         // FIXME(eddyb) distinguish closure kind inference variables from the rest.
                         kind: TypeVariableOriginKind::ClosureSynthetic,
                         span: expr_span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -190,10 +190,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn errors_reported_since_creation(&self) -> bool {
         self.dcx().err_count() > self.err_count_on_creation
     }
-
-    pub fn next_root_ty_var(&self, origin: TypeVariableOrigin) -> Ty<'tcx> {
-        Ty::new_var(self.tcx, self.next_ty_var_id_in_universe(origin, ty::UniverseIndex::ROOT))
-    }
 }
 
 impl<'a, 'tcx> Deref for FnCtxt<'a, 'tcx> {


### PR DESCRIPTION
Uhh we seem to not have any test that relies on this anymore. Maybe due to the way we changed alias-relate or whatever. 

Removing this hack helper fn because #119106 is the general solution.

r? lcnr