### PR TITLE
Add instructions of how to use pre-vendored 'rustc-src'

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1034,7 +1034,16 @@ class RustBuild(object):
                 eprint('ERROR: vendoring required, but vendor directory does not exist.')
                 eprint('       Run `cargo vendor {}` to initialize the '
                       'vendor directory.'.format(sync_dirs))
-                eprint('Alternatively, use the pre-vendored `rustc-src` dist component.')
+                eprint('       Alternatively, use the pre-vendored `rustc-src` dist component.')
+                eprint('       To get a stable/beta/nightly version, download it from: ')
+                eprint('       '
+                'https://forge.rust-lang.org/infra/other-installation-methods.html#source-code')
+                eprint('       To get a specific commit version, download it using the below URL,')
+                eprint('       replacing <commit> with a specific commit checksum: ')
+                eprint('       '
+                'https://ci-artifacts.rust-lang.org/rustc-builds/<commit>/rustc-nightly-src.tar.xz')
+                eprint('       Once you have the source downloaded, place the vendor directory')
+                eprint('       from the archive in the root of the rust project.')
                 raise Exception("{} not found".format(vendor_dir))
 
             if not os.path.exists(cargo_dir):


### PR DESCRIPTION
This PR closes #110163.

I had to move the URL to the left, making it not aligned as it is three lines above, but the tidy check would yell at me otherwise. If that's not acceptable, I'd love some suggestions on how to make it better.

One question: in the original issue (https://github.com/rust-lang/rust/issues/110163#issuecomment-1502647562), it was suggested to mention how to download specific commit tarballs; however, it was said it's not documented anywhere, so I did not include that yet. If there is a want to have that, I'd gladly amend the commit.