### PR TITLE
Don't actually make bound ty/const for RTN

### DIFF
--- a/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.rs
@@ -1,0 +1,17 @@
+// edition: 2021
+
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait HealthCheck {
+    async fn check<const N: usize>() -> bool;
+}
+
+async fn do_health_check_par<HC>(hc: HC)
+where
+    HC: HealthCheck<check(): Send> + Send + 'static,
+    //~^ ERROR return type notation is not allowed for functions that have const parameters
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/issue-120208-higher-ranked-const.stderr
@@ -1,0 +1,20 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-120208-higher-ranked-const.rs:3:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed for functions that have const parameters
+  --> $DIR/issue-120208-higher-ranked-const.rs:12:21
+   |
+LL |     async fn check<const N: usize>() -> bool;
+   |                    -------------- const parameter declared here
+...
+LL |     HC: HealthCheck<check(): Send> + Send + 'static,
+   |                     ^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
Avoid creating an unnecessary non-lifetime binder when we do RTN on a method that has ty/const params.

Fixes #120208

r? oli-obk