### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/relate/combine.rs
+++ b/compiler/rustc_infer/src/infer/relate/combine.rs
@@ -167,9 +167,9 @@ impl<'tcx> InferCtxt<'tcx> {
         //
         // This probe is probably not strictly necessary but it seems better to be safe and not accidentally find
         // ourselves with a check to find bugs being required for code to compile because it made inference progress.
-        let compatible_types = self.probe(|_| {
+        self.probe(|_| {
             if a.ty() == b.ty() {
-                return Ok(());
+                return;
             }
 
             // We don't have access to trait solving machinery in `rustc_infer` so the logic for determining if the
@@ -179,31 +179,17 @@ impl<'tcx> InferCtxt<'tcx> {
                 relation.param_env().and((a.ty(), b.ty())),
                 &mut OriginalQueryValues::default(),
             );
-            self.tcx.check_tys_might_be_eq(canonical).map_err(|_| {
+            self.tcx.check_tys_might_be_eq(canonical).unwrap_or_else(|_| {
+                // The error will only be reported later. If we emit an ErrorGuaranteed
+                // here, then we will never get to the code that actually emits the error.
                 self.tcx.dcx().delayed_bug(format!(
                     "cannot relate consts of different types (a={a:?}, b={b:?})",
-                ))
-            })
+                ));
+                // We treat these constants as if they were of the same type, so that any
+                // such constants being used in impls make these impls match barring other mismatches.
+                // This helps with diagnostics down the road.
+            });
         });
-
-        // If the consts have differing types, just bail with a const error with
-        // the expected const's type. Specifically, we don't want const infer vars
-        // to do any type shapeshifting before and after resolution.
-        if let Err(guar) = compatible_types {
-            // HACK: equating both sides with `[const error]` eagerly prevents us
-            // from leaving unconstrained inference vars during things like impl
-            // matching in the solver.
-            let a_error = ty::Const::new_error(self.tcx, guar, a.ty());
-            if let ty::ConstKind::Infer(InferConst::Var(vid)) = a.kind() {
-                return self.unify_const_variable(vid, a_error, relation.param_env());
-            }
-            let b_error = ty::Const::new_error(self.tcx, guar, b.ty());
-            if let ty::ConstKind::Infer(InferConst::Var(vid)) = b.kind() {
-                return self.unify_const_variable(vid, b_error, relation.param_env());
-            }
-
-            return Ok(if relation.a_is_expected() { a_error } else { b_error });
-        }
 
         match (a.kind(), b.kind()) {
             (

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1130,7 +1130,7 @@ fn collect_non_exhaustive_tys<'tcx>(
         non_exhaustive_tys.insert(pat.ty().inner());
     }
     if let Constructor::IntRange(range) = pat.ctor() {
-        if cx.is_range_beyond_boundaries(range, pat.ty()) {
+        if cx.is_range_beyond_boundaries(range, *pat.ty()) {
             // The range denotes the values before `isize::MIN` or the values after `usize::MAX`/`isize::MAX`.
             non_exhaustive_tys.insert(pat.ty().inner());
         }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -4,6 +4,7 @@
 // is dead.
 
 use hir::def_id::{LocalDefIdMap, LocalDefIdSet};
+use hir::ItemKind;
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::MultiSpan;
 use rustc_hir as hir;
@@ -14,7 +15,7 @@ use rustc_hir::{Node, PatKind, TyKind};
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::middle::privacy::Level;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt, Visibility};
 use rustc_session::lint;
 use rustc_session::lint::builtin::DEAD_CODE;
 use rustc_span::symbol::{sym, Symbol};
@@ -376,9 +377,46 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                     intravisit::walk_item(self, item)
                 }
                 hir::ItemKind::ForeignMod { .. } => {}
+                hir::ItemKind::Trait(..) => {
+                    for impl_def_id in self.tcx.all_impls(item.owner_id.to_def_id()) {
+                        if let Some(local_def_id) = impl_def_id.as_local()
+                            && let ItemKind::Impl(impl_ref) =
+                                self.tcx.hir().expect_item(local_def_id).kind
+                        {
+                            // skip items
+                            // mark dependent traits live
+                            intravisit::walk_generics(self, impl_ref.generics);
+                            // mark dependent parameters live
+                            intravisit::walk_path(self, impl_ref.of_trait.unwrap().path);
+                        }
+                    }
+
+                    intravisit::walk_item(self, item)
+                }
                 _ => intravisit::walk_item(self, item),
             },
             Node::TraitItem(trait_item) => {
+                // mark corresponing ImplTerm live
+                let trait_item_id = trait_item.owner_id.to_def_id();
+                if let Some(trait_id) = self.tcx.trait_of_item(trait_item_id) {
+                    // mark the trait live
+                    self.check_def_id(trait_id);
+
+                    for impl_id in self.tcx.all_impls(trait_id) {
+                        if let Some(local_impl_id) = impl_id.as_local()
+                            && let ItemKind::Impl(impl_ref) =
+                                self.tcx.hir().expect_item(local_impl_id).kind
+                        {
+                            // mark self_ty live
+                            intravisit::walk_ty(self, impl_ref.self_ty);
+                            if let Some(&impl_item_id) =
+                                self.tcx.impl_item_implementor_ids(impl_id).get(&trait_item_id)
+                            {
+                                self.check_def_id(impl_item_id);
+                            }
+                        }
+                    }
+                }
                 intravisit::walk_trait_item(self, trait_item);
             }
             Node::ImplItem(impl_item) => {
@@ -627,10 +665,6 @@ fn check_item<'tcx>(
             }
         }
         DefKind::Impl { of_trait } => {
-            if of_trait {
-                worklist.push((id.owner_id.def_id, ComesFromAllowExpect::No));
-            }
-
             // get DefIds from another query
             let local_def_ids = tcx
                 .associated_item_def_ids(id.owner_id)
@@ -639,7 +673,11 @@ fn check_item<'tcx>(
 
             // And we access the Map here to get HirId from LocalDefId
             for id in local_def_ids {
-                if of_trait {
+                // for impl trait blocks, mark associate functions live if the trait is public
+                if of_trait
+                    && (!matches!(tcx.def_kind(id), DefKind::AssocFn)
+                        || tcx.local_visibility(id) == Visibility::Public)
+                {
                     worklist.push((id, ComesFromAllowExpect::No));
                 } else if let Some(comes_from_allow) = has_allow_dead_code_or_lang_attr(tcx, id) {
                     worklist.push((id, comes_from_allow));
@@ -670,7 +708,7 @@ fn check_trait_item(
     use hir::TraitItemKind::{Const, Fn};
     if matches!(tcx.def_kind(id.owner_id), DefKind::AssocConst | DefKind::AssocFn) {
         let trait_item = tcx.hir().trait_item(id);
-        if matches!(trait_item.kind, Const(_, Some(_)) | Fn(_, hir::TraitFn::Provided(_)))
+        if matches!(trait_item.kind, Const(_, Some(_)) | Fn(..))
             && let Some(comes_from_allow) =
                 has_allow_dead_code_or_lang_attr(tcx, trait_item.owner_id.def_id)
         {
@@ -939,7 +977,8 @@ impl<'tcx> DeadVisitor<'tcx> {
             | DefKind::TyAlias
             | DefKind::Enum
             | DefKind::Union
-            | DefKind::ForeignTy => self.warn_dead_code(def_id, "used"),
+            | DefKind::ForeignTy
+            | DefKind::Trait => self.warn_dead_code(def_id, "used"),
             DefKind::Struct => self.warn_dead_code(def_id, "constructed"),
             DefKind::Variant | DefKind::Field => bug!("should be handled specially"),
             _ => {}
@@ -964,18 +1003,33 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
     let module_items = tcx.hir_module_items(module);
 
     for item in module_items.items() {
-        if let hir::ItemKind::Impl(impl_item) = tcx.hir().item(item).kind {
-            let mut dead_items = Vec::new();
-            for item in impl_item.items {
-                let def_id = item.id.owner_id.def_id;
-                if !visitor.is_live_code(def_id) {
-                    let name = tcx.item_name(def_id.to_def_id());
-                    let level = visitor.def_lint_level(def_id);
+        let def_kind = tcx.def_kind(item.owner_id);
 
-                    dead_items.push(DeadItem { def_id, name, level })
+        let mut dead_codes = Vec::new();
+        // if we have diagnosed the trait, do not diagnose unused methods
+        if matches!(def_kind, DefKind::Impl { .. })
+            || (def_kind == DefKind::Trait && live_symbols.contains(&item.owner_id.def_id))
+        {
+            for &def_id in tcx.associated_item_def_ids(item.owner_id.def_id) {
+                // We have diagnosed unused methods in traits
+                if matches!(def_kind, DefKind::Impl { of_trait: true })
+                    && tcx.def_kind(def_id) == DefKind::AssocFn
+                    || def_kind == DefKind::Trait && tcx.def_kind(def_id) != DefKind::AssocFn
+                {
+                    continue;
+                }
+
+                if let Some(local_def_id) = def_id.as_local()
+                    && !visitor.is_live_code(local_def_id)
+                {
+                    let name = tcx.item_name(def_id);
+                    let level = visitor.def_lint_level(local_def_id);
+                    dead_codes.push(DeadItem { def_id: local_def_id, name, level });
                 }
             }
-            visitor.warn_multiple(item.owner_id.def_id, "used", dead_items, ReportOn::NamedField);
+        }
+        if !dead_codes.is_empty() {
+            visitor.warn_multiple(item.owner_id.def_id, "used", dead_codes, ReportOn::NamedField);
         }
 
         if !live_symbols.contains(&item.owner_id.def_id) {
@@ -988,7 +1042,6 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
             continue;
         }
 
-        let def_kind = tcx.def_kind(item.owner_id);
         if let DefKind::Struct | DefKind::Union | DefKind::Enum = def_kind {
             let adt = tcx.adt_def(item.owner_id);
             let mut dead_variants = Vec::new();
@@ -1035,8 +1088,6 @@ fn check_mod_deathness(tcx: TyCtxt<'_>, module: LocalModDefId) {
     for foreign_item in module_items.foreign_items() {
         visitor.check_definition(foreign_item.owner_id.def_id);
     }
-
-    // We do not warn trait items.
 }
 
 pub(crate) fn provide(providers: &mut Providers) {

--- a/compiler/rustc_pattern_analysis/src/lib.rs
+++ b/compiler/rustc_pattern_analysis/src/lib.rs
@@ -82,7 +82,7 @@ impl<'a, T: ?Sized> Captures<'a> for T {}
 /// Most of the crate is parameterized on a type that implements this trait.
 pub trait TypeCx: Sized + fmt::Debug {
     /// The type of a pattern.
-    type Ty: Copy + Clone + fmt::Debug; // FIXME: remove Copy
+    type Ty: Clone + fmt::Debug;
     /// Errors that can abort analysis.
     type Error: fmt::Debug;
     /// The index of an enum variant.
@@ -97,16 +97,16 @@ pub trait TypeCx: Sized + fmt::Debug {
     fn is_exhaustive_patterns_feature_on(&self) -> bool;
 
     /// The number of fields for this constructor.
-    fn ctor_arity(&self, ctor: &Constructor<Self>, ty: Self::Ty) -> usize;
+    fn ctor_arity(&self, ctor: &Constructor<Self>, ty: &Self::Ty) -> usize;
 
     /// The types of the fields for this constructor. The result must have a length of
     /// `ctor_arity()`.
-    fn ctor_sub_tys(&self, ctor: &Constructor<Self>, ty: Self::Ty) -> &[Self::Ty];
+    fn ctor_sub_tys(&self, ctor: &Constructor<Self>, ty: &Self::Ty) -> &[Self::Ty];
 
     /// The set of all the constructors for `ty`.
     ///
     /// This must follow the invariants of `ConstructorSet`
-    fn ctors_for_ty(&self, ty: Self::Ty) -> Result<ConstructorSet<Self>, Self::Error>;
+    fn ctors_for_ty(&self, ty: &Self::Ty) -> Result<ConstructorSet<Self>, Self::Error>;
 
     /// Best-effort `Debug` implementation.
     fn debug_pat(f: &mut fmt::Formatter<'_>, pat: &DeconstructedPat<'_, Self>) -> fmt::Result;

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -46,7 +46,7 @@ impl<'p, 'tcx> PatternColumn<'p, 'tcx> {
     }
 
     fn head_ty(&self) -> Option<RevealedTy<'tcx>> {
-        self.patterns.first().map(|pat| pat.ty())
+        self.patterns.first().map(|pat| *pat.ty())
     }
 
     /// Do constructor splitting on the constructors of the column.
@@ -101,7 +101,7 @@ fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
     let Some(ty) = column.head_ty() else {
         return Ok(Vec::new());
     };
-    let pcx = &PlaceCtxt::new_dummy(cx, ty);
+    let pcx = &PlaceCtxt::new_dummy(cx, &ty);
 
     let set = column.analyze_ctors(pcx)?;
     if set.present.is_empty() {

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -54,8 +54,8 @@ impl<'p, Cx: TypeCx> DeconstructedPat<'p, Cx> {
     pub fn ctor(&self) -> &Constructor<Cx> {
         &self.ctor
     }
-    pub fn ty(&self) -> Cx::Ty {
-        self.ty
+    pub fn ty(&self) -> &Cx::Ty {
+        &self.ty
     }
     /// Returns the extra data stored in a pattern. Returns `None` if the pattern is a wildcard that
     /// does not correspond to a user-supplied pattern.
@@ -242,15 +242,15 @@ impl<Cx: TypeCx> WitnessPat<Cx> {
     /// `Some(_)`.
     pub(crate) fn wild_from_ctor(pcx: &PlaceCtxt<'_, Cx>, ctor: Constructor<Cx>) -> Self {
         let field_tys = pcx.ctor_sub_tys(&ctor);
-        let fields = field_tys.iter().map(|ty| Self::wildcard(*ty)).collect();
-        Self::new(ctor, fields, pcx.ty)
+        let fields = field_tys.iter().cloned().map(|ty| Self::wildcard(ty)).collect();
+        Self::new(ctor, fields, pcx.ty.clone())
     }
 
     pub fn ctor(&self) -> &Constructor<Cx> {
         &self.ctor
     }
-    pub fn ty(&self) -> Cx::Ty {
-        self.ty
+    pub fn ty(&self) -> &Cx::Ty {
+        &self.ty
     }
 
     pub fn iter_fields(&self) -> impl Iterator<Item = &WitnessPat<Cx>> {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -766,7 +766,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
         let mut subpatterns = pat.iter_fields().map(|p| Box::new(cx.hoist_witness_pat(p)));
         let kind = match pat.ctor() {
             Bool(b) => PatKind::Constant { value: mir::Const::from_bool(cx.tcx, *b) },
-            IntRange(range) => return self.hoist_pat_range(range, pat.ty()),
+            IntRange(range) => return self.hoist_pat_range(range, *pat.ty()),
             Struct | Variant(_) | UnionField => match pat.ty().kind() {
                 ty::Tuple(..) => PatKind::Leaf {
                     subpatterns: subpatterns
@@ -785,7 +785,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
                         RustcMatchCheckCtxt::variant_index_for_adt(&pat.ctor(), *adt_def);
                     let variant = &adt_def.variant(variant_index);
                     let subpatterns = cx
-                        .list_variant_nonhidden_fields(pat.ty(), variant)
+                        .list_variant_nonhidden_fields(*pat.ty(), variant)
                         .zip(subpatterns)
                         .map(|((field, _ty), pattern)| FieldPat { field, pattern })
                         .collect();
@@ -796,7 +796,7 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
                         PatKind::Leaf { subpatterns }
                     }
                 }
-                _ => bug!("unexpected ctor for type {:?} {:?}", pat.ctor(), pat.ty()),
+                _ => bug!("unexpected ctor for type {:?} {:?}", pat.ctor(), *pat.ty()),
             },
             // Note: given the expansion of `&str` patterns done in `expand_pattern`, we should
             // be careful to reconstruct the correct constant pattern here. However a string
@@ -961,21 +961,21 @@ impl<'p, 'tcx> TypeCx for RustcMatchCheckCtxt<'p, 'tcx> {
         self.tcx.features().exhaustive_patterns
     }
 
-    fn ctor_arity(&self, ctor: &crate::constructor::Constructor<Self>, ty: Self::Ty) -> usize {
-        self.ctor_arity(ctor, ty)
+    fn ctor_arity(&self, ctor: &crate::constructor::Constructor<Self>, ty: &Self::Ty) -> usize {
+        self.ctor_arity(ctor, *ty)
     }
     fn ctor_sub_tys(
         &self,
         ctor: &crate::constructor::Constructor<Self>,
-        ty: Self::Ty,
+        ty: &Self::Ty,
     ) -> &[Self::Ty] {
-        self.ctor_sub_tys(ctor, ty)
+        self.ctor_sub_tys(ctor, *ty)
     }
     fn ctors_for_ty(
         &self,
-        ty: Self::Ty,
+        ty: &Self::Ty,
     ) -> Result<crate::constructor::ConstructorSet<Self>, Self::Error> {
-        self.ctors_for_ty(ty)
+        self.ctors_for_ty(*ty)
     }
 
     fn debug_pat(
@@ -994,7 +994,7 @@ impl<'p, 'tcx> TypeCx for RustcMatchCheckCtxt<'p, 'tcx> {
         overlaps_on: IntRange,
         overlaps_with: &[&crate::pat::DeconstructedPat<'_, Self>],
     ) {
-        let overlap_as_pat = self.hoist_pat_range(&overlaps_on, pat.ty());
+        let overlap_as_pat = self.hoist_pat_range(&overlaps_on, *pat.ty());
         let overlaps: Vec<_> = overlaps_with
             .iter()
             .map(|pat| pat.data().unwrap().span)

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -736,13 +736,14 @@ pub(crate) struct PlaceCtxt<'a, Cx: TypeCx> {
     #[derivative(Debug = "ignore")]
     pub(crate) mcx: MatchCtxt<'a, Cx>,
     /// Type of the place under investigation.
-    pub(crate) ty: Cx::Ty,
+    #[derivative(Clone(clone_with = "Clone::clone"))] // See rust-derivative#90
+    pub(crate) ty: &'a Cx::Ty,
 }
 
 impl<'a, Cx: TypeCx> PlaceCtxt<'a, Cx> {
     /// A `PlaceCtxt` when code other than `is_useful` needs one.
     #[cfg_attr(not(feature = "rustc"), allow(dead_code))]
-    pub(crate) fn new_dummy(mcx: MatchCtxt<'a, Cx>, ty: Cx::Ty) -> Self {
+    pub(crate) fn new_dummy(mcx: MatchCtxt<'a, Cx>, ty: &'a Cx::Ty) -> Self {
         PlaceCtxt { mcx, ty }
     }
 
@@ -1023,8 +1024,8 @@ impl<'p, Cx: TypeCx> Matrix<'p, Cx> {
         matrix
     }
 
-    fn head_ty(&self) -> Option<Cx::Ty> {
-        self.place_ty.first().copied()
+    fn head_ty(&self) -> Option<&Cx::Ty> {
+        self.place_ty.first()
     }
     fn column_count(&self) -> usize {
         self.place_ty.len()
@@ -1058,7 +1059,7 @@ impl<'p, Cx: TypeCx> Matrix<'p, Cx> {
         let ctor_sub_tys = pcx.ctor_sub_tys(ctor);
         let arity = ctor_sub_tys.len();
         let specialized_place_ty =
-            ctor_sub_tys.iter().chain(self.place_ty[1..].iter()).copied().collect();
+            ctor_sub_tys.iter().chain(self.place_ty[1..].iter()).cloned().collect();
         let ctor_sub_validity = self.place_validity[0].specialize(ctor);
         let specialized_place_validity = std::iter::repeat(ctor_sub_validity)
             .take(arity)
@@ -1214,7 +1215,7 @@ impl<Cx: TypeCx> WitnessStack<Cx> {
         let len = self.0.len();
         let arity = ctor.arity(pcx);
         let fields = self.0.drain((len - arity)..).rev().collect();
-        let pat = WitnessPat::new(ctor.clone(), fields, pcx.ty);
+        let pat = WitnessPat::new(ctor.clone(), fields, pcx.ty.clone());
         self.0.push(pat);
     }
 }
@@ -1410,7 +1411,7 @@ fn compute_exhaustiveness_and_usefulness<'a, 'p, Cx: TypeCx>(
         return Ok(WitnessMatrix::empty());
     }
 
-    let Some(ty) = matrix.head_ty() else {
+    let Some(ty) = matrix.head_ty().cloned() else {
         // The base case: there are no columns in the matrix. We are morally pattern-matching on ().
         // A row is useful iff it has no (unguarded) rows above it.
         let mut useful = true; // Whether the next row is useful.
@@ -1431,7 +1432,7 @@ fn compute_exhaustiveness_and_usefulness<'a, 'p, Cx: TypeCx>(
     };
 
     debug!("ty: {ty:?}");
-    let pcx = &PlaceCtxt { mcx, ty };
+    let pcx = &PlaceCtxt { mcx, ty: &ty };
     let ctors_for_ty = pcx.ctors_for_ty()?;
 
     // Whether the place/column we are inspecting is known to contain valid data.

--- a/compiler/rustc_span/src/source_map/tests.rs
+++ b/compiler/rustc_span/src/source_map/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use rustc_data_structures::sync::FreezeLock;
+
 fn init_source_map() -> SourceMap {
     let sm = SourceMap::new(FilePathMapping::empty());
     sm.new_source_file(PathBuf::from("blork.rs").into(), "first line.\nsecond line".to_string());
@@ -261,53 +263,6 @@ fn t10() {
         normalized,
         "imported source file should be normalized"
     );
-}
-
-/// Returns the span corresponding to the `n`th occurrence of `substring` in `source_text`.
-trait SourceMapExtension {
-    fn span_substr(
-        &self,
-        file: &Lrc<SourceFile>,
-        source_text: &str,
-        substring: &str,
-        n: usize,
-    ) -> Span;
-}
-
-impl SourceMapExtension for SourceMap {
-    fn span_substr(
-        &self,
-        file: &Lrc<SourceFile>,
-        source_text: &str,
-        substring: &str,
-        n: usize,
-    ) -> Span {
-        eprintln!(
-            "span_substr(file={:?}/{:?}, substring={:?}, n={})",
-            file.name, file.start_pos, substring, n
-        );
-        let mut i = 0;
-        let mut hi = 0;
-        loop {
-            let offset = source_text[hi..].find(substring).unwrap_or_else(|| {
-                panic!(
-                    "source_text `{}` does not have {} occurrences of `{}`, only {}",
-                    source_text, n, substring, i
-                );
-            });
-            let lo = hi + offset;
-            hi = lo + substring.len();
-            if i == n {
-                let span = Span::with_root_ctxt(
-                    BytePos(lo as u32 + file.start_pos.0),
-                    BytePos(hi as u32 + file.start_pos.0),
-                );
-                assert_eq!(&self.span_to_snippet(span).unwrap()[..], substring);
-                return span;
-            }
-            i += 1;
-        }
-    }
 }
 
 // Takes a unix-style path and returns a platform specific path.

--- a/library/alloc/src/vec/in_place_collect.rs
+++ b/library/alloc/src/vec/in_place_collect.rs
@@ -72,7 +72,7 @@
 //! This is handled by the [`InPlaceDrop`] guard for sink items (`U`) and by
 //! [`vec::IntoIter::forget_allocation_drop_remaining()`] for remaining source items (`T`).
 //!
-//! If dropping any remaining source item (`T`) panics then [`InPlaceDstBufDrop`] will handle dropping
+//! If dropping any remaining source item (`T`) panics then [`InPlaceDstDataSrcBufDrop`] will handle dropping
 //! the already collected sink items (`U`) and freeing the allocation.
 //!
 //! [`vec::IntoIter::forget_allocation_drop_remaining()`]: super::IntoIter::forget_allocation_drop_remaining()
@@ -158,11 +158,12 @@ use crate::alloc::{handle_alloc_error, Global};
 use core::alloc::Allocator;
 use core::alloc::Layout;
 use core::iter::{InPlaceIterable, SourceIter, TrustedRandomAccessNoCoerce};
+use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, SizedTypeProperties};
 use core::num::NonZeroUsize;
 use core::ptr::{self, NonNull};
 
-use super::{InPlaceDrop, InPlaceDstBufDrop, SpecFromIter, SpecFromIterNested, Vec};
+use super::{InPlaceDrop, InPlaceDstDataSrcBufDrop, SpecFromIter, SpecFromIterNested, Vec};
 
 const fn in_place_collectible<DEST, SRC>(
     step_merge: Option<NonZeroUsize>,
@@ -262,7 +263,7 @@ where
             );
         }
 
-        // The ownership of the allocation and the new `T` values is temporarily moved into `dst_guard`.
+        // The ownership of the source allocation and the new `T` values is temporarily moved into `dst_guard`.
         // This is safe because
         // * `forget_allocation_drop_remaining` immediately forgets the allocation
         // before any panic can occur in order to avoid any double free, and then proceeds to drop
@@ -273,7 +274,8 @@ where
         // Note: This access to the source wouldn't be allowed by the TrustedRandomIteratorNoCoerce
         // contract (used by SpecInPlaceCollect below). But see the "O(1) collect" section in the
         // module documentation why this is ok anyway.
-        let dst_guard = InPlaceDstBufDrop { ptr: dst_buf, len, cap: dst_cap };
+        let dst_guard =
+            InPlaceDstDataSrcBufDrop { ptr: dst_buf, len, src_cap, src: PhantomData::<I::Src> };
         src.forget_allocation_drop_remaining();
 
         // Adjust the allocation if the alignment didn't match or the source had a capacity in bytes

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -123,7 +123,7 @@ use self::set_len_on_drop::SetLenOnDrop;
 mod set_len_on_drop;
 
 #[cfg(not(no_global_oom_handling))]
-use self::in_place_drop::{InPlaceDrop, InPlaceDstBufDrop};
+use self::in_place_drop::{InPlaceDrop, InPlaceDstDataSrcBufDrop};
 
 #[cfg(not(no_global_oom_handling))]
 mod in_place_drop;

--- a/library/alloc/src/vec/spec_from_iter.rs
+++ b/library/alloc/src/vec/spec_from_iter.rs
@@ -13,13 +13,13 @@ use super::{IntoIter, SpecExtend, SpecFromIterNested, Vec};
 /// +-+-----------+
 ///   |
 ///   v
-/// +-+-------------------------------+  +---------------------+
-/// |SpecFromIter                  +---->+SpecFromIterNested   |
-/// |where I:                      |  |  |where I:             |
-/// |  Iterator (default)----------+  |  |  Iterator (default) |
-/// |  vec::IntoIter               |  |  |  TrustedLen         |
-/// |  SourceIterMarker---fallback-+  |  +---------------------+
-/// +---------------------------------+
+/// +-+---------------------------------+  +---------------------+
+/// |SpecFromIter                    +---->+SpecFromIterNested   |
+/// |where I:                        |  |  |where I:             |
+/// |  Iterator (default)------------+  |  |  Iterator (default) |
+/// |  vec::IntoIter                 |  |  |  TrustedLen         |
+/// |  InPlaceCollect--(fallback to)-+  |  +---------------------+
+/// +-----------------------------------+
 /// ```
 pub(super) trait SpecFromIter<T, I> {
     fn from_iter(iter: I) -> Self;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -162,6 +162,7 @@
 #![feature(const_slice_ptr_len)]
 #![feature(const_slice_split_at_mut)]
 #![feature(const_str_from_utf8_unchecked_mut)]
+#![feature(const_strict_overflow_ops)]
 #![feature(const_swap)]
 #![feature(const_try)]
 #![feature(const_type_id)]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -451,7 +451,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_add(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_add(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict integer addition. Computes `self + rhs`, panicking
@@ -461,7 +461,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -484,7 +484,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_add(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_add(rhs);
-            if unlikely!(b) {overflow_panic::add()} else {a}
+            if unlikely!(b) { overflow_panic::add() } else { a }
         }
 
         /// Unchecked integer addition. Computes `self + rhs`, assuming overflow
@@ -531,7 +531,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_add_unsigned(self, rhs: $UnsignedT) -> Option<Self> {
             let (a, b) = self.overflowing_add_unsigned(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict addition with an unsigned integer. Computes `self + rhs`,
@@ -541,7 +541,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -564,7 +564,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_add_unsigned(self, rhs: $UnsignedT) -> Self {
             let (a, b) = self.overflowing_add_unsigned(rhs);
-            if unlikely!(b) {overflow_panic::add()} else {a}
+            if unlikely!(b) { overflow_panic::add() } else { a }
         }
 
         /// Checked integer subtraction. Computes `self - rhs`, returning `None` if
@@ -585,7 +585,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_sub(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict integer subtraction. Computes `self - rhs`, panicking if
@@ -595,7 +595,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -618,7 +618,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_sub(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_sub(rhs);
-            if unlikely!(b) {overflow_panic::sub()} else {a}
+            if unlikely!(b) { overflow_panic::sub() } else { a }
         }
 
         /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
@@ -665,7 +665,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_sub_unsigned(self, rhs: $UnsignedT) -> Option<Self> {
             let (a, b) = self.overflowing_sub_unsigned(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict subtraction with an unsigned integer. Computes `self - rhs`,
@@ -675,7 +675,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -698,7 +698,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_sub_unsigned(self, rhs: $UnsignedT) -> Self {
             let (a, b) = self.overflowing_sub_unsigned(rhs);
-            if unlikely!(b) {overflow_panic::sub()} else {a}
+            if unlikely!(b) { overflow_panic::sub() } else { a }
         }
 
         /// Checked integer multiplication. Computes `self * rhs`, returning `None` if
@@ -719,7 +719,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_mul(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict integer multiplication. Computes `self * rhs`, panicking if
@@ -729,7 +729,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -752,7 +752,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_mul(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_mul(rhs);
-            if unlikely!(b) {overflow_panic::mul()} else {a}
+            if unlikely!(b) { overflow_panic::mul() } else { a }
         }
 
         /// Unchecked integer multiplication. Computes `self * rhs`, assuming overflow
@@ -816,7 +816,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// The only case where such an overflow can occur is when one divides `MIN / -1` on a signed type (where
         /// `MIN` is the negative minimal value for the type); this is equivalent to `-MIN`, a positive value
@@ -848,7 +848,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_div(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_div(rhs);
-            if unlikely!(b) {overflow_panic::div()} else {a}
+            if unlikely!(b) { overflow_panic::div() } else { a }
         }
 
         /// Checked Euclidean division. Computes `self.div_euclid(rhs)`,
@@ -886,7 +886,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// The only case where such an overflow can occur is when one divides `MIN / -1` on a signed type (where
         /// `MIN` is the negative minimal value for the type); this is equivalent to `-MIN`, a positive value
@@ -918,7 +918,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_div_euclid(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_div_euclid(rhs);
-            if unlikely!(b) {overflow_panic::div()} else {a}
+            if unlikely!(b) { overflow_panic::div() } else { a }
         }
 
         /// Checked integer remainder. Computes `self % rhs`, returning `None` if
@@ -956,7 +956,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// The only case where such an overflow can occur is `x % y` for `MIN / -1` on a
         /// signed type (where `MIN` is the negative minimal value), which is invalid due to implementation artifacts.
@@ -987,7 +987,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_rem(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_rem(rhs);
-            if unlikely!(b) {overflow_panic::rem()} else {a}
+            if unlikely!(b) { overflow_panic::rem() } else { a }
         }
 
         /// Checked Euclidean remainder. Computes `self.rem_euclid(rhs)`, returning `None`
@@ -1025,7 +1025,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// The only case where such an overflow can occur is `x % y` for `MIN / -1` on a
         /// signed type (where `MIN` is the negative minimal value), which is invalid due to implementation artifacts.
@@ -1056,7 +1056,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_rem_euclid(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_rem_euclid(rhs);
-            if unlikely!(b) {overflow_panic::rem()} else {a}
+            if unlikely!(b) { overflow_panic::rem() } else { a }
         }
 
         /// Checked negation. Computes `-self`, returning `None` if `self == MIN`.
@@ -1076,7 +1076,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_neg(self) -> Option<Self> {
             let (a, b) = self.overflowing_neg();
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Unchecked negation. Computes `-self`, assuming overflow cannot occur.
@@ -1110,7 +1110,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1133,7 +1133,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_neg(self) -> Self {
             let (a, b) = self.overflowing_neg();
-            if unlikely!(b) {overflow_panic::neg()} else {a}
+            if unlikely!(b) { overflow_panic::neg() } else { a }
         }
 
         /// Checked shift left. Computes `self << rhs`, returning `None` if `rhs` is larger
@@ -1154,7 +1154,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shl(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict shift left. Computes `self << rhs`, panicking if `rhs` is larger
@@ -1164,7 +1164,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1187,7 +1187,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_shl(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shl(rhs);
-            if unlikely!(b) {overflow_panic::shl()} else {a}
+            if unlikely!(b) { overflow_panic::shl() } else { a }
         }
 
         /// Unchecked shift left. Computes `self << rhs`, assuming that
@@ -1235,7 +1235,7 @@ macro_rules! int_impl {
         #[inline]
         pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shr(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict shift right. Computes `self >> rhs`, panicking `rhs` is
@@ -1245,7 +1245,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1268,7 +1268,7 @@ macro_rules! int_impl {
         #[track_caller]
         pub const fn strict_shr(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shr(rhs);
-            if unlikely!(b) {overflow_panic::shr()} else {a}
+            if unlikely!(b) { overflow_panic::shr() } else { a }
         }
 
         /// Unchecked shift right. Computes `self >> rhs`, assuming that
@@ -1329,7 +1329,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1403,7 +1403,7 @@ macro_rules! int_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -454,6 +454,38 @@ macro_rules! int_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
+        /// Strict integer addition. Computes `self + rhs`, panicking
+        /// if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!((", stringify!($SelfT), "::MAX - 2).strict_add(1), ", stringify!($SelfT), "::MAX - 1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (", stringify!($SelfT), "::MAX - 2).strict_add(3);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_add(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_add(rhs);
+            if unlikely!(b) {overflow_panic::add()} else {a}
+        }
+
         /// Unchecked integer addition. Computes `self + rhs`, assuming overflow
         /// cannot occur.
         ///
@@ -501,6 +533,38 @@ macro_rules! int_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
+        /// Strict addition with an unsigned integer. Computes `self + rhs`,
+        /// panicking if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(1", stringify!($SelfT), ".strict_add_unsigned(2), 3);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (", stringify!($SelfT), "::MAX - 2).strict_add_unsigned(3);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_add_unsigned(self, rhs: $UnsignedT) -> Self {
+            let (a, b) = self.overflowing_add_unsigned(rhs);
+            if unlikely!(b) {overflow_panic::add()} else {a}
+        }
+
         /// Checked integer subtraction. Computes `self - rhs`, returning `None` if
         /// overflow occurred.
         ///
@@ -520,6 +584,38 @@ macro_rules! int_impl {
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_sub(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict integer subtraction. Computes `self - rhs`, panicking if
+        /// overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!((", stringify!($SelfT), "::MIN + 2).strict_sub(1), ", stringify!($SelfT), "::MIN + 1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (", stringify!($SelfT), "::MIN + 2).strict_sub(3);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_sub(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_sub(rhs);
+            if unlikely!(b) {overflow_panic::sub()} else {a}
         }
 
         /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
@@ -569,6 +665,38 @@ macro_rules! int_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
+        /// Strict subtraction with an unsigned integer. Computes `self - rhs`,
+        /// panicking if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(1", stringify!($SelfT), ".strict_sub_unsigned(2), -1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (", stringify!($SelfT), "::MIN + 2).strict_sub_unsigned(3);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_sub_unsigned(self, rhs: $UnsignedT) -> Self {
+            let (a, b) = self.overflowing_sub_unsigned(rhs);
+            if unlikely!(b) {overflow_panic::sub()} else {a}
+        }
+
         /// Checked integer multiplication. Computes `self * rhs`, returning `None` if
         /// overflow occurred.
         ///
@@ -588,6 +716,38 @@ macro_rules! int_impl {
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_mul(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict integer multiplication. Computes `self * rhs`, panicking if
+        /// overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.strict_mul(1), ", stringify!($SelfT), "::MAX);")]
+        /// ```
+        ///
+        /// ``` should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MAX.strict_mul(2);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_mul(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_mul(rhs);
+            if unlikely!(b) {overflow_panic::mul()} else {a}
         }
 
         /// Unchecked integer multiplication. Computes `self * rhs`, assuming overflow
@@ -642,6 +802,49 @@ macro_rules! int_impl {
             }
         }
 
+        /// Strict integer division. Computes `self / rhs`, panicking
+        /// if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// The only case where such an overflow can occur is when one divides `MIN / -1` on a signed type (where
+        /// `MIN` is the negative minimal value for the type); this is equivalent to `-MIN`, a positive value
+        /// that is too large to represent in the type.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!((", stringify!($SelfT), "::MIN + 1).strict_div(-1), ", stringify!($Max), ");")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MIN.strict_div(-1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (1", stringify!($SelfT), ").strict_div(0);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_div(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_div(rhs);
+            if unlikely!(b) {overflow_panic::div()} else {a}
+        }
+
         /// Checked Euclidean division. Computes `self.div_euclid(rhs)`,
         /// returning `None` if `rhs == 0` or the division results in overflow.
         ///
@@ -666,6 +869,49 @@ macro_rules! int_impl {
             } else {
                 Some(self.div_euclid(rhs))
             }
+        }
+
+        /// Strict Euclidean division. Computes `self.div_euclid(rhs)`, panicking
+        /// if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// The only case where such an overflow can occur is when one divides `MIN / -1` on a signed type (where
+        /// `MIN` is the negative minimal value for the type); this is equivalent to `-MIN`, a positive value
+        /// that is too large to represent in the type.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!((", stringify!($SelfT), "::MIN + 1).strict_div_euclid(-1), ", stringify!($Max), ");")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MIN.strict_div_euclid(-1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (1", stringify!($SelfT), ").strict_div_euclid(0);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_div_euclid(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_div_euclid(rhs);
+            if unlikely!(b) {overflow_panic::div()} else {a}
         }
 
         /// Checked integer remainder. Computes `self % rhs`, returning `None` if
@@ -694,6 +940,48 @@ macro_rules! int_impl {
             }
         }
 
+        /// Strict integer remainder. Computes `self % rhs`, panicking if
+        /// the division results in overflow.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// The only case where such an overflow can occur is `x % y` for `MIN / -1` on a
+        /// signed type (where `MIN` is the negative minimal value), which is invalid due to implementation artifacts.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".strict_rem(2), 1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 5", stringify!($SelfT), ".strict_rem(0);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MIN.strict_rem(-1);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_rem(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_rem(rhs);
+            if unlikely!(b) {overflow_panic::rem()} else {a}
+        }
+
         /// Checked Euclidean remainder. Computes `self.rem_euclid(rhs)`, returning `None`
         /// if `rhs == 0` or the division results in overflow.
         ///
@@ -718,6 +1006,48 @@ macro_rules! int_impl {
             } else {
                 Some(self.rem_euclid(rhs))
             }
+        }
+
+        /// Strict Euclidean remainder. Computes `self.rem_euclid(rhs)`, panicking if
+        /// the division results in overflow.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// The only case where such an overflow can occur is `x % y` for `MIN / -1` on a
+        /// signed type (where `MIN` is the negative minimal value), which is invalid due to implementation artifacts.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".strict_rem_euclid(2), 1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 5", stringify!($SelfT), ".strict_rem_euclid(0);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MIN.strict_rem_euclid(-1);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_rem_euclid(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_rem_euclid(rhs);
+            if unlikely!(b) {overflow_panic::rem()} else {a}
         }
 
         /// Checked negation. Computes `-self`, returning `None` if `self == MIN`.
@@ -765,6 +1095,37 @@ macro_rules! int_impl {
             unsafe { intrinsics::unchecked_sub(0, self) }
         }
 
+        /// Strict negation. Computes `-self`, panicking if `self == MIN`.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".strict_neg(), -5);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MIN.strict_neg();")]
+        ///
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_neg(self) -> Self {
+            let (a, b) = self.overflowing_neg();
+            if unlikely!(b) {overflow_panic::neg()} else {a}
+        }
+
         /// Checked shift left. Computes `self << rhs`, returning `None` if `rhs` is larger
         /// than or equal to the number of bits in `self`.
         ///
@@ -784,6 +1145,38 @@ macro_rules! int_impl {
         pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shl(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict shift left. Computes `self << rhs`, panicking if `rhs` is larger
+        /// than or equal to the number of bits in `self`.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".strict_shl(4), 0x10);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 0x1", stringify!($SelfT), ".strict_shl(129);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_shl(self, rhs: u32) -> Self {
+            let (a, b) = self.overflowing_shl(rhs);
+            if unlikely!(b) {overflow_panic::shl()} else {a}
         }
 
         /// Unchecked shift left. Computes `self << rhs`, assuming that
@@ -832,6 +1225,38 @@ macro_rules! int_impl {
         pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shr(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict shift right. Computes `self >> rhs`, panicking `rhs` is
+        /// larger than or equal to the number of bits in `self`.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".strict_shr(4), 0x1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 0x10", stringify!($SelfT), ".strict_shr(128);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_shr(self, rhs: u32) -> Self {
+            let (a, b) = self.overflowing_shr(rhs);
+            if unlikely!(b) {overflow_panic::shr()} else {a}
         }
 
         /// Unchecked shift right. Computes `self >> rhs`, assuming that
@@ -885,6 +1310,41 @@ macro_rules! int_impl {
             }
         }
 
+        /// Strict absolute value. Computes `self.abs()`, panicking if
+        /// `self == MIN`.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!((-5", stringify!($SelfT), ").strict_abs(), 5);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MIN.strict_abs();")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_abs(self) -> Self {
+            if self.is_negative() {
+                self.strict_neg()
+            } else {
+                self
+            }
+        }
+
         /// Checked exponentiation. Computes `self.pow(exp)`, returning `None` if
         /// overflow occurred.
         ///
@@ -921,6 +1381,54 @@ macro_rules! int_impl {
             // squaring the base afterwards is not necessary and may cause a
             // needless overflow.
             acc.checked_mul(base)
+        }
+
+        /// Strict exponentiation. Computes `self.pow(exp)`, panicking if
+        /// overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(8", stringify!($SelfT), ".strict_pow(2), 64);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MAX.strict_pow(2);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_pow(self, mut exp: u32) -> Self {
+            if exp == 0 {
+                return 1;
+            }
+            let mut base = self;
+            let mut acc: Self = 1;
+
+            while exp > 1 {
+                if (exp & 1) == 1 {
+                    acc = acc.strict_mul(base);
+                }
+                exp /= 2;
+                base = base.strict_mul(base);
+            }
+            // since exp!=0, finally the exp must be 1.
+            // Deal with the final bit of the exponent separately, since
+            // squaring the base afterwards is not necessary and may cause a
+            // needless overflow.
+            acc.strict_mul(base)
         }
 
         /// Returns the square root of the number, rounded down.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -481,6 +481,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_add(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_add(rhs);
             if unlikely!(b) {overflow_panic::add()} else {a}
@@ -560,6 +561,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_add_unsigned(self, rhs: $UnsignedT) -> Self {
             let (a, b) = self.overflowing_add_unsigned(rhs);
             if unlikely!(b) {overflow_panic::add()} else {a}
@@ -613,6 +615,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_sub(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_sub(rhs);
             if unlikely!(b) {overflow_panic::sub()} else {a}
@@ -692,6 +695,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_sub_unsigned(self, rhs: $UnsignedT) -> Self {
             let (a, b) = self.overflowing_sub_unsigned(rhs);
             if unlikely!(b) {overflow_panic::sub()} else {a}
@@ -745,6 +749,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_mul(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_mul(rhs);
             if unlikely!(b) {overflow_panic::mul()} else {a}
@@ -840,6 +845,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_div(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_div(rhs);
             if unlikely!(b) {overflow_panic::div()} else {a}
@@ -909,6 +915,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_div_euclid(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_div_euclid(rhs);
             if unlikely!(b) {overflow_panic::div()} else {a}
@@ -977,6 +984,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_rem(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_rem(rhs);
             if unlikely!(b) {overflow_panic::rem()} else {a}
@@ -1045,6 +1053,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_rem_euclid(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_rem_euclid(rhs);
             if unlikely!(b) {overflow_panic::rem()} else {a}
@@ -1121,6 +1130,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_neg(self) -> Self {
             let (a, b) = self.overflowing_neg();
             if unlikely!(b) {overflow_panic::neg()} else {a}
@@ -1174,6 +1184,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_shl(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shl(rhs);
             if unlikely!(b) {overflow_panic::shl()} else {a}
@@ -1254,6 +1265,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_shr(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shr(rhs);
             if unlikely!(b) {overflow_panic::shr()} else {a}
@@ -1337,6 +1349,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_abs(self) -> Self {
             if self.is_negative() {
                 self.strict_neg()
@@ -1410,6 +1423,7 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_pow(self, mut exp: u32) -> Self {
             if exp == 0 {
                 return 1;

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -44,6 +44,7 @@ mod uint_macros; // import uint_impl!
 mod error;
 mod int_log10;
 mod nonzero;
+mod overflow_panic;
 mod saturating;
 mod wrapping;
 

--- a/library/core/src/num/overflow_panic.rs
+++ b/library/core/src/num/overflow_panic.rs
@@ -1,3 +1,7 @@
+//! Functions for panicking on overflow.
+//!
+//! In particular, these are used by the `strict_` methods on integers.
+
 #[cold]
 #[track_caller]
 pub const fn add() -> ! {

--- a/library/core/src/num/overflow_panic.rs
+++ b/library/core/src/num/overflow_panic.rs
@@ -1,0 +1,47 @@
+#[cold]
+#[track_caller]
+pub const fn add() -> ! {
+    panic!("attempt to add with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn sub() -> ! {
+    panic!("attempt to subtract with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn mul() -> ! {
+    panic!("attempt to multiply with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn div() -> ! {
+    panic!("attempt to divide with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn rem() -> ! {
+    panic!("attempt to calculate the remainder with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn neg() -> ! {
+    panic!("attempt to negate with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn shr() -> ! {
+    panic!("attempt to shift right with overflow")
+}
+
+#[cold]
+#[track_caller]
+pub const fn shl() -> ! {
+    panic!("attempt to shift left with overflow")
+}

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -459,7 +459,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_add(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_add(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict integer addition. Computes `self + rhs`, panicking
@@ -469,7 +469,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -492,8 +492,8 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_add(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_add(rhs);
-            if unlikely!(b) {overflow_panic::add()} else {a}
-        }
+            if unlikely!(b) { overflow_panic ::add()} else {a}
+         }
 
         /// Unchecked integer addition. Computes `self + rhs`, assuming overflow
         /// cannot occur.
@@ -540,7 +540,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_add_signed(self, rhs: $SignedT) -> Option<Self> {
             let (a, b) = self.overflowing_add_signed(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict addition with a signed integer. Computes `self + rhs`,
@@ -550,7 +550,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -578,8 +578,8 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_add_signed(self, rhs: $SignedT) -> Self {
             let (a, b) = self.overflowing_add_signed(rhs);
-            if unlikely!(b) {overflow_panic::add()} else {a}
-        }
+            if unlikely!(b) { overflow_panic ::add()} else {a}
+         }
 
         /// Checked integer subtraction. Computes `self - rhs`, returning
         /// `None` if overflow occurred.
@@ -599,7 +599,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_sub(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict integer subtraction. Computes `self - rhs`, panicking if
@@ -609,7 +609,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -632,8 +632,8 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_sub(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_sub(rhs);
-            if unlikely!(b) {overflow_panic::sub()} else {a}
-        }
+            if unlikely!(b) { overflow_panic ::sub()} else {a}
+         }
 
         /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
         /// cannot occur.
@@ -679,7 +679,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_mul(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict integer multiplication. Computes `self * rhs`, panicking if
@@ -689,7 +689,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -712,8 +712,8 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_mul(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_mul(rhs);
-            if unlikely!(b) {overflow_panic::mul()} else {a}
-        }
+            if unlikely!(b) { overflow_panic ::mul()} else {a}
+         }
 
         /// Unchecked integer multiplication. Computes `self * rhs`, assuming overflow
         /// cannot occur.
@@ -1147,7 +1147,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_neg(self) -> Option<Self> {
             let (a, b) = self.overflowing_neg();
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict negation. Computes `-self`, panicking unless `self ==
@@ -1159,7 +1159,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1182,7 +1182,7 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_neg(self) -> Self {
             let (a, b) = self.overflowing_neg();
-            if unlikely!(b) {overflow_panic::neg()} else {a}
+            if unlikely!(b) { overflow_panic::neg() } else { a }
         }
 
         /// Checked shift left. Computes `self << rhs`, returning `None`
@@ -1203,7 +1203,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shl(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict shift left. Computes `self << rhs`, panicking if `rhs` is larger
@@ -1213,7 +1213,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1236,7 +1236,7 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_shl(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shl(rhs);
-            if unlikely!(b) {overflow_panic::shl()} else {a}
+            if unlikely!(b) { overflow_panic::shl() } else { a }
         }
 
         /// Unchecked shift left. Computes `self << rhs`, assuming that
@@ -1284,7 +1284,7 @@ macro_rules! uint_impl {
         #[inline]
         pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shr(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            if unlikely!(b) { None } else { Some(a) }
         }
 
         /// Strict shift right. Computes `self >> rhs`, panicking `rhs` is
@@ -1294,7 +1294,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///
@@ -1317,7 +1317,7 @@ macro_rules! uint_impl {
         #[track_caller]
         pub const fn strict_shr(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shr(rhs);
-            if unlikely!(b) {overflow_panic::shr()} else {a}
+            if unlikely!(b) { overflow_panic::shr() } else { a }
         }
 
         /// Unchecked shift right. Computes `self >> rhs`, assuming that
@@ -1393,7 +1393,7 @@ macro_rules! uint_impl {
         ///
         /// ## Overflow behavior
         ///
-        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        /// This function will always panic on overflow, regardless of whether overflow checks are enabled.
         ///
         /// # Examples
         ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -462,6 +462,38 @@ macro_rules! uint_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
+        /// Strict integer addition. Computes `self + rhs`, panicking
+        /// if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!((", stringify!($SelfT), "::MAX - 2).strict_add(1), ", stringify!($SelfT), "::MAX - 1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (", stringify!($SelfT), "::MAX - 2).strict_add(3);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_add(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_add(rhs);
+            if unlikely!(b) {overflow_panic::add()} else {a}
+        }
+
         /// Unchecked integer addition. Computes `self + rhs`, assuming overflow
         /// cannot occur.
         ///
@@ -510,6 +542,43 @@ macro_rules! uint_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
+        /// Strict addition with a signed integer. Computes `self + rhs`,
+        /// panicking if overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(1", stringify!($SelfT), ".strict_add_signed(2), 3);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 1", stringify!($SelfT), ".strict_add_signed(-2);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = (", stringify!($SelfT), "::MAX - 2).strict_add_signed(3);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_add_signed(self, rhs: $SignedT) -> Self {
+            let (a, b) = self.overflowing_add_signed(rhs);
+            if unlikely!(b) {overflow_panic::add()} else {a}
+        }
+
         /// Checked integer subtraction. Computes `self - rhs`, returning
         /// `None` if overflow occurred.
         ///
@@ -529,6 +598,38 @@ macro_rules! uint_impl {
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_sub(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict integer subtraction. Computes `self - rhs`, panicking if
+        /// overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(1", stringify!($SelfT), ".strict_sub(1), 0);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 0", stringify!($SelfT), ".strict_sub(1);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_sub(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_sub(rhs);
+            if unlikely!(b) {overflow_panic::sub()} else {a}
         }
 
         /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
@@ -576,6 +677,38 @@ macro_rules! uint_impl {
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
             let (a, b) = self.overflowing_mul(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict integer multiplication. Computes `self * rhs`, panicking if
+        /// overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(5", stringify!($SelfT), ".strict_mul(1), 5);")]
+        /// ```
+        ///
+        /// ``` should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MAX.strict_mul(2);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_mul(self, rhs: Self) -> Self {
+            let (a, b) = self.overflowing_mul(rhs);
+            if unlikely!(b) {overflow_panic::mul()} else {a}
         }
 
         /// Unchecked integer multiplication. Computes `self * rhs`, assuming overflow
@@ -630,6 +763,33 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Strict integer division. Computes `self / rhs`.
+        /// Strict division on unsigned types is just normal division.
+        /// There's no way overflow could ever happen.
+        /// This function exists, so that all operations
+        /// are accounted for in the strict operations.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".strict_div(10), 10);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn strict_div(self, rhs: Self) -> Self {
+            self / rhs
+        }
+
         /// Checked Euclidean division. Computes `self.div_euclid(rhs)`, returning `None`
         /// if `rhs == 0`.
         ///
@@ -654,6 +814,35 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Strict Euclidean division. Computes `self.div_euclid(rhs)`.
+        /// Strict division on unsigned types is just normal division.
+        /// There's no way overflow could ever happen.
+        /// This function exists, so that all operations
+        /// are accounted for in the strict operations.
+        /// Since, for the positive integers, all common
+        /// definitions of division are equal, this
+        /// is exactly equal to `self.strict_div(rhs)`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".strict_div_euclid(10), 10);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn strict_div_euclid(self, rhs: Self) -> Self {
+            self / rhs
+        }
 
         /// Checked integer remainder. Computes `self % rhs`, returning `None`
         /// if `rhs == 0`.
@@ -681,6 +870,34 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Strict integer remainder. Computes `self % rhs`.
+        /// Strict remainder calculation on unsigned types is
+        /// just the regular remainder calculation.
+        /// There's no way overflow could ever happen.
+        /// This function exists, so that all operations
+        /// are accounted for in the strict operations.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".strict_rem(10), 0);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn strict_rem(self, rhs: Self) -> Self {
+            self % rhs
+        }
+
         /// Checked Euclidean modulo. Computes `self.rem_euclid(rhs)`, returning `None`
         /// if `rhs == 0`.
         ///
@@ -703,6 +920,37 @@ macro_rules! uint_impl {
             } else {
                 Some(self.rem_euclid(rhs))
             }
+        }
+
+        /// Strict Euclidean modulo. Computes `self.rem_euclid(rhs)`.
+        /// Strict modulo calculation on unsigned types is
+        /// just the regular remainder calculation.
+        /// There's no way overflow could ever happen.
+        /// This function exists, so that all operations
+        /// are accounted for in the strict operations.
+        /// Since, for the positive integers, all common
+        /// definitions of division are equal, this
+        /// is exactly equal to `self.strict_rem(rhs)`.
+        ///
+        /// # Panics
+        ///
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".strict_rem_euclid(10), 0);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline(always)]
+        pub const fn strict_rem_euclid(self, rhs: Self) -> Self {
+            self % rhs
         }
 
         /// Returns the logarithm of the number with respect to an arbitrary base,
@@ -894,6 +1142,40 @@ macro_rules! uint_impl {
             if unlikely!(b) {None} else {Some(a)}
         }
 
+        /// Strict negation. Computes `-self`, panicking unless `self ==
+        /// 0`.
+        ///
+        /// Note that negating any positive integer will overflow.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".strict_neg(), 0);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 1", stringify!($SelfT), ".strict_neg();")]
+        ///
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_neg(self) -> Self {
+            let (a, b) = self.overflowing_neg();
+            if unlikely!(b) {overflow_panic::neg()} else {a}
+        }
+
         /// Checked shift left. Computes `self << rhs`, returning `None`
         /// if `rhs` is larger than or equal to the number of bits in `self`.
         ///
@@ -913,6 +1195,38 @@ macro_rules! uint_impl {
         pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shl(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict shift left. Computes `self << rhs`, panicking if `rhs` is larger
+        /// than or equal to the number of bits in `self`.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".strict_shl(4), 0x10);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 0x10", stringify!($SelfT), ".strict_shl(129);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_shl(self, rhs: u32) -> Self {
+            let (a, b) = self.overflowing_shl(rhs);
+            if unlikely!(b) {overflow_panic::shl()} else {a}
         }
 
         /// Unchecked shift left. Computes `self << rhs`, assuming that
@@ -961,6 +1275,38 @@ macro_rules! uint_impl {
         pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
             let (a, b) = self.overflowing_shr(rhs);
             if unlikely!(b) {None} else {Some(a)}
+        }
+
+        /// Strict shift right. Computes `self >> rhs`, panicking `rhs` is
+        /// larger than or equal to the number of bits in `self`.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".strict_shr(4), 0x1);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = 0x10", stringify!($SelfT), ".strict_shr(129);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_shr(self, rhs: u32) -> Self {
+            let (a, b) = self.overflowing_shr(rhs);
+            if unlikely!(b) {overflow_panic::shr()} else {a}
         }
 
         /// Unchecked shift right. Computes `self >> rhs`, assuming that
@@ -1027,6 +1373,54 @@ macro_rules! uint_impl {
             // needless overflow.
 
             acc.checked_mul(base)
+        }
+
+        /// Strict exponentiation. Computes `self.pow(exp)`, panicking if
+        /// overflow occurred.
+        ///
+        /// # Panics
+        ///
+        /// ## Overflow behavior
+        ///
+        /// This function will always panic on overflow, regardless of if overflow checks are enabled.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("assert_eq!(2", stringify!($SelfT), ".strict_pow(5), 32);")]
+        /// ```
+        ///
+        /// ```should_panic
+        /// #![feature(strict_overflow_ops)]
+        #[doc = concat!("let _ = ", stringify!($SelfT), "::MAX.strict_pow(2);")]
+        /// ```
+        #[unstable(feature = "strict_overflow_ops", issue = "118260")]
+        #[rustc_const_unstable(feature = "const_strict_overflow_ops", issue = "118260")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn strict_pow(self, mut exp: u32) -> Self {
+            if exp == 0 {
+                return 1;
+            }
+            let mut base = self;
+            let mut acc: Self = 1;
+
+            while exp > 1 {
+                if (exp & 1) == 1 {
+                    acc = acc.strict_mul(base);
+                }
+                exp /= 2;
+                base = base.strict_mul(base);
+            }
+            // since exp!=0, finally the exp must be 1.
+            // Deal with the final bit of the exponent separately, since
+            // squaring the base afterwards is not necessary and may cause a
+            // needless overflow.
+            acc.strict_mul(base)
         }
 
         /// Saturating integer addition. Computes `self + rhs`, saturating at

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -489,6 +489,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_add(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_add(rhs);
             if unlikely!(b) {overflow_panic::add()} else {a}
@@ -574,6 +575,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_add_signed(self, rhs: $SignedT) -> Self {
             let (a, b) = self.overflowing_add_signed(rhs);
             if unlikely!(b) {overflow_panic::add()} else {a}
@@ -627,6 +629,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_sub(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_sub(rhs);
             if unlikely!(b) {overflow_panic::sub()} else {a}
@@ -706,6 +709,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_mul(self, rhs: Self) -> Self {
             let (a, b) = self.overflowing_mul(rhs);
             if unlikely!(b) {overflow_panic::mul()} else {a}
@@ -786,6 +790,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[track_caller]
         pub const fn strict_div(self, rhs: Self) -> Self {
             self / rhs
         }
@@ -840,6 +845,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[track_caller]
         pub const fn strict_div_euclid(self, rhs: Self) -> Self {
             self / rhs
         }
@@ -894,6 +900,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[track_caller]
         pub const fn strict_rem(self, rhs: Self) -> Self {
             self % rhs
         }
@@ -949,6 +956,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
+        #[track_caller]
         pub const fn strict_rem_euclid(self, rhs: Self) -> Self {
             self % rhs
         }
@@ -1171,6 +1179,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_neg(self) -> Self {
             let (a, b) = self.overflowing_neg();
             if unlikely!(b) {overflow_panic::neg()} else {a}
@@ -1224,6 +1233,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_shl(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shl(rhs);
             if unlikely!(b) {overflow_panic::shl()} else {a}
@@ -1304,6 +1314,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_shr(self, rhs: u32) -> Self {
             let (a, b) = self.overflowing_shr(rhs);
             if unlikely!(b) {overflow_panic::shr()} else {a}
@@ -1402,6 +1413,7 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
+        #[track_caller]
         pub const fn strict_pow(self, mut exp: u32) -> Self {
             if exp == 0 {
                 return 1;

--- a/library/core/tests/macros.rs
+++ b/library/core/tests/macros.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 trait Trait {
     fn blah(&self);
 }

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -37,6 +37,7 @@ static SETTINGS_HASHES: &[&str] = &[
     "3468fea433c25fff60be6b71e8a215a732a7b1268b6a83bf10d024344e140541",
     "47d227f424bf889b0d899b9cc992d5695e1b78c406e183cd78eafefbe5488923",
     "b526bd58d0262dd4dda2bff5bc5515b705fb668a46235ace3e057f807963a11a",
+    "828666b021d837a33e78d870b56d34c88a5e2c85de58b693607ec574f0c27000",
 ];
 static RUST_ANALYZER_SETTINGS: &str = include_str!("../../../../etc/rust_analyzer_settings.json");
 

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -1,4 +1,5 @@
 {
+    "git.detectSubmodulesLimit": 20,
     "rust-analyzer.check.invocationLocation": "root",
     "rust-analyzer.check.invocationStrategy": "once",
     "rust-analyzer.check.overrideCommand": [

--- a/src/tools/miri/tests/fail/dyn-call-trait-mismatch.rs
+++ b/src/tools/miri/tests/fail/dyn-call-trait-mismatch.rs
@@ -1,4 +1,5 @@
 trait T1 {
+    #[allow(dead_code)]
     fn method1(self: Box<Self>);
 }
 trait T2 {

--- a/src/tools/miri/tests/fail/dyn-upcast-trait-mismatch.rs
+++ b/src/tools/miri/tests/fail/dyn-upcast-trait-mismatch.rs
@@ -1,28 +1,34 @@
 trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+    #[allow(dead_code)]
     fn a(&self) -> i32 {
         10
     }
 
+    #[allow(dead_code)]
     fn z(&self) -> i32 {
         11
     }
 
+    #[allow(dead_code)]
     fn y(&self) -> i32 {
         12
     }
 }
 
 trait Bar: Foo {
+    #[allow(dead_code)]
     fn b(&self) -> i32 {
         20
     }
 
+    #[allow(dead_code)]
     fn w(&self) -> i32 {
         21
     }
 }
 
 trait Baz: Bar {
+    #[allow(dead_code)]
     fn c(&self) -> i32 {
         30
     }

--- a/src/tools/miri/tests/pass/cast-rfc0401-vtable-kinds.rs
+++ b/src/tools/miri/tests/pass/cast-rfc0401-vtable-kinds.rs
@@ -9,6 +9,7 @@ trait Foo<T> {
     }
 }
 
+#[allow(dead_code)]
 trait Bar {
     fn bar(&self) {
         println!("Bar!");

--- a/src/tools/miri/tests/pass/dyn-upcast.rs
+++ b/src/tools/miri/tests/pass/dyn-upcast.rs
@@ -380,14 +380,17 @@ fn struct_() {
 
 fn replace_vptr() {
     trait A {
+        #[allow(dead_code)]
         fn foo_a(&self);
     }
 
     trait B {
+        #[allow(dead_code)]
         fn foo_b(&self);
     }
 
     trait C: A + B {
+        #[allow(dead_code)]
         fn foo_c(&self);
     }
 

--- a/src/tools/miri/tests/pass/weak_memory/weak.rs
+++ b/src/tools/miri/tests/pass/weak_memory/weak.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::Ordering::*;
 use std::sync::atomic::{fence, AtomicUsize};
 use std::thread::spawn;
 
+#[allow(dead_code)]
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);
 

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
-const ISSUES_ENTRY_LIMIT: usize = 1849;
-const ROOT_ENTRY_LIMIT: usize = 870;
+const ISSUES_ENTRY_LIMIT: usize = 1861;
+const ROOT_ENTRY_LIMIT: usize = 872;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/codegen-units/item-collection/instantiation-through-vtable.rs
+++ b/tests/codegen-units/item-collection/instantiation-through-vtable.rs
@@ -26,7 +26,9 @@ fn start(_: isize, _: *const *const u8) -> isize {
     //~ MONO_ITEM fn std::ptr::drop_in_place::<Struct<u32>> - shim(None) @@ instantiation_through_vtable-cgu.0[Internal]
     //~ MONO_ITEM fn <Struct<u32> as Trait>::foo
     //~ MONO_ITEM fn <Struct<u32> as Trait>::bar
-    let _ = &s1 as &Trait;
+    let r1 = &s1 as &Trait;
+    r1.foo();
+    r1.bar();
 
     let s1 = Struct { _a: 0u64 };
     //~ MONO_ITEM fn std::ptr::drop_in_place::<Struct<u64>> - shim(None) @@ instantiation_through_vtable-cgu.0[Internal]

--- a/tests/codegen-units/item-collection/trait-method-default-impl.rs
+++ b/tests/codegen-units/item-collection/trait-method-default-impl.rs
@@ -57,5 +57,8 @@ fn start(_: isize, _: *const *const u8) -> isize {
     //~ MONO_ITEM fn <u32 as SomeGenericTrait<i16>>::bar::<()>
     0u32.bar(0i16, ());
 
+    0i8.foo();
+    0i32.foo();
+
     0
 }

--- a/tests/codegen-units/item-collection/unsizing.rs
+++ b/tests/codegen-units/item-collection/unsizing.rs
@@ -75,5 +75,7 @@ fn start(_: isize, _: *const *const u8) -> isize {
     //~ MONO_ITEM fn <u32 as Trait>::foo
     let _wrapper_sized = wrapper_sized as Wrapper<Trait>;
 
+    false.foo();
+
     0
 }

--- a/tests/rustdoc/async-fn.rs
+++ b/tests/rustdoc/async-fn.rs
@@ -48,6 +48,8 @@ impl Foo {
 
 pub trait Pattern<'a> {}
 
+impl Pattern<'_> for () {}
+
 pub trait Trait<const N: usize> {}
 // @has async_fn/fn.const_generics.html
 // @has - '//pre[@class="rust item-decl"]' 'pub async fn const_generics<const N: usize>(_: impl Trait<N>)'
@@ -57,18 +59,18 @@ pub async fn const_generics<const N: usize>(_: impl Trait<N>) {}
 // regression test for #63037
 // @has async_fn/fn.elided.html
 // @has - '//pre[@class="rust item-decl"]' 'pub async fn elided(foo: &str) -> &str'
-pub async fn elided(foo: &str) -> &str {}
+pub async fn elided(foo: &str) -> &str { "" }
 // This should really be shown as written, but for implementation reasons it's difficult.
 // See `impl Clean for TyKind::Ref`.
 // @has async_fn/fn.user_elided.html
 // @has - '//pre[@class="rust item-decl"]' 'pub async fn user_elided(foo: &str) -> &str'
-pub async fn user_elided(foo: &'_ str) -> &str {}
+pub async fn user_elided(foo: &'_ str) -> &str { "" }
 // @has async_fn/fn.static_trait.html
 // @has - '//pre[@class="rust item-decl"]' 'pub async fn static_trait(foo: &str) -> Box<dyn Bar>'
-pub async fn static_trait(foo: &str) -> Box<dyn Bar> {}
+pub async fn static_trait(foo: &str) -> Box<dyn Bar> { Box::new(()) }
 // @has async_fn/fn.lifetime_for_trait.html
 // @has - '//pre[@class="rust item-decl"]' "pub async fn lifetime_for_trait(foo: &str) -> Box<dyn Bar + '_>"
-pub async fn lifetime_for_trait(foo: &str) -> Box<dyn Bar + '_> {}
+pub async fn lifetime_for_trait(foo: &str) -> Box<dyn Bar + '_> { Box::new(()) }
 // @has async_fn/fn.elided_in_input_trait.html
 // @has - '//pre[@class="rust item-decl"]' "pub async fn elided_in_input_trait(t: impl Pattern<'_>)"
 pub async fn elided_in_input_trait(t: impl Pattern<'_>) {}
@@ -78,10 +80,12 @@ struct AsyncFdReadyGuard<'a, T> { x: &'a T }
 impl Foo {
     // @has async_fn/struct.Foo.html
     // @has - '//*[@class="method"]' 'pub async fn complicated_lifetimes( &self, context: &impl Bar ) -> impl Iterator<Item = &usize>'
-    pub async fn complicated_lifetimes(&self, context: &impl Bar) -> impl Iterator<Item = &usize> {}
+    pub async fn complicated_lifetimes(&self, context: &impl Bar) -> impl Iterator<Item = &usize> {
+        [0].iter()
+    }
     // taken from `tokio` as an example of a method that was particularly bad before
     // @has - '//*[@class="method"]' "pub async fn readable<T>(&self) -> Result<AsyncFdReadyGuard<'_, T>, ()>"
-    pub async fn readable<T>(&self) -> Result<AsyncFdReadyGuard<'_, T>, ()> {}
+    pub async fn readable<T>(&self) -> Result<AsyncFdReadyGuard<'_, T>, ()> { Err(()) }
     // @has - '//*[@class="method"]' "pub async fn mut_self(&mut self)"
     pub async fn mut_self(&mut self) {}
 }
@@ -89,7 +93,7 @@ impl Foo {
 // test named lifetimes, just in case
 // @has async_fn/fn.named.html
 // @has - '//pre[@class="rust item-decl"]' "pub async fn named<'a, 'b>(foo: &'a str) -> &'b str"
-pub async fn named<'a, 'b>(foo: &'a str) -> &'b str {}
+pub async fn named<'a, 'b>(foo: &'a str) -> &'b str { "" }
 // @has async_fn/fn.named_trait.html
 // @has - '//pre[@class="rust item-decl"]' "pub async fn named_trait<'a, 'b>(foo: impl Pattern<'a>) -> impl Pattern<'b>"
 pub async fn named_trait<'a, 'b>(foo: impl Pattern<'a>) -> impl Pattern<'b> {}

--- a/tests/rustdoc/impl-on-ty-alias-issue-119015.rs
+++ b/tests/rustdoc/impl-on-ty-alias-issue-119015.rs
@@ -1,0 +1,27 @@
+#![crate_name = "foo"]
+
+// @has 'foo/index.html'
+// There should be only `type A`.
+// @count - '//*[@class="item-table"]//*[@class="item-name"]' 1
+// @has - '//*[@class="item-name"]/a[@href="type.A.html"]' 'A'
+
+mod foo {
+    pub struct S;
+}
+
+use foo::S;
+
+pub type A = S;
+
+// @has 'foo/type.A.html'
+// @has - '//*[@id="method.default"]/h4' 'fn default() -> Self'
+impl Default for A {
+    fn default() -> Self {
+        S
+    }
+}
+
+// @has - '//*[@id="method.a"]/h4' 'pub fn a(&self)'
+impl A {
+    pub fn a(&self) {}
+}

--- a/tests/ui-fulldeps/rustc_encodable_hygiene.rs
+++ b/tests/ui-fulldeps/rustc_encodable_hygiene.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 #![feature(rustc_private)]
 

--- a/tests/ui/anon-params/anon-params-deprecated.fixed
+++ b/tests/ui/anon-params/anon-params-deprecated.fixed
@@ -5,6 +5,7 @@
 // edition:2015
 // run-rustfix
 
+#[allow(dead_code)]
 trait T {
     fn foo(_: i32); //~ WARNING anonymous parameters are deprecated
                  //~| WARNING this is accepted in the current edition

--- a/tests/ui/anon-params/anon-params-deprecated.rs
+++ b/tests/ui/anon-params/anon-params-deprecated.rs
@@ -5,6 +5,7 @@
 // edition:2015
 // run-rustfix
 
+#[allow(dead_code)]
 trait T {
     fn foo(i32); //~ WARNING anonymous parameters are deprecated
                  //~| WARNING this is accepted in the current edition

--- a/tests/ui/anon-params/anon-params-deprecated.stderr
+++ b/tests/ui/anon-params/anon-params-deprecated.stderr
@@ -1,5 +1,5 @@
 warning: anonymous parameters are deprecated and will be removed in the next edition
-  --> $DIR/anon-params-deprecated.rs:9:12
+  --> $DIR/anon-params-deprecated.rs:10:12
    |
 LL |     fn foo(i32);
    |            ^^^ help: try naming the parameter or explicitly ignoring it: `_: i32`
@@ -13,7 +13,7 @@ LL | #![warn(anonymous_parameters)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 warning: anonymous parameters are deprecated and will be removed in the next edition
-  --> $DIR/anon-params-deprecated.rs:12:30
+  --> $DIR/anon-params-deprecated.rs:13:30
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                              ^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: String`
@@ -22,7 +22,7 @@ LL |     fn bar_with_default_impl(String, String) {}
    = note: for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>
 
 warning: anonymous parameters are deprecated and will be removed in the next edition
-  --> $DIR/anon-params-deprecated.rs:12:38
+  --> $DIR/anon-params-deprecated.rs:13:38
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                      ^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: String`

--- a/tests/ui/associated-consts/associated-const-outer-ty-refs.rs
+++ b/tests/ui/associated-consts/associated-const-outer-ty-refs.rs
@@ -1,4 +1,5 @@
-// run-pass
+// check-pass
+
 trait Lattice {
     const BOTTOM: Self;
 }

--- a/tests/ui/associated-consts/associated-const-type-parameters.rs
+++ b/tests/ui/associated-consts/associated-const-type-parameters.rs
@@ -27,7 +27,7 @@ fn sub<A: Foo, B: Foo>() -> i32 {
     A::X - B::X
 }
 
-trait Bar: Foo {
+trait Bar: Foo { //~ WARN trait `Bar` is never used
     const Y: i32 = Self::X;
 }
 

--- a/tests/ui/associated-consts/associated-const-type-parameters.stderr
+++ b/tests/ui/associated-consts/associated-const-type-parameters.stderr
@@ -1,0 +1,10 @@
+warning: trait `Bar` is never used
+  --> $DIR/associated-const-type-parameters.rs:30:7
+   |
+LL | trait Bar: Foo {
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/dyn-impl-trait-type.rs
+++ b/tests/ui/associated-type-bounds/dyn-impl-trait-type.rs
@@ -5,7 +5,7 @@
 use std::ops::Add;
 
 trait Tr1 { type As1; fn mk(&self) -> Self::As1; }
-trait Tr2<'a> { fn tr2(self) -> &'a Self; }
+trait Tr2<'a> { fn tr2(self) -> &'a Self; } //~ WARN method `tr2` is never used
 
 fn assert_copy<T: Copy>(x: T) { let _x = x; let _x = x; }
 fn assert_static<T: 'static>(_: T) {}

--- a/tests/ui/associated-type-bounds/dyn-impl-trait-type.stderr
+++ b/tests/ui/associated-type-bounds/dyn-impl-trait-type.stderr
@@ -1,0 +1,12 @@
+warning: method `tr2` is never used
+  --> $DIR/dyn-impl-trait-type.rs:8:20
+   |
+LL | trait Tr2<'a> { fn tr2(self) -> &'a Self; }
+   |       ---          ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/dyn-rpit-and-let.rs
+++ b/tests/ui/associated-type-bounds/dyn-rpit-and-let.rs
@@ -7,7 +7,7 @@
 use std::ops::Add;
 
 trait Tr1 { type As1; fn mk(&self) -> Self::As1; }
-trait Tr2<'a> { fn tr2(self) -> &'a Self; }
+trait Tr2<'a> { fn tr2(self) -> &'a Self; } //~ WARN method `tr2` is never used
 
 fn assert_copy<T: Copy>(x: T) { let _x = x; let _x = x; }
 fn assert_static<T: 'static>(_: T) {}

--- a/tests/ui/associated-type-bounds/dyn-rpit-and-let.stderr
+++ b/tests/ui/associated-type-bounds/dyn-rpit-and-let.stderr
@@ -1,0 +1,12 @@
+warning: method `tr2` is never used
+  --> $DIR/dyn-rpit-and-let.rs:10:20
+   |
+LL | trait Tr2<'a> { fn tr2(self) -> &'a Self; }
+   |       ---          ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/rpit.rs
+++ b/tests/ui/associated-type-bounds/rpit.rs
@@ -5,7 +5,7 @@
 use std::ops::Add;
 
 trait Tr1 { type As1; fn mk(self) -> Self::As1; }
-trait Tr2<'a> { fn tr2(self) -> &'a Self; }
+trait Tr2<'a> { fn tr2(self) -> &'a Self; } //~ WARN method `tr2` is never used
 
 fn assert_copy<T: Copy>(x: T) { let _x = x; let _x = x; }
 fn assert_static<T: 'static>(_: T) {}

--- a/tests/ui/associated-type-bounds/rpit.stderr
+++ b/tests/ui/associated-type-bounds/rpit.stderr
@@ -1,0 +1,12 @@
+warning: method `tr2` is never used
+  --> $DIR/rpit.rs:8:20
+   |
+LL | trait Tr2<'a> { fn tr2(self) -> &'a Self; }
+   |       ---          ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.fixed
+++ b/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 trait O {
     type M;
 }

--- a/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.rs
+++ b/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 trait O {
     type M;
 }

--- a/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.stderr
+++ b/tests/ui/associated-type-bounds/suggest-contraining-assoc-type-because-of-assoc-const.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/suggest-contraining-assoc-type-because-of-assoc-const.rs:12:21
+  --> $DIR/suggest-contraining-assoc-type-because-of-assoc-const.rs:13:21
    |
 LL |     const N: C::M = 4u8;
    |                     ^^^ expected associated type, found `u8`

--- a/tests/ui/associated-type-bounds/trait-alias-impl-trait.rs
+++ b/tests/ui/associated-type-bounds/trait-alias-impl-trait.rs
@@ -1,5 +1,6 @@
 // run-pass
 
+#![allow(dead_code)]
 #![feature(associated_type_bounds)]
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.fixed
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 #![allow(unused_variables)]
 
 trait Get {

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.rs
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 #![allow(unused_variables)]
 
 trait Get {

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.stderr
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
-  --> $DIR/associated-types-for-unimpl-trait.rs:10:40
+  --> $DIR/associated-types-for-unimpl-trait.rs:11:40
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`

--- a/tests/ui/associated-types/associated-types-in-bound-type-arg.rs
+++ b/tests/ui/associated-types/associated-types-in-bound-type-arg.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Test the case where we resolve `C::Result` and the trait bound
 // itself includes a `Self::Item` shorthand.
 //

--- a/tests/ui/associated-types/associated-types-issue-20220.rs
+++ b/tests/ui/associated-types/associated-types-issue-20220.rs
@@ -4,7 +4,7 @@
 
 use std::vec;
 
-trait IntoIteratorX {
+trait IntoIteratorX { //~ WARN trait `IntoIteratorX` is never used
     type Item;
     type IntoIter: Iterator<Item=Self::Item>;
 

--- a/tests/ui/associated-types/associated-types-issue-20220.stderr
+++ b/tests/ui/associated-types/associated-types-issue-20220.stderr
@@ -1,0 +1,10 @@
+warning: trait `IntoIteratorX` is never used
+  --> $DIR/associated-types-issue-20220.rs:7:7
+   |
+LL | trait IntoIteratorX {
+   |       ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-types/associated-types-issue-20371.rs
+++ b/tests/ui/associated-types/associated-types-issue-20371.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Test that we are able to have an impl that defines an associated type
 // before the actual trait.
 

--- a/tests/ui/associated-types/associated-types-nested-projections.rs
+++ b/tests/ui/associated-types/associated-types-nested-projections.rs
@@ -13,7 +13,7 @@ impl<'a> Bound for &'a i32 {}
 trait IntoIterator {
     type Iter: Iterator;
 
-    fn into_iter(self) -> Self::Iter;
+    fn into_iter(self) -> Self::Iter; //~ WARN method `into_iter` is never used
 }
 
 impl<'a, T> IntoIterator for &'a [T; 3] {

--- a/tests/ui/associated-types/associated-types-nested-projections.stderr
+++ b/tests/ui/associated-types/associated-types-nested-projections.stderr
@@ -1,0 +1,13 @@
+warning: method `into_iter` is never used
+  --> $DIR/associated-types-nested-projections.rs:16:8
+   |
+LL | trait IntoIterator {
+   |       ------------ method in this trait
+...
+LL |     fn into_iter(self) -> Self::Iter;
+   |        ^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-types/associated-types-normalize-in-bounds-ufcs.rs
+++ b/tests/ui/associated-types/associated-types-normalize-in-bounds-ufcs.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(unused_variables)]
 // Test that we normalize associated types that appear in bounds; if
 // we didn't, the call to `self.split2()` fails to type check.

--- a/tests/ui/associated-types/associated-types-normalize-in-bounds.rs
+++ b/tests/ui/associated-types/associated-types-normalize-in-bounds.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(unused_variables)]
 // Test that we normalize associated types that appear in bounds; if
 // we didn't, the call to `self.split2()` fails to type check.

--- a/tests/ui/associated-types/associated-types-projection-bound-in-supertraits.rs
+++ b/tests/ui/associated-types/associated-types-projection-bound-in-supertraits.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(unused_variables)]
 // Test that we correctly handle projection bounds appearing in the
 // supertrait list (and in conjunction with overloaded operators). In

--- a/tests/ui/associated-types/associated-types-projection-from-known-type-in-impl.rs
+++ b/tests/ui/associated-types/associated-types-projection-from-known-type-in-impl.rs
@@ -6,7 +6,7 @@ trait Int
 {
     type T;
 
-    fn dummy(&self) { }
+    fn dummy(&self) { } //~ WARN method `dummy` is never used
 }
 
 trait NonZero

--- a/tests/ui/associated-types/associated-types-projection-from-known-type-in-impl.stderr
+++ b/tests/ui/associated-types/associated-types-projection-from-known-type-in-impl.stderr
@@ -1,0 +1,13 @@
+warning: method `dummy` is never used
+  --> $DIR/associated-types-projection-from-known-type-in-impl.rs:9:8
+   |
+LL | trait Int
+   |       --- method in this trait
+...
+LL |     fn dummy(&self) { }
+   |        ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.fixed
+++ b/tests/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.fixed
@@ -2,6 +2,7 @@
 // Check that we get an error when you use `<Self as Get>::Value` in
 // the trait definition even if there is no default method.
 
+#![allow(dead_code)]
 trait Get {
     type Value;
 }

--- a/tests/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.rs
+++ b/tests/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.rs
@@ -2,6 +2,7 @@
 // Check that we get an error when you use `<Self as Get>::Value` in
 // the trait definition even if there is no default method.
 
+#![allow(dead_code)]
 trait Get {
     type Value;
 }

--- a/tests/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.stderr
+++ b/tests/ui/associated-types/associated-types-projection-to-unrelated-trait-in-method-without-default.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
-  --> $DIR/associated-types-projection-to-unrelated-trait-in-method-without-default.rs:10:40
+  --> $DIR/associated-types-projection-to-unrelated-trait-in-method-without-default.rs:11:40
    |
 LL |     fn okay<U:Get>(&self, foo: U, bar: <Self as Get>::Value);
    |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`

--- a/tests/ui/associated-types/associated-types-projection-to-unrelated-trait.rs
+++ b/tests/ui/associated-types/associated-types-projection-to-unrelated-trait.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Check that we do not get an error when you use `<Self as Get>::Value` in
 // the trait definition if there is no default method and for every impl,
 // `Self` does implement `Get`.

--- a/tests/ui/associated-types/associated-types-qualified-path-with-trait-with-type-parameters.rs
+++ b/tests/ui/associated-types/associated-types-qualified-path-with-trait-with-type-parameters.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait Foo<T> {

--- a/tests/ui/associated-types/associated-types-resolve-lifetime.rs
+++ b/tests/ui/associated-types/associated-types-resolve-lifetime.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait Get<T> {

--- a/tests/ui/auto-traits/auto-trait-validation.fixed
+++ b/tests/ui/auto-traits/auto-trait-validation.fixed
@@ -1,4 +1,5 @@
 #![feature(auto_traits)]
+#![allow(dead_code)]
 
 // run-rustfix
 

--- a/tests/ui/auto-traits/auto-trait-validation.rs
+++ b/tests/ui/auto-traits/auto-trait-validation.rs
@@ -1,4 +1,5 @@
 #![feature(auto_traits)]
+#![allow(dead_code)]
 
 // run-rustfix
 

--- a/tests/ui/auto-traits/auto-trait-validation.stderr
+++ b/tests/ui/auto-traits/auto-trait-validation.stderr
@@ -1,5 +1,5 @@
 error[E0567]: auto traits cannot have generic parameters
-  --> $DIR/auto-trait-validation.rs:5:19
+  --> $DIR/auto-trait-validation.rs:6:19
    |
 LL | auto trait Generic<T> {}
    |            -------^^^ help: remove the parameters
@@ -7,7 +7,7 @@ LL | auto trait Generic<T> {}
    |            auto trait cannot have generic parameters
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/auto-trait-validation.rs:7:17
+  --> $DIR/auto-trait-validation.rs:8:17
    |
 LL | auto trait Bound : Copy {}
    |            -----^^^^^^^ help: remove the super traits or lifetime bounds
@@ -15,7 +15,7 @@ LL | auto trait Bound : Copy {}
    |            auto traits cannot have super traits or lifetime bounds
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/auto-trait-validation.rs:9:25
+  --> $DIR/auto-trait-validation.rs:10:25
    |
 LL | auto trait LifetimeBound : 'static {}
    |            -------------^^^^^^^^^^ help: remove the super traits or lifetime bounds
@@ -23,7 +23,7 @@ LL | auto trait LifetimeBound : 'static {}
    |            auto traits cannot have super traits or lifetime bounds
 
 error[E0380]: auto traits cannot have associated items
-  --> $DIR/auto-trait-validation.rs:11:25
+  --> $DIR/auto-trait-validation.rs:12:25
    |
 LL | auto trait MyTrait { fn foo() {} }
    |            -------   ---^^^-----

--- a/tests/ui/auto-traits/auto-traits.rs
+++ b/tests/ui/auto-traits/auto-traits.rs
@@ -19,8 +19,8 @@ fn take_auto_unsafe<T: AutoUnsafe>(_: T) {}
 
 fn main() {
     // Parse inside functions.
-    auto trait AutoInner {}
-    unsafe auto trait AutoUnsafeInner {}
+    auto trait AutoInner {} //~ WARN trait `AutoInner` is never used
+    unsafe auto trait AutoUnsafeInner {} //~ WARN trait `AutoUnsafeInner` is never used
 
     take_auto(0);
     take_auto(AutoBool(true));

--- a/tests/ui/auto-traits/auto-traits.stderr
+++ b/tests/ui/auto-traits/auto-traits.stderr
@@ -1,0 +1,16 @@
+warning: trait `AutoInner` is never used
+  --> $DIR/auto-traits.rs:22:16
+   |
+LL |     auto trait AutoInner {}
+   |                ^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: trait `AutoUnsafeInner` is never used
+  --> $DIR/auto-traits.rs:23:23
+   |
+LL |     unsafe auto trait AutoUnsafeInner {}
+   |                       ^^^^^^^^^^^^^^^
+
+warning: 2 warnings emitted
+

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata2.rs
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata2.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 #![allow(unused_imports)]
 

--- a/tests/ui/builtin-superkinds/builtin-superkinds-simple2.rs
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-simple2.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Simple test case of implementing a trait with super-builtin-kinds.
 
 // pretty-expanded FIXME #23616

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram.rs
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Tests correct implementation of traits with super-builtin-kinds
 // using a bounded type parameter.
 

--- a/tests/ui/cast/cast-rfc0401-vtable-kinds.rs
+++ b/tests/ui/cast/cast-rfc0401-vtable-kinds.rs
@@ -8,7 +8,7 @@ trait Foo<T> {
     fn foo(&self, _: T) -> u32 { 42 }
 }
 
-trait Bar {
+trait Bar { //~ WARN trait `Bar` is never used
     fn bar(&self) { println!("Bar!"); }
 }
 

--- a/tests/ui/cast/cast-rfc0401-vtable-kinds.stderr
+++ b/tests/ui/cast/cast-rfc0401-vtable-kinds.stderr
@@ -1,0 +1,10 @@
+warning: trait `Bar` is never used
+  --> $DIR/cast-rfc0401-vtable-kinds.rs:11:7
+   |
+LL | trait Bar {
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/cast/fat-ptr-cast-rpass.rs
+++ b/tests/ui/cast/fat-ptr-cast-rpass.rs
@@ -3,7 +3,7 @@
 #![feature(ptr_metadata)]
 
 trait Foo {
-    fn foo(&self) {}
+    fn foo(&self) {} //~ WARN method `foo` is never used
 }
 
 struct Bar;

--- a/tests/ui/cast/fat-ptr-cast-rpass.stderr
+++ b/tests/ui/cast/fat-ptr-cast-rpass.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/fat-ptr-cast-rpass.rs:6:8
+   |
+LL | trait Foo {
+   |       --- method in this trait
+LL |     fn foo(&self) {}
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/coercion/issue-14589.rs
+++ b/tests/ui/coercion/issue-14589.rs
@@ -19,6 +19,6 @@ impl<T> Test<T> {
     fn send(&self, _: T) {}
 }
 
-trait Foo { fn dummy(&self) { }}
+trait Foo { fn dummy(&self) { }} //~ WARN method `dummy` is never used
 struct Output(#[allow(dead_code)] isize);
 impl Foo for Output {}

--- a/tests/ui/coercion/issue-14589.stderr
+++ b/tests/ui/coercion/issue-14589.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/issue-14589.rs:22:16
+   |
+LL | trait Foo { fn dummy(&self) { }}
+   |       ---      ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/coherence/coherence-multidispatch-tuple.rs
+++ b/tests/ui/coherence/coherence-multidispatch-tuple.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(unused_imports)]
 // pretty-expanded FIXME #23616
 

--- a/tests/ui/const-generics/associated-type-bound.rs
+++ b/tests/ui/const-generics/associated-type-bound.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 trait Bar<const N: usize> {}
 
 trait Foo<const N: usize> {

--- a/tests/ui/const-generics/bad-subst-const-kind.rs
+++ b/tests/ui/const-generics/bad-subst-const-kind.rs
@@ -11,3 +11,4 @@ impl<const N: u64> Q for [u8; N] {
 }
 
 pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] { todo!() }
+//~^ ERROR: the constant `13` is not of type `u64`

--- a/tests/ui/const-generics/bad-subst-const-kind.stderr
+++ b/tests/ui/const-generics/bad-subst-const-kind.stderr
@@ -1,9 +1,23 @@
+error: the constant `13` is not of type `u64`
+  --> $DIR/bad-subst-const-kind.rs:13:24
+   |
+LL | pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] { todo!() }
+   |                        ^^^^^^^^ expected `u64`, found `usize`
+   |
+note: required for `[u8; 13]` to implement `Q`
+  --> $DIR/bad-subst-const-kind.rs:8:20
+   |
+LL | impl<const N: u64> Q for [u8; N] {
+   |      ------------  ^     ^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
+
 error[E0308]: mismatched types
   --> $DIR/bad-subst-const-kind.rs:8:31
    |
 LL | impl<const N: u64> Q for [u8; N] {
    |                               ^ expected `usize`, found `u64`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/condition-in-trait-const-arg.rs
+++ b/tests/ui/const-generics/condition-in-trait-const-arg.rs
@@ -1,5 +1,5 @@
 // Checks that `impl Trait<{anon_const}> for Type` evaluates successfully.
-// run-pass
+// check-pass
 // revisions: full min
 
 #![cfg_attr(full, feature(generic_const_exprs))]

--- a/tests/ui/const-generics/dyn-supertraits.rs
+++ b/tests/ui/const-generics/dyn-supertraits.rs
@@ -4,7 +4,7 @@ trait Foo<const N: usize> {
     fn myfun(&self) -> usize;
 }
 trait Bar<const N: usize> : Foo<N> {}
-trait Baz: Foo<3> {}
+trait Baz: Foo<3> {} //~ WARN trait `Baz` is never used
 
 struct FooType<const N: usize>;
 struct BarType<const N: usize>;
@@ -23,10 +23,10 @@ impl Foo<3> for BazType {
 impl Baz for BazType {}
 
 trait Foz {}
-trait Boz: Foo<3> + Foz {}
+trait Boz: Foo<3> + Foz {} //~ WARN trait `Boz` is never used
 trait Bok<const N: usize>: Foo<N> + Foz {}
 
-struct FozType;
+struct FozType; //~ WARN struct `FozType` is never constructed
 struct BozType;
 struct BokType<const N: usize>;
 

--- a/tests/ui/const-generics/dyn-supertraits.stderr
+++ b/tests/ui/const-generics/dyn-supertraits.stderr
@@ -1,0 +1,22 @@
+warning: trait `Baz` is never used
+  --> $DIR/dyn-supertraits.rs:7:7
+   |
+LL | trait Baz: Foo<3> {}
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: trait `Boz` is never used
+  --> $DIR/dyn-supertraits.rs:26:7
+   |
+LL | trait Boz: Foo<3> + Foz {}
+   |       ^^^
+
+warning: struct `FozType` is never constructed
+  --> $DIR/dyn-supertraits.rs:29:8
+   |
+LL | struct FozType;
+   |        ^^^^^^^
+
+warning: 3 warnings emitted
+

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
@@ -7,7 +7,10 @@ trait Q {
 
 impl<const N: u64> Q for [u8; N] {}
 //~^ ERROR not all trait items implemented
+//~| ERROR mismatched types
 
 pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+//~^ ERROR the constant `13` is not of type `u64`
+//~| ERROR mismatched types
 
 pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -7,6 +7,35 @@ LL |     const ASSOC: usize;
 LL | impl<const N: u64> Q for [u8; N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
 
-error: aborting due to 1 previous error
+error: the constant `13` is not of type `u64`
+  --> $DIR/type_mismatch.rs:12:26
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |                          ^^^^^^^^ expected `u64`, found `usize`
+   |
+note: required for `[u8; 13]` to implement `Q`
+  --> $DIR/type_mismatch.rs:8:20
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |      ------------  ^     ^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
 
-For more information about this error, try `rustc --explain E0046`.
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:12:20
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |        ------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; <[u8; 13] as Q>::ASSOC]`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:8:31
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |                               ^ expected `usize`, found `u64`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0308.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/issues/issue-69654-run-pass.rs
+++ b/tests/ui/const-generics/issues/issue-69654-run-pass.rs
@@ -1,5 +1,5 @@
 // run-pass
-trait Bar<T> {}
+trait Bar<T> {} //~ WARN trait `Bar` is never used
 impl<T> Bar<T> for [u8; 7] {}
 
 struct Foo<const N: usize> {}

--- a/tests/ui/const-generics/issues/issue-69654-run-pass.stderr
+++ b/tests/ui/const-generics/issues/issue-69654-run-pass.stderr
@@ -1,0 +1,10 @@
+warning: trait `Bar` is never used
+  --> $DIR/issue-69654-run-pass.rs:2:7
+   |
+LL | trait Bar<T> {}
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/consts/const-block-item.rs
+++ b/tests/ui/consts/const-block-item.rs
@@ -2,7 +2,7 @@
 #![allow(unused_imports)]
 
 mod foo {
-    pub trait Value {
+    pub trait Value { //~ WARN trait `Value` is never used
         fn value(&self) -> usize;
     }
 }

--- a/tests/ui/consts/const-block-item.stderr
+++ b/tests/ui/consts/const-block-item.stderr
@@ -1,0 +1,10 @@
+warning: trait `Value` is never used
+  --> $DIR/const-block-item.rs:5:15
+   |
+LL |     pub trait Value {
+   |               ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/consts/underscore_const_names.rs
+++ b/tests/ui/consts/underscore_const_names.rs
@@ -2,12 +2,12 @@
 
 #![deny(unused)]
 
-trait Trt {}
+pub trait Trt {}
 pub struct Str {}
 impl Trt for Str {}
 
 macro_rules! check_impl {
-    ($struct:ident,$trait:ident) => {
+    ($struct:ident, $trait:ident) => {
         const _ : () = {
             use std::marker::PhantomData;
             struct ImplementsTrait<T: $trait>(PhantomData<T>);

--- a/tests/ui/default-method-parsing.rs
+++ b/tests/ui/default-method-parsing.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait Foo {

--- a/tests/ui/delegation/target-expr-pass.rs
+++ b/tests/ui/delegation/target-expr-pass.rs
@@ -14,14 +14,14 @@ reuse to_reuse::foo {{
     x + self
 }}
 
-trait Trait {
+trait Trait { //~ WARN trait `Trait` is never used
     fn bar(&self, x: i32) -> i32 { x }
 }
 
-struct F;
+struct F; //~ WARN struct `F` is never constructed
 impl Trait for F {}
 
-struct S(F);
+struct S(F); //~ WARN struct `S` is never constructed
 impl Trait for S {
     reuse <F as Trait>::bar {
         #[allow(unused_imports)]

--- a/tests/ui/delegation/target-expr-pass.stderr
+++ b/tests/ui/delegation/target-expr-pass.stderr
@@ -7,5 +7,25 @@ LL | #![feature(fn_delegation)]
    = note: see issue #118212 <https://github.com/rust-lang/rust/issues/118212> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-warning: 1 warning emitted
+warning: trait `Trait` is never used
+  --> $DIR/target-expr-pass.rs:17:7
+   |
+LL | trait Trait {
+   |       ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: struct `F` is never constructed
+  --> $DIR/target-expr-pass.rs:21:8
+   |
+LL | struct F;
+   |        ^
+
+warning: struct `S` is never constructed
+  --> $DIR/target-expr-pass.rs:24:8
+   |
+LL | struct S(F);
+   |        ^
+
+warning: 4 warnings emitted
 

--- a/tests/ui/deriving/deriving-bounds.rs
+++ b/tests/ui/deriving/deriving-bounds.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #[derive(Copy, Clone)]
 struct Test;
 

--- a/tests/ui/drop/drop-struct-as-object.rs
+++ b/tests/ui/drop/drop-struct-as-object.rs
@@ -12,7 +12,7 @@ struct Cat {
 }
 
 trait Dummy {
-    fn get(&self) -> usize;
+    fn get(&self) -> usize; //~ WARN method `get` is never used
 }
 
 impl Dummy for Cat {

--- a/tests/ui/drop/drop-struct-as-object.stderr
+++ b/tests/ui/drop/drop-struct-as-object.stderr
@@ -1,0 +1,12 @@
+warning: method `get` is never used
+  --> $DIR/drop-struct-as-object.rs:15:8
+   |
+LL | trait Dummy {
+   |       ----- method in this trait
+LL |     fn get(&self) -> usize;
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/dynamically-sized-types/dst-coercions.rs
+++ b/tests/ui/dynamically-sized-types/dst-coercions.rs
@@ -5,7 +5,7 @@
 // pretty-expanded FIXME #23616
 
 struct S;
-trait T { fn dummy(&self) { } }
+trait T { fn dummy(&self) { } } //~ WARN method `dummy` is never used
 impl T for S {}
 
 pub fn main() {

--- a/tests/ui/dynamically-sized-types/dst-coercions.stderr
+++ b/tests/ui/dynamically-sized-types/dst-coercions.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/dst-coercions.rs:8:14
+   |
+LL | trait T { fn dummy(&self) { } }
+   |       -      ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/empty-type-parameter-list.rs
+++ b/tests/ui/empty-type-parameter-list.rs
@@ -3,7 +3,7 @@
 // no type parameters at all
 
 struct S<>;
-trait T<> {}
+trait T<> {} //~ WARN trait `T` is never used
 enum E<> { V }
 impl<> T<> for S<> {}
 impl T for E {}

--- a/tests/ui/empty-type-parameter-list.stderr
+++ b/tests/ui/empty-type-parameter-list.stderr
@@ -1,0 +1,10 @@
+warning: trait `T` is never used
+  --> $DIR/empty-type-parameter-list.rs:6:7
+   |
+LL | trait T<> {}
+   |       ^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/explicit/explicit-call-to-supertrait-dtor.fixed
+++ b/tests/ui/explicit/explicit-call-to-supertrait-dtor.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 
+#![allow(dead_code)]
 #![allow(dropping_references)]
 
 struct Foo {

--- a/tests/ui/explicit/explicit-call-to-supertrait-dtor.rs
+++ b/tests/ui/explicit/explicit-call-to-supertrait-dtor.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 
+#![allow(dead_code)]
 #![allow(dropping_references)]
 
 struct Foo {

--- a/tests/ui/explicit/explicit-call-to-supertrait-dtor.stderr
+++ b/tests/ui/explicit/explicit-call-to-supertrait-dtor.stderr
@@ -1,5 +1,5 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/explicit-call-to-supertrait-dtor.rs:22:14
+  --> $DIR/explicit-call-to-supertrait-dtor.rs:23:14
    |
 LL |         self.drop();
    |              ^^^^ explicit destructor calls not allowed

--- a/tests/ui/extern/no-mangle-associated-fn.rs
+++ b/tests/ui/extern/no-mangle-associated-fn.rs
@@ -12,7 +12,7 @@ impl Foo {
     }
 }
 
-trait Bar {
+trait Bar { //~ WARN trait `Bar` is never used
     fn qux() -> u8;
 }
 

--- a/tests/ui/extern/no-mangle-associated-fn.stderr
+++ b/tests/ui/extern/no-mangle-associated-fn.stderr
@@ -1,0 +1,10 @@
+warning: trait `Bar` is never used
+  --> $DIR/no-mangle-associated-fn.rs:15:7
+   |
+LL | trait Bar {
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/generic-associated-types/issue-88360.fixed
+++ b/tests/ui/generic-associated-types/issue-88360.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait GatTrait {
     type Gat<'a> where Self: 'a;

--- a/tests/ui/generic-associated-types/issue-88360.rs
+++ b/tests/ui/generic-associated-types/issue-88360.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait GatTrait {
     type Gat<'a> where Self: 'a;

--- a/tests/ui/generic-associated-types/issue-88360.stderr
+++ b/tests/ui/generic-associated-types/issue-88360.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-88360.rs:15:9
+  --> $DIR/issue-88360.rs:16:9
    |
 LL | trait SuperTrait<T>
    |                  - found this type parameter

--- a/tests/ui/generics/generic-no-mangle.fixed
+++ b/tests/ui/generics/generic-no-mangle.fixed
@@ -1,5 +1,5 @@
 // run-rustfix
-
+#![allow(dead_code)]
 #![deny(no_mangle_generic_items)]
 
 

--- a/tests/ui/generics/generic-no-mangle.rs
+++ b/tests/ui/generics/generic-no-mangle.rs
@@ -1,5 +1,5 @@
 // run-rustfix
-
+#![allow(dead_code)]
 #![deny(no_mangle_generic_items)]
 
 #[no_mangle]

--- a/tests/ui/impl-trait/example-st.rs
+++ b/tests/ui/impl-trait/example-st.rs
@@ -3,7 +3,7 @@
 struct State;
 type Error = ();
 
-trait Bind<F> {
+trait Bind<F> { //~ WARN trait `Bind` is never used
     type Output;
     fn bind(self, f: F) -> Self::Output;
 }

--- a/tests/ui/impl-trait/example-st.stderr
+++ b/tests/ui/impl-trait/example-st.stderr
@@ -1,0 +1,10 @@
+warning: trait `Bind` is never used
+  --> $DIR/example-st.rs:6:7
+   |
+LL | trait Bind<F> {
+   |       ^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/impl-trait/in-trait/suggest-missing-item.fixed
+++ b/tests/ui/impl-trait/in-trait/suggest-missing-item.fixed
@@ -1,6 +1,7 @@
 // edition:2021
 // run-rustfix
 
+#![allow(dead_code)]
 trait Trait {
     #[allow(async_fn_in_trait)]
     async fn foo();

--- a/tests/ui/impl-trait/in-trait/suggest-missing-item.rs
+++ b/tests/ui/impl-trait/in-trait/suggest-missing-item.rs
@@ -1,6 +1,7 @@
 // edition:2021
 // run-rustfix
 
+#![allow(dead_code)]
 trait Trait {
     #[allow(async_fn_in_trait)]
     async fn foo();

--- a/tests/ui/impl-trait/in-trait/suggest-missing-item.stderr
+++ b/tests/ui/impl-trait/in-trait/suggest-missing-item.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `foo`, `bar`, `test`, `baz`
-  --> $DIR/suggest-missing-item.rs:19:1
+  --> $DIR/suggest-missing-item.rs:20:1
    |
 LL |     async fn foo();
    |     --------------- `foo` from trait

--- a/tests/ui/impl-trait/type-alias-generic-param.rs
+++ b/tests/ui/impl-trait/type-alias-generic-param.rs
@@ -5,7 +5,7 @@
 // run-pass
 #![feature(impl_trait_in_assoc_type)]
 
-trait Meow {
+trait Meow { //~ WARN trait `Meow` is never used
     type MeowType;
     fn meow(self) -> Self::MeowType;
 }

--- a/tests/ui/impl-trait/type-alias-generic-param.stderr
+++ b/tests/ui/impl-trait/type-alias-generic-param.stderr
@@ -1,0 +1,10 @@
+warning: trait `Meow` is never used
+  --> $DIR/type-alias-generic-param.rs:8:7
+   |
+LL | trait Meow {
+   |       ^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-14399.rs
+++ b/tests/ui/issues/issue-14399.rs
@@ -9,7 +9,7 @@
 #[derive(Clone)]
 struct B1;
 
-trait A { fn foo(&self) {} }
+trait A { fn foo(&self) {} } //~ WARN method `foo` is never used
 impl A for B1 {}
 
 fn main() {

--- a/tests/ui/issues/issue-14399.stderr
+++ b/tests/ui/issues/issue-14399.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/issue-14399.rs:12:14
+   |
+LL | trait A { fn foo(&self) {} }
+   |       -      ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-15858.rs
+++ b/tests/ui/issues/issue-15858.rs
@@ -2,7 +2,7 @@
 static mut DROP_RAN: bool = false;
 
 trait Bar {
-    fn do_something(&mut self);
+    fn do_something(&mut self); //~ WARN method `do_something` is never used
 }
 
 struct BarImpl;

--- a/tests/ui/issues/issue-15858.stderr
+++ b/tests/ui/issues/issue-15858.stderr
@@ -1,0 +1,12 @@
+warning: method `do_something` is never used
+  --> $DIR/issue-15858.rs:5:8
+   |
+LL | trait Bar {
+   |       --- method in this trait
+LL |     fn do_something(&mut self);
+   |        ^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-17351.rs
+++ b/tests/ui/issues/issue-17351.rs
@@ -1,7 +1,7 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-trait Str { fn foo(&self) {} }
+trait Str { fn foo(&self) {} } //~ WARN method `foo` is never used
 impl Str for str {}
 impl<'a, S: ?Sized> Str for &'a S where S: Str {}
 

--- a/tests/ui/issues/issue-17351.stderr
+++ b/tests/ui/issues/issue-17351.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/issue-17351.rs:4:16
+   |
+LL | trait Str { fn foo(&self) {} }
+   |       ---      ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-18173.rs
+++ b/tests/ui/issues/issue-18173.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 trait Foo {
     type T;
 }

--- a/tests/ui/issues/issue-20055-box-trait.rs
+++ b/tests/ui/issues/issue-20055-box-trait.rs
@@ -8,7 +8,7 @@
 // statement surrounding the `match`.
 
 trait Boo {
-    fn dummy(&self) { }
+    fn dummy(&self) { } //~ WARN method `dummy` is never used
 }
 
 impl Boo for [i8; 1] { }

--- a/tests/ui/issues/issue-20055-box-trait.stderr
+++ b/tests/ui/issues/issue-20055-box-trait.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/issue-20055-box-trait.rs:11:8
+   |
+LL | trait Boo {
+   |       --- method in this trait
+LL |     fn dummy(&self) { }
+   |        ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-21909.rs
+++ b/tests/ui/issues/issue-21909.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait A<X> {

--- a/tests/ui/issues/issue-23485.rs
+++ b/tests/ui/issues/issue-23485.rs
@@ -17,7 +17,7 @@ trait Iterator {
 
     fn next(&mut self) -> Option<Self::Item>;
 
-    fn clone_first(mut self) -> Option<<Self::Item as Deref>::Target> where
+    fn clone_first(mut self) -> Option<<Self::Item as Deref>::Target> where //~ WARN method `clone_first` is never used
         Self: Sized,
         Self::Item: Deref,
         <Self::Item as Deref>::Target: Clone,

--- a/tests/ui/issues/issue-23485.stderr
+++ b/tests/ui/issues/issue-23485.stderr
@@ -1,0 +1,13 @@
+warning: method `clone_first` is never used
+  --> $DIR/issue-23485.rs:20:8
+   |
+LL | trait Iterator {
+   |       -------- method in this trait
+...
+LL |     fn clone_first(mut self) -> Option<<Self::Item as Deref>::Target> where
+   |        ^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-2989.rs
+++ b/tests/ui/issues/issue-2989.rs
@@ -1,8 +1,8 @@
 // run-pass
 #![allow(non_camel_case_types)]
 
-trait methods {
-    fn to_bytes(&self) -> Vec<u8> ;
+trait methods { //~ WARN trait `methods` is never used
+    fn to_bytes(&self) -> Vec<u8>;
 }
 
 impl methods for () {

--- a/tests/ui/issues/issue-2989.stderr
+++ b/tests/ui/issues/issue-2989.stderr
@@ -1,0 +1,10 @@
+warning: trait `methods` is never used
+  --> $DIR/issue-2989.rs:4:7
+   |
+LL | trait methods {
+   |       ^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-34074.rs
+++ b/tests/ui/issues/issue-34074.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Make sure several unnamed function parameters don't conflict with each other
 
 trait Tr {

--- a/tests/ui/issues/issue-34503.rs
+++ b/tests/ui/issues/issue-34503.rs
@@ -2,7 +2,7 @@
 fn main() {
     struct X;
     trait Foo<T> {
-        fn foo(&self) where (T, Option<T>): Ord {}
+        fn foo(&self) where (T, Option<T>): Ord {} //~ WARN methods `foo` and `bar` are never used
         fn bar(&self, x: &Option<T>) -> bool
         where Option<T>: Ord { *x < *x }
     }

--- a/tests/ui/issues/issue-34503.stderr
+++ b/tests/ui/issues/issue-34503.stderr
@@ -1,0 +1,14 @@
+warning: methods `foo` and `bar` are never used
+  --> $DIR/issue-34503.rs:5:12
+   |
+LL |     trait Foo<T> {
+   |           --- methods in this trait
+LL |         fn foo(&self) where (T, Option<T>): Ord {}
+   |            ^^^
+LL |         fn bar(&self, x: &Option<T>) -> bool
+   |            ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-3563-3.rs
+++ b/tests/ui/issues/issue-3563-3.rs
@@ -112,7 +112,7 @@ trait Canvas {
 
     // Unlike interfaces traits support default implementations.
     // Got an ICE as soon as I added this method.
-    fn add_points(&mut self, shapes: &[Point]) {
+    fn add_points(&mut self, shapes: &[Point]) { //~ WARN method `add_points` is never used
         for pt in shapes {self.add_point(*pt)};
     }
 }

--- a/tests/ui/issues/issue-3563-3.stderr
+++ b/tests/ui/issues/issue-3563-3.stderr
@@ -1,0 +1,13 @@
+warning: method `add_points` is never used
+  --> $DIR/issue-3563-3.rs:115:8
+   |
+LL | trait Canvas {
+   |       ------ method in this trait
+...
+LL |     fn add_points(&mut self, shapes: &[Point]) {
+   |        ^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-50571.fixed
+++ b/tests/ui/issues/issue-50571.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 
+#![allow(dead_code)]
 trait Foo {
     fn foo(_: [i32; 2]) {}
     //~^ ERROR: patterns aren't allowed in methods without bodies

--- a/tests/ui/issues/issue-50571.rs
+++ b/tests/ui/issues/issue-50571.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 
+#![allow(dead_code)]
 trait Foo {
     fn foo([a, b]: [i32; 2]) {}
     //~^ ERROR: patterns aren't allowed in methods without bodies

--- a/tests/ui/issues/issue-50571.stderr
+++ b/tests/ui/issues/issue-50571.stderr
@@ -1,5 +1,5 @@
 error[E0642]: patterns aren't allowed in methods without bodies
-  --> $DIR/issue-50571.rs:4:12
+  --> $DIR/issue-50571.rs:5:12
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^

--- a/tests/ui/issues/issue-7575.rs
+++ b/tests/ui/issues/issue-7575.rs
@@ -1,6 +1,6 @@
 // run-pass
 
-trait Foo {
+trait Foo { //~ WARN trait `Foo` is never used
     fn new() -> bool { false }
     fn dummy(&self) { }
 }

--- a/tests/ui/issues/issue-7575.stderr
+++ b/tests/ui/issues/issue-7575.stderr
@@ -1,0 +1,10 @@
+warning: trait `Foo` is never used
+  --> $DIR/issue-7575.rs:3:7
+   |
+LL | trait Foo {
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-7911.rs
+++ b/tests/ui/issues/issue-7911.rs
@@ -4,7 +4,7 @@
 
 #![allow(unused_variables)] // unused foobar_immut + foobar_mut
 trait FooBar {
-    fn dummy(&self) { }
+    fn dummy(&self) { } //~ WARN method `dummy` is never used
 }
 struct Bar(#[allow(dead_code)] i32);
 struct Foo { bar: Bar }

--- a/tests/ui/issues/issue-7911.stderr
+++ b/tests/ui/issues/issue-7911.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/issue-7911.rs:7:8
+   |
+LL | trait FooBar {
+   |       ------ method in this trait
+LL |     fn dummy(&self) { }
+   |        ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-8248.rs
+++ b/tests/ui/issues/issue-8248.rs
@@ -2,7 +2,7 @@
 // pretty-expanded FIXME #23616
 
 trait A {
-    fn dummy(&self) { }
+    fn dummy(&self) { } //~ WARN method `dummy` is never used
 }
 struct B;
 impl A for B {}

--- a/tests/ui/issues/issue-8248.stderr
+++ b/tests/ui/issues/issue-8248.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/issue-8248.rs:5:8
+   |
+LL | trait A {
+   |       - method in this trait
+LL |     fn dummy(&self) { }
+   |        ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/issues/issue-9951.rs
+++ b/tests/ui/issues/issue-9951.rs
@@ -4,7 +4,7 @@
 #![allow(unused_variables)]
 
 trait Bar {
-  fn noop(&self);
+  fn noop(&self); //~ WARN method `noop` is never used
 }
 impl Bar for u8 {
   fn noop(&self) {}

--- a/tests/ui/issues/issue-9951.stderr
+++ b/tests/ui/issues/issue-9951.stderr
@@ -1,0 +1,12 @@
+warning: method `noop` is never used
+  --> $DIR/issue-9951.rs:7:6
+   |
+LL | trait Bar {
+   |       --- method in this trait
+LL |   fn noop(&self);
+   |      ^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/lint/dead-code/associated-type.rs
+++ b/tests/ui/lint/dead-code/associated-type.rs
@@ -15,5 +15,5 @@ impl Foo for Ex {
 }
 
 pub fn main() {
-    let _x = Ex;
+    let _x: &dyn Foo<Bar = <Ex as Foo>::Bar> = &Ex;
 }

--- a/tests/ui/lint/dead-code/issue-41883.rs
+++ b/tests/ui/lint/dead-code/issue-41883.rs
@@ -1,0 +1,29 @@
+#![deny(dead_code)]
+
+enum Category {
+    Dead, //~ ERROR variant `Dead` is never constructed
+    Used,
+}
+
+trait UnusedTrait { //~ ERROR trait `UnusedTrait` is never used
+    fn this_is_unused(&self) -> Category {
+        Category::Dead
+    }
+}
+
+struct UnusedStruct; //~ ERROR struct `UnusedStruct` is never constructed
+
+impl UnusedTrait for UnusedStruct {
+    fn this_is_unused(&self) -> Category {
+        Category::Used
+    }
+}
+
+mod private {
+    #[derive(Debug)]
+    struct UnusedStruct; //~ ERROR struct `UnusedStruct` is never constructed
+}
+
+fn main() {
+    let _c = Category::Used;
+}

--- a/tests/ui/lint/dead-code/issue-41883.stderr
+++ b/tests/ui/lint/dead-code/issue-41883.stderr
@@ -1,0 +1,36 @@
+error: variant `Dead` is never constructed
+  --> $DIR/issue-41883.rs:4:5
+   |
+LL | enum Category {
+   |      -------- variant in this enum
+LL |     Dead,
+   |     ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-41883.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: trait `UnusedTrait` is never used
+  --> $DIR/issue-41883.rs:8:7
+   |
+LL | trait UnusedTrait {
+   |       ^^^^^^^^^^^
+
+error: struct `UnusedStruct` is never constructed
+  --> $DIR/issue-41883.rs:14:8
+   |
+LL | struct UnusedStruct;
+   |        ^^^^^^^^^^^^
+
+error: struct `UnusedStruct` is never constructed
+  --> $DIR/issue-41883.rs:24:12
+   |
+LL |     struct UnusedStruct;
+   |            ^^^^^^^^^^^^
+   |
+   = note: `UnusedStruct` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.rs
+++ b/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.rs
@@ -17,7 +17,7 @@ struct Bar {
 
 // Issue 119267: this should not ICE.
 #[derive(Debug)]
-struct Foo(usize, #[allow(unused)] usize); //~ WARN field `0` is never read
+struct Foo(usize, #[allow(unused)] usize); //~ WARN struct `Foo` is never constructed
 
 fn main() {
     Bar {

--- a/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
+++ b/tests/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
@@ -51,19 +51,13 @@ note: the lint level is defined here
 LL |     #[forbid(dead_code)]
    |              ^^^^^^^^^
 
-warning: field `0` is never read
-  --> $DIR/multiple-dead-codes-in-the-same-struct.rs:20:12
+warning: struct `Foo` is never constructed
+  --> $DIR/multiple-dead-codes-in-the-same-struct.rs:20:8
    |
 LL | struct Foo(usize, #[allow(unused)] usize);
-   |        --- ^^^^^
-   |        |
-   |        field in this struct
+   |        ^^^
    |
    = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
-help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
-   |
-LL | struct Foo((), #[allow(unused)] usize);
-   |            ~~
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/lint/issue-20343.rs
+++ b/tests/ui/lint/issue-20343.rs
@@ -22,6 +22,8 @@ impl B {
 
     // test for unused code in generics
     fn baz<A: T<D>>() {}
+
+    fn foz<A: T<D>>(a: A) { a.dummy(D); }
 }
 
 pub fn main() {
@@ -29,4 +31,5 @@ pub fn main() {
     B::foo(b);
     B::bar();
     B::baz::<()>();
+    B::foz::<()>(());
 }

--- a/tests/ui/macros/issue-22463.rs
+++ b/tests/ui/macros/issue-22463.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 macro_rules! items {
     () => {
         type A = ();

--- a/tests/ui/methods/method-lookup-order.rs
+++ b/tests/ui/methods/method-lookup-order.rs
@@ -1,6 +1,7 @@
 // ignore-tidy-linelength
 
 // run-pass
+#![allow(dead_code)]
 
 // There are five cfg's below. I explored the set of all non-empty combinations
 // of the below five cfg's, which is 2^5 - 1 = 31 combinations.

--- a/tests/ui/methods/method-recursive-blanket-impl.rs
+++ b/tests/ui/methods/method-recursive-blanket-impl.rs
@@ -11,7 +11,7 @@
 use std::marker::Sized;
 
 // Note: this must be generic for the problem to show up
-trait Foo<A> {
+trait Foo<A> { //~ WARN trait `Foo` is never used
     fn foo(&self, a: A);
 }
 

--- a/tests/ui/methods/method-recursive-blanket-impl.stderr
+++ b/tests/ui/methods/method-recursive-blanket-impl.stderr
@@ -1,0 +1,10 @@
+warning: trait `Foo` is never used
+  --> $DIR/method-recursive-blanket-impl.rs:14:7
+   |
+LL | trait Foo<A> {
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/methods/method-two-trait-defer-resolution-2.rs
+++ b/tests/ui/methods/method-two-trait-defer-resolution-2.rs
@@ -14,7 +14,7 @@ trait Foo {
     fn foo(&self) -> isize;
 }
 
-trait MyCopy { fn foo(&self) { } }
+trait MyCopy { fn foo(&self) { } } //~ WARN method `foo` is never used
 impl MyCopy for i32 { }
 
 impl<T:MyCopy> Foo for Vec<T> {

--- a/tests/ui/methods/method-two-trait-defer-resolution-2.stderr
+++ b/tests/ui/methods/method-two-trait-defer-resolution-2.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/method-two-trait-defer-resolution-2.rs:17:19
+   |
+LL | trait MyCopy { fn foo(&self) { } }
+   |       ------      ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/methods/method-two-traits-distinguished-via-where-clause.rs
+++ b/tests/ui/methods/method-two-traits-distinguished-via-where-clause.rs
@@ -4,7 +4,7 @@
 
 // pretty-expanded FIXME #23616
 
-trait A {
+trait A { //~ WARN trait `A` is never used
     fn foo(self);
 }
 

--- a/tests/ui/methods/method-two-traits-distinguished-via-where-clause.stderr
+++ b/tests/ui/methods/method-two-traits-distinguished-via-where-clause.stderr
@@ -1,0 +1,10 @@
+warning: trait `A` is never used
+  --> $DIR/method-two-traits-distinguished-via-where-clause.rs:7:7
+   |
+LL | trait A {
+   |       ^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/mir/mir_raw_fat_ptr.rs
+++ b/tests/ui/mir/mir_raw_fat_ptr.rs
@@ -98,7 +98,7 @@ fn assert_inorder<T: Copy>(a: &[T],
     }
 }
 
-trait Foo { fn foo(&self) -> usize; }
+trait Foo { fn foo(&self) -> usize; } //~ WARN method `foo` is never used
 impl<T> Foo for T {
     fn foo(&self) -> usize {
         mem::size_of::<T>()

--- a/tests/ui/mir/mir_raw_fat_ptr.stderr
+++ b/tests/ui/mir/mir_raw_fat_ptr.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/mir_raw_fat_ptr.rs:101:16
+   |
+LL | trait Foo { fn foo(&self) -> usize; }
+   |       ---      ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/moves/issue-22536-copy-mustnt-zero.rs
+++ b/tests/ui/moves/issue-22536-copy-mustnt-zero.rs
@@ -5,7 +5,7 @@
 
 trait Resources {
     type Buffer: Copy;
-    fn foo(&self) {}
+    fn foo(&self) {} //~ WARN method `foo` is never used
 }
 
 struct BufferHandle<R: Resources> {

--- a/tests/ui/moves/issue-22536-copy-mustnt-zero.stderr
+++ b/tests/ui/moves/issue-22536-copy-mustnt-zero.stderr
@@ -1,0 +1,13 @@
+warning: method `foo` is never used
+  --> $DIR/issue-22536-copy-mustnt-zero.rs:8:8
+   |
+LL | trait Resources {
+   |       --------- method in this trait
+LL |     type Buffer: Copy;
+LL |     fn foo(&self) {}
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/object-safety/assoc_type_bounds_implicit_sized.fixed
+++ b/tests/ui/object-safety/assoc_type_bounds_implicit_sized.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 trait TraitWithAType {
     type Item: ?Sized;
 }

--- a/tests/ui/object-safety/assoc_type_bounds_implicit_sized.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_implicit_sized.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 trait TraitWithAType {
     type Item;
 }

--- a/tests/ui/object-safety/assoc_type_bounds_implicit_sized.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_implicit_sized.stderr
@@ -1,12 +1,12 @@
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/assoc_type_bounds_implicit_sized.rs:8:17
+  --> $DIR/assoc_type_bounds_implicit_sized.rs:9:17
    |
 LL |     type Item = dyn Trait;
    |                 ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
 note: required by a bound in `TraitWithAType::Item`
-  --> $DIR/assoc_type_bounds_implicit_sized.rs:3:5
+  --> $DIR/assoc_type_bounds_implicit_sized.rs:4:5
    |
 LL |     type Item;
    |     ^^^^^^^^^^ required by this bound in `TraitWithAType::Item`

--- a/tests/ui/overloaded/issue-14958.rs
+++ b/tests/ui/overloaded/issue-14958.rs
@@ -3,7 +3,7 @@
 
 #![feature(fn_traits, unboxed_closures)]
 
-trait Foo { fn dummy(&self) { }}
+trait Foo { fn dummy(&self) { }} //~ WARN method `dummy` is never used
 
 struct Bar;
 

--- a/tests/ui/overloaded/issue-14958.stderr
+++ b/tests/ui/overloaded/issue-14958.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/issue-14958.rs:6:16
+   |
+LL | trait Foo { fn dummy(&self) { }}
+   |       ---      ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/overloaded/overloaded-index-in-field.rs
+++ b/tests/ui/overloaded/overloaded-index-in-field.rs
@@ -27,7 +27,7 @@ impl Index<isize> for Foo {
 
 trait Int {
     fn get(self) -> isize;
-    fn get_from_ref(&self) -> isize;
+    fn get_from_ref(&self) -> isize; //~ WARN methods `get_from_ref` and `inc` are never used
     fn inc(&mut self);
 }
 

--- a/tests/ui/overloaded/overloaded-index-in-field.stderr
+++ b/tests/ui/overloaded/overloaded-index-in-field.stderr
@@ -1,0 +1,15 @@
+warning: methods `get_from_ref` and `inc` are never used
+  --> $DIR/overloaded-index-in-field.rs:30:8
+   |
+LL | trait Int {
+   |       --- methods in this trait
+LL |     fn get(self) -> isize;
+LL |     fn get_from_ref(&self) -> isize;
+   |        ^^^^^^^^^^^^
+LL |     fn inc(&mut self);
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/parser/parse-assoc-type-lt.rs
+++ b/tests/ui/parser/parse-assoc-type-lt.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait Foo {

--- a/tests/ui/parser/suggest-assoc-const.fixed
+++ b/tests/ui/parser/suggest-assoc-const.fixed
@@ -1,5 +1,6 @@
 // Issue: 101797, Suggest associated const for incorrect use of let in traits
 // run-rustfix
+#![allow(dead_code)]
 trait Trait {
     const _X: i32;
     //~^ ERROR non-item in item list

--- a/tests/ui/parser/suggest-assoc-const.rs
+++ b/tests/ui/parser/suggest-assoc-const.rs
@@ -1,5 +1,6 @@
 // Issue: 101797, Suggest associated const for incorrect use of let in traits
 // run-rustfix
+#![allow(dead_code)]
 trait Trait {
     let _X: i32;
     //~^ ERROR non-item in item list

--- a/tests/ui/parser/suggest-assoc-const.stderr
+++ b/tests/ui/parser/suggest-assoc-const.stderr
@@ -1,5 +1,5 @@
 error: non-item in item list
-  --> $DIR/suggest-assoc-const.rs:4:5
+  --> $DIR/suggest-assoc-const.rs:5:5
    |
 LL |     let _X: i32;
    |     ^^^ help: consider using `const` instead of `let` for associated const: `const`

--- a/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.fixed
+++ b/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait Foo {
     fn bar() {} //~ ERROR non-item in item list

--- a/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.rs
+++ b/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait Foo {
     fn bar() {}; //~ ERROR non-item in item list

--- a/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.stderr
+++ b/tests/ui/parser/suggest-removing-semicolon-after-impl-trait-items.stderr
@@ -1,5 +1,5 @@
 error: non-item in item list
-  --> $DIR/suggest-removing-semicolon-after-impl-trait-items.rs:4:16
+  --> $DIR/suggest-removing-semicolon-after-impl-trait-items.rs:5:16
    |
 LL | trait Foo {
    |           - item list starts here

--- a/tests/ui/pattern/issue-22546.rs
+++ b/tests/ui/pattern/issue-22546.rs
@@ -15,7 +15,7 @@ impl<T: ::std::fmt::Display> Foo<T> {
     }
 }
 
-trait Tr {
+trait Tr { //~ WARN trait `Tr` is never used
     type U;
 }
 

--- a/tests/ui/pattern/issue-22546.stderr
+++ b/tests/ui/pattern/issue-22546.stderr
@@ -1,0 +1,10 @@
+warning: trait `Tr` is never used
+  --> $DIR/issue-22546.rs:18:7
+   |
+LL | trait Tr {
+   |       ^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/privacy/sealed-traits/re-exported-trait.fixed
+++ b/tests/ui/privacy/sealed-traits/re-exported-trait.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 pub mod a {
     pub use self::b::Trait;

--- a/tests/ui/privacy/sealed-traits/re-exported-trait.rs
+++ b/tests/ui/privacy/sealed-traits/re-exported-trait.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 pub mod a {
     pub use self::b::Trait;

--- a/tests/ui/privacy/sealed-traits/re-exported-trait.stderr
+++ b/tests/ui/privacy/sealed-traits/re-exported-trait.stderr
@@ -1,11 +1,11 @@
 error[E0603]: module `b` is private
-  --> $DIR/re-exported-trait.rs:11:9
+  --> $DIR/re-exported-trait.rs:12:9
    |
 LL | impl a::b::Trait for S {}
    |         ^ private module
    |
 note: the module `b` is defined here
-  --> $DIR/re-exported-trait.rs:5:5
+  --> $DIR/re-exported-trait.rs:6:5
    |
 LL |     mod b {
    |     ^^^^^

--- a/tests/ui/regions/regions-no-variance-from-fn-generics.rs
+++ b/tests/ui/regions/regions-no-variance-from-fn-generics.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(unused_variables)]
 // Issue #12856: a lifetime formal binding introduced by a generic fn
 // should not upset the variance inference for actual occurrences of

--- a/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.fixed
+++ b/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 
+#![allow(dead_code)]
 #![deny(unused_qualifications)]
 #![feature(unsized_fn_params)]
 

--- a/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.rs
+++ b/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 
+#![allow(dead_code)]
 #![deny(unused_qualifications)]
 #![feature(unsized_fn_params)]
 

--- a/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.stderr
+++ b/tests/ui/resolve/issue-113808-invalid-unused-qualifications-suggestion.stderr
@@ -1,11 +1,11 @@
 error: unnecessary qualification
-  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:12:6
+  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:13:6
    |
 LL | impl ops::Index<str> for A {
    |      ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:3:9
+  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:4:9
    |
 LL | #![deny(unused_qualifications)]
    |         ^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL + impl Index<str> for A {
    |
 
 error: unnecessary qualification
-  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:28:6
+  --> $DIR/issue-113808-invalid-unused-qualifications-suggestion.rs:29:6
    |
 LL | impl inner::Trait<u8> for () {}
    |      ^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.current.stderr
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.current.stderr
@@ -1,0 +1,15 @@
+warning: methods `good_virt` and `good_indirect` are never used
+  --> $DIR/manual-self-impl-for-unsafe-obj.rs:22:8
+   |
+LL | trait Good {
+   |       ---- methods in this trait
+LL |     fn good_virt(&self) -> char {
+   |        ^^^^^^^^^
+...
+LL |     fn good_indirect(&self) -> char {
+   |        ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.next.stderr
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.next.stderr
@@ -1,0 +1,15 @@
+warning: methods `good_virt` and `good_indirect` are never used
+  --> $DIR/manual-self-impl-for-unsafe-obj.rs:22:8
+   |
+LL | trait Good {
+   |       ---- methods in this trait
+LL |     fn good_virt(&self) -> char {
+   |        ^^^^^^^^^
+...
+LL |     fn good_indirect(&self) -> char {
+   |        ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.rs
+++ b/tests/ui/rfcs/rfc-2027-object-safe-for-dispatch/manual-self-impl-for-unsafe-obj.rs
@@ -19,7 +19,7 @@ trait Bad {
 }
 
 trait Good {
-    fn good_virt(&self) -> char {
+    fn good_virt(&self) -> char { //~ WARN methods `good_virt` and `good_indirect` are never used
         panic!()
     }
     fn good_indirect(&self) -> char {

--- a/tests/ui/rust-2018/issue-51008-1.rs
+++ b/tests/ui/rust-2018/issue-51008-1.rs
@@ -2,7 +2,7 @@
 // being incorrectly considered part of the "elided lifetimes" from
 // the impl.
 //
-// run-pass
+// check-pass
 
 trait A {
 

--- a/tests/ui/rust-2018/issue-51008.rs
+++ b/tests/ui/rust-2018/issue-51008.rs
@@ -2,7 +2,7 @@
 // being incorrectly considered part of the "elided lifetimes" from
 // the impl.
 //
-// run-pass
+// check-pass
 
 trait A {
 

--- a/tests/ui/sized/coinductive-2.rs
+++ b/tests/ui/sized/coinductive-2.rs
@@ -11,7 +11,7 @@ impl<T> CollectionFactory<T> for Vec<()> {
     type Collection = Vec<T>;
 }
 
-trait Collection<T>: Sized {
+trait Collection<T>: Sized { //~ WARN trait `Collection` is never used
     fn push(&mut self, v: T);
 }
 

--- a/tests/ui/sized/coinductive-2.stderr
+++ b/tests/ui/sized/coinductive-2.stderr
@@ -1,0 +1,10 @@
+warning: trait `Collection` is never used
+  --> $DIR/coinductive-2.rs:14:7
+   |
+LL | trait Collection<T>: Sized {
+   |       ^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/specialization/assoc-ty-graph-cycle.rs
+++ b/tests/ui/specialization/assoc-ty-graph-cycle.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // Make sure we don't crash with a cycle error during coherence.
 

--- a/tests/ui/specialization/defaultimpl/out-of-order.rs
+++ b/tests/ui/specialization/defaultimpl/out-of-order.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // Test that you can list the more specific impl before the more general one.
 

--- a/tests/ui/specialization/defaultimpl/overlap-projection.rs
+++ b/tests/ui/specialization/defaultimpl/overlap-projection.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // Test that impls on projected self types can resolve overlap, even when the
 // projections involve specialization, so long as the associated type is

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
@@ -6,7 +6,7 @@
 struct S<const L: usize>;
 
 impl<const N: i32> Copy for S<N> {}
-//~^ ERROR the constant `N` is not of type `usize`
 impl<const M: usize> Copy for S<M> {}
+//~^ ERROR: conflicting implementations of trait `Copy` for type `S<_>`
 
 fn main() {}

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
@@ -1,14 +1,11 @@
-error: the constant `N` is not of type `usize`
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:8:29
+error[E0119]: conflicting implementations of trait `Copy` for type `S<_>`
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:9:1
    |
 LL | impl<const N: i32> Copy for S<N> {}
-   |                             ^^^^ expected `usize`, found `i32`
-   |
-note: required by a bound in `S`
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:6:10
-   |
-LL | struct S<const L: usize>;
-   |          ^^^^^^^^^^^^^^ required by this bound in `S`
+   | -------------------------------- first implementation here
+LL | impl<const M: usize> Copy for S<M> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S<_>`
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/specialization/specialization-out-of-order.rs
+++ b/tests/ui/specialization/specialization-out-of-order.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // Test that you can list the more specific impl before the more general one.
 

--- a/tests/ui/specialization/specialization-overlap-projection.rs
+++ b/tests/ui/specialization/specialization-overlap-projection.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // Test that impls on projected self types can resolve overlap, even when the
 // projections involve specialization, so long as the associated type is

--- a/tests/ui/specialization/specialization-supertraits.rs
+++ b/tests/ui/specialization/specialization-supertraits.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 #![feature(specialization)] //~ WARN the feature `specialization` is incomplete
 

--- a/tests/ui/statics/static-impl.rs
+++ b/tests/ui/statics/static-impl.rs
@@ -35,7 +35,7 @@ impl uint_utils for usize {
 
 trait vec_utils<T> {
     fn length_(&self, ) -> usize;
-    fn iter_<F>(&self, f: F) where F: FnMut(&T);
+    fn iter_<F>(&self, f: F) where F: FnMut(&T); //~ WARN method `iter_` is never used
     fn map_<U, F>(&self, f: F) -> Vec<U> where F: FnMut(&T) -> U;
 }
 

--- a/tests/ui/statics/static-impl.stderr
+++ b/tests/ui/statics/static-impl.stderr
@@ -1,0 +1,13 @@
+warning: method `iter_` is never used
+  --> $DIR/static-impl.rs:38:8
+   |
+LL | trait vec_utils<T> {
+   |       --------- method in this trait
+LL |     fn length_(&self, ) -> usize;
+LL |     fn iter_<F>(&self, f: F) where F: FnMut(&T);
+   |        ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/stdlib-unit-tests/raw-fat-ptr.rs
+++ b/tests/ui/stdlib-unit-tests/raw-fat-ptr.rs
@@ -32,7 +32,7 @@ fn assert_inorder<T: PartialEq + PartialOrd>(a: &[T]) {
     }
 }
 
-trait Foo { fn foo(&self) -> usize; }
+trait Foo { fn foo(&self) -> usize; } //~ WARN method `foo` is never used
 impl<T> Foo for T {
     fn foo(&self) -> usize {
         mem::size_of::<T>()

--- a/tests/ui/stdlib-unit-tests/raw-fat-ptr.stderr
+++ b/tests/ui/stdlib-unit-tests/raw-fat-ptr.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/raw-fat-ptr.rs:35:16
+   |
+LL | trait Foo { fn foo(&self) -> usize; }
+   |       ---      ^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/structs-enums/enum-null-pointer-opt.rs
+++ b/tests/ui/structs-enums/enum-null-pointer-opt.rs
@@ -7,7 +7,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 
-trait Trait { fn dummy(&self) { } }
+trait Trait { fn dummy(&self) { } } //~ WARN method `dummy` is never used
 trait Mirror { type Image; }
 impl<T> Mirror for T { type Image = T; }
 struct ParamTypeStruct<T>(#[allow(dead_code)] T);

--- a/tests/ui/structs-enums/enum-null-pointer-opt.stderr
+++ b/tests/ui/structs-enums/enum-null-pointer-opt.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/enum-null-pointer-opt.rs:10:18
+   |
+LL | trait Trait { fn dummy(&self) { } }
+   |       -----      ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/suggestions/bound-suggestions.fixed
+++ b/tests/ui/suggestions/bound-suggestions.fixed
@@ -40,26 +40,31 @@ fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {
     //~^ ERROR doesn't implement
 }
 
+#[allow(dead_code)]
 trait Foo<T>: Sized {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Bar: std::fmt::Display + Sized {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Baz: Sized where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Qux<T>: Sized where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Bat<T>: std::fmt::Display + Sized {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time

--- a/tests/ui/suggestions/bound-suggestions.rs
+++ b/tests/ui/suggestions/bound-suggestions.rs
@@ -40,26 +40,31 @@ fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized {
     //~^ ERROR doesn't implement
 }
 
+#[allow(dead_code)]
 trait Foo<T> {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Bar: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Baz where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Qux<T> where Self: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time
 }
 
+#[allow(dead_code)]
 trait Bat<T>: std::fmt::Display {
     const SIZE: usize = core::mem::size_of::<Self>();
     //~^ ERROR the size for values of type `Self` cannot be known at compilation time

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -71,7 +71,7 @@ LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Siz
    |                                                   +++++++++++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:44:46
+  --> $DIR/bound-suggestions.rs:45:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -84,7 +84,7 @@ LL | trait Foo<T>: Sized {
    |             +++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:49:46
+  --> $DIR/bound-suggestions.rs:51:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -97,7 +97,7 @@ LL | trait Bar: std::fmt::Display + Sized {
    |                              +++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:54:46
+  --> $DIR/bound-suggestions.rs:57:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -110,7 +110,7 @@ LL | trait Baz: Sized where Self: std::fmt::Display {
    |          +++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:59:46
+  --> $DIR/bound-suggestions.rs:63:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
@@ -123,7 +123,7 @@ LL | trait Qux<T>: Sized where Self: std::fmt::Display {
    |             +++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/bound-suggestions.rs:64:46
+  --> $DIR/bound-suggestions.rs:69:46
    |
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time

--- a/tests/ui/suggestions/constrain-trait.fixed
+++ b/tests/ui/suggestions/constrain-trait.fixed
@@ -1,5 +1,6 @@
 // run-rustfix
 // check-only
+#![allow(dead_code)]
 
 #[derive(Debug)]
 struct Demo {

--- a/tests/ui/suggestions/constrain-trait.rs
+++ b/tests/ui/suggestions/constrain-trait.rs
@@ -1,5 +1,6 @@
 // run-rustfix
 // check-only
+#![allow(dead_code)]
 
 #[derive(Debug)]
 struct Demo {

--- a/tests/ui/suggestions/constrain-trait.stderr
+++ b/tests/ui/suggestions/constrain-trait.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `get_a` found for reference `&Self` in the current scope
-  --> $DIR/constrain-trait.rs:15:31
+  --> $DIR/constrain-trait.rs:16:31
    |
 LL |         println!("{:?}", self.get_a());
    |                               ^^^^^ method not found in `&Self`
@@ -11,7 +11,7 @@ LL | trait UseString: std::fmt::Debug + GetString {
    |                                  +++++++++++
 
 error[E0599]: no method named `get_a` found for reference `&Self` in the current scope
-  --> $DIR/constrain-trait.rs:21:31
+  --> $DIR/constrain-trait.rs:22:31
    |
 LL |         println!("{:?}", self.get_a());
    |                               ^^^^^ method not found in `&Self`

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.fixed
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.fixed
@@ -1,6 +1,7 @@
 // Make sure we suggest the bound `T: 'a` in the correct scope:
 // trait, impl or associated fn.
 // run-rustfix
+#![allow(dead_code)]
 
 struct Inv<'a>(#[allow(dead_code)] Option<*mut &'a u8>);
 

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.rs
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.rs
@@ -1,6 +1,7 @@
 // Make sure we suggest the bound `T: 'a` in the correct scope:
 // trait, impl or associated fn.
 // run-rustfix
+#![allow(dead_code)]
 
 struct Inv<'a>(#[allow(dead_code)] Option<*mut &'a u8>);
 

--- a/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
+++ b/tests/ui/suggestions/lifetimes/type-param-bound-scope.stderr
@@ -1,5 +1,5 @@
 error[E0309]: the parameter type `Self` may not live long enough
-  --> $DIR/type-param-bound-scope.rs:11:9
+  --> $DIR/type-param-bound-scope.rs:12:9
    |
 LL | trait Trait1<'a>: Sized {
    |              -- the parameter type `Self` must be valid for the lifetime `'a` as defined here...
@@ -13,7 +13,7 @@ LL | trait Trait1<'a>: Sized where Self: 'a {
    |                         ++++++++++++++
 
 error[E0309]: the parameter type `Self` may not live long enough
-  --> $DIR/type-param-bound-scope.rs:18:9
+  --> $DIR/type-param-bound-scope.rs:19:9
    |
 LL |     fn foo<'a>(self, lt: Inv<'a>) {
    |            -- the parameter type `Self` must be valid for the lifetime `'a` as defined here...
@@ -26,7 +26,7 @@ LL |     fn foo<'a>(self, lt: Inv<'a>) where Self: 'a {
    |                                   ++++++++++++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/type-param-bound-scope.rs:25:9
+  --> $DIR/type-param-bound-scope.rs:26:9
    |
 LL |     fn foo<'a>(arg: T, lt: Inv<'a>) {
    |            -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
@@ -39,7 +39,7 @@ LL |     fn foo<'a>(arg: T, lt: Inv<'a>) where T: 'a {
    |                                     +++++++++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/type-param-bound-scope.rs:32:9
+  --> $DIR/type-param-bound-scope.rs:33:9
    |
 LL | trait Trait4<'a> {
    |              -- the parameter type `T` must be valid for the lifetime `'a` as defined here...
@@ -53,7 +53,7 @@ LL |     fn foo<T: 'a>(arg: T, lt: Inv<'a>) {
    |             ++++
 
 error[E0309]: the parameter type `T` may not live long enough
-  --> $DIR/type-param-bound-scope.rs:42:9
+  --> $DIR/type-param-bound-scope.rs:43:9
    |
 LL | impl<'a, T> Trait5<'a> for T {
    |      -- the parameter type `T` must be valid for the lifetime `'a` as defined here...

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.fixed
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 #[derive(Clone)]
 struct Wrapper<T>(T);

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.rs
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 #[derive(Clone)]
 struct Wrapper<T>(T);

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -1,5 +1,5 @@
 error[E0204]: the trait `Copy` cannot be implemented for this type
-  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:16:18
+  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:17:18
    |
 LL | struct Wrapper<T>(T);
    |                   - this field does not implement `Copy`
@@ -8,7 +8,7 @@ LL | impl<S> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `OnlyCopyIfDisplay<S>` requires that `S: std::fmt::Display`
-  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:4:19
+  --> $DIR/missing-bound-in-manual-copy-impl-2.rs:5:19
    |
 LL | struct Wrapper<T>(T);
    |                   ^

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.fixed
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 #[derive(Clone)]
 struct Wrapper<T>(T);

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.rs
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 #[derive(Clone)]
 struct Wrapper<T>(T);

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
@@ -1,5 +1,5 @@
 error[E0204]: the trait `Copy` cannot be implemented for this type
-  --> $DIR/missing-bound-in-manual-copy-impl.rs:6:18
+  --> $DIR/missing-bound-in-manual-copy-impl.rs:7:18
    |
 LL | struct Wrapper<T>(T);
    |                   - this field does not implement `Copy`

--- a/tests/ui/suggestions/missing-trait-item.fixed
+++ b/tests/ui/suggestions/missing-trait-item.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait T {
     unsafe fn foo(a: &usize, b: &usize) -> usize;

--- a/tests/ui/suggestions/missing-trait-item.rs
+++ b/tests/ui/suggestions/missing-trait-item.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait T {
     unsafe fn foo(a: &usize, b: &usize) -> usize;

--- a/tests/ui/suggestions/missing-trait-item.stderr
+++ b/tests/ui/suggestions/missing-trait-item.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `foo`, `bar`
-  --> $DIR/missing-trait-item.rs:10:5
+  --> $DIR/missing-trait-item.rs:11:5
    |
 LL |     unsafe fn foo(a: &usize, b: &usize) -> usize;
    |     --------------------------------------------- `foo` from trait
@@ -10,7 +10,7 @@ LL |     impl T for () {}
    |     ^^^^^^^^^^^^^ missing `foo`, `bar` in implementation
 
 error[E0046]: not all trait items implemented, missing: `foo`, `bar`
-  --> $DIR/missing-trait-item.rs:12:5
+  --> $DIR/missing-trait-item.rs:13:5
    |
 LL |     unsafe fn foo(a: &usize, b: &usize) -> usize;
    |     --------------------------------------------- `foo` from trait

--- a/tests/ui/threads-sendsync/sync-send-atomics.rs
+++ b/tests/ui/threads-sendsync/sync-send-atomics.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // pretty-expanded FIXME #23616
 

--- a/tests/ui/traits/alias/bounds.rs
+++ b/tests/ui/traits/alias/bounds.rs
@@ -4,7 +4,7 @@
 
 use std::marker::PhantomData;
 
-trait Empty {}
+trait Empty {} //~ WARN trait `Empty` is never used
 trait EmptyAlias = Empty;
 trait CloneDefault = Clone + Default;
 trait SendSyncAlias = Send + Sync;

--- a/tests/ui/traits/alias/bounds.stderr
+++ b/tests/ui/traits/alias/bounds.stderr
@@ -1,0 +1,10 @@
+warning: trait `Empty` is never used
+  --> $DIR/bounds.rs:7:7
+   |
+LL | trait Empty {}
+   |       ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/alias/syntax.rs
+++ b/tests/ui/traits/alias/syntax.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 #![feature(trait_alias)]
 

--- a/tests/ui/traits/bound/impl-comparison-duplicates.rs
+++ b/tests/ui/traits/bound/impl-comparison-duplicates.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Tests that type parameter bounds on an implementation need not match the
 // trait exactly, as long as the implementation doesn't demand *more* bounds
 // than the trait.

--- a/tests/ui/traits/bound/recursion.rs
+++ b/tests/ui/traits/bound/recursion.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait I { fn i(&self) -> Self; }

--- a/tests/ui/traits/composition-trivial.rs
+++ b/tests/ui/traits/composition-trivial.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait Foo {

--- a/tests/ui/traits/cycle-generic-bound.rs
+++ b/tests/ui/traits/cycle-generic-bound.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // Regression test for #15477. This test just needs to compile.
 
 // pretty-expanded FIXME #23616

--- a/tests/ui/traits/default-method/bound-subst4.rs
+++ b/tests/ui/traits/default-method/bound-subst4.rs
@@ -4,7 +4,7 @@
 
 trait A<T> {
     fn g(&self, x: usize) -> usize { x }
-    fn h(&self, x: T) { }
+    fn h(&self, x: T) { } //~ WARN method `h` is never used
 }
 
 impl<T> A<T> for isize { }

--- a/tests/ui/traits/default-method/bound-subst4.stderr
+++ b/tests/ui/traits/default-method/bound-subst4.stderr
@@ -1,0 +1,13 @@
+warning: method `h` is never used
+  --> $DIR/bound-subst4.rs:7:8
+   |
+LL | trait A<T> {
+   |       - method in this trait
+LL |     fn g(&self, x: usize) -> usize { x }
+LL |     fn h(&self, x: T) { }
+   |        ^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/default-method/mut.rs
+++ b/tests/ui/traits/default-method/mut.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(unused_assignments)]
 // pretty-expanded FIXME #23616
 

--- a/tests/ui/traits/impl-inherent-prefer-over-trait.rs
+++ b/tests/ui/traits/impl-inherent-prefer-over-trait.rs
@@ -3,7 +3,7 @@
 struct Foo;
 
 trait Trait {
-    fn bar(&self);
+    fn bar(&self); //~ WARN method `bar` is never used
 }
 
 // Inherent impls should be preferred over trait ones.

--- a/tests/ui/traits/impl-inherent-prefer-over-trait.stderr
+++ b/tests/ui/traits/impl-inherent-prefer-over-trait.stderr
@@ -1,0 +1,12 @@
+warning: method `bar` is never used
+  --> $DIR/impl-inherent-prefer-over-trait.rs:6:8
+   |
+LL | trait Trait {
+   |       ----- method in this trait
+LL |     fn bar(&self);
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/impl-object-overlap-issue-23853.rs
+++ b/tests/ui/traits/impl-object-overlap-issue-23853.rs
@@ -5,7 +5,7 @@
 // including `Bar`, but the object type `Bar` also implicitly supplies
 // this context.
 
-trait Foo { fn dummy(&self) { } }
+trait Foo { fn dummy(&self) { } } //~ WARN method `dummy` is never used
 
 trait Bar: Foo { }
 

--- a/tests/ui/traits/impl-object-overlap-issue-23853.stderr
+++ b/tests/ui/traits/impl-object-overlap-issue-23853.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/impl-object-overlap-issue-23853.rs:8:16
+   |
+LL | trait Foo { fn dummy(&self) { } }
+   |       ---      ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/impl.rs
+++ b/tests/ui/traits/impl.rs
@@ -9,7 +9,7 @@ use traitimpl::Bar;
 static mut COUNT: usize = 1;
 
 trait T {
-    fn t(&self) {}
+    fn t(&self) {} //~ WARN method `t` is never used
 }
 
 impl<'a> dyn T+'a {

--- a/tests/ui/traits/impl.stderr
+++ b/tests/ui/traits/impl.stderr
@@ -1,0 +1,12 @@
+warning: method `t` is never used
+  --> $DIR/impl.rs:12:8
+   |
+LL | trait T {
+   |       - method in this trait
+LL |     fn t(&self) {}
+   |        ^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/issue-38033.rs
+++ b/tests/ui/traits/issue-38033.rs
@@ -19,7 +19,7 @@ trait IntoFuture {
     type Item;
     type Error;
 
-    fn into_future(self) -> Self::Future;
+    fn into_future(self) -> Self::Future; //~ WARN method `into_future` is never used
 }
 
 impl<F: Future> IntoFuture for F {

--- a/tests/ui/traits/issue-38033.stderr
+++ b/tests/ui/traits/issue-38033.stderr
@@ -1,0 +1,13 @@
+warning: method `into_future` is never used
+  --> $DIR/issue-38033.rs:22:8
+   |
+LL | trait IntoFuture {
+   |       ---------- method in this trait
+...
+LL |     fn into_future(self) -> Self::Future;
+   |        ^^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/issue-56488.rs
+++ b/tests/ui/traits/issue-56488.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 #![feature(trait_alias)]
 

--- a/tests/ui/traits/issue-59029-2.rs
+++ b/tests/ui/traits/issue-59029-2.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![feature(trait_alias)]
 
 trait Svc<Req> { type Res; }

--- a/tests/ui/traits/issue-6128.rs
+++ b/tests/ui/traits/issue-6128.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 trait Graph<Node, Edge> {
-    fn f(&self, _: Edge);
+    fn f(&self, _: Edge); //~ WARN methods `f` and `g` are never used
     fn g(&self, _: Node);
 }
 

--- a/tests/ui/traits/issue-6128.stderr
+++ b/tests/ui/traits/issue-6128.stderr
@@ -1,0 +1,14 @@
+warning: methods `f` and `g` are never used
+  --> $DIR/issue-6128.rs:6:8
+   |
+LL | trait Graph<Node, Edge> {
+   |       ----- methods in this trait
+LL |     fn f(&self, _: Edge);
+   |        ^
+LL |     fn g(&self, _: Node);
+   |        ^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/multidispatch-conditional-impl-not-considered.rs
+++ b/tests/ui/traits/multidispatch-conditional-impl-not-considered.rs
@@ -6,7 +6,7 @@
 
 use std::cell::RefCell;
 
-trait Foo {
+trait Foo { //~ WARN trait `Foo` is never used
     fn foo(&self) {}
 }
 

--- a/tests/ui/traits/multidispatch-conditional-impl-not-considered.stderr
+++ b/tests/ui/traits/multidispatch-conditional-impl-not-considered.stderr
@@ -1,0 +1,10 @@
+warning: trait `Foo` is never used
+  --> $DIR/multidispatch-conditional-impl-not-considered.rs:9:7
+   |
+LL | trait Foo {
+   |       ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/multidispatch-infer-convert-target.rs
+++ b/tests/ui/traits/multidispatch-infer-convert-target.rs
@@ -5,7 +5,7 @@
 use std::mem;
 
 trait Convert<Target> {
-    fn convert(&self) -> Target;
+    fn convert(&self) -> Target; //~ WARN method `convert` is never used
 }
 
 impl Convert<u32> for i16 {

--- a/tests/ui/traits/multidispatch-infer-convert-target.stderr
+++ b/tests/ui/traits/multidispatch-infer-convert-target.stderr
@@ -1,0 +1,12 @@
+warning: method `convert` is never used
+  --> $DIR/multidispatch-infer-convert-target.rs:8:8
+   |
+LL | trait Convert<Target> {
+   |       ------- method in this trait
+LL |     fn convert(&self) -> Target;
+   |        ^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/negative-impls/negative-specializes-negative.rs
+++ b/tests/ui/traits/negative-impls/negative-specializes-negative.rs
@@ -3,7 +3,7 @@
 
 // Test a negative impl that "specializes" another negative impl.
 //
-// run-pass
+// check-pass
 
 trait MyTrait {}
 

--- a/tests/ui/traits/trait-upcasting/lifetime.rs
+++ b/tests/ui/traits/trait-upcasting/lifetime.rs
@@ -5,7 +5,7 @@ trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
         10
     }
 
-    fn z(&self) -> i32 {
+    fn z(&self) -> i32 { //~ WARN methods `z` and `y` are never used
         11
     }
 
@@ -19,7 +19,7 @@ trait Bar: Foo {
         20
     }
 
-    fn w(&self) -> i32 {
+    fn w(&self) -> i32 { //~ WARN method `w` is never used
         21
     }
 }

--- a/tests/ui/traits/trait-upcasting/lifetime.stderr
+++ b/tests/ui/traits/trait-upcasting/lifetime.stderr
@@ -1,0 +1,25 @@
+warning: methods `z` and `y` are never used
+  --> $DIR/lifetime.rs:8:8
+   |
+LL | trait Foo: PartialEq<i32> + std::fmt::Debug + Send + Sync {
+   |       --- methods in this trait
+...
+LL |     fn z(&self) -> i32 {
+   |        ^
+...
+LL |     fn y(&self) -> i32 {
+   |        ^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: method `w` is never used
+  --> $DIR/lifetime.rs:22:8
+   |
+LL | trait Bar: Foo {
+   |       --- method in this trait
+...
+LL |     fn w(&self) -> i32 {
+   |        ^
+
+warning: 2 warnings emitted
+

--- a/tests/ui/traits/trait-upcasting/replace-vptr.rs
+++ b/tests/ui/traits/trait-upcasting/replace-vptr.rs
@@ -1,7 +1,7 @@
 // run-pass
 
 trait A {
-    fn foo_a(&self);
+    fn foo_a(&self); //~ WARN method `foo_a` is never used
 }
 
 trait B {
@@ -9,7 +9,7 @@ trait B {
 }
 
 trait C: A + B {
-    fn foo_c(&self);
+    fn foo_c(&self); //~ WARN method `foo_c` is never used
 }
 
 struct S(i32);

--- a/tests/ui/traits/trait-upcasting/replace-vptr.stderr
+++ b/tests/ui/traits/trait-upcasting/replace-vptr.stderr
@@ -1,0 +1,20 @@
+warning: method `foo_a` is never used
+  --> $DIR/replace-vptr.rs:4:8
+   |
+LL | trait A {
+   |       - method in this trait
+LL |     fn foo_a(&self);
+   |        ^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: method `foo_c` is never used
+  --> $DIR/replace-vptr.rs:12:8
+   |
+LL | trait C: A + B {
+   |       - method in this trait
+LL |     fn foo_c(&self);
+   |        ^^^^^
+
+warning: 2 warnings emitted
+

--- a/tests/ui/traits/use-before-def.rs
+++ b/tests/ui/traits/use-before-def.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 #![allow(non_camel_case_types)]
 
 // Issue #1761

--- a/tests/ui/traits/wf-object/reverse-order.rs
+++ b/tests/ui/traits/wf-object/reverse-order.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 // Ensure that `dyn $($AutoTrait)+ ObjSafe` is well-formed.
 

--- a/tests/ui/trivial_casts-rpass.rs
+++ b/tests/ui/trivial_casts-rpass.rs
@@ -4,7 +4,7 @@
 #![allow(trivial_casts, trivial_numeric_casts)]
 
 trait Foo {
-    fn foo(&self) {}
+    fn foo(&self) {} //~ WARN method `foo` is never used
 }
 
 pub struct Bar;

--- a/tests/ui/trivial_casts-rpass.stderr
+++ b/tests/ui/trivial_casts-rpass.stderr
@@ -1,0 +1,12 @@
+warning: method `foo` is never used
+  --> $DIR/trivial_casts-rpass.rs:7:8
+   |
+LL | trait Foo {
+   |       --- method in this trait
+LL |     fn foo(&self) {}
+   |        ^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/type-alias-impl-trait/issue-58887.rs
+++ b/tests/ui/type-alias-impl-trait/issue-58887.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.fixed
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait WithType<T> {}
 trait WithRegion<'a> { }

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.rs
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait WithType<T> {}
 trait WithRegion<'a> { }

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2015.stderr
@@ -1,5 +1,5 @@
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/where-clause-inherent-impl-ampersand-rust2015.rs:13:17
+  --> $DIR/where-clause-inherent-impl-ampersand-rust2015.rs:14:17
    |
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.fixed
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.fixed
@@ -1,5 +1,6 @@
 // edition:2018
 // run-rustfix
+#![allow(dead_code)]
 
 trait WithType<T> {}
 trait WithRegion<'a> { }

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.rs
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.rs
@@ -1,5 +1,6 @@
 // edition:2018
 // run-rustfix
+#![allow(dead_code)]
 
 trait WithType<T> {}
 trait WithRegion<'a> { }

--- a/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-inherent-impl-ampersand-rust2018.stderr
@@ -1,5 +1,5 @@
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/where-clause-inherent-impl-ampersand-rust2018.rs:14:17
+  --> $DIR/where-clause-inherent-impl-ampersand-rust2018.rs:15:17
    |
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.fixed
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait WithType<T> {}
 trait WithRegion<'a> { }

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.rs
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+#![allow(dead_code)]
 
 trait WithType<T> {}
 trait WithRegion<'a> { }

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2015.stderr
@@ -1,5 +1,5 @@
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/where-clause-trait-impl-region-2015.rs:10:17
+  --> $DIR/where-clause-trait-impl-region-2015.rs:11:17
    |
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.fixed
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.fixed
@@ -1,6 +1,8 @@
 // run-rustfix
 // edition:2018
 
+#![allow(dead_code)]
+
 trait WithType<T> {}
 trait WithRegion<'a> { }
 

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.rs
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.rs
@@ -1,6 +1,8 @@
 // run-rustfix
 // edition:2018
 
+#![allow(dead_code)]
+
 trait WithType<T> {}
 trait WithRegion<'a> { }
 

--- a/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.stderr
+++ b/tests/ui/underscore-lifetime/where-clause-trait-impl-region-2018.stderr
@@ -1,5 +1,5 @@
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/where-clause-trait-impl-region-2018.rs:11:17
+  --> $DIR/where-clause-trait-impl-region-2018.rs:13:17
    |
 LL |     T: WithType<&u32>
    |                 ^ explicit lifetime name needed here

--- a/tests/ui/where-clauses/issue-50825-1.rs
+++ b/tests/ui/where-clauses/issue-50825-1.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // regression test for issue #50825
 // Make sure that the `impl` bound (): X<T = ()> is preferred over
 // the (): X bound in the where clause.

--- a/tests/ui/where-clauses/where-clause-bounds-inconsistency.rs
+++ b/tests/ui/where-clauses/where-clause-bounds-inconsistency.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 // pretty-expanded FIXME #23616
 
 trait Bound {

--- a/tests/ui/where-clauses/where-clause-early-bound-lifetimes.rs
+++ b/tests/ui/where-clauses/where-clause-early-bound-lifetimes.rs
@@ -3,7 +3,7 @@
 
 // pretty-expanded FIXME #23616
 
-trait TheTrait { fn dummy(&self) { } }
+trait TheTrait { fn dummy(&self) { } } //~ WARN method `dummy` is never used
 
 impl TheTrait for &'static isize { }
 

--- a/tests/ui/where-clauses/where-clause-early-bound-lifetimes.stderr
+++ b/tests/ui/where-clauses/where-clause-early-bound-lifetimes.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/where-clause-early-bound-lifetimes.rs:6:21
+   |
+LL | trait TheTrait { fn dummy(&self) { } }
+   |       --------      ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/where-clauses/where-clause-method-substituion-rpass.rs
+++ b/tests/ui/where-clauses/where-clause-method-substituion-rpass.rs
@@ -2,7 +2,7 @@
 #![allow(unused_variables)]
 // pretty-expanded FIXME #23616
 
-trait Foo<T> { fn dummy(&self, arg: T) { } }
+trait Foo<T> { fn dummy(&self, arg: T) { } } //~ WARN method `dummy` is never used
 
 trait Bar<A> {
     fn method<B>(&self) where A: Foo<B>;

--- a/tests/ui/where-clauses/where-clause-method-substituion-rpass.stderr
+++ b/tests/ui/where-clauses/where-clause-method-substituion-rpass.stderr
@@ -1,0 +1,12 @@
+warning: method `dummy` is never used
+  --> $DIR/where-clause-method-substituion-rpass.rs:5:19
+   |
+LL | trait Foo<T> { fn dummy(&self, arg: T) { } }
+   |       ---         ^^^^^
+   |       |
+   |       method in this trait
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.fixed
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.fixed
@@ -1,6 +1,8 @@
 // check-pass
 // run-rustfix
 
+#![allow(dead_code)]
+
 trait Trait {
     // Fine.
     type Assoc where u32: Copy;

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.rs
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.rs
@@ -1,6 +1,8 @@
 // check-pass
 // run-rustfix
 
+#![allow(dead_code)]
+
 trait Trait {
     // Fine.
     type Assoc where u32: Copy;

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.stderr
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-impl.stderr
@@ -1,5 +1,5 @@
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:13:16
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:15:16
    |
 LL |     type Assoc where u32: Copy = ();
    |                ^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     type Assoc  = () where u32: Copy;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:16:17
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:18:17
    |
 LL |     type Assoc2 where u32: Copy = () where i32: Copy;
    |                 ^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL +     type Assoc2  = () where i32: Copy, u32: Copy;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:24:17
+  --> $DIR/where-clause-placement-assoc-type-in-impl.rs:26:17
    |
 LL |     type Assoc2 where u32: Copy, i32: Copy = ();
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.fixed
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.fixed
@@ -1,6 +1,7 @@
 // check-pass
 // run-rustfix
 
+#![allow(dead_code)]
 #![feature(associated_type_defaults)]
 
 trait Trait {

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.rs
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.rs
@@ -1,6 +1,7 @@
 // check-pass
 // run-rustfix
 
+#![allow(dead_code)]
 #![feature(associated_type_defaults)]
 
 trait Trait {

--- a/tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.stderr
+++ b/tests/ui/where-clauses/where-clause-placement-assoc-type-in-trait.stderr
@@ -1,5 +1,5 @@
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-trait.rs:8:16
+  --> $DIR/where-clause-placement-assoc-type-in-trait.rs:9:16
    |
 LL |     type Assoc where u32: Copy = ();
    |                ^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL +     type Assoc  = () where u32: Copy;
    |
 
 warning: where clause not allowed here
-  --> $DIR/where-clause-placement-assoc-type-in-trait.rs:11:17
+  --> $DIR/where-clause-placement-assoc-type-in-trait.rs:12:17
    |
 LL |     type Assoc2 where u32: Copy = () where i32: Copy;
    |                 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Successful merges:

 - #116090 (Implement strict integer operations that panic on overflow)
 - #118257 (Make traits / trait methods detected by the dead code lint)
 - #119997 (Fix impl stripped in rustdoc HTML whereas it should not be in case the impl is implemented on a type alias)
 - #120027 (pattern_analysis: Remove `Ty: Copy` bound)
 - #120059 (Make generic const type mismatches not hide trait impls from the trait solver)
 - #120116 (Remove alignment-changing in-place collect)
 - #120138 (Increase vscode settings.json `git.detectSubmodulesLimit`)
 - #120145 (fix: Drop guard was deallocating with the incorrect size)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116090,118257,119997,120027,120059,120116,120138,120145)
<!-- homu-ignore:end -->