### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you wish to _contribute_ to the compiler, you should read
 <summary>Table of Contents</summary>
 
 - [Quick Start](#quick-start)
+- [Installing from Source](#installing-from-source)
 - [Getting Help](#getting-help)
 - [Contributing](#contributing)
 - [License](#license)
@@ -29,9 +30,10 @@ Read ["Installation"] from [The Book].
 ["Installation"]: https://doc.rust-lang.org/book/ch01-01-installation.html
 [The Book]: https://doc.rust-lang.org/book/index.html
 
-## Installing from source
+## Installing from Source
 
-If you really want to install from source (though this is not recommended), see [INSTALL.md](INSTALL.md).
+If you really want to install from source (though this is not recommended), see
+[INSTALL.md](INSTALL.md).
 
 ## Getting Help
 

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -484,6 +484,19 @@ impl DroplessArena {
         }
     }
 
+    /// Used by `Lift` to check whether this slice is allocated
+    /// in this arena.
+    #[inline]
+    pub fn contains_slice<T>(&self, slice: &[T]) -> bool {
+        for chunk in self.chunks.borrow_mut().iter_mut() {
+            let ptr = slice.as_ptr().cast::<u8>().cast_mut();
+            if chunk.start() <= ptr && chunk.end() >= ptr {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Allocates a string slice that is copied into the `DroplessArena`, returning a
     /// reference to it. Will panic if passed an empty string.
     ///

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -195,7 +195,7 @@ impl<'tcx> ConstValue<'tcx> {
 /// Constants
 
 #[derive(Clone, Copy, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable, Debug)]
-#[derive(TypeFoldable, TypeVisitable)]
+#[derive(TypeFoldable, TypeVisitable, Lift)]
 pub enum Const<'tcx> {
     /// This constant came from the type system.
     ///
@@ -456,7 +456,7 @@ impl<'tcx> Const<'tcx> {
 
 /// An unevaluated (potentially generic) constant used in MIR.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable)]
-#[derive(Hash, HashStable, TypeFoldable, TypeVisitable)]
+#[derive(Hash, HashStable, TypeFoldable, TypeVisitable, Lift)]
 pub struct UnevaluatedConst<'tcx> {
     pub def: DefId,
     pub args: GenericArgsRef<'tcx>,

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -20,6 +20,10 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             @call(mir_storage_dead, args) => {
                 Ok(StatementKind::StorageDead(self.parse_local(args[0])?))
             },
+            @call(mir_assume, args) => {
+                let op = self.parse_operand(args[0])?;
+                Ok(StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::Assume(op))))
+            },
             @call(mir_deinit, args) => {
                 Ok(StatementKind::Deinit(Box::new(self.parse_place(args[0])?)))
             },

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -21,10 +21,10 @@ pub use self::drop_flag_effects::{
     move_path_children_matching, on_all_children_bits, on_lookup_result_bits,
 };
 pub use self::framework::{
-    fmt, lattice, visit_results, Analysis, AnalysisDomain, Direction, GenKill, GenKillAnalysis,
-    JoinSemiLattice, MaybeReachable, Results, ResultsCursor, ResultsVisitable, ResultsVisitor,
+    fmt, graphviz, lattice, visit_results, Analysis, AnalysisDomain, Backward, Direction, Engine,
+    Forward, GenKill, GenKillAnalysis, JoinSemiLattice, MaybeReachable, Results, ResultsCursor,
+    ResultsVisitable, ResultsVisitor, SwitchIntEdgeEffects,
 };
-use self::framework::{Backward, SwitchIntEdgeEffects};
 use self::move_paths::MoveData;
 
 pub mod debuginfo;

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -16,6 +16,8 @@ extern crate rustc_middle;
 
 use rustc_middle::ty;
 
+// Please change the public `use` directives cautiously, as they might be used by external tools.
+// See issue #120130.
 pub use self::drop_flag_effects::{
     drop_flag_effects_for_function_entry, drop_flag_effects_for_location,
     move_path_children_matching, on_all_children_bits, on_lookup_result_bits,

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -518,11 +518,6 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
         cost: &CostChecker<'_, 'tcx>,
         depth: usize,
     ) {
-        let register_opportunity = |c: Condition| {
-            debug!(?bb, ?c.target, "register");
-            self.opportunities.push(ThreadingOpportunity { chain: vec![bb], target: c.target })
-        };
-
         let term = self.body.basic_blocks[bb].terminator();
         let place_to_flood = match term.kind {
             // We come from a target, so those are not possible.
@@ -544,16 +539,8 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
             // Flood the overwritten place, and progress through.
             TerminatorKind::Drop { place: destination, .. }
             | TerminatorKind::Call { destination, .. } => Some(destination),
-            // Treat as an `assume(cond == expected)`.
-            TerminatorKind::Assert { ref cond, expected, .. } => {
-                if let Some(place) = cond.place()
-                    && let Some(conditions) = state.try_get(place.as_ref(), self.map)
-                {
-                    let expected = if expected { ScalarInt::TRUE } else { ScalarInt::FALSE };
-                    conditions.iter_matches(expected).for_each(register_opportunity);
-                }
-                None
-            }
+            // Ignore, as this can be a no-op at codegen time.
+            TerminatorKind::Assert { .. } => None,
         };
 
         // We can recurse through this terminator.

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -21,37 +21,37 @@ use stable_mir::{CrateItem, CrateNum, DefId};
 
 use super::RustcInternal;
 
-unsafe impl<'tcx> RustcInternal<'tcx> for CrateItem {
-    type T = rustc_span::def_id::DefId;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for CrateItem {
+    type T<'tcx> = rustc_span::def_id::DefId;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         self.0.internal(tables, tcx)
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for CrateNum {
-    type T = rustc_span::def_id::CrateNum;
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for CrateNum {
+    type T<'tcx> = rustc_span::def_id::CrateNum;
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         rustc_span::def_id::CrateNum::from_usize(*self)
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for DefId {
-    type T = rustc_span::def_id::DefId;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for DefId {
+    type T<'tcx> = rustc_span::def_id::DefId;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.lift(tables.def_ids[*self]).unwrap()
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for GenericArgs {
-    type T = rustc_ty::GenericArgsRef<'tcx>;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for GenericArgs {
+    type T<'tcx> = rustc_ty::GenericArgsRef<'tcx>;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.mk_args_from_iter(self.0.iter().map(|arg| arg.internal(tables, tcx)))
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for GenericArgKind {
-    type T = rustc_ty::GenericArg<'tcx>;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for GenericArgKind {
+    type T<'tcx> = rustc_ty::GenericArg<'tcx>;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         let arg: rustc_ty::GenericArg<'tcx> = match self {
             GenericArgKind::Lifetime(reg) => reg.internal(tables, tcx).into(),
             GenericArgKind::Type(ty) => ty.internal(tables, tcx).into(),
@@ -61,25 +61,25 @@ unsafe impl<'tcx> RustcInternal<'tcx> for GenericArgKind {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Region {
-    type T = rustc_ty::Region<'tcx>;
-    fn internal(&self, _tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for Region {
+    type T<'tcx> = rustc_ty::Region<'tcx>;
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         // Cannot recover region. Use erased for now.
         tcx.lifetimes.re_erased
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Ty {
-    type T = InternalTy<'tcx>;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for Ty {
+    type T<'tcx> = InternalTy<'tcx>;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.lift(tables.types[*self]).unwrap()
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for RigidTy {
-    type T = rustc_ty::TyKind<'tcx>;
+impl RustcInternal for RigidTy {
+    type T<'tcx> = rustc_ty::TyKind<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             RigidTy::Bool => rustc_ty::TyKind::Bool,
             RigidTy::Char => rustc_ty::TyKind::Char,
@@ -131,10 +131,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for RigidTy {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for IntTy {
-    type T = rustc_ty::IntTy;
+impl RustcInternal for IntTy {
+    type T<'tcx> = rustc_ty::IntTy;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             IntTy::Isize => rustc_ty::IntTy::Isize,
             IntTy::I8 => rustc_ty::IntTy::I8,
@@ -146,10 +146,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for IntTy {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for UintTy {
-    type T = rustc_ty::UintTy;
+impl RustcInternal for UintTy {
+    type T<'tcx> = rustc_ty::UintTy;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             UintTy::Usize => rustc_ty::UintTy::Usize,
             UintTy::U8 => rustc_ty::UintTy::U8,
@@ -161,10 +161,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for UintTy {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for FloatTy {
-    type T = rustc_ty::FloatTy;
+impl RustcInternal for FloatTy {
+    type T<'tcx> = rustc_ty::FloatTy;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             FloatTy::F32 => rustc_ty::FloatTy::F32,
             FloatTy::F64 => rustc_ty::FloatTy::F64,
@@ -172,10 +172,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for FloatTy {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Mutability {
-    type T = rustc_ty::Mutability;
+impl RustcInternal for Mutability {
+    type T<'tcx> = rustc_ty::Mutability;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             Mutability::Not => rustc_ty::Mutability::Not,
             Mutability::Mut => rustc_ty::Mutability::Mut,
@@ -183,10 +183,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for Mutability {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Movability {
-    type T = rustc_ty::Movability;
+impl RustcInternal for Movability {
+    type T<'tcx> = rustc_ty::Movability;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             Movability::Static => rustc_ty::Movability::Static,
             Movability::Movable => rustc_ty::Movability::Movable,
@@ -194,14 +194,12 @@ unsafe impl<'tcx> RustcInternal<'tcx> for Movability {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for FnSig {
-    type T = rustc_ty::FnSig<'tcx>;
+impl RustcInternal for FnSig {
+    type T<'tcx> = rustc_ty::FnSig<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.lift(rustc_ty::FnSig {
-            inputs_and_output: tables
-                .tcx
-                .mk_type_list(&self.inputs_and_output.internal(tables, tcx)),
+            inputs_and_output: tcx.mk_type_list(&self.inputs_and_output.internal(tables, tcx)),
             c_variadic: self.c_variadic,
             unsafety: self.unsafety.internal(tables, tcx),
             abi: self.abi.internal(tables, tcx),
@@ -210,25 +208,25 @@ unsafe impl<'tcx> RustcInternal<'tcx> for FnSig {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for VariantIdx {
-    type T = rustc_target::abi::VariantIdx;
+impl RustcInternal for VariantIdx {
+    type T<'tcx> = rustc_target::abi::VariantIdx;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         rustc_target::abi::VariantIdx::from(self.to_index())
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for VariantDef {
-    type T = &'tcx rustc_ty::VariantDef;
+impl RustcInternal for VariantDef {
+    type T<'tcx> = &'tcx rustc_ty::VariantDef;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         self.adt_def.internal(tables, tcx).variant(self.idx.internal(tables, tcx))
     }
 }
 
 fn ty_const<'tcx>(
     constant: &Const,
-    tables: &mut Tables<'tcx>,
+    tables: &mut Tables<'_>,
     tcx: TyCtxt<'tcx>,
 ) -> rustc_ty::Const<'tcx> {
     match constant.internal(tables, tcx) {
@@ -239,15 +237,15 @@ fn ty_const<'tcx>(
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Const {
-    type T = rustc_middle::mir::Const<'tcx>;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for Const {
+    type T<'tcx> = rustc_middle::mir::Const<'tcx>;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         let constant = tables.constants[self.id];
         match constant {
             rustc_middle::mir::Const::Ty(ty) => rustc_middle::mir::Const::Ty(tcx.lift(ty).unwrap()),
             rustc_middle::mir::Const::Unevaluated(uneval, ty) => {
                 rustc_middle::mir::Const::Unevaluated(
-                    lift_unevaluated(tcx, uneval),
+                    tcx.lift(uneval).unwrap(),
                     tcx.lift(ty).unwrap(),
                 )
             }
@@ -258,10 +256,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for Const {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for MonoItem {
-    type T = rustc_middle::mir::mono::MonoItem<'tcx>;
+impl RustcInternal for MonoItem {
+    type T<'tcx> = rustc_middle::mir::mono::MonoItem<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         use rustc_middle::mir::mono as rustc_mono;
         match self {
             MonoItem::Fn(instance) => rustc_mono::MonoItem::Fn(instance.internal(tables, tcx)),
@@ -273,31 +271,31 @@ unsafe impl<'tcx> RustcInternal<'tcx> for MonoItem {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Instance {
-    type T = rustc_ty::Instance<'tcx>;
+impl RustcInternal for Instance {
+    type T<'tcx> = rustc_ty::Instance<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.lift(tables.instances[self.def]).unwrap()
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for StaticDef {
-    type T = rustc_span::def_id::DefId;
+impl RustcInternal for StaticDef {
+    type T<'tcx> = rustc_span::def_id::DefId;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         self.0.internal(tables, tcx)
     }
 }
 
 #[allow(rustc::usage_of_qualified_ty)]
-unsafe impl<'tcx, T> RustcInternal<'tcx> for Binder<T>
+impl<T> RustcInternal for Binder<T>
 where
-    T: RustcInternal<'tcx>,
-    T::T: rustc_ty::TypeVisitable<rustc_ty::TyCtxt<'tcx>>,
+    T: RustcInternal,
+    for<'tcx> T::T<'tcx>: rustc_ty::TypeVisitable<rustc_ty::TyCtxt<'tcx>>,
 {
-    type T = rustc_ty::Binder<'tcx, T::T>;
+    type T<'tcx> = rustc_ty::Binder<'tcx, T::T<'tcx>>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         rustc_ty::Binder::bind_with_vars(
             self.value.internal(tables, tcx),
             tcx.mk_bound_variable_kinds_from_iter(
@@ -307,10 +305,10 @@ where
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for BoundVariableKind {
-    type T = rustc_ty::BoundVariableKind;
+impl RustcInternal for BoundVariableKind {
+    type T<'tcx> = rustc_ty::BoundVariableKind;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             BoundVariableKind::Ty(kind) => rustc_ty::BoundVariableKind::Ty(match kind {
                 BoundTyKind::Anon => rustc_ty::BoundTyKind::Anon,
@@ -332,10 +330,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for BoundVariableKind {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for DynKind {
-    type T = rustc_ty::DynKind;
+impl RustcInternal for DynKind {
+    type T<'tcx> = rustc_ty::DynKind;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             DynKind::Dyn => rustc_ty::DynKind::Dyn,
             DynKind::DynStar => rustc_ty::DynKind::DynStar,
@@ -343,10 +341,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for DynKind {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for ExistentialPredicate {
-    type T = rustc_ty::ExistentialPredicate<'tcx>;
+impl RustcInternal for ExistentialPredicate {
+    type T<'tcx> = rustc_ty::ExistentialPredicate<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             ExistentialPredicate::Trait(trait_ref) => {
                 rustc_ty::ExistentialPredicate::Trait(trait_ref.internal(tables, tcx))
@@ -361,10 +359,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for ExistentialPredicate {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for ExistentialProjection {
-    type T = rustc_ty::ExistentialProjection<'tcx>;
+impl RustcInternal for ExistentialProjection {
+    type T<'tcx> = rustc_ty::ExistentialProjection<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         rustc_ty::ExistentialProjection {
             def_id: self.def_id.0.internal(tables, tcx),
             args: self.generic_args.internal(tables, tcx),
@@ -373,10 +371,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for ExistentialProjection {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for TermKind {
-    type T = rustc_ty::Term<'tcx>;
+impl RustcInternal for TermKind {
+    type T<'tcx> = rustc_ty::Term<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             TermKind::Type(ty) => ty.internal(tables, tcx).into(),
             TermKind::Const(const_) => ty_const(const_, tables, tcx).into(),
@@ -384,10 +382,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for TermKind {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for ExistentialTraitRef {
-    type T = rustc_ty::ExistentialTraitRef<'tcx>;
+impl RustcInternal for ExistentialTraitRef {
+    type T<'tcx> = rustc_ty::ExistentialTraitRef<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         rustc_ty::ExistentialTraitRef {
             def_id: self.def_id.0.internal(tables, tcx),
             args: self.generic_args.internal(tables, tcx),
@@ -395,10 +393,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for ExistentialTraitRef {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for TraitRef {
-    type T = rustc_ty::TraitRef<'tcx>;
+impl RustcInternal for TraitRef {
+    type T<'tcx> = rustc_ty::TraitRef<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         rustc_ty::TraitRef::new(
             tcx,
             self.def_id.0.internal(tables, tcx),
@@ -407,17 +405,17 @@ unsafe impl<'tcx> RustcInternal<'tcx> for TraitRef {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for AllocId {
-    type T = rustc_middle::mir::interpret::AllocId;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for AllocId {
+    type T<'tcx> = rustc_middle::mir::interpret::AllocId;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.lift(tables.alloc_ids[*self]).unwrap()
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for ClosureKind {
-    type T = rustc_ty::ClosureKind;
+impl RustcInternal for ClosureKind {
+    type T<'tcx> = rustc_ty::ClosureKind;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             ClosureKind::Fn => rustc_ty::ClosureKind::Fn,
             ClosureKind::FnMut => rustc_ty::ClosureKind::FnMut,
@@ -426,17 +424,17 @@ unsafe impl<'tcx> RustcInternal<'tcx> for ClosureKind {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for AdtDef {
-    type T = rustc_ty::AdtDef<'tcx>;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+impl RustcInternal for AdtDef {
+    type T<'tcx> = rustc_ty::AdtDef<'tcx>;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.adt_def(self.0.internal(tables, tcx))
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Abi {
-    type T = rustc_target::spec::abi::Abi;
+impl RustcInternal for Abi {
+    type T<'tcx> = rustc_target::spec::abi::Abi;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match *self {
             Abi::Rust => rustc_target::spec::abi::Abi::Rust,
             Abi::C { unwind } => rustc_target::spec::abi::Abi::C { unwind },
@@ -469,10 +467,10 @@ unsafe impl<'tcx> RustcInternal<'tcx> for Abi {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Safety {
-    type T = rustc_hir::Unsafety;
+impl RustcInternal for Safety {
+    type T<'tcx> = rustc_hir::Unsafety;
 
-    fn internal(&self, _tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
             Safety::Unsafe => rustc_hir::Unsafety::Unsafe,
             Safety::Normal => rustc_hir::Unsafety::Normal,
@@ -480,62 +478,51 @@ unsafe impl<'tcx> RustcInternal<'tcx> for Safety {
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Span {
-    type T = rustc_span::Span;
+impl RustcInternal for Span {
+    type T<'tcx> = rustc_span::Span;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, _tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tables[*self]
     }
 }
 
-unsafe impl<'tcx> RustcInternal<'tcx> for Layout {
-    type T = rustc_target::abi::Layout<'tcx>;
+impl RustcInternal for Layout {
+    type T<'tcx> = rustc_target::abi::Layout<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         tcx.lift(tables.layouts[*self]).unwrap()
     }
 }
 
-unsafe impl<'tcx, T> RustcInternal<'tcx> for &T
+impl<T> RustcInternal for &T
 where
-    T: RustcInternal<'tcx>,
+    T: RustcInternal,
 {
-    type T = T::T;
+    type T<'tcx> = T::T<'tcx>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         (*self).internal(tables, tcx)
     }
 }
 
-unsafe impl<'tcx, T> RustcInternal<'tcx> for Option<T>
+impl<T> RustcInternal for Option<T>
 where
-    T: RustcInternal<'tcx>,
+    T: RustcInternal,
 {
-    type T = Option<T::T>;
+    type T<'tcx> = Option<T::T<'tcx>>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         self.as_ref().map(|inner| inner.internal(tables, tcx))
     }
 }
 
-unsafe impl<'tcx, T> RustcInternal<'tcx> for Vec<T>
+impl<T> RustcInternal for Vec<T>
 where
-    T: RustcInternal<'tcx>,
+    T: RustcInternal,
 {
-    type T = Vec<T::T>;
+    type T<'tcx> = Vec<T::T<'tcx>>;
 
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T {
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         self.iter().map(|e| e.internal(tables, tcx)).collect()
-    }
-}
-
-fn lift_unevaluated<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    uneval: rustc_middle::mir::UnevaluatedConst<'tcx>,
-) -> rustc_middle::mir::UnevaluatedConst<'tcx> {
-    rustc_middle::mir::UnevaluatedConst {
-        def: uneval.def,
-        args: tcx.lift(uneval.args).unwrap(),
-        promoted: uneval.promoted,
     }
 }

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -162,12 +162,12 @@ where
 
 /// Loads the current context and calls a function with it.
 /// Do not nest these, as that will ICE.
-pub(crate) fn with_tables<'tcx, R>(f: impl FnOnce(&mut Tables<'tcx>) -> R) -> R {
+pub(crate) fn with_tables<R>(f: impl for<'tcx> FnOnce(&mut Tables<'tcx>) -> R) -> R {
     assert!(TLV.is_set());
     TLV.with(|tlv| {
         let ptr = tlv.get();
         assert!(!ptr.is_null());
-        let wrapper = ptr as *const TablesWrapper<'tcx>;
+        let wrapper = ptr as *const TablesWrapper<'_>;
         let mut tables = unsafe { (*wrapper).0.borrow_mut() };
         f(&mut *tables)
     })

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -50,9 +50,9 @@ pub fn stable<'tcx, S: Stable<'tcx>>(item: S) -> S::T {
 /// # Panics
 ///
 /// This function will panic if StableMIR has not been properly initialized.
-pub fn internal<'tcx, S>(tcx: TyCtxt<'tcx>, item: S) -> S::T
+pub fn internal<'tcx, S>(tcx: TyCtxt<'tcx>, item: S) -> S::T<'tcx>
 where
-    S: RustcInternal<'tcx>,
+    S: RustcInternal,
 {
     // The tcx argument ensures that the item won't outlive the type context.
     with_tables(|tables| item.internal(tables, tcx))
@@ -419,12 +419,7 @@ impl<K: PartialEq + Hash + Eq, V: Copy + Debug + PartialEq + IndexedVal> Index<V
 /// Trait used to translate a stable construct to its rustc counterpart.
 ///
 /// This is basically a mirror of [crate::rustc_smir::Stable].
-///
-/// # Safety
-///
-/// This trait is unsafe, and every implementation should ensure that their translation
-/// is lifted if necessary with the given type context (`tcx`).
-pub unsafe trait RustcInternal<'tcx> {
-    type T;
-    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T;
+pub trait RustcInternal {
+    type T<'tcx>;
+    fn internal<'tcx>(&self, tables: &mut Tables<'_>, tcx: TyCtxt<'tcx>) -> Self::T<'tcx>;
 }

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -24,12 +24,38 @@ use std::ops::Index;
 mod internal;
 pub mod pretty;
 
+/// Convert an internal Rust compiler item into its stable counterpart, if one exists.
+///
+/// # Warning
+///
+/// This function is unstable, and its behavior may change at any point.
+/// E.g.: Items that were previously supported, may no longer be supported, or its translation may
+/// change.
+///
+/// # Panics
+///
+/// This function will panic if StableMIR has not been properly initialized.
 pub fn stable<'tcx, S: Stable<'tcx>>(item: S) -> S::T {
     with_tables(|tables| item.stable(tables))
 }
 
-pub fn internal<'tcx, S: RustcInternal<'tcx>>(item: S) -> S::T {
-    with_tables(|tables| item.internal(tables))
+/// Convert a stable item into its internal Rust compiler counterpart, if one exists.
+///
+/// # Warning
+///
+/// This function is unstable, and it's behavior may change at any point.
+/// Not every stable item can be converted to an internal one.
+/// Furthermore, items that were previously supported, may no longer be supported in newer versions.
+///
+/// # Panics
+///
+/// This function will panic if StableMIR has not been properly initialized.
+pub fn internal<'tcx, S>(tcx: TyCtxt<'tcx>, item: S) -> S::T
+where
+    S: RustcInternal<'tcx>,
+{
+    // The tcx argument ensures that the item won't outlive the type context.
+    with_tables(|tables| item.internal(tables, tcx))
 }
 
 impl<'tcx> Index<stable_mir::DefId> for Tables<'tcx> {
@@ -393,7 +419,12 @@ impl<K: PartialEq + Hash + Eq, V: Copy + Debug + PartialEq + IndexedVal> Index<V
 /// Trait used to translate a stable construct to its rustc counterpart.
 ///
 /// This is basically a mirror of [crate::rustc_smir::Stable].
-pub trait RustcInternal<'tcx> {
+///
+/// # Safety
+///
+/// This trait is unsafe, and every implementation should ensure that their translation
+/// is lifted if necessary with the given type context (`tcx`).
+pub unsafe trait RustcInternal<'tcx> {
     type T;
-    fn internal(&self, tables: &mut Tables<'tcx>) -> Self::T;
+    fn internal(&self, tables: &mut Tables<'tcx>, tcx: TyCtxt<'tcx>) -> Self::T;
 }

--- a/compiler/rustc_smir/src/rustc_smir/alloc.rs
+++ b/compiler/rustc_smir/src/rustc_smir/alloc.rs
@@ -27,7 +27,8 @@ pub fn new_allocation<'tcx>(
     const_value: ConstValue<'tcx>,
     tables: &mut Tables<'tcx>,
 ) -> Allocation {
-    try_new_allocation(ty, const_value, tables).unwrap()
+    try_new_allocation(ty, const_value, tables)
+        .expect(&format!("Failed to convert: {const_value:?} to {ty:?}"))
 }
 
 #[allow(rustc::usage_of_qualified_ty)]

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -29,7 +29,7 @@ use stable_mir::{Crate, CrateItem, CrateNum, DefId, Error, Filename, ItemKind, S
 use std::cell::RefCell;
 use std::iter;
 
-use crate::rustc_internal::{internal, RustcInternal};
+use crate::rustc_internal::RustcInternal;
 use crate::rustc_smir::builder::BodyBuilder;
 use crate::rustc_smir::{alloc, new_item_kind, smir_crate, Stable, Tables};
 
@@ -74,9 +74,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn trait_decls(&self, crate_num: CrateNum) -> stable_mir::TraitDecls {
         let mut tables = self.0.borrow_mut();
-        tables
-            .tcx
-            .traits(crate_num.internal(&mut *tables))
+        let tcx = tables.tcx;
+        tcx.traits(crate_num.internal(&mut *tables, tcx))
             .iter()
             .map(|trait_def_id| tables.trait_def(*trait_def_id))
             .collect()
@@ -101,9 +100,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn trait_impls(&self, crate_num: CrateNum) -> stable_mir::ImplTraitDecls {
         let mut tables = self.0.borrow_mut();
-        tables
-            .tcx
-            .trait_impls_in_crate(crate_num.internal(&mut *tables))
+        let tcx = tables.tcx;
+        tcx.trait_impls_in_crate(crate_num.internal(&mut *tables, tcx))
             .iter()
             .map(|impl_def_id| tables.impl_def(*impl_def_id))
             .collect()
@@ -229,57 +227,68 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn adt_kind(&self, def: AdtDef) -> AdtKind {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).adt_kind().stable(&mut *tables)
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).adt_kind().stable(&mut *tables)
     }
 
     fn adt_is_box(&self, def: AdtDef) -> bool {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).is_box()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).is_box()
     }
 
     fn adt_is_simd(&self, def: AdtDef) -> bool {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).repr().simd()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).repr().simd()
     }
 
     fn adt_is_cstr(&self, def: AdtDef) -> bool {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
         tables.tcx.lang_items().c_str() == Some(def_id)
     }
 
     fn fn_sig(&self, def: FnDef, args: &GenericArgs) -> PolyFnSig {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let sig = tables.tcx.fn_sig(def_id).instantiate(tables.tcx, args.internal(&mut *tables));
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let sig =
+            tables.tcx.fn_sig(def_id).instantiate(tables.tcx, args.internal(&mut *tables, tcx));
         sig.stable(&mut *tables)
     }
 
     fn closure_sig(&self, args: &GenericArgs) -> PolyFnSig {
         let mut tables = self.0.borrow_mut();
-        let args_ref = args.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let args_ref = args.internal(&mut *tables, tcx);
         let sig = args_ref.as_closure().sig();
         sig.stable(&mut *tables)
     }
 
     fn adt_variants_len(&self, def: AdtDef) -> usize {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).variants().len()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).variants().len()
     }
 
     fn variant_name(&self, def: VariantDef) -> Symbol {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).name.to_string()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).name.to_string()
     }
 
     fn variant_fields(&self, def: VariantDef) -> Vec<FieldDef> {
         let mut tables = self.0.borrow_mut();
-        def.internal(&mut *tables).fields.iter().map(|f| f.stable(&mut *tables)).collect()
+        let tcx = tables.tcx;
+        def.internal(&mut *tables, tcx).fields.iter().map(|f| f.stable(&mut *tables)).collect()
     }
 
     fn eval_target_usize(&self, cnst: &Const) -> Result<u64, Error> {
         let mut tables = self.0.borrow_mut();
-        let mir_const = cnst.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let mir_const = cnst.internal(&mut *tables, tcx);
         mir_const
             .try_eval_target_usize(tables.tcx, ParamEnv::empty())
             .ok_or_else(|| Error::new(format!("Const `{cnst:?}` cannot be encoded as u64")))
@@ -299,30 +308,36 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn new_rigid_ty(&self, kind: RigidTy) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let internal_kind = kind.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let internal_kind = kind.internal(&mut *tables, tcx);
         tables.tcx.mk_ty_from_kind(internal_kind).stable(&mut *tables)
     }
 
     fn new_box_ty(&self, ty: stable_mir::ty::Ty) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let inner = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let inner = ty.internal(&mut *tables, tcx);
         ty::Ty::new_box(tables.tcx, inner).stable(&mut *tables)
     }
 
     fn def_ty(&self, item: stable_mir::DefId) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        tables.tcx.type_of(item.internal(&mut *tables)).instantiate_identity().stable(&mut *tables)
+        let tcx = tables.tcx;
+        tcx.type_of(item.internal(&mut *tables, tcx)).instantiate_identity().stable(&mut *tables)
     }
 
     fn def_ty_with_args(&self, item: stable_mir::DefId, args: &GenericArgs) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let args = args.internal(&mut *tables);
-        let def_ty = tables.tcx.type_of(item.internal(&mut *tables));
+        let tcx = tables.tcx;
+        let args = args.internal(&mut *tables, tcx);
+        let def_ty = tables.tcx.type_of(item.internal(&mut *tables, tcx));
         def_ty.instantiate(tables.tcx, args).stable(&mut *tables)
     }
 
     fn const_literal(&self, cnst: &stable_mir::ty::Const) -> String {
-        internal(cnst).to_string()
+        let mut tables = self.0.borrow_mut();
+        let tcx = tables.tcx;
+        cnst.internal(&mut *tables, tcx).to_string()
     }
 
     fn span_of_an_item(&self, def_id: stable_mir::DefId) -> Span {
@@ -337,7 +352,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn rigid_ty_discriminant_ty(&self, ty: &RigidTy) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
-        let internal_kind = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let internal_kind = ty.internal(&mut *tables, tcx);
         let internal_ty = tables.tcx.mk_ty_from_kind(internal_kind);
         internal_ty.discriminant_ty(tables.tcx).stable(&mut *tables)
     }
@@ -407,8 +423,9 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         args: &stable_mir::ty::GenericArgs,
     ) -> Option<stable_mir::mir::mono::Instance> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let args_ref = args.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let args_ref = args.internal(&mut *tables, tcx);
         match Instance::resolve(tables.tcx, ParamEnv::reveal_all(), def_id, args_ref) {
             Ok(Some(instance)) => Some(instance.stable(&mut *tables)),
             Ok(None) | Err(_) => None,
@@ -417,7 +434,8 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn resolve_drop_in_place(&self, ty: stable_mir::ty::Ty) -> stable_mir::mir::mono::Instance {
         let mut tables = self.0.borrow_mut();
-        let internal_ty = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let internal_ty = ty.internal(&mut *tables, tcx);
         let instance = Instance::resolve_drop_in_place(tables.tcx, internal_ty);
         instance.stable(&mut *tables)
     }
@@ -428,8 +446,9 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         args: &GenericArgs,
     ) -> Option<stable_mir::mir::mono::Instance> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let args_ref = args.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let args_ref = args.internal(&mut *tables, tcx);
         Instance::resolve_for_fn_ptr(tables.tcx, ParamEnv::reveal_all(), def_id, args_ref)
             .stable(&mut *tables)
     }
@@ -441,36 +460,44 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
         kind: ClosureKind,
     ) -> Option<stable_mir::mir::mono::Instance> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
-        let args_ref = args.internal(&mut *tables);
-        let closure_kind = kind.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
+        let args_ref = args.internal(&mut *tables, tcx);
+        let closure_kind = kind.internal(&mut *tables, tcx);
         Instance::resolve_closure(tables.tcx, def_id, args_ref, closure_kind).stable(&mut *tables)
     }
 
     fn eval_instance(&self, def: InstanceDef, const_ty: Ty) -> Result<Allocation, Error> {
         let mut tables = self.0.borrow_mut();
         let instance = tables.instances[def];
-        let result = tables.tcx.const_eval_instance(
+        let tcx = tables.tcx;
+        let result = tcx.const_eval_instance(
             ParamEnv::reveal_all(),
             instance,
-            Some(tables.tcx.def_span(instance.def_id())),
+            Some(tcx.def_span(instance.def_id())),
         );
         result
             .map(|const_val| {
-                alloc::try_new_allocation(const_ty.internal(&mut *tables), const_val, &mut *tables)
+                alloc::try_new_allocation(
+                    const_ty.internal(&mut *tables, tcx),
+                    const_val,
+                    &mut *tables,
+                )
             })
             .map_err(|e| e.stable(&mut *tables))?
     }
 
     fn eval_static_initializer(&self, def: StaticDef) -> Result<Allocation, Error> {
         let mut tables = self.0.borrow_mut();
-        let def_id = def.0.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let def_id = def.0.internal(&mut *tables, tcx);
         tables.tcx.eval_static_initializer(def_id).stable(&mut *tables)
     }
 
     fn global_alloc(&self, alloc: stable_mir::mir::alloc::AllocId) -> GlobalAlloc {
         let mut tables = self.0.borrow_mut();
-        let alloc_id = alloc.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let alloc_id = alloc.internal(&mut *tables, tcx);
         tables.tcx.global_alloc(alloc_id).stable(&mut *tables)
     }
 
@@ -480,9 +507,11 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
     ) -> Option<stable_mir::mir::alloc::AllocId> {
         let mut tables = self.0.borrow_mut();
         let GlobalAlloc::VTable(ty, trait_ref) = global_alloc else { return None };
-        let alloc_id = tables
-            .tcx
-            .vtable_allocation((ty.internal(&mut *tables), trait_ref.internal(&mut *tables)));
+        let tcx = tables.tcx;
+        let alloc_id = tables.tcx.vtable_allocation((
+            ty.internal(&mut *tables, tcx),
+            trait_ref.internal(&mut *tables, tcx),
+        ));
         Some(alloc_id.stable(&mut *tables))
     }
 
@@ -510,14 +539,16 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
 
     fn ty_layout(&self, ty: Ty) -> Result<Layout, Error> {
         let mut tables = self.0.borrow_mut();
-        let ty = ty.internal(&mut *tables);
+        let tcx = tables.tcx;
+        let ty = ty.internal(&mut *tables, tcx);
         let layout = tables.layout_of(ty)?.layout;
         Ok(layout.stable(&mut *tables))
     }
 
     fn layout_shape(&self, id: Layout) -> LayoutShape {
         let mut tables = self.0.borrow_mut();
-        id.internal(&mut *tables).0.stable(&mut *tables)
+        let tcx = tables.tcx;
+        id.internal(&mut *tables, tcx).0.stable(&mut *tables)
     }
 }
 

--- a/compiler/rustc_smir/src/rustc_smir/convert/abi.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/abi.rs
@@ -14,7 +14,7 @@ use stable_mir::{opaque, Opaque};
 
 impl<'tcx> Stable<'tcx> for rustc_target::abi::VariantIdx {
     type T = VariantIdx;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         VariantIdx::to_val(self.as_usize())
     }
 }
@@ -22,7 +22,7 @@ impl<'tcx> Stable<'tcx> for rustc_target::abi::VariantIdx {
 impl<'tcx> Stable<'tcx> for rustc_abi::Endian {
     type T = stable_mir::target::Endian;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         match self {
             rustc_abi::Endian::Little => stable_mir::target::Endian::Little,
             rustc_abi::Endian::Big => stable_mir::target::Endian::Big,
@@ -33,7 +33,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::Endian {
 impl<'tcx> Stable<'tcx> for rustc_target::abi::TyAndLayout<'tcx, ty::Ty<'tcx>> {
     type T = TyAndLayout;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         TyAndLayout { ty: self.ty.stable(tables), layout: self.layout.stable(tables) }
     }
 }
@@ -41,8 +41,8 @@ impl<'tcx> Stable<'tcx> for rustc_target::abi::TyAndLayout<'tcx, ty::Ty<'tcx>> {
 impl<'tcx> Stable<'tcx> for rustc_target::abi::Layout<'tcx> {
     type T = Layout;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
-        tables.layout_id(*self)
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
+        tables.layout_id(tables.tcx.lift(*self).unwrap())
     }
 }
 
@@ -51,7 +51,7 @@ impl<'tcx> Stable<'tcx>
 {
     type T = LayoutShape;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         LayoutShape {
             fields: self.fields.stable(tables),
             variants: self.variants.stable(tables),
@@ -65,7 +65,7 @@ impl<'tcx> Stable<'tcx>
 impl<'tcx> Stable<'tcx> for rustc_target::abi::call::FnAbi<'tcx, ty::Ty<'tcx>> {
     type T = FnAbi;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         assert!(self.args.len() >= self.fixed_count as usize);
         assert!(!self.c_variadic || matches!(self.conv, Conv::C));
         FnAbi {
@@ -81,7 +81,7 @@ impl<'tcx> Stable<'tcx> for rustc_target::abi::call::FnAbi<'tcx, ty::Ty<'tcx>> {
 impl<'tcx> Stable<'tcx> for rustc_target::abi::call::ArgAbi<'tcx, ty::Ty<'tcx>> {
     type T = ArgAbi;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         ArgAbi {
             ty: self.layout.ty.stable(tables),
             layout: self.layout.layout.stable(tables),
@@ -93,7 +93,7 @@ impl<'tcx> Stable<'tcx> for rustc_target::abi::call::ArgAbi<'tcx, ty::Ty<'tcx>> 
 impl<'tcx> Stable<'tcx> for rustc_target::abi::call::Conv {
     type T = CallConvention;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         match self {
             Conv::C => CallConvention::C,
             Conv::Rust => CallConvention::Rust,
@@ -122,7 +122,7 @@ impl<'tcx> Stable<'tcx> for rustc_target::abi::call::Conv {
 impl<'tcx> Stable<'tcx> for rustc_target::abi::call::PassMode {
     type T = PassMode;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         match self {
             rustc_target::abi::call::PassMode::Ignore => PassMode::Ignore,
             rustc_target::abi::call::PassMode::Direct(attr) => PassMode::Direct(opaque(attr)),
@@ -146,7 +146,7 @@ impl<'tcx> Stable<'tcx> for rustc_target::abi::call::PassMode {
 impl<'tcx> Stable<'tcx> for rustc_abi::FieldsShape<rustc_target::abi::FieldIdx> {
     type T = FieldsShape;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             rustc_abi::FieldsShape::Primitive => FieldsShape::Primitive,
             rustc_abi::FieldsShape::Union(count) => FieldsShape::Union(*count),
@@ -165,7 +165,7 @@ impl<'tcx> Stable<'tcx>
 {
     type T = VariantsShape;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             rustc_abi::Variants::Single { index } => {
                 VariantsShape::Single { index: index.stable(tables) }
@@ -185,7 +185,7 @@ impl<'tcx> Stable<'tcx>
 impl<'tcx> Stable<'tcx> for rustc_abi::TagEncoding<rustc_target::abi::VariantIdx> {
     type T = TagEncoding;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             rustc_abi::TagEncoding::Direct => TagEncoding::Direct,
             rustc_abi::TagEncoding::Niche { untagged_variant, niche_variants, niche_start } => {
@@ -202,7 +202,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::TagEncoding<rustc_target::abi::VariantIdx
 impl<'tcx> Stable<'tcx> for rustc_abi::Abi {
     type T = ValueAbi;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match *self {
             rustc_abi::Abi::Uninhabited => ValueAbi::Uninhabited,
             rustc_abi::Abi::Scalar(scalar) => ValueAbi::Scalar(scalar.stable(tables)),
@@ -220,7 +220,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::Abi {
 impl<'tcx> Stable<'tcx> for rustc_abi::Size {
     type T = Size;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         self.bytes_usize()
     }
 }
@@ -228,7 +228,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::Size {
 impl<'tcx> Stable<'tcx> for rustc_abi::Align {
     type T = Align;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         self.bytes()
     }
 }
@@ -236,7 +236,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::Align {
 impl<'tcx> Stable<'tcx> for rustc_abi::Scalar {
     type T = Opaque;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         opaque(self)
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/error.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/error.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::layout::LayoutError;
 impl<'tcx> Stable<'tcx> for LayoutError<'tcx> {
     type T = stable_mir::Error;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         stable_mir::Error::new(format!("{self:?}"))
     }
 }
@@ -16,7 +16,7 @@ impl<'tcx> Stable<'tcx> for LayoutError<'tcx> {
 impl<'tcx> Stable<'tcx> for AllocError {
     type T = stable_mir::Error;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         stable_mir::Error::new(format!("{self:?}"))
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -13,7 +13,7 @@ use crate::rustc_smir::{alloc, Stable, Tables};
 impl<'tcx> Stable<'tcx> for mir::Body<'tcx> {
     type T = stable_mir::mir::Body;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         stable_mir::mir::Body::new(
             self.basic_blocks
                 .iter()
@@ -44,7 +44,7 @@ impl<'tcx> Stable<'tcx> for mir::Body<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::VarDebugInfo<'tcx> {
     type T = stable_mir::mir::VarDebugInfo;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         stable_mir::mir::VarDebugInfo {
             name: self.name.to_string(),
             source_info: self.source_info.stable(tables),
@@ -57,21 +57,21 @@ impl<'tcx> Stable<'tcx> for mir::VarDebugInfo<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::Statement<'tcx> {
     type T = stable_mir::mir::Statement;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         Statement { kind: self.kind.stable(tables), span: self.source_info.span.stable(tables) }
     }
 }
 
 impl<'tcx> Stable<'tcx> for mir::SourceInfo {
     type T = stable_mir::mir::SourceInfo;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         stable_mir::mir::SourceInfo { span: self.span.stable(tables), scope: self.scope.into() }
     }
 }
 
 impl<'tcx> Stable<'tcx> for mir::VarDebugInfoFragment<'tcx> {
     type T = stable_mir::mir::VarDebugInfoFragment;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         VarDebugInfoFragment {
             ty: self.ty.stable(tables),
             projection: self.projection.iter().map(|e| e.stable(tables)).collect(),
@@ -81,7 +81,7 @@ impl<'tcx> Stable<'tcx> for mir::VarDebugInfoFragment<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::VarDebugInfoContents<'tcx> {
     type T = stable_mir::mir::VarDebugInfoContents;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             mir::VarDebugInfoContents::Place(place) => {
                 stable_mir::mir::VarDebugInfoContents::Place(place.stable(tables))
@@ -100,7 +100,7 @@ impl<'tcx> Stable<'tcx> for mir::VarDebugInfoContents<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::StatementKind<'tcx> {
     type T = stable_mir::mir::StatementKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             mir::StatementKind::Assign(assign) => stable_mir::mir::StatementKind::Assign(
                 assign.0.stable(tables),
@@ -158,7 +158,7 @@ impl<'tcx> Stable<'tcx> for mir::StatementKind<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::Rvalue<'tcx> {
     type T = stable_mir::mir::Rvalue;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::Rvalue::*;
         match self {
             Use(op) => stable_mir::mir::Rvalue::Use(op.stable(tables)),
@@ -214,7 +214,7 @@ impl<'tcx> Stable<'tcx> for mir::Rvalue<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::Mutability {
     type T = stable_mir::mir::Mutability;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_hir::Mutability::*;
         match *self {
             Not => stable_mir::mir::Mutability::Not,
@@ -225,7 +225,7 @@ impl<'tcx> Stable<'tcx> for mir::Mutability {
 
 impl<'tcx> Stable<'tcx> for mir::BorrowKind {
     type T = stable_mir::mir::BorrowKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::BorrowKind::*;
         match *self {
             Shared => stable_mir::mir::BorrowKind::Shared,
@@ -237,7 +237,7 @@ impl<'tcx> Stable<'tcx> for mir::BorrowKind {
 
 impl<'tcx> Stable<'tcx> for mir::MutBorrowKind {
     type T = stable_mir::mir::MutBorrowKind;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::MutBorrowKind::*;
         match *self {
             Default => stable_mir::mir::MutBorrowKind::Default,
@@ -249,7 +249,7 @@ impl<'tcx> Stable<'tcx> for mir::MutBorrowKind {
 
 impl<'tcx> Stable<'tcx> for mir::NullOp<'tcx> {
     type T = stable_mir::mir::NullOp;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::NullOp::*;
         match self {
             SizeOf => stable_mir::mir::NullOp::SizeOf,
@@ -263,7 +263,7 @@ impl<'tcx> Stable<'tcx> for mir::NullOp<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::CastKind {
     type T = stable_mir::mir::CastKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::CastKind::*;
         match self {
             PointerExposeAddress => stable_mir::mir::CastKind::PointerExposeAddress,
@@ -283,7 +283,7 @@ impl<'tcx> Stable<'tcx> for mir::CastKind {
 
 impl<'tcx> Stable<'tcx> for mir::FakeReadCause {
     type T = stable_mir::mir::FakeReadCause;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::FakeReadCause::*;
         match self {
             ForMatchGuard => stable_mir::mir::FakeReadCause::ForMatchGuard,
@@ -299,7 +299,7 @@ impl<'tcx> Stable<'tcx> for mir::FakeReadCause {
 
 impl<'tcx> Stable<'tcx> for mir::Operand<'tcx> {
     type T = stable_mir::mir::Operand;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::Operand::*;
         match self {
             Copy(place) => stable_mir::mir::Operand::Copy(place.stable(tables)),
@@ -312,7 +312,7 @@ impl<'tcx> Stable<'tcx> for mir::Operand<'tcx> {
 impl<'tcx> Stable<'tcx> for mir::ConstOperand<'tcx> {
     type T = stable_mir::mir::Constant;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         stable_mir::mir::Constant {
             span: self.span.stable(tables),
             user_ty: self.user_ty.map(|u| u.as_usize()).or(None),
@@ -323,7 +323,7 @@ impl<'tcx> Stable<'tcx> for mir::ConstOperand<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::Place<'tcx> {
     type T = stable_mir::mir::Place;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         stable_mir::mir::Place {
             local: self.local.as_usize(),
             projection: self.projection.iter().map(|e| e.stable(tables)).collect(),
@@ -333,7 +333,7 @@ impl<'tcx> Stable<'tcx> for mir::Place<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::PlaceElem<'tcx> {
     type T = stable_mir::mir::ProjectionElem;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::ProjectionElem::*;
         match self {
             Deref => stable_mir::mir::ProjectionElem::Deref,
@@ -368,21 +368,21 @@ impl<'tcx> Stable<'tcx> for mir::PlaceElem<'tcx> {
 impl<'tcx> Stable<'tcx> for mir::UserTypeProjection {
     type T = stable_mir::mir::UserTypeProjection;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         UserTypeProjection { base: self.base.as_usize(), projection: opaque(&self.projs) }
     }
 }
 
 impl<'tcx> Stable<'tcx> for mir::Local {
     type T = stable_mir::mir::Local;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         self.as_usize()
     }
 }
 
 impl<'tcx> Stable<'tcx> for mir::RetagKind {
     type T = stable_mir::mir::RetagKind;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::RetagKind;
         match self {
             RetagKind::FnEntry => stable_mir::mir::RetagKind::FnEntry,
@@ -395,7 +395,7 @@ impl<'tcx> Stable<'tcx> for mir::RetagKind {
 
 impl<'tcx> Stable<'tcx> for mir::UnwindAction {
     type T = stable_mir::mir::UnwindAction;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::UnwindAction;
         match self {
             UnwindAction::Continue => stable_mir::mir::UnwindAction::Continue,
@@ -409,7 +409,7 @@ impl<'tcx> Stable<'tcx> for mir::UnwindAction {
 impl<'tcx> Stable<'tcx> for mir::NonDivergingIntrinsic<'tcx> {
     type T = stable_mir::mir::NonDivergingIntrinsic;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::NonDivergingIntrinsic;
         use stable_mir::mir::CopyNonOverlapping;
         match self {
@@ -429,7 +429,7 @@ impl<'tcx> Stable<'tcx> for mir::NonDivergingIntrinsic<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::AssertMessage<'tcx> {
     type T = stable_mir::mir::AssertMessage;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::AssertKind;
         match self {
             AssertKind::BoundsCheck { len, index } => stable_mir::mir::AssertMessage::BoundsCheck {
@@ -468,7 +468,7 @@ impl<'tcx> Stable<'tcx> for mir::AssertMessage<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::BinOp {
     type T = stable_mir::mir::BinOp;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::BinOp;
         match self {
             BinOp::Add => stable_mir::mir::BinOp::Add,
@@ -499,7 +499,7 @@ impl<'tcx> Stable<'tcx> for mir::BinOp {
 
 impl<'tcx> Stable<'tcx> for mir::UnOp {
     type T = stable_mir::mir::UnOp;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::UnOp;
         match self {
             UnOp::Not => stable_mir::mir::UnOp::Not,
@@ -510,7 +510,7 @@ impl<'tcx> Stable<'tcx> for mir::UnOp {
 
 impl<'tcx> Stable<'tcx> for mir::AggregateKind<'tcx> {
     type T = stable_mir::mir::AggregateKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             mir::AggregateKind::Array(ty) => {
                 stable_mir::mir::AggregateKind::Array(ty.stable(tables))
@@ -544,7 +544,7 @@ impl<'tcx> Stable<'tcx> for mir::AggregateKind<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::InlineAsmOperand<'tcx> {
     type T = stable_mir::mir::InlineAsmOperand;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::InlineAsmOperand;
 
         let (in_value, out_place) = match self {
@@ -564,7 +564,7 @@ impl<'tcx> Stable<'tcx> for mir::InlineAsmOperand<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::Terminator<'tcx> {
     type T = stable_mir::mir::Terminator;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::mir::Terminator;
         Terminator { kind: self.kind.stable(tables), span: self.source_info.span.stable(tables) }
     }
@@ -572,7 +572,7 @@ impl<'tcx> Stable<'tcx> for mir::Terminator<'tcx> {
 
 impl<'tcx> Stable<'tcx> for mir::TerminatorKind<'tcx> {
     type T = stable_mir::mir::TerminatorKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::mir::TerminatorKind;
         match self {
             mir::TerminatorKind::Goto { target } => {
@@ -649,7 +649,7 @@ impl<'tcx> Stable<'tcx> for mir::TerminatorKind<'tcx> {
 impl<'tcx> Stable<'tcx> for mir::interpret::ConstAllocation<'tcx> {
     type T = Allocation;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         self.inner().stable(tables)
     }
 }
@@ -657,7 +657,7 @@ impl<'tcx> Stable<'tcx> for mir::interpret::ConstAllocation<'tcx> {
 impl<'tcx> Stable<'tcx> for mir::interpret::Allocation {
     type T = stable_mir::ty::Allocation;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         alloc::allocation_filter(
             self,
             alloc_range(rustc_target::abi::Size::ZERO, self.size()),
@@ -668,7 +668,7 @@ impl<'tcx> Stable<'tcx> for mir::interpret::Allocation {
 
 impl<'tcx> Stable<'tcx> for mir::interpret::AllocId {
     type T = stable_mir::mir::alloc::AllocId;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         tables.create_alloc_id(*self)
     }
 }
@@ -676,7 +676,7 @@ impl<'tcx> Stable<'tcx> for mir::interpret::AllocId {
 impl<'tcx> Stable<'tcx> for mir::interpret::GlobalAlloc<'tcx> {
     type T = GlobalAlloc;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             mir::interpret::GlobalAlloc::Function(instance) => {
                 GlobalAlloc::Function(instance.stable(tables))
@@ -695,7 +695,7 @@ impl<'tcx> Stable<'tcx> for mir::interpret::GlobalAlloc<'tcx> {
 impl<'tcx> Stable<'tcx> for rustc_middle::mir::Const<'tcx> {
     type T = stable_mir::ty::Const;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match *self {
             mir::Const::Ty(c) => c.stable(tables),
             mir::Const::Unevaluated(unev_const, ty) => {
@@ -706,18 +706,20 @@ impl<'tcx> Stable<'tcx> for rustc_middle::mir::Const<'tcx> {
                         promoted: unev_const.promoted.map(|u| u.as_u32()),
                     });
                 let ty = ty.stable(tables);
-                let id = tables.intern_const(*self);
+                let id = tables.intern_const(tables.tcx.lift(*self).unwrap());
                 Const::new(kind, ty, id)
             }
             mir::Const::Val(mir::ConstValue::ZeroSized, ty) => {
                 let ty = ty.stable(tables);
-                let id = tables.intern_const(*self);
+                let id = tables.intern_const(tables.tcx.lift(*self).unwrap());
                 Const::new(ConstantKind::ZeroSized, ty, id)
             }
             mir::Const::Val(val, ty) => {
+                let ty = tables.tcx.lift(ty).unwrap();
+                let val = tables.tcx.lift(val).unwrap();
                 let kind = ConstantKind::Allocated(alloc::new_allocation(ty, val, tables));
                 let ty = ty.stable(tables);
-                let id = tables.intern_const(*self);
+                let id = tables.intern_const(tables.tcx.lift(*self).unwrap());
                 Const::new(kind, ty, id)
             }
         }
@@ -727,7 +729,7 @@ impl<'tcx> Stable<'tcx> for rustc_middle::mir::Const<'tcx> {
 impl<'tcx> Stable<'tcx> for mir::interpret::ErrorHandled {
     type T = Error;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         Error::new(format!("{self:?}"))
     }
 }
@@ -735,7 +737,7 @@ impl<'tcx> Stable<'tcx> for mir::interpret::ErrorHandled {
 impl<'tcx> Stable<'tcx> for MonoItem<'tcx> {
     type T = stable_mir::mir::mono::MonoItem;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::mir::mono::MonoItem as StableMonoItem;
         match self {
             MonoItem::Fn(instance) => StableMonoItem::Fn(instance.stable(tables)),

--- a/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
@@ -11,7 +11,7 @@ mod ty;
 
 impl<'tcx> Stable<'tcx> for rustc_hir::Unsafety {
     type T = stable_mir::mir::Safety;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             rustc_hir::Unsafety::Unsafe => stable_mir::mir::Safety::Unsafe,
             rustc_hir::Unsafety::Normal => stable_mir::mir::Safety::Normal,
@@ -21,14 +21,14 @@ impl<'tcx> Stable<'tcx> for rustc_hir::Unsafety {
 
 impl<'tcx> Stable<'tcx> for FieldIdx {
     type T = usize;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         self.as_usize()
     }
 }
 
 impl<'tcx> Stable<'tcx> for rustc_hir::CoroutineSource {
     type T = stable_mir::mir::CoroutineSource;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_hir::CoroutineSource;
         match self {
             CoroutineSource::Block => stable_mir::mir::CoroutineSource::Block,
@@ -40,7 +40,7 @@ impl<'tcx> Stable<'tcx> for rustc_hir::CoroutineSource {
 
 impl<'tcx> Stable<'tcx> for rustc_hir::CoroutineKind {
     type T = stable_mir::mir::CoroutineKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_hir::{CoroutineDesugaring, CoroutineKind};
         match *self {
             CoroutineKind::Desugared(CoroutineDesugaring::Async, source) => {
@@ -71,7 +71,7 @@ impl<'tcx> Stable<'tcx> for rustc_hir::CoroutineKind {
 impl<'tcx> Stable<'tcx> for rustc_span::Symbol {
     type T = stable_mir::Symbol;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         self.to_string()
     }
 }
@@ -79,7 +79,7 @@ impl<'tcx> Stable<'tcx> for rustc_span::Symbol {
 impl<'tcx> Stable<'tcx> for rustc_span::Span {
     type T = stable_mir::ty::Span;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         tables.create_span(*self)
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -11,7 +11,7 @@ use crate::rustc_smir::{alloc, Stable, Tables};
 
 impl<'tcx> Stable<'tcx> for ty::AliasKind {
     type T = stable_mir::ty::AliasKind;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::Projection => stable_mir::ty::AliasKind::Projection,
             ty::Inherent => stable_mir::ty::AliasKind::Inherent,
@@ -23,7 +23,7 @@ impl<'tcx> Stable<'tcx> for ty::AliasKind {
 
 impl<'tcx> Stable<'tcx> for ty::AliasTy<'tcx> {
     type T = stable_mir::ty::AliasTy;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::AliasTy { args, def_id, .. } = self;
         stable_mir::ty::AliasTy { def_id: tables.alias_def(*def_id), args: args.stable(tables) }
     }
@@ -32,7 +32,7 @@ impl<'tcx> Stable<'tcx> for ty::AliasTy<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::DynKind {
     type T = stable_mir::ty::DynKind;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::Dyn => stable_mir::ty::DynKind::Dyn,
             ty::DynStar => stable_mir::ty::DynKind::DynStar,
@@ -43,7 +43,7 @@ impl<'tcx> Stable<'tcx> for ty::DynKind {
 impl<'tcx> Stable<'tcx> for ty::ExistentialPredicate<'tcx> {
     type T = stable_mir::ty::ExistentialPredicate;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::ExistentialPredicate::*;
         match self {
             ty::ExistentialPredicate::Trait(existential_trait_ref) => {
@@ -60,7 +60,7 @@ impl<'tcx> Stable<'tcx> for ty::ExistentialPredicate<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::ExistentialTraitRef<'tcx> {
     type T = stable_mir::ty::ExistentialTraitRef;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::ExistentialTraitRef { def_id, args } = self;
         stable_mir::ty::ExistentialTraitRef {
             def_id: tables.trait_def(*def_id),
@@ -72,7 +72,7 @@ impl<'tcx> Stable<'tcx> for ty::ExistentialTraitRef<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::TermKind<'tcx> {
     type T = stable_mir::ty::TermKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::TermKind;
         match self {
             ty::TermKind::Ty(ty) => TermKind::Type(ty.stable(tables)),
@@ -87,7 +87,7 @@ impl<'tcx> Stable<'tcx> for ty::TermKind<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::ExistentialProjection<'tcx> {
     type T = stable_mir::ty::ExistentialProjection;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::ExistentialProjection { def_id, args, term } = self;
         stable_mir::ty::ExistentialProjection {
             def_id: tables.trait_def(*def_id),
@@ -99,7 +99,7 @@ impl<'tcx> Stable<'tcx> for ty::ExistentialProjection<'tcx> {
 
 impl<'tcx> Stable<'tcx> for ty::adjustment::PointerCoercion {
     type T = stable_mir::mir::PointerCoercion;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::ty::adjustment::PointerCoercion;
         match self {
             PointerCoercion::ReifyFnPointer => stable_mir::mir::PointerCoercion::ReifyFnPointer,
@@ -118,7 +118,7 @@ impl<'tcx> Stable<'tcx> for ty::adjustment::PointerCoercion {
 
 impl<'tcx> Stable<'tcx> for ty::UserTypeAnnotationIndex {
     type T = usize;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         self.as_usize()
     }
 }
@@ -126,7 +126,7 @@ impl<'tcx> Stable<'tcx> for ty::UserTypeAnnotationIndex {
 impl<'tcx> Stable<'tcx> for ty::AdtKind {
     type T = AdtKind;
 
-    fn stable(&self, _tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _tables: &mut Tables<'_>) -> Self::T {
         match self {
             ty::AdtKind::Struct => AdtKind::Struct,
             ty::AdtKind::Union => AdtKind::Union,
@@ -138,7 +138,7 @@ impl<'tcx> Stable<'tcx> for ty::AdtKind {
 impl<'tcx> Stable<'tcx> for ty::FieldDef {
     type T = stable_mir::ty::FieldDef;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         stable_mir::ty::FieldDef {
             def: tables.create_def_id(self.did),
             name: self.name.stable(tables),
@@ -148,7 +148,7 @@ impl<'tcx> Stable<'tcx> for ty::FieldDef {
 
 impl<'tcx> Stable<'tcx> for ty::GenericArgs<'tcx> {
     type T = stable_mir::ty::GenericArgs;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         GenericArgs(self.iter().map(|arg| arg.unpack().stable(tables)).collect())
     }
 }
@@ -156,7 +156,7 @@ impl<'tcx> Stable<'tcx> for ty::GenericArgs<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::GenericArgKind<'tcx> {
     type T = stable_mir::ty::GenericArgKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::GenericArgKind;
         match self {
             ty::GenericArgKind::Lifetime(region) => GenericArgKind::Lifetime(region.stable(tables)),
@@ -172,7 +172,7 @@ where
 {
     type T = stable_mir::ty::Binder<V>;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::Binder;
 
         Binder {
@@ -192,7 +192,7 @@ where
 {
     type T = stable_mir::ty::EarlyBinder<V>;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::EarlyBinder;
 
         EarlyBinder { value: self.as_ref().skip_binder().stable(tables) }
@@ -201,7 +201,7 @@ where
 
 impl<'tcx> Stable<'tcx> for ty::FnSig<'tcx> {
     type T = stable_mir::ty::FnSig;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_target::spec::abi;
         use stable_mir::ty::{Abi, FnSig};
 
@@ -245,7 +245,7 @@ impl<'tcx> Stable<'tcx> for ty::FnSig<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::BoundTyKind {
     type T = stable_mir::ty::BoundTyKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::BoundTyKind;
 
         match self {
@@ -260,7 +260,7 @@ impl<'tcx> Stable<'tcx> for ty::BoundTyKind {
 impl<'tcx> Stable<'tcx> for ty::BoundRegionKind {
     type T = stable_mir::ty::BoundRegionKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::BoundRegionKind;
 
         match self {
@@ -276,7 +276,7 @@ impl<'tcx> Stable<'tcx> for ty::BoundRegionKind {
 impl<'tcx> Stable<'tcx> for ty::BoundVariableKind {
     type T = stable_mir::ty::BoundVariableKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::BoundVariableKind;
 
         match self {
@@ -294,7 +294,7 @@ impl<'tcx> Stable<'tcx> for ty::BoundVariableKind {
 impl<'tcx> Stable<'tcx> for ty::IntTy {
     type T = IntTy;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::IntTy::Isize => IntTy::Isize,
             ty::IntTy::I8 => IntTy::I8,
@@ -309,7 +309,7 @@ impl<'tcx> Stable<'tcx> for ty::IntTy {
 impl<'tcx> Stable<'tcx> for ty::UintTy {
     type T = UintTy;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::UintTy::Usize => UintTy::Usize,
             ty::UintTy::U8 => UintTy::U8,
@@ -324,7 +324,7 @@ impl<'tcx> Stable<'tcx> for ty::UintTy {
 impl<'tcx> Stable<'tcx> for ty::FloatTy {
     type T = FloatTy;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::FloatTy::F32 => FloatTy::F32,
             ty::FloatTy::F64 => FloatTy::F64,
@@ -334,14 +334,14 @@ impl<'tcx> Stable<'tcx> for ty::FloatTy {
 
 impl<'tcx> Stable<'tcx> for Ty<'tcx> {
     type T = stable_mir::ty::Ty;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
-        tables.intern_ty(*self)
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
+        tables.intern_ty(tables.tcx.lift(*self).unwrap())
     }
 }
 
 impl<'tcx> Stable<'tcx> for ty::TyKind<'tcx> {
     type T = stable_mir::ty::TyKind;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             ty::Bool => TyKind::RigidTy(RigidTy::Bool),
             ty::Char => TyKind::RigidTy(RigidTy::Char),
@@ -414,17 +414,22 @@ impl<'tcx> Stable<'tcx> for ty::TyKind<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
     type T = stable_mir::ty::Const;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let kind = match self.kind() {
             ty::Value(val) => {
-                let const_val = tables.tcx.valtree_to_const_val((self.ty(), val));
+                let val = match val {
+                    ty::ValTree::Leaf(scalar) => ty::ValTree::Leaf(scalar),
+                    ty::ValTree::Branch(branch) => {
+                        ty::ValTree::Branch(tables.tcx.lift(branch).unwrap())
+                    }
+                };
+                let ty = tables.tcx.lift(self.ty()).unwrap();
+                let const_val = tables.tcx.valtree_to_const_val((ty, val));
                 if matches!(const_val, mir::ConstValue::ZeroSized) {
                     ConstantKind::ZeroSized
                 } else {
                     stable_mir::ty::ConstantKind::Allocated(alloc::new_allocation(
-                        self.ty(),
-                        const_val,
-                        tables,
+                        ty, const_val, tables,
                     ))
                 }
             }
@@ -443,14 +448,14 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
             ty::ExprCt(_) => unimplemented!(),
         };
         let ty = self.ty().stable(tables);
-        let id = tables.intern_const(mir::Const::Ty(*self));
+        let id = tables.intern_const(mir::Const::Ty(tables.tcx.lift(*self).unwrap()));
         Const::new(kind, ty, id)
     }
 }
 
 impl<'tcx> Stable<'tcx> for ty::ParamConst {
     type T = stable_mir::ty::ParamConst;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::ParamConst;
         ParamConst { index: self.index, name: self.name.to_string() }
     }
@@ -458,7 +463,7 @@ impl<'tcx> Stable<'tcx> for ty::ParamConst {
 
 impl<'tcx> Stable<'tcx> for ty::ParamTy {
     type T = stable_mir::ty::ParamTy;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::ParamTy;
         ParamTy { index: self.index, name: self.name.to_string() }
     }
@@ -466,7 +471,7 @@ impl<'tcx> Stable<'tcx> for ty::ParamTy {
 
 impl<'tcx> Stable<'tcx> for ty::BoundTy {
     type T = stable_mir::ty::BoundTy;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::BoundTy;
         BoundTy { var: self.var.as_usize(), kind: self.kind.stable(tables) }
     }
@@ -474,7 +479,7 @@ impl<'tcx> Stable<'tcx> for ty::BoundTy {
 
 impl<'tcx> Stable<'tcx> for ty::trait_def::TraitSpecializationKind {
     type T = stable_mir::ty::TraitSpecializationKind;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::TraitSpecializationKind;
 
         match self {
@@ -489,7 +494,7 @@ impl<'tcx> Stable<'tcx> for ty::trait_def::TraitSpecializationKind {
 
 impl<'tcx> Stable<'tcx> for ty::TraitDef {
     type T = stable_mir::ty::TraitDecl;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::opaque;
         use stable_mir::ty::TraitDecl;
 
@@ -514,7 +519,7 @@ impl<'tcx> Stable<'tcx> for ty::TraitDef {
 
 impl<'tcx> Stable<'tcx> for ty::TraitRef<'tcx> {
     type T = stable_mir::ty::TraitRef;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::TraitRef;
 
         TraitRef::try_new(tables.trait_def(self.def_id), self.args.stable(tables)).unwrap()
@@ -524,7 +529,7 @@ impl<'tcx> Stable<'tcx> for ty::TraitRef<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::Generics {
     type T = stable_mir::ty::Generics;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::Generics;
 
         let params: Vec<_> = self.params.iter().map(|param| param.stable(tables)).collect();
@@ -549,7 +554,7 @@ impl<'tcx> Stable<'tcx> for ty::Generics {
 impl<'tcx> Stable<'tcx> for rustc_middle::ty::GenericParamDefKind {
     type T = stable_mir::ty::GenericParamDefKind;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::GenericParamDefKind;
         match self {
             ty::GenericParamDefKind::Lifetime => GenericParamDefKind::Lifetime,
@@ -566,7 +571,7 @@ impl<'tcx> Stable<'tcx> for rustc_middle::ty::GenericParamDefKind {
 impl<'tcx> Stable<'tcx> for rustc_middle::ty::GenericParamDef {
     type T = stable_mir::ty::GenericParamDef;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         GenericParamDef {
             name: self.name.to_string(),
             def_id: tables.generic_def(self.def_id),
@@ -580,7 +585,7 @@ impl<'tcx> Stable<'tcx> for rustc_middle::ty::GenericParamDef {
 impl<'tcx> Stable<'tcx> for ty::PredicateKind<'tcx> {
     type T = stable_mir::ty::PredicateKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::ty::PredicateKind;
         match self {
             PredicateKind::Clause(clause_kind) => {
@@ -614,7 +619,7 @@ impl<'tcx> Stable<'tcx> for ty::PredicateKind<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::ClauseKind<'tcx> {
     type T = stable_mir::ty::ClauseKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::ty::ClauseKind;
         match *self {
             ClauseKind::Trait(trait_object) => {
@@ -650,7 +655,7 @@ impl<'tcx> Stable<'tcx> for ty::ClauseKind<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::ClosureKind {
     type T = stable_mir::ty::ClosureKind;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::ty::ClosureKind::*;
         match self {
             Fn => stable_mir::ty::ClosureKind::Fn,
@@ -663,7 +668,7 @@ impl<'tcx> Stable<'tcx> for ty::ClosureKind {
 impl<'tcx> Stable<'tcx> for ty::SubtypePredicate<'tcx> {
     type T = stable_mir::ty::SubtypePredicate;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::SubtypePredicate { a, b, a_is_expected: _ } = self;
         stable_mir::ty::SubtypePredicate { a: a.stable(tables), b: b.stable(tables) }
     }
@@ -672,7 +677,7 @@ impl<'tcx> Stable<'tcx> for ty::SubtypePredicate<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::CoercePredicate<'tcx> {
     type T = stable_mir::ty::CoercePredicate;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::CoercePredicate { a, b } = self;
         stable_mir::ty::CoercePredicate { a: a.stable(tables), b: b.stable(tables) }
     }
@@ -681,7 +686,7 @@ impl<'tcx> Stable<'tcx> for ty::CoercePredicate<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::AliasRelationDirection {
     type T = stable_mir::ty::AliasRelationDirection;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::ty::AliasRelationDirection::*;
         match self {
             Equate => stable_mir::ty::AliasRelationDirection::Equate,
@@ -693,7 +698,7 @@ impl<'tcx> Stable<'tcx> for ty::AliasRelationDirection {
 impl<'tcx> Stable<'tcx> for ty::TraitPredicate<'tcx> {
     type T = stable_mir::ty::TraitPredicate;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::TraitPredicate { trait_ref, polarity } = self;
         stable_mir::ty::TraitPredicate {
             trait_ref: trait_ref.stable(tables),
@@ -709,7 +714,7 @@ where
 {
     type T = stable_mir::ty::OutlivesPredicate<U, V>;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::OutlivesPredicate(a, b) = self;
         stable_mir::ty::OutlivesPredicate(a.stable(tables), b.stable(tables))
     }
@@ -718,7 +723,7 @@ where
 impl<'tcx> Stable<'tcx> for ty::ProjectionPredicate<'tcx> {
     type T = stable_mir::ty::ProjectionPredicate;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let ty::ProjectionPredicate { projection_ty, term } = self;
         stable_mir::ty::ProjectionPredicate {
             projection_ty: projection_ty.stable(tables),
@@ -730,7 +735,7 @@ impl<'tcx> Stable<'tcx> for ty::ProjectionPredicate<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::ImplPolarity {
     type T = stable_mir::ty::ImplPolarity;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         use rustc_middle::ty::ImplPolarity::*;
         match self {
             Positive => stable_mir::ty::ImplPolarity::Positive,
@@ -743,7 +748,7 @@ impl<'tcx> Stable<'tcx> for ty::ImplPolarity {
 impl<'tcx> Stable<'tcx> for ty::Region<'tcx> {
     type T = stable_mir::ty::Region;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         Region { kind: self.kind().stable(tables) }
     }
 }
@@ -751,7 +756,7 @@ impl<'tcx> Stable<'tcx> for ty::Region<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::RegionKind<'tcx> {
     type T = stable_mir::ty::RegionKind;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use stable_mir::ty::{BoundRegion, EarlyParamRegion, RegionKind};
         match self {
             ty::ReEarlyParam(early_reg) => RegionKind::ReEarlyParam(EarlyParamRegion {
@@ -782,8 +787,8 @@ impl<'tcx> Stable<'tcx> for ty::RegionKind<'tcx> {
 impl<'tcx> Stable<'tcx> for ty::Instance<'tcx> {
     type T = stable_mir::mir::mono::Instance;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
-        let def = tables.instance_def(*self);
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
+        let def = tables.instance_def(tables.tcx.lift(*self).unwrap());
         let kind = match self.def {
             ty::InstanceDef::Item(..) => stable_mir::mir::mono::InstanceKind::Item,
             ty::InstanceDef::Intrinsic(..) => stable_mir::mir::mono::InstanceKind::Intrinsic,
@@ -805,7 +810,7 @@ impl<'tcx> Stable<'tcx> for ty::Instance<'tcx> {
 
 impl<'tcx> Stable<'tcx> for ty::Variance {
     type T = stable_mir::mir::Variance;
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::Variance::Bivariant => stable_mir::mir::Variance::Bivariant,
             ty::Variance::Contravariant => stable_mir::mir::Variance::Contravariant,
@@ -818,7 +823,7 @@ impl<'tcx> Stable<'tcx> for ty::Variance {
 impl<'tcx> Stable<'tcx> for ty::Movability {
     type T = stable_mir::ty::Movability;
 
-    fn stable(&self, _: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
             ty::Movability::Static => stable_mir::ty::Movability::Static,
             ty::Movability::Movable => stable_mir::ty::Movability::Movable,

--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -102,11 +102,11 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
 }
 
 /// Trait used to convert between an internal MIR type to a Stable MIR type.
-pub trait Stable<'tcx> {
+pub trait Stable<'cx> {
     /// The stable representation of the type implementing Stable.
     type T;
     /// Converts an object to the equivalent Stable MIR representation.
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T;
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T;
 }
 
 impl<'tcx, T> Stable<'tcx> for &T
@@ -115,7 +115,7 @@ where
 {
     type T = T::T;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         (*self).stable(tables)
     }
 }
@@ -126,7 +126,7 @@ where
 {
     type T = Option<T::T>;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         self.as_ref().map(|value| value.stable(tables))
     }
 }
@@ -138,7 +138,7 @@ where
 {
     type T = Result<T::T, E::T>;
 
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         match self {
             Ok(val) => Ok(val.stable(tables)),
             Err(error) => Err(error.stable(tables)),
@@ -151,7 +151,7 @@ where
     T: Stable<'tcx>,
 {
     type T = Vec<T::T>;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         self.iter().map(|e| e.stable(tables)).collect()
     }
 }
@@ -162,7 +162,7 @@ where
     U: Stable<'tcx>,
 {
     type T = (T::T, U::T);
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         (self.0.stable(tables), self.1.stable(tables))
     }
 }
@@ -172,7 +172,7 @@ where
     T: Stable<'tcx>,
 {
     type T = RangeInclusive<T::T>;
-    fn stable(&self, tables: &mut Tables<'tcx>) -> Self::T {
+    fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         RangeInclusive::new(self.start().stable(tables), self.end().stable(tables))
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1027,6 +1027,7 @@ symbols! {
         minnumf32,
         minnumf64,
         mips_target_feature,
+        mir_assume,
         mir_basic_block,
         mir_call,
         mir_cast_transmute,

--- a/library/alloc/src/vec/in_place_collect.rs
+++ b/library/alloc/src/vec/in_place_collect.rs
@@ -72,7 +72,7 @@
 //! This is handled by the [`InPlaceDrop`] guard for sink items (`U`) and by
 //! [`vec::IntoIter::forget_allocation_drop_remaining()`] for remaining source items (`T`).
 //!
-//! If dropping any remaining source item (`T`) panics then [`InPlaceDstBufDrop`] will handle dropping
+//! If dropping any remaining source item (`T`) panics then [`InPlaceDstDataSrcBufDrop`] will handle dropping
 //! the already collected sink items (`U`) and freeing the allocation.
 //!
 //! [`vec::IntoIter::forget_allocation_drop_remaining()`]: super::IntoIter::forget_allocation_drop_remaining()
@@ -158,11 +158,12 @@ use crate::alloc::{handle_alloc_error, Global};
 use core::alloc::Allocator;
 use core::alloc::Layout;
 use core::iter::{InPlaceIterable, SourceIter, TrustedRandomAccessNoCoerce};
+use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, SizedTypeProperties};
 use core::num::NonZeroUsize;
 use core::ptr::{self, NonNull};
 
-use super::{InPlaceDrop, InPlaceDstBufDrop, SpecFromIter, SpecFromIterNested, Vec};
+use super::{InPlaceDrop, InPlaceDstDataSrcBufDrop, SpecFromIter, SpecFromIterNested, Vec};
 
 const fn in_place_collectible<DEST, SRC>(
     step_merge: Option<NonZeroUsize>,
@@ -262,7 +263,7 @@ where
             );
         }
 
-        // The ownership of the allocation and the new `T` values is temporarily moved into `dst_guard`.
+        // The ownership of the source allocation and the new `T` values is temporarily moved into `dst_guard`.
         // This is safe because
         // * `forget_allocation_drop_remaining` immediately forgets the allocation
         // before any panic can occur in order to avoid any double free, and then proceeds to drop
@@ -273,7 +274,8 @@ where
         // Note: This access to the source wouldn't be allowed by the TrustedRandomIteratorNoCoerce
         // contract (used by SpecInPlaceCollect below). But see the "O(1) collect" section in the
         // module documentation why this is ok anyway.
-        let dst_guard = InPlaceDstBufDrop { ptr: dst_buf, len, cap: dst_cap };
+        let dst_guard =
+            InPlaceDstDataSrcBufDrop { ptr: dst_buf, len, src_cap, src: PhantomData::<I::Src> };
         src.forget_allocation_drop_remaining();
 
         // Adjust the allocation if the alignment didn't match or the source had a capacity in bytes

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -123,7 +123,7 @@ use self::set_len_on_drop::SetLenOnDrop;
 mod set_len_on_drop;
 
 #[cfg(not(no_global_oom_handling))]
-use self::in_place_drop::{InPlaceDrop, InPlaceDstBufDrop};
+use self::in_place_drop::{InPlaceDrop, InPlaceDstDataSrcBufDrop};
 
 #[cfg(not(no_global_oom_handling))]
 mod in_place_drop;

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2167,6 +2167,12 @@ impl<T, A: Allocator> Vec<T, A> {
     /// `[at, len)`. After the call, the original vector will be left containing
     /// the elements `[0, at)` with its previous capacity unchanged.
     ///
+    /// - If you want to take ownership of the entire contents and capacity of
+    ///   the vector, see [`mem::take`] or [`mem::replace`].
+    /// - If you don't need the returned vector at all, see [`Vec::truncate`].
+    /// - If you want to take ownership of an arbitrary subslice, or you don't
+    ///   necessarily want to store the removed items in a vector, see [`Vec::drain`].
+    ///
     /// # Panics
     ///
     /// Panics if `at > len`.

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -357,6 +357,8 @@ define!("mir_unwind_resume",
 
 define!("mir_storage_live", fn StorageLive<T>(local: T));
 define!("mir_storage_dead", fn StorageDead<T>(local: T));
+#[cfg(not(bootstrap))]
+define!("mir_assume", fn Assume(operand: bool));
 define!("mir_deinit", fn Deinit<T>(place: T));
 define!("mir_checked", fn Checked<T>(binop: T) -> (T, bool));
 define!("mir_len", fn Len<T>(place: T) -> usize);

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -59,7 +59,6 @@ use crate::num::NonZeroUsize;
 /// ```
 #[inline]
 #[unstable(feature = "iter_repeat_n", issue = "104434")]
-#[doc(hidden)] // waiting on ACP#120 to decide whether to expose publicly
 pub fn repeat_n<T: Clone>(element: T, count: usize) -> RepeatN<T> {
     let mut element = ManuallyDrop::new(element);
 
@@ -79,7 +78,6 @@ pub fn repeat_n<T: Clone>(element: T, count: usize) -> RepeatN<T> {
 /// See its documentation for more.
 #[derive(Clone, Debug)]
 #[unstable(feature = "iter_repeat_n", issue = "104434")]
-#[doc(hidden)] // waiting on ACP#120 to decide whether to expose publicly
 pub struct RepeatN<A> {
     count: usize,
     // Invariant: has been dropped iff count == 0.

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -72,6 +72,12 @@ ensure that each tier 2 target can be used as build target after each change. Au
 not always run so it's not guaranteed to produce a working build, but tier 2
 targets often work to quite a good degree and patches are always welcome!
 
+Tier 2 target-specific code is not closely scrutinized by Rust team(s) when
+modifications are made. Bugs are possible in all code, but the level of quality
+control for these targets is likely to be lower. See [library team
+policy](https://std-dev-guide.rust-lang.org/policy/target-code.html) for
+details on the review practices for standard library code.
+
 Tier 2 targets with host tools additionally support running tools like `rustc`
 and `cargo` natively on the target, and automated builds ensure that the host
 tools build as well. This allows the target to be used as a development
@@ -120,6 +126,12 @@ The `std` column in the table below has the following meanings:
 * \* indicates the target only supports [`no_std`] development.
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
+
+Tier 2 target-specific code is not closely scrutinized by Rust team(s) when
+modifications are made. Bugs are possible in all code, but the level of quality
+control for these targets is likely to be lower. See [library team
+policy](https://std-dev-guide.rust-lang.org/policy/target-code.html) for
+details on the review practices for standard library code.
 
 **NOTE:** The `rust-docs` component is not usually built for tier 2 targets,
 so Rustup may install the documentation for a similar tier 1 target instead.
@@ -210,6 +222,12 @@ The `std` column in the table below has the following meanings:
 * ? indicates the standard library support is unknown or a work-in-progress.
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
+
+Tier 3 target-specific code is not closely scrutinized by Rust team(s) when
+modifications are made. Bugs are possible in all code, but the level of quality
+control for these targets is likely to be lower. See [library team
+policy](https://std-dev-guide.rust-lang.org/policy/target-code.html) for
+details on the review practices for standard library code.
 
 The `host` column indicates whether the codebase includes support for building
 host tools.

--- a/tests/mir-opt/building/custom/assume.assume_constant.built.after.mir
+++ b/tests/mir-opt/building/custom/assume.assume_constant.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `assume_constant` after built
+
+fn assume_constant() -> () {
+    let mut _0: ();
+
+    bb0: {
+        assume(const true);
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/assume.assume_local.built.after.mir
+++ b/tests/mir-opt/building/custom/assume.assume_local.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `assume_local` after built
+
+fn assume_local(_1: bool) -> () {
+    let mut _0: ();
+
+    bb0: {
+        assume(_1);
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/assume.assume_place.built.after.mir
+++ b/tests/mir-opt/building/custom/assume.assume_place.built.after.mir
@@ -1,0 +1,10 @@
+// MIR for `assume_place` after built
+
+fn assume_place(_1: (bool, u8)) -> () {
+    let mut _0: ();
+
+    bb0: {
+        assume((_1.0: bool));
+        return;
+    }
+}

--- a/tests/mir-opt/building/custom/assume.rs
+++ b/tests/mir-opt/building/custom/assume.rs
@@ -1,0 +1,44 @@
+// skip-filecheck
+#![feature(custom_mir, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+
+// EMIT_MIR assume.assume_local.built.after.mir
+#[custom_mir(dialect = "built")]
+fn assume_local(x: bool) {
+    mir!(
+        {
+            Assume(x);
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR assume.assume_place.built.after.mir
+#[custom_mir(dialect = "built")]
+fn assume_place(p: (bool, u8)) {
+    mir!(
+        {
+            Assume(p.0);
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR assume.assume_constant.built.after.mir
+#[custom_mir(dialect = "built")]
+fn assume_constant() {
+    mir!(
+        {
+            Assume(true);
+            Return()
+        }
+    )
+}
+
+fn main() {
+    assume_local(true);
+    assume_place((true, 50));
+    assume_constant();
+}

--- a/tests/mir-opt/jump_threading.assume.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.assume.JumpThreading.panic-abort.diff
@@ -1,0 +1,39 @@
+- // MIR for `assume` before JumpThreading
++ // MIR for `assume` after JumpThreading
+  
+  fn assume(_1: u8, _2: bool) -> u8 {
+      let mut _0: u8;
+  
+      bb0: {
+          switchInt(_1) -> [7: bb1, otherwise: bb2];
+      }
+  
+      bb1: {
+          assume(_2);
+-         goto -> bb3;
++         goto -> bb6;
+      }
+  
+      bb2: {
+          goto -> bb3;
+      }
+  
+      bb3: {
+          switchInt(_2) -> [0: bb4, otherwise: bb5];
+      }
+  
+      bb4: {
+          _0 = const 4_u8;
+          return;
+      }
+  
+      bb5: {
+          _0 = const 5_u8;
+          return;
++     }
++ 
++     bb6: {
++         goto -> bb5;
+      }
+  }
+  

--- a/tests/mir-opt/jump_threading.assume.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.assume.JumpThreading.panic-unwind.diff
@@ -1,0 +1,39 @@
+- // MIR for `assume` before JumpThreading
++ // MIR for `assume` after JumpThreading
+  
+  fn assume(_1: u8, _2: bool) -> u8 {
+      let mut _0: u8;
+  
+      bb0: {
+          switchInt(_1) -> [7: bb1, otherwise: bb2];
+      }
+  
+      bb1: {
+          assume(_2);
+-         goto -> bb3;
++         goto -> bb6;
+      }
+  
+      bb2: {
+          goto -> bb3;
+      }
+  
+      bb3: {
+          switchInt(_2) -> [0: bb4, otherwise: bb5];
+      }
+  
+      bb4: {
+          _0 = const 4_u8;
+          return;
+      }
+  
+      bb5: {
+          _0 = const 5_u8;
+          return;
++     }
++ 
++     bb6: {
++         goto -> bb5;
+      }
+  }
+  

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -453,6 +453,52 @@ fn disappearing_bb(x: u8) -> u8 {
     )
 }
 
+/// Verify that we can leverage the existence of an `Assume` terminator.
+#[custom_mir(dialect = "runtime", phase = "post-cleanup")]
+fn assume(a: u8, b: bool) -> u8 {
+    // CHECK-LABEL: fn assume(
+    mir!(
+        {
+            // CHECK: bb0: {
+            // CHECK-NEXT: switchInt(_1) -> [7: bb1, otherwise: bb2]
+            match a { 7 => bb1, _ => bb2 }
+        }
+        bb1 = {
+            // CHECK: bb1: {
+            // CHECK-NEXT: assume(_2);
+            // CHECK-NEXT: goto -> bb6;
+            Assume(b);
+            Goto(bb3)
+        }
+        bb2 = {
+            // CHECK: bb2: {
+            // CHECK-NEXT: goto -> bb3;
+            Goto(bb3)
+        }
+        bb3 = {
+            // CHECK: bb3: {
+            // CHECK-NEXT: switchInt(_2) -> [0: bb4, otherwise: bb5];
+            match b { false => bb4, _ => bb5 }
+        }
+        bb4 = {
+            // CHECK: bb4: {
+            // CHECK-NEXT: _0 = const 4_u8;
+            // CHECK-NEXT: return;
+            RET = 4;
+            Return()
+        }
+        bb5 = {
+            // CHECK: bb5: {
+            // CHECK-NEXT: _0 = const 5_u8;
+            // CHECK-NEXT: return;
+            RET = 5;
+            Return()
+        }
+        // CHECK: bb6: {
+        // CHECK-NEXT: goto -> bb5;
+    )
+}
+
 fn main() {
     too_complex(Ok(0));
     identity(Ok(0));
@@ -464,6 +510,7 @@ fn main() {
     mutable_ref();
     renumbered_bb(true);
     disappearing_bb(7);
+    assume(7, false);
 }
 
 // EMIT_MIR jump_threading.too_complex.JumpThreading.diff
@@ -476,3 +523,4 @@ fn main() {
 // EMIT_MIR jump_threading.mutable_ref.JumpThreading.diff
 // EMIT_MIR jump_threading.renumbered_bb.JumpThreading.diff
 // EMIT_MIR jump_threading.disappearing_bb.JumpThreading.diff
+// EMIT_MIR jump_threading.assume.JumpThreading.diff

--- a/tests/ui-fulldeps/stable-mir/smir_internal.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_internal.rs
@@ -26,11 +26,11 @@ use std::ops::ControlFlow;
 
 const CRATE_NAME: &str = "input";
 
-fn test_translation(_tcx: TyCtxt) -> ControlFlow<()> {
+fn test_translation(tcx: TyCtxt<'_>) -> ControlFlow<()> {
     let main_fn = stable_mir::entry_fn().unwrap();
     let body = main_fn.body();
     let orig_ty = body.locals()[0].ty;
-    let rustc_ty = rustc_internal::internal(&orig_ty);
+    let rustc_ty = rustc_internal::internal(tcx, &orig_ty);
     assert!(rustc_ty.is_unit());
     ControlFlow::Continue(())
 }


### PR DESCRIPTION
Successful merges:

 - #120005 (Update Readme)
 - #120045 (Un-hide `iter::repeat_n`)
 - #120128 (Make stable_mir::with_tables sound)
 - #120145 (fix: Drop guard was deallocating with the incorrect size)
 - #120158 (`rustc_mir_dataflow`: Restore removed exports)
 - #120167 (Capture the rationale for `-Zallow-features=` in bootstrap.py)
 - #120171 (Fix assume and assert in jump threading)
 - #120174 (Warn users about limited review for tier 2 and 3 code)
 - #120180 (Document some alternatives to `Vec::split_off`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=120005,120045,120128,120145,120158,120167,120171,120174,120180)
<!-- homu-ignore:end -->