### PR TITLE
Use UnhashMap for a few more maps

### DIFF
--- a/compiler/rustc_data_structures/src/hashes.rs
+++ b/compiler/rustc_data_structures/src/hashes.rs
@@ -75,9 +75,19 @@ impl fmt::LowerHex for Hash64 {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Hash128 {
     inner: u128,
+}
+
+// We expect Hash128 to be well mixed. So there's no point in hashing both parts.
+//
+// This also allows using Hash128-containing types in UnHash-based hashmaps, which would otherwise
+// debug_assert! that we're hashing more than a single u64.
+impl std::hash::Hash for Hash128 {
+    fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
+        h.write_u64(self.truncate().as_u64());
+    }
 }
 
 impl Hash128 {

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -314,7 +314,19 @@ impl_stable_traits_for_trivial_type!(char);
 impl_stable_traits_for_trivial_type!(());
 
 impl_stable_traits_for_trivial_type!(Hash64);
-impl_stable_traits_for_trivial_type!(Hash128);
+
+// We need a custom impl as the default hash function will only hash half the bits. For stable
+// hashing we want to hash the full 128-bit hash.
+impl<CTX> HashStable<CTX> for Hash128 {
+    #[inline]
+    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+        self.as_u128().hash(hasher);
+    }
+}
+
+unsafe impl StableOrd for Hash128 {
+    const CAN_USE_UNSTABLE_SORT: bool = true;
+}
 
 impl<CTX> HashStable<CTX> for ! {
     fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -330,7 +330,7 @@ pub(crate) struct HygieneData {
     /// would have collisions without a disambiguator.
     /// The keys of this map are always computed with `ExpnData.disambiguator`
     /// set to 0.
-    expn_data_disambiguators: FxHashMap<Hash64, u32>,
+    expn_data_disambiguators: UnhashMap<Hash64, u32>,
 }
 
 impl HygieneData {
@@ -359,7 +359,7 @@ impl HygieneData {
                 dollar_crate_name: kw::DollarCrate,
             }],
             syntax_context_map: FxHashMap::default(),
-            expn_data_disambiguators: FxHashMap::default(),
+            expn_data_disambiguators: UnhashMap::default(),
         }
     }
 

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -10,8 +10,8 @@
 //! information, source code snippets, etc.
 
 use crate::*;
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::{IntoDynSyncSend, MappedReadGuard, ReadGuard, RwLock};
+use rustc_data_structures::unhash::UnhashMap;
 use std::fs;
 use std::io::{self, BorrowedBuf, Read};
 use std::path::{self};
@@ -164,7 +164,7 @@ impl FileLoader for RealFileLoader {
 #[derive(Default)]
 struct SourceMapFiles {
     source_files: monotonic::MonotonicVec<Lrc<SourceFile>>,
-    stable_id_to_source_file: FxHashMap<StableSourceFileId, Lrc<SourceFile>>,
+    stable_id_to_source_file: UnhashMap<StableSourceFileId, Lrc<SourceFile>>,
 }
 
 pub struct SourceMap {


### PR DESCRIPTION
This avoids a few cases of hashing data that's already hashed.

cc https://github.com/rust-lang/rust/issues/56308