### PR TITLE
Don't add needs-triage to A-diagnostics

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -364,7 +364,8 @@ new_pr = true
 [autolabel."needs-triage"]
 new_issue = true
 exclude_labels = [
-    "C-tracking-issue"
+    "C-tracking-issue",
+    "A-diagnostics",
 ]
 
 [autolabel."WG-trait-system-refactor"]


### PR DESCRIPTION
A-diagnostics is already labeled correctly thanks to the template and there usually isn't much to do on those issues, so it's fine to just add them to the pile.