### PR TITLE
Fix -Zremap-path-scope typo

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
+++ b/src/doc/unstable-book/src/compiler-flags/remap-path-scope.md
@@ -20,5 +20,5 @@ This flag accepts a comma-separated list of values and may be specified multiple
 ```sh
 # This would produce an absolute path to main.rs in build outputs of
 # "./main.rs".
-rustc --remap-path-prefix=$(PWD)=/remapped -Zremap-path-prefix=object main.rs
+rustc --remap-path-prefix=$(PWD)=/remapped -Zremap-path-scope=object main.rs
 ```


### PR DESCRIPTION
This fixes a documentation typo from #115214 where `-Zremap-path-prefix=object` should be `-Zremap-path-scope=object`.

@rustbot label: +F-trim-paths
