### PR TITLE
Replace `#!/bin/bash` with `#!/usr/bin/env bash` in rust-installer tests

### DIFF
--- a/src/tools/rust-installer/test.sh
+++ b/src/tools/rust-installer/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u
 


### PR DESCRIPTION
This allows the rust-installer tests to pass on NixOS

This change has [already been made](https://github.com/rust-lang/rust/commit/302ad2175d938a5307dd34779e20aada691fd28a) for the actual installer, it appears that the tests were just forgotten.