### PR TITLE
Remove extra # from url in suggestion

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3155,7 +3155,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 } else {
                     // FIXME: we may suggest array::repeat instead
                     err.help("consider using `core::array::from_fn` to initialize the array");
-                    err.help("see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information");
+                    err.help("see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information");
                 }
 
                 if self.tcx.sess.is_nightly_build()

--- a/tests/ui/array-slice-vec/repeat_empty_ok.stderr
+++ b/tests/ui/array-slice-vec/repeat_empty_ok.stderr
@@ -6,7 +6,7 @@ LL |     let headers = [Header{value: &[]}; 128];
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Header<'_>` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]
@@ -21,7 +21,7 @@ LL |     let headers = [Header{value: &[0]}; 128];
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Header<'_>` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/const-generics/issues/issue-61336-2.stderr
+++ b/tests/ui/const-generics/issues/issue-61336-2.stderr
@@ -6,7 +6,7 @@ LL |     [x; { N }]
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider restricting type parameter `T`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {

--- a/tests/ui/const-generics/issues/issue-61336.stderr
+++ b/tests/ui/const-generics/issues/issue-61336.stderr
@@ -6,7 +6,7 @@ LL |     [x; N]
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider restricting type parameter `T`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {

--- a/tests/ui/consts/const-blocks/migrate-fail.stderr
+++ b/tests/ui/consts/const-blocks/migrate-fail.stderr
@@ -7,7 +7,7 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]
@@ -23,7 +23,7 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/consts/const-blocks/nll-fail.stderr
+++ b/tests/ui/consts/const-blocks/nll-fail.stderr
@@ -7,7 +7,7 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]
@@ -23,7 +23,7 @@ LL |         let arr: [Option<Bar>; 2] = [x; 2];
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Bar` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/repeat-expr/repeat-to-run-dtor-twice.stderr
+++ b/tests/ui/repeat-expr/repeat-to-run-dtor-twice.stderr
@@ -6,7 +6,7 @@ LL |     let _ = [ a; 5 ];
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 help: consider annotating `Foo` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/trait-bounds/issue-119530-sugg-from-fn.stderr
+++ b/tests/ui/trait-bounds/issue-119530-sugg-from-fn.stderr
@@ -6,7 +6,7 @@ LL |     let string_arr = [foo(); 64];
    |
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
-   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html# for more information
+   = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
The suggestion added in #119805 contains an unnecessary # hash sign.