### PR TITLE
Remove no-system-llvm

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1109,9 +1109,6 @@ fn ignore_lldb(config: &Config, line: &str) -> IgnoreDecision {
 }
 
 fn ignore_llvm(config: &Config, line: &str) -> IgnoreDecision {
-    if config.system_llvm && line.starts_with("no-system-llvm") {
-        return IgnoreDecision::Ignore { reason: "ignored when the system LLVM is used".into() };
-    }
     if let Some(needed_components) =
         config.parse_name_value_directive(line, "needs-llvm-components")
     {

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -243,15 +243,6 @@ fn aux_build() {
 }
 
 #[test]
-fn no_system_llvm() {
-    let config: Config = cfg().system_llvm(false).build();
-    assert!(!check_ignore(&config, "// no-system-llvm"));
-
-    let config: Config = cfg().system_llvm(true).build();
-    assert!(check_ignore(&config, "// no-system-llvm"));
-}
-
-#[test]
 fn llvm_version() {
     let config: Config = cfg().llvm_version("8.1.2").build();
     assert!(check_ignore(&config, "// min-llvm-version: 9.0"));
@@ -264,6 +255,18 @@ fn llvm_version() {
 
     let config: Config = cfg().llvm_version("10.0.0").build();
     assert!(!check_ignore(&config, "// min-llvm-version: 9.0"));
+}
+
+#[test]
+fn system_llvm_version() {
+    let config: Config = cfg().system_llvm(true).llvm_version("17.0.0").build();
+    assert!(check_ignore(&config, "// min-system-llvm-version: 18.0"));
+
+    let config: Config = cfg().system_llvm(true).llvm_version("18.0.0").build();
+    assert!(!check_ignore(&config, "// min-system-llvm-version: 18.0"));
+
+    let config: Config = cfg().llvm_version("17.0.0").build();
+    assert!(!check_ignore(&config, "// min-system-llvm-version: 18.0"));
 }
 
 #[test]

--- a/tests/codegen/alloc-optimisation.rs
+++ b/tests/codegen/alloc-optimisation.rs
@@ -1,5 +1,3 @@
-//
-// no-system-llvm
 // compile-flags: -O
 #![crate_type = "lib"]
 

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -10,7 +10,7 @@
 pub fn short_integer_map(x: [u32; 8]) -> [u32; 8] {
     // CHECK: load <8 x i32>
     // CHECK: shl <8 x i32>
-    // CHECK: or <8 x i32>
+    // CHECK: or{{( disjoint)?}} <8 x i32>
     // CHECK: store <8 x i32>
     x.map(|x| 2 * x + 1)
 }

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -1,5 +1,4 @@
 // compile-flags: -C opt-level=3 -C target-cpu=x86-64-v3
-// no-system-llvm
 // only-x86_64
 // ignore-debug (the extra assertions get in the way)
 

--- a/tests/codegen/dealloc-no-unwind.rs
+++ b/tests/codegen/dealloc-no-unwind.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O
 
 #![crate_type="lib"]

--- a/tests/codegen/fewer-names.rs
+++ b/tests/codegen/fewer-names.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -Coverflow-checks=no -O
 // revisions: YES NO
 // [YES]compile-flags: -Zfewer-names=yes

--- a/tests/codegen/integer-overflow.rs
+++ b/tests/codegen/integer-overflow.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O -C overflow-checks=on
 
 #![crate_type = "lib"]

--- a/tests/codegen/issues/issue-116878.rs
+++ b/tests/codegen/issues/issue-116878.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O
 // ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]

--- a/tests/codegen/issues/issue-44056-macos-tls-align.rs
+++ b/tests/codegen/issues/issue-44056-macos-tls-align.rs
@@ -1,6 +1,5 @@
 //
 // only-macos
-// no-system-llvm
 // compile-flags: -O
 
 #![crate_type = "rlib"]

--- a/tests/codegen/issues/issue-69101-bounds-check.rs
+++ b/tests/codegen/issues/issue-69101-bounds-check.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O
 // ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]

--- a/tests/codegen/match-optimizes-away.rs
+++ b/tests/codegen/match-optimizes-away.rs
@@ -1,5 +1,4 @@
 //
-// no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]
 

--- a/tests/codegen/ptr-read-metadata.rs
+++ b/tests/codegen/ptr-read-metadata.rs
@@ -1,5 +1,4 @@
 // compile-flags: -O -Z merge-functions=disabled
-// no-system-llvm
 // ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]

--- a/tests/codegen/slice-as_chunks.rs
+++ b/tests/codegen/slice-as_chunks.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O
 // only-64bit (because the LLVM type of i64 for usize shows up)
 // ignore-debug: the debug assertions get in the way

--- a/tests/codegen/slice-iter-len-eq-zero.rs
+++ b/tests/codegen/slice-iter-len-eq-zero.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O
 // ignore-debug: the debug assertions add extra comparisons
 #![crate_type = "lib"]

--- a/tests/codegen/slice-iter-nonnull.rs
+++ b/tests/codegen/slice-iter-nonnull.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O
 // ignore-debug (these add extra checks that make it hard to verify)
 #![crate_type = "lib"]

--- a/tests/codegen/slice-position-bounds-check.rs
+++ b/tests/codegen/slice-position-bounds-check.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -O -C panic=abort
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-iter-collect-len.rs
+++ b/tests/codegen/vec-iter-collect-len.rs
@@ -1,5 +1,4 @@
 // ignore-debug: the debug assertions get in the way
-// no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]
 

--- a/tests/codegen/vec-optimizes-away.rs
+++ b/tests/codegen/vec-optimizes-away.rs
@@ -1,5 +1,4 @@
 // ignore-debug: the debug assertions get in the way
-// no-system-llvm
 // compile-flags: -O
 #![crate_type = "lib"]
 

--- a/tests/rustdoc/doc-cfg-target-feature.rs
+++ b/tests/rustdoc/doc-cfg-target-feature.rs
@@ -1,7 +1,6 @@
 // only-x86_64
 // compile-flags:--test
 // should-fail
-// no-system-llvm
 
 // #49723: rustdoc didn't add target features when extracting or running doctests
 

--- a/tests/ui/for-loop-while/issue-69841.rs
+++ b/tests/ui/for-loop-while/issue-69841.rs
@@ -2,7 +2,6 @@
 // LLVM bug which needed a fix to be backported.
 
 // run-pass
-// no-system-llvm
 
 fn main() {
     let buffer = [49u8, 10];

--- a/tests/ui/issue-76387-llvm-miscompile.rs
+++ b/tests/ui/issue-76387-llvm-miscompile.rs
@@ -1,4 +1,3 @@
-// no-system-llvm
 // compile-flags: -C opt-level=3
 // aux-build: issue-76387.rs
 // run-pass


### PR DESCRIPTION
We currently have a bunch of codegen tests that use no-system-llvm -- however, all of those tests also pass with system LLVM 16.

I've opted to remove `no-system-llvm` entirely, as there's basically no valid use case for it anymore:

 * The only thing this option could have legitimately been used for (testing the target feature support that requires an LLVM patch) doesn't use it, and the need for this will go away with LLVM 18 anyway.
 * In cases where the test depends on optimizations/fixes from newer LLVM versions, `min-llvm-version` should be used instead.
 * In case it depends on optimization/fixes from newer LLVM versions that have been backported into our fork, `min-system-llvm-version` (with the major version larger than the one in our fork) should be used instead.

r? @cuviper