### PR TITLE
Make the coroutine def id of an async closure the child of the closure def id

### DIFF
--- a/tests/ui/async-await/async-closures/def-path.rs
+++ b/tests/ui/async-await/async-closures/def-path.rs
@@ -1,0 +1,14 @@
+// compile-flags: -Zverbose-internals
+// edition:2021
+
+#![feature(async_closure)]
+
+fn main() {
+    let x = async || {};
+    //~^ NOTE the expected `async` closure body
+    let () = x();
+    //~^ ERROR mismatched types
+    //~| NOTE this expression has type `{static main::{closure#0}::{closure#0} upvar_tys=
+    //~| NOTE expected `async` closure body, found `()`
+    //~| NOTE expected `async` closure body `{static main::{closure#0}::{closure#0}
+}

--- a/tests/ui/async-await/async-closures/def-path.stderr
+++ b/tests/ui/async-await/async-closures/def-path.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/def-path.rs:9:9
+   |
+LL |     let x = async || {};
+   |                      -- the expected `async` closure body
+LL |
+LL |     let () = x();
+   |         ^^   --- this expression has type `{static main::{closure#0}::{closure#0} upvar_tys=?7t witness=?8t}`
+   |         |
+   |         expected `async` closure body, found `()`
+   |
+   = note: expected `async` closure body `{static main::{closure#0}::{closure#0} upvar_tys=?7t witness=?8t}`
+                         found unit type `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Adjust def collection to make the (inner) coroutine returned by an async closure be a def id child of the (outer) closure. This makes it easy to map from coroutine -> closure by using `tcx.parent`, since currently it's not trivial to do this.