### PR TITLE
Give a better error message when CI download fails

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -271,6 +271,15 @@ pub fn output(cmd: &mut Command) -> String {
     String::from_utf8(output.stdout).unwrap()
 }
 
+#[track_caller]
+pub fn try_output(cmd: &mut Command) -> String {
+    let output = match cmd.stderr(Stdio::inherit()).output() {
+        Ok(status) => status,
+        Err(e) => fail(&format!("failed to execute command: {cmd:?}\nERROR: {e}")),
+    };
+    String::from_utf8(output.stdout).unwrap()
+}
+
 /// Returns the last-modified time for `path`, or zero if it doesn't exist.
 pub fn mtime(path: &Path) -> SystemTime {
     fs::metadata(path).and_then(|f| f.modified()).unwrap_or(UNIX_EPOCH)


### PR DESCRIPTION
Fixes an issue introduced in [7b5577985df7](https://github.com/rust-lang/rust/commit/7b5577985df7e7f3132c1e8db1eb6e1022f31276). Looks like a typo, checked the output from diff and doesn't look like there are any other issues in with the commit.

resolves [118758](https://github.com/rust-lang/rust/issues/118758)