### PR TITLE
rustc_data_structures: use either instead of itertools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3654,10 +3654,10 @@ version = "0.0.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.4.1",
+ "either",
  "elsa",
  "ena",
  "indexmap",
- "itertools",
  "jobserver",
  "libc",
  "measureme",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 # tidy-alphabetical-start
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
+either = "1.0"
 elsa = "=1.7.1"
 ena = "0.14.2"
 indexmap = { version = "2.0.0" }
-itertools = "0.11"
 jobserver_crate = { version = "0.1.27", package = "jobserver" }
 libc = "0.2"
 measureme = "11"

--- a/compiler/rustc_data_structures/src/sharded.rs
+++ b/compiler/rustc_data_structures/src/sharded.rs
@@ -3,7 +3,7 @@ use crate::fx::{FxHashMap, FxHasher};
 use crate::sync::{is_dyn_thread_safe, CacheAligned};
 use crate::sync::{Lock, LockGuard, Mode};
 #[cfg(parallel_compiler)]
-use itertools::Either;
+use either::Either;
 use std::borrow::Borrow;
 use std::collections::hash_map::RawEntryMut;
 use std::hash::{Hash, Hasher};

--- a/compiler/rustc_data_structures/src/sso/map.rs
+++ b/compiler/rustc_data_structures/src/sso/map.rs
@@ -1,6 +1,6 @@
 use crate::fx::FxHashMap;
 use arrayvec::ArrayVec;
-use itertools::Either;
+use either::Either;
 use std::fmt;
 use std::hash::Hash;
 use std::ops::Index;


### PR DESCRIPTION
`itertools::Either` is a re-export from `either`, so we might as well use the source.

This flattens the compiler build tree a little, but I don't really expect it to make much difference overall.