### PR TITLE
Un-hide `iter::repeat_n`

### DIFF
--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -59,7 +59,6 @@ use crate::num::NonZeroUsize;
 /// ```
 #[inline]
 #[unstable(feature = "iter_repeat_n", issue = "104434")]
-#[doc(hidden)] // waiting on ACP#120 to decide whether to expose publicly
 pub fn repeat_n<T: Clone>(element: T, count: usize) -> RepeatN<T> {
     let mut element = ManuallyDrop::new(element);
 
@@ -79,7 +78,6 @@ pub fn repeat_n<T: Clone>(element: T, count: usize) -> RepeatN<T> {
 /// See its documentation for more.
 #[derive(Clone, Debug)]
 #[unstable(feature = "iter_repeat_n", issue = "104434")]
-#[doc(hidden)] // waiting on ACP#120 to decide whether to expose publicly
 pub struct RepeatN<A> {
     count: usize,
     // Invariant: has been dropped iff count == 0.


### PR DESCRIPTION
ACP accepted in https://github.com/rust-lang/libs-team/issues/120#issuecomment-1894144403

