### PR TITLE
WIP: vendor rustc-hash and override str/length_prefix methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,8 +3312,6 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ strip = true
 rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
+rustc-hash = { path = "./rustc-hash" }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }

--- a/rustc-hash/.github/workflows/rust.yml
+++ b/rustc-hash/.github/workflows/rust.yml
@@ -1,0 +1,19 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: rust-lang/simpleinfra/github-actions/simple-ci@master
+    - name: "32-bit cross testing"
+      run: |
+        rustup toolchain install nightly
+        rustup override set nightly
+        rustup component add miri
+        cargo +nightly miri test --target i686-unknown-linux-gnu
+    strategy:
+      matrix:
+        os: [ubuntu, windows, macos]

--- a/rustc-hash/.gitignore
+++ b/rustc-hash/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+/Cargo.lock

--- a/rustc-hash/CODE_OF_CONDUCT.md
+++ b/rustc-hash/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# The Rust Code of Conduct
+
+A version of this document [can be found online](https://www.rust-lang.org/conduct.html).
+
+## Conduct
+
+**Contact**: [rust-mods@rust-lang.org](mailto:rust-mods@rust-lang.org)
+
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [Rust moderation team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+## Moderation
+
+
+These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact the [Rust moderation team][mod_team].
+
+1. Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
+3. Moderators will first respond to such remarks with a warning.
+4. If the warning is unheeded, the user will be "kicked," i.e., kicked out of the communication channel to cool off.
+5. If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
+6. Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.
+7. If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, **in private**. Complaints about bans in-channel are not allowed.
+8. Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.
+
+In the Rust community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
+
+The enforcement policies listed above apply to all official Rust venues; including official IRC channels (#rust, #rust-internals, #rust-tools, #rust-libs, #rustc, #rust-beginners, #rust-docs, #rust-community, #rust-lang, and #cargo); GitHub repositories under rust-lang, rust-lang-nursery, and rust-lang-deprecated; and all forums under rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your own moderation policy so as to avoid confusion.
+
+*Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*
+
+[mod_team]: https://www.rust-lang.org/team.html#Moderation-team

--- a/rustc-hash/Cargo.toml
+++ b/rustc-hash/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rustc-hash"
+version = "1.1.0"
+authors = ["The Rust Project Developers"]
+description = "speedy, non-cryptographic hash used in rustc"
+license = "Apache-2.0/MIT"
+readme = "README.md"
+keywords = ["hash", "hasher", "fxhash", "rustc"]
+repository = "https://github.com/rust-lang/rustc-hash"
+
+[features]
+default = ["std"]
+std = []
+rand = ["dep:rand", "std"]
+
+[dependencies]
+rand = { version = "0.8", optional = true }

--- a/rustc-hash/LICENSE-APACHE
+++ b/rustc-hash/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rustc-hash/LICENSE-MIT
+++ b/rustc-hash/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rustc-hash/README.md
+++ b/rustc-hash/README.md
@@ -1,0 +1,38 @@
+# rustc-hash
+
+[![crates.io](https://img.shields.io/crates/v/rustc-hash.svg)](https://crates.io/crates/rustc-hash)
+[![Documentation](https://docs.rs/rustc-hash/badge.svg)](https://docs.rs/rustc-hash)
+
+A speedy hash algorithm used within rustc. The hashmap in liballoc by
+default uses SipHash which isn't quite as speedy as we want. In the
+compiler we're not really worried about DOS attempts, so we use a fast
+non-cryptographic hash.
+
+This is the same as the algorithm used by Firefox -- which is a
+homespun one not based on any widely-known algorithm -- though
+modified to produce 64-bit hash values instead of 32-bit hash
+values. It consistently out-performs an FNV-based hash within rustc
+itself -- the collision rate is similar or slightly worse than FNV,
+but the speed of the hash function itself is much higher because it
+works on up to 8 bytes at a time.
+
+## Usage
+
+```rust
+use rustc_hash::FxHashMap;
+
+let mut map: FxHashMap<u32, u32> = FxHashMap::default();
+map.insert(22, 44);
+```
+
+### `no_std`
+
+This crate can be used as a `no_std` crate by disabling the `std`
+feature, which is on by default, as follows:
+
+```toml
+rustc-hash = { version = "1.1", default-features = false }
+```
+
+In this configuration, `FxHasher` is the only export, and the
+`FxHashMap`/`FxHashSet` type aliases are omitted.

--- a/rustc-hash/src/lib.rs
+++ b/rustc-hash/src/lib.rs
@@ -1,0 +1,324 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(hasher_prefixfree_extras)]
+
+//! Fast, non-cryptographic hash used by rustc and Firefox.
+//!
+//! # Example
+//!
+//! ```rust
+//! # #[cfg(feature = "std")]
+//! # fn main() {
+//! use rustc_hash::FxHashMap;
+//! let mut map: FxHashMap<u32, u32> = FxHashMap::default();
+//! map.insert(22, 44);
+//! # }
+//! # #[cfg(not(feature = "std"))]
+//! # fn main() { }
+//! ```
+
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "rand")]
+extern crate rand;
+
+#[cfg(feature = "rand")]
+mod random_state;
+
+mod seeded_state;
+
+use core::convert::TryInto;
+use core::default::Default;
+#[cfg(feature = "std")]
+use core::hash::BuildHasherDefault;
+use core::hash::Hasher;
+use core::mem::size_of;
+use core::ops::BitXor;
+#[cfg(feature = "std")]
+use std::collections::{HashMap, HashSet};
+
+/// Type alias for a hashmap using the `fx` hash algorithm.
+#[cfg(feature = "std")]
+pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// Type alias for a hashset using the `fx` hash algorithm.
+#[cfg(feature = "std")]
+pub type FxHashSet<V> = HashSet<V, BuildHasherDefault<FxHasher>>;
+
+#[cfg(feature = "rand")]
+pub use random_state::{FxHashMapRand, FxHashSetRand, FxRandomState};
+
+pub use seeded_state::{FxHashMapSeed, FxHashSetSeed, FxSeededState};
+
+/// A speedy hash algorithm for use within rustc. The hashmap in liballoc
+/// by default uses SipHash which isn't quite as speedy as we want. In the
+/// compiler we're not really worried about DOS attempts, so we use a fast
+/// non-cryptographic hash.
+///
+/// This is the same as the algorithm used by Firefox -- which is a homespun
+/// one not based on any widely-known algorithm -- though modified to produce
+/// 64-bit hash values instead of 32-bit hash values. It consistently
+/// out-performs an FNV-based hash within rustc itself -- the collision rate is
+/// similar or slightly worse than FNV, but the speed of the hash function
+/// itself is much higher because it works on up to 8 bytes at a time.
+#[derive(Clone)]
+pub struct FxHasher {
+    hash: usize,
+}
+
+#[cfg(target_pointer_width = "32")]
+const K: usize = 0x9e3779b9;
+#[cfg(target_pointer_width = "64")]
+const K: usize = 0x517cc1b727220a95;
+
+impl FxHasher {
+    /// Creates `fx` hasher with a given seed.
+    pub fn with_seed(seed: usize) -> FxHasher {
+        FxHasher { hash: seed }
+    }
+}
+
+impl Default for FxHasher {
+    #[inline]
+    fn default() -> FxHasher {
+        FxHasher { hash: 0 }
+    }
+}
+
+impl FxHasher {
+    #[inline]
+    fn add_to_hash(&mut self, i: usize) {
+        self.hash = self.hash.rotate_left(5).bitxor(i).wrapping_mul(K);
+    }
+}
+
+impl Hasher for FxHasher {
+    #[inline]
+    fn write(&mut self, mut bytes: &[u8]) {
+        #[cfg(target_pointer_width = "32")]
+        let read_usize = |bytes: &[u8]| u32::from_ne_bytes(bytes[..4].try_into().unwrap());
+        #[cfg(target_pointer_width = "64")]
+        let read_usize = |bytes: &[u8]| u64::from_ne_bytes(bytes[..8].try_into().unwrap());
+
+        let mut hash = FxHasher { hash: self.hash };
+        assert!(size_of::<usize>() <= 8);
+        while bytes.len() >= size_of::<usize>() {
+            hash.add_to_hash(read_usize(bytes) as usize);
+            bytes = &bytes[size_of::<usize>()..];
+        }
+        if (size_of::<usize>() > 4) && (bytes.len() >= 4) {
+            hash.add_to_hash(u32::from_ne_bytes(bytes[..4].try_into().unwrap()) as usize);
+            bytes = &bytes[4..];
+        }
+        if (size_of::<usize>() > 2) && bytes.len() >= 2 {
+            hash.add_to_hash(u16::from_ne_bytes(bytes[..2].try_into().unwrap()) as usize);
+            bytes = &bytes[2..];
+        }
+        if (size_of::<usize>() > 1) && bytes.len() >= 1 {
+            hash.add_to_hash(bytes[0] as usize);
+        }
+        self.hash = hash.hash;
+    }
+
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.add_to_hash(i as usize);
+        self.add_to_hash((i >> 32) as usize);
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.add_to_hash(i as usize);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        self.add_to_hash(i);
+    }
+
+    // Avoid hashing 0xFF sentinel; we don't need prefix-free hashes.
+    #[inline]
+    fn write_str(&mut self, s: &str) {
+        self.write(s.as_bytes());
+    }
+
+    // Avoid hashing length prefixes. For our purposes the actual data gives us plenty of entropy
+    // and FxHash provides pretty poor hash quality anyway: this is typically faster.
+    #[inline]
+    fn write_length_prefix(&mut self, _: usize) {
+        // no-op
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]
+    compile_error!("The test suite only supports 64 bit and 32 bit usize");
+
+    use crate::FxHasher;
+    use core::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+
+    macro_rules! test_hash {
+        (
+            $(
+                hash($value:expr) == $result:expr,
+            )*
+        ) => {
+            $(
+                assert_eq!(BuildHasherDefault::<FxHasher>::default().hash_one($value), $result);
+            )*
+        };
+    }
+
+    const B32: bool = cfg!(target_pointer_width = "32");
+
+    #[test]
+    fn unsigned() {
+        test_hash! {
+            hash(0_u8) == 0,
+            hash(1_u8) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_u8) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(u8::MAX) == if B32 { 2571255623 } else { 3117886703346944619 },
+
+            hash(0_u16) == 0,
+            hash(1_u16) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_u16) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(u16::MAX) == if B32 { 3682698823 } else { 8086887590654047595 },
+
+            hash(0_u32) == 0,
+            hash(1_u32) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_u32) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(u32::MAX) == if B32 { 1640531527 } else { 15394791018899305835 },
+
+            hash(0_u64) == 0,
+            hash(1_u64) == if B32 { 703266523 } else { 5871781006564002453 },
+            hash(100_u64) == if B32 { 2407204753 } else { 15329034371404145204 },
+            hash(u64::MAX) == if B32 { 1660667835 } else { 12574963067145549163 },
+
+            hash(0_u128) == 0,
+            hash(1_u128) == if B32 { 1294492036 } else { 956286968014291186 },
+            hash(100_u128) == if B32 { 3411300242 } else { 2770938889503972258 },
+            hash(u128::MAX) == if B32 { 3723263291 } else { 15973479568771280466 },
+
+            hash(0_usize) == 0,
+            hash(1_usize) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_usize) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(usize::MAX) == if B32 { 1640531527 } else { 12574963067145549163 },
+        }
+    }
+
+    #[test]
+    fn signed() {
+        test_hash! {
+            hash(i8::MIN) == if B32 { 465362048 } else { 13718205891810249344 },
+            hash(0_i8) == 0,
+            hash(1_i8) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_i8) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(i8::MAX) == if B32 { 2105893575 } else { 7846424885246246891 },
+
+            hash(i16::MIN) == if B32 { 3168567296 } else { 6979334298609025024 },
+            hash(0_i16) == 0,
+            hash(1_i16) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_i16) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(i16::MAX) == if B32 { 514131527 } else { 1107553292045022571 },
+
+            hash(i32::MIN) == if B32 { 2147483648 } else { 10633286012731654144 },
+            hash(0_i32) == 0,
+            hash(1_i32) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_i32) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(i32::MAX) == if B32 { 3788015175 } else { 4761505006167651691 },
+
+            hash(i64::MIN) == if B32 { 2147483648 } else { 9223372036854775808 },
+            hash(0_i64) == 0,
+            hash(1_i64) == if B32 { 703266523 } else { 5871781006564002453 },
+            hash(100_i64) == if B32 { 2407204753 } else { 15329034371404145204 },
+            hash(i64::MAX) == if B32 { 3808151483 } else { 3351591030290773355 },
+
+            hash(i128::MIN) == if B32 { 2147483648 } else { 9223372036854775808 },
+            hash(0_i128) == 0,
+            hash(1_i128) == if B32 { 1294492036 } else { 956286968014291186 },
+            hash(100_i128) == if B32 { 3411300242 } else { 2770938889503972258 },
+            hash(i128::MAX) == if B32 { 1575779643 } else { 6750107531916504658 },
+
+            hash(isize::MIN) == if B32 { 2147483648 } else { 9223372036854775808 },
+            hash(0_isize) == 0,
+            hash(1_isize) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(100_isize) == if B32 { 3450571844 } else { 15329034371404145204 },
+            hash(isize::MAX) == if B32 { 3788015175 } else { 3351591030290773355 },
+        }
+    }
+
+    // Avoid relying on any `Hash` implementations in the standard library.
+    struct HashBytes(&'static [u8]);
+    impl Hash for HashBytes {
+        fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+            state.write(self.0);
+        }
+    }
+
+    #[test]
+    fn bytes() {
+        test_hash! {
+            hash(HashBytes(&[])) == 0,
+            hash(HashBytes(&[0])) == 0,
+            hash(HashBytes(&[0, 0, 0, 0, 0, 0])) == 0,
+            hash(HashBytes(&[1])) == if B32 { 2654435769 } else { 5871781006564002453 },
+            hash(HashBytes(&[2])) == if B32 { 1013904242 } else { 11743562013128004906 },
+            hash(HashBytes(b"uwu")) == if B32 { 3939043750 } else { 16622306935539548858 },
+            hash(HashBytes(b"These are some bytes for testing rustc_hash.")) == if B32 { 2345708736 } else { 12390864548135261390 },
+        }
+    }
+
+    #[test]
+    fn with_seed_actually_different() {
+        let seeds = [[1, 2], [42, 17], [124436707, 99237], [usize::MIN, usize::MAX]];
+
+        for [a_seed, b_seed] in seeds {
+            let a = || FxHasher::with_seed(a_seed);
+            let b = || FxHasher::with_seed(b_seed);
+
+            for x in u8::MIN..=u8::MAX {
+                let mut a = a();
+                let mut b = b();
+
+                x.hash(&mut a);
+                x.hash(&mut b);
+
+                assert_ne!(a.finish(), b.finish())
+            }
+        }
+    }
+}

--- a/rustc-hash/src/lib.rs
+++ b/rustc-hash/src/lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(hasher_prefixfree_extras)]
+#![allow(rustc::default_hash_types)]
 
 //! Fast, non-cryptographic hash used by rustc and Firefox.
 //!

--- a/rustc-hash/src/lib.rs
+++ b/rustc-hash/src/lib.rs
@@ -165,10 +165,12 @@ impl Hasher for FxHasher {
         self.add_to_hash(i);
     }
 
-    // Avoid hashing 0xFF sentinel; we don't need prefix-free hashes.
     #[inline]
     fn write_str(&mut self, s: &str) {
         self.write(s.as_bytes());
+        // FIXME: Not having this seems to add significant cost to Symbol::intern(?), but it's not
+        // very clear why. That's interning &str, so it's not obvious why this matters.
+        self.write_u8(0xFF);
     }
 
     // Avoid hashing length prefixes. For our purposes the actual data gives us plenty of entropy

--- a/rustc-hash/src/random_state.rs
+++ b/rustc-hash/src/random_state.rs
@@ -1,0 +1,92 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::FxHasher;
+
+/// Type alias for a hashmap using the `fx` hash algorithm with [`FxRandomState`].
+pub type FxHashMapRand<K, V> = HashMap<K, V, FxRandomState>;
+
+/// Type alias for a hashmap using the `fx` hash algorithm with [`FxRandomState`].
+pub type FxHashSetRand<V> = HashSet<V, FxRandomState>;
+
+/// `FxRandomState` is an alternative state for `HashMap` types.
+///
+/// A particular instance `FxRandomState` will create the same instances of
+/// [`Hasher`], but the hashers created by two different `FxRandomState`
+/// instances are unlikely to produce the same result for the same values.
+pub struct FxRandomState {
+    seed: usize,
+}
+
+impl FxRandomState {
+    /// Constructs a new `FxRandomState` that is initialized with random seed.
+    pub fn new() -> FxRandomState {
+        use rand::Rng;
+        use std::{cell::Cell, thread_local};
+
+        // This mirrors what `std::collections::hash_map::RandomState` does, as of 2024-01-14.
+        //
+        // Basically
+        // 1. Cache result of the rng in a thread local, so repeatedly
+        //    creating maps is cheaper
+        // 2. Change the cached result on every creation, so maps created
+        //    on the same thread don't have the same iteration order
+        thread_local!(static SEED: Cell<usize> = {
+            Cell::new(rand::thread_rng().gen())
+        });
+
+        SEED.with(|seed| {
+            let s = seed.get();
+            seed.set(s.wrapping_add(1));
+            FxRandomState { seed: s }
+        })
+    }
+}
+
+impl core::hash::BuildHasher for FxRandomState {
+    type Hasher = FxHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        FxHasher::with_seed(self.seed)
+    }
+}
+
+impl Default for FxRandomState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use crate::FxHashMapRand;
+
+    #[test]
+    fn random_states_are_different() {
+        let a = FxHashMapRand::<&str, u32>::default();
+        let b = FxHashMapRand::<&str, u32>::default();
+
+        // That's the whole point of them being random!
+        //
+        // N.B.: `FxRandomState` uses a thread-local set to a random value and then incremented,
+        //       which means that this is *guaranteed* to pass :>
+        assert_ne!(a.hasher().seed, b.hasher().seed);
+    }
+
+    #[test]
+    fn random_states_are_different_cross_thread() {
+        // This is similar to the test above, but uses two different threads, so they both get
+        // completely random, unrelated values.
+        //
+        // This means that this test is technically flaky, but the probability of it failing is
+        // `1 / 2.pow(bit_size_of::<usize>())`. Or 1/1.7e19 for 64 bit platforms or 1/4294967295
+        // for 32 bit platforms. I suppose this is acceptable.
+        let a = FxHashMapRand::<&str, u32>::default();
+        let b = thread::spawn(|| FxHashMapRand::<&str, u32>::default())
+            .join()
+            .unwrap();
+
+        assert_ne!(a.hasher().seed, b.hasher().seed);
+    }
+}

--- a/rustc-hash/src/random_state.rs
+++ b/rustc-hash/src/random_state.rs
@@ -83,9 +83,7 @@ mod tests {
         // `1 / 2.pow(bit_size_of::<usize>())`. Or 1/1.7e19 for 64 bit platforms or 1/4294967295
         // for 32 bit platforms. I suppose this is acceptable.
         let a = FxHashMapRand::<&str, u32>::default();
-        let b = thread::spawn(|| FxHashMapRand::<&str, u32>::default())
-            .join()
-            .unwrap();
+        let b = thread::spawn(|| FxHashMapRand::<&str, u32>::default()).join().unwrap();
 
         assert_ne!(a.hasher().seed, b.hasher().seed);
     }

--- a/rustc-hash/src/seeded_state.rs
+++ b/rustc-hash/src/seeded_state.rs
@@ -48,9 +48,6 @@ mod tests {
         let a = FxHashMapSeed::<&str, u32>::with_hasher(FxSeededState::with_seed(1));
         let b = FxHashMapSeed::<&str, u32>::with_hasher(FxSeededState::with_seed(2));
 
-        assert_ne!(
-            a.hasher().build_hasher().hash,
-            b.hasher().build_hasher().hash
-        );
+        assert_ne!(a.hasher().build_hasher().hash, b.hasher().build_hasher().hash);
     }
 }

--- a/rustc-hash/src/seeded_state.rs
+++ b/rustc-hash/src/seeded_state.rs
@@ -1,0 +1,56 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::FxHasher;
+
+/// Type alias for a hashmap using the `fx` hash algorithm with [`FxSeededState`].
+pub type FxHashMapSeed<K, V> = HashMap<K, V, FxSeededState>;
+
+/// Type alias for a hashmap using the `fx` hash algorithm with [`FxSeededState`].
+pub type FxHashSetSeed<V> = HashSet<V, FxSeededState>;
+
+/// [`FxSetState`] is an alternative state for `HashMap` types, allowing to use [`FxHasher`] with a set seed.
+///
+/// ```
+/// # use std::collections::HashMap;
+/// use rustc_hash::FxSeededState;
+///
+/// let mut map = HashMap::with_hasher(FxSeededState::with_seed(12));
+/// map.insert(15, 610);
+/// assert_eq!(map[&15], 610);
+/// ```
+pub struct FxSeededState {
+    seed: usize,
+}
+
+impl FxSeededState {
+    /// Constructs a new `FxSeededState` that is initialized with a `seed`.
+    pub fn with_seed(seed: usize) -> FxSeededState {
+        Self { seed }
+    }
+}
+
+impl core::hash::BuildHasher for FxSeededState {
+    type Hasher = FxHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        FxHasher::with_seed(self.seed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::hash::BuildHasher;
+
+    use crate::{FxHashMapSeed, FxSeededState};
+
+    #[test]
+    fn different_states_are_different() {
+        let a = FxHashMapSeed::<&str, u32>::with_hasher(FxSeededState::with_seed(1));
+        let b = FxHashMapSeed::<&str, u32>::with_hasher(FxSeededState::with_seed(2));
+
+        assert_ne!(
+            a.hasher().build_hasher().hash,
+            b.hasher().build_hasher().hash
+        );
+    }
+}


### PR DESCRIPTION
Locally avoiding length and str sentinel hashing adds 2,611,200 cases of hashes with just one add_to_hash call (out of roughly 43,063,296 total cases). Unclear what kind of effect this will have on runtime performance at this time, but seems like it's worth trying!

cc https://github.com/rust-lang/rust/issues/56308