### PR TITLE
Increase vscode settings.json `git.detectSubmodulesLimit`

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -37,6 +37,7 @@ static SETTINGS_HASHES: &[&str] = &[
     "3468fea433c25fff60be6b71e8a215a732a7b1268b6a83bf10d024344e140541",
     "47d227f424bf889b0d899b9cc992d5695e1b78c406e183cd78eafefbe5488923",
     "b526bd58d0262dd4dda2bff5bc5515b705fb668a46235ace3e057f807963a11a",
+    "828666b021d837a33e78d870b56d34c88a5e2c85de58b693607ec574f0c27000",
 ];
 static RUST_ANALYZER_SETTINGS: &str = include_str!("../../../../etc/rust_analyzer_settings.json");
 

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -1,4 +1,5 @@
 {
+    "git.detectSubmodulesLimit": 20,
     "rust-analyzer.check.invocationLocation": "root",
     "rust-analyzer.check.invocationStrategy": "once",
     "rust-analyzer.check.overrideCommand": [


### PR DESCRIPTION
The default vscode git integration throws a warning on the rust repository because it has more than the default limit of 10 submodules. This adds an increase to 20 to the settings.json that x.py offers to install on setup.

<img width="461" alt="Screen Shot 2024-01-19 at 11 47 47 PM" src="https://github.com/rust-lang/rust/assets/230691/440dfa4e-32e3-41f7-b8c6-5a07ade7aa14">

Also reported at https://stackoverflow.com/questions/60917209/disable-vs-code-warning-submodules-which-wont-be-opened-automatically