### PR TITLE
`single_use_lifetimes`: Don't suggest deleting lifetimes with bounds

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2567,8 +2567,9 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     debug!(?param.ident, ?param.ident.span, ?use_span);
 
                     let elidable = matches!(use_ctxt, LifetimeCtxt::Ref);
+                    let deletion_span =
+                        if param.bounds.is_empty() { deletion_span() } else { None };
 
-                    let deletion_span = deletion_span();
                     self.r.lint_buffer.buffer_lint_with_diagnostic(
                         lint::builtin::SINGLE_USE_LIFETIMES,
                         param.id,

--- a/tests/ui/single-use-lifetime/issue-117965.rs
+++ b/tests/ui/single-use-lifetime/issue-117965.rs
@@ -1,0 +1,18 @@
+#![deny(single_use_lifetimes)]
+
+pub enum Data<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
+
+impl<'a> Data<'a> {
+    pub fn get<'b: 'a>(&'b self) -> &'a str {
+        //~^ ERROR lifetime parameter `'b` only used once
+        match &self {
+            Self::Borrowed(val) => val,
+            Self::Owned(val) => &val,
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/single-use-lifetime/issue-117965.stderr
+++ b/tests/ui/single-use-lifetime/issue-117965.stderr
@@ -11,11 +11,6 @@ note: the lint level is defined here
    |
 LL | #![deny(single_use_lifetimes)]
    |         ^^^^^^^^^^^^^^^^^^^^
-help: elide the single-use lifetime
-   |
-LL -     pub fn get<'b: 'a>(&'b self) -> &'a str {
-LL +     pub fn get(&self) -> &'a str {
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/single-use-lifetime/issue-117965.stderr
+++ b/tests/ui/single-use-lifetime/issue-117965.stderr
@@ -1,0 +1,21 @@
+error: lifetime parameter `'b` only used once
+  --> $DIR/issue-117965.rs:9:16
+   |
+LL |     pub fn get<'b: 'a>(&'b self) -> &'a str {
+   |                ^^       -- ...is used only here
+   |                |
+   |                this lifetime...
+   |
+note: the lint level is defined here
+  --> $DIR/issue-117965.rs:1:9
+   |
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+help: elide the single-use lifetime
+   |
+LL -     pub fn get<'b: 'a>(&'b self) -> &'a str {
+LL +     pub fn get(&self) -> &'a str {
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Closes #117965 

```
9 |     pub fn get<'b: 'a>(&'b self) -> &'a str {
  |                ^^       -- ...is used only here
  |                |
  |                this lifetime...
```

In this example, I think the `&'b self` can be replaced with the bound itself, yielding `&'a self`, but this would require a deeper refactor. Happy to do as a follow-on PR if desired.