### PR TITLE
check `RUST_BOOTSTRAP_CONFIG` in `profile_user_dist` test

### DIFF
--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -174,12 +174,14 @@ fn override_toml_duplicate() {
 #[test]
 fn profile_user_dist() {
     fn get_toml(file: &Path) -> TomlConfig {
-        let contents = if file.ends_with("config.toml") {
-            "profile = \"user\"".to_owned()
-        } else {
-            assert!(file.ends_with("config.dist.toml"));
-            std::fs::read_to_string(file).unwrap()
-        };
+        let contents =
+            if file.ends_with("config.toml") || env::var_os("RUST_BOOTSTRAP_CONFIG").is_some() {
+                "profile = \"user\"".to_owned()
+            } else {
+                assert!(file.ends_with("config.dist.toml"));
+                std::fs::read_to_string(file).unwrap()
+            };
+
         toml::from_str(&contents)
             .and_then(|table: toml::Value| TomlConfig::deserialize(table))
             .unwrap()


### PR DESCRIPTION
Fixes a logical bug in `profile_user_dist` test (explained in #120202).