### PR TITLE
Small improvements to internal documentation

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1139,6 +1139,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for WeakAliasTypeExpander<'tcx> {
 
 impl<'tcx> Ty<'tcx> {
     /// Returns the `Size` for primitive types (bool, uint, int, char, float).
+    /// If the type is not primitive, will panic with message "non primitive type".
     pub fn primitive_size(self, tcx: TyCtxt<'tcx>) -> Size {
         match *self.kind() {
             ty::Bool => Size::from_bytes(1),
@@ -1150,7 +1151,8 @@ impl<'tcx> Ty<'tcx> {
             _ => bug!("non primitive type"),
         }
     }
-
+    /// Returns the size and sign of an inieger type.
+    /// If the type is not an intieger, will panic with message "non integer discriminant".
     pub fn int_size_and_signed(self, tcx: TyCtxt<'tcx>) -> (Size, bool) {
         match *self.kind() {
             ty::Int(ity) => (Integer::from_int_ty(&tcx, ity).size(), true),

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -776,6 +776,10 @@ impl RiscvInterruptKind {
 /// Metadata describing how the arguments to a native function
 /// should be passed in order to respect the native ABI.
 ///
+/// Signature contained within this function does not have to match the one present in MIR.
+/// Certain attributtes, like `#[track_caller]` can introduce addtional arguments, which are present in [`FnAbi`], but not in[`rustc_middle::ty::FnSig`.
+/// This difference is not relevant in most cases, but should still be kept in mind.
+///
 /// I will do my best to describe this structure, but these
 /// comments are reverse-engineered and may be inaccurate. -NDM
 #[derive(Clone, PartialEq, Eq, Hash, HashStable_Generic)]
@@ -795,7 +799,7 @@ pub struct FnAbi<'a, Ty> {
     pub fixed_count: u32,
 
     pub conv: Conv,
-
+    /// This variable desribes if unwind can cross this function, or if it is invalid to unwind troguh it.
     pub can_unwind: bool,
 }
 


### PR DESCRIPTION
Hi!

While working on my project ([rustc_codegen_clr](https://github.com/FractalFir/rustc_codegen_clr)) I have noticed the internal `rustc` documentation is lacking in some places. So, I have decided to add documentation for a few types/methods, and extend some of it by adding additional information.

Those commits add documentation to `Instance`, some methods of Ty, and extend documentation of `FnSig` and `FnAbi` to add info about some edge cases.