### PR TITLE
Update comment to resolve ambiguity

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -478,7 +478,7 @@ impl isize {
     }
 }
 
-/// If the 6th bit is set ascii is lower case.
+/// If the 5th bit is set ascii is lower case.
 const ASCII_CASE_MASK: u8 = 0b0010_0000;
 
 impl u8 {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -478,7 +478,7 @@ impl isize {
     }
 }
 
-/// If the 5th bit is set ascii is lower case.
+/// If the bit selected by this mask is set, ascii is lower case.
 const ASCII_CASE_MASK: u8 = 0b0010_0000;
 
 impl u8 {


### PR DESCRIPTION
The documentation is incorrect as the determinant for lower or upper case is the 5th bit not the 6th bit as written in the codebase.
An excerpt from the book  the art of assembly language lays credence to this  :
"Upper case characters always contain a zero in bit five; lower case alphabetic characters always contain a one in bit five. You
can use this fact to quickly convert between upper and lower case. If you have an upper
case character you can force it to lower case by setting bit five to one." 