### PR TITLE
Classify closure arguments in refutable pattern in argument error

### DIFF
--- a/tests/ui/pattern/usefulness/refutable-pattern-in-fn-arg.rs
+++ b/tests/ui/pattern/usefulness/refutable-pattern-in-fn-arg.rs
@@ -1,6 +1,6 @@
 fn main() {
     let f = |3: isize| println!("hello");
-    //~^ ERROR refutable pattern in function argument
+    //~^ ERROR refutable pattern in closure argument
     //~| `..=2_isize` and `4_isize..` not covered
     f(4);
 }

--- a/tests/ui/pattern/usefulness/refutable-pattern-in-fn-arg.stderr
+++ b/tests/ui/pattern/usefulness/refutable-pattern-in-fn-arg.stderr
@@ -1,4 +1,4 @@
-error[E0005]: refutable pattern in function argument
+error[E0005]: refutable pattern in closure argument
   --> $DIR/refutable-pattern-in-fn-arg.rs:2:14
    |
 LL |     let f = |3: isize| println!("hello");


### PR DESCRIPTION
You can call it a function (and people may or may not agree with that), but it's better to just say those are closure arguments instead.