### PR TITLE
Don't fire `OPAQUE_HIDDEN_INFERRED_BOUND` on sized return of AFIT

### DIFF
--- a/tests/ui/async-await/in-trait/returning-possibly-unsized-self.rs
+++ b/tests/ui/async-await/in-trait/returning-possibly-unsized-self.rs
@@ -1,0 +1,18 @@
+// check-pass
+// edition:2021
+
+#![deny(opaque_hidden_inferred_bound)]
+
+trait Repository /* : ?Sized */ {
+    async fn new() -> Self;
+}
+
+struct MyRepository {}
+
+impl Repository for MyRepository {
+    async fn new() -> Self {
+        todo!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Conceptually, we should probably not fire `OPAQUE_HIDDEN_INFERRED_BOUND` for methods like:

```
trait Foo { async fn bar() -> Self; }
```

Even though we technically cannot prove that `Self: Sized`, which is one of the item bounds of the `Output` type in the `-> impl Future<Output = Sized>` from the async desugaring.

This is somewhat justifiable along the same lines as how we allow regular methods to return `-> Self` even though `Self` isn't sized.

Fixes #113538 

(side-note: some days i wonder if we should just remove the `OPAQUE_HIDDEN_INFERRED_BOUND` lint... it does make me sad that we have non-well-formed types in signatures, though.)