### PR TITLE
Fix a `trimmed_def_paths` assertion failure.

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3072,8 +3072,6 @@ fn for_each_def(tcx: TyCtxt<'_>, mut collect_fn: impl for<'b> FnMut(&'b Ident, N
 /// See also [`DelayDm`](rustc_error_messages::DelayDm) and [`with_no_trimmed_paths!`].
 // this is pub to be able to intra-doc-link it
 pub fn trimmed_def_paths(tcx: TyCtxt<'_>, (): ()) -> DefIdMap<Symbol> {
-    assert!(tcx.sess.opts.trimmed_def_paths);
-
     // Trimming paths is expensive and not optimized, since we expect it to only be used for error
     // reporting.
     //


### PR DESCRIPTION
`RegionHighlightMode::force_print_trimmed_def_path` can call `trimmed_def_paths` even when `tcx.sess.opts.trimmed_def_paths` is false. Based on the `force` in the method name, it seems this is deliberate, so I have removed the assertion.

Fixes #120035.

r? @compiler-errors