### PR TITLE
dead_code treats #[repr(transparent)] the same as #[repr(C)]

### DIFF
--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -171,7 +171,6 @@ struct WithHeader<H>(NonNull<u8>, PhantomData<H>);
 /// An opaque representation of `WithHeader<H>` to avoid the
 /// projection invariance of `<T as Pointee>::Metadata`.
 #[repr(transparent)]
-#[allow(dead_code)] // Field only used through `WithHeader` type above.
 struct WithOpaqueHeader(NonNull<u8>);
 
 impl WithOpaqueHeader {

--- a/src/tools/miri/tests/fail/issue-miri-1112.rs
+++ b/src/tools/miri/tests/fail/issue-miri-1112.rs
@@ -1,7 +1,7 @@
 trait Empty {}
 
 #[repr(transparent)]
-pub struct FunnyPointer(#[allow(dead_code)] dyn Empty);
+pub struct FunnyPointer(dyn Empty);
 
 #[repr(C)]
 pub struct Meta {

--- a/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.rs
+++ b/src/tools/miri/tests/fail/unaligned_pointers/drop_in_place.rs
@@ -1,7 +1,7 @@
 //@compile-flags: -Cdebug-assertions=no
 
 #[repr(transparent)]
-struct HasDrop(#[allow(dead_code)] u8);
+struct HasDrop(u8);
 
 impl Drop for HasDrop {
     fn drop(&mut self) {}

--- a/tests/ui/consts/transmute-const.rs
+++ b/tests/ui/consts/transmute-const.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 #[repr(transparent)]
-struct Foo(#[allow(dead_code)] u32);
+struct Foo(u32);
 
 const TRANSMUTED_U32: u32 = unsafe { mem::transmute(Foo(3)) };
 

--- a/tests/ui/layout/unsafe-cell-hides-niche.rs
+++ b/tests/ui/layout/unsafe-cell-hides-niche.rs
@@ -17,7 +17,7 @@ use std::sync::{Mutex, RwLock};
 struct Wrapper<T>(#[allow(dead_code)] T);
 
 #[repr(transparent)]
-struct Transparent<T>(#[allow(dead_code)] T);
+struct Transparent<T>(T);
 
 struct NoNiche<T>(UnsafeCell<T>);
 

--- a/tests/ui/lint/dead-code/type-in-transparent.rs
+++ b/tests/ui/lint/dead-code/type-in-transparent.rs
@@ -1,0 +1,14 @@
+// Verify that we do not warn on fields that are part of transparent types.
+// check-pass
+#![deny(dead_code)]
+
+#[repr(transparent)]
+struct NamedStruct { field: u8 }
+
+#[repr(transparent)]
+struct TupleStruct(u8);
+
+fn main() {
+    let _ = NamedStruct { field: 1 };
+    let _ = TupleStruct(1);
+}

--- a/tests/ui/packed/packed-struct-drop-aligned.rs
+++ b/tests/ui/packed/packed-struct-drop-aligned.rs
@@ -24,7 +24,7 @@ impl<'a> Drop for Aligned<'a> {
 }
 
 #[repr(transparent)]
-struct NotCopy(#[allow(dead_code)] u8);
+struct NotCopy(u8);
 
 #[repr(packed)]
 struct Packed<'a>(NotCopy, Aligned<'a>);


### PR DESCRIPTION
In #92972 we enabled linting on unused fields in tuple structs. In #118297 that lint was enabled by default. That exposed issues like #119659, where the fields of a struct marked `#[repr(transparent)]` were reported by the `dead_code` lint. The language team [decided](https://github.com/rust-lang/rust/issues/119659#issuecomment-1885172045) that the lint should treat `repr(transparent)` the same as `#[repr(C)]`.

Fixes #119659