### PR TITLE
add help message for `exclusive_range_pattern` error

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -398,7 +398,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                     &self,
                     exclusive_range_pattern,
                     pattern.span,
-                    "exclusive range pattern syntax is experimental"
+                    "exclusive range pattern syntax is experimental",
+                    "use an inclusive range pattern, like N..=M"
                 );
             }
             _ => {}

--- a/tests/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
+++ b/tests/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
@@ -7,6 +7,7 @@ LL |         0 .. 3 => {}
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
@@ -21,6 +21,7 @@ LL |         if let n @ 2..3|4 = x {
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions1.rs:14:23
@@ -31,6 +32,7 @@ LL |         } else if let 2..3 | 4 = x {
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/half-open-range-patterns/range_pat_interactions3.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions3.stderr
@@ -17,6 +17,7 @@ LL |             1 | -3..0 => first_or.push(x),
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:12:18
@@ -27,6 +28,7 @@ LL |             y @ (0..5 | 6) => or_two.push(y),
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:14:17
@@ -37,6 +39,7 @@ LL |             y @ 0..const { 5 + 1 } => assert_eq!(y, 5),
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/range_pat_interactions3.rs:18:17
@@ -47,6 +50,7 @@ LL |             y @ ..-7 => assert_eq!(y, -8),
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
@@ -17,6 +17,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error[E0658]: exclusive range pattern syntax is experimental
   --> $DIR/slice_pattern_syntax_problem1.rs:4:32
@@ -27,6 +28,7 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use an inclusive range pattern, like N..=M
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #120047 

this error
```
error[E0658]: exclusive range pattern syntax is experimental
 --> src/lib.rs:3:9
  |
3 |         0..42 => {},
  |         ^^^^^
  |
  = note: see issue #37854 <https://github.com/rust-lang/rust/issues/37854> for more information
  = help: use an inclusive range pattern, like N..=M
  ```
now includes a help message

Not sure of proper procedure here but this seemed like a good help message (used the one suggested in the original issue), if you have a idea for one that is better or something I missed please comment! 