### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -796,9 +796,15 @@ impl SyntaxExtension {
     /// | external      | no  | if-ext        | if-ext   | yes |
     /// | yes           | yes | yes           | yes      | yes |
     fn get_collapse_debuginfo(sess: &Session, attrs: &[ast::Attribute], is_local: bool) -> bool {
-        let collapse_debuginfo_attr = attr::find_by_name(attrs, sym::collapse_debuginfo)
+        let mut collapse_debuginfo_attr = attr::find_by_name(attrs, sym::collapse_debuginfo)
             .map(|v| Self::collapse_debuginfo_by_name(sess, v))
             .unwrap_or(CollapseMacroDebuginfo::Unspecified);
+        if collapse_debuginfo_attr == CollapseMacroDebuginfo::Unspecified
+            && attr::contains_name(attrs, sym::rustc_builtin_macro)
+        {
+            collapse_debuginfo_attr = CollapseMacroDebuginfo::Yes;
+        }
+
         let flag = sess.opts.unstable_opts.collapse_macro_debuginfo;
         let attr = collapse_debuginfo_attr;
         let ext = !is_local;

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -20,8 +20,9 @@
 //! [`rustc_parse::lexer`]: ../rustc_parse/lexer/index.html
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
-// We want to be able to build this crate with a stable compiler, so no
-// `#![feature]` attributes should be added.
+// We want to be able to build this crate with a stable compiler,
+// so no `#![feature]` attributes should be added.
+#![deny(unstable_features)]
 
 mod cursor;
 pub mod unescape;

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -148,7 +148,7 @@ lint_builtin_unsafe_impl = implementation of an `unsafe` trait
 
 lint_builtin_unsafe_trait = declaration of an `unsafe` trait
 
-lint_builtin_unstable_features = unstable feature
+lint_builtin_unstable_features = use of an unstable feature
 
 lint_builtin_unused_doc_comment = unused doc comment
     .label = rustdoc does not generate documentation for {$kind}

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1233,10 +1233,30 @@ impl<'tcx> LateLintPass<'tcx> for MutableTransmutes {
 }
 
 declare_lint! {
-    /// The `unstable_features` is deprecated and should no longer be used.
+    /// The `unstable_features` lint detects uses of `#![feature]`.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(unstable_features)]
+    /// #![feature(test)]
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// In larger nightly-based projects which
+    ///
+    /// * consist of a multitude of crates where a subset of crates has to compile on
+    ///   stable either unconditionally or depending on a `cfg` flag to for example
+    ///   allow stable users to depend on them,
+    /// * don't use nightly for experimental features but for, e.g., unstable options only,
+    ///
+    /// this lint may come in handy to enforce policies of these kinds.
     UNSTABLE_FEATURES,
     Allow,
-    "enabling unstable features (deprecated. do not use)"
+    "enabling unstable features"
 }
 
 declare_lint_pass!(
@@ -1246,11 +1266,11 @@ declare_lint_pass!(
 
 impl<'tcx> LateLintPass<'tcx> for UnstableFeatures {
     fn check_attribute(&mut self, cx: &LateContext<'_>, attr: &ast::Attribute) {
-        if attr.has_name(sym::feature) {
-            if let Some(items) = attr.meta_item_list() {
-                for item in items {
-                    cx.emit_spanned_lint(UNSTABLE_FEATURES, item.span(), BuiltinUnstableFeatures);
-                }
+        if attr.has_name(sym::feature)
+            && let Some(items) = attr.meta_item_list()
+        {
+            for item in items {
+                cx.emit_spanned_lint(UNSTABLE_FEATURES, item.span(), BuiltinUnstableFeatures);
             }
         }
     }

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -11,8 +11,9 @@
 )]
 #![deny(rustc::untranslatable_diagnostic)]
 #![deny(rustc::diagnostic_outside_of_impl)]
-// WARNING: We want to be able to build this crate with a stable compiler,
-//          so no `#![feature]` attributes should be added!
+// We want to be able to build this crate with a stable compiler,
+// so no `#![feature]` attributes should be added.
+#![deny(unstable_features)]
 
 use rustc_lexer::unescape;
 pub use Alignment::*;

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1924,7 +1924,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
 
             // Free the allocation without dropping its contents
             let (bptr, alloc) = Box::into_raw_with_allocator(src);
-            let src = Box::from_raw(bptr as *mut mem::ManuallyDrop<T>);
+            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, alloc.by_ref());
             drop(src);
 
             Self::from_ptr_in(ptr, alloc)

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1869,7 +1869,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
 
             // Free the allocation without dropping its contents
             let (bptr, alloc) = Box::into_raw_with_allocator(src);
-            let src = Box::from_raw(bptr as *mut mem::ManuallyDrop<T>);
+            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, alloc.by_ref());
             drop(src);
 
             Self::from_ptr_in(ptr, alloc)

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -166,7 +166,10 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// ```
 /// use std::cell::Cell;
 /// thread_local! {
-///     pub static FOO: Cell<u32> = const { Cell::new(1) };
+///     pub static FOO: Cell<u32> = const {
+///         let value = 1;
+///         Cell::new(value)
+///     };
 /// }
 ///
 /// assert_eq!(FOO.get(), 1);
@@ -186,12 +189,12 @@ macro_rules! thread_local {
     // empty (base case for the recursion)
     () => {};
 
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }; $($rest:tt)*) => (
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const $init:block; $($rest:tt)*) => (
         $crate::thread::local_impl::thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
         $crate::thread_local!($($rest)*);
     );
 
-    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const { $init:expr }) => (
+    ($(#[$attr:meta])* $vis:vis static $name:ident: $t:ty = const $init:block) => (
         $crate::thread::local_impl::thread_local_inner!($(#[$attr])* $vis $name, $t, const $init);
     );
 

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -166,10 +166,7 @@ impl<T: 'static> fmt::Debug for LocalKey<T> {
 /// ```
 /// use std::cell::Cell;
 /// thread_local! {
-///     pub static FOO: Cell<u32> = const {
-///         let value = 1;
-///         Cell::new(value)
-///     };
+///     pub static FOO: Cell<u32> = const { Cell::new(1) };
 /// }
 ///
 /// assert_eq!(FOO.get(), 1);

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -1,3 +1,4 @@
+use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -13,4 +14,25 @@ fn sleep() {
     });
     thread::sleep(Duration::from_millis(100));
     assert_eq!(*finished.lock().unwrap(), false);
+}
+
+#[test]
+fn thread_local_containing_const_statements() {
+    // This exercises the `const $init:block` cases of the thread_local macro.
+    // Despite overlapping with expression syntax, the `const { ... }` is not
+    // parsed as `$init:expr`.
+    thread_local! {
+        static CELL: Cell<u32> = const {
+            let value = 1;
+            Cell::new(value)
+        };
+
+        static REFCELL: RefCell<u32> = const {
+            let value = 1;
+            RefCell::new(value)
+        };
+    }
+
+    assert_eq!(CELL.get(), 1);
+    assert_eq!(REFCELL.take(), 1);
 }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1678,13 +1678,6 @@ impl Step for Assemble {
         // when not performing a full bootstrap).
         builder.ensure(Rustc::new(build_compiler, target_compiler.host));
 
-        // FIXME: For now patch over problems noted in #90244 by early returning here, even though
-        // we've not properly assembled the target sysroot. A full fix is pending further investigation,
-        // for now full bootstrap usage is rare enough that this is OK.
-        if target_compiler.stage >= 3 && !builder.config.full_bootstrap {
-            return target_compiler;
-        }
-
         for &backend in builder.config.rust_codegen_backends.iter() {
             if backend == "llvm" {
                 continue; // Already built as part of rustc

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -803,7 +803,14 @@ impl Rustc {
 }
 
 impl Step for Rustc {
-    type Output = ();
+    // We return the stage of the "actual" compiler (not the uplifted one).
+    //
+    // By "actual" we refer to the uplifting logic where we may not compile the requested stage;
+    // instead, we uplift it from the previous stages. Which can lead to bootstrap failures in
+    // specific situations where we request stage X from other steps. However we may end up
+    // uplifting it from stage Y, causing the other stage to fail when attempting to link with
+    // stage X which was never actually built.
+    type Output = u32;
     const ONLY_HOSTS: bool = true;
     const DEFAULT: bool = false;
 
@@ -834,7 +841,7 @@ impl Step for Rustc {
     /// This will build the compiler for a particular stage of the build using
     /// the `compiler` targeting the `target` architecture. The artifacts
     /// created will also be linked into the sysroot directory.
-    fn run(self, builder: &Builder<'_>) {
+    fn run(self, builder: &Builder<'_>) -> u32 {
         let compiler = self.compiler;
         let target = self.target;
 
@@ -848,7 +855,7 @@ impl Step for Rustc {
                 compiler,
                 builder.config.ci_rustc_dev_contents(),
             );
-            return;
+            return compiler.stage;
         }
 
         builder.ensure(Std::new(compiler, target));
@@ -857,7 +864,8 @@ impl Step for Rustc {
             builder.info("WARNING: Using a potentially old librustc. This may not behave well.");
             builder.info("WARNING: Use `--keep-stage-std` if you want to rebuild the compiler when it changes");
             builder.ensure(RustcLink::from_rustc(self, compiler));
-            return;
+
+            return compiler.stage;
         }
 
         let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);
@@ -880,7 +888,7 @@ impl Step for Rustc {
             };
             builder.info(&msg);
             builder.ensure(RustcLink::from_rustc(self, compiler_to_use));
-            return;
+            return compiler_to_use.stage;
         }
 
         // Ensure that build scripts and proc macros have a std / libproc_macro to link against.
@@ -984,6 +992,8 @@ impl Step for Rustc {
             self,
             builder.compiler(compiler.stage, builder.config.build),
         ));
+
+        compiler.stage
     }
 }
 
@@ -1642,21 +1652,6 @@ impl Step for Assemble {
             return target_compiler;
         }
 
-        // Get the compiler that we'll use to bootstrap ourselves.
-        //
-        // Note that this is where the recursive nature of the bootstrap
-        // happens, as this will request the previous stage's compiler on
-        // downwards to stage 0.
-        //
-        // Also note that we're building a compiler for the host platform. We
-        // only assume that we can run `build` artifacts, which means that to
-        // produce some other architecture compiler we need to start from
-        // `build` to get there.
-        //
-        // FIXME: It may be faster if we build just a stage 1 compiler and then
-        //        use that to bootstrap this compiler forward.
-        let build_compiler = builder.compiler(target_compiler.stage - 1, builder.config.build);
-
         // If we're downloading a compiler from CI, we can use the same compiler for all stages other than 0.
         if builder.download_rustc() {
             let sysroot =
@@ -1671,12 +1666,30 @@ impl Step for Assemble {
             return target_compiler;
         }
 
+        // Get the compiler that we'll use to bootstrap ourselves.
+        //
+        // Note that this is where the recursive nature of the bootstrap
+        // happens, as this will request the previous stage's compiler on
+        // downwards to stage 0.
+        //
+        // Also note that we're building a compiler for the host platform. We
+        // only assume that we can run `build` artifacts, which means that to
+        // produce some other architecture compiler we need to start from
+        // `build` to get there.
+        //
+        // FIXME: It may be faster if we build just a stage 1 compiler and then
+        //        use that to bootstrap this compiler forward.
+        let mut build_compiler = builder.compiler(target_compiler.stage - 1, builder.config.build);
+
         // Build the libraries for this compiler to link to (i.e., the libraries
         // it uses at runtime). NOTE: Crates the target compiler compiles don't
         // link to these. (FIXME: Is that correct? It seems to be correct most
         // of the time but I think we do link to these for stage2/bin compilers
         // when not performing a full bootstrap).
-        builder.ensure(Rustc::new(build_compiler, target_compiler.host));
+        let actual_stage = builder.ensure(Rustc::new(build_compiler, target_compiler.host));
+        // Current build_compiler.stage might be uplifted instead of being built; so update it
+        // to not fail while linking the artifacts.
+        build_compiler.stage = actual_stage;
 
         for &backend in builder.config.rust_codegen_backends.iter() {
             if backend == "llvm" {

--- a/src/tools/rustfmt/src/parse/macros/mod.rs
+++ b/src/tools/rustfmt/src/parse/macros/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod cfg_if;
 pub(crate) mod lazy_static;
 
 fn build_stream_parser<'a>(sess: &'a ParseSess, tokens: TokenStream) -> Parser<'a> {
-    stream_to_parser(sess, tokens, MACRO_ARGUMENTS)
+    stream_to_parser(sess, tokens, MACRO_ARGUMENTS).recovery(Recovery::Forbidden)
 }
 
 fn build_parser<'a>(context: &RewriteContext<'a>, tokens: TokenStream) -> Parser<'a> {

--- a/src/tools/rustfmt/tests/source/macros/rewrite-const-item.rs
+++ b/src/tools/rustfmt/tests/source/macros/rewrite-const-item.rs
@@ -1,0 +1,1 @@
+m!(const N: usize = 0;);

--- a/src/tools/rustfmt/tests/target/macros/rewrite-const-item.rs
+++ b/src/tools/rustfmt/tests/target/macros/rewrite-const-item.rs
@@ -1,0 +1,3 @@
+m!(
+    const N: usize = 0;
+);

--- a/tests/debuginfo/collapse-debuginfo-builtin.rs
+++ b/tests/debuginfo/collapse-debuginfo-builtin.rs
@@ -1,0 +1,32 @@
+// ignore-lldb
+#![feature(collapse_debuginfo)]
+
+use std::fmt;
+
+// Test that builtin macro debug info is collapsed.
+// Debug info for format_args must be #format_arg_external, not #format_arg_internal.
+// Because format_args is a builtin macro.
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:next 2
+// gdb-command:frame
+// gdb-check:[...]#format_arg_external[...]
+// gdb-command:continue
+
+fn main() {
+    let ret = 0; // #break
+    let w = "world".to_string();
+    let s = fmt::format(
+        format_args!( // #format_arg_external
+            "hello {}", w // #format_arg_internal
+        )
+    ); // #format_callsite
+    println!(
+        "{}",
+        s
+    ); // #println_callsite
+    std::process::exit(ret);
+}

--- a/tests/ui/const-generics/bad-subst-const-kind.rs
+++ b/tests/ui/const-generics/bad-subst-const-kind.rs
@@ -11,3 +11,4 @@ impl<const N: u64> Q for [u8; N] {
 }
 
 pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] { todo!() }
+//~^ ERROR: the constant `13` is not of type `u64`

--- a/tests/ui/const-generics/bad-subst-const-kind.stderr
+++ b/tests/ui/const-generics/bad-subst-const-kind.stderr
@@ -1,9 +1,23 @@
+error: the constant `13` is not of type `u64`
+  --> $DIR/bad-subst-const-kind.rs:13:24
+   |
+LL | pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] { todo!() }
+   |                        ^^^^^^^^ expected `u64`, found `usize`
+   |
+note: required for `[u8; 13]` to implement `Q`
+  --> $DIR/bad-subst-const-kind.rs:8:20
+   |
+LL | impl<const N: u64> Q for [u8; N] {
+   |      ------------  ^     ^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
+
 error[E0308]: mismatched types
   --> $DIR/bad-subst-const-kind.rs:8:31
    |
 LL | impl<const N: u64> Q for [u8; N] {
    |                               ^ expected `usize`, found `u64`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
@@ -7,7 +7,10 @@ trait Q {
 
 impl<const N: u64> Q for [u8; N] {}
 //~^ ERROR not all trait items implemented
+//~| ERROR mismatched types
 
 pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+//~^ ERROR the constant `13` is not of type `u64`
+//~| ERROR mismatched types
 
 pub fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -7,6 +7,35 @@ LL |     const ASSOC: usize;
 LL | impl<const N: u64> Q for [u8; N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
 
-error: aborting due to 1 previous error
+error: the constant `13` is not of type `u64`
+  --> $DIR/type_mismatch.rs:12:26
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |                          ^^^^^^^^ expected `u64`, found `usize`
+   |
+note: required for `[u8; 13]` to implement `Q`
+  --> $DIR/type_mismatch.rs:8:20
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |      ------------  ^     ^^^^^^^
+   |      |
+   |      unsatisfied trait bound introduced here
 
-For more information about this error, try `rustc --explain E0046`.
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:12:20
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |        ------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; <[u8; 13] as Q>::ASSOC]`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:8:31
+   |
+LL | impl<const N: u64> Q for [u8; N] {}
+   |                               ^ expected `usize`, found `u64`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0046, E0308.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/feature-gates/feature-gate-feature-gate.stderr
+++ b/tests/ui/feature-gates/feature-gate-feature-gate.stderr
@@ -1,4 +1,4 @@
-error: unstable feature
+error: use of an unstable feature
   --> $DIR/feature-gate-feature-gate.rs:2:12
    |
 LL | #![feature(intrinsics)]

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -162,12 +162,14 @@ fn main() {
 }
 
 fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
+//~^ ERROR unreachable
 
 fn unreachable_in_binding() {
     let bool_pair = (true, true);
     let bool_option = Some(true);
 
     let (_ | (_, _)) = bool_pair;
+    //~^ ERROR unreachable
     for (_ | (_, _)) in [bool_pair] {}
     //~^ ERROR unreachable
 

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -160,3 +160,21 @@ fn main() {
             | (y, x) => {} //~ ERROR unreachable
     }
 }
+
+fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
+
+fn unreachable_in_binding() {
+    let bool_pair = (true, true);
+    let bool_option = Some(true);
+
+    let (_ | (_, _)) = bool_pair;
+    for (_ | (_, _)) in [bool_pair] {}
+    //~^ ERROR unreachable
+
+    let (Some(_) | Some(true)) = bool_option else { return };
+    //~^ ERROR unreachable
+    if let Some(_) | Some(true) = bool_option {}
+    //~^ ERROR unreachable
+    while let Some(_) | Some(true) = bool_option {}
+    //~^ ERROR unreachable
+}

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -184,5 +184,29 @@ error: unreachable pattern
 LL |             | (y, x) => {}
    |               ^^^^^^
 
-error: aborting due to 29 previous errors
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:171:14
+   |
+LL |     for (_ | (_, _)) in [bool_pair] {}
+   |              ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:174:20
+   |
+LL |     let (Some(_) | Some(true)) = bool_option else { return };
+   |                    ^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:22
+   |
+LL |     if let Some(_) | Some(true) = bool_option {}
+   |                      ^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:25
+   |
+LL |     while let Some(_) | Some(true) = bool_option {}
+   |                         ^^^^^^^^^^
+
+error: aborting due to 33 previous errors
 

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -185,28 +185,40 @@ LL |             | (y, x) => {}
    |               ^^^^^^
 
 error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:164:30
+   |
+LL | fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
+   |                              ^^^^^^
+
+error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:171:14
+   |
+LL |     let (_ | (_, _)) = bool_pair;
+   |              ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:173:14
    |
 LL |     for (_ | (_, _)) in [bool_pair] {}
    |              ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:174:20
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:20
    |
 LL |     let (Some(_) | Some(true)) = bool_option else { return };
    |                    ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:176:22
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:22
    |
 LL |     if let Some(_) | Some(true) = bool_option {}
    |                      ^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:178:25
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:180:25
    |
 LL |     while let Some(_) | Some(true) = bool_option {}
    |                         ^^^^^^^^^^
 
-error: aborting due to 33 previous errors
+error: aborting due to 35 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
@@ -11,22 +11,34 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:21:12
+  --> $DIR/unreachable.rs:20:19
+   |
+LL |     let (Ok(_x) | Err(!)) = res_void;
+   |                   ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:22:12
    |
 LL |     if let Err(!) = res_void {}
    |            ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:23:24
+  --> $DIR/unreachable.rs:24:24
    |
 LL |     if let (Ok(true) | Err(!)) = res_void {}
    |                        ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:25:23
+  --> $DIR/unreachable.rs:26:23
    |
 LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    |                       ^^^^^^
 
-error: aborting due to 4 previous errors
+error: unreachable pattern
+  --> $DIR/unreachable.rs:30:18
+   |
+LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
+   |                  ^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.exh_pats.stderr
@@ -1,0 +1,32 @@
+error: unreachable pattern
+  --> $DIR/unreachable.rs:17:9
+   |
+LL |         Err(!),
+   |         ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unreachable.rs:7:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:21:12
+   |
+LL |     if let Err(!) = res_void {}
+   |            ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:23:24
+   |
+LL |     if let (Ok(true) | Err(!)) = res_void {}
+   |                        ^^^^^^
+
+error: unreachable pattern
+  --> $DIR/unreachable.rs:25:23
+   |
+LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
+   |                       ^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
@@ -1,0 +1,29 @@
+// revisions: normal exh_pats
+//[normal] check-pass
+#![feature(never_patterns)]
+#![allow(incomplete_features)]
+#![cfg_attr(exh_pats, feature(exhaustive_patterns))]
+#![allow(dead_code, unreachable_code)]
+#![deny(unreachable_patterns)]
+
+#[derive(Copy, Clone)]
+enum Void {}
+
+fn main() {
+    let res_void: Result<bool, Void> = Ok(true);
+
+    match res_void {
+        Ok(_x) => {}
+        Err(!),
+        //[exh_pats]~^ ERROR unreachable
+    }
+    let (Ok(_x) | Err(!)) = res_void;
+    if let Err(!) = res_void {}
+    //[exh_pats]~^ ERROR unreachable
+    if let (Ok(true) | Err(!)) = res_void {}
+    //[exh_pats]~^ ERROR unreachable
+    for (Ok(mut _x) | Err(!)) in [res_void] {}
+    //[exh_pats]~^ ERROR unreachable
+}
+
+fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
@@ -18,6 +18,7 @@ fn main() {
         //[exh_pats]~^ ERROR unreachable
     }
     let (Ok(_x) | Err(!)) = res_void;
+    //[exh_pats]~^ ERROR unreachable
     if let Err(!) = res_void {}
     //[exh_pats]~^ ERROR unreachable
     if let (Ok(true) | Err(!)) = res_void {}
@@ -27,3 +28,4 @@ fn main() {
 }
 
 fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
+//[exh_pats]~^ ERROR unreachable

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
@@ -8,5 +8,6 @@ struct S<const L: usize>;
 impl<const N: i32> Copy for S<N> {}
 //~^ ERROR the constant `N` is not of type `usize`
 impl<const M: usize> Copy for S<M> {}
+//~^ ERROR: conflicting implementations of trait `Copy` for type `S<_>`
 
 fn main() {}

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
@@ -1,14 +1,29 @@
+error[E0119]: conflicting implementations of trait `Copy` for type `S<_>`
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:10:1
+   |
+LL | impl<const N: i32> Copy for S<N> {}
+   | -------------------------------- first implementation here
+LL |
+LL | impl<const M: usize> Copy for S<M> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S<_>`
+
 error: the constant `N` is not of type `usize`
   --> $DIR/bad-const-wf-doesnt-specialize.rs:8:29
    |
 LL | impl<const N: i32> Copy for S<N> {}
    |                             ^^^^ expected `usize`, found `i32`
    |
-note: required by a bound in `S`
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:6:10
+note: required for `S<N>` to implement `Clone`
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:5:10
    |
+LL | #[derive(Clone)]
+   |          ^^^^^
 LL | struct S<const L: usize>;
-   |          ^^^^^^^^^^^^^^ required by this bound in `S`
+   |          ----- unsatisfied trait bound introduced in this `derive` macro
+note: required by a bound in `Copy`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021-without-dyn.rs
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021-without-dyn.rs
@@ -8,16 +8,18 @@ trait A: Sized {
     //~| ERROR the trait `A` cannot be made into an object
 }
 trait B {
-    fn f(a: B) -> B;
+    fn f(b: B) -> B;
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
     //~| ERROR associated item referring to unboxed trait object for its own trait
     //~| ERROR the trait `B` cannot be made into an object
 }
 trait C {
-    fn f(&self, a: C) -> C;
+    fn f(&self, c: C) -> C;
     //~^ ERROR trait objects must include the `dyn` keyword
     //~| ERROR trait objects must include the `dyn` keyword
+    //~| ERROR associated item referring to unboxed trait object for its own trait
+    //~| ERROR the trait `C` cannot be made into an object
 }
 
 fn main() {}

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021-without-dyn.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021-without-dyn.stderr
@@ -30,18 +30,18 @@ error: associated item referring to unboxed trait object for its own trait
    |
 LL | trait B {
    |       - in this trait
-LL |     fn f(a: B) -> B;
+LL |     fn f(b: B) -> B;
    |             ^     ^
    |
 help: you might have meant to use `Self` to refer to the implementing type
    |
-LL |     fn f(a: Self) -> Self;
+LL |     fn f(b: Self) -> Self;
    |             ~~~~     ~~~~
 
 error[E0038]: the trait `B` cannot be made into an object
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:11:13
    |
-LL |     fn f(a: B) -> B;
+LL |     fn f(b: B) -> B;
    |             ^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
@@ -49,16 +49,45 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
    |
 LL | trait B {
    |       - this trait cannot be made into an object...
-LL |     fn f(a: B) -> B;
+LL |     fn f(b: B) -> B;
    |        ^ ...because associated function `f` has no `self` parameter
 help: consider turning `f` into a method by giving it a `&self` argument
    |
-LL |     fn f(&self, a: B) -> B;
+LL |     fn f(&self, b: B) -> B;
    |          ++++++
 help: alternatively, consider constraining `f` so it does not apply to trait objects
    |
-LL |     fn f(a: B) -> B where Self: Sized;
+LL |     fn f(b: B) -> B where Self: Sized;
    |                     +++++++++++++++++
+
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:18:20
+   |
+LL | trait C {
+   |       - in this trait
+LL |     fn f(&self, c: C) -> C;
+   |                    ^     ^
+   |
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL |     fn f(&self, c: Self) -> Self;
+   |                    ~~~~     ~~~~
+
+error[E0038]: the trait `C` cannot be made into an object
+  --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:18:20
+   |
+LL |     fn f(&self, c: C) -> C;
+   |          -----     ^ `C` cannot be made into an object
+   |          |
+   |          help: consider changing method `f`'s `self` parameter to be `&self` (notice the capitalization): `&Self`
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:18:10
+   |
+LL | trait C {
+   |       - this trait cannot be made into an object...
+LL |     fn f(&self, c: C) -> C;
+   |          ^^^^^ ...because method `f`'s `self` parameter cannot be dispatched on
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:4:13
@@ -66,6 +95,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(a: A) -> A;
    |             ^
    |
+   = note: `A` it is not object safe, so it can't be `dyn`
 help: use a new generic type parameter, constrained by `A`
    |
 LL |     fn f<T: A>(a: T) -> A;
@@ -74,10 +104,6 @@ help: you can also use an opaque type, but users won't be able to specify the ty
    |
 LL |     fn f(a: impl A) -> A;
    |             ++++
-help: alternatively, use a trait object to accept any type that implements `A`, accessing its methods at runtime using dynamic dispatch
-   |
-LL |     fn f(a: &dyn A) -> A;
-   |             ++++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:4:19
@@ -85,84 +111,66 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(a: A) -> A;
    |                   ^
    |
-help: use `impl A` to return an opaque type, as long as you return a single underlying type
+help: `A` is not object safe, use `impl A` to return an opaque type, as long as you return a single underlying type
    |
 LL |     fn f(a: A) -> impl A;
    |                   ++++
-help: alternatively, you can return an owned trait object
-   |
-LL |     fn f(a: A) -> Box<dyn A>;
-   |                   +++++++  +
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:11:13
    |
-LL |     fn f(a: B) -> B;
+LL |     fn f(b: B) -> B;
    |             ^
    |
+   = note: `B` it is not object safe, so it can't be `dyn`
 help: use a new generic type parameter, constrained by `B`
    |
-LL |     fn f<T: B>(a: T) -> B;
+LL |     fn f<T: B>(b: T) -> B;
    |         ++++++    ~
 help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
    |
-LL |     fn f(a: impl B) -> B;
-   |             ++++
-help: alternatively, use a trait object to accept any type that implements `B`, accessing its methods at runtime using dynamic dispatch
-   |
-LL |     fn f(a: &dyn B) -> B;
+LL |     fn f(b: impl B) -> B;
    |             ++++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:11:19
    |
-LL |     fn f(a: B) -> B;
+LL |     fn f(b: B) -> B;
    |                   ^
    |
-help: use `impl B` to return an opaque type, as long as you return a single underlying type
+help: `B` is not object safe, use `impl B` to return an opaque type, as long as you return a single underlying type
    |
-LL |     fn f(a: B) -> impl B;
+LL |     fn f(b: B) -> impl B;
    |                   ++++
-help: alternatively, you can return an owned trait object
-   |
-LL |     fn f(a: B) -> Box<dyn B>;
-   |                   +++++++  +
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:18:20
    |
-LL |     fn f(&self, a: C) -> C;
+LL |     fn f(&self, c: C) -> C;
    |                    ^
    |
+   = note: `C` it is not object safe, so it can't be `dyn`
 help: use a new generic type parameter, constrained by `C`
    |
-LL |     fn f<T: C>(&self, a: T) -> C;
+LL |     fn f<T: C>(&self, c: T) -> C;
    |         ++++++           ~
 help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
    |
-LL |     fn f(&self, a: impl C) -> C;
-   |                    ++++
-help: alternatively, use a trait object to accept any type that implements `C`, accessing its methods at runtime using dynamic dispatch
-   |
-LL |     fn f(&self, a: &dyn C) -> C;
+LL |     fn f(&self, c: impl C) -> C;
    |                    ++++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:18:26
    |
-LL |     fn f(&self, a: C) -> C;
+LL |     fn f(&self, c: C) -> C;
    |                          ^
    |
-help: use `impl C` to return an opaque type, as long as you return a single underlying type
+help: `C` is not object safe, use `impl C` to return an opaque type, as long as you return a single underlying type
    |
-LL |     fn f(&self, a: C) -> impl C;
+LL |     fn f(&self, c: C) -> impl C;
    |                          ++++
-help: alternatively, you can return an owned trait object
-   |
-LL |     fn f(&self, a: C) -> Box<dyn C>;
-   |                          +++++++  +
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0038, E0782.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/unsafe/union_destructure.rs
+++ b/tests/ui/unsafe/union_destructure.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(unreachable_patterns)]
 
 #[derive(Copy, Clone)]
 #[allow(dead_code)]


### PR DESCRIPTION
Successful merges:

 - #117910 (Refactor uses of `objc_msgSend` to no longer have clashing definitions)
 - #118639 (Undeprecate lint `unstable_features` and make use of it in the compiler)
 - #119801 (Fix deallocation with wrong allocator in (A)Rc::from_box_in)
 - #120058 (bootstrap: improvements for compiler builds)
 - #120059 (Make generic const type mismatches not hide trait impls from the trait solver)
 - #120097 (Report unreachable subpatterns consistently)
 - #120137 (Validate AggregateKind types in MIR)
 - #120164 (`maybe_lint_impl_trait`: separate `is_downgradable` from `is_object_safe`)
 - #120181 (Allow any `const` expression blocks in `thread_local!`)
 - #120204 (Builtin macros effectively have implicit #[collapse_debuginfo(yes)])
 - #120218 (rustfmt: Check that a token can begin a nonterminal kind before parsing it as a macro arg)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=117910,118639,119801,120058,120059,120097,120137,120164,120181,120204,120218)
<!-- homu-ignore:end -->