### PR TITLE
Make `TerminatorKind::Call::func` `Spanned` and remove `::fn_span`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -554,7 +554,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         &block.terminator().kind
                     {
                         // Just point to the function, to reduce the chance of overlapping spans.
-                        let function_span = match func {
+                        let function_span = match &func.node {
                             Operand::Constant(c) => c.span,
                             Operand::Copy(place) | Operand::Move(place) => {
                                 if let Some(l) = place.as_local() {

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -103,7 +103,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let terminator = self.body[location.block].terminator();
         debug!("add_moved_or_invoked_closure_note: terminator={:?}", terminator);
         if let TerminatorKind::Call {
-            func: Operand::Constant(box ConstOperand { const_, .. }),
+            func: Spanned { node: Operand::Constant(box ConstOperand { const_, .. }), .. },
             args,
             ..
         } = &terminator.kind
@@ -430,7 +430,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     }) = &bbd.terminator
                     {
                         if let Some(source) =
-                            BorrowedContentSource::from_call(func.ty(self.body, tcx), tcx)
+                            BorrowedContentSource::from_call(func.node.ty(self.body, tcx), tcx)
                         {
                             return source;
                         }
@@ -855,7 +855,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         debug!("move_spans: target_temp = {:?}", target_temp);
 
         if let Some(Terminator {
-            kind: TerminatorKind::Call { fn_span, call_source, .. }, ..
+            kind: TerminatorKind::Call { func: Spanned { span: fn_span, .. }, call_source, .. },
+            ..
         }) = &self.body[location.block].terminator
         {
             let Some((method_did, method_args)) = rustc_middle::util::find_self_call(

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -699,9 +699,8 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
                 target: _,
                 unwind: _,
                 call_source: _,
-                fn_span: _,
             } => {
-                self.consume_operand(loc, (func, span), flow_state);
+                self.consume_operand(loc, (&func.node, span), flow_state);
                 for arg in args {
                     self.consume_operand(loc, (&arg.node, arg.span), flow_state);
                 }

--- a/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
@@ -116,9 +116,8 @@ impl<'cx, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'cx, 'tcx> {
                 target: _,
                 unwind: _,
                 call_source: _,
-                fn_span: _,
             } => {
-                self.consume_operand(location, func);
+                self.consume_operand(location, &func.node);
                 for arg in args {
                     self.consume_operand(location, &arg.node);
                 }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1367,12 +1367,12 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 // FIXME: check the values
             }
             TerminatorKind::Call { func, args, destination, call_source, target, .. } => {
-                self.check_operand(func, term_location);
+                self.check_operand(&func.node, term_location);
                 for arg in args {
                     self.check_operand(&arg.node, term_location);
                 }
 
-                let func_ty = func.ty(body, tcx);
+                let func_ty = func.node.ty(body, tcx);
                 debug!("func_ty.kind: {:?}", func_ty.kind());
 
                 let sig = match func_ty.kind() {
@@ -1441,7 +1441,15 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                         .add_location(region_vid, term_location);
                 }
 
-                self.check_call_inputs(body, term, func, &sig, args, term_location, *call_source);
+                self.check_call_inputs(
+                    body,
+                    term,
+                    &func.node,
+                    &sig,
+                    args,
+                    term_location,
+                    *call_source,
+                );
             }
             TerminatorKind::Assert { cond, msg, .. } => {
                 self.check_operand(cond, term_location);

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -421,20 +421,12 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                     switch.emit(&mut fx.bcx, discr, otherwise_block);
                 }
             }
-            TerminatorKind::Call {
-                func,
-                args,
-                destination,
-                target,
-                fn_span,
-                unwind: _,
-                call_source: _,
-            } => {
+            TerminatorKind::Call { func, args, destination, target, unwind: _, call_source: _ } => {
                 fx.tcx.prof.generic_activity("codegen call").run(|| {
                     crate::abi::codegen_terminator_call(
                         fx,
-                        mir::SourceInfo { span: *fn_span, ..source_info },
-                        func,
+                        mir::SourceInfo { span: func.span, ..source_info },
+                        &func.node,
                         args,
                         *destination,
                         *target,

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -18,7 +18,7 @@ use rustc_middle::ty::layout::{
 use rustc_middle::ty::{self, GenericArgsRef, ParamEnv, Ty, TyCtxt, TypeFoldable, Variance};
 use rustc_mir_dataflow::storage::always_storage_live_locals;
 use rustc_session::Limit;
-use rustc_span::Span;
+use rustc_span::{source_map::Spanned, Span};
 use rustc_target::abi::{call::FnAbi, Align, HasDataLayout, Size, TargetDataLayout};
 
 use super::{
@@ -620,8 +620,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     block.terminator(),
                     block.terminator().kind,
                 );
-                if let mir::TerminatorKind::Call { fn_span, .. } = block.terminator().kind {
-                    source_info.span = fn_span;
+                if let mir::TerminatorKind::Call { func: Spanned { span, .. }, .. } =
+                    block.terminator().kind
+                {
+                    source_info.span = span;
                 }
             }
 

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -111,18 +111,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.go_to_block(target_block);
             }
 
-            Call {
-                ref func,
-                ref args,
-                destination,
-                target,
-                unwind,
-                call_source: _,
-                fn_span: _,
-            } => {
+            Call { ref func, ref args, destination, target, unwind, call_source: _ } => {
                 let old_stack = self.frame_idx();
                 let old_loc = self.frame().loc;
-                let func = self.eval_operand(func, None)?;
+                let func = self.eval_operand(&func.node, None)?;
                 let args = self.eval_fn_call_arguments(args)?;
 
                 let fn_sig_binder = func.layout.ty.fn_sig(*self.tcx);

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -713,11 +713,11 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
         self.super_terminator(terminator, location);
 
         match &terminator.kind {
-            TerminatorKind::Call { func, args, fn_span, call_source, .. } => {
+            TerminatorKind::Call { func, args, call_source, .. } => {
                 let ConstCx { tcx, body, param_env, .. } = *self.ccx;
                 let caller = self.def_id();
 
-                let fn_ty = func.ty(body, tcx);
+                let fn_ty = func.node.ty(body, tcx);
 
                 let (mut callee, mut fn_args) = match *fn_ty.kind() {
                     ty::FnDef(def_id, fn_args) => (def_id, fn_args),
@@ -784,7 +784,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                             caller,
                             callee,
                             args: fn_args,
-                            span: *fn_span,
+                            span: func.span,
                             call_source: *call_source,
                             feature: Some(if tcx.features().const_trait_impl {
                                 sym::effects
@@ -831,7 +831,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                         caller,
                         callee,
                         args: fn_args,
-                        span: *fn_span,
+                        span: func.span,
                         call_source: *call_source,
                         feature: None,
                     });

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -1206,7 +1206,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 }
             }
             TerminatorKind::Call { func, .. } => {
-                let func_ty = func.ty(&self.body.local_decls, self.tcx);
+                let func_ty = func.node.ty(&self.body.local_decls, self.tcx);
                 match func_ty.kind() {
                     ty::FnPtr(..) | ty::FnDef(..) => {}
                     _ => self.fail(

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -668,8 +668,10 @@ pub enum TerminatorKind<'tcx> {
     ///
     /// [#71117]: https://github.com/rust-lang/rust/issues/71117
     Call {
-        /// The function that’s being called.
-        func: Operand<'tcx>,
+        /// The function that’s being called, including the `Span` of the
+        /// function, without the dot and receiver
+        /// e.g. `foo(a, b)` in `x.foo(a, b)`
+        func: Spanned<Operand<'tcx>>,
         /// Arguments the function is called with.
         /// These are owned by the callee, which is free to modify them.
         /// This allows the memory occupied by "by-value" arguments to be
@@ -685,9 +687,6 @@ pub enum TerminatorKind<'tcx> {
         unwind: UnwindAction,
         /// Where this call came from in HIR/THIR.
         call_source: CallSource,
-        /// This `Span` is the span of the function, without the dot and receiver
-        /// e.g. `foo(a, b)` in `x.foo(a, b)`
-        fn_span: Span,
     },
 
     /// Evaluates the operand, which must have type `bool`. If it is not equal to `expected`,

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -584,7 +584,7 @@ impl<'tcx> TerminatorKind<'tcx> {
                 }
             }
 
-            Call { unwind, destination, target, func: _, args: _, fn_span: _, call_source: _ } => {
+            Call { unwind, destination, target, func: _, args: _, call_source: _ } => {
                 TerminatorEdges::AssignOnReturn {
                     return_: target,
                     cleanup: unwind.cleanup_block(),

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -520,9 +520,8 @@ macro_rules! make_mir_visitor {
                         target: _,
                         unwind: _,
                         call_source: _,
-                        fn_span: _
                     } => {
-                        self.visit_operand(func, location);
+                        self.visit_operand(&$($mutability)? func.node, location);
                         for arg in args {
                             self.visit_operand(&$($mutability)? arg.node, location);
                         }

--- a/compiler/rustc_middle/src/util/find_self_call.rs
+++ b/compiler/rustc_middle/src/util/find_self_call.rs
@@ -18,7 +18,7 @@ pub fn find_self_call<'tcx>(
         &body[block].terminator
     {
         debug!("find_self_call: func={:?}", func);
-        if let Operand::Constant(box ConstOperand { const_, .. }) = func {
+        if let Operand::Constant(box ConstOperand { const_, .. }) = &func.node {
             if let ty::FnDef(def_id, fn_args) = *const_.ty().kind() {
                 if let Some(ty::AssocItem { fn_has_self_parameter: true, .. }) =
                     tcx.opt_associated_item(def_id)

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -168,7 +168,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                     )
                     .collect::<PResult<Vec<_>>>()?;
                 Ok(TerminatorKind::Call {
-                    func: fun,
+                    func: Spanned { node: fun, span: *fn_span },
                     args,
                     destination,
                     target: Some(target),
@@ -176,7 +176,6 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
                     call_source: if *from_hir_call { CallSource::Normal } else {
                         CallSource::OverloadedOperator
                     },
-                    fn_span: *fn_span,
                 })
             },
         )

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -156,7 +156,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     synth_info,
                     TerminatorKind::Call {
-                        func: exchange_malloc,
+                        func: Spanned { node: exchange_malloc, span: expr_span },
                         args: vec![
                             Spanned { node: Operand::Move(size), span: DUMMY_SP },
                             Spanned { node: Operand::Move(align), span: DUMMY_SP },
@@ -165,7 +165,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         target: Some(success),
                         unwind: UnwindAction::Continue,
                         call_source: CallSource::Misc,
-                        fn_span: expr_span,
                     },
                 );
                 this.diverge_from(block);

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -265,7 +265,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     source_info,
                     TerminatorKind::Call {
-                        func: fun,
+                        func: Spanned { node: fun, span: fn_span },
                         args,
                         unwind: UnwindAction::Continue,
                         destination,
@@ -282,7 +282,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         } else {
                             CallSource::OverloadedOperator
                         },
-                        fn_span,
                     },
                 );
                 this.diverge_from(block);

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -267,17 +267,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         block,
                         source_info,
                         TerminatorKind::Call {
-                            func: Operand::Constant(Box::new(ConstOperand {
-                                span: test.span,
-                                user_ty: None,
-                                const_: method,
-                            })),
+                            func: Spanned {
+                                node: Operand::Constant(Box::new(ConstOperand {
+                                    span: test.span,
+                                    user_ty: None,
+                                    const_: method,
+                                })),
+                                span: source_info.span,
+                            },
                             args: vec![Spanned { node: Operand::Move(ref_string), span: DUMMY_SP }],
                             destination: ref_str,
                             target: Some(eq_block),
                             unwind: UnwindAction::Continue,
                             call_source: CallSource::Misc,
-                            fn_span: source_info.span,
                         },
                     );
                     self.non_scalar_compare(
@@ -516,17 +518,20 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             block,
             source_info,
             TerminatorKind::Call {
-                func: Operand::Constant(Box::new(ConstOperand {
+                func: Spanned {
+                    node: Operand::Constant(Box::new(ConstOperand {
+                        span: source_info.span,
+
+                        // FIXME(#54571): This constant comes from user input (a
+                        // constant in a pattern). Are there forms where users can add
+                        // type annotations here?  For example, an associated constant?
+                        // Need to experiment.
+                        user_ty: None,
+
+                        const_: method,
+                    })),
                     span: source_info.span,
-
-                    // FIXME(#54571): This constant comes from user input (a
-                    // constant in a pattern). Are there forms where users can add
-                    // type annotations here?  For example, an associated constant?
-                    // Need to experiment.
-                    user_ty: None,
-
-                    const_: method,
-                })),
+                },
                 args: vec![
                     Spanned { node: Operand::Copy(val), span: DUMMY_SP },
                     Spanned { node: expect, span: DUMMY_SP },
@@ -535,7 +540,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 target: Some(eq_block),
                 unwind: UnwindAction::Continue,
                 call_source: CallSource::MatchCmp,
-                fn_span: source_info.span,
             },
         );
         self.diverge_from(block);

--- a/compiler/rustc_mir_build/src/lints.rs
+++ b/compiler/rustc_mir_build/src/lints.rs
@@ -136,7 +136,7 @@ impl<'tcx> TerminatorClassifier<'tcx> for CallRecursion<'tcx> {
         let caller = body.source.def_id();
         let param_env = tcx.param_env(caller);
 
-        let func_ty = func.ty(body, tcx);
+        let func_ty = func.node.ty(body, tcx);
         if let ty::FnDef(callee, args) = *func_ty.kind() {
             let normalized_args = tcx.normalize_erasing_regions(param_env, args);
             let (callee, call_args) = if let Ok(Some(instance)) =

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -648,12 +648,15 @@ where
             )],
             terminator: Some(Terminator {
                 kind: TerminatorKind::Call {
-                    func: Operand::function_handle(
-                        tcx,
-                        drop_fn,
-                        [ty.into()],
-                        self.source_info.span,
-                    ),
+                    func: Spanned {
+                        node: Operand::function_handle(
+                            tcx,
+                            drop_fn,
+                            [ty.into()],
+                            self.source_info.span,
+                        ),
+                        span: self.source_info.span,
+                    },
                     args: vec![Spanned {
                         node: Operand::Move(Place::from(ref_place)),
                         span: DUMMY_SP,
@@ -662,7 +665,6 @@ where
                     target: Some(succ),
                     unwind: unwind.into_action(),
                     call_source: CallSource::Misc,
-                    fn_span: self.source_info.span,
                 },
                 source_info: self.source_info,
             }),

--- a/compiler/rustc_mir_dataflow/src/framework/tests.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/tests.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use rustc_index::IndexVec;
 use rustc_middle::ty;
-use rustc_span::DUMMY_SP;
+use rustc_span::{source_map::Spanned, DUMMY_SP};
 
 use super::*;
 
@@ -33,13 +33,12 @@ fn mock_body<'tcx>() -> mir::Body<'tcx> {
     block(
         2,
         mir::TerminatorKind::Call {
-            func: mir::Operand::Copy(dummy_place.clone()),
+            func: Spanned { node: mir::Operand::Copy(dummy_place.clone()), span: DUMMY_SP },
             args: vec![],
             destination: dummy_place.clone(),
             target: Some(mir::START_BLOCK),
             unwind: mir::UnwindAction::Continue,
             call_source: mir::CallSource::Misc,
-            fn_span: DUMMY_SP,
         },
     );
     block(3, mir::TerminatorKind::Return);
@@ -47,13 +46,12 @@ fn mock_body<'tcx>() -> mir::Body<'tcx> {
     block(
         4,
         mir::TerminatorKind::Call {
-            func: mir::Operand::Copy(dummy_place.clone()),
+            func: Spanned { node: mir::Operand::Copy(dummy_place.clone()), span: DUMMY_SP },
             args: vec![],
             destination: dummy_place.clone(),
             target: Some(mir::START_BLOCK),
             unwind: mir::UnwindAction::Continue,
             call_source: mir::CallSource::Misc,
-            fn_span: DUMMY_SP,
         },
     );
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -465,9 +465,8 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
                 target,
                 unwind: _,
                 call_source: _,
-                fn_span: _,
             } => {
-                self.gather_operand(func);
+                self.gather_operand(&func.node);
                 for arg in args {
                     self.gather_operand(&arg.node);
                 }

--- a/compiler/rustc_mir_dataflow/src/rustc_peek.rs
+++ b/compiler/rustc_mir_dataflow/src/rustc_peek.rs
@@ -17,8 +17,7 @@ use rustc_middle::mir::MirPass;
 use rustc_middle::mir::{self, Body, Local, Location};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::symbol::{sym, Symbol};
-use rustc_span::Span;
-
+use rustc_span::{source_map::Spanned, Span};
 pub struct SanityCheck;
 
 fn has_rustc_mir_with(tcx: TyCtxt<'_>, def_id: DefId, name: Symbol) -> Option<MetaItem> {
@@ -198,8 +197,11 @@ impl PeekCall {
         use mir::Operand;
 
         let span = terminator.source_info.span;
-        if let mir::TerminatorKind::Call { func: Operand::Constant(func), args, .. } =
-            &terminator.kind
+        if let mir::TerminatorKind::Call {
+            func: Spanned { node: Operand::Constant(func), .. },
+            args,
+            ..
+        } = &terminator.kind
         {
             if let ty::FnDef(def_id, fn_args) = *func.const_.ty().kind() {
                 let name = tcx.item_name(def_id);

--- a/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
+++ b/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
@@ -59,7 +59,7 @@ impl<'tcx> MirPass<'tcx> for AbortUnwindingCalls {
 
             let call_can_unwind = match &terminator.kind {
                 TerminatorKind::Call { func, .. } => {
-                    let ty = func.ty(body, tcx);
+                    let ty = func.node.ty(body, tcx);
                     let sig = ty.fn_sig(tcx);
                     let fn_def_id = match ty.kind() {
                         ty::FnPtr(_) => None,

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -67,7 +67,7 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
             }
 
             TerminatorKind::Call { ref func, .. } => {
-                let func_ty = func.ty(self.body, self.tcx);
+                let func_ty = func.node.ty(self.body, self.tcx);
                 let func_id =
                     if let ty::FnDef(func_id, _) = func_ty.kind() { Some(func_id) } else { None };
                 let sig = func_ty.fn_sig(self.tcx);

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -653,7 +653,7 @@ fn transform_async_context<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
 
         match &bb_data.terminator().kind {
             TerminatorKind::Call { func, .. } => {
-                let func_ty = func.ty(body, tcx);
+                let func_ty = func.node.ty(body, tcx);
                 if let ty::FnDef(def_id, _) = *func_ty.kind() {
                     if def_id == get_context_def_id {
                         let local = eliminate_get_context_call(&mut body[bb]);
@@ -1860,10 +1860,9 @@ impl<'tcx> Visitor<'tcx> for EnsureCoroutineFieldAssignmentsNeverAlias<'_> {
                 target: Some(_),
                 unwind: _,
                 call_source: _,
-                fn_span: _,
             } => {
                 self.check_assigned_place(*destination, |this| {
-                    this.visit_operand(func, location);
+                    this.visit_operand(&func.node, location);
                     for arg in args {
                         this.visit_operand(&arg.node, location);
                     }

--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -1,6 +1,7 @@
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, ParamEnv, Ty, TyCtxt};
+use rustc_span::source_map::Spanned;
 
 const INSTR_COST: usize = 5;
 const CALL_PENALTY: usize = 25;
@@ -67,7 +68,11 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
                     self.cost += INSTR_COST;
                 }
             }
-            TerminatorKind::Call { func: Operand::Constant(ref f), unwind, .. } => {
+            TerminatorKind::Call {
+                func: Spanned { node: Operand::Constant(ref f), .. },
+                unwind,
+                ..
+            } => {
                 let fn_ty = self.instantiate_ty(f.const_.ty());
                 self.cost += if let ty::FnDef(def_id, _) = *fn_ty.kind()
                     && tcx.is_intrinsic(def_id)

--- a/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
@@ -237,7 +237,7 @@ fn filtered_terminator_span(terminator: &Terminator<'_>) -> Option<Span> {
         // Call `func` operand can have a more specific span when part of a chain of calls
         | TerminatorKind::Call { ref func, .. } => {
             let mut span = terminator.source_info.span;
-            if let mir::Operand::Constant(box constant) = func {
+            if let mir::Operand::Constant(box constant) = &func.node {
                 if constant.span.lo() > span.lo() {
                     span = span.with_lo(constant.span.lo());
                 }

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -33,7 +33,7 @@ use rustc_data_structures::graph::WithSuccessors;
 use rustc_index::{Idx, IndexVec};
 use rustc_middle::mir::*;
 use rustc_middle::ty;
-use rustc_span::{BytePos, Pos, Span, DUMMY_SP};
+use rustc_span::{source_map::Spanned, BytePos, Pos, Span, DUMMY_SP};
 
 fn bcb(index: u32) -> BasicCoverageBlock {
     BasicCoverageBlock::from_u32(index)
@@ -135,13 +135,12 @@ impl<'tcx> MockBlocks<'tcx> {
         self.add_block_from(
             some_from_block,
             TerminatorKind::Call {
-                func: Operand::Copy(self.dummy_place.clone()),
+                func: Spanned { node: Operand::Copy(self.dummy_place.clone()), span: DUMMY_SP },
                 args: vec![],
                 destination: self.dummy_place.clone(),
                 target: Some(TEMP_BLOCK),
                 unwind: UnwindAction::Continue,
                 call_source: CallSource::Misc,
-                fn_span: DUMMY_SP,
             },
         )
     }

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -621,7 +621,7 @@ impl WriteInfo {
             }
             TerminatorKind::Call { destination, func, args, .. } => {
                 self.add_place(*destination);
-                self.add_operand(func);
+                self.add_operand(&func.node);
                 for arg in args {
                     self.add_operand(&arg.node);
                 }

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -77,7 +77,7 @@ fn has_ffi_unwind_calls(tcx: TyCtxt<'_>, local_def_id: LocalDefId) -> bool {
         let Some(terminator) = &block.terminator else { continue };
         let TerminatorKind::Call { func, .. } = &terminator.kind else { continue };
 
-        let ty = func.ty(body, tcx);
+        let ty = func.node.ty(body, tcx);
         let sig = ty.fn_sig(tcx);
 
         // Rust calls cannot themselves create foreign unwinds.

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -36,11 +36,10 @@ impl<'tcx> Visitor<'tcx> for FunctionItemRefChecker<'_, 'tcx> {
             target: _,
             unwind: _,
             call_source: _,
-            fn_span: _,
         } = &terminator.kind
         {
             let source_info = *self.body.source_info(location);
-            let func_ty = func.ty(self.body, self.tcx);
+            let func_ty = func.node.ty(self.body, self.tcx);
             if let ty::FnDef(def_id, args_ref) = *func_ty.kind() {
                 // Handle calls to `transmute`
                 if self.tcx.is_diagnostic_item(sym::transmute, def_id) {

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -365,8 +365,8 @@ impl<'tcx> Inliner<'tcx> {
     ) -> Option<CallSite<'tcx>> {
         // Only consider direct calls to functions
         let terminator = bb_data.terminator();
-        if let TerminatorKind::Call { ref func, fn_span, .. } = terminator.kind {
-            let func_ty = func.ty(caller_body, self.tcx);
+        if let TerminatorKind::Call { ref func, .. } = terminator.kind {
+            let func_ty = func.node.ty(caller_body, self.tcx);
             if let ty::FnDef(def_id, args) = *func_ty.kind() {
                 // To resolve an instance its args have to be fully normalized.
                 let args = self.tcx.try_normalize_erasing_regions(self.param_env, args).ok()?;
@@ -382,7 +382,7 @@ impl<'tcx> Inliner<'tcx> {
                 }
 
                 let fn_sig = self.tcx.fn_sig(def_id).instantiate(self.tcx, args);
-                let source_info = SourceInfo { span: fn_span, ..terminator.source_info };
+                let source_info = SourceInfo { span: func.span, ..terminator.source_info };
 
                 return Some(CallSite { callee, fn_sig, block: bb, source_info });
             }

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -163,7 +163,7 @@ pub(crate) fn mir_inliner_callees<'tcx>(
     for bb_data in body.basic_blocks.iter() {
         let terminator = bb_data.terminator();
         if let TerminatorKind::Call { func, .. } = &terminator.kind {
-            let ty = func.ty(&body.local_decls, tcx);
+            let ty = func.node.ty(&body.local_decls, tcx);
             let call = match ty.kind() {
                 ty::FnDef(def_id, args) => (*def_id, *args),
                 _ => continue,

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -206,7 +206,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         let Some(destination_block) = *target else { return };
 
         // Only bother looking more if it's easy to know what we're calling
-        let Some((fn_def_id, fn_args)) = func.const_fn_def() else { return };
+        let Some((fn_def_id, fn_args)) = func.node.const_fn_def() else { return };
 
         // Clone needs one subst, so we can cheaply rule out other stuff
         if fn_args.len() != 1 {
@@ -263,7 +263,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         let Some(target_block) = target else {
             return;
         };
-        let func_ty = func.ty(self.local_decls, self.tcx);
+        let func_ty = func.node.ty(self.local_decls, self.tcx);
         let Some((intrinsic_name, args)) = resolve_rust_intrinsic(self.tcx, func_ty) else {
             return;
         };

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -157,12 +157,11 @@ fn remap_mir_for_const_eval_select<'tcx>(
         let terminator = bb.terminator.as_mut().expect("invalid terminator");
         match terminator.kind {
             TerminatorKind::Call {
-                func: Operand::Constant(box ConstOperand { ref const_, .. }),
+                func: Spanned { node: Operand::Constant(box ConstOperand { ref const_, .. }), span },
                 ref mut args,
                 destination,
                 target,
                 unwind,
-                fn_span,
                 ..
             } if let ty::FnDef(def_id, _) = *const_.ty().kind()
                 && tcx.item_name(def_id) == sym::const_eval_select
@@ -180,9 +179,9 @@ fn remap_mir_for_const_eval_select<'tcx>(
                         Operand::Constant(_) => {
                             // there is no good way of extracting a tuple arg from a constant (const generic stuff)
                             // so we just create a temporary and deconstruct that.
-                            let local = body.local_decls.push(LocalDecl::new(ty, fn_span));
+                            let local = body.local_decls.push(LocalDecl::new(ty, span));
                             bb.statements.push(Statement {
-                                source_info: SourceInfo::outermost(fn_span),
+                                source_info: SourceInfo::outermost(span),
                                 kind: StatementKind::Assign(Box::new((
                                     local.into(),
                                     Rvalue::Use(tupled_args.node.clone()),
@@ -204,13 +203,12 @@ fn remap_mir_for_const_eval_select<'tcx>(
                     })
                     .collect();
                 terminator.kind = TerminatorKind::Call {
-                    func: func.node,
+                    func: func,
                     args: arguments,
                     destination,
                     target,
                     unwind,
                     call_source: CallSource::Misc,
-                    fn_span,
                 };
             }
             _ => {}

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -13,7 +13,7 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
             let terminator = block.terminator.as_mut().unwrap();
             if let TerminatorKind::Call { func, args, destination, target, .. } =
                 &mut terminator.kind
-                && let ty::FnDef(def_id, generic_args) = *func.ty(local_decls, tcx).kind()
+                && let ty::FnDef(def_id, generic_args) = *func.node.ty(local_decls, tcx).kind()
                 && tcx.is_intrinsic(def_id)
             {
                 let intrinsic_name = tcx.item_name(def_id);

--- a/compiler/rustc_mir_transform/src/lower_slice_len.rs
+++ b/compiler/rustc_mir_transform/src/lower_slice_len.rs
@@ -51,7 +51,7 @@ fn lower_slice_len_call<'tcx>(
         // some heuristics for fast rejection
         && let [arg] = &args[..]
         && let Some(arg) = arg.node.place()
-        && let ty::FnDef(fn_def_id, _) = func.ty(local_decls, tcx).kind()
+        && let ty::FnDef(fn_def_id, _) = func.node.ty(local_decls, tcx).kind()
         && *fn_def_id == slice_len_fn_item_def_id
     {
         // perform modifications from something like:

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -525,13 +525,12 @@ impl<'tcx> CloneShimBuilder<'tcx> {
         self.block(
             vec![statement],
             TerminatorKind::Call {
-                func,
+                func: Spanned { node: func, span: self.span },
                 args: vec![Spanned { node: Operand::Move(ref_loc), span: DUMMY_SP }],
                 destination: dest,
                 target: Some(next),
                 unwind: UnwindAction::Cleanup(cleanup),
                 call_source: CallSource::Normal,
-                fn_span: self.span,
             },
             false,
         );
@@ -816,7 +815,7 @@ fn build_call_shim<'tcx>(
         &mut blocks,
         statements,
         TerminatorKind::Call {
-            func: callee,
+            func: Spanned { node: callee, span },
             args,
             destination: Place::return_place(),
             target: Some(BasicBlock::new(1)),
@@ -826,7 +825,6 @@ fn build_call_shim<'tcx>(
                 UnwindAction::Continue
             },
             call_source: CallSource::Misc,
-            fn_span: span,
         },
         false,
     );

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -839,10 +839,10 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
         };
 
         match terminator.kind {
-            mir::TerminatorKind::Call { ref func, ref args, ref fn_span, .. } => {
-                let callee_ty = func.ty(self.body, tcx);
+            mir::TerminatorKind::Call { ref func, ref args, .. } => {
+                let callee_ty = func.node.ty(self.body, tcx);
                 let callee_ty = self.monomorphize(callee_ty);
-                self.check_fn_args_move_size(callee_ty, args, *fn_span, location);
+                self.check_fn_args_move_size(callee_ty, args, func.span, location);
                 visit_fn_use(self.tcx, callee_ty, true, source, &mut self.output)
             }
             mir::TerminatorKind::Drop { ref place, .. } => {

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -606,9 +606,8 @@ impl<'tcx> Stable<'tcx> for mir::TerminatorKind<'tcx> {
                 target,
                 unwind,
                 call_source: _,
-                fn_span: _,
             } => TerminatorKind::Call {
-                func: func.stable(tables),
+                func: func.node.stable(tables),
                 args: args.iter().map(|arg| arg.node.stable(tables)).collect(),
                 destination: destination.stable(tables),
                 target: target.map(|t| t.as_usize()),

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -258,7 +258,7 @@ fn is_call_with_ref_arg<'tcx>(
     } = kind
         && args.len() == 1
         && let mir::Operand::Move(mir::Place { local, .. }) = &args[0].node
-        && let ty::FnDef(def_id, _) = *func.ty(mir, cx.tcx).kind()
+        && let ty::FnDef(def_id, _) = *func.node.ty(mir, cx.tcx).kind()
         && let (inner_ty, 1) = walk_ptrs_ty_depth(args[0].node.ty(mir, cx.tcx))
         && !is_copy(cx, inner_ty)
     {

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -316,9 +316,8 @@ fn check_terminator<'tcx>(
             destination: _,
             target: _,
             unwind: _,
-            fn_span: _,
         } => {
-            let fn_ty = func.ty(body, tcx);
+            let fn_ty = func.node.ty(body, tcx);
             if let ty::FnDef(fn_def_id, _) = *fn_ty.kind() {
                 if !is_const_fn(tcx, fn_def_id, msrv) {
                     return Err((
@@ -342,7 +341,7 @@ fn check_terminator<'tcx>(
                     ));
                 }
 
-                check_operand(tcx, func, span, body)?;
+                check_operand(tcx, &func.node, span, body)?;
 
                 for arg in args {
                     check_operand(tcx, &arg.node, span, body)?;


### PR DESCRIPTION
To get structural symmetry between `TerminatorKind::Call::func` and `TerminatorKind::Call::args`, make `func` `Spanned`, since `args` already is `Spanned`. This way we can remove the separate `fn_span` field.

Doing this was briefly discussed [here](https://github.com/rust-lang/rust/pull/116520#issuecomment-1762722842).

For easier review, this PR is split into two commits. The first commit is the actual change. The second commit just makes the code build again and is very repetitive.

Can someone start a perf run of this change please?