### PR TITLE
compiletest: few naive improvements

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -650,7 +650,7 @@ fn iter_header_extra(
 
     let comment = if testfile.extension().is_some_and(|e| e == "rs") { "//" } else { "#" };
 
-    let mut rdr = BufReader::new(rdr);
+    let mut rdr = BufReader::with_capacity(1024, rdr);
     let mut ln = String::new();
     let mut line_number = 0;
 

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -675,6 +675,8 @@ fn collect_tests_from_dir(
 
     // Add each `.rs` file as a test, and recurse further on any
     // subdirectories we find, except for `aux` directories.
+    // FIXME: this walks full tests tree, even if we have something to ignore
+    // use walkdir/ignore like in tidy?
     for file in fs::read_dir(dir)? {
         let file = file?;
         let file_path = file.path();

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -25,7 +25,7 @@ use build_helper::git::{get_git_modified_files, get_git_untracked_files};
 use core::panic;
 use getopts::Options;
 use lazycell::AtomicLazyCell;
-use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::fs;
 use std::io::{self, ErrorKind};
@@ -415,7 +415,7 @@ pub fn run_tests(config: Arc<Config>) {
 
     let mut tests = Vec::new();
     for c in configs {
-        let mut found_paths = BTreeSet::new();
+        let mut found_paths = HashSet::new();
         make_tests(c, &mut tests, &mut found_paths);
         check_overlapping_tests(&found_paths);
     }
@@ -550,7 +550,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
 pub fn make_tests(
     config: Arc<Config>,
     tests: &mut Vec<test::TestDescAndFn>,
-    found_paths: &mut BTreeSet<PathBuf>,
+    found_paths: &mut HashSet<PathBuf>,
 ) {
     debug!("making tests from {:?}", config.src_base.display());
     let inputs = common_inputs_stamp(&config);
@@ -646,7 +646,7 @@ fn collect_tests_from_dir(
     relative_dir_path: &Path,
     inputs: &Stamp,
     tests: &mut Vec<test::TestDescAndFn>,
-    found_paths: &mut BTreeSet<PathBuf>,
+    found_paths: &mut HashSet<PathBuf>,
     modified_tests: &Vec<PathBuf>,
     poisoned: &mut bool,
 ) -> io::Result<()> {
@@ -1128,7 +1128,7 @@ fn not_a_digit(c: char) -> bool {
     !c.is_digit(10)
 }
 
-fn check_overlapping_tests(found_paths: &BTreeSet<PathBuf>) {
+fn check_overlapping_tests(found_paths: &HashSet<PathBuf>) {
     let mut collisions = Vec::new();
     for path in found_paths {
         for ancestor in path.ancestors().skip(1) {
@@ -1138,6 +1138,7 @@ fn check_overlapping_tests(found_paths: &BTreeSet<PathBuf>) {
         }
     }
     if !collisions.is_empty() {
+        collisions.sort();
         let collisions: String = collisions
             .into_iter()
             .map(|(path, check_parent)| format!("test {path:?} clashes with {check_parent:?}\n"))

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -4315,10 +4315,11 @@ impl<'test> TestCx<'test> {
             let mut seen_allocs = indexmap::IndexSet::new();
 
             // The alloc-id appears in pretty-printed allocations.
-            let re =
+            static ALLOC_ID_PP_RE: Lazy<Regex> = Lazy::new(|| {
                 Regex::new(r"╾─*a(lloc)?([0-9]+)(\+0x[0-9]+)?(<imm>)?( \([0-9]+ ptr bytes\))?─*╼")
-                    .unwrap();
-            normalized = re
+                    .unwrap()
+            });
+            normalized = ALLOC_ID_PP_RE
                 .replace_all(&normalized, |caps: &Captures<'_>| {
                     // Renumber the captured index.
                     let index = caps.get(2).unwrap().as_str().to_string();
@@ -4331,8 +4332,9 @@ impl<'test> TestCx<'test> {
                 .into_owned();
 
             // The alloc-id appears in a sentence.
-            let re = Regex::new(r"\balloc([0-9]+)\b").unwrap();
-            normalized = re
+            static ALLOC_ID_RE: Lazy<Regex> =
+                Lazy::new(|| Regex::new(r"\balloc([0-9]+)\b").unwrap());
+            normalized = ALLOC_ID_RE
                 .replace_all(&normalized, |caps: &Captures<'_>| {
                     let index = caps.get(1).unwrap().as_str().to_string();
                     let (index, _) = seen_allocs.insert_full(index);


### PR DESCRIPTION
Tested on `python x.py --stage=1 t tests/ui/borrowck/ --force-rerun`, see individual commits.

Wall time didn't improved :-) .