### PR TITLE
adapt test for v0 symbol mangling

### DIFF
--- a/tests/codegen/infallible-unwrap-in-opt-z.rs
+++ b/tests/codegen/infallible-unwrap-in-opt-z.rs
@@ -21,6 +21,6 @@ pub fn read_up_to_8(buf: &[u8]) -> u64 {
 // CHECK-LABEL: @checking_unwrap_expectation(
 #[no_mangle]
 pub fn checking_unwrap_expectation(buf: &[u8]) -> &[u8; 4] {
-    // CHECK: call void @_ZN4core6result13unwrap_failed17h
+    // CHECK: call void @{{.*core6result13unwrap_failed}}
     buf.try_into().unwrap()
 }


### PR DESCRIPTION
No functional changes intended.

Adapts the test to also work under `new-symbol-mangling = true`.