### PR TITLE
Bound errors span label cleanup

### DIFF
--- a/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-in-multiple-impls.stderr
+++ b/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-in-multiple-impls.stderr
@@ -4,10 +4,7 @@ error: the associated type `X` exists for `S<Featureless, Featureless>`, but its
 LL | struct S<A, B>(A, B);
    | -------------- associated item `X` not found for this struct
 LL | struct Featureless;
-   | ------------------
-   | |
-   | doesn't satisfy `Featureless: One`
-   | doesn't satisfy `Featureless: Two`
+   | ------------------ doesn't satisfy `Featureless: One` or `Featureless: Two`
 ...
 LL |     let _: S::<Featureless, Featureless>::X;
    |                                           ^ associated type cannot be referenced on `S<Featureless, Featureless>` due to unsatisfied trait bounds

--- a/tests/ui/box/unit/unique-object-noncopyable.stderr
+++ b/tests/ui/box/unit/unique-object-noncopyable.stderr
@@ -1,18 +1,11 @@
 error[E0599]: the method `clone` exists for struct `Box<dyn Foo>`, but its trait bounds were not satisfied
   --> $DIR/unique-object-noncopyable.rs:24:16
    |
-LL |   trait Foo {
-   |   ---------
-   |   |
-   |   doesn't satisfy `dyn Foo: Clone`
-   |   doesn't satisfy `dyn Foo: Sized`
+LL | trait Foo {
+   | --------- doesn't satisfy `dyn Foo: Clone` or `dyn Foo: Sized`
 ...
-LL |       let _z = y.clone();
-   |                  ^^^^^ method cannot be called on `Box<dyn Foo>` due to unsatisfied trait bounds
-  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
-  ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
-   |
-   = note: doesn't satisfy `Box<dyn Foo>: Clone`
+LL |     let _z = y.clone();
+   |                ^^^^^ method cannot be called on `Box<dyn Foo>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `dyn Foo: Sized`

--- a/tests/ui/box/unit/unique-pinned-nocopy.stderr
+++ b/tests/ui/box/unit/unique-pinned-nocopy.stderr
@@ -1,15 +1,11 @@
 error[E0599]: the method `clone` exists for struct `Box<R>`, but its trait bounds were not satisfied
   --> $DIR/unique-pinned-nocopy.rs:12:16
    |
-LL |   struct R {
-   |   -------- doesn't satisfy `R: Clone`
+LL | struct R {
+   | -------- doesn't satisfy `R: Clone`
 ...
-LL |       let _j = i.clone();
-   |                  ^^^^^ method cannot be called on `Box<R>` due to unsatisfied trait bounds
-  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
-  ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
-   |
-   = note: doesn't satisfy `Box<R>: Clone`
+LL |     let _j = i.clone();
+   |                ^^^^^ method cannot be called on `Box<R>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `R: Clone`

--- a/tests/ui/derives/derive-assoc-type-not-impl.stderr
+++ b/tests/ui/derives/derive-assoc-type-not-impl.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `clone` exists for struct `Bar<NotClone>`, but its trai
   --> $DIR/derive-assoc-type-not-impl.rs:18:30
    |
 LL | struct Bar<T: Foo> {
-   | ------------------
-   | |
-   | method `clone` not found for this struct
-   | doesn't satisfy `Bar<NotClone>: Clone`
+   | ------------------ method `clone` not found for this struct because it doesn't satisfy `Bar<NotClone>: Clone`
 ...
 LL | struct NotClone;
    | --------------- doesn't satisfy `NotClone: Clone`

--- a/tests/ui/derives/deriving-with-repr-packed-2.stderr
+++ b/tests/ui/derives/deriving-with-repr-packed-2.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `clone` exists for struct `Foo<NonCopy>`, but its trait
   --> $DIR/deriving-with-repr-packed-2.rs:18:11
    |
 LL | pub struct Foo<T>(T, T, T);
-   | -----------------
-   | |
-   | method `clone` not found for this struct
-   | doesn't satisfy `Foo<NonCopy>: Clone`
+   | ----------------- method `clone` not found for this struct because it doesn't satisfy `Foo<NonCopy>: Clone`
 LL |
 LL | struct NonCopy;
    | -------------- doesn't satisfy `NonCopy: Clone` or `NonCopy: Copy`

--- a/tests/ui/derives/deriving-with-repr-packed-2.stderr
+++ b/tests/ui/derives/deriving-with-repr-packed-2.stderr
@@ -8,10 +8,7 @@ LL | pub struct Foo<T>(T, T, T);
    | doesn't satisfy `Foo<NonCopy>: Clone`
 LL |
 LL | struct NonCopy;
-   | --------------
-   | |
-   | doesn't satisfy `NonCopy: Clone`
-   | doesn't satisfy `NonCopy: Copy`
+   | -------------- doesn't satisfy `NonCopy: Clone` or `NonCopy: Copy`
 ...
 LL |     _ = x.clone();
    |           ^^^^^ method cannot be called on `Foo<NonCopy>` due to unsatisfied trait bounds

--- a/tests/ui/derives/issue-91550.stderr
+++ b/tests/ui/derives/issue-91550.stderr
@@ -2,11 +2,7 @@ error[E0599]: the method `insert` exists for struct `HashSet<Value>`, but its tr
   --> $DIR/issue-91550.rs:8:8
    |
 LL | struct Value(u32);
-   | ------------
-   | |
-   | doesn't satisfy `Value: Eq`
-   | doesn't satisfy `Value: Hash`
-   | doesn't satisfy `Value: PartialEq`
+   | ------------ doesn't satisfy `Value: Eq`, `Value: Hash` or `Value: PartialEq`
 ...
 LL |     hs.insert(Value(0));
    |        ^^^^^^
@@ -26,10 +22,7 @@ error[E0599]: the method `use_eq` exists for struct `Object<NoDerives>`, but its
   --> $DIR/issue-91550.rs:26:9
    |
 LL | pub struct NoDerives;
-   | --------------------
-   | |
-   | doesn't satisfy `NoDerives: Eq`
-   | doesn't satisfy `NoDerives: PartialEq`
+   | -------------------- doesn't satisfy `NoDerives: Eq` or `NoDerives: PartialEq`
 LL |
 LL | struct Object<T>(T);
    | ---------------- method `use_eq` not found for this struct
@@ -57,12 +50,7 @@ error[E0599]: the method `use_ord` exists for struct `Object<NoDerives>`, but it
   --> $DIR/issue-91550.rs:27:9
    |
 LL | pub struct NoDerives;
-   | --------------------
-   | |
-   | doesn't satisfy `NoDerives: Eq`
-   | doesn't satisfy `NoDerives: Ord`
-   | doesn't satisfy `NoDerives: PartialEq`
-   | doesn't satisfy `NoDerives: PartialOrd`
+   | -------------------- doesn't satisfy `NoDerives: Eq`, `NoDerives: Ord`, `NoDerives: PartialEq` or `NoDerives: PartialOrd`
 LL |
 LL | struct Object<T>(T);
    | ---------------- method `use_ord` not found for this struct
@@ -94,12 +82,7 @@ error[E0599]: the method `use_ord_and_partial_ord` exists for struct `Object<NoD
   --> $DIR/issue-91550.rs:28:9
    |
 LL | pub struct NoDerives;
-   | --------------------
-   | |
-   | doesn't satisfy `NoDerives: Eq`
-   | doesn't satisfy `NoDerives: Ord`
-   | doesn't satisfy `NoDerives: PartialEq`
-   | doesn't satisfy `NoDerives: PartialOrd`
+   | -------------------- doesn't satisfy `NoDerives: Eq`, `NoDerives: Ord`, `NoDerives: PartialEq` or `NoDerives: PartialOrd`
 LL |
 LL | struct Object<T>(T);
    | ---------------- method `use_ord_and_partial_ord` not found for this struct

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
@@ -19,10 +19,7 @@ error[E0599]: the size for values of type `Node<i32, RcFamily>` cannot be known 
   --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:31:35
    |
 LL | enum Node<T, P: PointerFamily> {
-   | ------------------------------
-   | |
-   | variant or associated item `new` not found for this enum
-   | doesn't satisfy `Node<i32, RcFamily>: Sized`
+   | ------------------------------ variant or associated item `new` not found for this enum because it doesn't satisfy `Node<i32, RcFamily>: Sized`
 ...
 LL |     let mut list = RcNode::<i32>::new();
    |                                   ^^^ doesn't have a size known at compile-time

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
@@ -26,9 +26,6 @@ LL | enum Node<T, P: PointerFamily> {
 ...
 LL |     let mut list = RcNode::<i32>::new();
    |                                   ^^^ doesn't have a size known at compile-time
-  --> $SRC_DIR/core/src/ops/deref.rs:LL:COL
-   |
-   = note: doesn't satisfy `_: Sized`
    |
 note: trait bound `Node<i32, RcFamily>: Sized` was not satisfied
   --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:4:18

--- a/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.rs
+++ b/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.rs
@@ -17,8 +17,7 @@ impl<T: X<Y<i32> = i32>> M for T {}
 
 struct S;
 //~^ NOTE method `f` not found for this
-//~| NOTE doesn't satisfy `<S as X>::Y<i32> = i32`
-//~| NOTE doesn't satisfy `S: M`
+//~| NOTE doesn't satisfy `<S as X>::Y<i32> = i32` or `S: M`
 
 impl X for S {
     type Y<T> = bool;

--- a/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.rs
+++ b/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.rs
@@ -16,8 +16,7 @@ impl<T: X<Y<i32> = i32>> M for T {}
 //~| NOTE
 
 struct S;
-//~^ NOTE method `f` not found for this
-//~| NOTE doesn't satisfy `<S as X>::Y<i32> = i32` or `S: M`
+//~^ NOTE method `f` not found for this struct because it doesn't satisfy `<S as X>::Y<i32> = i32` or `S: M`
 
 impl X for S {
     type Y<T> = bool;

--- a/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.stderr
+++ b/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.stderr
@@ -1,12 +1,11 @@
 error[E0599]: the method `f` exists for struct `S`, but its trait bounds were not satisfied
-  --> $DIR/method-unsatisfied-assoc-type-predicate.rs:28:7
+  --> $DIR/method-unsatisfied-assoc-type-predicate.rs:27:7
    |
 LL | struct S;
    | --------
    | |
    | method `f` not found for this struct
-   | doesn't satisfy `<S as X>::Y<i32> = i32`
-   | doesn't satisfy `S: M`
+   | doesn't satisfy `<S as X>::Y<i32> = i32` or `S: M`
 ...
 LL |     a.f();
    |       ^ method cannot be called on `S` due to unsatisfied trait bounds

--- a/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.stderr
+++ b/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.stderr
@@ -1,11 +1,8 @@
 error[E0599]: the method `f` exists for struct `S`, but its trait bounds were not satisfied
-  --> $DIR/method-unsatisfied-assoc-type-predicate.rs:27:7
+  --> $DIR/method-unsatisfied-assoc-type-predicate.rs:26:7
    |
 LL | struct S;
-   | --------
-   | |
-   | method `f` not found for this struct
-   | doesn't satisfy `<S as X>::Y<i32> = i32` or `S: M`
+   | -------- method `f` not found for this struct because it doesn't satisfy `<S as X>::Y<i32> = i32` or `S: M`
 ...
 LL |     a.f();
    |       ^ method cannot be called on `S` due to unsatisfied trait bounds

--- a/tests/ui/higher-ranked/trait-bounds/issue-30786.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-30786.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `filterx` exists for struct `Map<Repeat, {closure@issue
   --> $DIR/issue-30786.rs:120:22
    |
 LL | pub struct Map<S, F> {
-   | --------------------
-   | |
-   | method `filterx` not found for this struct
-   | doesn't satisfy `_: StreamExt`
+   | -------------------- method `filterx` not found for this struct because it doesn't satisfy `_: StreamExt`
 ...
 LL |     let filter = map.filterx(|x: &_| true);
    |                      ^^^^^^^ method cannot be called on `Map<Repeat, {closure@issue-30786.rs:119:27}>` due to unsatisfied trait bounds
@@ -23,10 +20,7 @@ error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, fn(&u64)
   --> $DIR/issue-30786.rs:132:24
    |
 LL | pub struct Filter<S, F> {
-   | -----------------------
-   | |
-   | method `countx` not found for this struct
-   | doesn't satisfy `_: StreamExt`
+   | ----------------------- method `countx` not found for this struct because it doesn't satisfy `_: StreamExt`
 ...
 LL |     let count = filter.countx();
    |                        ^^^^^^ method cannot be called due to unsatisfied trait bounds

--- a/tests/ui/iterators/vec-on-unimplemented.stderr
+++ b/tests/ui/iterators/vec-on-unimplemented.stderr
@@ -3,9 +3,6 @@ error[E0599]: `Vec<bool>` is not an iterator
    |
 LL |     vec![true, false].map(|v| !v).collect::<Vec<_>>();
    |                       ^^^ `Vec<bool>` is not an iterator; try calling `.into_iter()` or `.iter()`
-  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-   |
-   = note: doesn't satisfy `Vec<bool>: Iterator`
    |
    = note: the following trait bounds were not satisfied:
            `Vec<bool>: Iterator`

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -49,10 +49,7 @@ error[E0599]: `Foo` is not an iterator
   --> $DIR/method-call-err-msg.rs:19:7
    |
 LL |   pub struct Foo;
-   |   --------------
-   |   |
-   |   method `take` not found for this struct
-   |   doesn't satisfy `Foo: Iterator`
+   |   -------------- method `take` not found for this struct because it doesn't satisfy `Foo: Iterator`
 ...
 LL | /     y.zero()
 LL | |      .take()

--- a/tests/ui/mismatched_types/issue-36053-2.stderr
+++ b/tests/ui/mismatched_types/issue-36053-2.stderr
@@ -21,11 +21,7 @@ error[E0599]: the method `count` exists for struct `Filter<Fuse<Once<&str>>, {cl
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |                                       ---------       ^^^^^ method cannot be called due to unsatisfied trait bounds
    |                                       |
-   |                                       doesn't satisfy `<_ as FnOnce<(&&str,)>>::Output = bool`
-   |                                       doesn't satisfy `_: FnMut<(&&str,)>`
-  --> $SRC_DIR/core/src/iter/adapters/filter.rs:LL:COL
-   |
-   = note: doesn't satisfy `_: Iterator`
+   |                                       doesn't satisfy `<_ as FnOnce<(&&str,)>>::Output = bool` or `_: FnMut<(&&str,)>`
    |
    = note: the following trait bounds were not satisfied:
            `<{closure@$DIR/issue-36053-2.rs:7:39: 7:48} as FnOnce<(&&str,)>>::Output = bool`

--- a/tests/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
+++ b/tests/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
@@ -12,10 +12,7 @@ error[E0599]: the method `foo_one` exists for struct `MyStruct`, but its trait b
   --> $DIR/specialization-trait-not-implemented.rs:22:29
    |
 LL | struct MyStruct;
-   | ---------------
-   | |
-   | method `foo_one` not found for this struct
-   | doesn't satisfy `MyStruct: Foo`
+   | --------------- method `foo_one` not found for this struct because it doesn't satisfy `MyStruct: Foo`
 ...
 LL |     println!("{}", MyStruct.foo_one());
    |                             ^^^^^^^ method cannot be called on `MyStruct` due to unsatisfied trait bounds

--- a/tests/ui/suggestions/derive-trait-for-method-call.stderr
+++ b/tests/ui/suggestions/derive-trait-for-method-call.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `test` exists for struct `Foo<Enum, CloneEnum>`, but it
   --> $DIR/derive-trait-for-method-call.rs:28:15
    |
 LL | enum Enum {
-   | ---------
-   | |
-   | doesn't satisfy `Enum: Clone`
-   | doesn't satisfy `Enum: Default`
+   | --------- doesn't satisfy `Enum: Clone` or `Enum: Default`
 ...
 LL | enum CloneEnum {
    | -------------- doesn't satisfy `CloneEnum: Default`
@@ -40,10 +37,7 @@ error[E0599]: the method `test` exists for struct `Foo<Struct, CloneStruct>`, bu
   --> $DIR/derive-trait-for-method-call.rs:34:15
    |
 LL | struct Struct {
-   | -------------
-   | |
-   | doesn't satisfy `Struct: Clone`
-   | doesn't satisfy `Struct: Default`
+   | ------------- doesn't satisfy `Struct: Clone` or `Struct: Default`
 ...
 LL | struct CloneStruct {
    | ------------------ doesn't satisfy `CloneStruct: Default`
@@ -85,12 +79,6 @@ LL | struct Foo<X, Y> (X, Y);
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Vec<Enum>, Instant>` due to unsatisfied trait bounds
-  --> $SRC_DIR/std/src/time.rs:LL:COL
-   |
-   = note: doesn't satisfy `Instant: Default`
-  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
-   |
-   = note: doesn't satisfy `Vec<Enum>: Clone`
    |
 note: the following trait bounds were not satisfied:
       `Instant: Default`

--- a/tests/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/tests/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -25,9 +25,6 @@ error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn Write>`, 
    |
 LL |     writeln!(fp, "hello world").unwrap();
    |     ---------^^---------------- method cannot be called on `BufWriter<&dyn Write>` due to unsatisfied trait bounds
-  --> $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
-   |
-   = note: doesn't satisfy `BufWriter<&dyn std::io::Write>: std::io::Write`
    |
 note: must implement `io::Write`, `fmt::Write`, or have a `write_fmt` method
   --> $DIR/mut-borrow-needed-by-trait.rs:21:14

--- a/tests/ui/suggestions/suggest-change-mut.stderr
+++ b/tests/ui/suggestions/suggest-change-mut.stderr
@@ -27,9 +27,6 @@ error[E0599]: the method `read_until` exists for struct `BufReader<&T>`, but its
    |
 LL |         stream_reader.read_until(b'\n', &mut buffer).expect("Reading into buffer failed");
    |                       ^^^^^^^^^^ method cannot be called on `BufReader<&T>` due to unsatisfied trait bounds
-  --> $SRC_DIR/std/src/io/buffered/bufreader.rs:LL:COL
-   |
-   = note: doesn't satisfy `BufReader<&T>: BufRead`
    |
    = note: the following trait bounds were not satisfied:
            `&T: std::io::Read`

--- a/tests/ui/trait-bounds/impl-derived-implicit-sized-bound-2.stderr
+++ b/tests/ui/trait-bounds/impl-derived-implicit-sized-bound-2.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `get` exists for struct `Victim<'_, Self>`, but its tra
   --> $DIR/impl-derived-implicit-sized-bound-2.rs:28:19
    |
 LL | struct Victim<'a, T: Perpetrator + ?Sized> {
-   | ------------------------------------------
-   | |
-   | method `get` not found for this struct
-   | doesn't satisfy `Victim<'_, Self>: VictimTrait`
+   | ------------------------------------------ method `get` not found for this struct because it doesn't satisfy `Victim<'_, Self>: VictimTrait`
 ...
 LL |     self.getter().get();
    |                   ^^^ method cannot be called on `Victim<'_, Self>` due to unsatisfied trait bounds

--- a/tests/ui/trait-bounds/impl-derived-implicit-sized-bound.stderr
+++ b/tests/ui/trait-bounds/impl-derived-implicit-sized-bound.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `get` exists for struct `Victim<'_, Self>`, but its tra
   --> $DIR/impl-derived-implicit-sized-bound.rs:31:19
    |
 LL | struct Victim<'a, T: Perpetrator + ?Sized>
-   | ------------------------------------------
-   | |
-   | method `get` not found for this struct
-   | doesn't satisfy `Victim<'_, Self>: VictimTrait`
+   | ------------------------------------------ method `get` not found for this struct because it doesn't satisfy `Victim<'_, Self>: VictimTrait`
 ...
 LL |     self.getter().get();
    |                   ^^^ method cannot be called on `Victim<'_, Self>` due to unsatisfied trait bounds

--- a/tests/ui/traits/track-obligations.stderr
+++ b/tests/ui/traits/track-obligations.stderr
@@ -2,10 +2,7 @@ error[E0599]: the method `check` exists for struct `Client<()>`, but its trait b
   --> $DIR/track-obligations.rs:83:16
    |
 LL | struct ALayer<C>(C);
-   | ----------------
-   | |
-   | doesn't satisfy `<_ as Layer<()>>::Service = <ALayer<()> as ParticularServiceLayer<()>>::Service`
-   | doesn't satisfy `ALayer<()>: ParticularServiceLayer<()>`
+   | ---------------- doesn't satisfy `<_ as Layer<()>>::Service = <ALayer<()> as ParticularServiceLayer<()>>::Service` or `ALayer<()>: ParticularServiceLayer<()>`
 ...
 LL | struct Client<C>(C);
    | ---------------- method `check` not found for this struct

--- a/tests/ui/typeck/derive-sugg-arg-arity.stderr
+++ b/tests/ui/typeck/derive-sugg-arg-arity.stderr
@@ -5,8 +5,7 @@ LL | pub struct A;
    | ------------
    | |
    | function or associated item `partial_cmp` not found for this struct
-   | doesn't satisfy `A: Iterator`
-   | doesn't satisfy `A: PartialOrd<_>`
+   | doesn't satisfy `A: Iterator` or `A: PartialOrd<_>`
 ...
 LL |         _ => match A::partial_cmp() {},
    |                       ^^^^^^^^^^^ function or associated item cannot be called on `A` due to unsatisfied trait bounds

--- a/tests/ui/typeck/derive-sugg-arg-arity.stderr
+++ b/tests/ui/typeck/derive-sugg-arg-arity.stderr
@@ -2,10 +2,7 @@ error[E0599]: the function or associated item `partial_cmp` exists for struct `A
   --> $DIR/derive-sugg-arg-arity.rs:5:23
    |
 LL | pub struct A;
-   | ------------
-   | |
-   | function or associated item `partial_cmp` not found for this struct
-   | doesn't satisfy `A: Iterator` or `A: PartialOrd<_>`
+   | ------------ function or associated item `partial_cmp` not found for this struct because it doesn't satisfy `A: Iterator` or `A: PartialOrd<_>`
 ...
 LL |         _ => match A::partial_cmp() {},
    |                       ^^^^^^^^^^^ function or associated item cannot be called on `A` due to unsatisfied trait bounds

--- a/tests/ui/typeck/issue-31173.stderr
+++ b/tests/ui/typeck/issue-31173.stderr
@@ -35,12 +35,6 @@ LL | |         .collect();
    | |         -^^^^^^^ method cannot be called due to unsatisfied trait bounds
    | |_________|
    | 
-  --> $SRC_DIR/core/src/iter/adapters/take_while.rs:LL:COL
-   |
-   = note: doesn't satisfy `<_ as Iterator>::Item = &_`
-  --> $SRC_DIR/core/src/iter/adapters/cloned.rs:LL:COL
-   |
-   = note: doesn't satisfy `_: Iterator`
    |
    = note: the following trait bounds were not satisfied:
            `<TakeWhile<&mut std::vec::IntoIter<u8>, {closure@$DIR/issue-31173.rs:7:21: 7:25}> as Iterator>::Item = &_`

--- a/tests/ui/union/union-derive-clone.stderr
+++ b/tests/ui/union/union-derive-clone.stderr
@@ -17,10 +17,7 @@ error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its tra
   --> $DIR/union-derive-clone.rs:35:15
    |
 LL | union U5<T> {
-   | -----------
-   | |
-   | method `clone` not found for this union
-   | doesn't satisfy `U5<CloneNoCopy>: Clone`
+   | ----------- method `clone` not found for this union because it doesn't satisfy `U5<CloneNoCopy>: Clone`
 ...
 LL | struct CloneNoCopy;
    | ------------------ doesn't satisfy `CloneNoCopy: Copy`


### PR DESCRIPTION
Consolidate span labels for "this type doesn't satisfy a bound" for more compact diagnostic output.