### PR TITLE
Keep stable attr in metadata

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -493,7 +493,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // DuplicatesOk since it has its own validation
     ungated!(
         stable, Normal,
-        template!(List: r#"feature = "name", since = "version""#), DuplicatesOk, @only_local: true,
+        template!(List: r#"feature = "name", since = "version""#), DuplicatesOk,
     ),
     ungated!(
         unstable, Normal,


### PR DESCRIPTION
Linked to https://github.com/rust-lang/rust/pull/98450.

When working on https://github.com/rust-lang/rust-clippy/pull/12160, I realized I couldn't make it work for the simple reason that the `stable` attribute is not kept in the metadata, making it impossible to compare an item's version to the configured MSRV.

So the question here is: would it be ok to not strip this attribute anymore to allow adding this clippy lint or is it not worth it?

| file | with `stable` | without `stable` | diff |
|-|-|-|-|
| libstd-b7a9436ca14188d2.rlib | 11985136 | 11756208 | +1.95% |
| libstd-b7a9436ca14188d2.so | 9060872 | 8831944 | +2.59% |

r? @lqd