### PR TITLE
privacy: Refactor top-level visiting in `TypePrivacyVisitor`

### DIFF
--- a/tests/ui/privacy/private-type-in-interface.rs
+++ b/tests/ui/privacy/private-type-in-interface.rs
@@ -26,6 +26,7 @@ type A = <m::Alias as m::Trait>::X; //~ ERROR type `Priv` is private
 trait Tr2<T> {}
 impl<T> Tr2<T> for u8 {}
 fn g() -> impl Tr2<m::Alias> { 0 } //~ ERROR type `Priv` is private
+                                   //~| ERROR type `Priv` is private
 fn g_ext() -> impl Tr2<ext::Alias> { 0 } //~ ERROR type `ext::Priv` is private
-
+                                         //~| ERROR type `ext::Priv` is private
 fn main() {}

--- a/tests/ui/privacy/private-type-in-interface.stderr
+++ b/tests/ui/privacy/private-type-in-interface.stderr
@@ -46,11 +46,23 @@ error: type `Priv` is private
 LL | fn g() -> impl Tr2<m::Alias> { 0 }
    |           ^^^^^^^^^^^^^^^^^^ private type
 
+error: type `Priv` is private
+  --> $DIR/private-type-in-interface.rs:28:16
+   |
+LL | fn g() -> impl Tr2<m::Alias> { 0 }
+   |                ^^^^^^^^^^^^^ private type
+
 error: type `ext::Priv` is private
-  --> $DIR/private-type-in-interface.rs:29:15
+  --> $DIR/private-type-in-interface.rs:30:15
    |
 LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
    |               ^^^^^^^^^^^^^^^^^^^^ private type
 
-error: aborting due to 9 previous errors
+error: type `ext::Priv` is private
+  --> $DIR/private-type-in-interface.rs:30:20
+   |
+LL | fn g_ext() -> impl Tr2<ext::Alias> { 0 }
+   |                    ^^^^^^^^^^^^^^^ private type
+
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Full hierarchical visiting (`nested_filter::All`) is not necessary, visiting all item-likes in isolation is enough.
Tracking current item is not necessary, just keeping the current `mod` item is enough.
`visit_generic_arg` should behave like its default version, including checking types of const arguments.
Some comments, including FIXMEs, are also added.

Noticed while reading code to review https://github.com/rust-lang/rust/pull/113671.
r? @oli-obk 