### PR TITLE
On E0277 be clearer about implicit `Sized` bounds on type params and assoc types

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3010,7 +3010,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     }
                 }
                 let mut a = "a";
-                let mut this = "this";
+                let mut this = "this bound";
                 let mut note = None;
                 let mut help = None;
                 if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
@@ -3036,7 +3036,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             .any(|param| tcx.def_span(param.def_id) == span)
                         {
                             a = "an implicit `Sized`";
-                            this = "the implicit `Sized` requirement on this";
+                            this = "the implicit `Sized` requirement on this type parameter";
                         }
                         if let Some(hir::Node::TraitItem(hir::TraitItem {
                             ident,
@@ -3106,7 +3106,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 };
                 let descr = format!("required by {a} bound in `{item_name}`");
                 if span.is_visible(sm) {
-                    let msg = format!("required by {this} bound in `{short_item_name}`");
+                    let msg = format!("required by {this} in `{short_item_name}`");
                     multispan.push_span_label(span, msg);
                     err.span_note(multispan, descr);
                 } else {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3009,35 +3009,44 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         );
                     }
                 }
-                let descr = format!("required by a bound in `{item_name}`");
-                if span.is_visible(sm) {
-                    let msg = format!("required by this bound in `{short_item_name}`");
-                    multispan.push_span_label(span, msg);
-                    err.span_note(multispan, descr);
-                    if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
-                        && let ty::ClauseKind::Trait(trait_pred) = clause
-                    {
-                        let def_id = trait_pred.def_id();
-                        let visible_item = if let Some(local) = def_id.as_local() {
-                            // Check for local traits being reachable.
-                            let vis = &tcx.resolutions(()).effective_visibilities;
-                            // Account for non-`pub` traits in the root of the local crate.
-                            let is_locally_reachable = tcx.parent(def_id).is_crate_root();
-                            vis.is_reachable(local) || is_locally_reachable
-                        } else {
-                            // Check for foreign traits being reachable.
-                            tcx.visible_parent_map(()).get(&def_id).is_some()
-                        };
-                        if Some(def_id) == tcx.lang_items().sized_trait()
-                            && let Some(hir::Node::TraitItem(hir::TraitItem {
-                                ident,
-                                kind: hir::TraitItemKind::Type(bounds, None),
-                                ..
-                            })) = tcx.hir().get_if_local(item_def_id)
-                            // Do not suggest relaxing if there is an explicit `Sized` obligation.
-                            && !bounds.iter()
-                                .filter_map(|bound| bound.trait_ref())
-                                .any(|tr| tr.trait_def_id() == tcx.lang_items().sized_trait())
+                let mut a = "a";
+                let mut this = "this";
+                let mut note = None;
+                let mut help = None;
+                if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
+                    && let ty::ClauseKind::Trait(trait_pred) = clause
+                {
+                    let def_id = trait_pred.def_id();
+                    let visible_item = if let Some(local) = def_id.as_local() {
+                        // Check for local traits being reachable.
+                        let vis = &tcx.resolutions(()).effective_visibilities;
+                        // Account for non-`pub` traits in the root of the local crate.
+                        let is_locally_reachable = tcx.parent(def_id).is_crate_root();
+                        vis.is_reachable(local) || is_locally_reachable
+                    } else {
+                        // Check for foreign traits being reachable.
+                        tcx.visible_parent_map(()).get(&def_id).is_some()
+                    };
+                    if Some(def_id) == tcx.lang_items().sized_trait() {
+                        // Check if this is an implicit bound, even in foreign crates.
+                        if tcx
+                            .generics_of(item_def_id)
+                            .params
+                            .iter()
+                            .any(|param| tcx.def_span(param.def_id) == span)
+                        {
+                            a = "an implicit `Sized`";
+                            this = "the implicit `Sized` requirement on this";
+                        }
+                        if let Some(hir::Node::TraitItem(hir::TraitItem {
+                            ident,
+                            kind: hir::TraitItemKind::Type(bounds, None),
+                            ..
+                        })) = tcx.hir().get_if_local(item_def_id)
+                        // Do not suggest relaxing if there is an explicit `Sized` obligation.
+                        && !bounds.iter()
+                            .filter_map(|bound| bound.trait_ref())
+                            .any(|tr| tr.trait_def_id() == tcx.lang_items().sized_trait())
                         {
                             let (span, separator) = if let [.., last] = bounds {
                                 (last.span().shrink_to_hi(), " +")
@@ -3051,51 +3060,63 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 Applicability::MachineApplicable,
                             );
                         }
-                        if let DefKind::Trait = tcx.def_kind(item_def_id)
-                            && !visible_item
-                        {
-                            err.note(format!(
-                                "`{short_item_name}` is a \"sealed trait\", because to implement \
-                                 it you also need to implement `{}`, which is not accessible; \
-                                 this is usually done to force you to use one of the provided \
-                                 types that already implement it",
-                                with_no_trimmed_paths!(tcx.def_path_str(def_id)),
-                            ));
-                            let impls_of = tcx.trait_impls_of(def_id);
-                            let impls = impls_of
-                                .non_blanket_impls()
-                                .values()
-                                .flatten()
-                                .chain(impls_of.blanket_impls().iter())
+                    }
+                    if let DefKind::Trait = tcx.def_kind(item_def_id)
+                        && !visible_item
+                    {
+                        note = Some(format!(
+                            "`{short_item_name}` is a \"sealed trait\", because to implement it \
+                             you also need to implement `{}`, which is not accessible; this is \
+                             usually done to force you to use one of the provided types that \
+                             already implement it",
+                            with_no_trimmed_paths!(tcx.def_path_str(def_id)),
+                        ));
+                        let impls_of = tcx.trait_impls_of(def_id);
+                        let impls = impls_of
+                            .non_blanket_impls()
+                            .values()
+                            .flatten()
+                            .chain(impls_of.blanket_impls().iter())
+                            .collect::<Vec<_>>();
+                        if !impls.is_empty() {
+                            let len = impls.len();
+                            let mut types = impls
+                                .iter()
+                                .map(|t| {
+                                    with_no_trimmed_paths!(format!(
+                                        "  {}",
+                                        tcx.type_of(*t).instantiate_identity(),
+                                    ))
+                                })
                                 .collect::<Vec<_>>();
-                            if !impls.is_empty() {
-                                let len = impls.len();
-                                let mut types = impls
-                                    .iter()
-                                    .map(|t| {
-                                        with_no_trimmed_paths!(format!(
-                                            "  {}",
-                                            tcx.type_of(*t).instantiate_identity(),
-                                        ))
-                                    })
-                                    .collect::<Vec<_>>();
-                                let post = if types.len() > 9 {
-                                    types.truncate(8);
-                                    format!("\nand {} others", len - 8)
-                                } else {
-                                    String::new()
-                                };
-                                err.help(format!(
-                                    "the following type{} implement{} the trait:\n{}{post}",
-                                    pluralize!(len),
-                                    if len == 1 { "s" } else { "" },
-                                    types.join("\n"),
-                                ));
-                            }
+                            let post = if types.len() > 9 {
+                                types.truncate(8);
+                                format!("\nand {} others", len - 8)
+                            } else {
+                                String::new()
+                            };
+                            help = Some(format!(
+                                "the following type{} implement{} the trait:\n{}{post}",
+                                pluralize!(len),
+                                if len == 1 { "s" } else { "" },
+                                types.join("\n"),
+                            ));
                         }
                     }
+                };
+                let descr = format!("required by {a} bound in `{item_name}`");
+                if span.is_visible(sm) {
+                    let msg = format!("required by {this} bound in `{short_item_name}`");
+                    multispan.push_span_label(span, msg);
+                    err.span_note(multispan, descr);
                 } else {
                     err.span_note(tcx.def_span(item_def_id), descr);
+                }
+                if let Some(note) = note {
+                    err.note(note);
+                }
+                if let Some(help) = help {
+                    err.help(help);
                 }
             }
             ObligationCauseCode::Coercion { source, target } => {

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -559,10 +559,10 @@ trait TraitAddBuiltinBoundToMethodTypeParameter {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -559,7 +559,7 @@ trait TraitAddBuiltinBoundToMethodTypeParameter {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
     #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]

--- a/tests/ui/associated-types/defaults-wf.stderr
+++ b/tests/ui/associated-types/defaults-wf.stderr
@@ -5,7 +5,7 @@ LL |     type Ty = Vec<[u8]>;
    |               ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -4,11 +4,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
    |                                                 ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `From`
+note: required by an implicit `Sized` bound in `From`
   --> $DIR/issue-20005.rs:1:12
    |
 LL | trait From<Src> {
-   |            ^^^ required by this bound in `From`
+   |            ^^^ required by the implicit `Sized` requirement on this bound in `From`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -8,7 +8,7 @@ note: required by an implicit `Sized` bound in `From`
   --> $DIR/issue-20005.rs:1:12
    |
 LL | trait From<Src> {
-   |            ^^^ required by the implicit `Sized` requirement on this bound in `From`
+   |            ^^^ required by the implicit `Sized` requirement on this type parameter in `From`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {

--- a/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> {}
    |                      ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Add`
+note: required by an implicit `Sized` bound in `Add`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: consider further restricting `Self`
    |

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -17,7 +17,7 @@ LL |         println!("{:?}", foo);
    |                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn Foo`
-note: required by a bound in `core::fmt::rt::Argument::<'a>::new_debug`
+note: required by an implicit `Sized` bound in `core::fmt::rt::Argument::<'a>::new_debug`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/coroutine/sized-yield.stderr
+++ b/tests/ui/coroutine/sized-yield.stderr
@@ -18,7 +18,7 @@ LL |     Pin::new(&mut gen).resume(());
    |                        ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `CoroutineState`
+note: required by an implicit `Sized` bound in `CoroutineState`
   --> $SRC_DIR/core/src/ops/coroutine.rs:LL:COL
 
 error: aborting due to 2 previous errors

--- a/tests/ui/dst/dst-sized-trait-param.stderr
+++ b/tests/ui/dst/dst-sized-trait-param.stderr
@@ -5,11 +5,11 @@ LL | impl Foo<[isize]> for usize { }
    |      ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[isize]`
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/dst-sized-trait-param.rs:5:11
    |
 LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
-   |           ^ required by this bound in `Foo`
+   |           ^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Foo<T: ?Sized> : Sized { fn take(self, x: &T) { } } // Note: T is sized

--- a/tests/ui/dst/dst-sized-trait-param.stderr
+++ b/tests/ui/dst/dst-sized-trait-param.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/dst-sized-trait-param.rs:5:11
    |
 LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
-   |           ^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Foo<T: ?Sized> : Sized { fn take(self, x: &T) { } } // Note: T is sized

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -5,11 +5,11 @@ LL |     assert_sized::<A>();
    |                    ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `A`
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -27,11 +27,11 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo {
    |        ^^^
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -49,11 +49,11 @@ note: required because it appears within the type `Bar<A>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -71,11 +71,11 @@ note: required because it appears within the type `Bar<A>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -31,7 +31,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -53,7 +53,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -75,7 +75,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}

--- a/tests/ui/generic-associated-types/issue-88287.stderr
+++ b/tests/ui/generic-associated-types/issue-88287.stderr
@@ -11,7 +11,7 @@ note: required by an implicit `Sized` bound in `<T as SearchableResourceExt<Crit
   --> $DIR/issue-88287.rs:24:6
    |
 LL | impl<T, Criteria> SearchableResourceExt<Criteria> for T
-   |      ^ required by the implicit `Sized` requirement on this bound in `<T as SearchableResourceExt<Criteria>>`
+   |      ^ required by the implicit `Sized` requirement on this type parameter in `<T as SearchableResourceExt<Criteria>>`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL -     A: SearchableResource<B> + ?Sized + 'f,

--- a/tests/ui/generic-associated-types/issue-88287.stderr
+++ b/tests/ui/generic-associated-types/issue-88287.stderr
@@ -7,11 +7,11 @@ LL | type SearchFutureTy<'f, A, B: 'f>
 LL |         async move { todo!() }
    |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `<T as SearchableResourceExt<Criteria>>`
+note: required by an implicit `Sized` bound in `<T as SearchableResourceExt<Criteria>>`
   --> $DIR/issue-88287.rs:24:6
    |
 LL | impl<T, Criteria> SearchableResourceExt<Criteria> for T
-   |      ^ required by this bound in `<T as SearchableResourceExt<Criteria>>`
+   |      ^ required by the implicit `Sized` requirement on this bound in `<T as SearchableResourceExt<Criteria>>`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL -     A: SearchableResource<B> + ?Sized + 'f,

--- a/tests/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/tests/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -6,10 +6,10 @@ LL | impl Tsized for () {}
    |
    = help: the trait `Sized` is not implemented for `[()]`
 note: required by a bound in `Tsized`
-  --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:14
+  --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:17
    |
 LL | trait Tsized<P: Sized = [Self]> {}
-   |              ^^^^^^^^^^^^^^^^^ required by this bound in `Tsized`
+   |                 ^^^^^ required by this bound in `Tsized`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -5,7 +5,7 @@ LL |     fn nya() -> impl Wf<Vec<[u8]>>;
    |                      ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -15,11 +15,11 @@ LL |     fn nya2() -> impl Wf<[u8]>;
    |                       ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Wf`
+note: required by an implicit `Sized` bound in `Wf`
   --> $DIR/wf-bounds.rs:7:10
    |
 LL | trait Wf<T> {
-   |          ^ required by this bound in `Wf`
+   |          ^ required by the implicit `Sized` requirement on this bound in `Wf`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Wf<T: ?Sized> {
@@ -32,7 +32,7 @@ LL |     fn nya3() -> impl Wf<(), Output = impl Wf<Vec<[u8]>>>;
    |                                            ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: `T` doesn't implement `std::fmt::Display`

--- a/tests/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -19,7 +19,7 @@ note: required by an implicit `Sized` bound in `Wf`
   --> $DIR/wf-bounds.rs:7:10
    |
 LL | trait Wf<T> {
-   |          ^ required by the implicit `Sized` requirement on this bound in `Wf`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `Wf`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Wf<T: ?Sized> {

--- a/tests/ui/issues/issue-10412.stderr
+++ b/tests/ui/issues/issue-10412.stderr
@@ -62,7 +62,7 @@ note: required by an implicit `Sized` bound in `Serializable`
   --> $DIR/issue-10412.rs:1:27
    |
 LL | trait Serializable<'self, T> {
-   |                           ^ required by the implicit `Sized` requirement on this bound in `Serializable`
+   |                           ^ required by the implicit `Sized` requirement on this type parameter in `Serializable`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Serializable<'self, T: ?Sized> {

--- a/tests/ui/issues/issue-10412.stderr
+++ b/tests/ui/issues/issue-10412.stderr
@@ -58,11 +58,11 @@ LL | impl<'self> Serializable<str> for &'self str {
    |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `Serializable`
+note: required by an implicit `Sized` bound in `Serializable`
   --> $DIR/issue-10412.rs:1:27
    |
 LL | trait Serializable<'self, T> {
-   |                           ^ required by this bound in `Serializable`
+   |                           ^ required by the implicit `Sized` requirement on this bound in `Serializable`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Serializable<'self, T: ?Sized> {

--- a/tests/ui/issues/issue-18919.stderr
+++ b/tests/ui/issues/issue-18919.stderr
@@ -5,11 +5,11 @@ LL | fn ho_func(f: Option<FuncType>) {
    |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn for<'a> Fn(&'a isize) -> isize`
-note: required by a bound in `Option`
+note: required by an implicit `Sized` bound in `Option`
   --> $DIR/issue-18919.rs:7:13
    |
 LL | enum Option<T> {
-   |             ^ required by this bound in `Option`
+   |             ^ required by the implicit `Sized` requirement on this bound in `Option`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-18919.rs:7:13
    |

--- a/tests/ui/issues/issue-18919.stderr
+++ b/tests/ui/issues/issue-18919.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `Option`
   --> $DIR/issue-18919.rs:7:13
    |
 LL | enum Option<T> {
-   |             ^ required by the implicit `Sized` requirement on this bound in `Option`
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Option`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-18919.rs:7:13
    |

--- a/tests/ui/issues/issue-20433.stderr
+++ b/tests/ui/issues/issue-20433.stderr
@@ -5,7 +5,7 @@ LL |     fn iceman(c: Vec<[i32]>) {}
    |                  ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-23281.stderr
+++ b/tests/ui/issues/issue-23281.stderr
@@ -5,11 +5,11 @@ LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/issue-23281.rs:8:12
    |
 LL | struct Vec<T> {
-   |            ^ required by this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-23281.rs:8:12
    |

--- a/tests/ui/issues/issue-23281.stderr
+++ b/tests/ui/issues/issue-23281.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/issue-23281.rs:8:12
    |
 LL | struct Vec<T> {
-   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-23281.rs:8:12
    |

--- a/tests/ui/issues/issue-87199.stderr
+++ b/tests/ui/issues/issue-87199.stderr
@@ -27,7 +27,7 @@ note: required by an implicit `Sized` bound in `ref_arg`
   --> $DIR/issue-87199.rs:10:12
    |
 LL | fn ref_arg<T: ?Send>(_: &T) {}
-   |            ^ required by the implicit `Sized` requirement on this bound in `ref_arg`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `ref_arg`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn ref_arg<T: ?Send + ?Sized>(_: &T) {}

--- a/tests/ui/issues/issue-87199.stderr
+++ b/tests/ui/issues/issue-87199.stderr
@@ -23,11 +23,11 @@ LL |     ref_arg::<[i32]>(&[5]);
    |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by a bound in `ref_arg`
+note: required by an implicit `Sized` bound in `ref_arg`
   --> $DIR/issue-87199.rs:10:12
    |
 LL | fn ref_arg<T: ?Send>(_: &T) {}
-   |            ^ required by this bound in `ref_arg`
+   |            ^ required by the implicit `Sized` requirement on this bound in `ref_arg`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn ref_arg<T: ?Send + ?Sized>(_: &T) {}

--- a/tests/ui/iterators/collect-into-slice.rs
+++ b/tests/ui/iterators/collect-into-slice.rs
@@ -8,7 +8,7 @@ fn main() {
     //~| ERROR the size for values of type `[i32]` cannot be known at compilation time
     //~| ERROR a slice of type `[i32]` cannot be built since `[i32]` has no definite size
     //~| NOTE try explicitly collecting into a `Vec<{integer}>`
-    //~| NOTE required by a bound in `collect`
+    //~| NOTE required by an implicit `Sized` bound in `collect`
     //~| NOTE required by a bound in `collect`
     //~| NOTE all local variables must have a statically known size
     //~| NOTE doesn't have a size known at compile-time

--- a/tests/ui/iterators/collect-into-slice.stderr
+++ b/tests/ui/iterators/collect-into-slice.stderr
@@ -25,7 +25,7 @@ LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by a bound in `collect`
+note: required by an implicit `Sized` bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0277]: a slice of type `&[i32]` cannot be built since we need to store the elements somewhere

--- a/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
+++ b/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
@@ -64,7 +64,7 @@ note: required by an implicit `Sized` bound in `A`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |
 LL | struct A<B>(B);
-   |          ^ required by the implicit `Sized` requirement on this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `A`
 help: you could relax the implicit `Sized` bound on `B` if it were used through indirection like `&B` or `Box<B>`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |

--- a/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
+++ b/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
@@ -60,11 +60,11 @@ LL | impl<B>A<B>{fn d(){fn d(){Self(1)}}}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `A`
+note: required by an implicit `Sized` bound in `A`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |
 LL | struct A<B>(B);
-   |          ^ required by this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this bound in `A`
 help: you could relax the implicit `Sized` bound on `B` if it were used through indirection like `&B` or `Box<B>`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |

--- a/tests/ui/methods/issues/issue-61525.stderr
+++ b/tests/ui/methods/issues/issue-61525.stderr
@@ -7,11 +7,11 @@ LL |         1.query::<dyn ToString>("")
    |           required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn ToString`
-note: required by a bound in `Example::query`
+note: required by an implicit `Sized` bound in `Example::query`
   --> $DIR/issue-61525.rs:2:14
    |
 LL |     fn query<Q>(self, q: Q);
-   |              ^ required by this bound in `Example::query`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Example::query`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     fn query<Q: ?Sized>(self, q: Q);

--- a/tests/ui/methods/issues/issue-61525.stderr
+++ b/tests/ui/methods/issues/issue-61525.stderr
@@ -11,7 +11,7 @@ note: required by an implicit `Sized` bound in `Example::query`
   --> $DIR/issue-61525.rs:2:14
    |
 LL |     fn query<Q>(self, q: Q);
-   |              ^ required by the implicit `Sized` requirement on this bound in `Example::query`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Example::query`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     fn query<Q: ?Sized>(self, q: Q);

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -26,7 +26,7 @@ note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
    |
 LL | trait Bar<T> {
-   |           ^ required by the implicit `Sized` requirement on this bound in `Bar`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `Bar`
 help: consider further restricting `Self`
    |
 LL | trait Baz : Bar<Self> + Sized {

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | trait Baz : Bar<Self> {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Bar`
+note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
    |
 LL | trait Bar<T> {
-   |           ^ required by this bound in `Bar`
+   |           ^ required by the implicit `Sized` requirement on this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL | trait Baz : Bar<Self> + Sized {

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -30,7 +30,7 @@ LL |     let range = *arr..;
    |                 ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[{integer}]`
-note: required by a bound in `RangeFrom`
+note: required by an implicit `Sized` bound in `RangeFrom`
   --> $SRC_DIR/core/src/ops/range.rs:LL:COL
 
 error: aborting due to 3 previous errors

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -5,11 +5,11 @@ LL |     s[1..2] = bot();
    |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `bot`
+note: required by an implicit `Sized` bound in `bot`
   --> $DIR/str-mut-idx.rs:1:8
    |
 LL | fn bot<T>() -> T { loop {} }
-   |        ^ required by this bound in `bot`
+   |        ^ required by the implicit `Sized` requirement on this bound in `bot`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn bot<T: ?Sized>() -> T { loop {} }

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `bot`
   --> $DIR/str-mut-idx.rs:1:8
    |
 LL | fn bot<T>() -> T { loop {} }
-   |        ^ required by the implicit `Sized` requirement on this bound in `bot`
+   |        ^ required by the implicit `Sized` requirement on this type parameter in `bot`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn bot<T: ?Sized>() -> T { loop {} }

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -6,11 +6,11 @@ LL | struct Struct5<T: ?Sized>{
 LL |     _t: X<T>,
    |         ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `X`
+note: required by an implicit `Sized` bound in `X`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
 LL | struct X<T>(T);
-   |          ^ required by this bound in `X`
+   |          ^ required by the implicit `Sized` requirement on this bound in `X`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
@@ -30,11 +30,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func1() -> Struct1<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct1`
+note: required by an implicit `Sized` bound in `Struct1`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:8:16
    |
 LL | struct Struct1<T>{
-   |                ^ required by this bound in `Struct1`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Struct1`
 help: consider further restricting `Self`
    |
 LL |     fn func1() -> Struct1<Self> where Self: Sized;
@@ -50,11 +50,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func2<'a>() -> Struct2<'a, Self>;
    |                       ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct2`
+note: required by an implicit `Sized` bound in `Struct2`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:11:20
    |
 LL | struct Struct2<'a, T>{
-   |                    ^ required by this bound in `Struct2`
+   |                    ^ required by the implicit `Sized` requirement on this bound in `Struct2`
 help: consider further restricting `Self`
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self> where Self: Sized;
@@ -70,11 +70,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func3() -> Struct3<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct3`
+note: required by an implicit `Sized` bound in `Struct3`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
 LL | struct Struct3<T>{
-   |                ^ required by this bound in `Struct3`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Struct3`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
@@ -93,11 +93,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func4() -> Struct4<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct4`
+note: required by an implicit `Sized` bound in `Struct4`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:20:16
    |
 LL | struct Struct4<T>{
-   |                ^ required by this bound in `Struct4`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Struct4`
 help: consider further restricting `Self`
    |
 LL |     fn func4() -> Struct4<Self> where Self: Sized;

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `X`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
 LL | struct X<T>(T);
-   |          ^ required by the implicit `Sized` requirement on this bound in `X`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `X`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
@@ -34,7 +34,7 @@ note: required by an implicit `Sized` bound in `Struct1`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:8:16
    |
 LL | struct Struct1<T>{
-   |                ^ required by the implicit `Sized` requirement on this bound in `Struct1`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Struct1`
 help: consider further restricting `Self`
    |
 LL |     fn func1() -> Struct1<Self> where Self: Sized;
@@ -54,7 +54,7 @@ note: required by an implicit `Sized` bound in `Struct2`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:11:20
    |
 LL | struct Struct2<'a, T>{
-   |                    ^ required by the implicit `Sized` requirement on this bound in `Struct2`
+   |                    ^ required by the implicit `Sized` requirement on this type parameter in `Struct2`
 help: consider further restricting `Self`
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self> where Self: Sized;
@@ -74,7 +74,7 @@ note: required by an implicit `Sized` bound in `Struct3`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
 LL | struct Struct3<T>{
-   |                ^ required by the implicit `Sized` requirement on this bound in `Struct3`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Struct3`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
@@ -97,7 +97,7 @@ note: required by an implicit `Sized` bound in `Struct4`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:20:16
    |
 LL | struct Struct4<T>{
-   |                ^ required by the implicit `Sized` requirement on this bound in `Struct4`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Struct4`
 help: consider further restricting `Self`
    |
 LL |     fn func4() -> Struct4<Self> where Self: Sized;

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -76,7 +76,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -89,7 +89,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -102,7 +102,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -115,7 +115,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -128,7 +128,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -57,10 +57,10 @@ LL |     f_sized(*ref_cl);
    |
    = help: the trait `Sized` is not implemented for `dyn Fn()`
 note: required by a bound in `f_sized`
-  --> $DIR/issue-84973-blacklist.rs:9:12
+  --> $DIR/issue-84973-blacklist.rs:9:15
    |
 LL | fn f_sized<T: Sized>(t: T) {}
-   |            ^ required by this bound in `f_sized`
+   |               ^^^^^ required by this bound in `f_sized`
 
 error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/issue-84973-blacklist.rs:27:12

--- a/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
+++ b/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
@@ -5,11 +5,11 @@ LL | struct B(A<[u8]>);
    |          ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `A`
+note: required by an implicit `Sized` bound in `A`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |
 LL | struct A<T>(T) where T: Send;
-   |          ^ required by this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this bound in `A`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |

--- a/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
+++ b/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `A`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |
 LL | struct A<T>(T) where T: Send;
-   |          ^ required by the implicit `Sized` requirement on this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `A`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |

--- a/tests/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.stderr
+++ b/tests/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.stderr
@@ -8,10 +8,10 @@ LL | fn bar() { foo(""); }
    |
    = help: the trait `Sized` is not implemented for `str`
 note: required by a bound in `foo`
-  --> $DIR/issue-85945-check-where-clause-before-suggesting-unsized.rs:3:8
+  --> $DIR/issue-85945-check-where-clause-before-suggesting-unsized.rs:3:27
    |
 LL | fn foo<T>(_: &T) where T: Sized {}
-   |        ^ required by this bound in `foo`
+   |                           ^^^^^ required by this bound in `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -39,7 +39,7 @@ note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -64,7 +64,7 @@ note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -6,11 +6,11 @@ LL | fn foo<T>(foo: Wrapper<T>)
    |        |
    |        this type parameter needs to be `Sized`
    |
-note: required by a bound in `Wrapper`
+note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -35,11 +35,11 @@ LL | fn bar<T>(foo: Wrapper<T>)
    |        |
    |        this type parameter needs to be `Sized`
    |
-note: required by a bound in `Wrapper`
+note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -60,11 +60,11 @@ LL | fn qux<T>(foo: Wrapper<T>)
    |        |
    |        this type parameter needs to be `Sized`
    |
-note: required by a bound in `Wrapper`
+note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -11,7 +11,7 @@ note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
@@ -50,7 +50,7 @@ note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
@@ -100,7 +100,7 @@ note: required by an implicit `Sized` bound in `Trait2`
   --> $DIR/unsized-bound.rs:9:14
    |
 LL | trait Trait2<A> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait2`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
@@ -138,7 +138,7 @@ note: required by an implicit `Sized` bound in `Trait3`
   --> $DIR/unsized-bound.rs:13:14
    |
 LL | trait Trait3<A> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait3`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait3`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A> Trait3<A> for A where A: ?Sized {}
@@ -161,7 +161,7 @@ note: required by an implicit `Sized` bound in `Trait4`
   --> $DIR/unsized-bound.rs:16:14
    |
 LL | trait Trait4<A> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait4`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized> Trait4<A> for A {}
@@ -184,7 +184,7 @@ note: required by an implicit `Sized` bound in `Trait5`
   --> $DIR/unsized-bound.rs:19:14
    |
 LL | trait Trait5<A, B> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait5`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
@@ -207,7 +207,7 @@ note: required by an implicit `Sized` bound in `Trait6`
   --> $DIR/unsized-bound.rs:22:14
    |
 LL | trait Trait6<A, B> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait6`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait6`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized, Y> Trait6<X, Y> for X {}
@@ -230,7 +230,7 @@ note: required by an implicit `Sized` bound in `Trait7`
   --> $DIR/unsized-bound.rs:25:17
    |
 LL | trait Trait7<A, B> {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait7`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `Trait7`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
@@ -253,7 +253,7 @@ note: required by an implicit `Sized` bound in `Trait8`
   --> $DIR/unsized-bound.rs:28:17
    |
 LL | trait Trait8<A, B> {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait8`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `Trait8`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y: ?Sized> Trait8<X, Y> for X {}

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -7,11 +7,11 @@ LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |         this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
-note: required by a bound in `Trait`
+note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
@@ -46,11 +46,11 @@ LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Size
    |                    this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B, C)`
-note: required by a bound in `Trait`
+note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
@@ -96,11 +96,11 @@ LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |                 this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
-note: required by a bound in `Trait2`
+note: required by an implicit `Sized` bound in `Trait2`
   --> $DIR/unsized-bound.rs:9:14
    |
 LL | trait Trait2<A> {}
-   |              ^ required by this bound in `Trait2`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
@@ -134,11 +134,11 @@ LL | impl<A> Trait3<A> for A where A: ?Sized {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait3`
+note: required by an implicit `Sized` bound in `Trait3`
   --> $DIR/unsized-bound.rs:13:14
    |
 LL | trait Trait3<A> {}
-   |              ^ required by this bound in `Trait3`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait3`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A> Trait3<A> for A where A: ?Sized {}
@@ -157,11 +157,11 @@ LL | impl<A: ?Sized> Trait4<A> for A {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait4`
+note: required by an implicit `Sized` bound in `Trait4`
   --> $DIR/unsized-bound.rs:16:14
    |
 LL | trait Trait4<A> {}
-   |              ^ required by this bound in `Trait4`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized> Trait4<A> for A {}
@@ -180,11 +180,11 @@ LL | impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait5`
+note: required by an implicit `Sized` bound in `Trait5`
   --> $DIR/unsized-bound.rs:19:14
    |
 LL | trait Trait5<A, B> {}
-   |              ^ required by this bound in `Trait5`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
@@ -203,11 +203,11 @@ LL | impl<X: ?Sized, Y> Trait6<X, Y> for X {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait6`
+note: required by an implicit `Sized` bound in `Trait6`
   --> $DIR/unsized-bound.rs:22:14
    |
 LL | trait Trait6<A, B> {}
-   |              ^ required by this bound in `Trait6`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait6`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized, Y> Trait6<X, Y> for X {}
@@ -226,11 +226,11 @@ LL | impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait7`
+note: required by an implicit `Sized` bound in `Trait7`
   --> $DIR/unsized-bound.rs:25:17
    |
 LL | trait Trait7<A, B> {}
-   |                 ^ required by this bound in `Trait7`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait7`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
@@ -249,11 +249,11 @@ LL | impl<X, Y: ?Sized> Trait8<X, Y> for X {}
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait8`
+note: required by an implicit `Sized` bound in `Trait8`
   --> $DIR/unsized-bound.rs:28:17
    |
 LL | trait Trait8<A, B> {}
-   |                 ^ required by this bound in `Trait8`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait8`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y: ?Sized> Trait8<X, Y> for X {}

--- a/tests/ui/traits/bad-sized.stderr
+++ b/tests/ui/traits/bad-sized.stderr
@@ -16,7 +16,7 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
@@ -36,7 +36,7 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                                     ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 4 previous errors

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -25,11 +25,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | pub trait Bar: Foo<Assoc=()> {
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: consider further restricting `Self`
    |
 LL | pub trait Bar: Foo<Assoc=()> + Sized {
@@ -45,11 +45,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | pub trait Bar: Foo<Assoc=()> {
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: consider further restricting `Self`
    |
 LL |     ) where Self: Sized;

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -29,7 +29,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider further restricting `Self`
    |
 LL | pub trait Bar: Foo<Assoc=()> + Sized {
@@ -49,7 +49,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider further restricting `Self`
    |
 LL |     ) where Self: Sized;

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -8,11 +8,9 @@ use core::marker::PhantomData;
 fn main() {
     test::<MaskedStorage<GenericComp<Pos>>>(make());
     //~^ ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-    //~| ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
 
     test::<MaskedStorage<GenericComp2<Pos>>>(make());
     //~^ ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-    //~| ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
 }
 
 #[rustc_evaluate_where_clauses]

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -5,28 +5,10 @@ LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | fn test<T: Sized>(_: T) {}
-   |         - predicate
-
-error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-  --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
-   |
-LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
 error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
-   |
-LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn test<T: Sized>(_: T) {}
-   |         - predicate
-
-error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
+  --> $DIR/issue-85360-eval-obligation-ice.rs:12:5
    |
 LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,5 +16,5 @@ LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
 LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/mutual-recursion-issue-75860.stderr
+++ b/tests/ui/traits/mutual-recursion-issue-75860.stderr
@@ -5,7 +5,7 @@ LL |     iso(left, right)
    |     ^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`mutual_recursion_issue_75860`)
-note: required by a bound in `Option`
+note: required by an implicit `Sized` bound in `Option`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.stderr
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.stderr
@@ -26,11 +26,11 @@ LL |     needs_bar::<T::Assoc1>();
    |                 ^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization_2`)
-note: required by a bound in `needs_bar`
+note: required by an implicit `Sized` bound in `needs_bar`
   --> $DIR/recursive-self-normalization-2.rs:12:14
    |
 LL | fn needs_bar<S: Bar>() {}
-   |              ^ required by this bound in `needs_bar`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `needs_bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn needs_bar<S: Bar + ?Sized>() {}

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization.stderr
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization.stderr
@@ -26,11 +26,11 @@ LL |     needs_bar::<T::Assoc>();
    |                 ^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization`)
-note: required by a bound in `needs_bar`
+note: required by an implicit `Sized` bound in `needs_bar`
   --> $DIR/recursive-self-normalization.rs:8:14
    |
 LL | fn needs_bar<S: Bar>() {}
-   |              ^ required by this bound in `needs_bar`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `needs_bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn needs_bar<S: Bar + ?Sized>() {}

--- a/tests/ui/traits/suggest-where-clause.stderr
+++ b/tests/ui/traits/suggest-where-clause.stderr
@@ -7,7 +7,7 @@ LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
@@ -29,7 +29,7 @@ note: required because it appears within the type `Misc<U>`
    |
 LL | struct Misc<T:?Sized>(T);
    |        ^^^^
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
@@ -72,7 +72,7 @@ LL |     mem::size_of::<[T]>();
    |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[T]`
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `[&U]` cannot be known at compilation time
@@ -82,7 +82,7 @@ LL |     mem::size_of::<[&U]>();
    |                    ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[&U]`
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 7 previous errors

--- a/tests/ui/unsized/unsized-bare-typaram.stderr
+++ b/tests/ui/unsized/unsized-bare-typaram.stderr
@@ -7,10 +7,10 @@ LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `bar`
-  --> $DIR/unsized-bare-typaram.rs:1:8
+  --> $DIR/unsized-bare-typaram.rs:1:11
    |
 LL | fn bar<T: Sized>() { }
-   |        ^ required by this bound in `bar`
+   |           ^^^^^ required by this bound in `bar`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo<T: ?Sized>() { bar::<T>() }

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -6,11 +6,11 @@ LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-enum.rs:4:10
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   |          ^ required by this bound in `Foo`
+   |          ^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: you could relax the implicit `Sized` bound on `U` if it were used through indirection like `&U` or `Box<U>`
   --> $DIR/unsized-enum.rs:4:10
    |

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-enum.rs:4:10
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   |          ^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: you could relax the implicit `Sized` bound on `U` if it were used through indirection like `&U` or `Box<U>`
   --> $DIR/unsized-enum.rs:4:10
    |

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized> S5<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `S5`
+note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -6,11 +6,11 @@ LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-struct.rs:4:12
    |
 LL | struct Foo<T> { data: T }
-   |            ^ required by this bound in `Foo`
+   |            ^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/unsized-struct.rs:4:12
    |
@@ -38,10 +38,10 @@ note: required because it appears within the type `Bar<T>`
 LL | struct Bar<T: ?Sized> { data: T }
    |        ^^^
 note: required by a bound in `is_sized`
-  --> $DIR/unsized-struct.rs:1:13
+  --> $DIR/unsized-struct.rs:1:15
    |
 LL | fn is_sized<T:Sized>() { }
-   |             ^ required by this bound in `is_sized`
+   |               ^^^^^ required by this bound in `is_sized`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-struct.rs:4:12
    |
 LL | struct Foo<T> { data: T }
-   |            ^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/unsized-struct.rs:4:12
    |

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `S5`
+note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `T2`
+note: required by an implicit `Sized` bound in `T2`
   --> $DIR/unsized-trait-impl-trait-arg.rs:4:10
    |
 LL | trait T2<Z> {
-   |          ^ required by this bound in `T2`
+   |          ^ required by the implicit `Sized` requirement on this bound in `T2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T2<X> for S4<X> {

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `T2`
   --> $DIR/unsized-trait-impl-trait-arg.rs:4:10
    |
 LL | trait T2<Z> {
-   |          ^ required by the implicit `Sized` requirement on this bound in `T2`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `T2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T2<X> for S4<X> {

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `f2`
   --> $DIR/unsized3.rs:10:7
    |
 LL | fn f2<X>(x: &X) {
-   |       ^ required by the implicit `Sized` requirement on this bound in `f2`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<X: ?Sized>(x: &X) {
@@ -33,7 +33,7 @@ note: required by an implicit `Sized` bound in `f4`
   --> $DIR/unsized3.rs:21:7
    |
 LL | fn f4<X: T>(x: &X) {
-   |       ^ required by the implicit `Sized` requirement on this bound in `f4`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized + T>(x: &X) {
@@ -63,7 +63,7 @@ note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
@@ -135,7 +135,7 @@ note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -6,11 +6,11 @@ LL | fn f1<X: ?Sized>(x: &X) {
 LL |     f2::<X>(x);
    |          ^ doesn't have a size known at compile-time
    |
-note: required by a bound in `f2`
+note: required by an implicit `Sized` bound in `f2`
   --> $DIR/unsized3.rs:10:7
    |
 LL | fn f2<X>(x: &X) {
-   |       ^ required by this bound in `f2`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<X: ?Sized>(x: &X) {
@@ -29,11 +29,11 @@ LL | fn f3<X: ?Sized + T>(x: &X) {
 LL |     f4::<X>(x);
    |          ^ doesn't have a size known at compile-time
    |
-note: required by a bound in `f4`
+note: required by an implicit `Sized` bound in `f4`
   --> $DIR/unsized3.rs:21:7
    |
 LL | fn f4<X: T>(x: &X) {
-   |       ^ required by this bound in `f4`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized + T>(x: &X) {
@@ -59,11 +59,11 @@ note: required because it appears within the type `S<X>`
    |
 LL | struct S<X: ?Sized> {
    |        ^
-note: required by a bound in `f5`
+note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
@@ -131,11 +131,11 @@ note: required because it appears within the type `S<X>`
 LL | struct S<X: ?Sized> {
    |        ^
    = note: required because it appears within the type `({integer}, S<X>)`
-note: required by a bound in `f5`
+note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `T1`
   --> $DIR/unsized7.rs:7:10
    |
 LL | trait T1<Z: T> {
-   |          ^ required by the implicit `Sized` requirement on this bound in `T1`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `T1`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized + T> T1<X> for S3<X> {

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `T1`
+note: required by an implicit `Sized` bound in `T1`
   --> $DIR/unsized7.rs:7:10
    |
 LL | trait T1<Z: T> {
-   |          ^ required by this bound in `T1`
+   |          ^ required by the implicit `Sized` requirement on this bound in `T1`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized + T> T1<X> for S3<X> {

--- a/tests/ui/wf/hir-wf-canonicalized.stderr
+++ b/tests/ui/wf/hir-wf-canonicalized.stderr
@@ -29,11 +29,11 @@ LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static)`
-note: required by a bound in `Bar`
+note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/hir-wf-canonicalized.rs:9:16
    |
 LL | struct Bar<'a, T> {
-   |                ^ required by this bound in `Bar`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | struct Bar<'a, T: ?Sized> {

--- a/tests/ui/wf/hir-wf-canonicalized.stderr
+++ b/tests/ui/wf/hir-wf-canonicalized.stderr
@@ -33,7 +33,7 @@ note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/hir-wf-canonicalized.rs:9:16
    |
 LL | struct Bar<'a, T> {
-   |                ^ required by the implicit `Sized` requirement on this bound in `Bar`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | struct Bar<'a, T: ?Sized> {

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -34,7 +34,7 @@ note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |
 LL | struct Vec<T> {
-   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -30,11 +30,11 @@ LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |
 LL | struct Vec<T> {
-   |            ^ required by this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |

--- a/tests/ui/wf/wf-impl-self-type.stderr
+++ b/tests/ui/wf/wf-impl-self-type.stderr
@@ -5,7 +5,7 @@ LL | impl Foo for Option<[u8]> {}
    |              ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Option`
+note: required by an implicit `Sized` bound in `Option`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
```
error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
   --> f100.rs:2:33
    |
2   |     let _ = std::mem::size_of::<[i32]>();
    |                                 ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> /home/gh-estebank/rust/library/core/src/mem/mod.rs:312:22
    |
312 | pub const fn size_of<T>() -> usize {
    |                      ^ required by the implicit `Sized` requirement on this type parameter in `size_of`
```

Fix #120178.