### PR TITLE
Don't ICE when deducing future output if other errors already occurred

### DIFF
--- a/tests/ui/async-await/inference_var_self_argument.rs
+++ b/tests/ui/async-await/inference_var_self_argument.rs
@@ -1,0 +1,12 @@
+//! This is a regression test for an ICE.
+// edition: 2021
+
+trait Foo {
+    async fn foo(self: &dyn Foo) {
+        //~^ ERROR: `Foo` cannot be made into an object
+        //~| ERROR invalid `self` parameter type: &dyn Foo
+        todo!()
+    }
+}
+
+fn main() {}

--- a/tests/ui/async-await/inference_var_self_argument.stderr
+++ b/tests/ui/async-await/inference_var_self_argument.stderr
@@ -1,0 +1,28 @@
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/inference_var_self_argument.rs:5:5
+   |
+LL |     async fn foo(self: &dyn Foo) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/inference_var_self_argument.rs:5:14
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     async fn foo(self: &dyn Foo) {
+   |              ^^^ ...because method `foo` is `async`
+   = help: consider moving `foo` to another trait
+
+error[E0307]: invalid `self` parameter type: &dyn Foo
+  --> $DIR/inference_var_self_argument.rs:5:24
+   |
+LL |     async fn foo(self: &dyn Foo) {
+   |                        ^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0307.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/erroneous_signature.rs
+++ b/tests/ui/object-safety/erroneous_signature.rs
@@ -1,0 +1,17 @@
+trait Foo {
+    fn err(&self) -> MissingType;
+    //~^ ERROR cannot find type `MissingType` in this scope
+}
+
+impl Foo for i32 {
+    fn err(&self) -> MissingType {
+        //~^ ERROR cannot find type `MissingType` in this scope
+        0
+    }
+}
+
+fn coerce(x: &i32) -> &dyn Foo {
+    x
+}
+
+fn main() {}

--- a/tests/ui/object-safety/erroneous_signature.stderr
+++ b/tests/ui/object-safety/erroneous_signature.stderr
@@ -1,0 +1,15 @@
+error[E0412]: cannot find type `MissingType` in this scope
+  --> $DIR/erroneous_signature.rs:2:22
+   |
+LL |     fn err(&self) -> MissingType;
+   |                      ^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `MissingType` in this scope
+  --> $DIR/erroneous_signature.rs:7:22
+   |
+LL |     fn err(&self) -> MissingType {
+   |                      ^^^^^^^^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
The situation can't really happen outside of erroneous code. What was interesting is that it ICEd before emitting any other diagnostics. This was because the other errors were silenced due to cycle_delay_bug cycle errors.

r? @compiler-errors 

fixes #119890