### PR TITLE
Make generic const type mismatches not hide trait impls from the trait solver

### DIFF
--- a/tests/ui/const-generics/bad-subst-const-kind.rs
+++ b/tests/ui/const-generics/bad-subst-const-kind.rs
@@ -11,3 +11,4 @@ impl<const N: u64> Q for [u8; N] {
 }
 
 pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] { todo!() }
+//~^ ERROR: the constant `13` is not of type `u64`

--- a/tests/ui/const-generics/bad-subst-const-kind.stderr
+++ b/tests/ui/const-generics/bad-subst-const-kind.stderr
@@ -1,9 +1,23 @@
+error: the constant `13` is not of type `u64`
+  --> $DIR/bad-subst-const-kind.rs:13:24
+   |
+LL | pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] { todo!() }
+   |                        ^^^^^^^^ expected `u64`, found `usize`
+   |
+note: required for `[u8; 13]` to implement `Q`
+  --> $DIR/bad-subst-const-kind.rs:8:20
+   |
+LL | impl<const N: u64> Q for [u8; N] {
+   |      ------------  ^     ^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
+
 error[E0308]: mismatched types
   --> $DIR/bad-subst-const-kind.rs:8:31
    |
 LL | impl<const N: u64> Q for [u8; N] {
    |                               ^ expected `usize`, found `u64`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
@@ -7,7 +7,10 @@ trait Q {
 
 impl<const N: u64> Q for [u8; N] {}
 //~^ ERROR not all trait items implemented
+//~| ERROR mismatched types
 
 pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+//~^ ERROR the constant `13` is not of type `u64`
+//~| ERROR mismatched types
 
 pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -7,6 +7,35 @@ LL |     const ASSOC: usize;
 LL | impl<const N: u64> Q for [u8; N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
 
-error: aborting due to 1 previous error
+error: the constant `13` is not of type `u64`
+  --> $DIR/type_mismatch.rs:12:26
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |                          ^^^^^^^^ expected `u64`, found `usize`
+   |
+note: required for `[u8; 13]` to implement `Q`
+  --> $DIR/type_mismatch.rs:8:20
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |      ------------  ^     ^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
 
-For more information about this error, try `rustc --explain E0046`.
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:12:20
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |        ------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; <[u8; 13] as Q>::ASSOC]`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:8:31
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |                               ^ expected `usize`, found `u64`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0308.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
@@ -8,5 +8,6 @@ struct S<const L: usize>;
 impl<const N: i32> Copy for S<N> {}
 //~^ ERROR the constant `N` is not of type `usize`
 impl<const M: usize> Copy for S<M> {}
+//~^ ERROR: conflicting implementations of trait `Copy` for type `S<_>`
 
 fn main() {}

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
@@ -1,14 +1,29 @@
+error[E0119]: conflicting implementations of trait `Copy` for type `S<_>`
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:10:1
+   |
+LL | impl<const N: i32> Copy for S<N> {}
+   | -------------------------------- first implementation here
+LL |
+LL | impl<const M: usize> Copy for S<M> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S<_>`
+
 error: the constant `N` is not of type `usize`
   --> $DIR/bad-const-wf-doesnt-specialize.rs:8:29
    |
 LL | impl<const N: i32> Copy for S<N> {}
    |                             ^^^^ expected `usize`, found `i32`
    |
-note: required by a bound in `S`
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:6:10
+note: required for `S<N>` to implement `Clone`
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:5:10
    |
+LL | #[derive(Clone)]
+   |          ^^^^^
 LL | struct S<const L: usize>;
-   |          ^^^^^^^^^^^^^^ required by this bound in `S`
+   |          ----- unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `Copy`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
pulled out of https://github.com/rust-lang/rust/pull/119895

It does improve diagnostics somewhat, but also causes some extraneous diagnostics in potentially misleading order.

The issue was that a const type mismatch, instead of reporting an error, would silently poison the constant, only for that information to be thrown away and the impl to be treated as "not matching". In #119895 this would cause ICEs as well as errors on impls stating that the impl needs to exist for itself to be valid.