### PR TITLE
Relocate coroutine upvars into Unresumed state

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1523,8 +1523,7 @@ pub struct LayoutS<FieldIdx: Idx, VariantIdx: Idx> {
 
     /// Encodes information about multi-variant layouts.
     /// Even with `Multiple` variants, a layout still has its own fields! Those are then
-    /// shared between all variants. One of them will be the discriminant,
-    /// but e.g. coroutines can have more.
+    /// shared between all variants. One of them will be the discriminant.
     ///
     /// To access all fields of this layout, both `fields` and the fields of the active variant
     /// must be taken into account.

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -810,6 +810,9 @@ fn codegen_stmt<'tcx>(
                             let variant_dest = lval.downcast_variant(fx, variant_index);
                             (variant_index, variant_dest, active_field_index)
                         }
+                        mir::AggregateKind::Coroutine(_, _) => {
+                            (FIRST_VARIANT, lval.downcast_variant(fx, FIRST_VARIANT), None)
+                        }
                         _ => (FIRST_VARIANT, lval, None),
                     };
                     if active_field_index.is_some() {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1080,7 +1080,7 @@ fn build_upvar_field_di_nodes<'ll, 'tcx>(
     closure_or_coroutine_di_node: &'ll DIType,
 ) -> SmallVec<&'ll DIType> {
     let (&def_id, up_var_tys) = match closure_or_coroutine_ty.kind() {
-        ty::Coroutine(def_id, args) => (def_id, args.as_coroutine().prefix_tys()),
+        ty::Coroutine(def_id, args) => (def_id, args.as_coroutine().upvar_tys()),
         ty::Closure(def_id, args) => (def_id, args.as_closure().upvar_tys()),
         ty::CoroutineClosure(def_id, args) => (def_id, args.as_coroutine_closure().upvar_tys()),
         _ => {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
@@ -686,12 +686,12 @@ fn build_union_fields_for_direct_tag_coroutine<'ll, 'tcx>(
     let coroutine_layout =
         cx.tcx.coroutine_layout(coroutine_def_id, coroutine_args.kind_ty()).unwrap();
 
-    let common_upvar_names = cx.tcx.closure_saved_names_of_captured_variables(coroutine_def_id);
     let variant_range = coroutine_args.variant_range(coroutine_def_id, cx.tcx);
     let variant_count = (variant_range.start.as_u32()..variant_range.end.as_u32()).len();
 
     let tag_base_type = tag_base_type(cx, coroutine_type_and_layout);
 
+    let common_upvar_names = cx.tcx.closure_saved_names_of_captured_variables(coroutine_def_id);
     let variant_names_type_di_node = build_variant_names_type_di_node(
         cx,
         coroutine_type_di_node,

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -126,6 +126,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         let variant_dest = dest.project_downcast(bx, variant_index);
                         (variant_index, variant_dest, active_field_index)
                     }
+                    mir::AggregateKind::Coroutine(_, _) => {
+                        (FIRST_VARIANT, dest.project_downcast(bx, FIRST_VARIANT), None)
+                    }
                     _ => (FIRST_VARIANT, dest, None),
                 };
                 if active_field_index.is_some() {

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -303,6 +303,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let variant_dest = self.project_downcast(dest, variant_index)?;
                 (variant_index, variant_dest, active_field_index)
             }
+            mir::AggregateKind::Coroutine(_def_id, _args) => {
+                (FIRST_VARIANT, self.project_downcast(dest, FIRST_VARIANT)?, None)
+            }
             _ => (FIRST_VARIANT, dest.clone(), None),
         };
         if active_field_index.is_some() {

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -743,14 +743,12 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                             };
 
                             ty::EarlyBinder::bind(f_ty.ty).instantiate(self.tcx, args)
+                        } else if let Some(&ty) = args.as_coroutine().upvar_tys().get(f.as_usize())
+                        {
+                            ty
                         } else {
-                            let Some(&f_ty) = args.as_coroutine().prefix_tys().get(f.index())
-                            else {
-                                fail_out_of_bounds(self, location);
-                                return;
-                            };
-
-                            f_ty
+                            fail_out_of_bounds(self, location);
+                            return;
                         };
 
                         check_equal(self, location, f_ty);

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -51,6 +51,9 @@ pub struct CoroutineLayout<'tcx> {
     /// await).
     pub variant_source_info: IndexVec<VariantIdx, SourceInfo>,
 
+    /// The starting index of upvars.
+    pub upvar_start: CoroutineSavedLocal,
+
     /// Which saved locals are storage-live at the same time. Locals that do not
     /// have conflicts with each other are allowed to overlap in the computed
     /// layout.
@@ -101,6 +104,7 @@ impl Debug for CoroutineLayout<'_> {
         }
 
         fmt.debug_struct("CoroutineLayout")
+            .field("upvar_start", &self.upvar_start)
             .field("field_tys", &MapPrinter::new(self.field_tys.iter_enumerated()))
             .field(
                 "variant_fields",
@@ -110,7 +114,12 @@ impl Debug for CoroutineLayout<'_> {
                         .map(|(k, v)| (GenVariantPrinter(k), OneLinePrinter(v))),
                 ),
             )
+            .field("field_names", &MapPrinter::new(self.field_names.iter_enumerated()))
             .field("storage_conflicts", &self.storage_conflicts)
+            .field(
+                "variant_source_info",
+                &MapPrinter::new(self.variant_source_info.iter_enumerated()),
+            )
             .finish()
     }
 }

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -74,7 +74,11 @@ impl<'tcx> PlaceTy<'tcx> {
         T: ::std::fmt::Debug + Copy,
     {
         if self.variant_index.is_some() && !matches!(elem, ProjectionElem::Field(..)) {
-            bug!("cannot use non field projection on downcasted place")
+            bug!(
+                "cannot use non field projection on downcasted place from {:?} (variant {:?}), got {elem:?}",
+                self.ty,
+                self.variant_index
+            )
         }
         let answer = match *elem {
             ProjectionElem::Deref => {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -856,7 +856,7 @@ where
                         if i == tag_field {
                             return TyMaybeWithLayout::TyAndLayout(tag_layout(tag));
                         }
-                        TyMaybeWithLayout::Ty(args.as_coroutine().prefix_tys()[i])
+                        bug!("coroutine has no prefix field");
                     }
                 },
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -609,7 +609,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
                 witness: witness.expect_ty(),
                 tupled_upvars_ty: tupled_upvars_ty.expect_ty(),
             },
-            _ => bug!("coroutine args missing synthetics"),
+            _ => bug!("coroutine args missing synthetics, got {:?}", self.args),
         }
     }
 
@@ -761,13 +761,6 @@ impl<'tcx> CoroutineArgs<'tcx> {
                 ty::EarlyBinder::bind(layout.field_tys[*field].ty).instantiate(tcx, self.args)
             })
         })
-    }
-
-    /// This is the types of the fields of a coroutine which are not stored in a
-    /// variant.
-    #[inline]
-    pub fn prefix_tys(self) -> &'tcx List<Ty<'tcx>> {
-        self.upvar_tys()
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/framework/engine.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/engine.rs
@@ -288,7 +288,7 @@ where
             }
 
             None if dump_enabled(tcx, A::NAME, def_id) => {
-                create_dump_file(tcx, ".dot", false, A::NAME, &pass_name.unwrap_or("-----"), body)?
+                create_dump_file(tcx, ".dot", true, A::NAME, &pass_name.unwrap_or("-----"), body)?
             }
 
             _ => return (Ok(()), results),

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -1,6 +1,6 @@
 use rustc_index::bit_set::BitSet;
 use rustc_middle::mir::visit::{NonMutatingUseContext, PlaceContext, Visitor};
-use rustc_middle::mir::*;
+use rustc_middle::{mir::*, ty};
 
 use std::borrow::Cow;
 
@@ -23,13 +23,12 @@ impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageLive<'a> {
 
     const NAME: &'static str = "maybe_storage_live";
 
-    fn bottom_value(&self, body: &Body<'tcx>) -> Self::Domain {
+    fn bottom_value(&self, _: &Body<'tcx>) -> Self::Domain {
         // bottom = dead
-        BitSet::new_empty(body.local_decls.len())
+        BitSet::new_empty(self.always_live_locals.domain_size())
     }
 
     fn initialize_start_block(&self, body: &Body<'tcx>, on_entry: &mut Self::Domain) {
-        assert_eq!(body.local_decls.len(), self.always_live_locals.domain_size());
         for local in self.always_live_locals.iter() {
             on_entry.insert(local);
         }
@@ -43,8 +42,8 @@ impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageLive<'a> {
 impl<'tcx, 'a> crate::GenKillAnalysis<'tcx> for MaybeStorageLive<'a> {
     type Idx = Local;
 
-    fn domain_size(&self, body: &Body<'tcx>) -> usize {
-        body.local_decls.len()
+    fn domain_size(&self, _body: &Body<'tcx>) -> usize {
+        self.always_live_locals.domain_size()
     }
 
     fn statement_effect(
@@ -96,13 +95,12 @@ impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageDead<'a> {
 
     const NAME: &'static str = "maybe_storage_dead";
 
-    fn bottom_value(&self, body: &Body<'tcx>) -> Self::Domain {
+    fn bottom_value(&self, _body: &Body<'tcx>) -> Self::Domain {
         // bottom = live
-        BitSet::new_empty(body.local_decls.len())
+        BitSet::new_empty(self.always_live_locals.domain_size())
     }
 
     fn initialize_start_block(&self, body: &Body<'tcx>, on_entry: &mut Self::Domain) {
-        assert_eq!(body.local_decls.len(), self.always_live_locals.domain_size());
         // Do not iterate on return place and args, as they are trivially always live.
         for local in body.vars_and_temps_iter() {
             if !self.always_live_locals.contains(local) {
@@ -115,8 +113,8 @@ impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageDead<'a> {
 impl<'tcx, 'a> crate::GenKillAnalysis<'tcx> for MaybeStorageDead<'a> {
     type Idx = Local;
 
-    fn domain_size(&self, body: &Body<'tcx>) -> usize {
-        body.local_decls.len()
+    fn domain_size(&self, _body: &Body<'tcx>) -> usize {
+        self.always_live_locals.domain_size()
     }
 
     fn statement_effect(
@@ -158,11 +156,18 @@ type BorrowedLocalsResults<'mir, 'tcx> = ResultsCursor<'mir, 'tcx, MaybeBorrowed
 /// given location; i.e. whether its storage can go away without being observed.
 pub struct MaybeRequiresStorage<'mir, 'tcx> {
     borrowed_locals: BorrowedLocalsResults<'mir, 'tcx>,
+    upvars: Option<(Local, usize)>,
 }
 
 impl<'mir, 'tcx> MaybeRequiresStorage<'mir, 'tcx> {
     pub fn new(borrowed_locals: BorrowedLocalsResults<'mir, 'tcx>) -> Self {
-        MaybeRequiresStorage { borrowed_locals }
+        MaybeRequiresStorage { borrowed_locals, upvars: None }
+    }
+    pub fn new_with_upvar(
+        borrowed_locals: BorrowedLocalsResults<'mir, 'tcx>,
+        upvars: (Local, usize),
+    ) -> Self {
+        MaybeRequiresStorage { borrowed_locals, upvars: Some(upvars) }
     }
 }
 
@@ -173,7 +178,7 @@ impl<'tcx> crate::AnalysisDomain<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
 
     fn bottom_value(&self, body: &Body<'tcx>) -> Self::Domain {
         // bottom = dead
-        BitSet::new_empty(body.local_decls.len())
+        BitSet::new_empty(body.local_decls.len() + self.upvars.map_or(0, |(_, nr_upvar)| nr_upvar))
     }
 
     fn initialize_start_block(&self, body: &Body<'tcx>, on_entry: &mut Self::Domain) {
@@ -182,6 +187,13 @@ impl<'tcx> crate::AnalysisDomain<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
         for arg in body.args_iter().skip(1) {
             on_entry.insert(arg);
         }
+        if let Some((upvar_start, nr_upvar)) = self.upvars {
+            assert_eq!(body.local_decls.next_index(), upvar_start);
+            // The upvars requires storage on entry, too.
+            for idx in 0..nr_upvar {
+                on_entry.insert(upvar_start + idx);
+            }
+        }
     }
 }
 
@@ -189,7 +201,7 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
     type Idx = Local;
 
     fn domain_size(&self, body: &Body<'tcx>) -> usize {
-        body.local_decls.len()
+        body.local_decls.len() + self.upvars.map_or(0, |(_, nr_upvar)| nr_upvar)
     }
 
     fn before_statement_effect(
@@ -208,7 +220,18 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
             StatementKind::Assign(box (place, _))
             | StatementKind::SetDiscriminant { box place, .. }
             | StatementKind::Deinit(box place) => {
-                trans.gen(place.local);
+                if place.local == ty::CAPTURE_STRUCT_LOCAL
+                    && let Some((upvar_start, nr_upvar)) = self.upvars
+                {
+                    match **place.projection {
+                        [ProjectionElem::Field(field, _), ..] if field.as_usize() < nr_upvar => {
+                            trans.gen(upvar_start + field.as_usize())
+                        }
+                        _ => bug!("unexpected upvar access"),
+                    }
+                } else {
+                    trans.gen(place.local)
+                }
             }
 
             // Nothing to do for these. Match exhaustively so this fails to compile when new
@@ -250,7 +273,18 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
 
         match &terminator.kind {
             TerminatorKind::Call { destination, .. } => {
-                trans.gen(destination.local);
+                if destination.local == ty::CAPTURE_STRUCT_LOCAL
+                    && let Some((upvar_start, nr_upvar)) = self.upvars
+                {
+                    match **destination.projection {
+                        [ProjectionElem::Field(field, _), ..] if field.as_usize() < nr_upvar => {
+                            trans.gen(upvar_start + field.as_usize())
+                        }
+                        _ => bug!("unexpected upvar access"),
+                    }
+                } else {
+                    trans.gen(destination.local);
+                }
             }
 
             // Note that we do *not* gen the `resume_arg` of `Yield` terminators. The reason for
@@ -265,7 +299,20 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
                         InlineAsmOperand::Out { place, .. }
                         | InlineAsmOperand::InOut { out_place: place, .. } => {
                             if let Some(place) = place {
-                                trans.gen(place.local);
+                                if place.local == ty::CAPTURE_STRUCT_LOCAL
+                                    && let Some((upvar_start, nr_upvar)) = self.upvars
+                                {
+                                    match **place.projection {
+                                        [ProjectionElem::Field(field, _), ..]
+                                            if field.as_usize() < nr_upvar =>
+                                        {
+                                            trans.gen(upvar_start + field.as_usize())
+                                        }
+                                        _ => bug!("unexpected upvar access"),
+                                    }
+                                } else {
+                                    trans.gen(place.local)
+                                }
                             }
                         }
                         InlineAsmOperand::In { .. }
@@ -305,12 +352,56 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
             // Since `propagate_call_unwind` doesn't exist, we have to kill the
             // destination here, and then gen it again in `call_return_effect`.
             TerminatorKind::Call { destination, .. } => {
-                trans.kill(destination.local);
+                if destination.local == ty::CAPTURE_STRUCT_LOCAL
+                    && let Some((upvar_start, nr_upvar)) = self.upvars
+                {
+                    match **destination.projection {
+                        [ProjectionElem::Field(field, _), ..] if field.as_usize() < nr_upvar => {
+                            trans.kill(upvar_start + field.as_usize())
+                        }
+                        _ => bug!("unexpected upvar access"),
+                    }
+                } else {
+                    trans.kill(destination.local);
+                }
             }
 
             // The same applies to InlineAsm outputs.
             TerminatorKind::InlineAsm { ref operands, .. } => {
-                CallReturnPlaces::InlineAsm(operands).for_each(|place| trans.kill(place.local));
+                CallReturnPlaces::InlineAsm(operands).for_each(|place| {
+                    if place.local == ty::CAPTURE_STRUCT_LOCAL
+                        && let Some((upvar_start, nr_upvar)) = self.upvars
+                    {
+                        match **place.projection {
+                            [ProjectionElem::Field(field, _), ..]
+                                if field.as_usize() < nr_upvar =>
+                            {
+                                trans.kill(upvar_start + field.as_usize())
+                            }
+                            _ => bug!("unexpected upvar access"),
+                        }
+                    } else {
+                        trans.kill(place.local)
+                    }
+                });
+            }
+
+            TerminatorKind::Drop { place, .. } => {
+                if place.local == ty::CAPTURE_STRUCT_LOCAL
+                    && let Some((upvar_start, nr_upvar)) = self.upvars
+                {
+                    match **place.projection {
+                        [] => {
+                            for field in 0..nr_upvar {
+                                trans.kill(upvar_start + field)
+                            }
+                        }
+                        [ProjectionElem::Field(field, _), ..] if field.as_usize() < nr_upvar => {
+                            trans.kill(upvar_start + field.as_usize())
+                        }
+                        _ => bug!("unexpected upvar access"),
+                    }
+                }
             }
 
             // Nothing to do for these. Match exhaustively so this fails to compile when new
@@ -318,7 +409,6 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
             TerminatorKind::Yield { .. }
             | TerminatorKind::UnwindTerminate(_)
             | TerminatorKind::Assert { .. }
-            | TerminatorKind::Drop { .. }
             | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
             | TerminatorKind::CoroutineDrop
@@ -339,7 +429,20 @@ impl<'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'_, 'tcx> {
         _block: BasicBlock,
         return_places: CallReturnPlaces<'_, 'tcx>,
     ) {
-        return_places.for_each(|place| trans.gen(place.local));
+        return_places.for_each(|place| {
+            if place.local == ty::CAPTURE_STRUCT_LOCAL
+                && let Some((upvar_start, nr_upvar)) = self.upvars
+            {
+                match **place.projection {
+                    [ProjectionElem::Field(field, _), ..] if field.as_usize() < nr_upvar => {
+                        trans.gen(upvar_start + field.as_usize())
+                    }
+                    _ => bug!("unexpected upvar access"),
+                }
+            } else {
+                trans.gen(place.local)
+            }
+        });
     }
 }
 
@@ -347,7 +450,11 @@ impl<'tcx> MaybeRequiresStorage<'_, 'tcx> {
     /// Kill locals that are fully moved and have not been borrowed.
     fn check_for_move(&mut self, trans: &mut impl GenKill<Local>, loc: Location) {
         let body = self.borrowed_locals.body();
-        let mut visitor = MoveVisitor { trans, borrowed_locals: &mut self.borrowed_locals };
+        let mut visitor = MoveVisitor {
+            trans,
+            borrowed_locals: &mut self.borrowed_locals,
+            upvar_start: self.upvars.map(|(upvar_start, _)| upvar_start),
+        };
         visitor.visit_location(body, loc);
     }
 }
@@ -355,6 +462,7 @@ impl<'tcx> MaybeRequiresStorage<'_, 'tcx> {
 struct MoveVisitor<'a, 'mir, 'tcx, T> {
     borrowed_locals: &'a mut BorrowedLocalsResults<'mir, 'tcx>,
     trans: &'a mut T,
+    upvar_start: Option<Local>,
 }
 
 impl<'tcx, T> Visitor<'tcx> for MoveVisitor<'_, '_, 'tcx, T>
@@ -362,11 +470,28 @@ where
     T: GenKill<Local>,
 {
     fn visit_local(&mut self, local: Local, context: PlaceContext, loc: Location) {
-        if PlaceContext::NonMutatingUse(NonMutatingUseContext::Move) == context {
+        if matches!(context, PlaceContext::NonMutatingUse(NonMutatingUseContext::Move)) {
             self.borrowed_locals.seek_before_primary_effect(loc);
             if !self.borrowed_locals.contains(local) {
                 self.trans.kill(local);
             }
+        }
+    }
+    fn visit_operand(&mut self, operand: &Operand<'tcx>, location: Location) {
+        if let (
+            Operand::Move(Place { local: ty::CAPTURE_STRUCT_LOCAL, projection }),
+            Some(upvar_start),
+        ) = (operand, self.upvar_start)
+            && let [ProjectionElem::Field(field, _)] = ***projection
+        {
+            // QUESTION: what to do with subprojection?
+            self.borrowed_locals.seek_before_primary_effect(location);
+            let local = upvar_start + field.as_usize();
+            if !self.borrowed_locals.contains(local) {
+                self.trans.kill(local);
+            }
+        } else {
+            self.super_operand(operand, location);
         }
     }
 }

--- a/compiler/rustc_mir_dataflow/src/rustc_peek.rs
+++ b/compiler/rustc_mir_dataflow/src/rustc_peek.rs
@@ -74,7 +74,8 @@ impl<'tcx> MirPass<'tcx> for SanityCheck {
         }
 
         if has_rustc_mir_with(tcx, def_id, sym::rustc_peek_liveness).is_some() {
-            let flow_liveness = MaybeLiveLocals.into_engine(tcx, body).iterate_to_fixpoint();
+            let flow_liveness =
+                MaybeLiveLocals { upvars: None }.into_engine(tcx, body).iterate_to_fixpoint();
 
             sanity_check_via_rustc_peek(tcx, flow_liveness.into_results_cursor(body));
         }

--- a/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/by_move_body.rs
@@ -223,6 +223,7 @@ impl<'tcx> MirPass<'tcx> for ByMoveBody {
             );
 
         let mut by_move_body = body.clone();
+        by_move_body.local_decls[ty::CAPTURE_STRUCT_LOCAL].ty = by_move_coroutine_ty;
         MakeByMoveBody { tcx, field_remapping, by_move_coroutine_ty }.visit_body(&mut by_move_body);
         dump_mir(tcx, false, "coroutine_by_move", &0, &by_move_body, |_, _| Ok(()));
         // FIXME: use query feeding to generate the body right here and then only store the `DefId` of the new body.

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -69,7 +69,8 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
                 }
 
                 // Account that `arg` is read from, so we don't promote another argument to a move.
-                LivenessTransferFunction(&mut state).visit_operand(arg, loc);
+                LivenessTransferFunction { trans: &mut state, upvars: None }
+                    .visit_operand(arg, loc);
             }
         }
 

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -169,7 +169,7 @@ impl<'tcx> MirPass<'tcx> for DestinationPropagation {
 
         let borrowed = rustc_mir_dataflow::impls::borrowed_locals(body);
 
-        let live = MaybeLiveLocals
+        let live = MaybeLiveLocals { upvars: None }
             .into_engine(tcx, body)
             .pass_name("MaybeLiveLocals-DestinationPropagation")
             .iterate_to_fixpoint();

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -26,9 +26,8 @@ pub fn provide(providers: &mut Providers) {
     providers.mir_shims = make_shim;
 }
 
+#[instrument(level = "debug", skip(tcx))]
 fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'tcx> {
-    debug!("make_shim({:?})", instance);
-
     let mut result = match instance {
         ty::InstanceDef::Item(..) => bug!("item {:?} passed to make_shim", instance),
         ty::InstanceDef::VTableShim(def_id) => {
@@ -206,9 +205,8 @@ fn local_decls_for_sig<'tcx>(
         .collect()
 }
 
+#[instrument(level = "debug", skip(tcx))]
 fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>) -> Body<'tcx> {
-    debug!("build_drop_shim(def_id={:?}, ty={:?})", def_id, ty);
-
     assert!(!matches!(ty, Some(ty) if ty.is_coroutine()));
 
     let args = if let Some(ty) = ty {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2414,8 +2414,12 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             && let Some(coroutine_info) = self.tcx.mir_coroutine_witnesses(coroutine_did)
         {
             debug!(?coroutine_info);
-            'find_source: for (variant, source_info) in
-                coroutine_info.variant_fields.iter().zip(&coroutine_info.variant_source_info)
+            // The first variant is a collection of upvars, which is handled below
+            'find_source: for (variant, source_info) in coroutine_info
+                .variant_fields
+                .iter()
+                .zip(&coroutine_info.variant_source_info)
+                .skip(1)
             {
                 debug!(?variant);
                 for &local in variant {
@@ -3203,8 +3207,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         let parent_trait_ref =
                             self.resolve_vars_if_possible(data.parent_trait_pred);
                         let nested_ty = parent_trait_ref.skip_binder().self_ty();
-                        matches!(nested_ty.kind(), ty::Coroutine(..))
-                            || matches!(nested_ty.kind(), ty::Closure(..))
+                        matches!(nested_ty.kind(), ty::Coroutine(..) | ty::Closure(..))
                     } else {
                         false
                     }

--- a/src/tools/clippy/tests/ui/await_holding_lock.rs
+++ b/src/tools/clippy/tests/ui/await_holding_lock.rs
@@ -4,7 +4,7 @@
 // When adding or modifying a test, please do the same for parking_lot::Mutex.
 mod std_mutex {
     use super::baz;
-    use std::sync::{Mutex, RwLock};
+    use std::sync::{Mutex, MutexGuard, RwLock};
 
     pub async fn bad(x: &Mutex<u32>) -> u32 {
         let guard = x.lock().unwrap();
@@ -59,6 +59,11 @@ mod std_mutex {
         let third = baz().await;
 
         first + second + third
+    }
+
+    pub async fn equally_bad(x: MutexGuard<'_, u32>) {
+        //~^ ERROR: this `MutexGuard` is passed in through an argument or captured by the closure body
+        drop(x);
     }
 
     pub async fn not_good(x: &Mutex<u32>) -> u32 {

--- a/src/tools/clippy/tests/ui/await_holding_lock.stderr
+++ b/src/tools/clippy/tests/ui/await_holding_lock.stderr
@@ -55,80 +55,88 @@ LL |
 LL |         let third = baz().await;
    |                           ^^^^^
 
+error: this `MutexGuard` is passed in through an argument or captured by the closure body
+  --> tests/ui/await_holding_lock.rs:64:30
+   |
+LL |     pub async fn equally_bad(x: MutexGuard<'_, u32>) {
+   |                              ^
+   |
+   = help: consider using an async-aware `Mutex` type
+
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:68:17
+  --> tests/ui/await_holding_lock.rs:73:17
    |
 LL |             let guard = x.lock().unwrap();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:70:19
+  --> tests/ui/await_holding_lock.rs:75:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:81:17
+  --> tests/ui/await_holding_lock.rs:86:17
    |
 LL |             let guard = x.lock().unwrap();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:83:19
+  --> tests/ui/await_holding_lock.rs:88:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:94:13
+  --> tests/ui/await_holding_lock.rs:99:13
    |
 LL |         let guard = x.lock();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:96:15
+  --> tests/ui/await_holding_lock.rs:101:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:110:13
+  --> tests/ui/await_holding_lock.rs:115:13
    |
 LL |         let guard = x.read();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:112:15
+  --> tests/ui/await_holding_lock.rs:117:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:116:13
+  --> tests/ui/await_holding_lock.rs:121:13
    |
 LL |         let mut guard = x.write();
    |             ^^^^^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:118:15
+  --> tests/ui/await_holding_lock.rs:123:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:138:13
+  --> tests/ui/await_holding_lock.rs:143:13
    |
 LL |         let guard = x.lock();
    |             ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:141:28
+  --> tests/ui/await_holding_lock.rs:146:28
    |
 LL |         let second = baz().await;
    |                            ^^^^^
@@ -137,43 +145,43 @@ LL |         let third = baz().await;
    |                           ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:152:17
+  --> tests/ui/await_holding_lock.rs:157:17
    |
 LL |             let guard = x.lock();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:154:19
+  --> tests/ui/await_holding_lock.rs:159:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:165:17
+  --> tests/ui/await_holding_lock.rs:170:17
    |
 LL |             let guard = x.lock();
    |                 ^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:167:19
+  --> tests/ui/await_holding_lock.rs:172:19
    |
 LL |             baz().await
    |                   ^^^^^
 
 error: this `MutexGuard` is held across an `await` point
-  --> tests/ui/await_holding_lock.rs:186:9
+  --> tests/ui/await_holding_lock.rs:191:9
    |
 LL |     let mut guard = x.lock().unwrap();
    |         ^^^^^^^^^
    |
    = help: consider using an async-aware `Mutex` type or ensuring the `MutexGuard` is dropped before calling await
 note: these are all the `await` points this lock is held through
-  --> tests/ui/await_holding_lock.rs:190:11
+  --> tests/ui/await_holding_lock.rs:195:11
    |
 LL |     baz().await;
    |           ^^^^^
 
-error: aborting due to 13 previous errors
+error: aborting due to 14 previous errors
 

--- a/src/tools/clippy/tests/ui/await_holding_refcell_ref.rs
+++ b/src/tools/clippy/tests/ui/await_holding_refcell_ref.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::await_holding_refcell_ref)]
 
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 
 async fn bad(x: &RefCell<u32>) -> u32 {
     let b = x.borrow();
@@ -39,6 +39,10 @@ async fn also_bad(x: &RefCell<u32>) -> u32 {
     let third = baz().await;
 
     first + second + third
+}
+
+async fn equally_bad(x: Ref<'_, u32>) {
+    //~^ ERROR: this `RefCell` reference is passed in through an argument or captured
 }
 
 async fn less_bad(x: &RefCell<u32>) -> u32 {

--- a/src/tools/clippy/tests/ui/await_holding_refcell_ref.stderr
+++ b/src/tools/clippy/tests/ui/await_holding_refcell_ref.stderr
@@ -42,44 +42,52 @@ LL |
 LL |     let third = baz().await;
    |                       ^^^^^
 
+error: this `RefCell` reference is passed in through an argument or captured by the closure body
+  --> tests/ui/await_holding_refcell_ref.rs:44:22
+   |
+LL | async fn equally_bad(x: Ref<'_, u32>) {
+   |                      ^
+   |
+   = help: ensure the `RefCell` reference is not passed as an argument, captured or kept before calling `await`
+
 error: this `RefCell` reference is held across an `await` point
-  --> tests/ui/await_holding_refcell_ref.rs:47:9
+  --> tests/ui/await_holding_refcell_ref.rs:51:9
    |
 LL |     let b = x.borrow_mut();
    |         ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the `await` points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:50:24
+  --> tests/ui/await_holding_refcell_ref.rs:54:24
    |
 LL |     let second = baz().await;
    |                        ^^^^^
 
 error: this `RefCell` reference is held across an `await` point
-  --> tests/ui/await_holding_refcell_ref.rs:63:13
+  --> tests/ui/await_holding_refcell_ref.rs:67:13
    |
 LL |         let b = x.borrow_mut();
    |             ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the `await` points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:65:15
+  --> tests/ui/await_holding_refcell_ref.rs:69:15
    |
 LL |         baz().await
    |               ^^^^^
 
 error: this `RefCell` reference is held across an `await` point
-  --> tests/ui/await_holding_refcell_ref.rs:76:13
+  --> tests/ui/await_holding_refcell_ref.rs:80:13
    |
 LL |         let b = x.borrow_mut();
    |             ^
    |
    = help: ensure the reference is dropped before calling `await`
 note: these are all the `await` points this reference is held through
-  --> tests/ui/await_holding_refcell_ref.rs:78:15
+  --> tests/ui/await_holding_refcell_ref.rs:82:15
    |
 LL |         baz().await
    |               ^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/future_not_send.stderr
+++ b/src/tools/clippy/tests/ui/future_not_send.stderr
@@ -13,11 +13,14 @@ LL |
 LL |     async { true }.await
    |                    ^^^^^ await occurs here, with `rc` maybe used later
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Send`
-note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> tests/ui/future_not_send.rs:7:39
+note: future is not `Send` as this value is used across an await
+  --> tests/ui/future_not_send.rs:9:20
    |
 LL | async fn private_future(rc: Rc<[u8]>, cell: &Cell<usize>) -> bool {
-   |                                       ^^^^ has type `&std::cell::Cell<usize>` which is not `Send`, because `std::cell::Cell<usize>` is not `Sync`
+   |                                       ---- has type `&std::cell::Cell<usize>` which is not `Send`
+LL |
+LL |     async { true }.await
+   |                    ^^^^^ await occurs here, with `cell` maybe used later
    = note: `std::cell::Cell<usize>` doesn't implement `std::marker::Sync`
    = note: `-D clippy::future-not-send` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::future_not_send)]`
@@ -92,11 +95,14 @@ error: future cannot be sent between threads safely
 LL |     pub async fn public_future(&self) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `public_future` is not `Send`
    |
-note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> tests/ui/future_not_send.rs:44:32
+note: future is not `Send` as this value is used across an await
+  --> tests/ui/future_not_send.rs:46:31
    |
 LL |     pub async fn public_future(&self) {
-   |                                ^^^^^ has type `&Dummy` which is not `Send`, because `Dummy` is not `Sync`
+   |                                 ---- has type `&Dummy` which is not `Send`
+LL |
+LL |         self.private_future().await;
+   |                               ^^^^^ await occurs here, with `self` maybe used later
    = note: `std::rc::Rc<[u8]>` doesn't implement `std::marker::Sync`
 
 error: future cannot be sent between threads safely

--- a/src/tools/clippy/tests/ui/large_futures.fixed
+++ b/src/tools/clippy/tests/ui/large_futures.fixed
@@ -33,7 +33,7 @@ pub async fn test() {
     Box::pin(foo()).await;
     //~^ ERROR: large future with a size of 65540 bytes
     Box::pin(calls_fut(fut)).await;
-    //~^ ERROR: large future with a size of 49159 bytes
+    //~^ ERROR: large future with a size of 32774 bytes
 }
 
 pub fn foo() -> impl std::future::Future<Output = ()> {

--- a/src/tools/clippy/tests/ui/large_futures.rs
+++ b/src/tools/clippy/tests/ui/large_futures.rs
@@ -33,7 +33,7 @@ pub async fn test() {
     foo().await;
     //~^ ERROR: large future with a size of 65540 bytes
     calls_fut(fut).await;
-    //~^ ERROR: large future with a size of 49159 bytes
+    //~^ ERROR: large future with a size of 32774 bytes
 }
 
 pub fn foo() -> impl std::future::Future<Output = ()> {

--- a/src/tools/clippy/tests/ui/large_futures.stderr
+++ b/src/tools/clippy/tests/ui/large_futures.stderr
@@ -31,7 +31,7 @@ error: large future with a size of 65540 bytes
 LL |     foo().await;
    |     ^^^^^ help: consider `Box::pin` on it: `Box::pin(foo())`
 
-error: large future with a size of 49159 bytes
+error: large future with a size of 32774 bytes
   --> tests/ui/large_futures.rs:35:5
    |
 LL |     calls_fut(fut).await;

--- a/src/tools/clippy/tests/ui/needless_lifetimes.fixed
+++ b/src/tools/clippy/tests/ui/needless_lifetimes.fixed
@@ -533,6 +533,7 @@ mod issue5787 {
 
     impl Foo {
         // doesn't get linted without async
+        #[allow(clippy::await_holding_lock)]
         pub async fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
             guard
         }

--- a/src/tools/clippy/tests/ui/needless_lifetimes.rs
+++ b/src/tools/clippy/tests/ui/needless_lifetimes.rs
@@ -533,6 +533,7 @@ mod issue5787 {
 
     impl Foo {
         // doesn't get linted without async
+        #[allow(clippy::await_holding_lock)]
         pub async fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
             guard
         }

--- a/tests/debuginfo/coroutine-objects.rs
+++ b/tests/debuginfo/coroutine-objects.rs
@@ -11,16 +11,16 @@
 
 // gdb-command:run
 // gdb-command:print b
-// gdb-check:$1 = coroutine_objects::main::{coroutine_env#0}::Unresumed{_ref__a: 0x[...]}
+// gdb-check:$1 = coroutine_objects::main::{coroutine_env#0}::Unresumed{a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$2 = coroutine_objects::main::{coroutine_env#0}::Suspend0{c: 6, d: 7, _ref__a: 0x[...]}
+// gdb-check:$2 = coroutine_objects::main::{coroutine_env#0}::Suspend0{c: 6, d: 7, a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$3 = coroutine_objects::main::{coroutine_env#0}::Suspend1{c: 7, d: 8, _ref__a: 0x[...]}
+// gdb-check:$3 = coroutine_objects::main::{coroutine_env#0}::Suspend1{c: 7, d: 8, a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$4 = coroutine_objects::main::{coroutine_env#0}::Returned{_ref__a: 0x[...]}
+// gdb-check:$4 = coroutine_objects::main::{coroutine_env#0}::Returned
 
 // === LLDB TESTS ==================================================================================
 

--- a/tests/mir-opt/building/async_await.a-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.a-{closure#0}.coroutine_resume.0.mir
@@ -1,12 +1,28 @@
 // MIR for `a::{closure#0}` 0 coroutine_resume
 /* coroutine_layout = CoroutineLayout {
+    upvar_start: _0,
     field_tys: {},
     variant_fields: {
         Unresumed(0): [],
         Returned (1): [],
         Panicked (2): [],
     },
+    field_names: {},
     storage_conflicts: BitMatrix(0x0) {},
+    variant_source_info: {
+        0: SourceInfo {
+            span: $DIR/async_await.rs:12:14: 12:14 (#0),
+            scope: scope[0],
+        },
+        1: SourceInfo {
+            span: $DIR/async_await.rs:12:16: 12:16 (#0),
+            scope: scope[0],
+        },
+        2: SourceInfo {
+            span: $DIR/async_await.rs:12:16: 12:16 (#0),
+            scope: scope[0],
+        },
+    },
 } */
 
 fn a::{closure#0}(_1: Pin<&mut {async fn body of a()}>, _2: &mut Context<'_>) -> Poll<()> {

--- a/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
@@ -1,5 +1,6 @@
 // MIR for `b::{closure#0}` 0 coroutine_resume
 /* coroutine_layout = CoroutineLayout {
+    upvar_start: _2,
     field_tys: {
         _0: CoroutineSavedTy {
             ty: Coroutine(
@@ -45,9 +46,39 @@
         Suspend0 (3): [_0],
         Suspend1 (4): [_1],
     },
+    field_names: {
+        _0: Some(
+            "__awaitee",
+        ),
+        _1: Some(
+            "__awaitee",
+        ),
+    },
     storage_conflicts: BitMatrix(2x2) {
         (_0, _0),
         (_1, _1),
+    },
+    variant_source_info: {
+        0: SourceInfo {
+            span: $DIR/async_await.rs:15:18: 15:18 (#0),
+            scope: scope[0],
+        },
+        1: SourceInfo {
+            span: $DIR/async_await.rs:18:2: 18:2 (#0),
+            scope: scope[0],
+        },
+        2: SourceInfo {
+            span: $DIR/async_await.rs:18:2: 18:2 (#0),
+            scope: scope[0],
+        },
+        3: SourceInfo {
+            span: $DIR/async_await.rs:16:9: 16:14 (#8),
+            scope: scope[1],
+        },
+        4: SourceInfo {
+            span: $DIR/async_await.rs:17:9: 17:14 (#10),
+            scope: scope[3],
+        },
     },
 } */
 

--- a/tests/mir-opt/coroutine_tiny.main-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/coroutine_tiny.main-{closure#0}.coroutine_resume.0.mir
@@ -1,5 +1,6 @@
 // MIR for `main::{closure#0}` 0 coroutine_resume
 /* coroutine_layout = CoroutineLayout {
+    upvar_start: _1,
     field_tys: {
         _0: CoroutineSavedTy {
             ty: HasDrop,
@@ -16,8 +17,31 @@
         Panicked (2): [],
         Suspend0 (3): [_0],
     },
+    field_names: {
+        _0: Some(
+            "_d",
+        ),
+    },
     storage_conflicts: BitMatrix(1x1) {
         (_0, _0),
+    },
+    variant_source_info: {
+        0: SourceInfo {
+            span: $DIR/coroutine_tiny.rs:20:16: 20:16 (#0),
+            scope: scope[0],
+        },
+        1: SourceInfo {
+            span: $DIR/coroutine_tiny.rs:26:6: 26:6 (#0),
+            scope: scope[0],
+        },
+        2: SourceInfo {
+            span: $DIR/coroutine_tiny.rs:26:6: 26:6 (#0),
+            scope: scope[0],
+        },
+        3: SourceInfo {
+            span: $DIR/coroutine_tiny.rs:23:13: 23:18 (#0),
+            scope: scope[1],
+        },
     },
 } */
 

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
@@ -22,7 +22,7 @@
               }
 +             scope 6 (inlined ActionPermit::<'_, T>::perform::{closure#0}) {
 +                 debug _task_context => _31;
-+                 debug self => ((*(_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()})).0: ActionPermit<'_, T>);
++                 debug self => (((*(_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()})) as variant#0).0: ActionPermit<'_, T>);
 +                 let _11: ActionPermit<'_, T>;
 +                 let mut _12: std::future::Ready<()>;
 +                 let mut _13: std::future::Ready<()>;
@@ -162,7 +162,7 @@
 +         _31 = move _9;
 +         _34 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _35 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         (((*_34) as variant#3).0: ActionPermit<'_, T>) = move ((*_35).0: ActionPermit<'_, T>);
++         (((*_34) as variant#3).0: ActionPermit<'_, T>) = move (((*_35) as variant#0).0: ActionPermit<'_, T>);
 +         StorageLive(_12);
 +         StorageLive(_13);
 +         StorageLive(_14);

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
@@ -22,7 +22,7 @@
               }
 +             scope 6 (inlined ActionPermit::<'_, T>::perform::{closure#0}) {
 +                 debug _task_context => _31;
-+                 debug self => ((*(_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()})).0: ActionPermit<'_, T>);
++                 debug self => (((*(_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()})) as variant#0).0: ActionPermit<'_, T>);
 +                 let _11: ActionPermit<'_, T>;
 +                 let mut _12: std::future::Ready<()>;
 +                 let mut _13: std::future::Ready<()>;
@@ -179,7 +179,7 @@
 +         _31 = move _9;
 +         _34 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _35 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         (((*_34) as variant#3).0: ActionPermit<'_, T>) = move ((*_35).0: ActionPermit<'_, T>);
++         (((*_34) as variant#3).0: ActionPermit<'_, T>) = move (((*_35) as variant#0).0: ActionPermit<'_, T>);
 +         StorageLive(_12);
 +         StorageLive(_13);
 +         StorageLive(_14);

--- a/tests/ui/async-await/awaiting-unsized-param.rs
+++ b/tests/ui/async-await/awaiting-unsized-param.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 
 async fn bug<T>(mut f: dyn Future<Output = T> + Unpin) -> T {
     //~^ ERROR the size for values of type `(dyn Future<Output = T> + Unpin + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `dyn Future<Output = T> + Unpin` cannot be known at compilation time
     (&mut f).await
 }
 

--- a/tests/ui/async-await/awaiting-unsized-param.stderr
+++ b/tests/ui/async-await/awaiting-unsized-param.stderr
@@ -16,6 +16,15 @@ LL | async fn bug<T>(mut f: dyn Future<Output = T> + Unpin) -> T {
    = help: the trait `Sized` is not implemented for `(dyn Future<Output = T> + Unpin + 'static)`
    = note: all values captured by value by a closure must have a statically known size
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0277]: the size for values of type `dyn Future<Output = T> + Unpin` cannot be known at compilation time
+  --> $DIR/awaiting-unsized-param.rs:8:21
+   |
+LL | async fn bug<T>(mut f: dyn Future<Output = T> + Unpin) -> T {
+   |                     ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn Future<Output = T> + Unpin`
+   = note: all values live across `await` must have a statically known size
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
@@ -1,41 +1,35 @@
-print-type-size type: `{async fn body of test()}`: 3078 bytes, alignment: 1 bytes
+print-type-size type: `{async fn body of test()}`: 2053 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
-print-type-size     variant `Suspend0`: 3077 bytes
-print-type-size         local `.__awaitee`: 3077 bytes, type: {async fn body of calls_fut<{async fn body of big_fut()}>()}
+print-type-size     variant `Suspend0`: 2052 bytes
+print-type-size         local `.__awaitee`: 2052 bytes, type: {async fn body of calls_fut<{async fn body of big_fut()}>()}
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 3077 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 3077 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 3077 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 3077 bytes
+print-type-size type: `std::mem::ManuallyDrop<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 2052 bytes, alignment: 1 bytes
+print-type-size     field `.value`: 2052 bytes
+print-type-size type: `std::mem::MaybeUninit<{async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 2052 bytes, alignment: 1 bytes
+print-type-size     variant `MaybeUninit`: 2052 bytes
 print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 3077 bytes
-print-type-size type: `{async fn body of calls_fut<{async fn body of big_fut()}>()}`: 3077 bytes, alignment: 1 bytes
+print-type-size         field `.value`: 2052 bytes
+print-type-size type: `{async fn body of calls_fut<{async fn body of big_fut()}>()}`: 2052 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
-print-type-size     variant `Unresumed`: 1025 bytes
-print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size     variant `Suspend0`: 2052 bytes
-print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size         padding: 1 bytes
+print-type-size     variant `Unresumed`: 2051 bytes
+print-type-size         padding: 1026 bytes
 print-type-size         local `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size     variant `Suspend0`: 1027 bytes
+print-type-size         local `.fut`: 1025 bytes
 print-type-size         local `..coroutine_field4`: 1 bytes, type: bool
 print-type-size         local `.__awaitee`: 1 bytes, type: {async fn body of wait()}
-print-type-size     variant `Suspend1`: 3076 bytes
-print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size         padding: 1026 bytes
+print-type-size     variant `Suspend1`: 2051 bytes
+print-type-size         padding: 1025 bytes
 print-type-size         local `..coroutine_field4`: 1 bytes, alignment: 1 bytes, type: bool
 print-type-size         local `.__awaitee`: 1025 bytes, type: {async fn body of big_fut()}
-print-type-size     variant `Suspend2`: 2052 bytes
-print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size         padding: 1 bytes
-print-type-size         local `.fut`: 1025 bytes, alignment: 1 bytes
+print-type-size     variant `Suspend2`: 1027 bytes
+print-type-size         local `.fut`: 1025 bytes
 print-type-size         local `..coroutine_field4`: 1 bytes, type: bool
 print-type-size         local `.__awaitee`: 1 bytes, type: {async fn body of wait()}
-print-type-size     variant `Returned`: 1025 bytes
-print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
-print-type-size     variant `Panicked`: 1025 bytes
-print-type-size         upvar `.fut`: 1025 bytes, offset: 0 bytes, alignment: 1 bytes
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `std::mem::ManuallyDrop<{async fn body of big_fut()}>`: 1025 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1025 bytes
 print-type-size type: `std::mem::MaybeUninit<{async fn body of big_fut()}>`: 1025 bytes, alignment: 1 bytes
@@ -45,11 +39,15 @@ print-type-size         field `.value`: 1025 bytes
 print-type-size type: `{async fn body of big_fut()}`: 1025 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.arg`: 1024 bytes
-print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.arg`: 1024 bytes
-print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.arg`: 1024 bytes
+print-type-size         local `.arg`: 1024 bytes
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
+print-type-size type: `std::mem::ManuallyDrop<[u8; 1024]>`: 1024 bytes, alignment: 1 bytes
+print-type-size     field `.value`: 1024 bytes
+print-type-size type: `std::mem::MaybeUninit<[u8; 1024]>`: 1024 bytes, alignment: 1 bytes
+print-type-size     variant `MaybeUninit`: 1024 bytes
+print-type-size         field `.uninit`: 0 bytes
+print-type-size         field `.value`: 1024 bytes
 print-type-size type: `std::mem::ManuallyDrop<bool>`: 1 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1 bytes
 print-type-size type: `std::mem::ManuallyDrop<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes

--- a/tests/ui/async-await/future-sizes/future-as-arg.rs
+++ b/tests/ui/async-await/future-sizes/future-as-arg.rs
@@ -8,9 +8,10 @@ async fn use_future(fut: impl std::future::Future<Output = ()>) {
 }
 
 fn main() {
-    let actual = std::mem::size_of_val(
-        &use_future(use_future(use_future(use_future(use_future(test([0; 16])))))));
+    let actual = std::mem::size_of_val(&use_future(use_future(use_future(use_future(
+        use_future(test([0; 16])),
+    )))));
     // Not using an exact number in case it slightly changes over different commits
     let expected = 550;
-    assert!(actual > expected, "expected: >{expected}, actual: {actual}");
+    assert!(actual < expected, "expected: >{expected}, actual: {actual}");
 }

--- a/tests/ui/async-await/future-sizes/large-arg.stdout
+++ b/tests/ui/async-await/future-sizes/large-arg.stdout
@@ -1,44 +1,38 @@
-print-type-size type: `{async fn body of test()}`: 3076 bytes, alignment: 1 bytes
+print-type-size type: `{async fn body of test()}`: 1028 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 0 bytes
-print-type-size     variant `Suspend0`: 3075 bytes
-print-type-size         local `.__awaitee`: 3075 bytes, type: {async fn body of a<[u8; 1024]>()}
+print-type-size     variant `Suspend0`: 1027 bytes
+print-type-size         local `.__awaitee`: 1027 bytes, type: {async fn body of a<[u8; 1024]>()}
 print-type-size     variant `Returned`: 0 bytes
 print-type-size     variant `Panicked`: 0 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of a<[u8; 1024]>()}>`: 3075 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 3075 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of a<[u8; 1024]>()}>`: 3075 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 3075 bytes
+print-type-size type: `std::mem::ManuallyDrop<{async fn body of a<[u8; 1024]>()}>`: 1027 bytes, alignment: 1 bytes
+print-type-size     field `.value`: 1027 bytes
+print-type-size type: `std::mem::MaybeUninit<{async fn body of a<[u8; 1024]>()}>`: 1027 bytes, alignment: 1 bytes
+print-type-size     variant `MaybeUninit`: 1027 bytes
 print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 3075 bytes
-print-type-size type: `{async fn body of a<[u8; 1024]>()}`: 3075 bytes, alignment: 1 bytes
+print-type-size         field `.value`: 1027 bytes
+print-type-size type: `{async fn body of a<[u8; 1024]>()}`: 1027 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size     variant `Suspend0`: 3074 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size         local `.__awaitee`: 2050 bytes, type: {async fn body of b<[u8; 1024]>()}
-print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size type: `std::mem::ManuallyDrop<{async fn body of b<[u8; 1024]>()}>`: 2050 bytes, alignment: 1 bytes
-print-type-size     field `.value`: 2050 bytes
-print-type-size type: `std::mem::MaybeUninit<{async fn body of b<[u8; 1024]>()}>`: 2050 bytes, alignment: 1 bytes
-print-type-size     variant `MaybeUninit`: 2050 bytes
+print-type-size         local `.t`: 1024 bytes
+print-type-size     variant `Suspend0`: 1026 bytes
+print-type-size         local `.__awaitee`: 1026 bytes, type: {async fn body of b<[u8; 1024]>()}
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
+print-type-size type: `std::mem::ManuallyDrop<{async fn body of b<[u8; 1024]>()}>`: 1026 bytes, alignment: 1 bytes
+print-type-size     field `.value`: 1026 bytes
+print-type-size type: `std::mem::MaybeUninit<{async fn body of b<[u8; 1024]>()}>`: 1026 bytes, alignment: 1 bytes
+print-type-size     variant `MaybeUninit`: 1026 bytes
 print-type-size         field `.uninit`: 0 bytes
-print-type-size         field `.value`: 2050 bytes
-print-type-size type: `{async fn body of b<[u8; 1024]>()}`: 2050 bytes, alignment: 1 bytes
+print-type-size         field `.value`: 1026 bytes
+print-type-size type: `{async fn body of b<[u8; 1024]>()}`: 1026 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size     variant `Suspend0`: 2049 bytes
-print-type-size         upvar `.t`: 1024 bytes
+print-type-size         local `.t`: 1024 bytes
+print-type-size     variant `Suspend0`: 1025 bytes
 print-type-size         local `.__awaitee`: 1025 bytes, type: {async fn body of c<[u8; 1024]>()}
-print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `std::mem::ManuallyDrop<{async fn body of c<[u8; 1024]>()}>`: 1025 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1025 bytes
 print-type-size type: `std::mem::MaybeUninit<{async fn body of c<[u8; 1024]>()}>`: 1025 bytes, alignment: 1 bytes
@@ -53,8 +47,12 @@ print-type-size     variant `Pending`: 0 bytes
 print-type-size type: `{async fn body of c<[u8; 1024]>()}`: 1025 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size     variant `Returned`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
-print-type-size     variant `Panicked`: 1024 bytes
-print-type-size         upvar `.t`: 1024 bytes
+print-type-size         local `.t`: 1024 bytes
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
+print-type-size type: `std::mem::ManuallyDrop<[u8; 1024]>`: 1024 bytes, alignment: 1 bytes
+print-type-size     field `.value`: 1024 bytes
+print-type-size type: `std::mem::MaybeUninit<[u8; 1024]>`: 1024 bytes, alignment: 1 bytes
+print-type-size     variant `MaybeUninit`: 1024 bytes
+print-type-size         field `.uninit`: 0 bytes
+print-type-size         field `.value`: 1024 bytes

--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
@@ -3,6 +3,9 @@ error[E0733]: recursion in an async fn requires boxing
    |
 LL |     async fn second(self) {
    |     ^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         self.first().await.second().await;
+   |         --------------------------------- recursive call here
    |
    = note: a recursive `async fn` call must introduce indirection such as `Box::pin` to avoid an infinitely sized future
 

--- a/tests/ui/async-await/issue-70818.rs
+++ b/tests/ui/async-await/issue-70818.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
     //~^ Error future cannot be sent between threads safely
+    //~| Error future cannot be sent between threads safely
     async { (ty, ty1) }
 }
 

--- a/tests/ui/async-await/issue-70818.stderr
+++ b/tests/ui/async-await/issue-70818.stderr
@@ -5,7 +5,7 @@ LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
 note: captured value is not `Send`
-  --> $DIR/issue-70818.rs:6:18
+  --> $DIR/issue-70818.rs:7:18
    |
 LL |     async { (ty, ty1) }
    |                  ^^^ has type `U` which is not `Send`
@@ -14,5 +14,22 @@ help: consider restricting type parameter `U`
 LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                  +++++++++++++++++++
 
-error: aborting due to 1 previous error
+error: future cannot be sent between threads safely
+  --> $DIR/issue-70818.rs:4:38
+   |
+LL | fn foo<T: Send, U>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+   |
+note: captured value is not `Send`
+  --> $DIR/issue-70818.rs:7:18
+   |
+LL |     async { (ty, ty1) }
+   |                  ^^^ has type `U` which is not `Send`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider restricting type parameter `U`
+   |
+LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                  +++++++++++++++++++
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/issue-86507.rs
+++ b/tests/ui/async-await/issue-86507.rs
@@ -15,6 +15,7 @@ impl Foo for () {
         -> Pin<Box<dyn Future<Output = ()> + Send + 'async_trait>>
         where 'me:'async_trait {
             Box::pin( //~ ERROR future cannot be sent between threads safely
+                //~^ ERROR future cannot be sent between threads safely
                 async move {
                     let x = x;
                 }

--- a/tests/ui/async-await/issue-86507.stderr
+++ b/tests/ui/async-await/issue-86507.stderr
@@ -2,6 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-86507.rs:17:13
    |
 LL | /             Box::pin(
+LL | |
 LL | |                 async move {
 LL | |                     let x = x;
 LL | |                 }
@@ -9,15 +10,37 @@ LL | |             )
    | |_____________^ future created by async block is not `Send`
    |
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> $DIR/issue-86507.rs:19:29
+  --> $DIR/issue-86507.rs:20:29
    |
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
-   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 20:18}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:19:17: 21:18}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
 help: consider further restricting this bound
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)
    |                                       +++++++++++++++++++
 
-error: aborting due to 1 previous error
+error: future cannot be sent between threads safely
+  --> $DIR/issue-86507.rs:17:13
+   |
+LL | /             Box::pin(
+LL | |
+LL | |                 async move {
+LL | |                     let x = x;
+LL | |                 }
+LL | |             )
+   | |_____________^ future created by async block is not `Send`
+   |
+note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+  --> $DIR/issue-86507.rs:20:29
+   |
+LL |                     let x = x;
+   |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
+   = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:19:17: 21:18}>>` to `Pin<Box<dyn Future<Output = ()> + Send>>`
+help: consider further restricting this bound
+   |
+LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)
+   |                                       +++++++++++++++++++
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/coroutine/clone-impl.stderr
+++ b/tests/ui/coroutine/clone-impl.stderr
@@ -7,11 +7,14 @@ LL |     let gen_clone_0 = move || {
 LL |     check_copy(&gen_clone_0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}: Copy`
    |
-note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:40:14
+note: coroutine does not implement `Copy` as this value is used across a yield
+  --> $DIR/clone-impl.rs:38:9
    |
-LL |         drop(clonable_0);
-   |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
+LL |     let clonable_0: Vec<u32> = Vec::new();
+   |         ---------- has type `Vec<u32>` which does not implement `Copy`
+...
+LL |         yield;
+   |         ^^^^^ yield occurs here, with `clonable_0` maybe used later
 note: required by a bound in `check_copy`
   --> $DIR/clone-impl.rs:72:18
    |
@@ -49,11 +52,14 @@ LL |     let gen_clone_1 = move || {
 LL |     check_copy(&gen_clone_1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}: Copy`
    |
-note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:56:14
+note: coroutine does not implement `Copy` as this value is used across a yield
+  --> $DIR/clone-impl.rs:52:9
    |
-LL |         drop(clonable_1);
-   |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
+LL |     let clonable_1: Vec<u32> = Vec::new();
+   |         ---------- has type `Vec<u32>` which does not implement `Copy`
+...
+LL |         yield;
+   |         ^^^^^ yield occurs here, with `clonable_1` maybe used later
 note: required by a bound in `check_copy`
   --> $DIR/clone-impl.rs:72:18
    |
@@ -92,11 +98,14 @@ LL |     let gen_non_clone = move || {
 LL |     check_copy(&gen_non_clone);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Copy` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}: Copy`
    |
-note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:64:14
+note: coroutine does not implement `Copy` as this value is used across a yield
+  --> $DIR/clone-impl.rs:63:9
    |
-LL |         drop(non_clonable);
-   |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Copy`
+LL |     let non_clonable: NonClone = NonClone;
+   |         ------------ has type `NonClone` which does not implement `Copy`
+...
+LL |         yield;
+   |         ^^^^^ yield occurs here, with `non_clonable` maybe used later
 note: required by a bound in `check_copy`
   --> $DIR/clone-impl.rs:72:18
    |
@@ -117,11 +126,14 @@ LL |     let gen_non_clone = move || {
 LL |     check_clone(&gen_non_clone);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Clone` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}: Clone`
    |
-note: captured value does not implement `Clone`
-  --> $DIR/clone-impl.rs:64:14
+note: coroutine does not implement `Clone` as this value is used across a yield
+  --> $DIR/clone-impl.rs:63:9
    |
-LL |         drop(non_clonable);
-   |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Clone`
+LL |     let non_clonable: NonClone = NonClone;
+   |         ------------ has type `NonClone` which does not implement `Clone`
+...
+LL |         yield;
+   |         ^^^^^ yield occurs here, with `non_clonable` maybe used later
 note: required by a bound in `check_clone`
   --> $DIR/clone-impl.rs:73:19
    |

--- a/tests/ui/coroutine/ref-upvar-not-send.rs
+++ b/tests/ui/coroutine/ref-upvar-not-send.rs
@@ -8,6 +8,10 @@ fn assert_send<T: Send>(_: T) {}
 //~| NOTE required by this bound in `assert_send`
 //~| NOTE required by a bound in `assert_send`
 //~| NOTE required by this bound in `assert_send`
+//~| NOTE required by a bound in `assert_send`
+//~| NOTE required by this bound in `assert_send`
+//~| NOTE required by a bound in `assert_send`
+//~| NOTE required by this bound in `assert_send`
 
 fn main() {
     let x: &*mut () = &std::ptr::null_mut();
@@ -15,17 +19,25 @@ fn main() {
     assert_send(move || {
         //~^ ERROR coroutine cannot be sent between threads safely
         //~| NOTE coroutine is not `Send`
+        //~| ERROR coroutine cannot be sent between threads safely
+        //~| NOTE coroutine is not `Send`
         yield;
         let _x = x;
+        //~^ NOTE captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+        //~| NOTE has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
+        //~| NOTE captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+        //~| NOTE has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
     });
-    //~^^ NOTE captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-    //~| NOTE has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
     assert_send(move || {
         //~^ ERROR coroutine cannot be sent between threads safely
         //~| NOTE coroutine is not `Send`
+        //~| ERROR coroutine cannot be sent between threads safely
+        //~| NOTE coroutine is not `Send`
         yield;
         let _y = y;
+        //~^ captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+        //~| has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
+        //~| captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+        //~| has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
     });
-    //~^^ NOTE captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
-    //~| NOTE has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
 }

--- a/tests/ui/coroutine/ref-upvar-not-send.stderr
+++ b/tests/ui/coroutine/ref-upvar-not-send.stderr
@@ -1,18 +1,19 @@
 error: coroutine cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:15:17
+  --> $DIR/ref-upvar-not-send.rs:19:17
    |
 LL |       assert_send(move || {
    |  _________________^
 LL | |
 LL | |
-LL | |         yield;
-LL | |         let _x = x;
+LL | |
+...  |
+LL | |
 LL | |     });
    | |_____^ coroutine is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:15:17: 15:24}: Send`
+   = help: the trait `Sync` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:19:17: 19:24}: Send`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
-  --> $DIR/ref-upvar-not-send.rs:19:18
+  --> $DIR/ref-upvar-not-send.rs:25:18
    |
 LL |         let _x = x;
    |                  ^ has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
@@ -23,20 +24,21 @@ LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/ref-upvar-not-send.rs:23:17
+  --> $DIR/ref-upvar-not-send.rs:31:17
    |
 LL |       assert_send(move || {
    |  _________________^
 LL | |
 LL | |
-LL | |         yield;
-LL | |         let _y = y;
+LL | |
+...  |
+LL | |
 LL | |     });
    | |_____^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}: Send`
+   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:31:17: 31:24}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:31:17: 31:24}: Send`
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
-  --> $DIR/ref-upvar-not-send.rs:27:18
+  --> $DIR/ref-upvar-not-send.rs:37:18
    |
 LL |         let _y = y;
    |                  ^ has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
@@ -46,5 +48,53 @@ note: required by a bound in `assert_send`
 LL | fn assert_send<T: Send>(_: T) {}
    |                   ^^^^ required by this bound in `assert_send`
 
-error: aborting due to 2 previous errors
+error: coroutine cannot be sent between threads safely
+  --> $DIR/ref-upvar-not-send.rs:19:5
+   |
+LL | /     assert_send(move || {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     });
+   | |______^ coroutine is not `Send`
+   |
+   = help: the trait `Sync` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:19:17: 19:24}: Send`
+note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
+  --> $DIR/ref-upvar-not-send.rs:25:18
+   |
+LL |         let _x = x;
+   |                  ^ has type `&*mut ()` which is not `Send`, because `*mut ()` is not `Sync`
+note: required by a bound in `assert_send`
+  --> $DIR/ref-upvar-not-send.rs:6:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: coroutine cannot be sent between threads safely
+  --> $DIR/ref-upvar-not-send.rs:31:5
+   |
+LL | /     assert_send(move || {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | |     });
+   | |______^ coroutine is not `Send`
+   |
+   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:31:17: 31:24}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:31:17: 31:24}: Send`
+note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
+  --> $DIR/ref-upvar-not-send.rs:37:18
+   |
+LL |         let _y = y;
+   |                  ^ has type `&mut *mut ()` which is not `Send`, because `*mut ()` is not `Send`
+note: required by a bound in `assert_send`
+  --> $DIR/ref-upvar-not-send.rs:6:19
+   |
+LL | fn assert_send<T: Send>(_: T) {}
+   |                   ^^^^ required by this bound in `assert_send`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/coroutine/unsized-capture-across-yield.rs
+++ b/tests/ui/coroutine/unsized-capture-across-yield.rs
@@ -7,6 +7,7 @@ use std::ops::Coroutine;
 
 fn capture() -> impl Coroutine {
     let b: [u8] = *(Box::new([]) as Box<[u8]>);
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
     move || {
         println!("{:?}", &b);
         //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time

--- a/tests/ui/coroutine/unsized-capture-across-yield.stderr
+++ b/tests/ui/coroutine/unsized-capture-across-yield.stderr
@@ -8,7 +8,7 @@ LL | #![feature(unsized_locals)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/unsized-capture-across-yield.rs:11:27
+  --> $DIR/unsized-capture-across-yield.rs:12:27
    |
 LL |     move || {
    |          -- this closure captures all values by move
@@ -18,6 +18,15 @@ LL |         println!("{:?}", &b);
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: all values captured by value by a closure must have a statically known size
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/unsized-capture-across-yield.rs:9:9
+   |
+LL |     let b: [u8] = *(Box::new([]) as Box<[u8]>);
+   |         ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: all values live across `yield` must have a statically known size
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
+++ b/tests/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
@@ -92,7 +92,9 @@ error[E0720]: cannot resolve opaque type
    |
 LL |   fn coroutine_capture() -> impl Sized {
    |                             ^^^^^^^^^^ recursive opaque type
-...
+LL |
+LL |       let x = coroutine_capture();
+   |           - coroutine captures itself here
 LL | /     move || {
 LL | |         yield;
 LL | |         x;

--- a/tests/ui/print_type_sizes/async.stdout
+++ b/tests/ui/print_type_sizes/async.stdout
@@ -1,15 +1,14 @@
 print-type-size type: `{async fn body of test()}`: 16386 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
-print-type-size     variant `Unresumed`: 8192 bytes
-print-type-size         upvar `.arg`: 8192 bytes
+print-type-size     variant `Unresumed`: 16385 bytes
+print-type-size         padding: 8193 bytes
+print-type-size         local `.arg`: 8192 bytes, alignment: 1 bytes
 print-type-size     variant `Suspend0`: 16385 bytes
-print-type-size         upvar `.arg`: 8192 bytes
 print-type-size         local `.arg`: 8192 bytes
 print-type-size         local `.__awaitee`: 1 bytes, type: {async fn body of wait()}
-print-type-size     variant `Returned`: 8192 bytes
-print-type-size         upvar `.arg`: 8192 bytes
-print-type-size     variant `Panicked`: 8192 bytes
-print-type-size         upvar `.arg`: 8192 bytes
+print-type-size         local `.arg`: 8192 bytes
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
 print-type-size type: `std::mem::ManuallyDrop<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 8192 bytes
 print-type-size type: `std::mem::MaybeUninit<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes

--- a/tests/ui/print_type_sizes/coroutine.stdout
+++ b/tests/ui/print_type_sizes/coroutine.stdout
@@ -1,10 +1,14 @@
 print-type-size type: `{coroutine@$DIR/coroutine.rs:10:5: 10:14}`: 8193 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes
 print-type-size     variant `Unresumed`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes
+print-type-size         local `.array`: 8192 bytes
 print-type-size     variant `Suspend0`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes
-print-type-size     variant `Returned`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes
-print-type-size     variant `Panicked`: 8192 bytes
-print-type-size         upvar `.array`: 8192 bytes
+print-type-size         local `.array`: 8192 bytes
+print-type-size     variant `Returned`: 0 bytes
+print-type-size     variant `Panicked`: 0 bytes
+print-type-size type: `std::mem::ManuallyDrop<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
+print-type-size     field `.value`: 8192 bytes
+print-type-size type: `std::mem::MaybeUninit<[u8; 8192]>`: 8192 bytes, alignment: 1 bytes
+print-type-size     variant `MaybeUninit`: 8192 bytes
+print-type-size         field `.uninit`: 0 bytes
+print-type-size         field `.value`: 8192 bytes


### PR DESCRIPTION
Related to #62958

This PR is an attempt to address the async/coroutine size issue by allowing independent def-use/liveness analysis on individual upvars in coroutines. It has appeared to address partially the size doubling issue introduced by the use of upvars.

However, there are caveats detailed in the following list that I would like to address before turning this draft in.
- The treatment here towards the `ty::Coroutine` in MIR passes is unfortunately "messier" than my liking, which is something I definitely want to change. I propose to promote upvars into `Body<'tcx>` along with `local_decls`, so that we can safely handle them safely. I would happily open a new separate PR to improve the upvar management.
- It is not a generic solution, yet. For instance, we are still doubling the size in the example of #62958. If we insert a pass before MIR type analysis to remove unnecessary drops, which we can, that particular size doubling will be solved. However, if a `Future` upvar is alive across more than one yield points, that upvar is still ineligible. It makes sense because we would like to minimize moving of variant fields. How to handle these upvars is not the focus of this PR for now.

Out of expectation of possible change in the high level plan, I am keeping this as a draft in hope of invoking conversations. :bow: 

cc @pnkfelix for the context.