### PR TITLE
Ensure SMIR `internal` function is safe

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1416,6 +1416,7 @@ nop_lift! {const_; Const<'a> => Const<'tcx>}
 nop_lift! {const_allocation; ConstAllocation<'a> => ConstAllocation<'tcx>}
 nop_lift! {predicate; Predicate<'a> => Predicate<'tcx>}
 nop_lift! {predicate; Clause<'a> => Clause<'tcx>}
+nop_lift! {layout; Layout<'a> => Layout<'tcx>}
 
 nop_list_lift! {type_lists; Ty<'a> => Ty<'tcx>}
 nop_list_lift! {poly_existential_predicates; PolyExistentialPredicate<'a> => PolyExistentialPredicate<'tcx>}

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -24,12 +24,38 @@ use std::ops::Index;
 mod internal;
 pub mod pretty;
 
+/// Convert an internal Rust compiler item into its stable counterpart, if one exists.
+///
+/// # Warning
+///
+/// This function is unstable, and its behavior may change at any point.
+/// E.g.: Items that were previously supported, may no longer be supported, or its translation may
+/// change.
+///
+/// # Panics
+///
+/// This function will panic if StableMIR has not been properly initialized.
 pub fn stable<'tcx, S: Stable<'tcx>>(item: S) -> S::T {
     with_tables(|tables| item.stable(tables))
 }
 
-pub fn internal<'tcx, S: RustcInternal<'tcx>>(item: S) -> S::T {
-    with_tables(|tables| item.internal(tables))
+/// Convert a stable item into its internal Rust compiler counterpart, if one exists.
+///
+/// # Warning
+///
+/// This function is unstable, and it's behavior may change at any point.
+/// Not every stable item can be converted to an internal one.
+/// Furthermore, items that were previously supported, may no longer be supported in newer versions.
+///
+/// # Panics
+///
+/// This function will panic if StableMIR has not been properly initialized.
+pub fn internal<'tcx, S>(tcx: TyCtxt<'tcx>, item: S) -> S::T
+where
+    S: RustcInternal<'tcx>,
+{
+    // The tcx argument ensures that the item won't outlive the type context.
+    with_tables(|tables| item.internal(tables, tcx))
 }
 
 impl<'tcx> Index<stable_mir::DefId> for Tables<'tcx> {
@@ -393,7 +419,12 @@ impl<K: PartialEq + Hash + Eq, V: Copy + Debug + PartialEq + IndexedVal> Index<V
 /// Trait used to translate a stable construct to its rustc counterpart.
 ///
 /// This is basically a mirror of [crate::rustc_smir::Stable].
-pub trait RustcInternal<'tcx> {
+///
+/// # Safety
+///
+/// This trait is unsafe, and every implementation should ensure that their translation
+/// is lifted if necessary with the given type context (`tcx`).
+pub unsafe trait RustcInternal<'tcx> {
     type T;
-    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T;
+    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T;
 }

--- a/compiler/rustc_smir/src/rustc_smir/alloc.rs
+++ b/compiler/rustc_smir/src/rustc_smir/alloc.rs
@@ -27,7 +27,8 @@ pub fn new_allocation<'tcx>(
     const_value: ConstValue<'tcx>,
     tables: &mut Tables<'tcx>,
 ) -> Allocation {
-    try_new_allocation(ty, const_value, tables).unwrap()
+    try_new_allocation(ty, const_value, tables)
+        .expect(&format!("Failed to convert: {const_value:?} to {ty:?}"))
 }
 
 #[allow(rustc::usage_of_qualified_ty)]

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -29,7 +29,7 @@ use stable_mir::{Crate, CrateItem, CrateNum, DefId, Error, Filename, ItemKind, S
 use std::cell::RefCell;
 use std::iter;
 
-use crate::rustc_internal::{internal, RustcInternal};
+use crate::rustc_internal::RustcInternal;
 use crate::rustc_smir::builder::BodyBuilder;
 use crate::rustc_smir::{alloc, new_item_kind, smir_crate, Stable, Tables};
 
@@ -74,9 +74,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn trait_decls(&self, crate_num: CrateNum) -> stable_mir::TraitDecls {
         let mut tables = self.0.borrow_mut();
-        tables
-            .tcx
-            .traits(crate_num.internal(&mut *tables))
+        let tcx = tables.tcx;
+        tcx.traits(crate_num.internal(&mut *tables, tcx))
             .iter()
             .map(|trait_def_id| tables.trait_def(*trait_def_id))
             .collect()
@@ -101,9 +100,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn trait_impls(&self, crate_num: CrateNum) -> stable_mir::ImplTraitDecls {
         let mut tables = self.0.borrow_mut();
-        tables
-            .tcx
-            .trait_impls_in_crate(crate_num.internal(&mut *tables))
+        let tcx = tables.tcx;
+        tcx.trait_impls_in_crate(crate_num.internal(&mut *tables, tcx))
             .iter()
             .map(|impl_def_id| tables.impl_def(*impl_def_id))
             .collect()
@@ -229,57 +227,68 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn adt_kind(&self, def: AdtDef) -> AdtKind {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).adt_kind().stable(&mut *tables)
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).adt_kind().stable(&mut *tables)
     }
 
     fn adt_is_box(&self, def: AdtDef) -> bool {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).is_box()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).is_box()
     }
 
     fn adt_is_simd(&self, def: AdtDef) -> bool {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).repr().simd()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).repr().simd()
     }
 
     fn adt_is_cstr(&self, def: AdtDef) -> bool {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
         tables.tcx.lang_items().c_str() == Some(def_id)
     }
 
     fn fn_sig(&self, def: FnDef, args: &GenericArgs) -> PolyFnSig {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let sig = tables.tcx.fn_sig(def_id).instantiate(tables.tcx, args.internal(&mut *tables));
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let sig =
+            tables.tcx.fn_sig(def_id).instantiate(tables.tcx, args.internal(&mut *tables, tcx));
         sig.stable(&mut *tables)
     }
 
     fn closure_sig(&self, args: &GenericArgs) -> PolyFnSig {
         let mut tables = self.0.borrow_mut();
-        let args_ref = args.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let args_ref = args.internal(&mut *tables, tcx);
         let sig = args_ref.as_closure().sig();
         sig.stable(&mut *tables)
     }
 
     fn adt_variants_len(&self, def: AdtDef) -> usize {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).variants().len()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).variants().len()
     }
 
     fn variant_name(&self, def: VariantDef) -> Symbol {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).name.to_string()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).name.to_string()
     }
 
     fn variant_fields(&self, def: VariantDef) -> Vec<FieldDef> {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).fields.iter().map(|f| f.stable(&mut *tables)).collect()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).fields.iter().map(|f| f.stable(&mut *tables)).collect()
     }
 
     fn eval_target_usize(&self, cnst: &Const) -> Result<u64, Error> {
         let mut tables = self.0.borrow_mut();
-        let mir_const = cnst.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let mir_const = cnst.internal(&mut *tables, tcx);
         mir_const
             .try_eval_target_usize(tables.tcx, ParamEnv::empty())
             .ok_or_else(|| Error::new(format!("Const `{cnst:?}` cannot be encoded as u64")))
@@ -299,30 +308,36 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn new_rigid_ty(&self, kind: RigidTy) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let internal_kind = kind.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let internal_kind = kind.internal(&mut *tables, tcx);
         tables.tcx.mk_ty_from_kind(internal_kind).stable(&mut *tables)
     }
 
     fn new_box_ty(&self, ty: stable_mir::ty::Ty) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let inner = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let inner = ty.internal(&mut *tables, tcx);
         ty::Ty::new_box(tables.tcx, inner).stable(&mut *tables)
     }
 
     fn def_ty(&self, item: stable_mir::DefId) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        tables.tcx.type_of(item.internal(&mut *tables)).instantiate_identity().stable(&mut *tables)
+        let tcx = tables.tcx;
+        tcx.type_of(item.internal(&mut *tables, tcx)).instantiate_identity().stable(&mut *tables)
     }
 
     fn def_ty_with_args(&self, item: stable_mir::DefId, args: &GenericArgs) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let args = args.internal(&mut *tables);
-        let def_ty = tables.tcx.type_of(item.internal(&mut *tables));
+        let tcx = tables.tcx;
+        let args = args.internal(&mut *tables, tcx);
+        let def_ty = tables.tcx.type_of(item.internal(&mut *tables, tcx));
         def_ty.instantiate(tables.tcx, args).stable(&mut *tables)
     }
 
     fn const_literal(&self, cnst: &stable_mir::ty::Const) -> String {
-        internal(cnst).to_string()
+        let mut tables = self.0.borrow_mut();
+        let tcx = tables.tcx;
+        cnst.internal(&mut *tables, tcx).to_string()
     }
 
     fn span_of_an_item(&self, def_id: stable_mir::DefId) -> Span {
@@ -337,7 +352,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn rigid_ty_discriminant_ty(&self, ty: &RigidTy) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let internal_kind = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let internal_kind = ty.internal(&mut *tables, tcx);
         let internal_ty = tables.tcx.mk_ty_from_kind(internal_kind);
         internal_ty.discriminant_ty(tables.tcx).stable(&mut *tables)
     }
@@ -407,8 +423,9 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         args: &stable_mir::ty::GenericArgs,
     ) -> Option<stable_mir::mir::mono::Instance> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let args_ref = args.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let args_ref = args.internal(&mut *tables, tcx);
         match Instance::resolve(tables.tcx, ParamEnv::reveal_all(), def_id, args_ref) {
             Ok(Some(instance)) => Some(instance.stable(&mut *tables)),
             Ok(None) | Err(_) => None,
@@ -417,7 +434,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn resolve_drop_in_place(&self, ty: stable_mir::ty::Ty) -> stable_mir::mir::mono::Instance {
         let mut tables = self.0.borrow_mut();
-        let internal_ty = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let internal_ty = ty.internal(&mut *tables, tcx);
         let instance = Instance::resolve_drop_in_place(tables.tcx, internal_ty);
         instance.stable(&mut *tables)
     }
@@ -428,8 +446,9 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         args: &GenericArgs,
     ) -> Option<stable_mir::mir::mono::Instance> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let args_ref = args.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let args_ref = args.internal(&mut *tables, tcx);
         Instance::resolve_for_fn_ptr(tables.tcx, ParamEnv::reveal_all(), def_id, args_ref)
             .stable(&mut *tables)
     }
@@ -441,36 +460,44 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         kind: ClosureKind,
     ) -> Option<stable_mir::mir::mono::Instance> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let args_ref = args.internal(&mut *tables);
-        let closure_kind = kind.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let args_ref = args.internal(&mut *tables, tcx);
+        let closure_kind = kind.internal(&mut *tables, tcx);
         Instance::resolve_closure(tables.tcx, def_id, args_ref, closure_kind).stable(&mut *tables)
     }
 
     fn eval_instance(&self, def: InstanceDef, const_ty: Ty) -> Result<Allocation, Error> {
         let mut tables = self.0.borrow_mut();
         let instance = tables.instances[def];
-        let result = tables.tcx.const_eval_instance(
+        let tcx = tables.tcx;
+        let result = tcx.const_eval_instance(
             ParamEnv::reveal_all(),
             instance,
-            Some(tables.tcx.def_span(instance.def_id())),
+            Some(tcx.def_span(instance.def_id())),
         );
         result
             .map(|const_val| {
-                alloc::try_new_allocation(const_ty.internal(&mut *tables), const_val, &mut *tables)
+                alloc::try_new_allocation(
+                    const_ty.internal(&mut *tables, tcx),
+                    const_val,
+                    &mut *tables,
+                )
             })
             .map_err(|e| e.stable(&mut *tables))?
     }
 
     fn eval_static_initializer(&self, def: StaticDef) -> Result<Allocation, Error> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
         tables.tcx.eval_static_initializer(def_id).stable(&mut *tables)
     }
 
     fn global_alloc(&self, alloc: stable_mir::mir::alloc::AllocId) -> GlobalAlloc {
         let mut tables = self.0.borrow_mut();
-        let alloc_id = alloc.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let alloc_id = alloc.internal(&mut *tables, tcx);
         tables.tcx.global_alloc(alloc_id).stable(&mut *tables)
     }
 
@@ -480,9 +507,11 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
     ) -> Option<stable_mir::mir::alloc::AllocId> {
         let mut tables = self.0.borrow_mut();
         let GlobalAlloc::VTable(ty, trait_ref) = global_alloc else { return None };
-        let alloc_id = tables
-            .tcx
-            .vtable_allocation((ty.internal(&mut *tables), trait_ref.internal(&mut *tables)));
+        let tcx = tables.tcx;
+        let alloc_id = tables.tcx.vtable_allocation((
+            ty.internal(&mut *tables, tcx),
+            trait_ref.internal(&mut *tables, tcx),
+        ));
         Some(alloc_id.stable(&mut *tables))
     }
 
@@ -510,14 +539,16 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn ty_layout(&self, ty: Ty) -> Result<Layout, Error> {
         let mut tables = self.0.borrow_mut();
-        let ty = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let ty = ty.internal(&mut *tables, tcx);
         let layout = tables.layout_of(ty)?.layout;
         Ok(layout.stable(&mut *tables))
     }
 
     fn layout_shape(&self, id: Layout) -> LayoutShape {
         let mut tables = self.0.borrow_mut();
-        id.internal(&mut *tables).0.stable(&mut *tables)
+        let tcx = tables.tcx;
+        id.internal(&mut *tables, tcx).0.stable(&mut *tables)
     }
 }
 

--- a/tests/ui-fulldeps/stable-mir/smir_internal.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_internal.rs
@@ -26,11 +26,11 @@ use std::ops::ControlFlow;
 
 const CRATE_NAME: &str = "input";
 
-fn test_translation(_tcx: TyCtxt) -> ControlFlow<()> {
+fn test_translation(tcx: TyCtxt<'_>) -> ControlFlow<()> {
     let main_fn = stable_mir::entry_fn().unwrap();
     let body = main_fn.body();
     let orig_ty = body.locals()[0].ty;
-    let rustc_ty = rustc_internal::internal(&orig_ty);
+    let rustc_ty = rustc_internal::internal(tcx, &orig_ty);
     assert!(rustc_ty.is_unit());
     ControlFlow::Continue(())
 }


### PR DESCRIPTION
The `rustc_smir::rustc_internal::internal` function was unsound. It could cause UB in rare cases where the user inadvertently stored the returned object in a location that could outlive the TyCtxt.

In order to make it safe, we now take a type context as an argument to the internal function, and we ensure that interned items are lifted using the provided context.

Thus, this change ensures that the compiler can properly enforce that the object does not outlive the type context it was lifted to.

## Call-outs
1. I added a `Lift` implementation to `Layout` since it is directly interned, but it didn't have a `Lift` implementation.
2. To be on the safe side, I think we will need to make a similar change to the code that stores objects with `'tcx` lifetime into `tables`. In cases where the code is reachable via `stable()` function call, there is no guarantee that tables won't outlive the object being stored.

r? @oli-obk 
