### PR TITLE
Allow any `const` expression blocks in `thread_local!`

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -166,7 +166,10 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// ```
 /// use std::cell::Cell;
 /// thread_local! {
-///     pub static FOO: Cell<u32> = const { Cell::new(1) };
+///     pub static FOO: Cell<u32> = const {
+///         let value = 1;
+///         Cell::new(value)
+///     };
 /// }
 ///
 /// assert_eq!(FOO.get(), 1);
@@ -186,12 +189,12 @@ macro_rules! thread_local {
     // empty (base case for the recursion)
     () => {};
 
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }; $($rest:tt)*) => (
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const $init:block; $($rest:tt)*) => (
         $crate::thread::local_impl::thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
         $crate::thread_local!($($rest)*);
     );
 
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }) => (
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const $init:block) => (
         $crate::thread::local_impl::thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
     );
 

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -166,10 +166,7 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// ```
 /// use std::cell::Cell;
 /// thread_local! {
-///     pub static FOO: Cell<u32> = const {
-///         let value = 1;
-///         Cell::new(value)
-///     };
+///     pub static FOO: Cell<u32> = const { Cell::new(1) };
 /// }
 ///
 /// assert_eq!(FOO.get(), 1);

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -1,3 +1,4 @@
+use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -13,4 +14,25 @@ fn sleep() {
     });
     thread::sleep(Duration::from_millis(100));
     assert_eq!(*finished.lock().unwrap(), false);
+}
+
+#[test]
+fn thread_local_containing_const_statements() {
+    // This exercises the `const $init:block` cases of the thread_local macro.
+    // Despite overlapping with expression syntax, the `const { ... }` is not
+    // parsed as `$init:expr`.
+    thread_local! {
+        static CELL: Cell<u32> = const {
+            let value = 1;
+            Cell::new(value)
+        };
+
+        static REFCELL: RefCell<u32> = const {
+            let value = 1;
+            RefCell::new(value)
+        };
+    }
+
+    assert_eq!(CELL.get(), 1);
+    assert_eq!(REFCELL.take(), 1);
 }


### PR DESCRIPTION
This PR contains a rebase of the macro change from #116392, together with adding a test under library/std/tests.

Testing this feature by making the documentation's example code needlessly more complicated was not appropriate as pointed out in https://github.com/rust-lang/rust/pull/116392#pullrequestreview-1753097757.

Without the macro change, this new test would fail to build as follows:

```console
error: no rules expected the token `let`
   --> library/std/tests/thread.rs:26:13
    |
26  |             let value = 1;
    |             ^^^ no rules expected this token in macro call
    |
note: while trying to match meta-variable `$init:expr`
   --> library/std/src/thread/local.rs:189:69
    |
189 |     ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }; $($rest:tt)*) => (
    |                                                                     ^^^^^^^^^^
```

Closes #116392.