### PR TITLE
Improve `E0617` to Distinguish Between Fn Item and Fn Pointer in FFI

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -663,7 +663,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     p!(print_def_path(def_id, args));
                 } else {
                     let sig = self.tcx().fn_sig(def_id).instantiate(self.tcx(), args);
-                    p!(print(sig), " {{", print_value_path(def_id, args), "}}");
+                    p!("{{fn item ", print_value_path(def_id, args), ": ", print(sig), "}}");
                 }
             }
             ty::FnPtr(ref bare_fn) => p!(print(bare_fn)),

--- a/tests/ui/asm/x86_64/type-check-2.rs
+++ b/tests/ui/asm/x86_64/type-check-2.rs
@@ -64,7 +64,7 @@ fn main() {
         let mut r = &mut 0;
         asm!("{}", in(reg) f);
         asm!("{}", inout(reg) f);
-        //~^ ERROR cannot use value of type `fn() {main}` for inline assembly
+        //~^ ERROR cannot use value of type `{fn item main: fn()}` for inline assembly
         asm!("{}", in(reg) r);
         asm!("{}", inout(reg) r);
         //~^ ERROR cannot use value of type `&mut i32` for inline assembly

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -63,7 +63,7 @@ LL |         asm!("{}", in(reg) [1, 2, 3]);
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
-error: cannot use value of type `fn() {main}` for inline assembly
+error: cannot use value of type `{fn item main: fn()}` for inline assembly
   --> $DIR/type-check-2.rs:66:31
    |
 LL |         asm!("{}", inout(reg) f);

--- a/tests/ui/associated-types/substs-ppaux.normal.stderr
+++ b/tests/ui/associated-types/substs-ppaux.normal.stderr
@@ -10,7 +10,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+                found fn item `{fn item <i8 as Foo<'static, 'static, u8>>::bar::<'static, char>: fn()}`
 help: use parentheses to call this associated function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>();
@@ -28,7 +28,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+                found fn item `{fn item <i8 as Foo<'static, 'static>>::bar::<'static, char>: fn()}`
 help: use parentheses to call this associated function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>();
@@ -46,7 +46,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+                found fn item `{fn item <i8 as Foo<'static, 'static, u8>>::baz: fn()}`
 help: use parentheses to call this associated function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz();
@@ -64,7 +64,7 @@ LL |     let x: () = foo::<'static>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {foo::<'static>}`
+                found fn item `{fn item foo::<'static>: fn()}`
 help: use parentheses to call this function
    |
 LL |     let x: () = foo::<'static>();

--- a/tests/ui/associated-types/substs-ppaux.rs
+++ b/tests/ui/associated-types/substs-ppaux.rs
@@ -16,35 +16,35 @@ fn foo<'z>() where &'z (): Sized {
     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
+    //[verbose]~| found fn item `{fn item <i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>: fn()}`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+    //[normal]~| found fn item `{fn item <i8 as Foo<'static, 'static, u8>>::bar::<'static, char>: fn()}`
 
 
     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
+    //[verbose]~| found fn item `{fn item <i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>: fn()}`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+    //[normal]~| found fn item `{fn item <i8 as Foo<'static, 'static>>::bar::<'static, char>: fn()}`
 
     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
+    //[verbose]~| found fn item `{fn item <i8 as Foo<ReStatic, ReStatic, u8>>::baz: fn()}`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+    //[normal]~| found fn item `{fn item <i8 as Foo<'static, 'static, u8>>::baz: fn()}`
 
     let x: () = foo::<'static>;
     //[verbose]~^ ERROR mismatched types
     //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {foo::<ReStatic>}`
+    //[verbose]~| found fn item `{fn item foo::<ReStatic>: fn()}`
     //[normal]~^^^^ ERROR mismatched types
     //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {foo::<'static>}`
+    //[normal]~| found fn item `{fn item foo::<'static>: fn()}`
 
     <str as Foo<u8>>::bar;
     //[verbose]~^ ERROR the size for values of type

--- a/tests/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/tests/ui/associated-types/substs-ppaux.verbose.stderr
@@ -10,7 +10,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
+                found fn item `{fn item <i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>: fn()}`
 help: use parentheses to call this associated function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>();
@@ -28,7 +28,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
+                found fn item `{fn item <i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>: fn()}`
 help: use parentheses to call this associated function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>();
@@ -46,7 +46,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
+                found fn item `{fn item <i8 as Foo<ReStatic, ReStatic, u8>>::baz: fn()}`
 help: use parentheses to call this associated function
    |
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz();
@@ -64,7 +64,7 @@ LL |     let x: () = foo::<'static>;
    |            expected due to this
    |
    = note: expected unit type `()`
-                found fn item `fn() {foo::<ReStatic>}`
+                found fn item `{fn item foo::<ReStatic>: fn()}`
 help: use parentheses to call this function
    |
 LL |     let x: () = foo::<'static>();

--- a/tests/ui/async-await/drop-tracking-unresolved-typeck-results.stderr
+++ b/tests/ui/async-await/drop-tracking-unresolved-typeck-results.stderr
@@ -8,7 +8,7 @@ LL | |         Next(&Buffered(Map(Empty(PhantomData), ready::<&()>), FuturesOrde
 LL | |     });
    | |______^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&'0 ()) -> std::future::Ready<&'0 ()> {std::future::ready::<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
+   = note: `{fn item std::future::ready::<&'0 ()>: fn(&'0 ()) -> std::future::Ready<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `FnOnce<(&(),)>`
 
 error: implementation of `FnOnce` is not general enough
@@ -21,7 +21,7 @@ LL | |         Next(&Buffered(Map(Empty(PhantomData), ready::<&()>), FuturesOrde
 LL | |     });
    | |______^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&'0 ()) -> std::future::Ready<&'0 ()> {std::future::ready::<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
+   = note: `{fn item std::future::ready::<&'0 ()>: fn(&'0 ()) -> std::future::Ready<&'0 ()>}` must implement `FnOnce<(&'1 (),)>`, for any two lifetimes `'0` and `'1`...
    = note: ...but it actually implements `FnOnce<(&(),)>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/binop/issue-77910-1.rs
+++ b/tests/ui/binop/issue-77910-1.rs
@@ -7,5 +7,5 @@ fn main() {
     // we shouldn't ice with the bound var here.
     assert_eq!(foo, y);
     //~^ ERROR binary operation `==` cannot be applied to type
-    //~| ERROR `for<'a> fn(&'a i32) -> &'a i32 {foo}` doesn't implement `Debug`
+    //~| ERROR `{fn item foo: for<'a> fn(&'a i32) -> &'a i32}` doesn't implement `Debug`
 }

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -1,24 +1,24 @@
-error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a i32) -> &'a i32 {foo}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item foo: for<'a> fn(&'a i32) -> &'a i32}`
   --> $DIR/issue-77910-1.rs:8:5
    |
 LL |     assert_eq!(foo, y);
    |     ^^^^^^^^^^^^^^^^^^
    |     |
-   |     for<'a> fn(&'a i32) -> &'a i32 {foo}
+   |     {fn item foo: for<'a> fn(&'a i32) -> &'a i32}
    |     _
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `for<'a> fn(&'a i32) -> &'a i32 {foo}` doesn't implement `Debug`
+error[E0277]: `{fn item foo: for<'a> fn(&'a i32) -> &'a i32}` doesn't implement `Debug`
   --> $DIR/issue-77910-1.rs:8:5
    |
 LL | fn foo(s: &i32) -> &i32 {
    |    --- consider calling this function
 ...
 LL |     assert_eq!(foo, y);
-   |     ^^^^^^^^^^^^^^^^^^ `for<'a> fn(&'a i32) -> &'a i32 {foo}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^ `{fn item foo: for<'a> fn(&'a i32) -> &'a i32}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for fn item `for<'a> fn(&'a i32) -> &'a i32 {foo}`
+   = help: the trait `Debug` is not implemented for fn item `{fn item foo: for<'a> fn(&'a i32) -> &'a i32}`
    = help: use parentheses to call this function: `foo(/* &i32 */)`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/binop/issue-77910-2.stderr
+++ b/tests/ui/binop/issue-77910-2.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `for<'a> fn(&'a i32) -> &'a i32 {foo}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item foo: for<'a> fn(&'a i32) -> &'a i32}`
   --> $DIR/issue-77910-2.rs:7:12
    |
 LL |     if foo == y {}
    |        --- ^^ - _
    |        |
-   |        for<'a> fn(&'a i32) -> &'a i32 {foo}
+   |        {fn item foo: for<'a> fn(&'a i32) -> &'a i32}
    |
 help: use parentheses to call this function
    |

--- a/tests/ui/c-variadic/issue-32201.rs
+++ b/tests/ui/c-variadic/issue-32201.rs
@@ -7,7 +7,9 @@ fn bar(_: *const u8) {}
 fn main() {
     unsafe {
         foo(0, bar);
-        //~^ ERROR can't pass `fn(*const u8) {bar}` to variadic function
-        //~| HELP cast the value to `fn(*const u8)`
+        //~^ ERROR can't pass `{fn item bar: fn(*const u8)}` to variadic function
+        //~| HELP a function item is zero-sized and needs to be casted into a function pointer to be used in FFI
+        //~| HELP cast the value into a function pointer
+        //~| HELP cast the value to `fn(*const u8)
     }
 }

--- a/tests/ui/c-variadic/issue-69232.rs
+++ b/tests/ui/c-variadic/issue-69232.rs
@@ -1,0 +1,12 @@
+extern "C" {
+    fn foo(x: usize, ...);
+}
+
+fn test() -> u8 {
+    127
+}
+
+fn main() {
+    foo(1, test);
+    //~^ ERROR can't pass `{fn item test: fn() -> u8}` to variadic function
+}

--- a/tests/ui/c-variadic/issue-69232.stderr
+++ b/tests/ui/c-variadic/issue-69232.stderr
@@ -1,19 +1,19 @@
-error[E0617]: can't pass `{fn item bar: fn(*const u8)}` to variadic function
-  --> $DIR/issue-32201.rs:9:16
+error[E0617]: can't pass `{fn item test: fn() -> u8}` to variadic function
+  --> $DIR/issue-69232.rs:10:12
    |
-LL |         foo(0, bar);
-   |                ^^^
+LL |     foo(1, test);
+   |            ^^^^
    |
    = help: a function item is zero-sized and needs to be casted into a function pointer to be used in FFI
    = note: for more information on function items, visit https://doc.rust-lang.org/reference/types/function-item.html
-help: cast the value to `fn(*const u8)`
+help: cast the value to `fn() -> u8`
    |
-LL |         foo(0, bar as fn(*const u8));
-   |                ~~~~~~~~~~~~~~~~~~~~
+LL |     foo(1, test as fn() -> u8);
+   |            ~~~~~~~~~~~~~~~~~~
 help: cast the value into a function pointer
    |
-LL |         foo(0, bar as fn(*const u8));
-   |                    ++++++++++++++++
+LL |     foo(1, test as fn() -> u8);
+   |                 +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -62,37 +62,91 @@ error[E0617]: can't pass `f32` to variadic function
   --> $DIR/variadic-ffi-1.rs:28:19
    |
 LL |         foo(1, 2, 3f32);
-   |                   ^^^^ help: cast the value to `c_double`: `3f32 as c_double`
+   |                   ^^^^
+   |
+help: cast the value to `c_double`
+   |
+LL |         foo(1, 2, 3f32 as c_double);
+   |                   ~~~~~~~~~~~~~~~~
+help: cast the value to `c_double`
+   |
+LL |         foo(1, 2, 3f32 as c_double);
+   |                        +++++++++++
 
 error[E0617]: can't pass `bool` to variadic function
   --> $DIR/variadic-ffi-1.rs:29:19
    |
 LL |         foo(1, 2, true);
-   |                   ^^^^ help: cast the value to `c_int`: `true as c_int`
+   |                   ^^^^
+   |
+help: cast the value to `c_int`
+   |
+LL |         foo(1, 2, true as c_int);
+   |                   ~~~~~~~~~~~~~
+help: cast the value to `c_int`
+   |
+LL |         foo(1, 2, true as c_int);
+   |                        ++++++++
 
 error[E0617]: can't pass `i8` to variadic function
   --> $DIR/variadic-ffi-1.rs:30:19
    |
 LL |         foo(1, 2, 1i8);
-   |                   ^^^ help: cast the value to `c_int`: `1i8 as c_int`
+   |                   ^^^
+   |
+help: cast the value to `c_int`
+   |
+LL |         foo(1, 2, 1i8 as c_int);
+   |                   ~~~~~~~~~~~~
+help: cast the value to `c_int`
+   |
+LL |         foo(1, 2, 1i8 as c_int);
+   |                       ++++++++
 
 error[E0617]: can't pass `u8` to variadic function
   --> $DIR/variadic-ffi-1.rs:31:19
    |
 LL |         foo(1, 2, 1u8);
-   |                   ^^^ help: cast the value to `c_uint`: `1u8 as c_uint`
+   |                   ^^^
+   |
+help: cast the value to `c_uint`
+   |
+LL |         foo(1, 2, 1u8 as c_uint);
+   |                   ~~~~~~~~~~~~~
+help: cast the value to `c_uint`
+   |
+LL |         foo(1, 2, 1u8 as c_uint);
+   |                       +++++++++
 
 error[E0617]: can't pass `i16` to variadic function
   --> $DIR/variadic-ffi-1.rs:32:19
    |
 LL |         foo(1, 2, 1i16);
-   |                   ^^^^ help: cast the value to `c_int`: `1i16 as c_int`
+   |                   ^^^^
+   |
+help: cast the value to `c_int`
+   |
+LL |         foo(1, 2, 1i16 as c_int);
+   |                   ~~~~~~~~~~~~~
+help: cast the value to `c_int`
+   |
+LL |         foo(1, 2, 1i16 as c_int);
+   |                        ++++++++
 
 error[E0617]: can't pass `u16` to variadic function
   --> $DIR/variadic-ffi-1.rs:33:19
    |
 LL |         foo(1, 2, 1u16);
-   |                   ^^^^ help: cast the value to `c_uint`: `1u16 as c_uint`
+   |                   ^^^^
+   |
+help: cast the value to `c_uint`
+   |
+LL |         foo(1, 2, 1u16 as c_uint);
+   |                   ~~~~~~~~~~~~~~
+help: cast the value to `c_uint`
+   |
+LL |         foo(1, 2, 1u16 as c_uint);
+   |                        +++++++++
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/cast/cast-as-bool.rs
+++ b/tests/ui/cast/cast-as-bool.rs
@@ -30,9 +30,9 @@ fn main() {
     unsafe fn owo() {}
 
     // fn item to bool
-    let _ = uwu as bool; //~ ERROR cannot cast `fn(u8) -> String {uwu}` as `bool`
+    let _ = uwu as bool; //~ ERROR cannot cast `{fn item uwu: fn(u8) -> String}` as `bool`
     // unsafe fn item
-    let _ = owo as bool; //~ ERROR cannot cast `unsafe fn() {owo}` as `bool`
+    let _ = owo as bool; //~ ERROR cannot cast `{fn item owo: unsafe fn()}` as `bool`
 
     // fn ptr to bool
     let _ = uwu as fn(u8) -> String as bool; //~ ERROR cannot cast `fn(u8) -> String` as `bool`

--- a/tests/ui/cast/cast-as-bool.stderr
+++ b/tests/ui/cast/cast-as-bool.stderr
@@ -48,13 +48,13 @@ error[E0054]: cannot cast `IntEnum` as `bool`
 LL |     let _ = IntEnum::One as bool;
    |             ^^^^^^^^^^^^^^^^^^^^ unsupported cast
 
-error[E0054]: cannot cast `fn(u8) -> String {uwu}` as `bool`
+error[E0054]: cannot cast `{fn item uwu: fn(u8) -> String}` as `bool`
   --> $DIR/cast-as-bool.rs:33:13
    |
 LL |     let _ = uwu as bool;
    |             ^^^^^^^^^^^ unsupported cast
 
-error[E0054]: cannot cast `unsafe fn() {owo}` as `bool`
+error[E0054]: cannot cast `{fn item owo: unsafe fn()}` as `bool`
   --> $DIR/cast-as-bool.rs:35:13
    |
 LL |     let _ = owo as bool;

--- a/tests/ui/cast/cast-to-bare-fn.stderr
+++ b/tests/ui/cast/cast-to-bare-fn.stderr
@@ -1,4 +1,4 @@
-error[E0605]: non-primitive cast: `fn(isize) {foo}` as `extern "C" fn() -> isize`
+error[E0605]: non-primitive cast: `{fn item foo: fn(isize)}` as `extern "C" fn() -> isize`
   --> $DIR/cast-to-bare-fn.rs:5:13
    |
 LL |     let x = foo as extern "C" fn() -> isize;

--- a/tests/ui/closures/closure_cap_coerce_many_fail.stderr
+++ b/tests/ui/closures/closure_cap_coerce_many_fail.stderr
@@ -4,14 +4,14 @@ error[E0308]: `match` arms have incompatible types
 LL |       let _ = match "+" {
    |  _____________-
 LL | |         "+" => add,
-   | |                --- this is found to be of type `fn(i32, i32) -> i32 {add}`
+   | |                --- this is found to be of type `{fn item add: fn(i32, i32) -> i32}`
 LL | |         "-" => |a, b| (a - b + cap) as i32,
    | |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn item, found closure
 LL | |         _ => unimplemented!(),
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected fn item `fn(i32, i32) -> i32 {add}`
+   = note: expected fn item `{fn item add: fn(i32, i32) -> i32}`
               found closure `{closure@$DIR/closure_cap_coerce_many_fail.rs:9:16: 9:22}`
 
 error[E0308]: `match` arms have incompatible types

--- a/tests/ui/closures/coerce-unsafe-to-closure.stderr
+++ b/tests/ui/closures/coerce-unsafe-to-closure.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce(&str)` closure, found `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+error[E0277]: expected a `FnOnce(&str)` closure, found `{fn item transmute::<_, _>: unsafe extern "rust-intrinsic" fn(_) -> _}`
   --> $DIR/coerce-unsafe-to-closure.rs:2:44
    |
 LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);
@@ -6,7 +6,7 @@ LL |     let x: Option<&[u8]> = Some("foo").map(std::mem::transmute);
    |                                        |
    |                                        required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(&str,)>` is not implemented for fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
+   = help: the trait `FnOnce<(&str,)>` is not implemented for fn item `{fn item transmute::<_, _>: unsafe extern "rust-intrinsic" fn(_) -> _}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.rs
@@ -4,7 +4,7 @@
 fn check(_: impl std::marker::ConstParamTy) {}
 
 fn main() {
-    check(main);               //~ error: `fn() {main}` can't be used as a const parameter type
+    check(main);               //~ error: `{fn item main: fn()}` can't be used as a const parameter type
     check(|| {});              //~ error: `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}` can't be used as a const parameter type
     check(main as fn());       //~ error: `fn()` can't be used as a const parameter type
     check(&mut ());            //~ error: `&mut ()` can't be used as a const parameter type

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `fn() {main}` can't be used as a const parameter type
+error[E0277]: `{fn item main: fn()}` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad.rs:7:11
    |
 LL |     check(main);
-   |     ----- ^^^^ the trait `ConstParamTy` is not implemented for fn item `fn() {main}`
+   |     ----- ^^^^ the trait `ConstParamTy` is not implemented for fn item `{fn item main: fn()}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/eval-privacy.stderr
@@ -1,11 +1,11 @@
-error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+error[E0446]: private type `{fn item my_const_fn: fn(u8) -> u8}` in public interface
   --> $DIR/eval-privacy.rs:16:5
    |
 LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   | ----------------------------------- `{fn item my_const_fn: fn(u8) -> u8}` declared as private
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0617.rs
+++ b/tests/ui/error-codes/E0617.rs
@@ -7,20 +7,27 @@ fn main() {
         printf(::std::ptr::null(), 0f32);
         //~^ ERROR can't pass `f32` to variadic function
         //~| HELP cast the value to `c_double`
+        //~| HELP cast the value to `c_double`
         printf(::std::ptr::null(), 0i8);
         //~^ ERROR can't pass `i8` to variadic function
+        //~| HELP cast the value to `c_int`
         //~| HELP cast the value to `c_int`
         printf(::std::ptr::null(), 0i16);
         //~^ ERROR can't pass `i16` to variadic function
         //~| HELP cast the value to `c_int`
+        //~| HELP cast the value to `c_int`
         printf(::std::ptr::null(), 0u8);
         //~^ ERROR can't pass `u8` to variadic function
+        //~| HELP cast the value to `c_uint`
         //~| HELP cast the value to `c_uint`
         printf(::std::ptr::null(), 0u16);
         //~^ ERROR can't pass `u16` to variadic function
         //~| HELP cast the value to `c_uint`
+        //~| HELP cast the value to `c_uint`
         printf(::std::ptr::null(), printf);
-        //~^ ERROR can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to variadic function
+        //~^ ERROR can't pass `{fn item printf: unsafe extern "C" fn(*const i8, ...)}` to variadic function
+        //~| HELP a function item is zero-sized and needs to be casted into a function pointer to be used in FFI
+        //~| HELP cast the value into a function pointer
         //~| HELP cast the value to `unsafe extern "C" fn(*const i8, ...)`
     }
 }

--- a/tests/ui/error-codes/E0617.stderr
+++ b/tests/ui/error-codes/E0617.stderr
@@ -2,42 +2,93 @@ error[E0617]: can't pass `f32` to variadic function
   --> $DIR/E0617.rs:7:36
    |
 LL |         printf(::std::ptr::null(), 0f32);
-   |                                    ^^^^ help: cast the value to `c_double`: `0f32 as c_double`
+   |                                    ^^^^
+   |
+help: cast the value to `c_double`
+   |
+LL |         printf(::std::ptr::null(), 0f32 as c_double);
+   |                                    ~~~~~~~~~~~~~~~~
+help: cast the value to `c_double`
+   |
+LL |         printf(::std::ptr::null(), 0f32 as c_double);
+   |                                         +++++++++++
 
 error[E0617]: can't pass `i8` to variadic function
-  --> $DIR/E0617.rs:10:36
+  --> $DIR/E0617.rs:11:36
    |
 LL |         printf(::std::ptr::null(), 0i8);
-   |                                    ^^^ help: cast the value to `c_int`: `0i8 as c_int`
+   |                                    ^^^
+   |
+help: cast the value to `c_int`
+   |
+LL |         printf(::std::ptr::null(), 0i8 as c_int);
+   |                                    ~~~~~~~~~~~~
+help: cast the value to `c_int`
+   |
+LL |         printf(::std::ptr::null(), 0i8 as c_int);
+   |                                        ++++++++
 
 error[E0617]: can't pass `i16` to variadic function
-  --> $DIR/E0617.rs:13:36
+  --> $DIR/E0617.rs:15:36
    |
 LL |         printf(::std::ptr::null(), 0i16);
-   |                                    ^^^^ help: cast the value to `c_int`: `0i16 as c_int`
+   |                                    ^^^^
+   |
+help: cast the value to `c_int`
+   |
+LL |         printf(::std::ptr::null(), 0i16 as c_int);
+   |                                    ~~~~~~~~~~~~~
+help: cast the value to `c_int`
+   |
+LL |         printf(::std::ptr::null(), 0i16 as c_int);
+   |                                         ++++++++
 
 error[E0617]: can't pass `u8` to variadic function
-  --> $DIR/E0617.rs:16:36
-   |
-LL |         printf(::std::ptr::null(), 0u8);
-   |                                    ^^^ help: cast the value to `c_uint`: `0u8 as c_uint`
-
-error[E0617]: can't pass `u16` to variadic function
   --> $DIR/E0617.rs:19:36
    |
-LL |         printf(::std::ptr::null(), 0u16);
-   |                                    ^^^^ help: cast the value to `c_uint`: `0u16 as c_uint`
+LL |         printf(::std::ptr::null(), 0u8);
+   |                                    ^^^
+   |
+help: cast the value to `c_uint`
+   |
+LL |         printf(::std::ptr::null(), 0u8 as c_uint);
+   |                                    ~~~~~~~~~~~~~
+help: cast the value to `c_uint`
+   |
+LL |         printf(::std::ptr::null(), 0u8 as c_uint);
+   |                                        +++++++++
 
-error[E0617]: can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to variadic function
-  --> $DIR/E0617.rs:22:36
+error[E0617]: can't pass `u16` to variadic function
+  --> $DIR/E0617.rs:23:36
+   |
+LL |         printf(::std::ptr::null(), 0u16);
+   |                                    ^^^^
+   |
+help: cast the value to `c_uint`
+   |
+LL |         printf(::std::ptr::null(), 0u16 as c_uint);
+   |                                    ~~~~~~~~~~~~~~
+help: cast the value to `c_uint`
+   |
+LL |         printf(::std::ptr::null(), 0u16 as c_uint);
+   |                                         +++++++++
+
+error[E0617]: can't pass `{fn item printf: unsafe extern "C" fn(*const i8, ...)}` to variadic function
+  --> $DIR/E0617.rs:27:36
    |
 LL |         printf(::std::ptr::null(), printf);
    |                                    ^^^^^^
    |
+   = help: a function item is zero-sized and needs to be casted into a function pointer to be used in FFI
+   = note: for more information on function items, visit https://doc.rust-lang.org/reference/types/function-item.html
 help: cast the value to `unsafe extern "C" fn(*const i8, ...)`
    |
 LL |         printf(::std::ptr::null(), printf as unsafe extern "C" fn(*const i8, ...));
    |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+help: cast the value into a function pointer
+   |
+LL |         printf(::std::ptr::null(), printf as unsafe extern "C" fn(*const i8, ...));
+   |                                           +++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/expr/if/if-typeck.stderr
+++ b/tests/ui/expr/if/if-typeck.stderr
@@ -5,7 +5,7 @@ LL |     if f { }
    |        ^ expected `bool`, found fn item
    |
    = note: expected type `bool`
-           found fn item `fn() {f}`
+           found fn item `{fn item f: fn()}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/expr/malformed_closure/missing_block_in_fn_call.stderr
+++ b/tests/ui/expr/malformed_closure/missing_block_in_fn_call.stderr
@@ -27,7 +27,7 @@ LL | fn foo() {}
    | -------- function `foo` defined here
    |
    = note: expected unit type `()`
-                found fn item `fn() {foo}`
+                found fn item `{fn item foo: fn()}`
 help: use parentheses to call this function
    |
 LL |     let _: () = foo();

--- a/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.stderr
+++ b/tests/ui/expr/malformed_closure/ruby_style_closure_parse_error.stderr
@@ -25,7 +25,7 @@ LL | fn foo() {}
    | -------- function `foo` defined here
    |
    = note: expected unit type `()`
-                found fn item `fn() {foo}`
+                found fn item `{fn item foo: fn()}`
 help: use parentheses to call this function
    |
 LL |     let _: () = foo();

--- a/tests/ui/extern/extern-wrong-value-type.rs
+++ b/tests/ui/extern/extern-wrong-value-type.rs
@@ -7,5 +7,5 @@ fn main() {
     // extern functions are extern "C" fn
     let _x: extern "C" fn() = f; // OK
     is_fn(f);
-    //~^ ERROR expected a `Fn()` closure, found `extern "C" fn() {f}`
+    //~^ ERROR expected a `Fn()` closure, found `{fn item f: extern "C" fn()}`
 }

--- a/tests/ui/extern/extern-wrong-value-type.stderr
+++ b/tests/ui/extern/extern-wrong-value-type.stderr
@@ -1,13 +1,13 @@
-error[E0277]: expected a `Fn()` closure, found `extern "C" fn() {f}`
+error[E0277]: expected a `Fn()` closure, found `{fn item f: extern "C" fn()}`
   --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL |     is_fn(f);
-   |     ----- ^ expected an `Fn()` closure, found `extern "C" fn() {f}`
+   |     ----- ^ expected an `Fn()` closure, found `{fn item f: extern "C" fn()}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `extern "C" fn() {f}`
-   = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn<()>` is not implemented for fn item `{fn item f: extern "C" fn()}`
+   = note: wrap the `{fn item f: extern "C" fn()}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `is_fn`
   --> $DIR/extern-wrong-value-type.rs:4:28
    |

--- a/tests/ui/fn/fn-compare-mismatch.stderr
+++ b/tests/ui/fn/fn-compare-mismatch.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `fn() {f}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item f: fn()}`
   --> $DIR/fn-compare-mismatch.rs:4:15
    |
 LL |     let x = f == g;
-   |             - ^^ - fn() {g}
+   |             - ^^ - {fn item g: fn()}
    |             |
-   |             fn() {f}
+   |             {fn item f: fn()}
    |
 help: use parentheses to call these
    |

--- a/tests/ui/fn/fn-pointer-mismatch.stderr
+++ b/tests/ui/fn/fn-pointer-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0308]: `if` and `else` have incompatible types
   --> $DIR/fn-pointer-mismatch.rs:11:43
    |
 LL |     let g = if n % 2 == 0 { &foo } else { &bar };
-   |                             ----          ^^^^ expected `&fn(u32) -> u32 {foo}`, found `&fn(u32) -> u32 {bar}`
+   |                             ----          ^^^^ expected `&{fn item foo: fn(u32) -> u32}`, found `&{fn item bar: fn(u32) -> u32}`
    |                             |
    |                             expected because of this
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-pointer-mismatch.rs:36:29
    |
 LL |     let c: fn(u32) -> u32 = &foo;
-   |            --------------   ^^^^ expected fn pointer, found `&fn(u32) -> u32 {foo}`
+   |            --------------   ^^^^ expected fn pointer, found `&{fn item foo: fn(u32) -> u32}`
    |            |
    |            expected due to this
    |
@@ -73,7 +73,7 @@ error[E0308]: mismatched types
   --> $DIR/fn-pointer-mismatch.rs:48:30
    |
 LL |     let e: &fn(u32) -> u32 = &foo;
-   |            ---------------   ^^^^ expected `&fn(u32) -> u32`, found `&fn(u32) -> u32 {foo}`
+   |            ---------------   ^^^^ expected `&fn(u32) -> u32`, found `&{fn item foo: fn(u32) -> u32}`
    |            |
    |            expected due to this
    |

--- a/tests/ui/higher-ranked/higher-ranked-lifetime-error.stderr
+++ b/tests/ui/higher-ranked/higher-ranked-lifetime-error.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     assert_all::<_, &String>(id);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `for<'a> <for<'a> fn(&'a String) -> &'a String {id} as FnMut<(&'a String,)>>`
-              found trait `for<'a> <for<'a> fn(&'a String) -> &'a String {id} as FnMut<(&'a String,)>>`
+   = note: expected trait `for<'a> <{fn item id: for<'a> fn(&'a String) -> &'a String} as FnMut<(&'a String,)>>`
+              found trait `for<'a> <{fn item id: for<'a> fn(&'a String) -> &'a String} as FnMut<(&'a String,)>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/higher-ranked/trait-bounds/issue-30786.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-30786.stderr
@@ -22,7 +22,7 @@ note: `StreamExt` defines an item `filterx`, perhaps you need to implement it
 LL | pub trait StreamExt
    | ^^^^^^^^^^^^^^^^^^^
 
-error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, fn(&u64) -> &u64 {identity::<u64>}>, {closure@issue-30786.rs:131:30}>`, but its trait bounds were not satisfied
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, {fn item identity::<u64>: fn(&u64) -> &u64}>, {closure@issue-30786.rs:131:30}>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:132:24
    |
 LL | pub struct Filter<S, F> {
@@ -32,9 +32,9 @@ LL |     let count = filter.countx();
    |                        ^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
 note: the following trait bounds were not satisfied:
-      `&'a mut &Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/issue-30786.rs:131:30: 131:37}>: Stream`
-      `&'a mut &mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/issue-30786.rs:131:30: 131:37}>: Stream`
-      `&'a mut Filter<Map<Repeat, for<'a> fn(&'a u64) -> &'a u64 {identity::<u64>}>, {closure@$DIR/issue-30786.rs:131:30: 131:37}>: Stream`
+      `&'a mut &Filter<Map<Repeat, {fn item identity::<u64>: for<'a> fn(&'a u64) -> &'a u64}>, {closure@$DIR/issue-30786.rs:131:30: 131:37}>: Stream`
+      `&'a mut &mut Filter<Map<Repeat, {fn item identity::<u64>: for<'a> fn(&'a u64) -> &'a u64}>, {closure@$DIR/issue-30786.rs:131:30: 131:37}>: Stream`
+      `&'a mut Filter<Map<Repeat, {fn item identity::<u64>: for<'a> fn(&'a u64) -> &'a u64}>, {closure@$DIR/issue-30786.rs:131:30: 131:37}>: Stream`
   --> $DIR/issue-30786.rs:98:50
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}

--- a/tests/ui/hygiene/impl_items.rs
+++ b/tests/ui/hygiene/impl_items.rs
@@ -7,7 +7,7 @@ mod foo {
     }
 
     pub macro m() {
-        let _: () = S.f(); //~ ERROR type `for<'a> fn(&'a foo::S) {foo::S::f}` is private
+        let _: () = S.f(); //~ ERROR type `{fn item foo::S::f: for<'a> fn(&'a foo::S)}` is private
     }
 }
 

--- a/tests/ui/hygiene/impl_items.stderr
+++ b/tests/ui/hygiene/impl_items.stderr
@@ -1,4 +1,4 @@
-error: type `for<'a> fn(&'a foo::S) {foo::S::f}` is private
+error: type `{fn item foo::S::f: for<'a> fn(&'a foo::S)}` is private
   --> $DIR/impl_items.rs:10:23
    |
 LL |         let _: () = S.f();

--- a/tests/ui/hygiene/intercrate.rs
+++ b/tests/ui/hygiene/intercrate.rs
@@ -6,5 +6,5 @@ extern crate intercrate;
 
 fn main() {
     assert_eq!(intercrate::foo::m!(), 1);
-    //~^ ERROR type `fn() -> u32 {foo::bar::f}` is private
+    //~^ ERROR type `{fn item foo::bar::f: fn() -> u32}` is private
 }

--- a/tests/ui/hygiene/intercrate.stderr
+++ b/tests/ui/hygiene/intercrate.stderr
@@ -1,4 +1,4 @@
-error: type `fn() -> u32 {foo::bar::f}` is private
+error: type `{fn item foo::bar::f: fn() -> u32}` is private
   --> $DIR/intercrate.rs:8:16
    |
 LL |     assert_eq!(intercrate::foo::m!(), 1);

--- a/tests/ui/inline-const/pat-match-fndef.rs
+++ b/tests/ui/inline-const/pat-match-fndef.rs
@@ -6,7 +6,7 @@ fn main() {
     let x = [];
     match x[123] {
         const { uwu } => {}
-        //~^ ERROR `fn() {uwu}` cannot be used in patterns
+        //~^ ERROR `{fn item uwu: fn()}` cannot be used in patterns
         _ => {}
     }
 }

--- a/tests/ui/inline-const/pat-match-fndef.stderr
+++ b/tests/ui/inline-const/pat-match-fndef.stderr
@@ -1,4 +1,4 @@
-error: `fn() {uwu}` cannot be used in patterns
+error: `{fn item uwu: fn()}` cannot be used in patterns
   --> $DIR/pat-match-fndef.rs:8:9
    |
 LL |         const { uwu } => {}

--- a/tests/ui/issues/issue-21554.stderr
+++ b/tests/ui/issues/issue-21554.stderr
@@ -1,4 +1,4 @@
-error[E0606]: casting `fn(i32) -> Inches {Inches}` as `f32` is invalid
+error[E0606]: casting `{fn item Inches: fn(i32) -> Inches}` as `f32` is invalid
   --> $DIR/issue-21554.rs:4:5
    |
 LL |     Inches as f32;

--- a/tests/ui/issues/issue-24322.stderr
+++ b/tests/ui/issues/issue-24322.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-24322.rs:8:29
    |
 LL |     let x: &fn(&B) -> u32 = &B::func;
-   |            --------------   ^^^^^^^^ expected `&fn(&B) -> u32`, found `&fn(&B) -> u32 {B::func}`
+   |            --------------   ^^^^^^^^ expected `&fn(&B) -> u32`, found `&{fn item B::func: fn(&B) -> u32}`
    |            |
    |            expected due to this
    |

--- a/tests/ui/issues/issue-35241.stderr
+++ b/tests/ui/issues/issue-35241.stderr
@@ -10,7 +10,7 @@ LL | fn test() -> Foo { Foo }
    |              expected `Foo` because of return type
    |
    = note:          expected struct `Foo`
-           found struct constructor `fn(u32) -> Foo {Foo}`
+           found struct constructor `{fn item Foo: fn(u32) -> Foo}`
 help: use parentheses to construct this tuple struct
    |
 LL | fn test() -> Foo { Foo(/* u32 */) }

--- a/tests/ui/issues/issue-59488.rs
+++ b/tests/ui/issues/issue-59488.rs
@@ -12,23 +12,23 @@ enum Foo {
 
 fn main() {
     foo > 12;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn() -> i32 {foo}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `{fn item foo: fn() -> i32}` [E0369]
     //~| ERROR mismatched types [E0308]
 
     bar > 13;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn(i64) -> i64 {bar}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `{fn item bar: fn(i64) -> i64}` [E0369]
     //~| ERROR mismatched types [E0308]
 
     foo > foo;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn() -> i32 {foo}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `{fn item foo: fn() -> i32}` [E0369]
 
     foo > bar;
-    //~^ ERROR binary operation `>` cannot be applied to type `fn() -> i32 {foo}` [E0369]
+    //~^ ERROR binary operation `>` cannot be applied to type `{fn item foo: fn() -> i32}` [E0369]
     //~| ERROR mismatched types [E0308]
 
     let i = Foo::Bar;
     assert_eq!(Foo::Bar, i);
-    //~^ ERROR binary operation `==` cannot be applied to type `fn(usize) -> Foo {Foo::Bar}` [E0369]
-    //~| ERROR `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug` [E0277]
-    //~| ERROR `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug` [E0277]
+    //~^ ERROR binary operation `==` cannot be applied to type `{fn item Foo::Bar: fn(usize) -> Foo}` [E0369]
+    //~| ERROR `{fn item Foo::Bar: fn(usize) -> Foo}` doesn't implement `Debug` [E0277]
+    //~| ERROR `{fn item Foo::Bar: fn(usize) -> Foo}` doesn't implement `Debug` [E0277]
 }

--- a/tests/ui/issues/issue-59488.stderr
+++ b/tests/ui/issues/issue-59488.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
+error[E0369]: binary operation `>` cannot be applied to type `{fn item foo: fn() -> i32}`
   --> $DIR/issue-59488.rs:14:9
    |
 LL |     foo > 12;
    |     --- ^ -- {integer}
    |     |
-   |     fn() -> i32 {foo}
+   |     {fn item foo: fn() -> i32}
    |
 help: use parentheses to call this function
    |
@@ -17,16 +17,16 @@ error[E0308]: mismatched types
 LL |     foo > 12;
    |           ^^ expected fn item, found `i32`
    |
-   = note: expected fn item `fn() -> i32 {foo}`
+   = note: expected fn item `{fn item foo: fn() -> i32}`
                  found type `i32`
 
-error[E0369]: binary operation `>` cannot be applied to type `fn(i64) -> i64 {bar}`
+error[E0369]: binary operation `>` cannot be applied to type `{fn item bar: fn(i64) -> i64}`
   --> $DIR/issue-59488.rs:18:9
    |
 LL |     bar > 13;
    |     --- ^ -- {integer}
    |     |
-   |     fn(i64) -> i64 {bar}
+   |     {fn item bar: fn(i64) -> i64}
    |
 help: use parentheses to call this function
    |
@@ -39,29 +39,29 @@ error[E0308]: mismatched types
 LL |     bar > 13;
    |           ^^ expected fn item, found `i64`
    |
-   = note: expected fn item `fn(i64) -> i64 {bar}`
+   = note: expected fn item `{fn item bar: fn(i64) -> i64}`
                  found type `i64`
 
-error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
+error[E0369]: binary operation `>` cannot be applied to type `{fn item foo: fn() -> i32}`
   --> $DIR/issue-59488.rs:22:9
    |
 LL |     foo > foo;
-   |     --- ^ --- fn() -> i32 {foo}
+   |     --- ^ --- {fn item foo: fn() -> i32}
    |     |
-   |     fn() -> i32 {foo}
+   |     {fn item foo: fn() -> i32}
    |
 help: use parentheses to call these
    |
 LL |     foo() > foo();
    |        ++      ++
 
-error[E0369]: binary operation `>` cannot be applied to type `fn() -> i32 {foo}`
+error[E0369]: binary operation `>` cannot be applied to type `{fn item foo: fn() -> i32}`
   --> $DIR/issue-59488.rs:25:9
    |
 LL |     foo > bar;
-   |     --- ^ --- fn(i64) -> i64 {bar}
+   |     --- ^ --- {fn item bar: fn(i64) -> i64}
    |     |
-   |     fn() -> i32 {foo}
+   |     {fn item foo: fn() -> i32}
 
 error[E0308]: mismatched types
   --> $DIR/issue-59488.rs:25:11
@@ -72,33 +72,33 @@ LL |     foo > bar;
    = note: expected fn item `fn() -> i32 {foo}`
               found fn item `fn(i64) -> i64 {bar}`
 
-error[E0369]: binary operation `==` cannot be applied to type `fn(usize) -> Foo {Foo::Bar}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item Foo::Bar: fn(usize) -> Foo}`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |     |
-   |     fn(usize) -> Foo {Foo::Bar}
-   |     fn(usize) -> Foo {Foo::Bar}
+   |     {fn item Foo::Bar: fn(usize) -> Foo}
+   |     {fn item Foo::Bar: fn(usize) -> Foo}
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
+error[E0277]: `{fn item Foo::Bar: fn(usize) -> Foo}` doesn't implement `Debug`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ `fn(usize) -> Foo {Foo::Bar}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ `{fn item Foo::Bar: fn(usize) -> Foo}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for fn item `fn(usize) -> Foo {Foo::Bar}`
+   = help: the trait `Debug` is not implemented for fn item `{fn item Foo::Bar: fn(usize) -> Foo}`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
+error[E0277]: `{fn item Foo::Bar: fn(usize) -> Foo}` doesn't implement `Debug`
   --> $DIR/issue-59488.rs:30:5
    |
 LL |     assert_eq!(Foo::Bar, i);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ `fn(usize) -> Foo {Foo::Bar}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ `{fn item Foo::Bar: fn(usize) -> Foo}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for fn item `fn(usize) -> Foo {Foo::Bar}`
+   = help: the trait `Debug` is not implemented for fn item `{fn item Foo::Bar: fn(usize) -> Foo}`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors

--- a/tests/ui/issues/issue-62375.stderr
+++ b/tests/ui/issues/issue-62375.stderr
@@ -2,15 +2,15 @@ error[E0369]: binary operation `==` cannot be applied to type `A`
   --> $DIR/issue-62375.rs:7:7
    |
 LL |     a == A::Value;
-   |     - ^^ -------- fn(()) -> A {A::Value}
+   |     - ^^ -------- {fn item A::Value: fn(()) -> A}
    |     |
    |     A
    |
-note: an implementation of `PartialEq<fn(()) -> A {A::Value}>` might be missing for `A`
+note: an implementation of `PartialEq<{fn item A::Value: fn(()) -> A}>` might be missing for `A`
   --> $DIR/issue-62375.rs:1:1
    |
 LL | enum A {
-   | ^^^^^^ must implement `PartialEq<fn(()) -> A {A::Value}>`
+   | ^^^^^^ must implement `PartialEq<{fn item A::Value: fn(()) -> A}>`
 help: use parentheses to construct this tuple variant
    |
 LL |     a == A::Value(/* () */);

--- a/tests/ui/issues/issue-66667-function-cmp-cycle.stderr
+++ b/tests/ui/issues/issue-66667-function-cmp-cycle.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `fn() {second}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item second: fn()}`
   --> $DIR/issue-66667-function-cmp-cycle.rs:2:12
    |
 LL |     second == 1
    |     ------ ^^ - {integer}
    |     |
-   |     fn() {second}
+   |     {fn item second: fn()}
 
 error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:2:15
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
 LL |     second == 1
    |               ^ expected fn item, found integer
    |
-   = note: expected fn item `fn() {second}`
+   = note: expected fn item `{fn item second: fn()}`
                  found type `{integer}`
 
 error[E0308]: mismatched types
@@ -23,13 +23,13 @@ LL | fn first() {
 LL |     second == 1
    |     ^^^^^^^^^^^ expected `()`, found `bool`
 
-error[E0369]: binary operation `==` cannot be applied to type `fn() {first}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item first: fn()}`
   --> $DIR/issue-66667-function-cmp-cycle.rs:8:11
    |
 LL |     first == 1
    |     ----- ^^ - {integer}
    |     |
-   |     fn() {first}
+   |     {fn item first: fn()}
 
 error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:8:14
@@ -37,7 +37,7 @@ error[E0308]: mismatched types
 LL |     first == 1
    |              ^ expected fn item, found integer
    |
-   = note: expected fn item `fn() {first}`
+   = note: expected fn item `{fn item first: fn()}`
                  found type `{integer}`
 
 error[E0308]: mismatched types
@@ -48,13 +48,13 @@ LL | fn second() {
 LL |     first == 1
    |     ^^^^^^^^^^ expected `()`, found `bool`
 
-error[E0369]: binary operation `==` cannot be applied to type `fn() {bar}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item bar: fn()}`
   --> $DIR/issue-66667-function-cmp-cycle.rs:14:9
    |
 LL |     bar == 1
    |     --- ^^ - {integer}
    |     |
-   |     fn() {bar}
+   |     {fn item bar: fn()}
 
 error[E0308]: mismatched types
   --> $DIR/issue-66667-function-cmp-cycle.rs:14:12
@@ -62,7 +62,7 @@ error[E0308]: mismatched types
 LL |     bar == 1
    |            ^ expected fn item, found integer
    |
-   = note: expected fn item `fn() {bar}`
+   = note: expected fn item `{fn item bar: fn()}`
                  found type `{integer}`
 
 error[E0308]: mismatched types

--- a/tests/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
+++ b/tests/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
@@ -1,10 +1,10 @@
-error[E0369]: binary operation `==` cannot be applied to type `fn() -> i32 {a}`
+error[E0369]: binary operation `==` cannot be applied to type `{fn item a: fn() -> i32}`
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
    |
 LL |     assert_eq!(a, 0);
    |     ^^^^^^^^^^^^^^^^
    |     |
-   |     fn() -> i32 {a}
+   |     {fn item a: fn() -> i32}
    |     {integer}
    |
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -15,20 +15,20 @@ error[E0308]: mismatched types
 LL |     assert_eq!(a, 0);
    |     ^^^^^^^^^^^^^^^^ expected fn item, found integer
    |
-   = note: expected fn item `fn() -> i32 {a}`
+   = note: expected fn item `{fn item a: fn() -> i32}`
                  found type `{integer}`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `fn() -> i32 {a}` doesn't implement `Debug`
+error[E0277]: `{fn item a: fn() -> i32}` doesn't implement `Debug`
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
    |
 LL | fn a() -> i32 {
    |    - consider calling this function
 ...
 LL |     assert_eq!(a, 0);
-   |     ^^^^^^^^^^^^^^^^ `fn() -> i32 {a}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^^^^^^^^ `{fn item a: fn() -> i32}` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = help: the trait `Debug` is not implemented for fn item `fn() -> i32 {a}`
+   = help: the trait `Debug` is not implemented for fn item `{fn item a: fn() -> i32}`
    = help: use parentheses to call this function: `a()`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/issues/issue-87490.stderr
+++ b/tests/ui/issues/issue-87490.stderr
@@ -7,7 +7,7 @@ LL |     String::new
    |     ^^^^^^^^^^^ expected `usize`, found fn item
    |
    = note: expected type `usize`
-           found fn item `fn() -> String {String::new}`
+           found fn item `{fn item String::new: fn() -> String}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -62,7 +62,7 @@ error: implementation of `FnOnce` is not general enough
 LL |     f(data, identity)
    |     ^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&'2 T) -> &'2 T {identity::<&'2 T>}` must implement `FnOnce<(&'1 T,)>`, for any lifetime `'1`...
+   = note: `{fn item identity::<&'2 T>: fn(&'2 T) -> &'2 T}` must implement `FnOnce<(&'1 T,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 T,)>`, for some specific lifetime `'2`
 
 error: aborting due to 5 previous errors

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -47,7 +47,7 @@ LL | fn a() -> [u8; foo::()] {
    |                ^^^^^^^ expected `usize`, found fn item
    |
    = note: expected type `usize`
-           found fn item `fn() {foo}`
+           found fn item `{fn item foo: fn()}`
 
 error: `S<'_>` is forbidden as the type of a const generic parameter
   --> $DIR/unusual-rib-combinations.rs:24:15

--- a/tests/ui/lint/issue-106991.stderr
+++ b/tests/ui/lint/issue-106991.stderr
@@ -4,7 +4,7 @@ error[E0271]: expected `foo` to be a fn item that returns `i32`, but it returns 
 LL | fn bar() -> impl Iterator<Item = i32> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `i32`
    |
-   = note: required for `Map<std::slice::IterMut<'_, Vec<u8>>, for<'a> fn(&'a mut Vec<u8>) {foo}>` to implement `Iterator`
+   = note: required for `Map<std::slice::IterMut<'_, Vec<u8>>, {fn item foo: for<'a> fn(&'a mut Vec<u8>)}>` to implement `Iterator`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/ptr_null_checks.stderr
+++ b/tests/ui/lint/ptr_null_checks.stderr
@@ -4,7 +4,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *mut ()).is_null() {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
    = note: `#[warn(useless_ptr_null_checks)]` on by default
@@ -15,7 +15,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *const u8).is_null() {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -25,7 +25,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *const ()) == std::ptr::null() {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -35,7 +35,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *mut ()) == std::ptr::null_mut() {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -45,7 +45,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *const ()) == (0 as *const ()) {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -55,7 +55,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if <*const _>::is_null(fn_ptr as *const ()) {}
    |        ^^^^^^^^^^^^^^^^^^^^------^^^^^^^^^^^^^^
    |                            |
-   |                            expression has type `fn() {main}`
+   |                            expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -65,7 +65,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *mut fn() as *const fn() as *const ()).is_null() {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -75,7 +75,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (fn_ptr as *mut fn() as *const fn()).cast_mut().is_null() {}
    |        ^------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `fn() {main}`
+   |         expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -85,7 +85,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if ((fn_ptr as *mut fn()).cast() as *const fn()).cast_mut().is_null() {}
    |        ^^------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |          |
-   |          expression has type `fn() {main}`
+   |          expression has type `{fn item main: fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 
@@ -105,7 +105,7 @@ warning: function pointers are not nullable, so checking them for null will alwa
 LL |     if (c_fn as *const fn()).is_null() {}
    |        ^----^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         expression has type `extern "C" fn() {c_fn}`
+   |         expression has type `{fn item c_fn: extern "C" fn()}`
    |
    = help: wrap the function pointer inside an `Option` and use `Option::is_none` to check for null pointer value
 

--- a/tests/ui/lint/trivial_casts.rs
+++ b/tests/ui/lint/trivial_casts.rs
@@ -67,7 +67,7 @@ pub fn main() {
 
     // functions
     fn baz(_x: i32) {}
-    let _ = &baz as &dyn Fn(i32); //~ERROR `&fn(i32) {baz}` as `&dyn Fn(i32)`
+    let _ = &baz as &dyn Fn(i32); //~ERROR trivial cast: `&{fn item baz: fn(i32)}` as `&dyn Fn(i32)`
     let _: &dyn Fn(i32) = &baz;
     let x = |_x: i32| {};
     let _ = &x as &dyn Fn(i32); //~ERROR trivial cast

--- a/tests/ui/lint/trivial_casts.stderr
+++ b/tests/ui/lint/trivial_casts.stderr
@@ -120,7 +120,7 @@ LL |     let _ = x as Box<dyn Foo>;
    |
    = help: cast can be replaced by coercion; this might require a temporary variable
 
-error: trivial cast: `&fn(i32) {baz}` as `&dyn Fn(i32)`
+error: trivial cast: `&{fn item baz: fn(i32)}` as `&dyn Fn(i32)`
   --> $DIR/trivial_casts.rs:70:13
    |
 LL |     let _ = &baz as &dyn Fn(i32);

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -11,6 +11,6 @@ fn main() ({
                 ({ } as
                     ()) else if (let Some(a) =
                        ((Some as
-                               fn(i32) -> Option<i32> {Option::<i32>::Some})((3 as i32)) as
-                           Option<i32>) as bool) ({ } as ()) as ())
+                               {fn item Option::<i32>::Some: fn(i32) -> Option<i32>})((3 as
+                               i32)) as Option<i32>) as bool) ({ } as ()) as ())
                } as ())

--- a/tests/ui/mismatched_types/cast-rfc0401.stderr
+++ b/tests/ui/mismatched_types/cast-rfc0401.stderr
@@ -14,7 +14,7 @@ LL |     u as *const str
    |
    = note: vtable kinds may not match
 
-error[E0609]: no field `f` on type `fn() {main}`
+error[E0609]: no field `f` on type `{fn item main: fn()}`
   --> $DIR/cast-rfc0401.rs:65:18
    |
 LL |     let _ = main.f as *const u32;
@@ -62,7 +62,7 @@ error[E0606]: casting `*const u8` as `f32` is invalid
 LL |     let _ = v as f32;
    |             ^^^^^^^^
 
-error[E0606]: casting `fn() {main}` as `f64` is invalid
+error[E0606]: casting `{fn item main: fn()}` as `f64` is invalid
   --> $DIR/cast-rfc0401.rs:36:13
    |
 LL |     let _ = main as f64;
@@ -176,7 +176,7 @@ error[E0606]: casting `&dyn Foo` as `*mut str` is invalid
 LL |     let _ = foo as *mut str;
    |             ^^^^^^^^^^^^^^^
 
-error[E0606]: casting `fn() {main}` as `*mut str` is invalid
+error[E0606]: casting `{fn item main: fn()}` as `*mut str` is invalid
   --> $DIR/cast-rfc0401.rs:56:13
    |
 LL |     let _ = main as *mut str;

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.rs
@@ -24,9 +24,9 @@ fn main() {
     let _ = produces_string().and_then(takes_str_but_too_many_refs);
     //~^ ERROR type mismatch in function arguments
     let _ = produces_string().and_then(takes_str_but_wrong_abi);
-    //~^ ERROR expected a `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+    //~^ ERROR expected a `FnOnce(String)` closure, found `{fn item takes_str_but_wrong_abi: for<'a> extern "C" fn(&'a str) -> Option<()>}`
     let _ = produces_string().and_then(takes_str_but_unsafe);
-    //~^ ERROR expected a `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+    //~^ ERROR expected a `FnOnce(String)` closure, found `{fn item takes_str_but_unsafe: for<'a> unsafe fn(&'a str) -> Option<()>}`
     let _ = produces_string().and_then(no_args);
     //~^ ERROR function is expected to take 1 argument, but it takes 0 arguments
     let _ = Some(TypeWithoutDeref).and_then(takes_str_but_too_many_refs);

--- a/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
+++ b/tests/ui/mismatched_types/suggest-option-asderef-unfixable.stderr
@@ -18,19 +18,19 @@ help: consider wrapping the function in a closure
 LL |     let _ = produces_string().and_then(|arg0: String| takes_str_but_too_many_refs(/* &&str */));
    |                                        ++++++++++++++                            +++++++++++++
 
-error[E0277]: expected a `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+error[E0277]: expected a `FnOnce(String)` closure, found `{fn item takes_str_but_wrong_abi: for<'a> extern "C" fn(&'a str) -> Option<()>}`
   --> $DIR/suggest-option-asderef-unfixable.rs:26:40
    |
 LL |     let _ = produces_string().and_then(takes_str_but_wrong_abi);
-   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(String)` closure, found `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+   |                               -------- ^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnOnce(String)` closure, found `{fn item takes_str_but_wrong_abi: for<'a> extern "C" fn(&'a str) -> Option<()>}`
    |                               |
    |                               required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a str) -> Option<()> {takes_str_but_wrong_abi}`
+   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `{fn item takes_str_but_wrong_abi: for<'a> extern "C" fn(&'a str) -> Option<()>}`
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
-error[E0277]: expected a `FnOnce(String)` closure, found `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+error[E0277]: expected a `FnOnce(String)` closure, found `{fn item takes_str_but_unsafe: for<'a> unsafe fn(&'a str) -> Option<()>}`
   --> $DIR/suggest-option-asderef-unfixable.rs:28:40
    |
 LL |     let _ = produces_string().and_then(takes_str_but_unsafe);
@@ -38,7 +38,7 @@ LL |     let _ = produces_string().and_then(takes_str_but_unsafe);
    |                               |
    |                               required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `for<'a> unsafe fn(&'a str) -> Option<()> {takes_str_but_unsafe}`
+   = help: the trait `FnOnce<(String,)>` is not implemented for fn item `{fn item takes_str_but_unsafe: for<'a> unsafe fn(&'a str) -> Option<()>}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::and_then`
   --> $SRC_DIR/core/src/option.rs:LL:COL

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -239,11 +239,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfied
+error[E0277]: the trait bound `{fn item c::TS: fn() -> c::TS}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:56:11
    |
 LL |     check(m3::TS);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for fn item `fn() -> c::TS {c::TS}`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for fn item `{fn item c::TS: fn() -> c::TS}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -315,11 +315,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}: Impossible` is not satisfied
+error[E0277]: the trait bound `{fn item namespace_mix::c::TS: fn() -> namespace_mix::c::TS}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:62:11
    |
 LL |     check(xm3::TS);
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for fn item `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for fn item `{fn item namespace_mix::c::TS: fn() -> namespace_mix::c::TS}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -657,11 +657,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satisfied
+error[E0277]: the trait bound `{fn item c::E::TV: fn() -> c::E}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:122:11
    |
 LL |     check(m9::TV);
-   |     ----- ^^^^^^ the trait `Impossible` is not implemented for fn item `fn() -> c::E {c::E::TV}`
+   |     ----- ^^^^^^ the trait `Impossible` is not implemented for fn item `{fn item c::E::TV: fn() -> c::E}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -733,11 +733,11 @@ note: required by a bound in `check`
 LL | fn check<T: Impossible>(_: T) {}
    |             ^^^^^^^^^^ required by this bound in `check`
 
-error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}: Impossible` is not satisfied
+error[E0277]: the trait bound `{fn item namespace_mix::xm7::TV: fn() -> namespace_mix::c::E}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:128:11
    |
 LL |     check(xm9::TV);
-   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for fn item `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
+   |     ----- ^^^^^^^ the trait `Impossible` is not implemented for fn item `{fn item namespace_mix::xm7::TV: fn() -> namespace_mix::c::E}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/privacy/associated-item-privacy-inherent.rs
+++ b/tests/ui/privacy/associated-item-privacy-inherent.rs
@@ -11,11 +11,11 @@ mod priv_nominal {
 
     pub macro mac() {
         let value = Pub::method;
-        //~^ ERROR type `for<'a> fn(&'a priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR type `{fn item priv_nominal::Pub::method: for<'a> fn(&'a priv_nominal::Pub)}` is private
         value;
-        //~^ ERROR type `for<'a> fn(&'a priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR type `{fn item priv_nominal::Pub::method: for<'a> fn(&'a priv_nominal::Pub)}` is private
         Pub.method();
-        //~^ ERROR type `for<'a> fn(&'a priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+        //~^ ERROR type `{fn item priv_nominal::Pub::method: for<'a> fn(&'a priv_nominal::Pub)}` is private
         Pub::CONST;
         //~^ ERROR associated constant `CONST` is private
         // let _: Pub::AssocTy;

--- a/tests/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/tests/ui/privacy/associated-item-privacy-inherent.stderr
@@ -1,4 +1,4 @@
-error: type `for<'a> fn(&'a priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: type `{fn item priv_nominal::Pub::method: for<'a> fn(&'a priv_nominal::Pub)}` is private
   --> $DIR/associated-item-privacy-inherent.rs:13:21
    |
 LL |         let value = Pub::method;
@@ -9,7 +9,7 @@ LL |     priv_nominal::mac!();
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'a> fn(&'a priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: type `{fn item priv_nominal::Pub::method: for<'a> fn(&'a priv_nominal::Pub)}` is private
   --> $DIR/associated-item-privacy-inherent.rs:15:9
    |
 LL |         value;
@@ -20,7 +20,7 @@ LL |     priv_nominal::mac!();
    |
    = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'a> fn(&'a priv_nominal::Pub) {priv_nominal::Pub::method}` is private
+error: type `{fn item priv_nominal::Pub::method: for<'a> fn(&'a priv_nominal::Pub)}` is private
   --> $DIR/associated-item-privacy-inherent.rs:17:13
    |
 LL |         Pub.method();

--- a/tests/ui/privacy/associated-item-privacy-trait.rs
+++ b/tests/ui/privacy/associated-item-privacy-trait.rs
@@ -13,11 +13,11 @@ mod priv_trait {
 
     pub macro mac() {
         let value = <Pub as PrivTr>::method;
-        //~^ ERROR type `for<'a> fn(&'a priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+        //~^ ERROR type `{fn item <priv_trait::Pub as PrivTr>::method: for<'a> fn(&'a priv_trait::Pub)}` is private
         value;
-        //~^ ERROR type `for<'a> fn(&'a priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+        //~^ ERROR type `{fn item <priv_trait::Pub as PrivTr>::method: for<'a> fn(&'a priv_trait::Pub)}` is private
         Pub.method();
-        //~^ ERROR type `for<'a> fn(&'a Self) {<Self as PrivTr>::method}` is private
+        //~^ ERROR type `{fn item <Self as PrivTr>::method: for<'a> fn(&'a Self)}` is private
         <Pub as PrivTr>::CONST;
         //~^ ERROR associated constant `PrivTr::CONST` is private
         let _: <Pub as PrivTr>::AssocTy;

--- a/tests/ui/privacy/associated-item-privacy-trait.stderr
+++ b/tests/ui/privacy/associated-item-privacy-trait.stderr
@@ -1,4 +1,4 @@
-error: type `for<'a> fn(&'a priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+error: type `{fn item <priv_trait::Pub as PrivTr>::method: for<'a> fn(&'a priv_trait::Pub)}` is private
   --> $DIR/associated-item-privacy-trait.rs:15:21
    |
 LL |         let value = <Pub as PrivTr>::method;
@@ -9,7 +9,7 @@ LL |     priv_trait::mac!();
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'a> fn(&'a priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
+error: type `{fn item <priv_trait::Pub as PrivTr>::method: for<'a> fn(&'a priv_trait::Pub)}` is private
   --> $DIR/associated-item-privacy-trait.rs:17:9
    |
 LL |         value;
@@ -20,7 +20,7 @@ LL |     priv_trait::mac!();
    |
    = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'a> fn(&'a Self) {<Self as PrivTr>::method}` is private
+error: type `{fn item <Self as PrivTr>::method: for<'a> fn(&'a Self)}` is private
   --> $DIR/associated-item-privacy-trait.rs:19:13
    |
 LL |         Pub.method();

--- a/tests/ui/privacy/private-inferred-type-3.rs
+++ b/tests/ui/privacy/private-inferred-type-3.rs
@@ -1,12 +1,12 @@
 // aux-build:private-inferred-type.rs
 
-// error-pattern:type `fn() {ext::priv_fn}` is private
+// error-pattern:type `{fn item ext::priv_fn: fn()}` is private
 // error-pattern:static `ext::PRIV_STATIC` is private
 // error-pattern:type `ext::PrivEnum` is private
-// error-pattern:type `fn() {<u8 as ext::PrivTrait>::method}` is private
-// error-pattern:type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
-// error-pattern:type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
-// error-pattern:type `for<'a> fn(&'a Pub<u8>) {Pub::<u8>::priv_method}` is private
+// error-pattern:type `{fn item <u8 as ext::PrivTrait>::method: fn()}` is private
+// error-pattern:type `{fn item <u8 as ext::PrivTrait>::method: fn()}` is private
+// error-pattern:type `{fn item ext::PrivTupleStruct: fn(u8) -> ext::PrivTupleStruct}` is private
+// error-pattern:type `{fn item Pub::<u8>::priv_method: for<'a> fn(&'a Pub<u8>)}` is private
 
 #![feature(decl_macro)]
 

--- a/tests/ui/privacy/private-inferred-type-3.stderr
+++ b/tests/ui/privacy/private-inferred-type-3.stderr
@@ -1,4 +1,4 @@
-error: type `fn() {ext::priv_fn}` is private
+error: type `{fn item ext::priv_fn: fn()}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -22,7 +22,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
+error: type `{fn item <u8 as ext::PrivTrait>::method: fn()}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -30,7 +30,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
+error: type `{fn item ext::PrivTupleStruct: fn(u8) -> ext::PrivTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -38,7 +38,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
+error: type `{fn item PubTupleStruct: fn(u8) -> PubTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();
@@ -46,7 +46,7 @@ LL |     ext::m!();
    |
    = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'a> fn(&'a Pub<u8>) {Pub::<u8>::priv_method}` is private
+error: type `{fn item Pub::<u8>::priv_method: for<'a> fn(&'a Pub<u8>)}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
    |
 LL |     ext::m!();

--- a/tests/ui/privacy/private-inferred-type.rs
+++ b/tests/ui/privacy/private-inferred-type.rs
@@ -36,18 +36,18 @@ mod m {
     impl TraitWithAssocTy for Priv { type AssocTy = u8; }
 
     pub macro m() {
-        priv_fn; //~ ERROR type `fn() {priv_fn}` is private
+        priv_fn; //~ ERROR type `{fn item priv_fn: fn()}` is private
         PRIV_STATIC; // OK, not cross-crate
         PrivEnum::Variant; //~ ERROR type `PrivEnum` is private
         PubEnum::Variant; // OK
-        <u8 as PrivTrait>::method; //~ ERROR type `fn() {<u8 as PrivTrait>::method}` is private
+        <u8 as PrivTrait>::method; //~ ERROR type `{fn item <u8 as PrivTrait>::method: fn()}` is private
         <u8 as PubTrait>::method; // OK
         PrivTupleStruct;
-        //~^ ERROR type `fn(u8) -> PrivTupleStruct {PrivTupleStruct}` is private
+        //~^ ERROR type `{fn item PrivTupleStruct: fn(u8) -> PrivTupleStruct}` is private
         PubTupleStruct;
-        //~^ ERROR type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
+        //~^ ERROR type `{fn item PubTupleStruct: fn(u8) -> PubTupleStruct}` is private
         Pub(0u8).priv_method();
-        //~^ ERROR type `for<'a> fn(&'a Pub<u8>) {Pub::<u8>::priv_method}` is private
+        //~^ ERROR type `{fn item Pub::<u8>::priv_method: for<'a> fn(&'a Pub<u8>)}` is private
     }
 
     trait Trait {}

--- a/tests/ui/privacy/private-inferred-type.stderr
+++ b/tests/ui/privacy/private-inferred-type.stderr
@@ -106,7 +106,7 @@ error: type `S2` is private
 LL |     adjust::S1.method_s3();
    |     ^^^^^^^^^^ private type
 
-error: type `fn() {priv_fn}` is private
+error: type `{fn item priv_fn: fn()}` is private
   --> $DIR/private-inferred-type.rs:39:9
    |
 LL |         priv_fn;
@@ -128,7 +128,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn() {<u8 as PrivTrait>::method}` is private
+error: type `{fn item <u8 as PrivTrait>::method: fn()}` is private
   --> $DIR/private-inferred-type.rs:43:9
    |
 LL |         <u8 as PrivTrait>::method;
@@ -139,7 +139,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> PrivTupleStruct {PrivTupleStruct}` is private
+error: type `{fn item PrivTupleStruct: fn(u8) -> PrivTupleStruct}` is private
   --> $DIR/private-inferred-type.rs:45:9
    |
 LL |         PrivTupleStruct;
@@ -150,7 +150,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
+error: type `{fn item PubTupleStruct: fn(u8) -> PubTupleStruct}` is private
   --> $DIR/private-inferred-type.rs:47:9
    |
 LL |         PubTupleStruct;
@@ -161,7 +161,7 @@ LL |     m::m!();
    |
    = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: type `for<'a> fn(&'a Pub<u8>) {Pub::<u8>::priv_method}` is private
+error: type `{fn item Pub::<u8>::priv_method: for<'a> fn(&'a Pub<u8>)}` is private
   --> $DIR/private-inferred-type.rs:49:18
    |
 LL |         Pub(0u8).priv_method();

--- a/tests/ui/privacy/where-priv-type.stderr
+++ b/tests/ui/privacy/where-priv-type.stderr
@@ -68,14 +68,14 @@ note: but type `PrivTy` is only usable at visibility `pub(crate)`
 LL | struct PrivTy;
    | ^^^^^^^^^^^^^
 
-error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+error[E0446]: private type `{fn item my_const_fn: fn(u8) -> u8}` in public interface
   --> $DIR/where-priv-type.rs:75:5
    |
 LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^ can't leak private type
 ...
 LL | const fn my_const_fn(val: u8) -> u8 {
-   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+   | ----------------------------------- `{fn item my_const_fn: fn(u8) -> u8}` declared as private
 
 error: aborting due to 1 previous error; 5 warnings emitted
 

--- a/tests/ui/qualified/qualified-path-params.stderr
+++ b/tests/ui/qualified/qualified-path-params.stderr
@@ -8,7 +8,7 @@ error[E0029]: only `char` and numeric types are allowed in range patterns
   --> $DIR/qualified-path-params.rs:22:15
    |
 LL |         0 ..= <S as Tr>::A::f::<u8> => {}
-   |         -     ^^^^^^^^^^^^^^^^^^^^^ this is of type `fn() {S::f::<u8>}` but it should be `char` or numeric
+   |         -     ^^^^^^^^^^^^^^^^^^^^^ this is of type `{fn item S::f::<u8>: fn()}` but it should be `char` or numeric
    |         |
    |         this is of type `{integer}`
 

--- a/tests/ui/reify-intrinsic.stderr
+++ b/tests/ui/reify-intrinsic.stderr
@@ -9,7 +9,7 @@ LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::tr
    = note: expected fn pointer `unsafe extern "rust-intrinsic" fn(isize) -> usize`
                  found fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
 
-error[E0606]: casting `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
+error[E0606]: casting `{fn item transmute::<_, _>: unsafe extern "rust-intrinsic" fn(_) -> _}` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
   --> $DIR/reify-intrinsic.rs:11:13
    |
 LL |     let _ = std::mem::transmute as unsafe extern "rust-intrinsic" fn(isize) -> usize;

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -276,7 +276,7 @@ LL |         let _: Z = Z::Fn;
    |                expected due to this
    |
    = note:          expected enum `Z`
-           found enum constructor `fn(u8) -> Z {Z::Fn}`
+           found enum constructor `{fn item Z::Fn: fn(u8) -> Z}`
 help: use parentheses to construct this tuple variant
    |
 LL |         let _: Z = Z::Fn(/* u8 */);
@@ -317,7 +317,7 @@ LL |     let _: E = m::E::Fn;
    |            expected due to this
    |
    = note:          expected enum `E`
-           found enum constructor `fn(u8) -> E {E::Fn}`
+           found enum constructor `{fn item E::Fn: fn(u8) -> E}`
 help: use parentheses to construct this tuple variant
    |
 LL |     let _: E = m::E::Fn(/* u8 */);
@@ -358,7 +358,7 @@ LL |     let _: E = E::Fn;
    |            expected due to this
    |
    = note:          expected enum `E`
-           found enum constructor `fn(u8) -> E {E::Fn}`
+           found enum constructor `{fn item E::Fn: fn(u8) -> E}`
 help: use parentheses to construct this tuple variant
    |
 LL |     let _: E = E::Fn(/* u8 */);

--- a/tests/ui/rfcs/rfc-1623-static/rfc1623-2.stderr
+++ b/tests/ui/rfcs/rfc-1623-static/rfc1623-2.stderr
@@ -23,7 +23,7 @@ error: implementation of `FnOnce` is not general enough
 LL |     f: &id,
    |        ^^^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&'2 Foo<'_>) -> &'2 Foo<'_> {id::<&'2 Foo<'_>>}` must implement `FnOnce<(&'1 Foo<'b>,)>`, for any lifetime `'1`...
+   = note: `{fn item id::<&'2 Foo<'_>>: fn(&'2 Foo<'_>) -> &'2 Foo<'_>}` must implement `FnOnce<(&'1 Foo<'b>,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 Foo<'_>,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
@@ -32,7 +32,7 @@ error: implementation of `FnOnce` is not general enough
 LL |     f: &id,
    |        ^^^ implementation of `FnOnce` is not general enough
    |
-   = note: `fn(&Foo<'2>) -> &Foo<'2> {id::<&Foo<'2>>}` must implement `FnOnce<(&'a Foo<'1>,)>`, for any lifetime `'1`...
+   = note: `{fn item id::<&Foo<'2>>: fn(&Foo<'2>) -> &Foo<'2>}` must implement `FnOnce<(&'a Foo<'1>,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&Foo<'2>,)>`, for some specific lifetime `'2`
 
 error: aborting due to 4 previous errors

--- a/tests/ui/rfcs/rfc-1623-static/rfc1623-3.stderr
+++ b/tests/ui/rfcs/rfc-1623-static/rfc1623-3.stderr
@@ -23,7 +23,7 @@ help: consider making the type lifetime-generic with a new `'a` lifetime
 LL |     &(non_elidable as for<'a> fn(&'a u8, &'a u8) -> &'a u8);
    |                       +++++++     ++      ++         ++
 
-error[E0605]: non-primitive cast: `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8 {non_elidable}` as `for<'a, 'b> fn(&'a u8, &'b u8) -> &u8`
+error[E0605]: non-primitive cast: `{fn item non_elidable: for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8}` as `for<'a, 'b> fn(&'a u8, &'b u8) -> &u8`
   --> $DIR/rfc1623-3.rs:10:6
    |
 LL |     &(non_elidable as fn(&u8, &u8) -> &u8);

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -21,14 +21,14 @@ fn call_once(f: impl FnOnce()) {
 }
 
 fn main() {
-    call(foo); //~ ERROR expected a `Fn()` closure, found `fn() {foo}`
-    call_mut(foo); //~ ERROR expected a `FnMut()` closure, found `fn() {foo}`
-    call_once(foo); //~ ERROR expected a `FnOnce()` closure, found `fn() {foo}`
+    call(foo); //~ ERROR expected a `Fn()` closure, found `{fn item foo: fn()}`
+    call_mut(foo); //~ expected a `FnMut()` closure, found `{fn item foo: fn()}`
+    call_once(foo); //~ expected a `FnOnce()` closure, found `{fn item foo: fn()}`
 
     call(foo_unsafe);
-    //~^ ERROR expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ expected a `Fn()` closure, found `{fn item foo_unsafe: unsafe fn()}
     call_mut(foo_unsafe);
-    //~^ ERROR expected a `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `FnMut()` closure, found `{fn item foo_unsafe: unsafe fn()}`
     call_once(foo_unsafe);
-    //~^ ERROR expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
+    //~^ ERROR expected a `FnOnce()` closure, found `{fn item foo_unsafe: unsafe fn()}`
 }

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,13 +1,13 @@
-error[E0277]: expected a `Fn()` closure, found `fn() {foo}`
+error[E0277]: expected a `Fn()` closure, found `{fn item foo: fn()}`
   --> $DIR/fn-traits.rs:24:10
    |
 LL |     call(foo);
-   |     ---- ^^^ expected an `Fn()` closure, found `fn() {foo}`
+   |     ---- ^^^ expected an `Fn()` closure, found `{fn item foo: fn()}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn<()>` is not implemented for fn item `{fn item foo: fn()}`
+   = note: wrap the `{fn item foo: fn()}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:11:17
@@ -15,16 +15,16 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut()` closure, found `fn() {foo}`
+error[E0277]: expected a `FnMut()` closure, found `{fn item foo: fn()}`
   --> $DIR/fn-traits.rs:25:14
    |
 LL |     call_mut(foo);
-   |     -------- ^^^ expected an `FnMut()` closure, found `fn() {foo}`
+   |     -------- ^^^ expected an `FnMut()` closure, found `{fn item foo: fn()}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut<()>` is not implemented for fn item `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnMut<()>` is not implemented for fn item `{fn item foo: fn()}`
+   = note: wrap the `{fn item foo: fn()}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:15:21
@@ -32,16 +32,16 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(f: impl FnMut()) {
    |                     ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce()` closure, found `fn() {foo}`
+error[E0277]: expected a `FnOnce()` closure, found `{fn item foo: fn()}`
   --> $DIR/fn-traits.rs:26:15
    |
 LL |     call_once(foo);
-   |     --------- ^^^ expected an `FnOnce()` closure, found `fn() {foo}`
+   |     --------- ^^^ expected an `FnOnce()` closure, found `{fn item foo: fn()}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for fn item `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnOnce<()>` is not implemented for fn item `{fn item foo: fn()}`
+   = note: wrap the `{fn item foo: fn()}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:19:22
@@ -49,7 +49,7 @@ note: required by a bound in `call_once`
 LL | fn call_once(f: impl FnOnce()) {
    |                      ^^^^^^^^ required by this bound in `call_once`
 
-error[E0277]: expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `Fn()` closure, found `{fn item foo_unsafe: unsafe fn()}`
   --> $DIR/fn-traits.rs:28:10
    |
 LL |     call(foo_unsafe);
@@ -57,9 +57,9 @@ LL |     call(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `unsafe fn() {foo_unsafe}`
+   = help: the trait `Fn<()>` is not implemented for fn item `{fn item foo_unsafe: unsafe fn()}`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
+   = note: wrap the `{fn item foo_unsafe: unsafe fn()}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:11:17
@@ -67,7 +67,7 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut()` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `FnMut()` closure, found `{fn item foo_unsafe: unsafe fn()}`
   --> $DIR/fn-traits.rs:30:14
    |
 LL |     call_mut(foo_unsafe);
@@ -75,9 +75,9 @@ LL |     call_mut(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut<()>` is not implemented for fn item `unsafe fn() {foo_unsafe}`
+   = help: the trait `FnMut<()>` is not implemented for fn item `{fn item foo_unsafe: unsafe fn()}`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
+   = note: wrap the `{fn item foo_unsafe: unsafe fn()}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:15:21
@@ -85,7 +85,7 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(f: impl FnMut()) {
    |                     ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
+error[E0277]: expected a `FnOnce()` closure, found `{fn item foo_unsafe: unsafe fn()}`
   --> $DIR/fn-traits.rs:32:15
    |
 LL |     call_once(foo_unsafe);
@@ -93,9 +93,9 @@ LL |     call_once(foo_unsafe);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<()>` is not implemented for fn item `unsafe fn() {foo_unsafe}`
+   = help: the trait `FnOnce<()>` is not implemented for fn item `{fn item foo_unsafe: unsafe fn()}`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
+   = note: wrap the `{fn item foo_unsafe: unsafe fn()}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:19:22

--- a/tests/ui/static/issue-5216.stderr
+++ b/tests/ui/static/issue-5216.stderr
@@ -7,7 +7,7 @@ LL | pub static C: S = S(f);
    |                   arguments to this struct are incorrect
    |
    = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
-             found fn item `fn() {f}`
+             found fn item `{fn item f: fn()}`
 note: tuple struct defined here
   --> $DIR/issue-5216.rs:2:8
    |
@@ -21,7 +21,7 @@ LL | pub static D: T = g;
    |                   ^ expected `Box<dyn FnMut() + Sync>`, found fn item
    |
    = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
-             found fn item `fn() {g}`
+             found fn item `{fn item g: fn()}`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/static-reference-to-fn-1.stderr
+++ b/tests/ui/static/static-reference-to-fn-1.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/static-reference-to-fn-1.rs:17:15
    |
 LL |         func: &foo,
-   |               ^^^^ expected `&fn() -> Option<isize>`, found `&fn() -> Option<isize> {foo}`
+   |               ^^^^ expected `&fn() -> Option<isize>`, found `&{fn item foo: fn() -> Option<...>}`
    |
    = note: expected reference `&fn() -> Option<_>`
               found reference `&fn() -> Option<_> {foo}`

--- a/tests/ui/suggestions/assoc-ct-for-assoc-method.stderr
+++ b/tests/ui/suggestions/assoc-ct-for-assoc-method.stderr
@@ -7,7 +7,7 @@ LL |     let x: i32 = MyS::foo;
    |            expected due to this
    |
    = note: expected type `i32`
-           found fn item `fn() -> MyS {MyS::foo}`
+           found fn item `{fn item MyS::foo: fn() -> MyS}`
 help: try referring to the associated const `FOO` instead
    |
 LL |     let x: i32 = MyS::FOO;
@@ -22,19 +22,19 @@ LL |     let z: i32 = i32::max;
    |            expected due to this
    |
    = note: expected type `i32`
-           found fn item `fn(i32, i32) -> i32 {<i32 as Ord>::max}`
+           found fn item `{fn item <i32 as Ord>::max: fn(i32, i32) -> i32}`
 help: try referring to the associated const `MAX` instead
    |
 LL |     let z: i32 = i32::MAX;
    |                       ~~~
 
-error[E0369]: cannot subtract `{integer}` from `fn(i32, i32) -> i32 {<i32 as Ord>::max}`
+error[E0369]: cannot subtract `{integer}` from `{fn item <i32 as Ord>::max: fn(i32, i32) -> i32}`
   --> $DIR/assoc-ct-for-assoc-method.rs:22:27
    |
 LL |     let y: i32 = i32::max - 42;
    |                  -------- ^ -- {integer}
    |                  |
-   |                  fn(i32, i32) -> i32 {<i32 as Ord>::max}
+   |                  {fn item <i32 as Ord>::max: fn(i32, i32) -> i32}
    |
 help: use parentheses to call this method
    |

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,13 +1,13 @@
-error[E0277]: `fn() -> impl Future<Output = ()> {foo}` is not a future
+error[E0277]: `{fn item foo: fn() -> impl Future<Output = ()>}` is not a future
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:10:9
    |
 LL |     bar(foo);
-   |     --- ^^^ `fn() -> impl Future<Output = ()> {foo}` is not a future
+   |     --- ^^^ `{fn item foo: fn() -> impl Future<Output = ()>}` is not a future
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Future` is not implemented for fn item `fn() -> impl Future<Output = ()> {foo}`
-   = note: fn() -> impl Future<Output = ()> {foo} must be a future or must implement `IntoFuture` to be awaited
+   = help: the trait `Future` is not implemented for fn item `{fn item foo: fn() -> impl Future<Output = ()>}`
+   = note: {fn item foo: fn() -> impl Future<Output = ()>} must be a future or must implement `IntoFuture` to be awaited
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
    |

--- a/tests/ui/suggestions/call-on-missing.stderr
+++ b/tests/ui/suggestions/call-on-missing.stderr
@@ -1,15 +1,15 @@
-error[E0599]: no method named `bar` found for fn item `fn() -> Foo {foo}` in the current scope
+error[E0599]: no method named `bar` found for fn item `{fn item foo: fn() -> Foo}` in the current scope
   --> $DIR/call-on-missing.rs:12:9
    |
 LL |     foo.bar();
-   |         ^^^ method not found in `fn() -> Foo {foo}`
+   |         ^^^ method not found in `{fn item foo: fn() -> Foo}`
    |
 help: use parentheses to call this function
    |
 LL |     foo().bar();
    |        ++
 
-error[E0609]: no field `i` on type `fn() -> Foo {foo}`
+error[E0609]: no field `i` on type `{fn item foo: fn() -> Foo}`
   --> $DIR/call-on-missing.rs:16:9
    |
 LL |     foo.i;

--- a/tests/ui/suggestions/call-on-unimplemented-ctor.rs
+++ b/tests/ui/suggestions/call-on-unimplemented-ctor.rs
@@ -1,7 +1,7 @@
 fn main() {
     insert_resource(Marker);
     insert_resource(Time);
-    //~^ ERROR the trait bound `fn(u32) -> Time {Time}: Resource` is not satisfied
+    //~^ ERROR the trait bound `{fn item Time: fn(u32) -> Time}: Resource` is not satisfied
     //~| HELP use parentheses to construct this tuple struct
 }
 

--- a/tests/ui/suggestions/call-on-unimplemented-ctor.stderr
+++ b/tests/ui/suggestions/call-on-unimplemented-ctor.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `fn(u32) -> Time {Time}: Resource` is not satisfied
+error[E0277]: the trait bound `{fn item Time: fn(u32) -> Time}: Resource` is not satisfied
   --> $DIR/call-on-unimplemented-ctor.rs:3:21
    |
 LL |     insert_resource(Time);
-   |     --------------- ^^^^ the trait `Resource` is not implemented for fn item `fn(u32) -> Time {Time}`
+   |     --------------- ^^^^ the trait `Resource` is not implemented for fn item `{fn item Time: fn(u32) -> Time}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `fn() -> impl T<O = ()> {foo}: T` is not satisfied
+error[E0277]: the trait bound `{fn item foo: fn() -> impl T<O = ()>}: T` is not satisfied
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:17:9
    |
 LL |     bar(foo);
-   |     --- ^^^ the trait `T` is not implemented for fn item `fn() -> impl T<O = ()> {foo}`
+   |     --- ^^^ the trait `T` is not implemented for fn item `{fn item foo: fn() -> impl T<O = ()>}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/tests/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -10,7 +10,7 @@ LL |     let _: usize = foo;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize, usize) -> usize {foo}`
+           found fn item `{fn item foo: fn(usize, usize) -> usize}`
 help: use parentheses to call this function
    |
 LL |     let _: usize = foo(/* usize */, /* usize */);
@@ -28,7 +28,7 @@ LL |     let _: S = S;
    |            expected due to this
    |
    = note:          expected struct `S`
-           found struct constructor `fn(usize, usize) -> S {S}`
+           found struct constructor `{fn item S: fn(usize, usize) -> S}`
 help: use parentheses to construct this tuple struct
    |
 LL |     let _: S = S(/* usize */, /* usize */);
@@ -46,7 +46,7 @@ LL |     let _: usize = bar;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn() -> usize {bar}`
+           found fn item `{fn item bar: fn() -> usize}`
 help: use parentheses to call this function
    |
 LL |     let _: usize = bar();
@@ -64,7 +64,7 @@ LL |     let _: V = V;
    |            expected due to this
    |
    = note:          expected struct `V`
-           found struct constructor `fn() -> V {V}`
+           found struct constructor `{fn item V: fn() -> V}`
 help: use parentheses to construct this tuple struct
    |
 LL |     let _: V = V();
@@ -82,7 +82,7 @@ LL |     let _: usize = T::baz;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize, usize) -> usize {<_ as T>::baz}`
+           found fn item `{fn item <_ as T>::baz: fn(usize, usize) -> usize}`
 help: use parentheses to call this associated function
    |
 LL |     let _: usize = T::baz(/* usize */, /* usize */);
@@ -100,7 +100,7 @@ LL |     let _: usize = T::bat;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<_ as T>::bat}`
+           found fn item `{fn item <_ as T>::bat: fn(usize) -> usize}`
 help: use parentheses to call this associated function
    |
 LL |     let _: usize = T::bat(/* usize */);
@@ -118,7 +118,7 @@ LL |     let _: E = E::A;
    |            expected due to this
    |
    = note:          expected enum `E`
-           found enum constructor `fn(usize) -> E {E::A}`
+           found enum constructor `{fn item E::A: fn(usize) -> E}`
 help: use parentheses to construct this tuple variant
    |
 LL |     let _: E = E::A(/* usize */);
@@ -142,7 +142,7 @@ LL |     let _: usize = X::baz;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize, usize) -> usize {<X as T>::baz}`
+           found fn item `{fn item <X as T>::baz: fn(usize, usize) -> usize}`
 help: use parentheses to call this associated function
    |
 LL |     let _: usize = X::baz(/* usize */, /* usize */);
@@ -160,7 +160,7 @@ LL |     let _: usize = X::bat;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<X as T>::bat}`
+           found fn item `{fn item <X as T>::bat: fn(usize) -> usize}`
 help: use parentheses to call this associated function
    |
 LL |     let _: usize = X::bat(/* usize */);
@@ -178,7 +178,7 @@ LL |     let _: usize = X::bax;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<X as T>::bax}`
+           found fn item `{fn item <X as T>::bax: fn(usize) -> usize}`
 help: use parentheses to call this associated function
    |
 LL |     let _: usize = X::bax(/* usize */);
@@ -196,7 +196,7 @@ LL |     let _: usize = X::bach;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `fn(usize) -> usize {<X as T>::bach}`
+           found fn item `{fn item <X as T>::bach: fn(usize) -> usize}`
 help: use parentheses to call this associated function
    |
 LL |     let _: usize = X::bach(/* usize */);
@@ -214,7 +214,7 @@ LL |     let _: usize = X::ban;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `for<'a> fn(&'a X) -> usize {<X as T>::ban}`
+           found fn item `{fn item <X as T>::ban: for<'a> fn(&'a X) -> usize}`
 help: use parentheses to call this method
    |
 LL |     let _: usize = X::ban(/* &X */);
@@ -232,7 +232,7 @@ LL |     let _: usize = X::bal;
    |            expected due to this
    |
    = note: expected type `usize`
-           found fn item `for<'a> fn(&'a X) -> usize {<X as T>::bal}`
+           found fn item `{fn item <X as T>::bal: for<'a> fn(&'a X) -> usize}`
 help: use parentheses to call this method
    |
 LL |     let _: usize = X::bal(/* &X */);

--- a/tests/ui/suggestions/issue-107860.stderr
+++ b/tests/ui/suggestions/issue-107860.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/issue-107860.rs:3:36
    |
 LL | async fn str<T>(T: &str) -> &str { &str }
-   |                                    ^^^^ expected `&str`, found `&fn(&str) -> ... {str::<...>}`
+   |                                    ^^^^ expected `&str`, found `&{fn item str::<_>: fn(...) -> ...}`
    |
    = note: expected reference `&str`
-              found reference `&for<'a> fn(&'a str) -> impl Future<Output = &'a str> {str::<_>}`
+              found reference `&{fn item str::<_>: for<'a> fn(&'a str) -> impl Future<Output = &'a str>}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-109854.stderr
+++ b/tests/ui/suggestions/issue-109854.stderr
@@ -17,7 +17,7 @@ note: expected `usize`, found fn item
 LL |     generate_setter,
    |     ^^^^^^^^^^^^^^^
    = note: expected type `usize`
-           found fn item `fn() {generate_setter}`
+           found fn item `{fn item generate_setter: fn()}`
 note: associated function defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: remove the extra arguments

--- a/tests/ui/suggestions/suggest-call-on-pat-mismatch.stderr
+++ b/tests/ui/suggestions/suggest-call-on-pat-mismatch.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/suggest-call-on-pat-mismatch.rs:7:12
    |
 LL |     if let E::One(var1, var2) = var {
-   |            ^^^^^^^^^^^^^^^^^^   --- this expression has type `fn(i32, i32) -> E {E::One}`
+   |            ^^^^^^^^^^^^^^^^^^   --- this expression has type `{fn item E::One: fn(i32, i32) -> E}`
    |            |
    |            expected enum constructor, found `E`
    |
-   = note: expected enum constructor `fn(i32, i32) -> E {E::One}`
+   = note: expected enum constructor `{fn item E::One: fn(i32, i32) -> E}`
                           found enum `E`
 help: use parentheses to construct this tuple variant
    |
@@ -17,11 +17,11 @@ error[E0308]: mismatched types
   --> $DIR/suggest-call-on-pat-mismatch.rs:13:9
    |
 LL |     let Some(x) = Some;
-   |         ^^^^^^^   ---- this expression has type `fn(_) -> Option<_> {Option::<_>::Some}`
+   |         ^^^^^^^   ---- this expression has type `{fn item Option::<_>::Some: fn(_) -> Option<_>}`
    |         |
    |         expected enum constructor, found `Option<_>`
    |
-   = note: expected enum constructor `fn(_) -> Option<_> {Option::<_>::Some}`
+   = note: expected enum constructor `{fn item Option::<_>::Some: fn(_) -> Option<_>}`
                           found enum `Option<_>`
 help: use parentheses to construct this tuple variant
    |

--- a/tests/ui/traits/fn-trait-cast-diagnostic.stderr
+++ b/tests/ui/traits/fn-trait-cast-diagnostic.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `fn() -> bool {example}: Foo` is not satisfied
+error[E0277]: the trait bound `{fn item example: fn() -> bool}: Foo` is not satisfied
   --> $DIR/fn-trait-cast-diagnostic.rs:21:15
    |
 LL |     do_on_foo(example);
-   |     --------- ^^^^^^^ the trait `Foo` is not implemented for fn item `fn() -> bool {example}`
+   |     --------- ^^^^^^^ the trait `Foo` is not implemented for fn item `{fn item example: fn() -> bool}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -20,11 +20,11 @@ help: the trait `Foo` is implemented for fn pointer `fn() -> bool`, try casting 
 LL |     do_on_foo(example as fn() -> bool);
    |                       +++++++++++++++
 
-error[E0277]: the trait bound `fn() -> bool {example}: NoOtherFoo` is not satisfied
+error[E0277]: the trait bound `{fn item example: fn() -> bool}: NoOtherFoo` is not satisfied
   --> $DIR/fn-trait-cast-diagnostic.rs:24:22
    |
 LL |     do_on_single_foo(example);
-   |     ---------------- ^^^^^^^ the trait `NoOtherFoo` is not implemented for fn item `fn() -> bool {example}`
+   |     ---------------- ^^^^^^^ the trait `NoOtherFoo` is not implemented for fn item `{fn item example: fn() -> bool}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/traits/issue-99875.stderr
+++ b/tests/ui/traits/issue-99875.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `fn(Argument) -> Return {function}: Trait` is not satisfied
+error[E0277]: the trait bound `{fn item function: fn(Argument) -> Return}: Trait` is not satisfied
   --> $DIR/issue-99875.rs:12:11
    |
 LL |     takes(function);
-   |     ----- ^^^^^^^^ the trait `Trait` is not implemented for fn item `fn(Argument) -> Return {function}`
+   |     ----- ^^^^^^^^ the trait `Trait` is not implemented for fn item `{fn item function: fn(Argument) -> Return}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/traits/next-solver/fn-trait.rs
+++ b/tests/ui/traits/next-solver/fn-trait.rs
@@ -21,12 +21,12 @@ fn main() {
     //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32`
     //~| ERROR: type mismatch resolving `<unsafe fn() -> i32 as FnOnce<()>>::Output == i32`
     require_fn(g);
-    //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
-    //~| ERROR: type mismatch resolving `<extern "C" fn() -> i32 {g} as FnOnce<()>>::Output == i32`
+    //~^ ERROR: expected a `Fn()` closure, found `{fn item g: extern "C" fn() -> i32}`
+    //~| ERROR: type mismatch resolving `<{fn item g: extern "C" fn() -> i32} as FnOnce<()>>::Output == i32`
     require_fn(g as extern "C" fn() -> i32);
     //~^ ERROR: expected a `Fn()` closure, found `extern "C" fn() -> i32`
     //~| ERROR: type mismatch resolving `<extern "C" fn() -> i32 as FnOnce<()>>::Output == i32`
     require_fn(h);
-    //~^ ERROR: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
-    //~| ERROR: type mismatch resolving `<unsafe fn() -> i32 {h} as FnOnce<()>>::Output == i32`
+    //~^ ERROR: expected a `Fn()` closure, found `{fn item h: unsafe fn() -> i32}`
+    //~| ERROR: type mismatch resolving `<{fn item h: unsafe fn() -> i32} as FnOnce<()>>::Output == i32`
 }

--- a/tests/ui/traits/next-solver/fn-trait.stderr
+++ b/tests/ui/traits/next-solver/fn-trait.stderr
@@ -29,23 +29,23 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                               ^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn()` closure, found `extern "C" fn() -> i32 {g}`
+error[E0277]: expected a `Fn()` closure, found `{fn item g: extern "C" fn() -> i32}`
   --> $DIR/fn-trait.rs:23:16
    |
 LL |     require_fn(g);
-   |     ---------- ^ expected an `Fn()` closure, found `extern "C" fn() -> i32 {g}`
+   |     ---------- ^ expected an `Fn()` closure, found `{fn item g: extern "C" fn() -> i32}`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `extern "C" fn() -> i32 {g}`
-   = note: wrap the `extern "C" fn() -> i32 {g}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn<()>` is not implemented for fn item `{fn item g: extern "C" fn() -> i32}`
+   = note: wrap the `{fn item g: extern "C" fn() -> i32}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `require_fn`
   --> $DIR/fn-trait.rs:3:23
    |
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0271]: type mismatch resolving `<extern "C" fn() -> i32 {g} as FnOnce<()>>::Output == i32`
+error[E0271]: type mismatch resolving `<{fn item g: extern "C" fn() -> i32} as FnOnce<()>>::Output == i32`
   --> $DIR/fn-trait.rs:23:16
    |
 LL |     require_fn(g);
@@ -89,7 +89,7 @@ note: required by a bound in `require_fn`
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                               ^^^ required by this bound in `require_fn`
 
-error[E0277]: expected a `Fn()` closure, found `unsafe fn() -> i32 {h}`
+error[E0277]: expected a `Fn()` closure, found `{fn item h: unsafe fn() -> i32}`
   --> $DIR/fn-trait.rs:29:16
    |
 LL |     require_fn(h);
@@ -97,16 +97,16 @@ LL |     require_fn(h);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn<()>` is not implemented for fn item `unsafe fn() -> i32 {h}`
+   = help: the trait `Fn<()>` is not implemented for fn item `{fn item h: unsafe fn() -> i32}`
    = note: unsafe function cannot be called generically without an unsafe block
-   = note: wrap the `unsafe fn() -> i32 {h}` in a closure with no arguments: `|| { /* code */ }`
+   = note: wrap the `{fn item h: unsafe fn() -> i32}` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `require_fn`
   --> $DIR/fn-trait.rs:3:23
    |
 LL | fn require_fn(_: impl Fn() -> i32) {}
    |                       ^^^^^^^^^^^ required by this bound in `require_fn`
 
-error[E0271]: type mismatch resolving `<unsafe fn() -> i32 {h} as FnOnce<()>>::Output == i32`
+error[E0271]: type mismatch resolving `<{fn item h: unsafe fn() -> i32} as FnOnce<()>>::Output == i32`
   --> $DIR/fn-trait.rs:29:16
    |
 LL |     require_fn(h);

--- a/tests/ui/traits/unsend-future.stderr
+++ b/tests/ui/traits/unsend-future.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     require_handler(handler)
    |                     ^^^^^^^ future returned by `handler` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`, which is required by `fn() -> impl Future<Output = ()> {handler}: Handler`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`, which is required by `{fn item handler: fn() -> impl Future<Output = ()>}: Handler`
 note: future is not `Send` as this value is used across an await
   --> $DIR/unsend-future.rs:15:14
    |

--- a/tests/ui/transmute/transmute-from-fn-item-types-error.stderr
+++ b/tests/ui/transmute/transmute-from-fn-item-types-error.stderr
@@ -4,7 +4,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     let i = mem::transmute(bar);
    |             ^^^^^^^^^^^^^^
    |
-   = note: source type: `unsafe fn() {bar}` (0 bits)
+   = note: source type: `{fn item bar: unsafe fn()}` (0 bits)
    = note: target type: `i8` (8 bits)
 
 error[E0591]: can't transmute zero-sized type
@@ -13,7 +13,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     let p = mem::transmute(foo);
    |             ^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() -> (i8, *const (), Option<fn()>) {foo}
+   = note: source type: {fn item foo: unsafe fn() -> (i8, *const (), Option<fn()>)}
    = note: target type: *const ()
    = help: cast with `as` to a pointer instead
 
@@ -23,7 +23,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     let of = mem::transmute(main);
    |              ^^^^^^^^^^^^^^
    |
-   = note: source type: fn() {main}
+   = note: source type: {fn item main: fn()}
    = note: target type: Option<fn()>
    = help: cast with `as` to a pointer instead
 
@@ -33,7 +33,7 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 LL |     mem::transmute::<_, u8>(main);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: `fn() {main}` (0 bits)
+   = note: source type: `{fn item main: fn()}` (0 bits)
    = note: target type: `u8` (8 bits)
 
 error[E0591]: can't transmute zero-sized type
@@ -42,7 +42,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, *mut ()>(foo);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() -> (i8, *const (), Option<fn()>) {foo}
+   = note: source type: {fn item foo: unsafe fn() -> (i8, *const (), Option<fn()>)}
    = note: target type: *mut ()
    = help: cast with `as` to a pointer instead
 
@@ -52,7 +52,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, fn()>(bar);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {bar}
+   = note: source type: {fn item bar: unsafe fn()}
    = note: target type: fn()
    = help: cast with `as` to a pointer instead
 
@@ -62,7 +62,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, *mut ()>(Some(foo));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() -> (i8, *const (), Option<fn()>) {foo}
+   = note: source type: {fn item foo: unsafe fn() -> (i8, *const (), Option<fn()>)}
    = note: target type: *mut ()
    = help: cast with `as` to a pointer instead
 
@@ -72,7 +72,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, fn()>(Some(bar));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {bar}
+   = note: source type: {fn item bar: unsafe fn()}
    = note: target type: fn()
    = help: cast with `as` to a pointer instead
 
@@ -82,7 +82,7 @@ error[E0591]: can't transmute zero-sized type
 LL |     mem::transmute::<_, Option<fn()>>(Some(baz));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: source type: unsafe fn() {baz}
+   = note: source type: {fn item baz: unsafe fn()}
    = note: target type: Option<fn()>
    = help: cast with `as` to a pointer instead
 

--- a/tests/ui/type-alias-impl-trait/issue-98604.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-98604.stderr
@@ -4,7 +4,7 @@ error[E0271]: expected `test` to be a fn item that returns `Pin<Box<dyn Future<O
 LL |     Box::new(test) as AsyncFnPtr;
    |     ^^^^^^^^^^^^^^ expected `Pin<Box<dyn Future<Output = ()>>>`, found future
    |
-   = note: required for the cast from `Box<fn() -> impl Future<Output = ()> {test}>` to `Box<(dyn Fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> + 'static)>`
+   = note: required for the cast from `Box<{fn item test: fn() -> impl Future<Output = ()>}>` to `Box<(dyn Fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> + 'static)>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/issue-98608.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-98608.stderr
@@ -9,7 +9,7 @@ LL |     let b: Box<dyn Fn() -> Box<u8>> = Box::new(hi);
    |
    = note:   expected struct `Box<u8>`
            found opaque type `impl Sized`
-   = note: required for the cast from `Box<fn() -> impl Sized {hi}>` to `Box<dyn Fn() -> Box<u8>>`
+   = note: required for the cast from `Box<{fn item hi: fn() -> impl Sized}>` to `Box<dyn Fn() -> Box<u8>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/escaping_bound_vars.stderr
+++ b/tests/ui/typeck/escaping_bound_vars.stderr
@@ -24,13 +24,13 @@ help: this trait has no implementations, consider adding one
 LL | trait Elide<T> {
    | ^^^^^^^^^^^^^^
 
-error[E0277]: cannot add `fn() {<() as Elide<(&(),)>>::call}` to `{integer}`
+error[E0277]: cannot add `{fn item <() as Elide<(&(),)>>::call: fn()}` to `{integer}`
   --> $DIR/escaping_bound_vars.rs:11:18
    |
 LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
-   |                  ^ no implementation for `{integer} + fn() {<() as Elide<(&(),)>>::call}`
+   |                  ^ no implementation for `{integer} + {fn item <() as Elide<(&(),)>>::call: fn()}`
    |
-   = help: the trait `Add<fn() {<() as Elide<(&(),)>>::call}>` is not implemented for `{integer}`
+   = help: the trait `Add<{fn item <() as Elide<(&(),)>>::call: fn()}>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
              <isize as Add>
              <isize as Add<&isize>>

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -2,9 +2,9 @@ error[E0308]: mismatched types
   --> $DIR/issue-107775.rs:35:16
    |
 LL |         map.insert(1, Struct::do_something);
-   |         ---           -------------------- this argument has type `fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}`...
+   |         ---           -------------------- this argument has type `{fn item <Struct as Trait>::do_something::<'_>: fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>>}`...
    |         |
-   |         ... which causes `map` to have type `HashMap<{integer}, fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
+   |         ... which causes `map` to have type `HashMap<{integer}, {fn item <Struct as Trait>::do_something::<'_>: fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send>>}>`
 LL |         Self { map }
    |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<...>>`, found `HashMap<{integer}, ...>`
    |

--- a/tests/ui/typeck/issue-29124.stderr
+++ b/tests/ui/typeck/issue-29124.stderr
@@ -1,14 +1,14 @@
-error[E0599]: no method named `x` found for fn item `fn() -> Ret {Obj::func}` in the current scope
+error[E0599]: no method named `x` found for fn item `{fn item Obj::func: fn() -> Ret}` in the current scope
   --> $DIR/issue-29124.rs:15:15
    |
 LL |     Obj::func.x();
-   |               ^ method not found in `fn() -> Ret {Obj::func}`
+   |               ^ method not found in `{fn item Obj::func: fn() -> Ret}`
 
-error[E0599]: no method named `x` found for fn item `fn() -> Ret {func}` in the current scope
+error[E0599]: no method named `x` found for fn item `{fn item func: fn() -> Ret}` in the current scope
   --> $DIR/issue-29124.rs:17:10
    |
 LL |     func.x();
-   |          ^ method not found in `fn() -> Ret {func}`
+   |          ^ method not found in `{fn item func: fn() -> Ret}`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/issue-87181/empty-tuple-method.rs
+++ b/tests/ui/typeck/issue-87181/empty-tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for struct constructor `fn() -> Foo {Foo}` in the current scope [E0599]
+    //~^ ERROR  no method named `foo` found for struct constructor `{fn item Foo: fn() -> Foo}` in the current scope [E0599]
 }

--- a/tests/ui/typeck/issue-87181/empty-tuple-method.stderr
+++ b/tests/ui/typeck/issue-87181/empty-tuple-method.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for struct constructor `fn() -> Foo {Foo}` in the current scope
+error[E0599]: no method named `foo` found for struct constructor `{fn item Foo: fn() -> Foo}` in the current scope
   --> $DIR/empty-tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();
-   |               ^^^ method not found in `fn() -> Foo {Foo}`
+   |               ^^^ method not found in `{fn item Foo: fn() -> Foo}`
    |
 help: use parentheses to construct this tuple struct
    |

--- a/tests/ui/typeck/issue-87181/enum-variant.rs
+++ b/tests/ui/typeck/issue-87181/enum-variant.rs
@@ -12,5 +12,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo::Tup };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for enum constructor `fn() -> Foo {Foo::Tup}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for enum constructor `{fn item Foo::Tup: fn() -> Foo}` in the current scope [E0599]
 }

--- a/tests/ui/typeck/issue-87181/enum-variant.stderr
+++ b/tests/ui/typeck/issue-87181/enum-variant.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for enum constructor `fn() -> Foo {Foo::Tup}` in the current scope
+error[E0599]: no method named `foo` found for enum constructor `{fn item Foo::Tup: fn() -> Foo}` in the current scope
   --> $DIR/enum-variant.rs:14:15
    |
 LL |     thing.bar.foo();
-   |               ^^^ method not found in `fn() -> Foo {Foo::Tup}`
+   |               ^^^ method not found in `{fn item Foo::Tup: fn() -> Foo}`
    |
 help: use parentheses to construct this tuple variant
    |

--- a/tests/ui/typeck/issue-87181/tuple-field.rs
+++ b/tests/ui/typeck/issue-87181/tuple-field.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.0;
-    //~^ ERROR no field `0` on type `fn(char, u16) -> Foo {Foo}` [E0609]
+    //~^ ERROR no field `0` on type `{fn item Foo: fn(char, u16) -> Foo}` [E0609]
 }

--- a/tests/ui/typeck/issue-87181/tuple-field.stderr
+++ b/tests/ui/typeck/issue-87181/tuple-field.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `0` on type `fn(char, u16) -> Foo {Foo}`
+error[E0609]: no field `0` on type `{fn item Foo: fn(char, u16) -> Foo}`
   --> $DIR/tuple-field.rs:12:15
    |
 LL |     thing.bar.0;

--- a/tests/ui/typeck/issue-87181/tuple-method.rs
+++ b/tests/ui/typeck/issue-87181/tuple-method.rs
@@ -10,5 +10,5 @@ impl Foo {
 fn main() {
     let thing = Bar { bar: Foo };
     thing.bar.foo();
-    //~^ ERROR no method named `foo` found for struct constructor `fn(u8, i32) -> Foo {Foo}` in the current scope [E0599]
+    //~^ ERROR no method named `foo` found for struct constructor `{fn item Foo: fn(u8, i32) -> Foo}` in the current scope [E0599]
 }

--- a/tests/ui/typeck/issue-87181/tuple-method.stderr
+++ b/tests/ui/typeck/issue-87181/tuple-method.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `foo` found for struct constructor `fn(u8, i32) -> Foo {Foo}` in the current scope
+error[E0599]: no method named `foo` found for struct constructor `{fn item Foo: fn(u8, i32) -> Foo}` in the current scope
   --> $DIR/tuple-method.rs:12:15
    |
 LL |     thing.bar.foo();
-   |               ^^^ method not found in `fn(u8, i32) -> Foo {Foo}`
+   |               ^^^ method not found in `{fn item Foo: fn(u8, i32) -> Foo}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-96738.stderr
+++ b/tests/ui/typeck/issue-96738.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `nonexistent_method` found for enum constructor `fn(_) -> Option<_> {Option::<_>::Some}` in the current scope
+error[E0599]: no method named `nonexistent_method` found for enum constructor `{fn item Option::<_>::Some: fn(_) -> Option<_>}` in the current scope
   --> $DIR/issue-96738.rs:2:10
    |
 LL |     Some.nonexistent_method();
-   |          ^^^^^^^^^^^^^^^^^^ method not found in `fn(_) -> Option<_> {Option::<_>::Some}`
+   |          ^^^^^^^^^^^^^^^^^^ method not found in `{fn item Option::<_>::Some: fn(_) -> Option<_>}`
 
-error[E0609]: no field `nonexistent_field` on type `fn(_) -> Option<_> {Option::<_>::Some}`
+error[E0609]: no field `nonexistent_field` on type `{fn item Option::<_>::Some: fn(_) -> Option<_>}`
   --> $DIR/issue-96738.rs:3:10
    |
 LL |     Some.nonexistent_field;

--- a/tests/ui/typeck/while-type-error.stderr
+++ b/tests/ui/typeck/while-type-error.stderr
@@ -5,7 +5,7 @@ LL | fn main() { while main { } }
    |                   ^^^^ expected `bool`, found fn item
    |
    = note: expected type `bool`
-           found fn item `fn() {main}`
+           found fn item `{fn item main: fn()}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `Fn(&isize)` closure, found `{fn item square: for<'a> unsafe fn(&'a isize) -> isize}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `{fn item square: for<'a> unsafe fn(&'a isize) -> isize}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:9:15
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnMut(&isize)` closure, found `{fn item square: for<'a> unsafe fn(&'a isize) -> isize}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -22,7 +22,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `{fn item square: for<'a> unsafe fn(&'a isize) -> isize}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:19
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce(&isize)` closure, found `for<'a> unsafe fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnOnce(&isize)` closure, found `{fn item square: for<'a> unsafe fn(&'a isize) -> isize}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
@@ -38,7 +38,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `for<'a> unsafe fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `{fn item square: for<'a> unsafe fn(&'a isize) -> isize}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:15:20

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,42 +1,42 @@
-error[E0277]: expected a `Fn(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `Fn(&isize)` closure, found `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
   --> $DIR/unboxed-closures-wrong-abi.rs:20:21
    |
 LL |     let x = call_it(&square, 22);
-   |             ------- ^^^^^^^ expected an `Fn(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   |             ------- ^^^^^^^ expected an `Fn(&isize)` closure, found `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-wrong-abi.rs:9:15
    |
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnMut(&isize)` closure, found `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
   --> $DIR/unboxed-closures-wrong-abi.rs:25:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ----------- ^^^^^^^^^^^ expected an `FnMut(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   |             ----------- ^^^^^^^^^^^ expected an `FnMut(&isize)` closure, found `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-wrong-abi.rs:12:19
    |
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+error[E0277]: expected a `FnOnce(&isize)` closure, found `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
   --> $DIR/unboxed-closures-wrong-abi.rs:30:26
    |
 LL |     let z = call_it_once(square, 22);
-   |             ------------ ^^^^^^ expected an `FnOnce(&isize)` closure, found `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   |             ------------ ^^^^^^ expected an `FnOnce(&isize)` closure, found `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `for<'a> extern "C" fn(&'a isize) -> isize {square}`
+   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `{fn item square: for<'a> extern "C" fn(&'a isize) -> isize}`
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-wrong-abi.rs:15:20
    |

--- a/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `Fn(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `Fn(&isize)` closure, found `{fn item square: unsafe fn(isize) -> isize}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:21:21
    |
 LL |     let x = call_it(&square, 22);
@@ -6,7 +6,7 @@ LL |     let x = call_it(&square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'a> Fn<(&'a isize,)>` is not implemented for fn item `{fn item square: unsafe fn(isize) -> isize}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:10:15
@@ -14,7 +14,7 @@ note: required by a bound in `call_it`
 LL | fn call_it<F: Fn(&isize) -> isize>(_: &F, _: isize) -> isize {
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it`
 
-error[E0277]: expected a `FnMut(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `FnMut(&isize)` closure, found `{fn item square: unsafe fn(isize) -> isize}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:26:25
    |
 LL |     let y = call_it_mut(&mut square, 22);
@@ -22,7 +22,7 @@ LL |     let y = call_it_mut(&mut square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'a> FnMut<(&'a isize,)>` is not implemented for fn item `{fn item square: unsafe fn(isize) -> isize}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_mut`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:19
@@ -30,7 +30,7 @@ note: required by a bound in `call_it_mut`
 LL | fn call_it_mut<F: FnMut(&isize) -> isize>(_: &mut F, _: isize) -> isize {
    |                   ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `call_it_mut`
 
-error[E0277]: expected a `FnOnce(&isize)` closure, found `unsafe fn(isize) -> isize {square}`
+error[E0277]: expected a `FnOnce(&isize)` closure, found `{fn item square: unsafe fn(isize) -> isize}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:31:26
    |
 LL |     let z = call_it_once(square, 22);
@@ -38,7 +38,7 @@ LL |     let z = call_it_once(square, 22);
    |             |
    |             required by a bound introduced by this call
    |
-   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `unsafe fn(isize) -> isize {square}`
+   = help: the trait `for<'a> FnOnce<(&'a isize,)>` is not implemented for fn item `{fn item square: unsafe fn(isize) -> isize}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `call_it_once`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:16:20

--- a/tests/ui/unsafe/initializing-ranged-via-ctor.rs
+++ b/tests/ui/unsafe/initializing-ranged-via-ctor.rs
@@ -7,5 +7,5 @@ struct NonZeroAndOneU8(u8);
 
 fn main() {
     println!("{:?}", Some(1).map(NonZeroAndOneU8).unwrap());
-    //~^ ERROR found `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
+    //~^ ERROR expected a `FnOnce({integer})` closure, found `{fn item NonZeroAndOneU8: unsafe fn(u8) -> NonZeroAndOneU8}`
 }

--- a/tests/ui/unsafe/initializing-ranged-via-ctor.stderr
+++ b/tests/ui/unsafe/initializing-ranged-via-ctor.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnOnce({integer})` closure, found `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
+error[E0277]: expected a `FnOnce({integer})` closure, found `{fn item NonZeroAndOneU8: unsafe fn(u8) -> NonZeroAndOneU8}`
   --> $DIR/initializing-ranged-via-ctor.rs:9:34
    |
 LL |     println!("{:?}", Some(1).map(NonZeroAndOneU8).unwrap());
@@ -6,7 +6,7 @@ LL |     println!("{:?}", Some(1).map(NonZeroAndOneU8).unwrap());
    |                              |
    |                              required by a bound introduced by this call
    |
-   = help: the trait `FnOnce<({integer},)>` is not implemented for fn item `unsafe fn(u8) -> NonZeroAndOneU8 {NonZeroAndOneU8}`
+   = help: the trait `FnOnce<({integer},)>` is not implemented for fn item `{fn item NonZeroAndOneU8: unsafe fn(u8) -> NonZeroAndOneU8}`
    = note: unsafe function cannot be called generically without an unsafe block
 note: required by a bound in `Option::<T>::map`
   --> $SRC_DIR/core/src/option.rs:LL:COL


### PR DESCRIPTION
This Pull Requests aims to improve the diagnostics emitted in the error E0617 when making with the difference between **`fn` types** and **`fn` pointers** more obvious.

This involves changing the way how `ty::FnDef` is pretty-printed. This implementation specifically proposes to change it to be printed in this way:
```
{fn item <value path of the function>: <function signature>}
```

Rendered diagnostic:
```
error[E0617]: can't pass `{fn item test: fn() -> u8}` to variadic function
  --> $DIR/issue-69232.rs:10:12
   |
LL |     foo(1, test);
   |            ^^^^
   |
   = help: a function item is zero-sized and needs to be casted into a function pointer to be used in FFI
   = note: for more information on function items, visit https://doc.rust-lang.org/reference/types/function-item.html
help: cast the value to `fn() -> u8`
   |
LL |     foo(1, test as fn() -> u8);
   |            ~~~~~~~~~~~~~~~~~~
help: cast the value into a function pointer
   |
LL |     foo(1, test as fn() -> u8);
   |            ~~~~~~~~~~~~~~~~~~

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0617`.
```

This also causes all diagnostic messages that utilize the pretty-printing of `ty::FnDef` to use this implementation.

Tests in `tests/ui` are currently left untouched before a consensus can be reached over how the `ty::FnDef` pretty-print should be modified for diagnostics.

Supersedes #94637. Possible resolution of #69232.

_Edit 1: I made the output a bit shorter._

_Edit 2: Added example diagnostic._