### PR TITLE
core: add `From<core::ascii::Char>` implementations

### DIFF
--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -537,6 +537,22 @@ impl AsciiChar {
     }
 }
 
+macro_rules! into_int_impl {
+    ($($ty:ty)*) => {
+        $(
+            #[unstable(feature = "ascii_char", issue = "110998")]
+            impl From<AsciiChar> for $ty {
+                #[inline]
+                fn from(chr: AsciiChar) -> $ty {
+                    chr as u8 as $ty
+                }
+            }
+        )*
+    }
+}
+
+into_int_impl!(u8 u16 u32 u64 u128 char);
+
 impl [AsciiChar] {
     /// Views this slice of ASCII characters as a UTF-8 `str`.
     #[unstable(feature = "ascii_char", issue = "110998")]

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -44,6 +44,7 @@ LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect(
    |                                            type must be known at this point
    |
    = note: multiple `impl`s satisfying `u32: From<_>` found in the `core` crate:
+           - impl From<Char> for u32;
            - impl From<Ipv4Addr> for u32;
            - impl From<NonZeroU32> for u32;
            - impl From<bool> for u32;

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -12,6 +12,7 @@ LL |     Ok(Err(123_i32)?)
    = help: the following other types implement trait `From<T>`:
              <u8 as From<bool>>
              <u8 as From<NonZeroU8>>
+             <u8 as From<Char>>
    = note: required for `Result<u64, u8>` to implement `FromResidual<Result<Infallible, i32>>`
 
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`


### PR DESCRIPTION
Introduce `From<core::ascii::Char>` implementations for all unsigned
numeric types and `char`.  This matches the API of `char` type.

Issue: https://github.com/rust-lang/rust/issues/110998
