### PR TITLE
core: optimise Debug impl for ascii::Char

### DIFF
--- a/library/core/tests/ascii_char.rs
+++ b/library/core/tests/ascii_char.rs
@@ -1,0 +1,28 @@
+use core::ascii::Char;
+use core::fmt::Write;
+
+/// Tests Display implementation for ascii::Char.
+#[test]
+fn test_display() {
+    let want = (0..128u8).map(|b| b as char).collect::<String>();
+    let mut got = String::with_capacity(128);
+    for byte in 0..128 {
+        write!(&mut got, "{}", Char::from_u8(byte).unwrap()).unwrap();
+    }
+    assert_eq!(want, got);
+}
+
+/// Tests Debug implementation for ascii::Char.
+#[test]
+fn test_debug_control() {
+    for byte in 0..128u8 {
+        let mut want = format!("{:?}", byte as char);
+        // `char` uses `'\u{#}'` representation where ascii::char uses `'\x##'`.
+        // Transform former into the latter.
+        if let Some(rest) = want.strip_prefix("'\\u{") {
+            want = format!("'\\x{:0>2}'", rest.strip_suffix("}'").unwrap());
+        }
+        let chr = core::ascii::Char::from_u8(byte).unwrap();
+        assert_eq!(want, format!("{chr:?}"), "byte: {byte}");
+    }
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -122,6 +122,7 @@ mod alloc;
 mod any;
 mod array;
 mod ascii;
+mod ascii_char;
 mod asserting;
 mod async_iter;
 mod atomic;


### PR DESCRIPTION
Rather than writing character at a time, optimise Debug implementation
for core::ascii::Char such that it writes the entire representation
with a single write_str call.

With that, add tests for Display and Debug.

Issue: https://github.com/rust-lang/rust/issues/110998
