### PR TITLE
SMIR: Make the remaining "private" fields actually private

### DIFF
--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -12,7 +12,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::Range;
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Ty(pub usize);
+pub struct Ty(usize);
 
 impl Debug for Ty {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -138,7 +138,7 @@ impl Const {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ConstId(pub usize);
+pub struct ConstId(usize);
 
 type Ident = Opaque;
 


### PR DESCRIPTION
Turns out we have already created a trait that allows us to make the fields private: https://doc.rust-lang.org/nightly/nightly-rustc/stable_mir/ty/trait.IndexedVal.html

fixes https://github.com/rust-lang/project-stable-mir/issues/56

r? @celinval 