### PR TITLE
core: implement Add and AddAssign for ascii::Char

### DIFF
--- a/library/core/tests/ascii_char.rs
+++ b/library/core/tests/ascii_char.rs
@@ -1,0 +1,38 @@
+use core::ascii::Char;
+
+/// Tests addition of u8 values to ascii::Char;
+#[test]
+fn test_arithmetic_ok() {
+    assert_eq!(Char::Digit8, Char::Digit0 + 8);
+    assert_eq!(Char::Colon, Char::Digit0 + 10);
+    assert_eq!(Char::Digit8, 8 + Char::Digit0);
+    assert_eq!(Char::Colon, 10 + Char::Digit0);
+
+    let mut digit = Char::Digit0;
+    digit += 8;
+    assert_eq!(Char::Digit8, digit);
+}
+
+/// Tests addition wraps values when built in release mode.
+#[test]
+#[cfg_attr(debug_assertions, ignore = "works in release builds only")]
+fn test_arithmetic_wrapping() {
+    assert_eq!(Char::Digit0, Char::Digit8 + 120);
+    assert_eq!(Char::Digit0, Char::Digit8 + 248);
+}
+
+/// Tests addition panics in debug build when it produces an invalid ASCII char.
+#[test]
+#[cfg_attr(not(debug_assertions), ignore = "works in debug builds only")]
+#[should_panic]
+fn test_arithmetic_non_ascii() {
+    let _ = Char::Digit0 + 120;
+}
+
+/// Tests addition panics in debug build when it overflowing u8.
+#[test]
+#[cfg_attr(not(debug_assertions), ignore = "works in debug builds only")]
+#[should_panic]
+fn test_arithmetic_overflow() {
+    let _ = Char::Digit0 + 250;
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -124,6 +124,7 @@ mod alloc;
 mod any;
 mod array;
 mod ascii;
+mod ascii_char;
 mod asserting;
 mod async_iter;
 mod atomic;

--- a/tests/ui/issues/issue-11771.stderr
+++ b/tests/ui/issues/issue-11771.stderr
@@ -14,7 +14,7 @@ LL |     1 +
              <i16 as Add<&i16>>
              <i32 as Add>
              <i32 as Add<&i32>>
-           and 48 others
+           and 52 others
 
 error[E0277]: cannot add `()` to `{integer}`
   --> $DIR/issue-11771.rs:8:7
@@ -32,7 +32,7 @@ LL |     1 +
              <i16 as Add<&i16>>
              <i32 as Add>
              <i32 as Add<&i32>>
-           and 48 others
+           and 52 others
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-50582.stderr
+++ b/tests/ui/issues/issue-50582.stderr
@@ -24,7 +24,7 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
              <i16 as Add<&i16>>
              <i32 as Add>
              <i32 as Add<&i32>>
-           and 48 others
+           and 52 others
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -14,7 +14,7 @@ LL |     1 + Some(1);
              <i16 as Add<&i16>>
              <i32 as Add>
              <i32 as Add<&i32>>
-           and 48 others
+           and 52 others
 
 error[E0277]: cannot subtract `Option<{integer}>` from `usize`
   --> $DIR/binops.rs:3:16

--- a/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -7,9 +7,13 @@ LL |     x + 100.0
    = help: the trait `Add<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Add<Rhs>`:
              <u8 as Add>
+             <u8 as Add<Char>>
              <u8 as Add<&u8>>
+             <u8 as Add<&Char>>
              <&'a u8 as Add<u8>>
+             <&'a u8 as Add<Char>>
              <&u8 as Add<&u8>>
+             <&u8 as Add<&Char>>
 
 error[E0277]: cannot add `&str` to `f64`
   --> $DIR/not-suggest-float-literal.rs:6:7

--- a/tests/ui/typeck/escaping_bound_vars.stderr
+++ b/tests/ui/typeck/escaping_bound_vars.stderr
@@ -40,7 +40,7 @@ LL |     (): Test<{ 1 + (<() as Elide(&())>::call) }>,
              <i16 as Add<&i16>>
              <i32 as Add>
              <i32 as Add<&i32>>
-           and 48 others
+           and 52 others
 
 error[E0277]: the trait bound `(): Elide<(&(),)>` is not satisfied
   --> $DIR/escaping_bound_vars.rs:11:18


### PR DESCRIPTION
Implement Add and AddAssign for ascii::Char which panics in debug
builds if sum isn’t an ASCII character and wraps the result in release
builds.  The operators can be used to convert an integer into a digit
or a letter of an alphabet:

    use core::ascii::Char;

    assert_eq!(Char::Digit8, Char::Digit0 + 8);
    assert_eq!(Char::SmallI, Char::SmallA + 8);

Issue: https://github.com/rust-lang/rust/issues/110998
