### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -129,7 +129,7 @@ Clement Miao <clementmiao@gmail.com>
 Clément Renault <renault.cle@gmail.com>
 Cliff Dyer <jcd@sdf.org>
 Clinton Ryan <clint.ryan3@gmail.com>
-Corey Richardson <corey@octayn.net> Elaine "See More" Nemo <corey@octayn.net>
+ember arlynx <ember@lunar.town> <corey@octayn.net>
 Crazycolorz5 <Crazycolorz5@gmail.com>
 csmoe <35686186+csmoe@users.noreply.github.com>
 Cyryl Płotnicki <cyplo@cyplo.net>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,12 +878,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.0"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
  "nix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2512,14 +2512,13 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
- "static_assertions",
 ]
 
 [[package]]
@@ -6144,6 +6143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6174,6 +6182,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6184,6 +6207,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6198,6 +6227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6208,6 +6243,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6222,6 +6263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6232,6 +6279,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6246,6 +6299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6256,6 +6315,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,11 +2640,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2672,9 +2672,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",

--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -12,7 +12,9 @@ use rustc_trait_selection::traits::StructurallyNormalizeExt;
 
 #[derive(Copy, Clone, Debug)]
 pub enum AutoderefKind {
+    /// A true pointer type, such as `&T` and `*mut T`.
     Builtin,
+    /// A type which must dispatch to a `Deref` implementation.
     Overloaded,
 }
 
@@ -83,6 +85,7 @@ impl<'a, 'tcx> Iterator for Autoderef<'a, 'tcx> {
                 (AutoderefKind::Builtin, ty)
             }
         } else if let Some(ty) = self.overloaded_deref_ty(self.state.cur_ty) {
+            // The overloaded deref check already normalizes the pointee type.
             (AutoderefKind::Overloaded, ty)
         } else {
             return None;

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -254,7 +254,7 @@ fn compare_method_predicate_entailment<'tcx>(
     // checks. For the comparison to be valid, we need to
     // normalize the associated types in the impl/trait methods
     // first. However, because function types bind regions, just
-    // calling `normalize_associated_types_in` would have no effect on
+    // calling `FnCtxt::normalize` would have no effect on
     // any associated types appearing in the fn arguments or return
     // type.
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -6,7 +6,7 @@ use crate::method::MethodCallee;
 use crate::TupleArgumentsFlag::*;
 use crate::{errors, Expectation::*};
 use crate::{
-    struct_span_code_err, BreakableCtxt, Diverges, Expectation, FnCtxt, Needs, RawTy,
+    struct_span_code_err, BreakableCtxt, Diverges, Expectation, FnCtxt, LoweredTy, Needs,
     TupleArgumentsFlag,
 };
 use itertools::Itertools;
@@ -1786,12 +1786,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         qpath: &QPath<'tcx>,
         path_span: Span,
         hir_id: hir::HirId,
-    ) -> (Res, RawTy<'tcx>) {
+    ) -> (Res, LoweredTy<'tcx>) {
         match *qpath {
             QPath::Resolved(ref maybe_qself, path) => {
                 let self_ty = maybe_qself.as_ref().map(|qself| self.to_ty(qself).raw);
                 let ty = self.astconv().res_to_ty(self_ty, path, hir_id, true);
-                (path.res, self.handle_raw_ty(path_span, ty))
+                (path.res, LoweredTy::from_raw(self, path_span, ty))
             }
             QPath::TypeRelative(qself, segment) => {
                 let ty = self.to_ty(qself);
@@ -1802,7 +1802,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let ty = result
                     .map(|(ty, _, _)| ty)
                     .unwrap_or_else(|guar| Ty::new_error(self.tcx(), guar));
-                let ty = self.handle_raw_ty(path_span, ty);
+                let ty = LoweredTy::from_raw(self, path_span, ty);
                 let result = result.map(|(_, kind, def_id)| (kind, def_id));
 
                 // Write back the new resolution.
@@ -1812,7 +1812,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             QPath::LangItem(lang_item, span) => {
                 let (res, ty) = self.resolve_lang_item_path(lang_item, span, hir_id);
-                (res, self.handle_raw_ty(path_span, ty))
+                (res, LoweredTy::from_raw(self, path_span, ty))
             }
         }
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -344,14 +344,22 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
     }
 }
 
-/// Represents a user-provided type in the raw form (never normalized).
+/// The `ty` representation of a user-provided type. Depending on the use-site
+/// we want to either use the unnormalized or the normalized form of this type.
 ///
 /// This is a bridge between the interface of `AstConv`, which outputs a raw `Ty`,
 /// and the API in this module, which expect `Ty` to be fully normalized.
 #[derive(Clone, Copy, Debug)]
-pub struct RawTy<'tcx> {
+pub struct LoweredTy<'tcx> {
+    /// The unnormalized type provided by the user.
     pub raw: Ty<'tcx>,
 
     /// The normalized form of `raw`, stored here for efficiency.
     pub normalized: Ty<'tcx>,
+}
+
+impl<'tcx> LoweredTy<'tcx> {
+    pub fn from_raw(fcx: &FnCtxt<'_, 'tcx>, span: Span, raw: Ty<'tcx>) -> LoweredTy<'tcx> {
+        LoweredTy { raw, normalized: fcx.normalize(span, raw) }
+    }
 }

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -49,7 +49,7 @@ use crate::check::check_fn;
 use crate::coercion::DynamicCoerceMany;
 use crate::diverges::Diverges;
 use crate::expectation::Expectation;
-use crate::fn_ctxt::RawTy;
+use crate::fn_ctxt::LoweredTy;
 use crate::gather_locals::GatherLocalsVisitor;
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::{struct_span_code_err, ErrorGuaranteed};

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -746,11 +746,13 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             let (xform_self_ty, xform_ret_ty) = self.xform_self_ty(item, impl_ty, impl_args);
             debug!("xform_self_ty: {:?}, xform_ret_ty: {:?}", xform_self_ty, xform_ret_ty);
 
-            // We can't use normalize_associated_types_in as it will pollute the
+            // We can't use `FnCtxt::normalize` as it will pollute the
             // fcx's fulfillment context after this probe is over.
+            //
             // Note: we only normalize `xform_self_ty` here since the normalization
             // of the return type can lead to inference results that prohibit
             // valid candidates from being found, see issue #85671
+            //
             // FIXME Postponing the normalization of the return type likely only hides a deeper bug,
             // which might be caused by the `param_env` itself. The clauses of the `param_env`
             // maybe shouldn't include `Param`s, but rather fresh variables or be canonicalized,

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1,5 +1,5 @@
 use crate::gather_locals::DeclOrigin;
-use crate::{errors, FnCtxt, RawTy};
+use crate::{errors, FnCtxt, LoweredTy};
 use rustc_ast as ast;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{
@@ -891,7 +891,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         pat: &Pat<'tcx>,
         qpath: &hir::QPath<'_>,
-        path_resolution: (Res, Option<RawTy<'tcx>>, &'tcx [hir::PathSegment<'tcx>]),
+        path_resolution: (Res, Option<LoweredTy<'tcx>>, &'tcx [hir::PathSegment<'tcx>]),
         expected: Ty<'tcx>,
         ti: TopInfo<'tcx>,
     ) -> Ty<'tcx> {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -804,17 +804,12 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     }
                 } else {
                     p!(print_def_path(did, args));
-                    p!(" upvar_tys=(");
-                    if !args.as_coroutine().is_valid() {
-                        p!("unavailable");
-                    } else {
-                        self.comma_sep(args.as_coroutine().upvar_tys().iter())?;
-                    }
-                    p!(")");
-
-                    if args.as_coroutine().is_valid() {
-                        p!(" ", print(args.as_coroutine().witness()));
-                    }
+                    p!(
+                        " upvar_tys=",
+                        print(args.as_coroutine().tupled_upvars_ty()),
+                        " witness=",
+                        print(args.as_coroutine().witness())
+                    );
                 }
 
                 p!("}}")
@@ -868,19 +863,14 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     }
                 } else {
                     p!(print_def_path(did, args));
-                    if !args.as_closure().is_valid() {
-                        p!(" closure_args=(unavailable)");
-                        p!(write(" args={}", args.print_as_list()));
-                    } else {
-                        p!(" closure_kind_ty=", print(args.as_closure().kind_ty()));
-                        p!(
-                            " closure_sig_as_fn_ptr_ty=",
-                            print(args.as_closure().sig_as_fn_ptr_ty())
-                        );
-                        p!(" upvar_tys=(");
-                        self.comma_sep(args.as_closure().upvar_tys().iter())?;
-                        p!(")");
-                    }
+                    p!(
+                        " closure_kind_ty=",
+                        print(args.as_closure().kind_ty()),
+                        " closure_sig_as_fn_ptr_ty=",
+                        print(args.as_closure().sig_as_fn_ptr_ty()),
+                        " upvar_tys=",
+                        print(args.as_closure().tupled_upvars_ty())
+                    );
                 }
                 p!("}}");
             }

--- a/compiler/rustc_mir_transform/src/remove_storage_markers.rs
+++ b/compiler/rustc_mir_transform/src/remove_storage_markers.rs
@@ -7,14 +7,10 @@ pub struct RemoveStorageMarkers;
 
 impl<'tcx> MirPass<'tcx> for RemoveStorageMarkers {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
+        sess.mir_opt_level() > 0 && !sess.emit_lifetime_markers()
     }
 
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if tcx.sess.emit_lifetime_markers() {
-            return;
-        }
-
+    fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         trace!("Running RemoveStorageMarkers on {:?}", body.source);
         for data in body.basic_blocks.as_mut_preserves_cfg() {
             data.statements.retain(|statement| match statement.kind {

--- a/compiler/rustc_target/src/spec/base/dragonfly.rs
+++ b/compiler/rustc_target/src/spec/base/dragonfly.rs
@@ -8,6 +8,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         position_independent_executables: true,
         relro_level: RelroLevel::Full,
+        has_thread_local: true,
         default_dwarf_version: 2,
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/base/freebsd.rs
+++ b/compiler/rustc_target/src/spec/base/freebsd.rs
@@ -9,6 +9,7 @@ pub fn opts() -> TargetOptions {
         crt_static_respected: true,
         position_independent_executables: true,
         relro_level: RelroLevel::Full,
+        has_thread_local: true,
         abi_return_struct_as_int: true,
         default_dwarf_version: 2,
         ..Default::default()

--- a/compiler/rustc_target/src/spec/base/netbsd.rs
+++ b/compiler/rustc_target/src/spec/base/netbsd.rs
@@ -9,6 +9,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         position_independent_executables: true,
         relro_level: RelroLevel::Full,
+        has_thread_local: true,
         use_ctors_section: true,
         default_dwarf_version: 2,
         ..Default::default()

--- a/compiler/rustc_trait_selection/src/solve/normalizes_to/weak_types.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalizes_to/weak_types.rs
@@ -1,7 +1,7 @@
 //! Computes a normalizes-to (projection) goal for inherent associated types,
 //! `#![feature(lazy_type_alias)]` and `#![feature(type_alias_impl_trait)]`.
 //!
-//! Since a weak alias is not ambiguous, this just computes the `type_of` of
+//! Since a weak alias is never ambiguous, this just computes the `type_of` of
 //! the alias and registers the where-clauses of the type alias.
 use rustc_middle::traits::solve::{Certainty, Goal, GoalSource, QueryResult};
 use rustc_middle::ty;

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3152,6 +3152,10 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         ],
                         Applicability::MachineApplicable,
                     );
+                } else {
+                    // FIXME: we may suggest array::repeat instead
+                    err.help("consider using `core::array::from_fn` to initialize the array");
+                    err.help("see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information");
                 }
 
                 if self.tcx.sess.is_nightly_build()

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -141,6 +141,13 @@ where
         infcx: &InferCtxt<'tcx>,
         span: Span,
     ) -> Result<TypeOpOutput<'tcx, Self>, ErrorGuaranteed> {
+        // In the new trait solver, query type ops are performed locally. This
+        // is because query type ops currently use the old canonicalizer, and
+        // that doesn't preserve things like opaques which have been registered
+        // during MIR typeck. Even after the old canonicalizer is gone, it's
+        // probably worthwhile just keeping this run-locally logic, since we
+        // probably don't gain much from caching here given the new solver does
+        // caching internally.
         if infcx.next_trait_solver() {
             return Ok(scrape_region_constraints(
                 infcx,

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -317,7 +317,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn checked_mul(self, other: $Ty) -> Option<$Ty> {
+            pub const fn checked_mul(self, other: Self) -> Option<Self> {
                 if let Some(result) = self.get().checked_mul(other.get()) {
                     // SAFETY:
                     // - `checked_mul` returns `None` on overflow
@@ -326,7 +326,7 @@ macro_rules! nonzero_integer {
                     //   of the sides to be zero
                     //
                     // So the result cannot be zero.
-                    Some(unsafe { $Ty::new_unchecked(result) })
+                    Some(unsafe { Self::new_unchecked(result) })
                 } else {
                     None
                 }
@@ -356,7 +356,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn saturating_mul(self, other: $Ty) -> $Ty {
+            pub const fn saturating_mul(self, other: Self) -> Self {
                 // SAFETY:
                 // - `saturating_mul` returns `u*::MAX`/`i*::MAX`/`i*::MIN` on overflow/underflow,
                 //   all of which are non-zero
@@ -365,7 +365,7 @@ macro_rules! nonzero_integer {
                 //   of the sides to be zero
                 //
                 // So the result cannot be zero.
-                unsafe { $Ty::new_unchecked(self.get().saturating_mul(other.get())) }
+                unsafe { Self::new_unchecked(self.get().saturating_mul(other.get())) }
             }
 
             /// Multiplies two non-zero integers together,
@@ -403,9 +403,9 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const unsafe fn unchecked_mul(self, other: $Ty) -> $Ty {
+            pub const unsafe fn unchecked_mul(self, other: Self) -> Self {
                 // SAFETY: The caller ensures there is no overflow.
-                unsafe { $Ty::new_unchecked(self.get().unchecked_mul(other.get())) }
+                unsafe { Self::new_unchecked(self.get().unchecked_mul(other.get())) }
             }
 
             /// Raises non-zero value to an integer power.
@@ -433,7 +433,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn checked_pow(self, other: u32) -> Option<$Ty> {
+            pub const fn checked_pow(self, other: u32) -> Option<Self> {
                 if let Some(result) = self.get().checked_pow(other) {
                     // SAFETY:
                     // - `checked_pow` returns `None` on overflow/underflow
@@ -442,7 +442,7 @@ macro_rules! nonzero_integer {
                     //   for base to be zero
                     //
                     // So the result cannot be zero.
-                    Some(unsafe { $Ty::new_unchecked(result) })
+                    Some(unsafe { Self::new_unchecked(result) })
                 } else {
                     None
                 }
@@ -481,7 +481,7 @@ macro_rules! nonzero_integer {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[inline]
-            pub const fn saturating_pow(self, other: u32) -> $Ty {
+            pub const fn saturating_pow(self, other: u32) -> Self {
                 // SAFETY:
                 // - `saturating_pow` returns `u*::MAX`/`i*::MAX`/`i*::MIN` on overflow/underflow,
                 //   all of which are non-zero
@@ -490,7 +490,7 @@ macro_rules! nonzero_integer {
                 //   for base to be zero
                 //
                 // So the result cannot be zero.
-                unsafe { $Ty::new_unchecked(self.get().saturating_pow(other)) }
+                unsafe { Self::new_unchecked(self.get().saturating_pow(other)) }
             }
         }
 
@@ -508,29 +508,32 @@ macro_rules! nonzero_integer {
         #[stable(feature = "nonzero_bitor", since = "1.45.0")]
         impl BitOr for $Ty {
             type Output = Self;
+
             #[inline]
             fn bitor(self, rhs: Self) -> Self::Output {
                 // SAFETY: since `self` and `rhs` are both nonzero, the
                 // result of the bitwise-or will be nonzero.
-                unsafe { $Ty::new_unchecked(self.get() | rhs.get()) }
+                unsafe { Self::new_unchecked(self.get() | rhs.get()) }
             }
         }
 
         #[stable(feature = "nonzero_bitor", since = "1.45.0")]
         impl BitOr<$Int> for $Ty {
             type Output = Self;
+
             #[inline]
             fn bitor(self, rhs: $Int) -> Self::Output {
                 // SAFETY: since `self` is nonzero, the result of the
                 // bitwise-or will be nonzero regardless of the value of
                 // `rhs`.
-                unsafe { $Ty::new_unchecked(self.get() | rhs) }
+                unsafe { Self::new_unchecked(self.get() | rhs) }
             }
         }
 
         #[stable(feature = "nonzero_bitor", since = "1.45.0")]
         impl BitOr<$Ty> for $Int {
             type Output = $Ty;
+
             #[inline]
             fn bitor(self, rhs: $Ty) -> Self::Output {
                 // SAFETY: since `rhs` is nonzero, the result of the
@@ -603,6 +606,7 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
         #[stable(feature = "nonzero_div", since = "1.51.0")]
         impl Div<$Ty> for $Int {
             type Output = $Int;
+
             /// This operation rounds towards zero,
             /// truncating any fractional part of the exact result, and cannot panic.
             #[inline]
@@ -616,6 +620,7 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
         #[stable(feature = "nonzero_div", since = "1.51.0")]
         impl Rem<$Ty> for $Int {
             type Output = $Int;
+
             /// This operation satisfies `n % d == n - (n / d) * d`, and cannot panic.
             #[inline]
             fn rem(self, other: $Ty) -> $Int {
@@ -630,12 +635,12 @@ macro_rules! nonzero_integer_signedness_dependent_impls {
     ($Ty:ident signed $Int:ty) => {
         #[stable(feature = "signed_nonzero_neg", since = "1.71.0")]
         impl Neg for $Ty {
-            type Output = $Ty;
+            type Output = Self;
 
             #[inline]
-            fn neg(self) -> $Ty {
+            fn neg(self) -> Self {
                 // SAFETY: negation of nonzero cannot yield zero values.
-                unsafe { $Ty::new_unchecked(self.get().neg()) }
+                unsafe { Self::new_unchecked(self.get().neg()) }
             }
         }
 
@@ -703,7 +708,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_add(self, other: $Int) -> Option<$Ty> {
+        pub const fn checked_add(self, other: $Int) -> Option<Self> {
             if let Some(result) = self.get().checked_add(other) {
                 // SAFETY:
                 // - `checked_add` returns `None` on overflow
@@ -712,7 +717,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
                 //   sides to be zero
                 //
                 // So the result cannot be zero.
-                Some(unsafe { $Ty::new_unchecked(result) })
+                Some(unsafe { Self::new_unchecked(result) })
             } else {
                 None
             }
@@ -742,7 +747,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn saturating_add(self, other: $Int) -> $Ty {
+        pub const fn saturating_add(self, other: $Int) -> Self {
             // SAFETY:
             // - `saturating_add` returns `u*::MAX` on overflow, which is non-zero
             // - `self` is non-zero
@@ -750,7 +755,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
             //   sides to be zero
             //
             // So the result cannot be zero.
-            unsafe { $Ty::new_unchecked(self.get().saturating_add(other)) }
+            unsafe { Self::new_unchecked(self.get().saturating_add(other)) }
         }
 
         /// Adds an unsigned integer to a non-zero value,
@@ -779,9 +784,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const unsafe fn unchecked_add(self, other: $Int) -> $Ty {
+        pub const unsafe fn unchecked_add(self, other: $Int) -> Self {
             // SAFETY: The caller ensures there is no overflow.
-            unsafe { $Ty::new_unchecked(self.get().unchecked_add(other)) }
+            unsafe { Self::new_unchecked(self.get().unchecked_add(other)) }
         }
 
         /// Returns the smallest power of two greater than or equal to n.
@@ -812,11 +817,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_next_power_of_two(self) -> Option<$Ty> {
+        pub const fn checked_next_power_of_two(self) -> Option<Self> {
             if let Some(nz) = self.get().checked_next_power_of_two() {
                 // SAFETY: The next power of two is positive
                 // and overflow is checked.
-                Some(unsafe { $Ty::new_unchecked(nz) })
+                Some(unsafe { Self::new_unchecked(nz) })
             } else {
                 None
             }
@@ -902,9 +907,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         pub const fn midpoint(self, rhs: Self) -> Self {
             // SAFETY: The only way to get `0` with midpoint is to have two opposite or
             // near opposite numbers: (-5, 5), (0, 1), (0, 0) which is impossible because
-            // of the unsignedness of this number and also because $Ty is guaranteed to
+            // of the unsignedness of this number and also because `Self` is guaranteed to
             // never being 0.
-            unsafe { $Ty::new_unchecked(self.get().midpoint(rhs.get())) }
+            unsafe { Self::new_unchecked(self.get().midpoint(rhs.get())) }
         }
 
         /// Returns `true` if and only if `self == (1 << k)` for some `k`.
@@ -1000,9 +1005,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn abs(self) -> $Ty {
+        pub const fn abs(self) -> Self {
             // SAFETY: This cannot overflow to zero.
-            unsafe { $Ty::new_unchecked(self.get().abs()) }
+            unsafe { Self::new_unchecked(self.get().abs()) }
         }
 
         /// Checked absolute value.
@@ -1031,10 +1036,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn checked_abs(self) -> Option<$Ty> {
+        pub const fn checked_abs(self) -> Option<Self> {
             if let Some(nz) = self.get().checked_abs() {
                 // SAFETY: absolute value of nonzero cannot yield zero values.
-                Some(unsafe { $Ty::new_unchecked(nz) })
+                Some(unsafe { Self::new_unchecked(nz) })
             } else {
                 None
             }
@@ -1066,11 +1071,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn overflowing_abs(self) -> ($Ty, bool) {
+        pub const fn overflowing_abs(self) -> (Self, bool) {
             let (nz, flag) = self.get().overflowing_abs();
             (
                 // SAFETY: absolute value of nonzero cannot yield zero values.
-                unsafe { $Ty::new_unchecked(nz) },
+                unsafe { Self::new_unchecked(nz) },
                 flag,
             )
         }
@@ -1105,9 +1110,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn saturating_abs(self) -> $Ty {
+        pub const fn saturating_abs(self) -> Self {
             // SAFETY: absolute value of nonzero cannot yield zero values.
-            unsafe { $Ty::new_unchecked(self.get().saturating_abs()) }
+            unsafe { Self::new_unchecked(self.get().saturating_abs()) }
         }
 
         /// Wrapping absolute value, see
@@ -1138,9 +1143,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn wrapping_abs(self) -> $Ty {
+        pub const fn wrapping_abs(self) -> Self {
             // SAFETY: absolute value of nonzero cannot yield zero values.
-            unsafe { $Ty::new_unchecked(self.get().wrapping_abs()) }
+            unsafe { Self::new_unchecked(self.get().wrapping_abs()) }
         }
 
         /// Computes the absolute value of self
@@ -1250,10 +1255,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn checked_neg(self) -> Option<$Ty> {
+        pub const fn checked_neg(self) -> Option<Self> {
             if let Some(result) = self.get().checked_neg() {
                 // SAFETY: negation of nonzero cannot yield zero values.
-                return Some(unsafe { $Ty::new_unchecked(result) });
+                return Some(unsafe { Self::new_unchecked(result) });
             }
             None
         }
@@ -1282,10 +1287,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn overflowing_neg(self) -> ($Ty, bool) {
+        pub const fn overflowing_neg(self) -> (Self, bool) {
             let (result, overflow) = self.get().overflowing_neg();
             // SAFETY: negation of nonzero cannot yield zero values.
-            ((unsafe { $Ty::new_unchecked(result) }), overflow)
+            ((unsafe { Self::new_unchecked(result) }), overflow)
         }
 
         /// Saturating negation. Computes `-self`,
@@ -1317,11 +1322,11 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn saturating_neg(self) -> $Ty {
+        pub const fn saturating_neg(self) -> Self {
             if let Some(result) = self.checked_neg() {
                 return result;
             }
-            $Ty::MAX
+            Self::MAX
         }
 
         /// Wrapping (modular) negation. Computes `-self`, wrapping around at the boundary
@@ -1349,10 +1354,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[inline]
         #[stable(feature = "nonzero_negation_ops", since = "1.71.0")]
         #[rustc_const_stable(feature = "nonzero_negation_ops", since = "1.71.0")]
-        pub const fn wrapping_neg(self) -> $Ty {
+        pub const fn wrapping_neg(self) -> Self {
             let result = self.get().wrapping_neg();
             // SAFETY: negation of nonzero cannot yield zero values.
-            unsafe { $Ty::new_unchecked(result) }
+            unsafe { Self::new_unchecked(result) }
         }
     };
 }

--- a/library/std/src/sys/pal/unix/thread_local_dtor.rs
+++ b/library/std/src/sys/pal/unix/thread_local_dtor.rs
@@ -17,7 +17,10 @@
     target_os = "android",
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "hurd"
+    target_os = "hurd",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
 ))]
 // FIXME: The Rust compiler currently omits weakly function definitions (i.e.,
 // __cxa_thread_atexit_impl) and its metadata from LLVM IR.

--- a/tests/ui/array-slice-vec/repeat_empty_ok.stderr
+++ b/tests/ui/array-slice-vec/repeat_empty_ok.stderr
@@ -5,6 +5,8 @@ LL |     let headers = [Header{value: &[]}; 128];
    |                    ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Header<'_>`
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Header<'_>` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]
@@ -18,6 +20,8 @@ LL |     let headers = [Header{value: &[0]}; 128];
    |                    ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Header<'_>`
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Header<'_>` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-trim-off-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `{mod1::f<T>::{closure#0} closure_args=(unavailable) args=[T, ?8t, extern "rust-call" fn(()), ?7t]}`
+                found closure `{mod1::f<T>::{closure#0} closure_kind_ty=?8t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?7t}`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
+++ b/tests/ui/closures/print/closure-print-generic-verbose-2.stderr
@@ -9,7 +9,7 @@ LL |         let c1 : () = c;
    |                  expected due to this
    |
    = note: expected unit type `()`
-                found closure `{f<T>::{closure#0} closure_args=(unavailable) args=[T, ?8t, extern "rust-call" fn(()), ?7t]}`
+                found closure `{f<T>::{closure#0} closure_kind_ty=?8t closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=?7t}`
 help: use parentheses to call this closure
    |
 LL |         let c1 : () = c();

--- a/tests/ui/closures/print/closure-print-verbose.stderr
+++ b/tests/ui/closures/print/closure-print-verbose.stderr
@@ -7,7 +7,7 @@ LL |     let foo: fn(u8) -> u8 = |v: u8| { a += v; a };
    |              expected due to this
    |
    = note: expected fn pointer `fn(u8) -> u8`
-                 found closure `{main::{closure#0} closure_args=(unavailable) args=[i8, extern "rust-call" fn((u8,)) -> u8, ?4t]}`
+                 found closure `{main::{closure#0} closure_kind_ty=i8 closure_sig_as_fn_ptr_ty=extern "rust-call" fn((u8,)) -> u8 upvar_tys=?4t}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
   --> $DIR/closure-print-verbose.rs:10:39
    |

--- a/tests/ui/const-generics/issues/issue-61336.stderr
+++ b/tests/ui/const-generics/issues/issue-61336.stderr
@@ -5,6 +5,8 @@ LL |     [x; N]
    |      ^ the trait `Copy` is not implemented for `T`
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider restricting type parameter `T`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {

--- a/tests/ui/consts/const-blocks/migrate-fail.stderr
+++ b/tests/ui/consts/const-blocks/migrate-fail.stderr
@@ -6,6 +6,8 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]
@@ -20,6 +22,8 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/consts/const-blocks/nll-fail.stderr
+++ b/tests/ui/consts/const-blocks/nll-fail.stderr
@@ -6,6 +6,8 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]
@@ -20,6 +22,8 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -4,7 +4,7 @@ error: coroutine cannot be shared between threads safely
 LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ coroutine is not `Sync`
    |
-   = help: within `{main::{closure#0} upvar_tys=() {main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`
+   = help: within `{main::{closure#0} upvar_tys=() witness={main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:20:9
    |
@@ -24,7 +24,7 @@ error: coroutine cannot be sent between threads safely
 LL |     assert_send(|| {
    |     ^^^^^^^^^^^ coroutine is not `Send`
    |
-   = help: within `{main::{closure#1} upvar_tys=() {main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`
+   = help: within `{main::{closure#1} upvar_tys=() witness={main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:27:9
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-3.stderr
@@ -12,7 +12,7 @@ LL | |     };
    | |_____^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{main::{closure#0} upvar_tys=(unavailable)}`
+              found coroutine `{main::{closure#0} upvar_tys=?4t witness=?6t}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/repeat-expr/repeat-to-run-dtor-twice.stderr
+++ b/tests/ui/repeat-expr/repeat-to-run-dtor-twice.stderr
@@ -5,6 +5,8 @@ LL |     let _ = [ a; 5 ];
    |               ^ the trait `Copy` is not implemented for `Foo`
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
+   = help: consider using `core::array::from_fn` to initialize the array
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
 help: consider annotating `Foo` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/trait-bounds/issue-119530-sugg-from-fn.rs
+++ b/tests/ui/trait-bounds/issue-119530-sugg-from-fn.rs
@@ -1,0 +1,5 @@
+fn foo() -> String { String::new() }
+
+fn main() {
+    let string_arr = [foo(); 64]; //~ ERROR the trait bound `String: Copy` is not satisfied
+}

--- a/tests/ui/trait-bounds/issue-119530-sugg-from-fn.stderr
+++ b/tests/ui/trait-bounds/issue-119530-sugg-from-fn.stderr
@@ -1,16 +1,12 @@
-error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/issue-61336-2.rs:6:6
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/issue-119530-sugg-from-fn.rs:4:23
    |
-LL |     [x; { N }]
-   |      ^ the trait `Copy` is not implemented for `T`
+LL |     let string_arr = [foo(); 64];
+   |                       ^^^^^ the trait `Copy` is not implemented for `String`
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
    = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
-help: consider restricting type parameter `T`
-   |
-LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
-   |       +++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/weird-exprs.rs
+++ b/tests/ui/weird-exprs.rs
@@ -231,6 +231,31 @@ fn infcx() {
     let _cx: cx::cx::Cx = cx::cx::cx::cx::cx::Cx;
 }
 
+fn return_already() -> impl std::fmt::Debug {
+    loop {
+        return !!!!!!!
+        break !!!!!!1111
+    }
+}
+
+fn cursed_macros() -> impl std::fmt::Debug {
+    loop {
+        if! {
+            match! (
+                break! {
+                    return! {
+                        1337
+                    }
+                }
+            )
+
+            {}
+        }
+
+        {}
+    }
+}
+
 pub fn main() {
     strange();
     funny();
@@ -257,4 +282,6 @@ pub fn main() {
     semisemisemisemisemi();
     useful_syntax();
     infcx();
+    return_already();
+    cursed_macros();
 }

--- a/tests/ui/weird-exprs.rs
+++ b/tests/ui/weird-exprs.rs
@@ -238,7 +238,7 @@ fn return_already() -> impl std::fmt::Debug {
     }
 }
 
-fn cursed_macros() -> impl std::fmt::Debug {
+fn fake_macros() -> impl std::fmt::Debug {
     loop {
         if! {
             match! (
@@ -283,5 +283,5 @@ pub fn main() {
     useful_syntax();
     infcx();
     return_already();
-    cursed_macros();
+    fake_macros();
 }

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -639,6 +639,7 @@ compiler-team = [
     "@compiler-errors",
     "@petrochenkov",
     "@davidtwco",
+    "@estebank",
     "@oli-obk",
     "@wesleywiser",
 ]
@@ -688,18 +689,21 @@ incremental = [
 diagnostics = [
     "@compiler-errors",
     "@davidtwco",
+    "@estebank",
     "@oli-obk",
     "@TaKO8Ki",
 ]
 parser = [
     "@compiler-errors",
     "@davidtwco",
+    "@estebank",
     "@nnethercote",
     "@petrochenkov",
 ]
 lexer = [
     "@nnethercote",
     "@petrochenkov",
+    "@estebank",
 ]
 mir = [
     "@davidtwco",
@@ -723,6 +727,7 @@ borrowck = [
 ]
 ast_lowering = [
     "@compiler-errors",
+    "@estebank",
     "@spastorino",
 ]
 fallback = [


### PR DESCRIPTION
Successful merges:

 - #119028 (Add more weirdness to weird-exprs.rs)
 - #119805 (Suggest array::from_fn for array initialization)
 - #120188 (compiler: update freebsd and netbsd base specs.)
 - #120215 (Update some deps with `bitflags` v1 dependencies)
 - #120244 (Use `Self` in `NonZero*` implementations.)
 - #120246 (Re-add estebank to review rotation)
 - #120252 (rename `RawTy` to `LoweredTy`)
 - #120255 (correct my mailmap entry)
 - #120270 (A bunch of random modifications)
 - #120280 (Move condition enabling the pass to `is_enabled`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119028,119805,120188,120215,120244,120246,120252,120255,120270,120280)
<!-- homu-ignore:end -->