### PR TITLE
change `.unwrap()` to `?` on write where `fmt::Result` is returned

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -1116,10 +1116,10 @@ fn pre_fmt_projection(projection: &[PlaceElem<'_>], fmt: &mut Formatter<'_>) -> 
             | ProjectionElem::Subtype(_)
             | ProjectionElem::Downcast(_, _)
             | ProjectionElem::Field(_, _) => {
-                write!(fmt, "(").unwrap();
+                write!(fmt, "(")?;
             }
             ProjectionElem::Deref => {
-                write!(fmt, "(*").unwrap();
+                write!(fmt, "(*")?;
             }
             ProjectionElem::Index(_)
             | ProjectionElem::ConstantIndex { .. }


### PR DESCRIPTION
Fixes #120090 which points out that some of the `.unwrap()`s in `rustc_middle/src/mir/pretty.rs` are likely meant to be `?`s