### PR TITLE
coverage: Flatten the functions for extracting/refining coverage spans

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> Instrumentor<'a, 'tcx> {
     fn inject_counters(&'a mut self) {
         ////////////////////////////////////////////////////
         // Compute coverage spans from the `CoverageGraph`.
-        let Some(coverage_spans) = CoverageSpans::generate_coverage_spans(
+        let Some(coverage_spans) = spans::generate_coverage_spans(
             self.mir_body,
             &self.hir_info,
             &self.basic_coverage_blocks,

--- a/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans/from_mir.rs
@@ -12,6 +12,12 @@ use crate::coverage::graph::{
 use crate::coverage::spans::CoverageSpan;
 use crate::coverage::ExtractedHirInfo;
 
+/// Traverses the MIR body to produce an initial collection of coverage-relevant
+/// spans, each associated with a node in the coverage graph (BCB) and possibly
+/// other metadata.
+///
+/// The returned spans are sorted in a specific order that is expected by the
+/// subsequent span-refinement step.
 pub(super) fn mir_to_initial_sorted_coverage_spans(
     mir_body: &mir::Body<'_>,
     hir_info: &ExtractedHirInfo,


### PR DESCRIPTION
Consolidating this code into flatter functions reduces the amount of pointer-chasing required to read and modify it.

No functional changes.

Ignoring whitespace is recommended, as it shows that most of the moved code has not been modified.

---

This has a trivial conflict with #120292 (renamed function called by re-indented code), so when one merges, the other will require a tiny fixup.

@rustbot label +A-code-coverage