### PR TITLE
Use `Self` in `NonZero*` implementations.

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -317,7 +317,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn checked_mul(self, other: $Ty) -> Option<$Ty> {
+            pub const fn checked_mul(self, other: Self) -> Option<Self> {
                 if let Some(result) = self.get().checked_mul(other.get()) {
                     // SAFETY:
                     // - `checked_mul` returns `None` on overflow
@@ -326,7 +326,7 @@ macro_rules! nonzero_integer {
                     //   of the sides to be zero
                     //
                     // So the result cannot be zero.
-                    Some(unsafe { $Ty::new_unchecked(result) })
+                    Some(unsafe { Self::new_unchecked(result) })
                 } else {
                     None
                 }
@@ -356,7 +356,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn saturating_mul(self, other: $Ty) -> $Ty {
+            pub const fn saturating_mul(self, other: Self) -> Self {
                 // SAFETY:
                 // - `saturating_mul` returns `u*::MAX`/`i*::MAX`/`i*::MIN` on overflow/underflow,
                 //   all of which are non-zero
@@ -365,7 +365,7 @@ macro_rules! nonzero_integer {
                 //   of the sides to be zero
                 //
                 // So the result cannot be zero.
-                unsafe { $Ty::new_unchecked(self.get().saturating_mul(other.get())) }
+                unsafe { Self::new_unchecked(self.get().saturating_mul(other.get())) }
             }
 
             /// Multiplies two non-zero integers together,
@@ -403,9 +403,9 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const unsafe fn unchecked_mul(self, other: $Ty) -> $Ty {
+            pub const unsafe fn unchecked_mul(self, other: Self) -> Self {
                 // SAFETY: The caller ensures there is no overflow.
-                unsafe { $Ty::new_unchecked(self.get().unchecked_mul(other.get())) }
+                unsafe { Self::new_unchecked(self.get().unchecked_mul(other.get())) }
             }
 
             /// Raises non-zero value to an integer power.
@@ -433,7 +433,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn checked_pow(self, other: u32) -> Option<$Ty> {
+            pub const fn checked_pow(self, other: u32) -> Option<Self> {
                 if let Some(result) = self.get().checked_pow(other) {
                     // SAFETY:
                     // - `checked_pow` returns `None` on overflow/underflow
@@ -442,7 +442,7 @@ macro_rules! nonzero_integer {
                     //   for base to be zero
                     //
                     // So the result cannot be zero.
-                    Some(unsafe { $Ty::new_unchecked(result) })
+                    Some(unsafe { Self::new_unchecked(result) })
                 } else {
                     None
                 }
@@ -481,7 +481,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn saturating_pow(self, other: u32) -> $Ty {
+            pub const fn saturating_pow(self, other: u32) -> Self {
                 // SAFETY:
                 // - `saturating_pow` returns `u*::MAX`/`i*::MAX`/`i*::MIN` on overflow/underflow,
                 //   all of which are non-zero
@@ -490,7 +490,7 @@ macro_rules! nonzero_integer {
                 //   for base to be zero
                 //
                 // So the result cannot be zero.
-                unsafe { $Ty::new_unchecked(self.get().saturating_pow(other)) }
+                unsafe { Self::new_unchecked(self.get().saturating_pow(other)) }
             }
         }
 
@@ -508,29 +508,32 @@ macro_rules! nonzero_integer {
         #[stable(feature = "nonzero_bitor", since = "1.45.0")]
         impl BitOr for $Ty {
             type Output = Self;
+
             #[inline]
             fn bitor(self, rhs: Self) -> Self::Output {
                 // SAFETY: since `self` and `rhs` are both nonzero, the
                 // result of the bitwise-or will be nonzero.
-                unsafe { $Ty::new_unchecked(self.get() | rhs.get()) }
+                unsafe { Self::new_unchecked(self.get() | rhs.get()) }
             }
         }
 
         #[stable(feature = "nonzero_bitor", since = "1.45.0")]
         impl BitOr<$Int> for $Ty {
             type Output = Self;
+
             #[inline]
             fn bitor(self, rhs: $Int) -> Self::Output {
                 // SAFETY: since `self` is nonzero, the result of the
                 // bitwise-or will be nonzero regardless of the value of
                 // `rhs`.
-                unsafe { $Ty::new_unchecked(self.get() | rhs) }
+                unsafe { Self::new_unchecked(self.get() | rhs) }
             }
         }
 
         #[stable(feature = "nonzero_bitor", since = "1.45.0")]
         impl BitOr<$Ty> for $Int {
             type Output = $Ty;
+
             #[inline]
             fn bitor(self, rhs: $Ty) -> Self::Output {
                 // SAFETY: since `rhs` is nonzero, the result of the
@@ -603,6 +606,7 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
         #[stable(feature = "nonzero_div", since = "1.51.0")]
         impl Div<$Ty> for $Int {
             type Output = $Int;
+
             /// This operation rounds towards zero,
             /// truncating any fractional part of the exact result, and cannot panic.
             #[inline]
@@ -616,6 +620,7 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
         #[stable(feature = "nonzero_div", since = "1.51.0")]
         impl Rem<$Ty> for $Int {
             type Output = $Int;
+
             /// This operation satisfies `n % d == n - (n / d) * d`, and cannot panic.
             #[inline]
             fn rem(self, other: $Ty) -> $Int {
@@ -630,12 +635,12 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
     ($Ty:ident signed $Int:ty) => {
         #[stable(feature = "signed_nonzero_neg", since = "1.71.0")]
         impl Neg for $Ty {
-            type Output = $Ty;
+            type Output = Self;
 
             #[inline]
-            fn neg(self) -> $Ty {
+            fn neg(self) -> Self {
                 // SAFETY: negation of nonzero cannot yield zero values.
-                unsafe { $Ty::new_unchecked(self.get().neg()) }
+                unsafe { Self::new_unchecked(self.get().neg()) }
             }
         }
 
@@ -703,7 +708,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_add(self, other: $Int) -> Option<$Ty> {
+        pub const fn checked_add(self, other: $Int) -> Option<Self> {
             if let Some(result) = self.get().checked_add(other) {
                 // SAFETY:
                 // - `checked_add` returns `None` on overflow
@@ -712,7 +717,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
                 //   sides to be zero
                 //
                 // So the result cannot be zero.
-                Some(unsafe { $Ty::new_unchecked(result) })
+                Some(unsafe { Self::new_unchecked(result) })
             } else {
                 None
             }
@@ -742,7 +747,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn saturating_add(self, other: $Int) -> $Ty {
+        pub const fn saturating_add(self, other: $Int) -> Self {
             // SAFETY:
             // - `saturating_add` returns `u*::MAX` on overflow, which is non-zero
             // - `self` is non-zero
@@ -750,7 +755,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
             //   sides to be zero
             //
             // So the result cannot be zero.
-            unsafe { $Ty::new_unchecked(self.get().saturating_add(other)) }
+            unsafe { Self::new_unchecked(self.get().saturating_add(other)) }
         }
 
         /// Adds an unsigned integer to a non-zero value,
@@ -779,9 +784,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const unsafe fn unchecked_add(self, other: $Int) -> $Ty {
+        pub const unsafe fn unchecked_add(self, other: $Int) -> Self {
             // SAFETY: The caller ensures there is no overflow.
-            unsafe { $Ty::new_unchecked(self.get().unchecked_add(other)) }
+            unsafe { Self::new_unchecked(self.get().unchecked_add(other)) }
         }
 
         /// Returns the smallest power of two greater than or equal to n.
@@ -812,11 +817,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_next_power_of_two(self) -> Option<$Ty> {
+        pub const fn checked_next_power_of_two(self) -> Option<Self> {
             if let Some(nz) = self.get().checked_next_power_of_two() {
                 // SAFETY: The next power of two is positive
                 // and overflow is checked.
-                Some(unsafe { $Ty::new_unchecked(nz) })
+                Some(unsafe { Self::new_unchecked(nz) })
             } else {
                 None
             }
@@ -902,9 +907,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         pub const fn midpoint(self, rhs: Self) -> Self {
             // SAFETY: The only way to get `0` with midpoint is to have two opposite or
             // near opposite numbers: (-5, 5), (0, 1), (0, 0) which is impossible because
-            // of the unsignedness of this number and also because $Ty is guaranteed to
+            // of the unsignedness of this number and also because `Self` is guaranteed to
             // never being 0.
-            unsafe { $Ty::new_unchecked(self.get().midpoint(rhs.get())) }
+            unsafe { Self::new_unchecked(self.get().midpoint(rhs.get())) }
         }
 
         /// Returns `true` if and only if `self == (1 << k)` for some `k`.
@@ -1000,9 +1005,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn abs(self) -> $Ty {
+        pub const fn abs(self) -> Self {
             // SAFETY: This cannot overflow to zero.
-            unsafe { $Ty::new_unchecked(self.get().abs()) }
+            unsafe { Self::new_unchecked(self.get().abs()) }
         }
 
         /// Checked absolute value.
@@ -1031,10 +1036,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_abs(self) -> Option<$Ty> {
+        pub const fn checked_abs(self) -> Option<Self> {
             if let Some(nz) = self.get().checked_abs() {
                 // SAFETY: absolute value of nonzero cannot yield zero values.
-                Some(unsafe { $Ty::new_unchecked(nz) })
+                Some(unsafe { Self::new_unchecked(nz) })
             } else {
                 None
             }
@@ -1066,11 +1071,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn overflowing_abs(self) -> ($Ty, bool) {
+        pub const fn overflowing_abs(self) -> (Self, bool) {
             let (nz, flag) = self.get().overflowing_abs();
             (
                 // SAFETY: absolute value of nonzero cannot yield zero values.
-                unsafe { $Ty::new_unchecked(nz) },
+                unsafe { Self::new_unchecked(nz) },
                 flag,
             )
         }
@@ -1105,9 +1110,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn saturating_abs(self) -> $Ty {
+        pub const fn saturating_abs(self) -> Self {
             // SAFETY: absolute value of nonzero cannot yield zero values.
-            unsafe { $Ty::new_unchecked(self.get().saturating_abs()) }
+            unsafe { Self::new_unchecked(self.get().saturating_abs()) }
         }
 
         /// Wrapping absolute value, see
@@ -1138,9 +1143,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn wrapping_abs(self) -> $Ty {
+        pub const fn wrapping_abs(self) -> Self {
             // SAFETY: absolute value of nonzero cannot yield zero values.
-            unsafe { $Ty::new_unchecked(self.get().wrapping_abs()) }
+            unsafe { Self::new_unchecked(self.get().wrapping_abs()) }
         }
 
         /// Computes the absolute value of self
@@ -1250,10 +1255,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn checked_neg(self) -> Option<$Ty> {
+        pub const fn checked_neg(self) -> Option<Self> {
             if let Some(result) = self.get().checked_neg() {
                 // SAFETY: negation of nonzero cannot yield zero values.
-                return Some(unsafe { $Ty::new_unchecked(result) });
+                return Some(unsafe { Self::new_unchecked(result) });
             }
             None
         }
@@ -1282,10 +1287,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn overflowing_neg(self) -> ($Ty, bool) {
+        pub const fn overflowing_neg(self) -> (Self, bool) {
             let (result, overflow) = self.get().overflowing_neg();
             // SAFETY: negation of nonzero cannot yield zero values.
-            ((unsafe { $Ty::new_unchecked(result) }), overflow)
+            ((unsafe { Self::new_unchecked(result) }), overflow)
         }
 
         /// Saturating negation. Computes `-self`,
@@ -1317,11 +1322,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn saturating_neg(self) -> $Ty {
+        pub const fn saturating_neg(self) -> Self {
             if let Some(result) = self.checked_neg() {
                 return result;
             }
-            $Ty::MAX
+            Self::MAX
         }
 
         /// Wrapping (modular) negation. Computes `-self`, wrapping around at the boundary
@@ -1349,10 +1354,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn wrapping_neg(self) -> $Ty {
+        pub const fn wrapping_neg(self) -> Self {
             let result = self.get().wrapping_neg();
             // SAFETY: negation of nonzero cannot yield zero values.
-            unsafe { $Ty::new_unchecked(result) }
+            unsafe { Self::new_unchecked(result) }
         }
     };
 }


### PR DESCRIPTION
This slightly reduces the size of the eventual diff when making these generic, since this can be merged independently.