### PR TITLE
Warn when not having a profiler runtime means that coverage tests won't be run/blessed

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -15,6 +15,15 @@ fn main() {
         eprintln!("warning: `tidy` is not installed; diffs will not be generated");
     }
 
+    if !config.profiler_support && config.mode == Mode::CoverageRun {
+        let actioned = if config.bless { "blessed" } else { "checked" };
+        eprintln!(
+            r#"
+WARNING: profiler runtime is not available, so `.coverage` files won't be {actioned}
+help: try setting `profiler = true` in the `[build]` section of `config.toml`"#
+        );
+    }
+
     log_config(&config);
     run_tests(config);
 }


### PR DESCRIPTION
On a few occasions (e.g. #118036, #119984) people have been tripped up by the fact that half of the coverage test suite is skipped by default, because it `// needs-profiler-support` and the profiler runtime is not actually built in any of the default config profiles.

(This is made worse by the fact that it isn't enabled in any of the PR CI jobs either. So people think that they've successfully blessed the test suite, and then get a rude surprise when their merge only fails in the full CI job suite.)

This PR adds a simple warning to compiletest that should alert the user in some cases. It's not foolproof, but it should increase the chances of catching this problem earlier in the PR process.
