### PR TITLE
Track `verbose` and `verbose_internals`

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -98,6 +98,7 @@ fn assert_same_hash(x: &Options, y: &Options) {
     assert_same_clone(y);
 }
 
+#[track_caller]
 fn assert_different_hash(x: &Options, y: &Options) {
     assert_ne!(x.dep_tracking_hash(true), y.dep_tracking_hash(true));
     assert_ne!(x.dep_tracking_hash(false), y.dep_tracking_hash(false));
@@ -713,7 +714,6 @@ fn test_unstable_options_tracking_hash() {
     untracked!(unpretty, Some("expanded".to_string()));
     untracked!(unstable_options, true);
     untracked!(validate_mir, true);
-    untracked!(verbose_internals, true);
     untracked!(write_long_types_to_disk, false);
     // tidy-alphabetical-end
 
@@ -845,6 +845,7 @@ fn test_unstable_options_tracking_hash() {
         };
     }
     tracked_no_crate_hash!(no_codegen, true);
+    tracked_no_crate_hash!(verbose_internals, true);
 }
 
 #[test]

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -224,7 +224,7 @@ top_level_options!(
         working_dir: RealFileName [TRACKED],
         color: ColorConfig [UNTRACKED],
 
-        verbose: bool [UNTRACKED],
+        verbose: bool [TRACKED_NO_CRATE_HASH],
     }
 );
 
@@ -1986,7 +1986,7 @@ written to standard error output)"),
     validate_mir: bool = (false, parse_bool, [UNTRACKED],
         "validate MIR after each transformation"),
     #[rustc_lint_opt_deny_field_access("use `Session::verbose_internals` instead of this field")]
-    verbose_internals: bool = (false, parse_bool, [UNTRACKED],
+    verbose_internals: bool = (false, parse_bool, [TRACKED_NO_CRATE_HASH],
         "in general, enable more debug printouts (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::verify_llvm_ir` instead of this field")]
     verify_llvm_ir: bool = (false, parse_bool, [TRACKED],

--- a/tests/incremental/commandline-args.rs
+++ b/tests/incremental/commandline-args.rs
@@ -11,13 +11,13 @@
 #![rustc_partition_codegened(module="commandline_args", cfg="rpass4")]
 
 // Between revisions 1 and 2, we are changing the debuginfo-level, which should
-// invalidate the cache. Between revisions 2 and 3, we are adding `--verbose`
+// invalidate the cache. Between revisions 2 and 3, we are adding `--diagnostic-width`
 // which should have no effect on the cache. Between revisions, we are adding
 // `--remap-path-prefix` which should invalidate the cache:
 //[rpass1] compile-flags: -C debuginfo=0
 //[rpass2] compile-flags: -C debuginfo=2
-//[rpass3] compile-flags: -C debuginfo=2 --verbose
-//[rpass4] compile-flags: -C debuginfo=2 --verbose --remap-path-prefix=/home/bors/rust=src
+//[rpass3] compile-flags: -C debuginfo=2 --diagnostic-width=80
+//[rpass4] compile-flags: -C debuginfo=2 --diagnostic-width=80 --remap-path-prefix=/home/bors/r=src
 
 pub fn main() {
     // empty


### PR DESCRIPTION
`verbose_internals` has been UNTRACKED since it was introduced. When i added `verbose` in https://github.com/rust-lang/rust/pull/119129 i made it UNTRACKED as well.

@bjorn3 says: https://github.com/rust-lang/rust/pull/119286#discussion_r1436134354
> On errors we don't finalize the incr comp cache, but non-fatal diagnostics are cached afaik.
Otherwise we would have to replay the query in question, which we may not be able to do if the query key is not reconstructible from the dep node fingerprint.

So we must track these flags to avoid replaying incorrect diagnostics.

r? incremental 