### PR TITLE
Add `#[coverage(off)]` to closures introduced by `#[test]` and `#[bench]`

### DIFF
--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(rust_logo)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
+#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(decl_macro)]
 #![feature(if_let_guard)]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1596,7 +1596,7 @@ pub(crate) mod builtin {
     ///
     /// [the reference]: ../../../reference/attributes/testing.html#the-test-attribute
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(test, rustc_attrs)]
+    #[allow_internal_unstable(test, rustc_attrs, coverage_attribute)]
     #[rustc_builtin_macro]
     pub macro test($item:item) {
         /* compiler built-in */
@@ -1609,7 +1609,7 @@ pub(crate) mod builtin {
         soft,
         reason = "`bench` is a part of custom test frameworks which are unstable"
     )]
-    #[allow_internal_unstable(test, rustc_attrs)]
+    #[allow_internal_unstable(test, rustc_attrs, coverage_attribute)]
     #[rustc_builtin_macro]
     pub macro bench($item:item) {
         /* compiler built-in */

--- a/tests/coverage/bench.cov-map
+++ b/tests/coverage/bench.cov-map
@@ -1,0 +1,16 @@
+Function name: bench::my_bench
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 08, 01, 00, 27]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 8, 1) to (start + 0, 39)
+
+Function name: bench::my_bench::{closure#0}
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 07, 01, 00, 09]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 7, 1) to (start + 0, 9)
+

--- a/tests/coverage/bench.cov-map
+++ b/tests/coverage/bench.cov-map
@@ -6,11 +6,3 @@ Number of expressions: 0
 Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 8, 1) to (start + 0, 39)
 
-Function name: bench::my_bench::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 07, 01, 00, 09]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 7, 1) to (start + 0, 9)
-

--- a/tests/coverage/bench.coverage
+++ b/tests/coverage/bench.coverage
@@ -4,6 +4,6 @@
    LL|       |
    LL|       |extern crate test;
    LL|       |
-   LL|      1|#[bench]
+   LL|       |#[bench]
    LL|      1|fn my_bench(_b: &mut test::Bencher) {}
 

--- a/tests/coverage/bench.coverage
+++ b/tests/coverage/bench.coverage
@@ -1,0 +1,9 @@
+   LL|       |#![feature(test)]
+   LL|       |// edition: 2021
+   LL|       |// compile-flags: --test
+   LL|       |
+   LL|       |extern crate test;
+   LL|       |
+   LL|      1|#[bench]
+   LL|      1|fn my_bench(_b: &mut test::Bencher) {}
+

--- a/tests/coverage/bench.rs
+++ b/tests/coverage/bench.rs
@@ -1,0 +1,8 @@
+#![feature(test)]
+// edition: 2021
+// compile-flags: --test
+
+extern crate test;
+
+#[bench]
+fn my_bench(_b: &mut test::Bencher) {}

--- a/tests/coverage/test_harness.cov-map
+++ b/tests/coverage/test_harness.cov-map
@@ -6,14 +6,6 @@ Number of expressions: 0
 Number of file 0 mappings: 1
 - Code(Counter(0)) at (prev + 10, 1) to (start + 0, 16)
 
-Function name: test_harness::my_test::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 09, 01, 00, 08]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 9, 1) to (start + 0, 8)
-
 Function name: test_harness::unused (unused)
 Raw bytes (9): 0x[01, 01, 00, 01, 00, 07, 01, 00, 0f]
 Number of files: 1

--- a/tests/coverage/test_harness.coverage
+++ b/tests/coverage/test_harness.coverage
@@ -6,6 +6,6 @@
    LL|       |#[allow(dead_code)]
    LL|      0|fn unused() {}
    LL|       |
-   LL|      1|#[test]
+   LL|       |#[test]
    LL|      1|fn my_test() {}
 

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -28,7 +28,8 @@ pub const m_test: test::TestDescAndFn =
             should_panic: test::ShouldPanic::No,
             test_type: test::TestType::Unknown,
         },
-        testfn: test::StaticTestFn(|| test::assert_test_result(m_test())),
+        testfn: test::StaticTestFn(#[coverage(off)] ||
+                test::assert_test_result(m_test())),
     };
 fn m_test() {}
 
@@ -51,7 +52,8 @@ pub const z_test: test::TestDescAndFn =
             should_panic: test::ShouldPanic::No,
             test_type: test::TestType::Unknown,
         },
-        testfn: test::StaticTestFn(|| test::assert_test_result(z_test())),
+        testfn: test::StaticTestFn(#[coverage(off)] ||
+                test::assert_test_result(z_test())),
     };
 #[ignore = "not yet implemented"]
 fn z_test() {}
@@ -75,7 +77,8 @@ pub const a_test: test::TestDescAndFn =
             should_panic: test::ShouldPanic::No,
             test_type: test::TestType::Unknown,
         },
-        testfn: test::StaticTestFn(|| test::assert_test_result(a_test())),
+        testfn: test::StaticTestFn(#[coverage(off)] ||
+                test::assert_test_result(a_test())),
     };
 fn a_test() {}
 #[rustc_main]


### PR DESCRIPTION
These closures are an internal implementation detail of the `#[test]` and `#[bench]` attribute macros, so from a user perspective there is no reason to instrument them for coverage.

Skipping them makes coverage reports slightly cleaner, and will also allow other changes to span processing during coverage instrumentation, without having to worry about how they affect the `#[test]` macro.

The `#[coverage(off)]` attribute has no effect when `-Cinstrument-coverage` is not used.

Fixes #120046.

---

Note that this PR has no effect on the user-written function that has the `#[test]` attribute attached to it. That function will still be instrumented as normal.
