### PR TITLE
Deduplicate more sized errors on call exprs

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -77,6 +77,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     callee_expr,
                     Expectation::NoExpectation,
                     arg_exprs,
+                    Some(call_expr),
                 ),
             _ => self.check_expr(callee_expr),
         };

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -177,7 +177,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &'tcx hir::Expr<'tcx>,
         expected: Expectation<'tcx>,
     ) -> Ty<'tcx> {
-        self.check_expr_with_expectation_and_args(expr, expected, &[])
+        self.check_expr_with_expectation_and_args(expr, expected, &[], None)
     }
 
     /// Same as `check_expr_with_expectation`, but allows us to pass in the arguments of a
@@ -187,6 +187,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr: &'tcx hir::Expr<'tcx>,
         expected: Expectation<'tcx>,
         args: &'tcx [hir::Expr<'tcx>],
+        call: Option<&'tcx hir::Expr<'tcx>>,
     ) -> Ty<'tcx> {
         if self.tcx().sess.verbose_internals() {
             // make this code only run with -Zverbose-internals because it is probably slow
@@ -233,7 +234,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let ty = ensure_sufficient_stack(|| match &expr.kind {
             hir::ExprKind::Path(
                 qpath @ (hir::QPath::Resolved(..) | hir::QPath::TypeRelative(..)),
-            ) => self.check_expr_path(qpath, expr, args),
+            ) => self.check_expr_path(qpath, expr, args, call),
             _ => self.check_expr_kind(expr, expected),
         });
         let ty = self.resolve_vars_if_possible(ty);
@@ -300,7 +301,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ExprKind::Path(QPath::LangItem(lang_item, _)) => {
                 self.check_lang_item_path(lang_item, expr)
             }
-            ExprKind::Path(ref qpath) => self.check_expr_path(qpath, expr, &[]),
+            ExprKind::Path(ref qpath) => self.check_expr_path(qpath, expr, &[], None),
             ExprKind::InlineAsm(asm) => {
                 // We defer some asm checks as we may not have resolved the input and output types yet (they may still be infer vars).
                 self.deferred_asm_checks.borrow_mut().push((asm, expr.hir_id));
@@ -514,6 +515,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         qpath: &'tcx hir::QPath<'tcx>,
         expr: &'tcx hir::Expr<'tcx>,
         args: &'tcx [hir::Expr<'tcx>],
+        call: Option<&'tcx hir::Expr<'tcx>>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let (res, opt_ty, segs) =
@@ -530,7 +532,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let e = report_unexpected_variant_res(tcx, res, qpath, expr.span, "E0533", "value");
                 Ty::new_error(tcx, e)
             }
-            _ => self.instantiate_value_path(segs, opt_ty, res, expr.span, expr.hir_id).0,
+            _ => {
+                self.instantiate_value_path(
+                    segs,
+                    opt_ty,
+                    res,
+                    call.map_or(expr.span, |e| e.span),
+                    expr.span,
+                    expr.hir_id,
+                )
+                .0
+            }
         };
 
         if let ty::FnDef(did, _) = *ty.kind() {
@@ -585,7 +597,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 infer::BoundRegionConversionTime::FnCall,
                 fn_sig.output(),
             );
-            self.require_type_is_sized_deferred(output, expr.span, traits::SizedReturnType);
+            self.require_type_is_sized_deferred(
+                output,
+                call.map_or(expr.span, |e| e.span),
+                traits::SizedCallReturnType,
+            );
         }
 
         // We always require that the type provided as the value for

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1073,6 +1073,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self_ty: Option<LoweredTy<'tcx>>,
         res: Res,
         span: Span,
+        path_span: Span,
         hir_id: hir::HirId,
     ) -> (Ty<'tcx>, Res) {
         let tcx = self.tcx;
@@ -1106,7 +1107,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 match container {
                     ty::TraitContainer => callee::check_legal_trait_for_method_call(
                         tcx,
-                        span,
+                        path_span,
                         None,
                         span,
                         container_id,

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -923,7 +923,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Type-check the path.
         let (pat_ty, pat_res) =
-            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id);
+            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.span, pat.hir_id);
         if let Some(err) =
             self.demand_suptype_with_origin(&self.pattern_cause(ti, pat.span), expected, pat_ty)
         {
@@ -1078,7 +1078,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Type-check the path.
         let (pat_ty, res) =
-            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.hir_id);
+            self.instantiate_value_path(segments, opt_ty, res, pat.span, pat.span, pat.hir_id);
         if !pat_ty.is_fn() {
             let e = report_unexpected_res(res);
             return Ty::new_error(tcx, e);

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -292,6 +292,8 @@ pub enum ObligationCauseCode<'tcx> {
     SizedArgumentType(Option<hir::HirId>),
     /// Return type must be `Sized`.
     SizedReturnType,
+    /// Return type of a call expression must be `Sized`.
+    SizedCallReturnType,
     /// Yield type must be `Sized`.
     SizedYieldType,
     /// Inline asm operand type must be `Sized`.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3294,7 +3294,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     err.help("unsized fn params are gated as an unstable feature");
                 }
             }
-            ObligationCauseCode::SizedReturnType => {
+            ObligationCauseCode::SizedReturnType | ObligationCauseCode::SizedCallReturnType => {
                 err.note("the return type of a function must have a statically known size");
             }
             ObligationCauseCode::SizedYieldType => {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2493,7 +2493,15 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     expr_finder.visit_expr(self.tcx.hir().body(body_id).value);
 
                     if let Some(hir::Expr {
-                        kind: hir::ExprKind::Path(hir::QPath::Resolved(None, path)),
+                        kind:
+                            hir::ExprKind::Call(
+                                hir::Expr {
+                                    kind: hir::ExprKind::Path(hir::QPath::Resolved(None, path)),
+                                    ..
+                                },
+                                _,
+                            )
+                            | hir::ExprKind::Path(hir::QPath::Resolved(None, path)),
                         ..
                     }) = expr_finder.result
                         && let [

--- a/tests/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/tests/ui/anonymous-higher-ranked-lifetime.stderr
@@ -2,8 +2,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:2:5
    |
 LL |     f1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a, 'b> fn(&'a (), &'b ()) -> _`
@@ -22,8 +23,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:3:5
    |
 LL |     f2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a, 'b> fn(&'a (), &'b ()) -> _`
@@ -42,8 +44,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
    |
 LL |     f3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&(), &'a ()) -> _`
@@ -62,8 +65,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:5:5
    |
 LL |     f4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'r, 'a> fn(&'a (), &'r ()) -> _`
@@ -82,8 +86,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
    |
 LL |     f5(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'r> fn(&'r (), &'r ()) -> _`
@@ -102,8 +107,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:7:5
    |
 LL |     g1(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>) -> _`
@@ -122,8 +128,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
    |
 LL |     g2(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a (), for<'a> fn(&'a ())) -> _`
@@ -142,8 +149,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:9:5
    |
 LL |     g3(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'s> fn(&'s (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>) -> _`
@@ -162,8 +170,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
    |
 LL |     g4(|_: (), _: ()| {});
-   |     ^^ -------------- found signature defined here
-   |     |
+   |     ^^^--------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a> fn(&'a (), for<'r> fn(&'r ())) -> _`
@@ -182,8 +191,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:11:5
    |
 LL |     h1(|_: (), _: (), _: (), _: ()| {});
-   |     ^^ ---------------------------- found signature defined here
-   |     |
+   |     ^^^----------------------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'a, 'b> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'b (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
@@ -202,8 +212,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
    |
 LL |     h2(|_: (), _: (), _: (), _: ()| {});
-   |     ^^ ---------------------------- found signature defined here
-   |     |
+   |     ^^^----------------------------^^^^
+   |     |  |
+   |     |  found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `for<'t0, 'a> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`

--- a/tests/ui/associated-types/associated-types-path-2.rs
+++ b/tests/ui/associated-types/associated-types-path-2.rs
@@ -29,13 +29,11 @@ pub fn f1_uint_uint() {
     f1(2u32, 4u32);
     //~^ ERROR `u32: Foo` is not satisfied
     //~| ERROR `u32: Foo` is not satisfied
-    //~| ERROR `u32: Foo` is not satisfied
 }
 
 pub fn f1_uint_int() {
     f1(2u32, 4i32);
     //~^ ERROR `u32: Foo` is not satisfied
-    //~| ERROR `u32: Foo` is not satisfied
     //~| ERROR `u32: Foo` is not satisfied
 }
 

--- a/tests/ui/associated-types/associated-types-path-2.stderr
+++ b/tests/ui/associated-types/associated-types-path-2.stderr
@@ -32,14 +32,6 @@ LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:29:5
-   |
-LL |     f1(2u32, 4u32);
-   |     ^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `u32`
-   |
-   = help: the trait `Foo` is implemented for `i32`
-
-error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:14
    |
 LL |     f1(2u32, 4u32);
@@ -48,7 +40,7 @@ LL |     f1(2u32, 4u32);
    = help: the trait `Foo` is implemented for `i32`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:36:8
+  --> $DIR/associated-types-path-2.rs:35:8
    |
 LL |     f1(2u32, 4i32);
    |     -- ^^^^ the trait `Foo` is not implemented for `u32`
@@ -63,15 +55,7 @@ LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:36:5
-   |
-LL |     f1(2u32, 4i32);
-   |     ^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `u32`
-   |
-   = help: the trait `Foo` is implemented for `i32`
-
-error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:36:14
+  --> $DIR/associated-types-path-2.rs:35:14
    |
 LL |     f1(2u32, 4i32);
    |              ^^^^ the trait `Foo` is not implemented for `u32`
@@ -79,7 +63,7 @@ LL |     f1(2u32, 4i32);
    = help: the trait `Foo` is implemented for `i32`
 
 error[E0308]: mismatched types
-  --> $DIR/associated-types-path-2.rs:43:18
+  --> $DIR/associated-types-path-2.rs:41:18
    |
 LL |     let _: i32 = f2(2i32);
    |            ---   ^^^^^^^^ expected `i32`, found `u32`
@@ -91,7 +75,7 @@ help: you can convert a `u32` to an `i32` and panic if the converted value doesn
 LL |     let _: i32 = f2(2i32).try_into().unwrap();
    |                          ++++++++++++++++++++
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-types-unconstrained.stderr
+++ b/tests/ui/associated-types/associated-types-unconstrained.stderr
@@ -5,7 +5,7 @@ LL |     fn bar() -> isize;
    |     ------------------ `Foo::bar` defined here
 ...
 LL |     let x: isize = Foo::bar();
-   |                    ^^^^^^^^ cannot call associated function of trait
+   |                    ^^^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |

--- a/tests/ui/async-await/async-is-unwindsafe.stderr
+++ b/tests/ui/async-await/async-is-unwindsafe.stderr
@@ -1,17 +1,19 @@
 error[E0277]: the type `&mut Context<'_>` may not be safely transferred across an unwind boundary
   --> $DIR/async-is-unwindsafe.rs:12:5
    |
-LL |       is_unwindsafe(async {
-   |  _____^^^^^^^^^^^^^_-
-   | |     |
-   | |     `&mut Context<'_>` may not be safely transferred across an unwind boundary
-LL | |
-LL | |         use std::ptr::null;
-LL | |         use std::task::{Context, RawWaker, RawWakerVTable, Waker};
-...  |
-LL | |         drop(cx_ref);
-LL | |     });
-   | |_____- within this `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`
+LL |        is_unwindsafe(async {
+   |   _____^_____________-
+   |  |_____|
+   | ||
+LL | ||
+LL | ||         use std::ptr::null;
+LL | ||         use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+...  ||
+LL | ||         drop(cx_ref);
+LL | ||     });
+   | ||_____-^ `&mut Context<'_>` may not be safely transferred across an unwind boundary
+   |  |_____|
+   |        within this `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`
    |
    = help: within `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`, the trait `UnwindSafe` is not implemented for `&mut Context<'_>`
    = note: `UnwindSafe` is implemented for `&Context<'_>`, but not for `&mut Context<'_>`

--- a/tests/ui/async-await/issue-67252-unnamed-future.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.stderr
@@ -1,8 +1,12 @@
 error: future cannot be sent between threads safely
   --> $DIR/issue-67252-unnamed-future.rs:18:5
    |
-LL |     spawn(async {
-   |     ^^^^^ future created by async block is not `Send`
+LL | /     spawn(async {
+LL | |         let a = std::ptr::null_mut::<()>(); // `*mut ()` is not `Send`
+LL | |         AFuture.await;
+LL | |         let _a = a;
+LL | |     });
+   | |______^ future created by async block is not `Send`
    |
    = help: within `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 22:6}`, the trait `Send` is not implemented for `*mut ()`
 note: future is not `Send` as this value is used across an await

--- a/tests/ui/async-await/issue-68112.stderr
+++ b/tests/ui/async-await/issue-68112.stderr
@@ -2,7 +2,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-68112.rs:34:5
    |
 LL |     require_send(send_fut);
-   |     ^^^^^^^^^^^^ future created by async block is not `Send`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
@@ -21,7 +21,7 @@ error: future cannot be sent between threads safely
   --> $DIR/issue-68112.rs:43:5
    |
 LL |     require_send(send_fut);
-   |     ^^^^^^^^^^^^ future created by async block is not `Send`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
@@ -40,7 +40,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/issue-68112.rs:62:5
    |
 LL |     require_send(send_fut);
-   |     ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
+   |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead

--- a/tests/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/tests/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -1,10 +1,13 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
-LL |     with_closure(|x: u32, y: i32| {
-   |     ^^^^^^^^^^^^ ---------------- found signature defined here
-   |     |
-   |     expected due to this
+LL |       with_closure(|x: u32, y: i32| {
+   |       ^            ---------------- found signature defined here
+   |  _____|
+   | |
+LL | |
+LL | |     });
+   | |______^ expected due to this
    |
    = note: expected closure signature `fn(_, _) -> _`
               found closure signature `fn(u32, i32) -> _`

--- a/tests/ui/closures/closure-return-type-must-be-sized.stderr
+++ b/tests/ui/closures/closure-return-type-must-be-sized.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
   --> $DIR/closure-return-type-must-be-sized.rs:54:5
    |
 LL |     a::foo::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -25,7 +25,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
   --> $DIR/closure-return-type-must-be-sized.rs:56:5
    |
 LL |     a::baz::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -34,7 +34,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
   --> $DIR/closure-return-type-must-be-sized.rs:61:5
    |
 LL |     b::foo::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -57,7 +57,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
   --> $DIR/closure-return-type-must-be-sized.rs:63:5
    |
 LL |     b::baz::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -66,7 +66,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
   --> $DIR/closure-return-type-must-be-sized.rs:68:5
    |
 LL |     c::foo::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`
@@ -89,7 +89,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
   --> $DIR/closure-return-type-must-be-sized.rs:70:5
    |
 LL |     c::baz::<fn() -> dyn A>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
    = note: required because it appears within the type `fn() -> dyn A`

--- a/tests/ui/closures/multiple-fn-bounds.stderr
+++ b/tests/ui/closures/multiple-fn-bounds.stderr
@@ -2,8 +2,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/multiple-fn-bounds.rs:10:5
    |
 LL |     foo(move |x| v);
-   |     ^^^ -------- found signature defined here
-   |     |
+   |     ^^^^--------^^^
+   |     |   |
+   |     |   found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `fn(_) -> _`

--- a/tests/ui/const-generics/ensure_is_evaluatable.stderr
+++ b/tests/ui/const-generics/ensure_is_evaluatable.stderr
@@ -2,7 +2,7 @@ error: unconstrained generic constant
   --> $DIR/ensure_is_evaluatable.rs:9:5
    |
 LL |     bar()
-   |     ^^^
+   |     ^^^^^
    |
    = help: try adding a `where` bound using this expression: `where [(); N + 1]:`
 note: required by a bound in `bar`

--- a/tests/ui/const-generics/fn_with_two_const_inputs.stderr
+++ b/tests/ui/const-generics/fn_with_two_const_inputs.stderr
@@ -2,7 +2,7 @@ error: unconstrained generic constant
   --> $DIR/fn_with_two_const_inputs.rs:12:5
    |
 LL |     bar()
-   |     ^^^
+   |     ^^^^^
    |
    = help: try adding a `where` bound using this expression: `where [(); N + 1]:`
 note: required by a bound in `bar`

--- a/tests/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed for `Mask<_, N>`
   --> $DIR/issue-91614.rs:6:9
    |
 LL |     let y = Mask::<_, _>::splat(false);
-   |         ^   ------------------- type must be known at this point
+   |         ^   -------------------------- type must be known at this point
    |
    = note: cannot satisfy `_: MaskElement`
    = help: the following types implement trait `MaskElement`:

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
@@ -20,7 +20,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:17:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as u128 }`, found `{ O as u128 }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as u128 }`, found `{ O as u128 }`
    |
    = note: expected constant `{ N as u128 }`
               found constant `{ O as u128 }`
@@ -52,7 +52,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:20:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as _ }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as _ }`, found `{ O as u128 }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as _ }`, found `{ O as u128 }`
    |
    = note: expected constant `{ N as _ }`
               found constant `{ O as u128 }`
@@ -66,7 +66,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:23:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<13, { 12 as u128 }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12`, found `13`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12`, found `13`
    |
    = note: expected constant `12`
               found constant `13`
@@ -80,7 +80,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:25:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13`, found `14`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13`, found `14`
    |
    = note: expected constant `13`
               found constant `14`
@@ -112,7 +112,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:35:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as u128 }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as u128 }`, found `{ O as u128 }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as u128 }`, found `{ O as u128 }`
    |
    = note: expected constant `{ N as u128 }`
               found constant `{ O as u128 }`
@@ -144,7 +144,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:38:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<{ N + 1 }, { N as _ }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as _ }`, found `{ O as u128 }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{ N as _ }`, found `{ O as u128 }`
    |
    = note: expected constant `{ N as _ }`
               found constant `{ O as u128 }`
@@ -158,7 +158,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:41:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<13, { 12 as u128 }>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12`, found `13`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `12`, found `13`
    |
    = note: expected constant `12`
               found constant `13`
@@ -172,7 +172,7 @@ error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:43:5
    |
 LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13`, found `14`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `13`, found `14`
    |
    = note: expected constant `13`
               found constant `14`

--- a/tests/ui/const-generics/generic_const_exprs/issue-85848.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-85848.stderr
@@ -58,7 +58,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-85848.rs:24:5
    |
 LL |     writes_to_specific_path(&cap);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected `true`, found `{ contains::<T, U>() }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `true`, found `{ contains::<T, U>() }`
    |
    = note: expected constant `true`
               found constant `{ contains::<T, U>() }`

--- a/tests/ui/const-generics/generic_const_exprs/obligation-cause.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/obligation-cause.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/obligation-cause.rs:20:5
    |
 LL |     g::<usize>();
-   |     ^^^^^^^^^^ expected `false`, found `true`
+   |     ^^^^^^^^^^^^ expected `false`, found `true`
    |
    = note: expected constant `false`
               found constant `true`

--- a/tests/ui/const-generics/issues/issue-79674.stderr
+++ b/tests/ui/const-generics/issues/issue-79674.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-79674.rs:26:5
    |
 LL |     requires_distinct("str", 12);
-   |     ^^^^^^^^^^^^^^^^^ expected `true`, found `false`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `true`, found `false`
    |
    = note: expected constant `true`
               found constant `false`

--- a/tests/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
+++ b/tests/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
@@ -2,7 +2,7 @@ error[E0284]: type annotations needed
   --> $DIR/parent_generics_of_encoding_impl_trait.rs:9:5
    |
 LL |     generics_of_parent_impl_trait::foo([()]);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `foo`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `foo`
    |
 note: required by a bound in `foo`
   --> $DIR/auxiliary/generics_of_parent_impl_trait.rs:6:48

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -11,7 +11,7 @@ error[E0790]: cannot call associated function on trait without specifying the co
   --> $DIR/issue-54954.rs:1:24
    |
 LL |   const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
 ...
 LL | /     const fn const_val<T: Sized>() -> usize {
 LL | |

--- a/tests/ui/coroutine/clone-impl.stderr
+++ b/tests/ui/coroutine/clone-impl.stderr
@@ -5,7 +5,7 @@ LL |     let gen_clone_0 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<u32>`
    |
 note: captured value does not implement `Copy`
   --> $DIR/clone-impl.rs:40:14
@@ -25,7 +25,7 @@ LL |     let gen_clone_0 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<char>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<char>`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
   --> $DIR/clone-impl.rs:38:9
@@ -47,7 +47,7 @@ LL |     let gen_clone_1 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<u32>`
    |
 note: captured value does not implement `Copy`
   --> $DIR/clone-impl.rs:56:14
@@ -67,7 +67,7 @@ LL |     let gen_clone_1 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<char>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<char>`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
   --> $DIR/clone-impl.rs:52:9
@@ -90,7 +90,7 @@ LL |     let gen_non_clone = move || {
    |                         ------- within this `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`
 ...
 LL |     check_copy(&gen_non_clone);
-   |     ^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Copy` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Copy` is not implemented for `NonClone`
    |
 note: captured value does not implement `Copy`
   --> $DIR/clone-impl.rs:64:14
@@ -115,7 +115,7 @@ LL |     let gen_non_clone = move || {
    |                         ------- within this `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`
 ...
 LL |     check_clone(&gen_non_clone);
-   |     ^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Clone` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Clone` is not implemented for `NonClone`
    |
 note: captured value does not implement `Clone`
   --> $DIR/clone-impl.rs:64:14

--- a/tests/ui/coroutine/drop-tracking-parent-expression.stderr
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.stderr
@@ -2,7 +2,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/drop-tracking-parent-expression.rs:23:13
    |
 LL |               assert_send(g);
-   |               ^^^^^^^^^^^ coroutine is not `Send`
+   |               ^^^^^^^^^^^^^^ coroutine is not `Send`
 ...
 LL | /     type_combinations!(
 LL | |         // OK
@@ -42,7 +42,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/drop-tracking-parent-expression.rs:23:13
    |
 LL |               assert_send(g);
-   |               ^^^^^^^^^^^ coroutine is not `Send`
+   |               ^^^^^^^^^^^^^^ coroutine is not `Send`
 ...
 LL | /     type_combinations!(
 LL | |         // OK
@@ -82,7 +82,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/drop-tracking-parent-expression.rs:23:13
    |
 LL |               assert_send(g);
-   |               ^^^^^^^^^^^ coroutine is not `Send`
+   |               ^^^^^^^^^^^^^^ coroutine is not `Send`
 ...
 LL | /     type_combinations!(
 LL | |         // OK

--- a/tests/ui/coroutine/drop-yield-twice.stderr
+++ b/tests/ui/coroutine/drop-yield-twice.stderr
@@ -1,8 +1,13 @@
 error: coroutine cannot be sent between threads safely
   --> $DIR/drop-yield-twice.rs:7:5
    |
-LL |     assert_send(|| {
-   |     ^^^^^^^^^^^ coroutine is not `Send`
+LL | /     assert_send(|| {
+LL | |         let guard = Foo(42);
+LL | |         yield;
+LL | |         drop(guard);
+LL | |         yield;
+LL | |     })
+   | |______^ coroutine is not `Send`
    |
    = help: within `{coroutine@$DIR/drop-yield-twice.rs:7:17: 7:19}`, the trait `Send` is not implemented for `Foo`
 note: coroutine is not `Send` as this value is used across a yield

--- a/tests/ui/coroutine/issue-105084.stderr
+++ b/tests/ui/coroutine/issue-105084.stderr
@@ -29,7 +29,7 @@ LL |     let mut g = || {
    |                 -- within this `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`
 ...
 LL |     let mut h = copy(g);
-   |                 ^^^^ within `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`, the trait `Copy` is not implemented for `Box<(i32, ())>`
+   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`, the trait `Copy` is not implemented for `Box<(i32, ())>`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
   --> $DIR/issue-105084.rs:21:22

--- a/tests/ui/coroutine/issue-68112.stderr
+++ b/tests/ui/coroutine/issue-68112.stderr
@@ -2,7 +2,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/issue-68112.rs:40:5
    |
 LL |     require_send(send_gen);
-   |     ^^^^^^^^^^^^ coroutine is not `Send`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ coroutine is not `Send`
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
@@ -24,7 +24,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/issue-68112.rs:64:5
    |
 LL |     require_send(send_gen);
-   |     ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
+   |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead

--- a/tests/ui/coroutine/not-send-sync.stderr
+++ b/tests/ui/coroutine/not-send-sync.stderr
@@ -1,8 +1,13 @@
 error: coroutine cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:14:5
    |
-LL |     assert_sync(|| {
-   |     ^^^^^^^^^^^ coroutine is not `Sync`
+LL | /     assert_sync(|| {
+LL | |
+LL | |         let a = NotSync;
+LL | |         yield;
+LL | |         drop(a);
+LL | |     });
+   | |______^ coroutine is not `Sync`
    |
    = help: within `{coroutine@$DIR/not-send-sync.rs:14:17: 14:19}`, the trait `Sync` is not implemented for `NotSync`
 note: coroutine is not `Sync` as this value is used across a yield
@@ -21,8 +26,13 @@ LL |     fn assert_sync<T: Sync>(_: T) {}
 error: coroutine cannot be sent between threads safely
   --> $DIR/not-send-sync.rs:21:5
    |
-LL |     assert_send(|| {
-   |     ^^^^^^^^^^^ coroutine is not `Send`
+LL | /     assert_send(|| {
+LL | |
+LL | |         let a = NotSend;
+LL | |         yield;
+LL | |         drop(a);
+LL | |     });
+   | |______^ coroutine is not `Send`
    |
    = help: within `{coroutine@$DIR/not-send-sync.rs:21:17: 21:19}`, the trait `Send` is not implemented for `NotSend`
 note: coroutine is not `Send` as this value is used across a yield

--- a/tests/ui/coroutine/parent-expression.stderr
+++ b/tests/ui/coroutine/parent-expression.stderr
@@ -2,7 +2,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/parent-expression.rs:23:13
    |
 LL |               assert_send(g);
-   |               ^^^^^^^^^^^ coroutine is not `Send`
+   |               ^^^^^^^^^^^^^^ coroutine is not `Send`
 ...
 LL | /     type_combinations!(
 LL | |         // OK
@@ -42,7 +42,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/parent-expression.rs:23:13
    |
 LL |               assert_send(g);
-   |               ^^^^^^^^^^^ coroutine is not `Send`
+   |               ^^^^^^^^^^^^^^ coroutine is not `Send`
 ...
 LL | /     type_combinations!(
 LL | |         // OK
@@ -82,7 +82,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/parent-expression.rs:23:13
    |
 LL |               assert_send(g);
-   |               ^^^^^^^^^^^ coroutine is not `Send`
+   |               ^^^^^^^^^^^^^^ coroutine is not `Send`
 ...
 LL | /     type_combinations!(
 LL | |         // OK

--- a/tests/ui/coroutine/print/coroutine-print-verbose-1.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-1.stderr
@@ -2,7 +2,7 @@ error: coroutine cannot be sent between threads safely
   --> $DIR/coroutine-print-verbose-1.rs:37:5
    |
 LL |     require_send(send_gen);
-   |     ^^^^^^^^^^^^ coroutine is not `Send`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ coroutine is not `Send`
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
@@ -23,7 +23,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
   --> $DIR/coroutine-print-verbose-1.rs:56:5
    |
 LL |     require_send(send_gen);
-   |     ^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
+   |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `RefCell<i32>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -1,8 +1,13 @@
 error: coroutine cannot be shared between threads safely
   --> $DIR/coroutine-print-verbose-2.rs:17:5
    |
-LL |     assert_sync(|| {
-   |     ^^^^^^^^^^^ coroutine is not `Sync`
+LL | /     assert_sync(|| {
+LL | |
+LL | |         let a = NotSync;
+LL | |         yield;
+LL | |         drop(a);
+LL | |     });
+   | |______^ coroutine is not `Sync`
    |
    = help: within `{main::{closure#0} upvar_tys=() witness={main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`
 note: coroutine is not `Sync` as this value is used across a yield
@@ -21,8 +26,13 @@ LL |     fn assert_sync<T: Sync>(_: T) {}
 error: coroutine cannot be sent between threads safely
   --> $DIR/coroutine-print-verbose-2.rs:24:5
    |
-LL |     assert_send(|| {
-   |     ^^^^^^^^^^^ coroutine is not `Send`
+LL | /     assert_send(|| {
+LL | |
+LL | |         let a = NotSend;
+LL | |         yield;
+LL | |         drop(a);
+LL | |     });
+   | |______^ coroutine is not `Send`
    |
    = help: within `{main::{closure#1} upvar_tys=() witness={main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`
 note: coroutine is not `Send` as this value is used across a yield

--- a/tests/ui/did_you_mean/recursion_limit.stderr
+++ b/tests/ui/did_you_mean/recursion_limit.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `J: Send`
   --> $DIR/recursion_limit.rs:34:5
    |
 LL |     is_send::<A>();
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "20"]` attribute to your crate (`recursion_limit`)
 note: required because it appears within the type `I`

--- a/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-not-suggestion-110063.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `[u8; 1]: Test` is not satisfied
   --> $DIR/issue-90528-unsizing-not-suggestion-110063.rs:11:22
    |
 LL |     let x: [u8; 1] = needs_test();
-   |                      ^^^^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
+   |                      ^^^^^^^^^^^^ the trait `Test` is not implemented for `[u8; 1]`
    |
    = help: the trait `Test` is implemented for `&[u8]`
 note: required by a bound in `needs_test`

--- a/tests/ui/error-codes/E0283.stderr
+++ b/tests/ui/error-codes/E0283.stderr
@@ -5,7 +5,7 @@ LL |     fn create() -> u32;
    |     ------------------- `Coroutine::create` defined here
 ...
 LL |     let cont: u32 = Coroutine::create();
-   |                     ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |                     ^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use a fully-qualified path to a specific available implementation
    |

--- a/tests/ui/error-codes/E0790.stderr
+++ b/tests/ui/error-codes/E0790.stderr
@@ -5,7 +5,7 @@ LL |         fn my_fn();
    |         ----------- `MyTrait::my_fn` defined here
 ...
 LL |         MyTrait::my_fn();
-   |         ^^^^^^^^^^^^^^ cannot call associated function of trait
+   |         ^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |
@@ -33,7 +33,7 @@ LL |         fn my_fn();
    |         ----------- `MyTrait::my_fn` defined here
 ...
 LL |     inner::MyTrait::my_fn();
-   |     ^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |
@@ -61,7 +61,7 @@ LL |     fn my_fn();
    |     ----------- `MyTrait2::my_fn` defined here
 ...
 LL |     MyTrait2::my_fn();
-   |     ^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |     ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use a fully-qualified path to a specific available implementation
    |

--- a/tests/ui/higher-ranked/trait-bounds/fn-ptr.classic.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/fn-ptr.classic.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `Fn(&'w ())` closure, found `fn(&'w ())`
   --> $DIR/fn-ptr.rs:12:5
    |
 LL |     ice();
-   |     ^^^ expected an `Fn(&'w ())` closure, found `fn(&'w ())`
+   |     ^^^^^ expected an `Fn(&'w ())` closure, found `fn(&'w ())`
    |
    = help: the trait `for<'w> Fn<(&'w (),)>` is not implemented for `fn(&'w ())`
 note: required by a bound in `ice`

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-85455.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-85455.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `for<'a> T: SomeTrait<'a>` is not satisfied
   --> $DIR/issue-85455.rs:8:5
    |
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> SomeTrait<'a>` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> SomeTrait<'a>` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution.stderr
@@ -2,13 +2,13 @@ error[E0277]: the trait bound `for<'a> <_ as Trait<'a>>::Out: Copy` is not satis
   --> $DIR/norm-before-method-resolution.rs:22:17
    |
 LL |     let _: () = weird_bound();
-   |                 ^^^^^^^^^^^ the trait `for<'a> Copy` is not implemented for `<_ as Trait<'a>>::Out`
+   |                 ^^^^^^^^^^^^^ the trait `for<'a> Copy` is not implemented for `<_ as Trait<'a>>::Out`
    |
 note: this is a known limitation of the trait solver that will be lifted in the future
   --> $DIR/norm-before-method-resolution.rs:22:17
    |
 LL |     let _: () = weird_bound();
-   |                 ^^^^^^^^^^^ try adding turbofish arguments to this expression to specify the types manually, even if it's redundant
+   |                 ^^^^^^^^^^^^^ try adding turbofish arguments to this expression to specify the types manually, even if it's redundant
 note: required by a bound in `weird_bound`
   --> $DIR/norm-before-method-resolution.rs:18:40
    |

--- a/tests/ui/impl-trait/cross-return-site-inference.stderr
+++ b/tests/ui/impl-trait/cross-return-site-inference.stderr
@@ -13,7 +13,7 @@ error[E0790]: cannot call associated function on trait without specifying the co
   --> $DIR/cross-return-site-inference.rs:38:16
    |
 LL |     return Err(From::from("foo"));
-   |                ^^^^^^^^^^ cannot call associated function of trait
+   |                ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use a fully-qualified path to a specific available implementation
    |
@@ -24,7 +24,7 @@ error[E0790]: cannot call associated function on trait without specifying the co
   --> $DIR/cross-return-site-inference.rs:44:9
    |
 LL |     Err(From::from("foo"))
-   |         ^^^^^^^^^^ cannot call associated function of trait
+   |         ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use a fully-qualified path to a specific available implementation
    |

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.rs
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.rs
@@ -20,7 +20,6 @@ impl dyn MyTrait {
         MyTrait::foo(&self)
         //~^ ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
         //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-        //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
         //~| ERROR the trait `MyTrait` cannot be made into an object
     }
 }

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.stderr
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.stderr
@@ -32,14 +32,6 @@ LL |         MyTrait::foo(&self)
    |
    = help: the trait `MyTrait` is implemented for `Outer`
 
-error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/cycle-effective-visibilities-during-object-safety.rs:20:9
-   |
-LL |         MyTrait::foo(&self)
-   |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
-   |
-   = help: the trait `MyTrait` is implemented for `Outer`
-
 error[E0038]: the trait `MyTrait` cannot be made into an object
   --> $DIR/cycle-effective-visibilities-during-object-safety.rs:16:6
    |
@@ -72,7 +64,7 @@ LL |     fn foo(&self) -> impl Marker;
    = help: consider moving `foo` to another trait
    = help: only type `Outer` implements the trait, consider using it directly instead
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0038, E0277.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/issue-102140.rs
+++ b/tests/ui/impl-trait/in-trait/issue-102140.rs
@@ -20,7 +20,6 @@ impl dyn MyTrait {
         MyTrait::foo(&self)
         //~^ ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
         //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-        //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
     }
 }
 

--- a/tests/ui/impl-trait/in-trait/issue-102140.stderr
+++ b/tests/ui/impl-trait/in-trait/issue-102140.stderr
@@ -20,14 +20,6 @@ LL |         MyTrait::foo(&self)
    |
    = help: the trait `MyTrait` is implemented for `Outer`
 
-error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-  --> $DIR/issue-102140.rs:20:9
-   |
-LL |         MyTrait::foo(&self)
-   |         ^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `&dyn MyTrait`
-   |
-   = help: the trait `MyTrait` is implemented for `Outer`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/inference/erase-type-params-in-label.stderr
+++ b/tests/ui/inference/erase-type-params-in-label.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed for `Foo<i32, &str, W, Z>`
   --> $DIR/erase-type-params-in-label.rs:2:9
    |
 LL |     let foo = foo(1, "");
-   |         ^^^   --- type must be known at this point
+   |         ^^^   ---------- type must be known at this point
    |
    = note: cannot satisfy `_: Default`
 note: required by a bound in `foo`
@@ -19,7 +19,7 @@ error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
   --> $DIR/erase-type-params-in-label.rs:5:9
    |
 LL |     let bar = bar(1, "");
-   |         ^^^   --- type must be known at this point
+   |         ^^^   ---------- type must be known at this point
    |
    = note: cannot satisfy `_: Default`
 note: required by a bound in `bar`

--- a/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
+++ b/tests/ui/inference/need_type_info/infer-var-for-self-param.stderr
@@ -2,7 +2,7 @@ error[E0790]: cannot call associated function on trait without specifying the co
   --> $DIR/infer-var-for-self-param.rs:5:14
    |
 LL |     let _ = (Default::default(),);
-   |              ^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |              ^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use a fully-qualified path to a specific available implementation
    |

--- a/tests/ui/inference/need_type_info/type-alias.stderr
+++ b/tests/ui/inference/need_type_info/type-alias.stderr
@@ -2,13 +2,13 @@ error[E0282]: type annotations needed
   --> $DIR/type-alias.rs:12:5
    |
 LL |     DirectAlias::new()
-   |     ^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |     ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
 error[E0282]: type annotations needed
   --> $DIR/type-alias.rs:32:5
    |
 LL |     DirectButWithDefaultAlias::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-56199.stderr
+++ b/tests/ui/issues/issue-56199.stderr
@@ -10,7 +10,7 @@ error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56199.rs:8:17
    |
 LL |         let _ = Self();
-   |                 ^^^^
+   |                 ^^^^^^
    |
    = help: did you mean to use one of the enum's variants?
 
@@ -24,7 +24,7 @@ error: the `Self` constructor can only be used with tuple or unit structs
   --> $DIR/issue-56199.rs:17:17
    |
 LL |         let _ = Self();
-   |                 ^^^^ help: use curly brackets: `Self { /* fields */ }`
+   |                 ^^^^^^ help: use curly brackets: `Self { /* fields */ }`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/iterators/issue-28098.rs
+++ b/tests/ui/iterators/issue-28098.rs
@@ -2,14 +2,12 @@ fn main() {
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
     //~| ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
 
     for _ in false {}
     //~^ ERROR `bool` is not an iterator
 
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
 
     other()
 }
@@ -20,11 +18,9 @@ pub fn other() {
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
     //~| ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
 
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
 
     for _ in false {}
     //~^ ERROR `bool` is not an iterator

--- a/tests/ui/iterators/issue-28098.stderr
+++ b/tests/ui/iterators/issue-28098.stderr
@@ -8,16 +8,8 @@ LL |     let _ = Iterator::next(&mut ());
    |
    = help: the trait `Iterator` is not implemented for `()`
 
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:2:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
 error[E0277]: `bool` is not an iterator
-  --> $DIR/issue-28098.rs:7:14
+  --> $DIR/issue-28098.rs:6:14
    |
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
@@ -26,20 +18,12 @@ LL |     for _ in false {}
    = note: required for `bool` to implement `IntoIterator`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:10:28
+  --> $DIR/issue-28098.rs:9:28
    |
 LL |     let _ = Iterator::next(&mut ());
    |             -------------- ^^^^^^^ `()` is not an iterator
    |             |
    |             required by a bound introduced by this call
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:10:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
 
@@ -47,12 +31,12 @@ error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:2:13
    |
 LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:28
+  --> $DIR/issue-28098.rs:18:28
    |
 LL |     let _ = Iterator::next(&mut ());
    |             -------------- ^^^^^^^ `()` is not an iterator
@@ -62,33 +46,17 @@ LL |     let _ = Iterator::next(&mut ());
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:25:28
+  --> $DIR/issue-28098.rs:22:28
    |
 LL |     let _ = Iterator::next(&mut ());
    |             -------------- ^^^^^^^ `()` is not an iterator
    |             |
    |             required by a bound introduced by this call
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:25:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
 
 error[E0277]: `bool` is not an iterator
-  --> $DIR/issue-28098.rs:29:14
+  --> $DIR/issue-28098.rs:25:14
    |
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
@@ -97,13 +65,13 @@ LL |     for _ in false {}
    = note: required for `bool` to implement `IntoIterator`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:13
+  --> $DIR/issue-28098.rs:18:13
    |
 LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `()`
 
-error: aborting due to 12 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/E0631.stderr
+++ b/tests/ui/mismatched_types/E0631.stderr
@@ -2,8 +2,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
 LL |     foo(|_: isize| {});
-   |     ^^^ ---------- found signature defined here
-   |     |
+   |     ^^^^----------^^^^
+   |     |   |
+   |     |   found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `fn(usize) -> _`
@@ -18,8 +19,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
 LL |     bar(|_: isize| {});
-   |     ^^^ ---------- found signature defined here
-   |     |
+   |     ^^^^----------^^^^
+   |     |   |
+   |     |   found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `fn(usize) -> _`

--- a/tests/ui/mismatched_types/closure-arg-count.stderr
+++ b/tests/ui/mismatched_types/closure-arg-count.stderr
@@ -49,8 +49,9 @@ error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:13:5
    |
 LL |     f(|| panic!());
-   |     ^ -- takes 0 arguments
-   |     |
+   |     ^^--^^^^^^^^^^
+   |     | |
+   |     | takes 0 arguments
    |     expected closure that takes 1 argument
    |
 note: required by a bound in `f`
@@ -67,8 +68,9 @@ error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
    |
 LL |     f(  move    || panic!());
-   |     ^   ---------- takes 0 arguments
-   |     |
+   |     ^^^^----------^^^^^^^^^^
+   |     |   |
+   |     |   takes 0 arguments
    |     expected closure that takes 1 argument
    |
 note: required by a bound in `f`

--- a/tests/ui/on-unimplemented/multiple-impls.rs
+++ b/tests/ui/on-unimplemented/multiple-impls.rs
@@ -33,13 +33,10 @@ fn main() {
     Index::index(&[] as &[i32], 2u32);
     //~^ ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
     Index::index(&[] as &[i32], Foo(2u32));
     //~^ ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
     Index::index(&[] as &[i32], Bar(2u32));
     //~^ ERROR E0277
-    //~| ERROR E0277
     //~| ERROR E0277
 }

--- a/tests/ui/on-unimplemented/multiple-impls.stderr
+++ b/tests/ui/on-unimplemented/multiple-impls.stderr
@@ -11,6 +11,32 @@ LL |     Index::index(&[] as &[i32], 2u32);
              <[i32] as Index<Foo<usize>>>
              <[i32] as Index<Bar<usize>>>
 
+error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
+  --> $DIR/multiple-impls.rs:36:33
+   |
+LL |     Index::index(&[] as &[i32], Foo(2u32));
+   |     ------------                ^^^^^^^^^ on impl for Foo
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
+   = help: the following other types implement trait `Index<Idx>`:
+             <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
+
+error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
+  --> $DIR/multiple-impls.rs:39:33
+   |
+LL |     Index::index(&[] as &[i32], Bar(2u32));
+   |     ------------                ^^^^^^^^^ on impl for Bar
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
+   = help: the following other types implement trait `Index<Idx>`:
+             <[i32] as Index<Foo<usize>>>
+             <[i32] as Index<Bar<usize>>>
+
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
    |
@@ -23,20 +49,7 @@ LL |     Index::index(&[] as &[i32], 2u32);
              <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:37:33
-   |
-LL |     Index::index(&[] as &[i32], Foo(2u32));
-   |     ------------                ^^^^^^^^^ on impl for Foo
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Foo<usize>>>
-             <[i32] as Index<Bar<usize>>>
-
-error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:37:5
+  --> $DIR/multiple-impls.rs:36:5
    |
 LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Foo
@@ -47,20 +60,7 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
              <[i32] as Index<Bar<usize>>>
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:41:33
-   |
-LL |     Index::index(&[] as &[i32], Bar(2u32));
-   |     ------------                ^^^^^^^^^ on impl for Bar
-   |     |
-   |     required by a bound introduced by this call
-   |
-   = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Foo<usize>>>
-             <[i32] as Index<Bar<usize>>>
-
-error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:41:5
+  --> $DIR/multiple-impls.rs:39:5
    |
 LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Bar
@@ -70,39 +70,6 @@ LL |     Index::index(&[] as &[i32], Bar(2u32));
              <[i32] as Index<Foo<usize>>>
              <[i32] as Index<Bar<usize>>>
 
-error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
-  --> $DIR/multiple-impls.rs:33:5
-   |
-LL |     Index::index(&[] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^ trait message
-   |
-   = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Foo<usize>>>
-             <[i32] as Index<Bar<usize>>>
-
-error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:37:5
-   |
-LL |     Index::index(&[] as &[i32], Foo(2u32));
-   |     ^^^^^^^^^^^^ on impl for Foo
-   |
-   = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Foo<usize>>>
-             <[i32] as Index<Bar<usize>>>
-
-error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:41:5
-   |
-LL |     Index::index(&[] as &[i32], Bar(2u32));
-   |     ^^^^^^^^^^^^ on impl for Bar
-   |
-   = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-   = help: the following other types implement trait `Index<Idx>`:
-             <[i32] as Index<Foo<usize>>>
-             <[i32] as Index<Bar<usize>>>
-
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/on-unimplemented/on-impl.rs
+++ b/tests/ui/on-unimplemented/on-impl.rs
@@ -22,5 +22,4 @@ fn main() {
     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
     //~^ ERROR E0277
     //~| ERROR E0277
-    //~| ERROR E0277
 }

--- a/tests/ui/on-unimplemented/on-impl.stderr
+++ b/tests/ui/on-unimplemented/on-impl.stderr
@@ -20,16 +20,6 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    = help: the trait `Index<usize>` is implemented for `[i32]`
    = help: for that trait implementation, expected `usize`, found `u32`
 
-error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
-  --> $DIR/on-impl.rs:22:5
-   |
-LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
-   |
-   = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
-   = help: for that trait implementation, expected `usize`, found `u32`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/on-unimplemented/on-trait.stderr
+++ b/tests/ui/on-unimplemented/on-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Option<Vec<u8>>: MyFromIterator<&u8>` is not sati
   --> $DIR/on-trait.rs:28:30
    |
 LL |     let y: Option<Vec<u8>> = collect(x.iter()); // this should give approximately the same error for x.iter().collect()
-   |                              ^^^^^^^ a collection of type `Option<Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
+   |                              ^^^^^^^^^^^^^^^^^ a collection of type `Option<Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
    |
    = help: the trait `MyFromIterator<&u8>` is not implemented for `Option<Vec<u8>>`
 help: this trait has no implementations, consider adding one
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `String: Foo<u8, _, u32>` is not satisfied
   --> $DIR/on-trait.rs:31:21
    |
 LL |     let x: String = foobar();
-   |                     ^^^^^^ test error `String` with `u8` `_` `u32` in `Foo`
+   |                     ^^^^^^^^ test error `String` with `u8` `_` `u32` in `Foo`
    |
    = help: the trait `Foo<u8, _, u32>` is not implemented for `String`
 help: this trait has no implementations, consider adding one

--- a/tests/ui/parser/recover/recover-fn-trait-from-fn-kw.stderr
+++ b/tests/ui/parser/recover/recover-fn-trait-from-fn-kw.stderr
@@ -30,8 +30,9 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/recover-fn-trait-from-fn-kw.rs:10:5
    |
 LL |     foo2(|_: ()| {});
-   |     ^^^^ ------- found signature defined here
-   |     |
+   |     ^^^^^-------^^^^
+   |     |    |
+   |     |    found signature defined here
    |     expected due to this
    |
    = note: expected closure signature `fn(i32) -> _`

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/str-mut-idx.rs:4:15
    |
 LL |     s[1..2] = bot();
-   |               ^^^ doesn't have a size known at compile-time
+   |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
 note: required by a bound in `bot`

--- a/tests/ui/suggestions/issue-104327.stderr
+++ b/tests/ui/suggestions/issue-104327.stderr
@@ -5,7 +5,7 @@ LL |     fn f() {}
    |     --------- `Foo::f` defined here
 ...
 LL |     Foo::f();
-   |     ^^^^^^ cannot call associated function of trait
+   |     ^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |

--- a/tests/ui/suggestions/issue-104328.stderr
+++ b/tests/ui/suggestions/issue-104328.stderr
@@ -5,7 +5,7 @@ LL |     fn f() {}
    |     --------- `Foo::f` defined here
 ...
 LL |     Foo::f();
-   |     ^^^^^^ cannot call associated function of trait
+   |     ^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |

--- a/tests/ui/suggestions/issue-89333.stderr
+++ b/tests/ui/suggestions/issue-89333.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a> &'a _: Trait` is not satisfied
   --> $DIR/issue-89333.rs:6:5
    |
 LL |     test(&|| 0);
-   |     ^^^^ the trait `for<'a> Trait` is not implemented for `&'a _`
+   |     ^^^^^^^^^^^ the trait `for<'a> Trait` is not implemented for `&'a _`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-89333.rs:9:1

--- a/tests/ui/suggestions/suggest-adding-reference-to-trait-assoc-item.stderr
+++ b/tests/ui/suggestions/suggest-adding-reference-to-trait-assoc-item.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&mut usize: Default` is not satisfied
   --> $DIR/suggest-adding-reference-to-trait-assoc-item.rs:13:9
    |
 LL |     foo(Default::default());
-   |         ^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `&mut usize`
+   |         ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `&mut usize`
    |
 help: consider mutably borrowing here
    |
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `&usize: Default` is not satisfied
   --> $DIR/suggest-adding-reference-to-trait-assoc-item.rs:14:9
    |
 LL |     bar(Default::default());
-   |         ^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `&usize`
+   |         ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `&usize`
    |
 help: consider borrowing here
    |

--- a/tests/ui/traits/bad-sized.stderr
+++ b/tests/ui/traits/bad-sized.stderr
@@ -23,7 +23,7 @@ error[E0277]: the size for values of type `dyn Trait` cannot be known at compila
   --> $DIR/bad-sized.rs:4:37
    |
 LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
-   |                                     ^^^^^^^^ doesn't have a size known at compile-time
+   |                                     ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
 note: required by a bound in `Vec::<T>::new`

--- a/tests/ui/traits/inductive-overflow/lifetime.stderr
+++ b/tests/ui/traits/inductive-overflow/lifetime.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `Box<X<C<'static>>>: NotAuto`
   --> $DIR/lifetime.rs:29:5
    |
 LL |     is_send::<X<C<'static>>>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: required for `X<C<'static>>` to implement `NotAuto`
   --> $DIR/lifetime.rs:19:12

--- a/tests/ui/traits/inductive-overflow/simultaneous.stderr
+++ b/tests/ui/traits/inductive-overflow/simultaneous.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `{integer}: Tweedledum`
   --> $DIR/simultaneous.rs:18:5
    |
 LL |     is_ee(4);
-   |     ^^^^^
+   |     ^^^^^^^^
    |
 note: required for `{integer}` to implement `Combo`
   --> $DIR/simultaneous.rs:11:34

--- a/tests/ui/traits/inductive-overflow/supertrait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `NoClone: Magic`
   --> $DIR/supertrait.rs:13:18
    |
 LL |     let (a, b) = copy(NoClone);
-   |                  ^^^^
+   |                  ^^^^^^^^^^^^^
    |
 note: required for `NoClone` to implement `Magic`
   --> $DIR/supertrait.rs:5:16

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -18,7 +18,7 @@ error[E0275]: overflow evaluating the requirement `*mut (): Magic`
   --> $DIR/two-traits.rs:20:5
    |
 LL |     wizard::<*mut ()>();
-   |     ^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
    |
 note: required by a bound in `wizard`
   --> $DIR/two-traits.rs:17:14

--- a/tests/ui/traits/next-solver/alias-bound-unsound.rs
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.rs
@@ -22,8 +22,7 @@ impl Foo for () {
 fn main() {
     let x = String::from("hello, world");
     drop(<() as Foo>::copy_me(&x));
-    //~^ ERROR overflow evaluating the requirement `<() as Foo>::Item: Sized`
-    //~| ERROR overflow evaluating the requirement `String <: <() as Foo>::Item`
+    //~^ ERROR overflow evaluating the requirement `String <: <() as Foo>::Item`
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item well-formed`
     //~| ERROR overflow evaluating the requirement `&<() as Foo>::Item well-formed`
     //~| ERROR overflow evaluating the requirement `<() as Foo>::Item == _`

--- a/tests/ui/traits/next-solver/alias-bound-unsound.stderr
+++ b/tests/ui/traits/next-solver/alias-bound-unsound.stderr
@@ -27,15 +27,6 @@ LL |     drop(<() as Foo>::copy_me(&x));
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`alias_bound_unsound`)
 
-error[E0275]: overflow evaluating the requirement `<() as Foo>::Item: Sized`
-  --> $DIR/alias-bound-unsound.rs:24:10
-   |
-LL |     drop(<() as Foo>::copy_me(&x));
-   |          ^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`alias_bound_unsound`)
-   = note: the return type of a function must have a statically known size
-
 error[E0275]: overflow evaluating the requirement `&<() as Foo>::Item well-formed`
   --> $DIR/alias-bound-unsound.rs:24:31
    |
@@ -61,6 +52,6 @@ LL |     drop(<() as Foo>::copy_me(&x));
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`alias_bound_unsound`)
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/more-object-bound.stderr
+++ b/tests/ui/traits/next-solver/more-object-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `dyn Trait<A = A, B = B>: Trait` is not satisfied
   --> $DIR/more-object-bound.rs:12:5
    |
 LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `dyn Trait<A = A, B = B>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `dyn Trait<A = A, B = B>`
    |
 note: required by a bound in `foo`
   --> $DIR/more-object-bound.rs:18:8

--- a/tests/ui/traits/next-solver/object-unsafety.stderr
+++ b/tests/ui/traits/next-solver/object-unsafety.stderr
@@ -46,10 +46,7 @@ error[E0277]: the size for values of type `<dyn Setup<From = T> as Setup>::From`
   --> $DIR/object-unsafety.rs:12:5
    |
 LL |     copy::<dyn Setup<From=T>>(t)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |     |
-   |     doesn't have a size known at compile-time
-   |     this returned value is of type `<dyn Setup<From = T> as Setup>::From`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<dyn Setup<From = T> as Setup>::From`
    = note: the return type of a function must have a statically known size

--- a/tests/ui/traits/next-solver/specialization-unconstrained.stderr
+++ b/tests/ui/traits/next-solver/specialization-unconstrained.stderr
@@ -12,7 +12,7 @@ error[E0284]: type annotations needed: cannot satisfy `<u32 as Default>::Id == (
   --> $DIR/specialization-unconstrained.rs:20:5
    |
 LL |     test::<u32, ()>();
-   |     ^^^^^^^^^^^^^^^ cannot satisfy `<u32 as Default>::Id == ()`
+   |     ^^^^^^^^^^^^^^^^^ cannot satisfy `<u32 as Default>::Id == ()`
    |
 note: required by a bound in `test`
   --> $DIR/specialization-unconstrained.rs:17:20

--- a/tests/ui/traits/non_lifetime_binders/bad-copy-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-copy-cond.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/bad-copy-cond.rs:7:5
    |
 LL |     foo();
-   |     ^^^ the trait `Copy` is not implemented for `T`
+   |     ^^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `foo`
   --> $DIR/bad-copy-cond.rs:4:26

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
@@ -11,7 +11,7 @@ error[E0277]: the size for values of type `V` cannot be known at compilation tim
   --> $DIR/bad-sized-cond.rs:17:5
    |
 LL |     foo();
-   |     ^^^ doesn't have a size known at compile-time
+   |     ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `V`
 note: required by a bound in `foo`
@@ -27,7 +27,7 @@ error[E0277]: `V` is not an iterator
   --> $DIR/bad-sized-cond.rs:20:5
    |
 LL |     bar();
-   |     ^^^ `V` is not an iterator
+   |     ^^^^^ `V` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `V`
    = note: required for `V` to implement `IntoIterator`
@@ -44,7 +44,7 @@ error[E0277]: the size for values of type `V` cannot be known at compilation tim
   --> $DIR/bad-sized-cond.rs:20:5
    |
 LL |     bar();
-   |     ^^^ doesn't have a size known at compile-time
+   |     ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `V`
    = note: required for `V` to implement `IntoIterator`

--- a/tests/ui/traits/non_lifetime_binders/fail.stderr
+++ b/tests/ui/traits/non_lifetime_binders/fail.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/fail.rs:19:5
    |
 LL |     fail();
-   |     ^^^^ the trait `Trait` is not implemented for `T`
+   |     ^^^^^^ the trait `Trait` is not implemented for `T`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/fail.rs:6:1
@@ -31,7 +31,7 @@ error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/fail.rs:21:5
    |
 LL |     auto_trait();
-   |     ^^^^^^^^^^ `T` cannot be sent between threads safely
+   |     ^^^^^^^^^^^^ `T` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `T`
 note: required by a bound in `auto_trait`

--- a/tests/ui/traits/non_lifetime_binders/foreach-partial-eq.stderr
+++ b/tests/ui/traits/non_lifetime_binders/foreach-partial-eq.stderr
@@ -11,7 +11,7 @@ error[E0277]: can't compare `T` with `T`
   --> $DIR/foreach-partial-eq.rs:10:5
    |
 LL |     auto_trait();
-   |     ^^^^^^^^^^ no implementation for `T < T` and `T > T`
+   |     ^^^^^^^^^^^^ no implementation for `T < T` and `T > T`
    |
    = help: the trait `PartialOrd` is not implemented for `T`
 note: required by a bound in `auto_trait`

--- a/tests/ui/traits/static-method-generic-inference.stderr
+++ b/tests/ui/traits/static-method-generic-inference.stderr
@@ -5,7 +5,7 @@ LL |         fn new() -> T;
    |         -------------- `HasNew::new` defined here
 ...
 LL |     let _f: base::Foo = base::HasNew::new();
-   |                         ^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |                         ^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |

--- a/tests/ui/transmutability/region-infer.stderr
+++ b/tests/ui/transmutability/region-infer.stderr
@@ -2,7 +2,7 @@ error[E0277]: `()` cannot be safely transmuted into `W<'_>` in the defining scop
   --> $DIR/region-infer.rs:20:5
    |
 LL |     test();
-   |     ^^^^ The size of `()` is smaller than the size of `W<'_>`
+   |     ^^^^^^ The size of `()` is smaller than the size of `W<'_>`
    |
 note: required by a bound in `test`
   --> $DIR/region-infer.rs:11:12

--- a/tests/ui/type/issue-101866.stderr
+++ b/tests/ui/type/issue-101866.stderr
@@ -5,7 +5,7 @@ LL |     fn func();
    |     ---------- `TraitA::func` defined here
 ...
 LL |     TraitA::<i32>::func();
-   |     ^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
+   |     ^^^^^^^^^^^^^^^^^^^^^ cannot call associated function of trait
    |
 help: use the fully-qualified path to the only available implementation
    |

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -59,7 +59,7 @@ error[E0277]: cannot add `u32` to `i32`
   --> $DIR/ufcs-qpath-self-mismatch.rs:4:5
    |
 LL |     <i32 as Add<u32>>::add(1, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u32`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u32`
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:

--- a/tests/ui/unsized-locals/unsized-exprs.stderr
+++ b/tests/ui/unsized-locals/unsized-exprs.stderr
@@ -26,7 +26,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
   --> $DIR/unsized-exprs.rs:26:22
    |
 LL |     udrop::<A<[u8]>>(A(*foo()));
-   |                      ^ doesn't have a size known at compile-time
+   |                      ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `A<[u8]>`, the trait `Sized` is not implemented for `[u8]`
 note: required because it appears within the type `A<[u8]>`

--- a/tests/ui/where-clauses/higher-ranked-fn-type.quiet.stderr
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.quiet.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'b> fn(&'b ()): Foo` is not satisfied
   --> $DIR/higher-ranked-fn-type.rs:20:5
    |
 LL |     called()
-   |     ^^^^^^ the trait `for<'b> Foo` is not implemented for `fn(&'b ())`
+   |     ^^^^^^^^ the trait `for<'b> Foo` is not implemented for `fn(&'b ())`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/higher-ranked-fn-type.rs:6:1

--- a/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_t
   --> $DIR/higher-ranked-fn-type.rs:20:5
    |
 LL |     called()
-   |     ^^^^^^ the trait `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b))> Foo` is not implemented for `fn(&ReBound(DebruijnIndex(1), BoundRegion { var: 0, kind: BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b) }) ())`
+   |     ^^^^^^^^ the trait `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b))> Foo` is not implemented for `fn(&ReBound(DebruijnIndex(1), BoundRegion { var: 0, kind: BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b) }) ())`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/higher-ranked-fn-type.rs:6:1


### PR DESCRIPTION
Change the implicit `Sized` `Obligation` `Span` for call expressions to include the whole expression. This aids the existing deduplication machinery to reduce the number of errors caused by a single unsized expression.