### PR TITLE
Use `<T, U>` for array/slice equality `impl`s

### DIFF
--- a/library/core/src/array/equality.rs
+++ b/library/core/src/array/equality.rs
@@ -2,36 +2,36 @@ use crate::cmp::BytewiseEq;
 use crate::convert::TryInto;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<[B; N]> for [A; N]
+impl<T, U, const N: usize> PartialEq<[U; N]> for [T; N]
 where
-    A: PartialEq<B>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &[B; N]) -> bool {
+    fn eq(&self, other: &[U; N]) -> bool {
         SpecArrayEq::spec_eq(self, other)
     }
     #[inline]
-    fn ne(&self, other: &[B; N]) -> bool {
+    fn ne(&self, other: &[U; N]) -> bool {
         SpecArrayEq::spec_ne(self, other)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<[B]> for [A; N]
+impl<T, U, const N: usize> PartialEq<[U]> for [T; N]
 where
-    A: PartialEq<B>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &[B]) -> bool {
-        let b: Result<&[B; N], _> = other.try_into();
+    fn eq(&self, other: &[U]) -> bool {
+        let b: Result<&[U; N], _> = other.try_into();
         match b {
             Ok(b) => *self == *b,
             Err(_) => false,
         }
     }
     #[inline]
-    fn ne(&self, other: &[B]) -> bool {
-        let b: Result<&[B; N], _> = other.try_into();
+    fn ne(&self, other: &[U]) -> bool {
+        let b: Result<&[U; N], _> = other.try_into();
         match b {
             Ok(b) => *self != *b,
             Err(_) => true,
@@ -40,21 +40,21 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<[A; N]> for [B]
+impl<T, U, const N: usize> PartialEq<[U; N]> for [T]
 where
-    B: PartialEq<A>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &[A; N]) -> bool {
-        let b: Result<&[B; N], _> = self.try_into();
+    fn eq(&self, other: &[U; N]) -> bool {
+        let b: Result<&[T; N], _> = self.try_into();
         match b {
             Ok(b) => *b == *other,
             Err(_) => false,
         }
     }
     #[inline]
-    fn ne(&self, other: &[A; N]) -> bool {
-        let b: Result<&[B; N], _> = self.try_into();
+    fn ne(&self, other: &[U; N]) -> bool {
+        let b: Result<&[T; N], _> = self.try_into();
         match b {
             Ok(b) => *b != *other,
             Err(_) => true,
@@ -63,61 +63,61 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<&[B]> for [A; N]
+impl<T, U, const N: usize> PartialEq<&[U]> for [T; N]
 where
-    A: PartialEq<B>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &&[B]) -> bool {
+    fn eq(&self, other: &&[U]) -> bool {
         *self == **other
     }
     #[inline]
-    fn ne(&self, other: &&[B]) -> bool {
+    fn ne(&self, other: &&[U]) -> bool {
         *self != **other
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<[A; N]> for &[B]
+impl<T, U, const N: usize> PartialEq<[U; N]> for &[T]
 where
-    B: PartialEq<A>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &[A; N]) -> bool {
+    fn eq(&self, other: &[U; N]) -> bool {
         **self == *other
     }
     #[inline]
-    fn ne(&self, other: &[A; N]) -> bool {
+    fn ne(&self, other: &[U; N]) -> bool {
         **self != *other
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<&mut [B]> for [A; N]
+impl<T, U, const N: usize> PartialEq<&mut [U]> for [T; N]
 where
-    A: PartialEq<B>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &&mut [B]) -> bool {
+    fn eq(&self, other: &&mut [U]) -> bool {
         *self == **other
     }
     #[inline]
-    fn ne(&self, other: &&mut [B]) -> bool {
+    fn ne(&self, other: &&mut [U]) -> bool {
         *self != **other
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B, const N: usize> PartialEq<[A; N]> for &mut [B]
+impl<T, U, const N: usize> PartialEq<[U; N]> for &mut [T]
 where
-    B: PartialEq<A>,
+    T: PartialEq<U>,
 {
     #[inline]
-    fn eq(&self, other: &[A; N]) -> bool {
+    fn eq(&self, other: &[U; N]) -> bool {
         **self == *other
     }
     #[inline]
-    fn ne(&self, other: &[A; N]) -> bool {
+    fn ne(&self, other: &[U; N]) -> bool {
         **self != *other
     }
 }

--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -8,15 +8,15 @@ use super::from_raw_parts;
 use super::memchr;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B> PartialEq<[B]> for [A]
+impl<T, U> PartialEq<[U]> for [T]
 where
-    A: PartialEq<B>,
+    T: PartialEq<U>,
 {
-    fn eq(&self, other: &[B]) -> bool {
+    fn eq(&self, other: &[U]) -> bool {
         SlicePartialEq::equal(self, other)
     }
 
-    fn ne(&self, other: &[B]) -> bool {
+    fn ne(&self, other: &[U]) -> bool {
         SlicePartialEq::not_equal(self, other)
     }
 }

--- a/tests/ui/consts/too_generic_eval_ice.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.stderr
@@ -22,13 +22,13 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
-             <[A; N] as PartialEq<[B; N]>>
-             <[A; N] as PartialEq<[B]>>
-             <[A; N] as PartialEq<&[B]>>
-             <[A; N] as PartialEq<&mut [B]>>
+             <[T; N] as PartialEq<[U; N]>>
+             <[T; N] as PartialEq<[U]>>
+             <[T; N] as PartialEq<&[U]>>
+             <[T; N] as PartialEq<&mut [U]>>
              <[T] as PartialEq<Vec<U, A>>>
-             <[A] as PartialEq<[B]>>
-             <[B] as PartialEq<[A; N]>>
+             <[T] as PartialEq<[U; N]>>
+             <[T] as PartialEq<[U]>>
              <&[T] as PartialEq<Vec<U, A>>>
            and 3 others
 


### PR DESCRIPTION
Makes the trait implementation documentation for arrays and slices appear more consistent.

[Example](https://doc.rust-lang.org/1.75.0/std/primitive.array.html): mixed `A`, `B`, and `U`.
![List of PartialEq implementations for arrays](https://github.com/wackbyte/rust/assets/29505620/823c010e-ee57-4de1-885b-a1cd6dcaf85f)

This change makes them all `U`.