### PR TITLE
stabilise assert_matches

### DIFF
--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -8,7 +8,6 @@ Rust MIR: a lowered representation of Rust.
 #![feature(rustdoc_internals)]
 #![doc(rust_logo)]
 #![deny(rustc::untranslatable_diagnostic)]
-#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(decl_macro)]
 #![feature(exact_size_is_empty)]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -27,7 +27,6 @@
 #![feature(rustdoc_internals)]
 #![feature(allocator_api)]
 #![feature(array_windows)]
-#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(core_intrinsics)]
 #![feature(discriminant_kind)]

--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -1,7 +1,6 @@
 //! Construction of MIR from HIR.
 //!
 //! This crate also contains the match exhaustiveness and usefulness checking.
-#![feature(assert_matches)]
 #![feature(associated_type_bounds)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
-#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(cow_is_borrowed)]
 #![feature(decl_macro)]

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(assert_matches)]
 #![feature(core_intrinsics)]
 #![feature(hash_raw_entry)]
 #![feature(min_specialization)]

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -9,7 +9,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
-#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(extract_if)]
 #![feature(if_let_guard)]

--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -10,7 +10,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
-#![feature(assert_matches)]
 #![feature(associated_type_bounds)]
 #![feature(exhaustive_patterns)]
 #![feature(iter_intersperse)]

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -8,7 +8,6 @@
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
 #![allow(internal_features)]
-#![feature(assert_matches)]
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -106,7 +106,6 @@
 #![feature(array_methods)]
 #![feature(array_windows)]
 #![feature(ascii_char)]
-#![feature(assert_matches)]
 #![feature(async_iterator)]
 #![feature(coerce_unsized)]
 #![feature(const_align_of_val)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -1,7 +1,6 @@
 #![feature(allocator_api)]
 #![feature(alloc_layout_extra)]
 #![feature(iter_array_chunks)]
-#![feature(assert_matches)]
 #![feature(btree_extract_if)]
 #![feature(cow_is_borrowed)]
 #![feature(const_cow_is_borrowed)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -288,10 +288,9 @@ mod macros;
 // We don't export this through #[macro_export] for now, to avoid breakage.
 // See https://github.com/rust-lang/rust/issues/82913
 #[cfg(not(test))]
-#[unstable(feature = "assert_matches", issue = "82775")]
-/// Unstable module containing the unstable `assert_matches` macro.
+#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
 pub mod assert_matches {
-    #[unstable(feature = "assert_matches", issue = "82775")]
+    #[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
     pub use crate::macros::{assert_matches, debug_assert_matches};
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -288,6 +288,7 @@ mod macros;
 // We don't export this through #[macro_export] for now, to avoid breakage.
 // See https://github.com/rust-lang/rust/issues/82913
 #[cfg(not(test))]
+#[allow(missing_docs)]
 #[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
 pub mod assert_matches {
     #[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -126,8 +126,6 @@ macro_rules! assert_ne {
 /// # Examples
 ///
 /// ```
-/// #![feature(assert_matches)]
-///
 /// use std::assert_matches::assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
@@ -138,7 +136,7 @@ macro_rules! assert_ne {
 /// let c = Ok("abc".to_string());
 /// assert_matches!(c, Ok(x) | Err(x) if x.len() < 100);
 /// ```
-#[unstable(feature = "assert_matches", issue = "82775")]
+#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro assert_matches {
@@ -388,8 +386,6 @@ macro_rules! debug_assert_ne {
 /// # Examples
 ///
 /// ```
-/// #![feature(assert_matches)]
-///
 /// use std::assert_matches::debug_assert_matches;
 ///
 /// let a = 1u32.checked_add(2);
@@ -400,7 +396,7 @@ macro_rules! debug_assert_ne {
 /// let c = Ok("abc".to_string());
 /// debug_assert_matches!(c, Ok(x) | Err(x) if x.len() < 100);
 /// ```
-#[unstable(feature = "assert_matches", issue = "82775")]
+#[stable(feature = "assert_matches", since= "CURRENT_RUSTC_VERSION")]
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro debug_assert_matches($($arg:tt)*) {
@@ -413,6 +409,8 @@ pub macro debug_assert_matches($($arg:tt)*) {
 ///
 /// Like in a `match` expression, the pattern can be optionally followed by `if`
 /// and a guard expression that has access to names bound by the pattern.
+///
+/// Use [`assert_matches`] to assert if an expression matches the given patterns. 
 ///
 /// # Examples
 ///

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -396,7 +396,7 @@ macro_rules! debug_assert_ne {
 /// let c = Ok("abc".to_string());
 /// debug_assert_matches!(c, Ok(x) | Err(x) if x.len() < 100);
 /// ```
-#[stable(feature = "assert_matches", since= "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "assert_matches", since = "CURRENT_RUSTC_VERSION")]
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro debug_assert_matches($($arg:tt)*) {
@@ -410,7 +410,7 @@ pub macro debug_assert_matches($($arg:tt)*) {
 /// Like in a `match` expression, the pattern can be optionally followed by `if`
 /// and a guard expression that has access to names bound by the pattern.
 ///
-/// Use [`assert_matches`] to assert if an expression matches the given patterns. 
+/// Use [`assert_matches`] to assert if an expression matches the given patterns.
 ///
 /// # Examples
 ///

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -365,7 +365,6 @@
 //
 // Only for re-exporting:
 // tidy-alphabetical-start
-#![feature(assert_matches)]
 #![feature(async_iterator)]
 #![feature(c_variadic)]
 #![feature(cfg_accessible)]

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -4,7 +4,6 @@
 )]
 #![feature(rustc_private)]
 #![feature(array_methods)]
-#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(lint_reasons)]
 #![feature(never_type)]
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![recursion_limit = "512"]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::must_use_candidate)]

--- a/tests/ui-fulldeps/stable-mir/check_abi.rs
+++ b/tests/ui-fulldeps/stable-mir/check_abi.rs
@@ -7,7 +7,6 @@
 // ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 #![feature(ascii_char, ascii_char_variants)]
 

--- a/tests/ui-fulldeps/stable-mir/check_allocation.rs
+++ b/tests/ui-fulldeps/stable-mir/check_allocation.rs
@@ -9,7 +9,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 #![feature(ascii_char, ascii_char_variants)]
 

--- a/tests/ui-fulldeps/stable-mir/check_defs.rs
+++ b/tests/ui-fulldeps/stable-mir/check_defs.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui-fulldeps/stable-mir/check_instance.rs
+++ b/tests/ui-fulldeps/stable-mir/check_instance.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui-fulldeps/stable-mir/check_item_kind.rs
+++ b/tests/ui-fulldeps/stable-mir/check_item_kind.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui-fulldeps/stable-mir/check_trait_queries.rs
+++ b/tests/ui-fulldeps/stable-mir/check_trait_queries.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
+++ b/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
@@ -9,7 +9,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui-fulldeps/stable-mir/compilation-result.rs
+++ b/tests/ui-fulldeps/stable-mir/compilation-result.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 
 #[macro_use]
 extern crate rustc_smir;

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 extern crate rustc_hir;

--- a/tests/ui-fulldeps/stable-mir/projections.rs
+++ b/tests/ui-fulldeps/stable-mir/projections.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 extern crate rustc_hir;

--- a/tests/ui-fulldeps/stable-mir/smir_internal.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_internal.rs
@@ -9,7 +9,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui-fulldeps/stable-mir/smir_visitor.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_visitor.rs
@@ -8,7 +8,6 @@
 // edition: 2021
 
 #![feature(rustc_private)]
-#![feature(assert_matches)]
 #![feature(control_flow_enum)]
 
 #[macro_use]

--- a/tests/ui/coroutine/uninhabited-field.rs
+++ b/tests/ui/coroutine/uninhabited-field.rs
@@ -1,7 +1,6 @@
 // Test that uninhabited saved local doesn't make the entire variant uninhabited.
 // run-pass
 #![allow(unused)]
-#![feature(assert_matches)]
 #![feature(coroutine_trait)]
 #![feature(coroutines)]
 #![feature(never_type)]

--- a/tests/ui/macros/assert-matches-macro-msg.rs
+++ b/tests/ui/macros/assert-matches-macro-msg.rs
@@ -4,8 +4,6 @@
 // error-pattern: right: 3
 // ignore-emscripten no processes
 
-#![feature(assert_matches)]
-
 use std::assert_matches::assert_matches;
 
 fn main() {

--- a/tests/ui/stdlib-unit-tests/matches2021.rs
+++ b/tests/ui/stdlib-unit-tests/matches2021.rs
@@ -3,8 +3,6 @@
 
 // regression test for https://github.com/rust-lang/rust/pull/85678
 
-#![feature(assert_matches)]
-
 use std::assert_matches::assert_matches;
 
 fn main() {


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/82775

Currently there is some discussion around https://github.com/rust-lang/rust/issues/82913. So I assume this would either be blocked on that if needed. 