### PR TITLE
Normalize field types before checking validity

### DIFF
--- a/tests/ui/type-alias-impl-trait/struct-assignment-validity.rs
+++ b/tests/ui/type-alias-impl-trait/struct-assignment-validity.rs
@@ -1,0 +1,31 @@
+// compile-flags: -Zvalidate-mir
+// check-pass
+
+// Check that we don't cause cycle errors when validating pre-`Reveal::All` MIR
+// that assigns opaques through normalized projections.
+
+#![feature(impl_trait_in_assoc_type)]
+
+struct Bar;
+
+trait Trait {
+    type Assoc;
+    fn foo() -> Foo;
+}
+
+impl Trait for Bar {
+    type Assoc = impl std::fmt::Debug;
+    fn foo() -> Foo
+    where
+        Self::Assoc:,
+    {
+        let x: <Bar as Trait>::Assoc = ();
+        Foo { field: () }
+    }
+}
+
+struct Foo {
+    field: <Bar as Trait>::Assoc,
+}
+
+fn main() {}


### PR DESCRIPTION
I forgot to normalize field types when checking ADT-like aggregates in the MIR validator.

This normalization is needed due to a crude check for opaque types in `mir_assign_valid_types` which prevents opaque type cycles -- if we pass in an unnormalized type, we may not detect that the destination type is an opaque, and therefore will call `type_of(opaque)` later on, which causes a cycle error -> ICE.

Fixes #120253