### PR TITLE
Remove duplicate dependencies for rustc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,7 +4774,7 @@ dependencies = [
  "annotate-snippets 0.9.2",
  "anyhow",
  "bytecount",
- "cargo_metadata 0.15.4",
+ "cargo_metadata 0.18.1",
  "clap",
  "clap-cargo",
  "diff",
@@ -5459,7 +5459,7 @@ name = "tidy"
 version = "0.1.0"
 dependencies = [
  "cargo-platform",
- "cargo_metadata 0.15.4",
+ "cargo_metadata 0.18.1",
  "ignore",
  "lazy_static",
  "miropt-test-tools",

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # FIXME: bumping memchr to 2.7.1 causes linker errors in MSVC thin-lto
 # tidy-alphabetical-start
 bitflags = "2.4.1"
-memchr = "=2.5.0"
+memchr = "2.5"
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_index = { path = "../rustc_index" }
 rustc_lexer = { path = "../rustc_lexer" }

--- a/src/tools/rustfmt/Cargo.toml
+++ b/src/tools/rustfmt/Cargo.toml
@@ -36,7 +36,7 @@ generic-simd = ["bytecount/generic-simd"]
 annotate-snippets = { version = "0.9", features = ["color"] }
 anyhow = "1.0"
 bytecount = "0.6.4"
-cargo_metadata = "0.15.4"
+cargo_metadata = "0.18"
 clap = { version = "4.4.2", features = ["derive"] }
 clap-cargo = "0.12.0"
 diff = "0.1"

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 autobins = false
 
 [dependencies]
-cargo_metadata = "0.15"
+cargo_metadata = "0.18"
 cargo-platform = "0.1.2"
 regex = "1"
 miropt-test-tools = { path = "../miropt-test-tools" }


### PR DESCRIPTION
Removed several duplicates for rustc: https://github.com/rust-lang/rust/issues/75704

Several duplicates still exist, but an external library would have to be updated first.

These are the duplicate dependencies still outstanding:
```
annotate-snippets v0.9.1
annotate-snippets v0.10.1

bitflags v1.3.2
bitflags v2.4.1

cargo_metadata v0.15.4
cargo_metadata v0.18.0

darling v0.14.4
darling v0.20.3

darling_core v0.14.4
darling_core v0.20.3

darling_macro v0.14.4
darling_macro v0.20.3

regex-automata v0.1.10
regex-automata v0.2.0
regex-automata v0.4.3

regex-syntax v0.6.29
regex-syntax v0.7.2
regex-syntax v0.8.2

self_cell v0.10.3
self_cell v1.0.2

syn v1.0.109
syn v2.0.32

toml v0.5.11
toml v0.7.5
```

It should not be hard to consolidate these remaining duplicate dependencies, but it will take time as it would be pull requests for external crates.

r? @jyn514