### PR TITLE
Report unreachable subpatterns consistently

### DIFF
--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -162,12 +162,14 @@ fn main() {
 }
 
 fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
+//~^ ERROR unreachable
 
 fn unreachable_in_binding() {
     let bool_pair = (true, true);
     let bool_option = Some(true);
 
     let (_ | (_, _)) = bool_pair;
+    //~^ ERROR unreachable
     for (_ | (_, _)) in [bool_pair] {}
     //~^ ERROR unreachable
 

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -160,3 +160,21 @@ fn main() {
             | (y, x) => {} //~ ERROR unreachable
     }
 }
+
+fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
+
+fn unreachable_in_binding() {
+    let bool_pair = (true, true);
+    let bool_option = Some(true);
+
+    let (_ | (_, _)) = bool_pair;
+    for (_ | (_, _)) in [bool_pair] {}
+    //~^ ERROR unreachable
+
+    let (Some(_) | Some(true)) = bool_option else { return };
+    //~^ ERROR unreachable
+    if let Some(_) | Some(true) = bool_option {}
+    //~^ ERROR unreachable
+    while let Some(_) | Some(true) = bool_option {}
+    //~^ ERROR unreachable
+}

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -184,5 +184,29 @@ error: unreachable pattern
 LL |             | (y, x) => {}
    |               ^^^^^^
 
-error: aborting due to 29 previous errors
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:171:14
+   |
+LL |     for (_ | (_, _)) in [bool_pair] {}
+   |              ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:174:20
+   |
+LL |     let (Some(_) | Some(true)) = bool_option else { return };
+   |                    ^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:22
+   |
+LL |     if let Some(_) | Some(true) = bool_option {}
+   |                      ^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:25
+   |
+LL |     while let Some(_) | Some(true) = bool_option {}
+   |                         ^^^^^^^^^^
+
+error: aborting due to 33 previous errors
 

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -185,28 +185,40 @@ LL |             | (y, x) => {}
    |               ^^^^^^
 
 error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:164:30
+   |
+LL | fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
+   |                              ^^^^^^
+
+error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:171:14
+   |
+LL |     let (_ | (_, _)) = bool_pair;
+   |              ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:173:14
    |
 LL |     for (_ | (_, _)) in [bool_pair] {}
    |              ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:174:20
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:20
    |
 LL |     let (Some(_) | Some(true)) = bool_option else { return };
    |                    ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:22
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:22
    |
 LL |     if let Some(_) | Some(true) = bool_option {}
    |                      ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:25
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:180:25
    |
 LL |     while let Some(_) | Some(true) = bool_option {}
    |                         ^^^^^^^^^^
 
-error: aborting due to 33 previous errors
+error: aborting due to 35 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
@@ -11,22 +11,34 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:21:12
+  --> $DIR/unreachable.rs:20:19
+   |
+LL |     let (Ok(_x) | Err(!)) = res_void;
+   |                   ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:22:12
    |
 LL |     if let Err(!) = res_void {}
    |            ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:23:24
+  --> $DIR/unreachable.rs:24:24
    |
 LL |     if let (Ok(true) | Err(!)) = res_void {}
    |                        ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:25:23
+  --> $DIR/unreachable.rs:26:23
    |
 LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    |                       ^^^^^^
 
-error: aborting due to 4 previous errors
+error: unreachable pattern
+  --> $DIR/unreachable.rs:30:18
+   |
+LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
+   |                  ^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
@@ -1,0 +1,32 @@
+error: unreachable pattern
+  --> $DIR/unreachable.rs:17:9
+   |
+LL |         Err(!),
+   |         ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unreachable.rs:7:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:21:12
+   |
+LL |     if let Err(!) = res_void {}
+   |            ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:23:24
+   |
+LL |     if let (Ok(true) | Err(!)) = res_void {}
+   |                        ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:25:23
+   |
+LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
+   |                       ^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
@@ -1,0 +1,29 @@
+// revisions: normal exh_pats
+//[normal] check-pass
+#![feature(never_patterns)]
+#![allow(incomplete_features)]
+#![cfg_attr(exh_pats, feature(exhaustive_patterns))]
+#![allow(dead_code, unreachable_code)]
+#![deny(unreachable_patterns)]
+
+#[derive(Copy, Clone)]
+enum Void {}
+
+fn main() {
+    let res_void: Result<bool, Void> = Ok(true);
+
+    match res_void {
+        Ok(_x) => {}
+        Err(!),
+        //[exh_pats]~^ ERROR unreachable
+    }
+    let (Ok(_x) | Err(!)) = res_void;
+    if let Err(!) = res_void {}
+    //[exh_pats]~^ ERROR unreachable
+    if let (Ok(true) | Err(!)) = res_void {}
+    //[exh_pats]~^ ERROR unreachable
+    for (Ok(mut _x) | Err(!)) in [res_void] {}
+    //[exh_pats]~^ ERROR unreachable
+}
+
+fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
@@ -18,6 +18,7 @@ fn main() {
         //[exh_pats]~^ ERROR unreachable
     }
     let (Ok(_x) | Err(!)) = res_void;
+    //[exh_pats]~^ ERROR unreachable
     if let Err(!) = res_void {}
     //[exh_pats]~^ ERROR unreachable
     if let (Ok(true) | Err(!)) = res_void {}
@@ -27,3 +28,4 @@ fn main() {
 }
 
 fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
+//[exh_pats]~^ ERROR unreachable

--- a/tests/ui/unsafe/union_destructure.rs
+++ b/tests/ui/unsafe/union_destructure.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(unreachable_patterns)]
 
 #[derive(Copy, Clone)]
 #[allow(dead_code)]


### PR DESCRIPTION
We weren't reporting unreachable subpatterns in function arguments and `let` expressions. This wasn't very important, but never patterns make it more relevant: a user might write `let (Ok(x) | Err(!)) = ...` in a case where `let Ok(x) = ...` is accepted, so we should report the `Err(!)` as redundant.

r? @compiler-errors 