### PR TITLE
mark a doctest with UB as no_run

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2531,7 +2531,7 @@ extern "rust-intrinsic" {
     /// or `false`, and the caller has to ensure sound behavior for both cases.
     /// In other words, the following code has *Undefined Behavior*:
     ///
-    /// ```
+    /// ```no_run
     /// #![feature(is_val_statically_known)]
     /// #![feature(core_intrinsics)]
     /// # #![allow(internal_features)]


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/119911 added a doctest with UB. That one shouldn't be run, or else Miri will complain.