### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -58,16 +58,29 @@ macro_rules! into_diagnostic_arg_using_display {
     }
 }
 
+macro_rules! into_diagnostic_arg_for_number {
+    ($( $ty:ty ),+ $(,)?) => {
+        $(
+            impl IntoDiagnosticArg for $ty {
+                fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
+                    // HACK: `FluentNumber` the underline backing struct represent
+                    // numbers using a f64 which can represent all the i128 numbers
+                    // So in order to be able to use fluent selectors and still
+                    // have all the numbers representable we only convert numbers
+                    // below a certain threshold.
+                    if let Ok(n) = TryInto::<i128>::try_into(self) && n >= -100 && n <= 100 {
+                        DiagnosticArgValue::Number(n)
+                    } else {
+                        self.to_string().into_diagnostic_arg()
+                    }
+                }
+            }
+        )+
+    }
+}
+
 into_diagnostic_arg_using_display!(
     ast::ParamKindOrd,
-    i8,
-    u8,
-    i16,
-    u16,
-    u32,
-    i64,
-    i128,
-    u128,
     std::io::Error,
     Box<dyn std::error::Error>,
     std::num::NonZeroU32,
@@ -82,17 +95,7 @@ into_diagnostic_arg_using_display!(
     ExitStatus,
 );
 
-impl IntoDiagnosticArg for i32 {
-    fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
-        DiagnosticArgValue::Number(self.into())
-    }
-}
-
-impl IntoDiagnosticArg for u64 {
-    fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
-        DiagnosticArgValue::Number(self.into())
-    }
-}
+into_diagnostic_arg_for_number!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize);
 
 impl IntoDiagnosticArg for bool {
     fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
@@ -151,12 +154,6 @@ impl<'a> IntoDiagnosticArg for &'a Path {
 impl IntoDiagnosticArg for PathBuf {
     fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
         DiagnosticArgValue::Str(Cow::Owned(self.display().to_string()))
-    }
-}
-
-impl IntoDiagnosticArg for usize {
-    fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
-        DiagnosticArgValue::Number(self as i128)
     }
 }
 

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -64,7 +64,7 @@ macro_rules! into_diagnostic_arg_for_number {
             impl IntoDiagnosticArg for $ty {
                 fn into_diagnostic_arg(self) -> DiagnosticArgValue<'static> {
                     // HACK: `FluentNumber` the underline backing struct represent
-                    // numbers using a f64 which can represent all the i128 numbers
+                    // numbers using a f64 which can't represent all the i128 numbers
                     // So in order to be able to use fluent selectors and still
                     // have all the numbers representable we only convert numbers
                     // below a certain threshold.

--- a/compiler/rustc_hir_analysis/src/astconv/lint.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/lint.rs
@@ -132,7 +132,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     ],
                     Applicability::MachineApplicable,
                 );
-            } else if diag.is_error() && is_downgradable {
+            } else if is_downgradable {
                 // We'll emit the object safety error already, with a structured suggestion.
                 diag.downgrade_to_delayed_bug();
             }
@@ -158,7 +158,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             if !is_object_safe {
                 diag.note(format!("`{trait_name}` it is not object safe, so it can't be `dyn`"));
-                if diag.is_error() && is_downgradable {
+                if is_downgradable {
                     // We'll emit the object safety error already, with a structured suggestion.
                     diag.downgrade_to_delayed_bug();
                 }
@@ -241,13 +241,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             } else {
                 let msg = "trait objects without an explicit `dyn` are deprecated";
                 tcx.node_span_lint(BARE_TRAIT_OBJECTS, self_ty.hir_id, self_ty.span, msg, |lint| {
-                    if self_ty.span.can_be_used_for_suggestions()
-                        && !self.maybe_lint_impl_trait(self_ty, lint)
-                    {
+                    if self_ty.span.can_be_used_for_suggestions() {
                         lint.multipart_suggestion_verbose(
                             "use `dyn`",
                             sugg,
-                            Applicability::MachineApplicable,
+                            Applicability::MaybeIncorrect,
                         );
                     }
                     self.maybe_lint_blanket_trait_impl(self_ty, lint);

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -221,9 +221,6 @@ pub struct ScopeTree {
     /// variable is declared.
     var_map: FxIndexMap<hir::ItemLocalId, Scope>,
 
-    /// Maps from a `NodeId` to the associated destruction scope (if any).
-    destruction_scopes: FxIndexMap<hir::ItemLocalId, Scope>,
-
     /// Identifies expressions which, if captured into a temporary, ought to
     /// have a temporary whose lifetime extends to the end of the enclosing *block*,
     /// and not the enclosing *statement*. Expressions that are not present in this
@@ -335,11 +332,6 @@ impl ScopeTree {
         if let Some(p) = parent {
             let prev = self.parent_map.insert(child, p);
             assert!(prev.is_none());
-        }
-
-        // Record the destruction scopes for later so we can query them.
-        if let ScopeData::Destruction = child.data {
-            self.destruction_scopes.insert(child.item_local_id(), child);
         }
     }
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -792,13 +792,28 @@ impl<'a> Parser<'a> {
                 && let [segment] = &attr_kind.item.path.segments[..]
                 && segment.ident.name == sym::cfg
                 && let Some(args_span) = attr_kind.item.args.span()
-                && let Ok(next_attr) = snapshot.parse_attribute(InnerAttrPolicy::Forbidden(None))
+                && let next_attr = match snapshot.parse_attribute(InnerAttrPolicy::Forbidden(None))
+                {
+                    Ok(next_attr) => next_attr,
+                    Err(inner_err) => {
+                        err.cancel();
+                        inner_err.cancel();
+                        return;
+                    }
+                }
                 && let ast::AttrKind::Normal(next_attr_kind) = next_attr.kind
                 && let Some(next_attr_args_span) = next_attr_kind.item.args.span()
                 && let [next_segment] = &next_attr_kind.item.path.segments[..]
                 && segment.ident.name == sym::cfg
-                && let Ok(next_expr) = snapshot.parse_expr()
             {
+                let next_expr = match snapshot.parse_expr() {
+                    Ok(next_expr) => next_expr,
+                    Err(inner_err) => {
+                        err.cancel();
+                        inner_err.cancel();
+                        return;
+                    }
+                };
                 // We have for sure
                 // #[cfg(..)]
                 // expr

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -200,10 +200,10 @@ where
         lo.saturating_sub(!started as usize)
             .saturating_add(next_is_some as usize)
             .saturating_add(lo),
-        hi.map(|hi| {
+        hi.and_then(|hi| {
             hi.saturating_sub(!started as usize)
                 .saturating_add(next_is_some as usize)
-                .saturating_add(hi)
+                .checked_add(hi)
         }),
     )
 }

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -1,5 +1,5 @@
-use core::fmt;
-use core::iter::{Fuse, FusedIterator};
+use crate::fmt;
+use crate::iter::{Fuse, FusedIterator};
 
 /// An iterator adapter that places a separator between all elements.
 ///

--- a/library/core/src/iter/adapters/intersperse.rs
+++ b/library/core/src/iter/adapters/intersperse.rs
@@ -72,7 +72,14 @@ where
         F: FnMut(B, Self::Item) -> B,
     {
         let separator = self.separator;
-        intersperse_fold(self.iter, init, f, move || separator.clone(), self.started,self.next_item)
+        intersperse_fold(
+            self.iter,
+            init,
+            f,
+            move || separator.clone(),
+            self.started,
+            self.next_item,
+        )
     }
 }
 

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -1860,7 +1860,6 @@ impl Ipv6Addr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(ip)]
     /// use std::net::Ipv6Addr;
     ///
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0x7f00, 0x1).is_loopback(), false);

--- a/tests/codegen/pow_of_two.rs
+++ b/tests/codegen/pow_of_two.rs
@@ -4,7 +4,7 @@
 #[no_mangle]
 pub fn a(exp: u32) -> u64 {
     // CHECK: %{{[^ ]+}} = icmp ugt i32 %exp, 64
-    // CHECK: %{{[^ ]+}} = zext i32 %exp to i64
+    // CHECK: %{{[^ ]+}} = zext{{( nneg)?}} i32 %exp to i64
     // CHECK: %{{[^ ]+}} = shl nuw i64 {{[^ ]+}}, %{{[^ ]+}}
     // CHECK: ret i64 %{{[^ ]+}}
     2u64.pow(exp)
@@ -14,7 +14,7 @@ pub fn a(exp: u32) -> u64 {
 #[no_mangle]
 pub fn b(exp: u32) -> i64 {
     // CHECK: %{{[^ ]+}} = icmp ugt i32 %exp, 64
-    // CHECK: %{{[^ ]+}} = zext i32 %exp to i64
+    // CHECK: %{{[^ ]+}} = zext{{( nneg)?}} i32 %exp to i64
     // CHECK: %{{[^ ]+}} = shl nuw i64 {{[^ ]+}}, %{{[^ ]+}}
     // CHECK: ret i64 %{{[^ ]+}}
     2i64.pow(exp)

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -9,8 +9,13 @@ fn main() {
     // CHECK: let mut [[array_lit:_.*]]: [u32; 4];
     // CHECK:     debug x => [[x:_.*]];
 
-    let x: u32 = [0, 1, 2, 3][2];
     // CHECK:       [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
-    // CHECK-LABEL: assert(const true,
-    // CHECK:     [[x]] = [[array_lit]][2 of 3];
+    // CHECK-NOT:   {{_.*}} = Len(
+    // CHECK-NOT:   {{_.*}} = Lt(
+    // CHECK-NOT:   assert(move _
+    // CHECK:       {{_.*}} = const 4_usize;
+    // CHECK:       {{_.*}} = const true;
+    // CHECK-LABEL: assert(const true
+    // CHECK:       [[x]] = [[array_lit]][2 of 3];
+    let x: u32 = [0, 1, 2, 3][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -10,10 +10,7 @@ fn main() {
     // CHECK:     debug x => [[x:_.*]];
 
     let x: u32 = [0, 1, 2, 3][2];
-    // CHECK: bb{{[0-9]+}}: {
-    // CHECK:     [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
-    // CHECK:     [[index:_.*]] = const 2_usize;
-    // CHECK: bb{{[0-9]+}}: {
-    // CHECK-NOT: [[x]] = [[array_lit]][[[index]]];
+    // CHECK:       [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
+    // CHECK-LABEL: assert(const true,
     // CHECK:     [[x]] = [[array_lit]][2 of 3];
 }

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -1,9 +1,19 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR array_index.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main() -> () {
 fn main() {
+    // CHECK: let mut [[array_lit:_.*]]: [u32; 4];
+    // CHECK:     debug x => [[x:_.*]];
+
     let x: u32 = [0, 1, 2, 3][2];
+    // CHECK: bb{{[0-9]+}}: {
+    // CHECK:     [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
+    // CHECK:     [[index:_.*]] = const 2_usize;
+    // CHECK: bb{{[0-9]+}}: {
+    // CHECK-NOT: [[x]] = [[array_lit]][[[index]]];
+    // CHECK:     [[x]] = [[array_lit]][2 of 3];
 }

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -15,7 +15,7 @@ fn main() {
     // CHECK-NOT:   assert(move _
     // CHECK:       {{_.*}} = const 4_usize;
     // CHECK:       {{_.*}} = const true;
-    // CHECK-LABEL: assert(const true
+    // CHECK:       assert(const true
     // CHECK:       [[x]] = [[array_lit]][2 of 3];
     let x: u32 = [0, 1, 2, 3][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
+++ b/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
@@ -1,11 +1,14 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR boolean_identities.test.DataflowConstProp.diff
+
+// CHECK-LABEL: fn test(
 pub fn test(x: bool, y: bool) -> bool {
     (y | true) & (x & false)
+    // CHECK: _0 = const false;
 }
 
+// CHECK-LABEL: fn main(
 fn main() {
     test(true, false);
 }

--- a/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
+++ b/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
@@ -4,8 +4,12 @@
 
 // CHECK-LABEL: fn test(
 pub fn test(x: bool, y: bool) -> bool {
+    // CHECK-NOT: BitAnd(
+    // CHECK-NOT: BitOr(
     (y | true) & (x & false)
     // CHECK: _0 = const false;
+    // CHECK-NOT: BitAnd(
+    // CHECK-NOT: BitOr(
 }
 
 // CHECK-LABEL: fn main(

--- a/tests/mir-opt/dataflow-const-prop/cast.rs
+++ b/tests/mir-opt/dataflow-const-prop/cast.rs
@@ -1,8 +1,14 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR cast.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main(
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+
+    // CHECK: [[a]] = const 257_i32;
     let a = 257;
+    // CHECK: [[b]] = const 2_u8;
     let b = a as u8 + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -1,15 +1,30 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // compile-flags: -Coverflow-checks=on
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR checked.main.DataflowConstProp.diff
 #[allow(arithmetic_overflow)]
+
+// CHECK-LABEL: fn main(
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: debug d => [[d:_.*]];
+    // CHECK: debug e => [[e:_.*]];
+
+    // CHECK: [[a]] = const 1_i32;
     let a = 1;
+
+    // CHECK: [[b]] = const 2_i32;
     let b = 2;
+
+    // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
+    // CHECK: [[d]] = const _;
     let d = i32::MAX;
+
+    // CHECK: [[e]] = const i32::MIN;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -19,12 +19,14 @@ fn main() {
     // CHECK: [[b]] = const 2_i32;
     let b = 2;
 
+    // CHECK-LABEL: assert(!const false,
     // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
     // CHECK: [[d]] = const _;
     let d = i32::MAX;
 
+    // CHECK-LABEL: assert(!const true,
     // CHECK: [[e]] = const i32::MIN;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -19,14 +19,14 @@ fn main() {
     // CHECK: [[b]] = const 2_i32;
     let b = 2;
 
-    // CHECK-LABEL: assert(!const false,
+    // CHECK: assert(!const false,
     // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
     // CHECK: [[d]] = const _;
     let d = i32::MAX;
 
-    // CHECK-LABEL: assert(!const true,
+    // CHECK: assert(!const true,
     // CHECK: [[e]] = const i32::MIN;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+GVN,+Inline
 // ignore-debug assertions change the output MIR
@@ -11,8 +10,20 @@ struct A {
 
 // EMIT_MIR default_boxed_slice.main.GVN.diff
 // EMIT_MIR default_boxed_slice.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main(
 fn main() {
     // ConstProp will create a constant of type `Box<[bool]>`.
     // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
+
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: scope {{[0-9]+}} (inlined <Box<[bool]> as Default>::default) {
+    // CHECK: scope {{[0-9]+}} (inlined Unique::<[bool; 0]>::dangling) {
+    // CHECK: scope {{[0-9]+}} (inlined NonNull::<[bool; 0]>::dangling) {
+    // We may check other inlined functions as well...
+
+    // CHECK: bb{{[0-9]+}}: {
+    // CHECK: [[box_obj:_.*]] = Box::<[bool]>(_3, const std::alloc::Global);
+    // CHECK: [[a]] = A { foo: move [[box_obj]] };
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -17,13 +17,10 @@ fn main() {
     // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
 
     // CHECK: debug a => [[a:_.*]];
-    // CHECK: scope {{[0-9]+}} (inlined <Box<[bool]> as Default>::default) {
-    // CHECK: scope {{[0-9]+}} (inlined Unique::<[bool; 0]>::dangling) {
-    // CHECK: scope {{[0-9]+}} (inlined NonNull::<[bool; 0]>::dangling) {
     // We may check other inlined functions as well...
 
-    // CHECK: bb{{[0-9]+}}: {
     // CHECK: [[box_obj:_.*]] = Box::<[bool]>(_3, const std::alloc::Global);
     // CHECK: [[a]] = A { foo: move [[box_obj]] };
+    // FIXME: we do not have `const Box::<[bool]>` after constprop right now.
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -4,6 +4,8 @@
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
+// This test is to check ICE in issue [#115789](https://github.com/rust-lang/rust/issues/115789).
+
 struct A {
     foo: Box<[bool]>,
 }
@@ -14,13 +16,14 @@ struct A {
 // CHECK-LABEL: fn main(
 fn main() {
     // ConstProp will create a constant of type `Box<[bool]>`.
+    // FIXME: it is not yet a constant.
+
     // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
 
     // CHECK: debug a => [[a:_.*]];
     // We may check other inlined functions as well...
 
-    // CHECK: [[box_obj:_.*]] = Box::<[bool]>(_3, const std::alloc::Global);
-    // CHECK: [[a]] = A { foo: move [[box_obj]] };
-    // FIXME: we do not have `const Box::<[bool]>` after constprop right now.
+    // CHECK-LABEL: _.* = Box::<[bool]>(
+    // FIXME: should be `_.* = const Box::<[bool]>`
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -23,7 +23,7 @@ fn main() {
     // CHECK: debug a => [[a:_.*]];
     // We may check other inlined functions as well...
 
-    // CHECK-LABEL: _.* = Box::<[bool]>(
-    // FIXME: should be `_.* = const Box::<[bool]>`
+    // CHECK: {{_.*}} = Box::<[bool]>(
+    // FIXME: should be `{{_.*}} = const Box::<[bool]>`
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.32bit.diff
@@ -14,7 +14,7 @@
           let _6: u8;
           let _8: u8;
           scope 2 {
-              debug x => _6;
+              debug x2 => _6;
               let _9: u8;
               scope 4 {
                   debug y => _9;

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.64bit.diff
@@ -14,7 +14,7 @@
           let _6: u8;
           let _8: u8;
           scope 2 {
-              debug x => _6;
+              debug x2 => _6;
               let _9: u8;
               scope 4 {
                   debug y => _9;

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -118,6 +118,7 @@ fn multiple(x: bool, i: u8) {
     // CHECK: debug x => [[x:_.*]];
     // CHECK: debug e => [[e:_.*]];
     // CHECK: debug x2 => [[x2:_.*]];
+    // CHECK: debug y => [[y:_.*]];
     let e = if x {
         // CHECK: [[e]] = Option::<u8>::Some(move {{_.*}});
         Some(i)
@@ -128,10 +129,18 @@ fn multiple(x: bool, i: u8) {
     // The dataflow state must have:
     //   discriminant(e) => Top
     //   (e as Some).0 => Top
+    // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[x2]] = const 0_u8;
-    // CHECK: [[x2]] = {{_.*}};
+    // CHECK-NOT: [[x2]] = const 5
+    // CHECK: [[some:_.*]] = (({{_.*}} as Some
+    // CHECK: [[x2]] = [[some]];
     let x2 = match e { Some(i) => i, None => 0 };
+
     // Therefore, `x2` should be `Top` here, and no replacement shall happen.
+
+    // CHECK-NOT: [[y]] = const
+    // CHECK: [[y]] = [[x2]];
+    // CHECK-NOT: [[y]] = const
     let y = x2;
 }
 

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -129,9 +129,7 @@ fn multiple(x: bool, i: u8) {
     // The dataflow state must have:
     //   discriminant(e) => Top
     //   (e as Some).0 => Top
-    // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[x2]] = const 0_u8;
-    // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[some:_.*]] = (({{_.*}} as Some).0: u8)
     // CHECK: [[x2]] = [[some]];
     let x2 = match e { Some(i) => i, None => 0 };

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -132,7 +132,7 @@ fn multiple(x: bool, i: u8) {
     // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[x2]] = const 0_u8;
     // CHECK-NOT: [[x2]] = const 5
-    // CHECK: [[some:_.*]] = (({{_.*}} as Some
+    // CHECK: [[some:_.*]] = (({{_.*}} as Some).0: u8)
     // CHECK: [[x2]] = [[some]];
     let x2 = match e { Some(i) => i, None => 0 };
 

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
@@ -9,34 +9,34 @@
       let mut _8: &&E;
       let mut _10: isize;
       scope 1 {
-          debug e => _1;
+          debug e1 => _1;
           let _3: i32;
           let _5: i32;
           let _6: i32;
           scope 2 {
-              debug x => _3;
+              debug x1 => _3;
               let _7: &E;
               scope 5 {
-                  debug e => _7;
+                  debug e2 => _7;
                   let _9: &i32;
                   let _11: &i32;
                   let _12: &i32;
                   scope 6 {
-                      debug x => _9;
+                      debug x2 => _9;
                   }
                   scope 7 {
-                      debug x => _11;
+                      debug x21 => _11;
                   }
                   scope 8 {
-                      debug x => _12;
+                      debug x22 => _12;
                   }
               }
           }
           scope 3 {
-              debug x => _5;
+              debug x11 => _5;
           }
           scope 4 {
-              debug x => _6;
+              debug x12 => _6;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
@@ -9,34 +9,34 @@
       let mut _8: &&E;
       let mut _10: isize;
       scope 1 {
-          debug e => _1;
+          debug e1 => _1;
           let _3: i32;
           let _5: i32;
           let _6: i32;
           scope 2 {
-              debug x => _3;
+              debug x1 => _3;
               let _7: &E;
               scope 5 {
-                  debug e => _7;
+                  debug e2 => _7;
                   let _9: &i32;
                   let _11: &i32;
                   let _12: &i32;
                   scope 6 {
-                      debug x => _9;
+                      debug x2 => _9;
                   }
                   scope 7 {
-                      debug x => _11;
+                      debug x21 => _11;
                   }
                   scope 8 {
-                      debug x => _12;
+                      debug x22 => _12;
                   }
               }
           }
           scope 3 {
-              debug x => _5;
+              debug x11 => _5;
           }
           scope 4 {
-              debug x => _6;
+              debug x12 => _6;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/if.rs
+++ b/tests/mir-opt/dataflow-const-prop/if.rs
@@ -10,16 +10,14 @@ fn main() {
 
     let a = 1;
 
-    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_first_true:bb[0-9]+]]];
-    // CHECK: [[bb_first_true]]: {
+    // CHECK: switchInt(const true) -> [0: {{bb.*}}, otherwise: {{bb.*}}];
     // CHECK: [[b]] = const 2_i32;
     let b = if a == 1 { 2 } else { 3 };
 
     // CHECK: [[c]] = const 3_i32;
     let c = b + 1;
 
-    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_second_true:bb[0-9]+]]];
-    // CHECK: [[bb_second_true]]: {
+    // CHECK: switchInt(const true) -> [0: {{bb.*}}, otherwise: {{bb.*}}];
     // CHECK: [[d]] = const 1_i32;
     let d = if a == 1 { a } else { a + 1 };
 

--- a/tests/mir-opt/dataflow-const-prop/if.rs
+++ b/tests/mir-opt/dataflow-const-prop/if.rs
@@ -1,12 +1,28 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR if.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main(
 fn main() {
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: debug d => [[d:_.*]];
+    // CHECK: debug e => [[e:_.*]];
+
     let a = 1;
+
+    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_first_true:bb[0-9]+]]];
+    // CHECK: [[bb_first_true]]: {
+    // CHECK: [[b]] = const 2_i32;
     let b = if a == 1 { 2 } else { 3 };
+
+    // CHECK: [[c]] = const 3_i32;
     let c = b + 1;
 
+    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_second_true:bb[0-9]+]]];
+    // CHECK: [[bb_second_true]]: {
+    // CHECK: [[d]] = const 1_i32;
     let d = if a == 1 { a } else { a + 1 };
+
+    // CHECK: [[e]] = const 2_i32;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
@@ -1,11 +1,14 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+Inline
 
 // EMIT_MIR inherit_overflow.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main(
 fn main() {
     // After inlining, this will contain a `CheckedBinaryOp`.
     // Propagating the overflow is ok as codegen will just skip emitting the panic.
+
+    // CHECK: {{_.*}} = const (0_u8, true);
+    // CHECK-LABEL: assert(!const true,
     let _ = <u8 as std::ops::Add>::add(255, 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
@@ -9,6 +9,6 @@ fn main() {
     // Propagating the overflow is ok as codegen will just skip emitting the panic.
 
     // CHECK: {{_.*}} = const (0_u8, true);
-    // CHECK-LABEL: assert(!const true,
+    // CHECK: assert(!const true,
     let _ = <u8 as std::ops::Add>::add(255, 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/issue_81605.rs
+++ b/tests/mir-opt/dataflow-const-prop/issue_81605.rs
@@ -2,9 +2,15 @@
 
 // EMIT_MIR issue_81605.f.DataflowConstProp.diff
 
-// CHECK-LABEL: fn f
+// Plese find the original issue [here](https://github.com/rust-lang/rust/issues/81605).
+// This test program comes directly from the issue. Prior to this issue,
+// the compiler cannot simplify the return value of `f` into 2. This was
+// solved by adding a new MIR constant propagation based on dataflow
+// analysis in [#101168](https://github.com/rust-lang/rust/pull/101168).
+
+// CHECK-LABEL: fn f(
 fn f() -> usize {
-    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: {{bb[0-9]+}}];
+    // CHECK: switchInt(const true) -> [0: {{bb.*}}, otherwise: {{bb.*}}];
     1 + if true { 1 } else { 2 }
     // CHECK: _0 = const 2_usize;
 }

--- a/tests/mir-opt/dataflow-const-prop/issue_81605.rs
+++ b/tests/mir-opt/dataflow-const-prop/issue_81605.rs
@@ -1,9 +1,12 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR issue_81605.f.DataflowConstProp.diff
+
+// CHECK-LABEL: fn f
 fn f() -> usize {
+    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: {{bb[0-9]+}}];
     1 + if true { 1 } else { 2 }
+    // CHECK: _0 = const 2_usize;
 }
 
 fn main() {

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -4,7 +4,7 @@
 
 // EMIT_MIR large_array_index.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // check that we don't propagate this, because it's too large
 

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -1,10 +1,18 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR large_array_index.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
     // check that we don't propagate this, because it's too large
+
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: [[array_lit:_.*]] = [const 0_u8; 5000];
+    // CHECK: {{_.*}} = const 5000_usize;
+    // CHECK: {{_.*}} = const true;
+    // CHECK-LABEL: assert(const true
+    // CHECK: [[x]] = [[array_lit]][2 of 3];
     let x: u8 = [0_u8; 5000][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -12,7 +12,7 @@ fn main() {
     // CHECK: [[array_lit:_.*]] = [const 0_u8; 5000];
     // CHECK: {{_.*}} = const 5000_usize;
     // CHECK: {{_.*}} = const true;
-    // CHECK-LABEL: assert(const true
+    // CHECK: assert(const true
     // CHECK: [[x]] = [[array_lit]][2 of 3];
     let x: u8 = [0_u8; 5000][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
+++ b/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
@@ -1,9 +1,10 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR mult_by_zero.test.DataflowConstProp.diff
+// CHECK-LABEL: fn test
 fn test(x : i32) -> i32 {
   x * 0
+  // CHECK: _0 = const 0_i32;
 }
 
 fn main() {

--- a/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
+++ b/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
@@ -1,7 +1,7 @@
 // unit-test: DataflowConstProp
 
 // EMIT_MIR mult_by_zero.test.DataflowConstProp.diff
-// CHECK-LABEL: fn test
+// CHECK-LABEL: fn test(
 fn test(x : i32) -> i32 {
   x * 0
   // CHECK: _0 = const 0_i32;

--- a/tests/mir-opt/dataflow-const-prop/offset_of.rs
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
@@ -29,18 +28,46 @@ struct Delta<T> {
 }
 
 // EMIT_MIR offset_of.concrete.DataflowConstProp.diff
+
+// CHECK-LABEL: fn concrete
 fn concrete() {
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: debug y => [[y:_.*]];
+    // CHECK: debug z0 => [[z0:_.*]];
+    // CHECK: debug z1 => [[z1:_.*]];
+
+    // CHECK: [[x]] = must_use::<usize>(const 4_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let x = offset_of!(Alpha, x);
+
+    // CHECK: [[y]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let y = offset_of!(Alpha, y);
+
+    // CHECK: [[z0]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let z0 = offset_of!(Alpha, z.0);
+
+    // CHECK: [[z1]] = must_use::<usize>(const 3_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let z1 = offset_of!(Alpha, z.1);
 }
 
 // EMIT_MIR offset_of.generic.DataflowConstProp.diff
+
+// CHECK-LABEL: generic
 fn generic<T>() {
+    // CHECK: debug gx => [[gx:_.*]];
+    // CHECK: debug gy => [[gy:_.*]];
+    // CHECK: debug dx => [[dx:_.*]];
+    // CHECK: debug dy => [[dy:_.*]];
+
+    // CHECK: [[gx]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
     let gx = offset_of!(Gamma<T>, x);
+
+    // CHECK: [[gy]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
     let gy = offset_of!(Gamma<T>, y);
+
+    // CHECK: [[dx]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let dx = offset_of!(Delta<T>, x);
+
+    // CHECK: [[dy]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let dy = offset_of!(Delta<T>, y);
 }
 

--- a/tests/mir-opt/dataflow-const-prop/offset_of.rs
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.rs
@@ -29,45 +29,45 @@ struct Delta<T> {
 
 // EMIT_MIR offset_of.concrete.DataflowConstProp.diff
 
-// CHECK-LABEL: fn concrete
+// CHECK-LABEL: fn concrete(
 fn concrete() {
     // CHECK: debug x => [[x:_.*]];
     // CHECK: debug y => [[y:_.*]];
     // CHECK: debug z0 => [[z0:_.*]];
     // CHECK: debug z1 => [[z1:_.*]];
 
-    // CHECK: [[x]] = must_use::<usize>(const 4_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[x]] = must_use::<usize>(const 4_usize) -> {{.*}}
     let x = offset_of!(Alpha, x);
 
-    // CHECK: [[y]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[y]] = must_use::<usize>(const 0_usize) -> {{.*}}
     let y = offset_of!(Alpha, y);
 
-    // CHECK: [[z0]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[z0]] = must_use::<usize>(const 2_usize) -> {{.*}}
     let z0 = offset_of!(Alpha, z.0);
 
-    // CHECK: [[z1]] = must_use::<usize>(const 3_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[z1]] = must_use::<usize>(const 3_usize) -> {{.*}}
     let z1 = offset_of!(Alpha, z.1);
 }
 
 // EMIT_MIR offset_of.generic.DataflowConstProp.diff
 
-// CHECK-LABEL: generic
+// CHECK-LABEL: fn generic(
 fn generic<T>() {
     // CHECK: debug gx => [[gx:_.*]];
     // CHECK: debug gy => [[gy:_.*]];
     // CHECK: debug dx => [[dx:_.*]];
     // CHECK: debug dy => [[dy:_.*]];
 
-    // CHECK: [[gx]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[gx]] = must_use::<usize>(move {{_.*}}) -> {{.*}}
     let gx = offset_of!(Gamma<T>, x);
 
-    // CHECK: [[gy]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[gy]] = must_use::<usize>(move {{_.*}}) -> {{.*}}
     let gy = offset_of!(Gamma<T>, y);
 
-    // CHECK: [[dx]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[dx]] = must_use::<usize>(const 0_usize) -> {{.*}}
     let dx = offset_of!(Delta<T>, x);
 
-    // CHECK: [[dy]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[dy]] = must_use::<usize>(const 2_usize) -> {{.*}}
     let dy = offset_of!(Delta<T>, y);
 }
 

--- a/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
+++ b/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
@@ -8,21 +8,23 @@ fn escape<T>(x: &T) {}
 fn some_function() {}
 
 // EMIT_MIR ref_without_sb.main.DataflowConstProp.diff
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug a => [[a:_.*]];
     // CHECK: debug b => [[b:_.*]];
 
     let mut a = 0;
 
-    // CHECK: {{_[0-9]+}} = escape::<i32>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: {{_.*}} = escape::<i32>(move {{_.*}}) ->  {{.*}}
     escape(&a);
     a = 1;
 
-    // CHECK: {{_[0-9]+}} = some_function() -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: {{_.*}} = some_function() ->  {{.*}}
     some_function();
     // This should currently not be propagated.
 
+    // CHECK-NOT: [[b]] = const
     // CHECK: [[b]] = [[a]];
+    // CHECK-NOT: [[b]] = const
     let b = a;
 }

--- a/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
+++ b/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 
@@ -9,11 +8,21 @@ fn escape<T>(x: &T) {}
 fn some_function() {}
 
 // EMIT_MIR ref_without_sb.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+
     let mut a = 0;
+
+    // CHECK: {{_[0-9]+}} = escape::<i32>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
     escape(&a);
     a = 1;
+
+    // CHECK: {{_[0-9]+}} = some_function() -> [return: {{bb[0-9]+}}, unwind continue];
     some_function();
     // This should currently not be propagated.
+
+    // CHECK: [[b]] = [[a]];
     let b = a;
 }

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -3,15 +3,19 @@
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR repeat.main.DataflowConstProp.diff
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug x => [[x:_.*]];
 
-    // CHECK: {{_[0-9]+}} = const 8_usize;
-    // CHECK: {{_[0-9]+}} = const true;
+    // CHECK: [[array_lit:_.*]] = [const 42_u32; 8];
+    // CHECK-NOT: {{_.*}} = Len(
+    // CHECK-NOT: {{_.*}} = Lt(
+    // CHECK: {{_.*}} = const 8_usize;
+    // CHECK: {{_.*}} = const true;
     // CHECK-LABEL: assert(const true
 
-    // CHECK: {{_[0-9]+}} = {{_[0-9]+}}[2 of 3];
-    // CHECK: [[x]] = Add(move {{_[0-9]+}}, const 0_u32);
+    // CHECK-NOT: [[t:_.*]] = [[array_lit]][_
+    // CHECK: [[t:_.*]] = [[array_lit]][2 of 3];
+    // CHECK: [[x]] = Add(move [[t]], const 0_u32);
     let x: u32 = [42; 8][2] + 0;
 }

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -1,9 +1,17 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR repeat.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug x => [[x:_.*]];
+
+    // CHECK: {{_[0-9]+}} = const 8_usize;
+    // CHECK: {{_[0-9]+}} = const true;
+    // CHECK-LABEL: assert(const true
+
+    // CHECK: {{_[0-9]+}} = {{_[0-9]+}}[2 of 3];
+    // CHECK: [[x]] = Add(move {{_[0-9]+}}, const 0_u32);
     let x: u32 = [42; 8][2] + 0;
 }

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -12,7 +12,7 @@ fn main() {
     // CHECK-NOT: {{_.*}} = Lt(
     // CHECK: {{_.*}} = const 8_usize;
     // CHECK: {{_.*}} = const true;
-    // CHECK-LABEL: assert(const true
+    // CHECK: assert(const true
 
     // CHECK-NOT: [[t:_.*]] = [[array_lit]][_
     // CHECK: [[t:_.*]] = [[array_lit]][2 of 3];

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // The struct has scalar ABI, but is not a scalar type.
@@ -7,7 +6,15 @@
 struct I32(i32);
 
 // EMIT_MIR repr_transparent.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: debug y => [[y:_.*]];
+
+    // CHECK: [[x]] = const I32(0_i32);
     let x = I32(0);
+
+    // CHECK: [[y]] = const I32(0_i32);
     let y = I32(x.0 + x.0);
 }

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
@@ -7,7 +7,7 @@ struct I32(i32);
 
 // EMIT_MIR repr_transparent.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug x => [[x:_.*]];
     // CHECK: debug y => [[y:_.*]];

--- a/tests/mir-opt/dataflow-const-prop/self_assign.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign.rs
@@ -2,25 +2,25 @@
 
 // EMIT_MIR self_assign.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug a => [[a:_.*]];
     // CHECK: debug b => [[b:_.*]];
 
     let mut a = 0;
 
-    // CHECK: [[a]] = Add(move {{_[0-9]+}}, const 1_i32);
+    // CHECK: [[a]] = Add(move {{_.*}}, const 1_i32);
     a = a + 1;
 
-    // CHECK: [[a]] = move {{_[0-9]+}};
+    // CHECK: [[a]] = move {{_.*}};
     a = a;
 
     // CHECK: [[b]] = &[[a]];
     let mut b = &a;
 
-    // CHECK: [[b]] = move {{_[0-9]+}};
+    // CHECK: [[b]] = move {{_.*}};
     b = b;
 
-    // CHECK: [[a]] = move {{_[0-9]+}};
+    // CHECK: [[a]] = move {{_.*}};
     a = *b;
 }

--- a/tests/mir-opt/dataflow-const-prop/self_assign.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign.rs
@@ -1,13 +1,26 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR self_assign.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+
     let mut a = 0;
+
+    // CHECK: [[a]] = Add(move {{_[0-9]+}}, const 1_i32);
     a = a + 1;
+
+    // CHECK: [[a]] = move {{_[0-9]+}};
     a = a;
 
+    // CHECK: [[b]] = &[[a]];
     let mut b = &a;
+
+    // CHECK: [[b]] = move {{_[0-9]+}};
     b = b;
+
+    // CHECK: [[a]] = move {{_[0-9]+}};
     a = *b;
 }

--- a/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
@@ -1,9 +1,15 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR self_assign_add.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
     let mut a = 0;
+
+    // CHECK: [[a]] = const 1_i32;
     a += 1;
+
+    // CHECK: [[a]] = const 2_i32;
     a += 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
@@ -2,7 +2,7 @@
 
 // EMIT_MIR self_assign_add.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug a => [[a:_.*]];
     let mut a = 0;

--- a/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
+++ b/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // This attempts to modify `x.1` via a pointer derived from `addr_of_mut!(x.0)`.
 // According to Miri, that is UB. However, T-opsem has not finalized that
@@ -10,11 +9,17 @@
 // unit-test: DataflowConstProp
 
 // EMIT_MIR sibling_ptr.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug x1 => [[x1:_[0-9]+]];
+
     let mut x: (u8, u8) = (0, 0);
     unsafe {
         let p = std::ptr::addr_of_mut!(x.0);
         *p.add(1) = 1;
     }
+
+    // CHECK: [[x1]] = ({{_[0-9]+}}.1: u8);
     let x1 = x.1; // should not be propagated
 }

--- a/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
+++ b/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
@@ -10,9 +10,9 @@
 
 // EMIT_MIR sibling_ptr.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug x1 => [[x1:_[0-9]+]];
+    // CHECK: debug x1 => [[x1:_.*]];
 
     let mut x: (u8, u8) = (0, 0);
     unsafe {
@@ -20,6 +20,6 @@ fn main() {
         *p.add(1) = 1;
     }
 
-    // CHECK: [[x1]] = ({{_[0-9]+}}.1: u8);
+    // CHECK: [[x1]] = ({{_.*}}.1: u8);
     let x1 = x.1; // should not be propagated
 }

--- a/tests/mir-opt/dataflow-const-prop/slice_len.rs
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.rs
@@ -1,13 +1,23 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+InstSimplify
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR slice_len.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug local => [[local:_[0-9]+]];
+    // CHECK: debug constant => [[constant:_[0-9]+]];
+
+    // CHECK: {{_[0-9]+}} = const 3_usize;
+    // CHECK: {{_[0-9]+}} = const true;
+
+    // CHECK: [[local]] = (*{{_[0-9]+}})[1 of 2];
     let local = (&[1u32, 2, 3] as &[u32])[1];
 
     const SLICE: &[u32] = &[1, 2, 3];
+
+    // CHECK: [[constant]] = (*{{_[0-9]+}})[1 of 2];
     let constant = SLICE[1];
 }

--- a/tests/mir-opt/dataflow-const-prop/slice_len.rs
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.rs
@@ -5,19 +5,30 @@
 
 // EMIT_MIR slice_len.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug local => [[local:_[0-9]+]];
-    // CHECK: debug constant => [[constant:_[0-9]+]];
+    // CHECK: debug local => [[local:_.*]];
+    // CHECK: debug constant => [[constant:_.*]];
 
-    // CHECK: {{_[0-9]+}} = const 3_usize;
-    // CHECK: {{_[0-9]+}} = const true;
+    // CHECK-NOT: {{_.*}} = Len(
+    // CHECK-NOT: {{_.*}} = Lt(
+    // CHECK-NOT: assert(move _
+    // CHECK: {{_.*}} = const 3_usize;
+    // CHECK: {{_.*}} = const true;
+    // CHECK: assert(const true,
 
-    // CHECK: [[local]] = (*{{_[0-9]+}})[1 of 2];
+    // CHECK: [[local]] = (*{{_.*}})[1 of 2];
     let local = (&[1u32, 2, 3] as &[u32])[1];
 
+    // CHECK-NOT: {{_.*}} = Len(
+    // CHECK-NOT: {{_.*}} = Lt(
+    // CHECK-NOT: assert(move _
     const SLICE: &[u32] = &[1, 2, 3];
+    // CHECK: {{_.*}} = const 3_usize;
+    // CHECK: {{_.*}} = const true;
+    // CHECK: assert(const true,
 
-    // CHECK: [[constant]] = (*{{_[0-9]+}})[1 of 2];
+    // CHECK-NOT: [[constant]] = (*{{_.*}})[_
+    // CHECK: [[constant]] = (*{{_.*}})[1 of 2];
     let constant = SLICE[1];
 }

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
@@ -37,16 +37,16 @@
                   let _8: std::option::Option<S>;
                   let _9: &[f32];
                   scope 4 {
-                      debug a => _7;
-                      debug b => _8;
-                      debug c => _9;
+                      debug a1 => _7;
+                      debug b1 => _8;
+                      debug c1 => _9;
                       let _11: f32;
                       let _12: std::option::Option<S>;
                       let _13: &[f32];
                       scope 5 {
-                          debug a => _11;
-                          debug b => _12;
-                          debug c => _13;
+                          debug a2 => _11;
+                          debug b2 => _12;
+                          debug c2 => _13;
                           let _15: SmallStruct;
                           scope 6 {
                               debug ss => _15;
@@ -54,16 +54,16 @@
                               let _20: std::option::Option<S>;
                               let _21: &[f32];
                               scope 7 {
-                                  debug a => _19;
-                                  debug b => _20;
-                                  debug c => _21;
+                                  debug a3 => _19;
+                                  debug b3 => _20;
+                                  debug c3 => _21;
                                   let _23: f32;
                                   let _24: std::option::Option<S>;
                                   let _25: &[f32];
                                   scope 8 {
-                                      debug a => _23;
-                                      debug b => _24;
-                                      debug c => _25;
+                                      debug a4 => _23;
+                                      debug b4 => _24;
+                                      debug c4 => _25;
                                       let _27: BigStruct;
                                       scope 9 {
                                           debug bs => _27;

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
@@ -37,16 +37,16 @@
                   let _8: std::option::Option<S>;
                   let _9: &[f32];
                   scope 4 {
-                      debug a => _7;
-                      debug b => _8;
-                      debug c => _9;
+                      debug a1 => _7;
+                      debug b1 => _8;
+                      debug c1 => _9;
                       let _11: f32;
                       let _12: std::option::Option<S>;
                       let _13: &[f32];
                       scope 5 {
-                          debug a => _11;
-                          debug b => _12;
-                          debug c => _13;
+                          debug a2 => _11;
+                          debug b2 => _12;
+                          debug c2 => _13;
                           let _15: SmallStruct;
                           scope 6 {
                               debug ss => _15;
@@ -54,16 +54,16 @@
                               let _20: std::option::Option<S>;
                               let _21: &[f32];
                               scope 7 {
-                                  debug a => _19;
-                                  debug b => _20;
-                                  debug c => _21;
+                                  debug a3 => _19;
+                                  debug b3 => _20;
+                                  debug c3 => _21;
                                   let _23: f32;
                                   let _24: std::option::Option<S>;
                                   let _25: &[f32];
                                   scope 8 {
-                                      debug a => _23;
-                                      debug b => _24;
-                                      debug c => _25;
+                                      debug a4 => _23;
+                                      debug b4 => _24;
+                                      debug c4 => _25;
                                       let _27: BigStruct;
                                       scope 9 {
                                           debug bs => _27;

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
@@ -12,27 +11,69 @@ struct SmallStruct(f32, Option<S>, &'static [f32]);
 struct BigStruct(f32, Option<S>, &'static [f32]);
 
 // EMIT_MIR struct.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug s => [[s:_[0-9]+]];
+    // CHECK: debug a => [[a:_[0-9]+]];
+    // CHECK: debug b => [[b:_[0-9]+]];
+    // CHECK: debug a1 => [[a1:_[0-9]+]];
+    // CHECK: debug b1 => [[b1:_[0-9]+]];
+    // CHECK: debug c1 => [[c1:_[0-9]+]];
+    // CHECK: debug a2 => [[a2:_[0-9]+]];
+    // CHECK: debug b2 => [[b2:_[0-9]+]];
+    // CHECK: debug c2 => [[c2:_[0-9]+]];
+    // CHECK: debug ss => [[ss:_[0-9]+]];
+    // CHECK: debug a3 => [[a3:_[0-9]+]];
+    // CHECK: debug b3 => [[b3:_[0-9]+]];
+    // CHECK: debug c3 => [[c3:_[0-9]+]];
+    // CHECK: debug a4 => [[a4:_[0-9]+]];
+    // CHECK: debug b4 => [[b4:_[0-9]+]];
+    // CHECK: debug c4 => [[c4:_[0-9]+]];
+    // CHECK: debug bs => [[bs:_[0-9]+]];
+
+    // CHECK: [[s]] = const S(1_i32);
     let mut s = S(1);
+
+    // CHECK: [[a]] = const 3_i32;
     let a = s.0 + 2;
     s.0 = 3;
+
+    // CHECK: [[b]] = const 6_i32;
     let b = a + s.0;
 
     const SMALL_VAL: SmallStruct = SmallStruct(4., Some(S(1)), &[]);
-    let SmallStruct(a, b, c) = SMALL_VAL;
+
+    // CHECK: [[a1]] = const 4f32;
+    // CHECK: [[b1]] = const Option::<S>::Some(S(1_i32));
+    // CHECK: [[c1]] = ({{_[0-9]+}}.2: &[f32]);
+    let SmallStruct(a1, b1, c1) = SMALL_VAL;
 
     static SMALL_STAT: &SmallStruct = &SmallStruct(9., None, &[13.]);
-    let SmallStruct(a, b, c) = *SMALL_STAT;
 
-    let ss = SmallStruct(a, b, c);
+    // CHECK: [[a2]] = const 9f32;
+    // CHECK: [[b2]] = ((*{{_[0-9]+}}).1: std::option::Option<S>);
+    // CHECK: [[c2]] = ((*{{_[0-9]+}}).2: &[f32]);
+    let SmallStruct(a2, b2, c2) = *SMALL_STAT;
+
+    // CHECK: [[ss]] = SmallStruct(const 9f32, move {{_[0-9]+}}, move {{_[0-9]+}});
+    let ss = SmallStruct(a2, b2, c2);
 
     const BIG_VAL: BigStruct = BigStruct(25., None, &[]);
-    let BigStruct(a, b, c) = BIG_VAL;
+
+    // CHECK: [[a3]] = const 25f32;
+    // CHECK: [[b3]] = ({{_[0-9]+}}.1: std::option::Option<S>);
+    // CHECK: [[c3]] = ({{_[0-9]+}}.2: &[f32]);
+    let BigStruct(a3, b3, c3) = BIG_VAL;
 
     static BIG_STAT: &BigStruct = &BigStruct(82., Some(S(35)), &[45., 72.]);
-    let BigStruct(a, b, c) = *BIG_STAT;
+    // CHECK: [[a4]] = const 82f32;
+    // CHECK: [[b4]] = const Option::<S>::Some(S(35_i32));
+    // CHECK: [[c4]] = ((*{{_[0-9]+}}).2: &[f32]);
+    let BigStruct(a4, b4, c4) = *BIG_STAT;
 
     // We arbitrarily limit the size of synthetized values to 4 pointers.
     // `BigStruct` can be read, but we will keep a MIR aggregate for this.
-    let bs = BigStruct(a, b, c);
+    // CHECK: [[bs]] = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move {{_[0-9]+}});
+    let bs = BigStruct(a4, b4, c4);
 }

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -12,25 +12,25 @@ struct BigStruct(f32, Option<S>, &'static [f32]);
 
 // EMIT_MIR struct.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug s => [[s:_[0-9]+]];
-    // CHECK: debug a => [[a:_[0-9]+]];
-    // CHECK: debug b => [[b:_[0-9]+]];
-    // CHECK: debug a1 => [[a1:_[0-9]+]];
-    // CHECK: debug b1 => [[b1:_[0-9]+]];
-    // CHECK: debug c1 => [[c1:_[0-9]+]];
-    // CHECK: debug a2 => [[a2:_[0-9]+]];
-    // CHECK: debug b2 => [[b2:_[0-9]+]];
-    // CHECK: debug c2 => [[c2:_[0-9]+]];
-    // CHECK: debug ss => [[ss:_[0-9]+]];
-    // CHECK: debug a3 => [[a3:_[0-9]+]];
-    // CHECK: debug b3 => [[b3:_[0-9]+]];
-    // CHECK: debug c3 => [[c3:_[0-9]+]];
-    // CHECK: debug a4 => [[a4:_[0-9]+]];
-    // CHECK: debug b4 => [[b4:_[0-9]+]];
-    // CHECK: debug c4 => [[c4:_[0-9]+]];
-    // CHECK: debug bs => [[bs:_[0-9]+]];
+    // CHECK: debug s => [[s:_.*]];
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug a1 => [[a1:_.*]];
+    // CHECK: debug b1 => [[b1:_.*]];
+    // CHECK: debug c1 => [[c1:_.*]];
+    // CHECK: debug a2 => [[a2:_.*]];
+    // CHECK: debug b2 => [[b2:_.*]];
+    // CHECK: debug c2 => [[c2:_.*]];
+    // CHECK: debug ss => [[ss:_.*]];
+    // CHECK: debug a3 => [[a3:_.*]];
+    // CHECK: debug b3 => [[b3:_.*]];
+    // CHECK: debug c3 => [[c3:_.*]];
+    // CHECK: debug a4 => [[a4:_.*]];
+    // CHECK: debug b4 => [[b4:_.*]];
+    // CHECK: debug c4 => [[c4:_.*]];
+    // CHECK: debug bs => [[bs:_.*]];
 
     // CHECK: [[s]] = const S(1_i32);
     let mut s = S(1);
@@ -46,34 +46,34 @@ fn main() {
 
     // CHECK: [[a1]] = const 4f32;
     // CHECK: [[b1]] = const Option::<S>::Some(S(1_i32));
-    // CHECK: [[c1]] = ({{_[0-9]+}}.2: &[f32]);
+    // CHECK: [[c1]] = ({{_.*}}.2: &[f32]);
     let SmallStruct(a1, b1, c1) = SMALL_VAL;
 
     static SMALL_STAT: &SmallStruct = &SmallStruct(9., None, &[13.]);
 
     // CHECK: [[a2]] = const 9f32;
-    // CHECK: [[b2]] = ((*{{_[0-9]+}}).1: std::option::Option<S>);
-    // CHECK: [[c2]] = ((*{{_[0-9]+}}).2: &[f32]);
+    // CHECK: [[b2]] = ((*{{_.*}}).1: std::option::Option<S>);
+    // CHECK: [[c2]] = ((*{{_.*}}).2: &[f32]);
     let SmallStruct(a2, b2, c2) = *SMALL_STAT;
 
-    // CHECK: [[ss]] = SmallStruct(const 9f32, move {{_[0-9]+}}, move {{_[0-9]+}});
+    // CHECK: [[ss]] = SmallStruct(const 9f32, move {{_.*}}, move {{_.*}});
     let ss = SmallStruct(a2, b2, c2);
 
     const BIG_VAL: BigStruct = BigStruct(25., None, &[]);
 
     // CHECK: [[a3]] = const 25f32;
-    // CHECK: [[b3]] = ({{_[0-9]+}}.1: std::option::Option<S>);
-    // CHECK: [[c3]] = ({{_[0-9]+}}.2: &[f32]);
+    // CHECK: [[b3]] = ({{_.*}}.1: std::option::Option<S>);
+    // CHECK: [[c3]] = ({{_.*}}.2: &[f32]);
     let BigStruct(a3, b3, c3) = BIG_VAL;
 
     static BIG_STAT: &BigStruct = &BigStruct(82., Some(S(35)), &[45., 72.]);
     // CHECK: [[a4]] = const 82f32;
     // CHECK: [[b4]] = const Option::<S>::Some(S(35_i32));
-    // CHECK: [[c4]] = ((*{{_[0-9]+}}).2: &[f32]);
+    // CHECK: [[c4]] = ((*{{_.*}}).2: &[f32]);
     let BigStruct(a4, b4, c4) = *BIG_STAT;
 
     // We arbitrarily limit the size of synthetized values to 4 pointers.
     // `BigStruct` can be read, but we will keep a MIR aggregate for this.
-    // CHECK: [[bs]] = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move {{_[0-9]+}});
+    // CHECK: [[bs]] = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move {{_.*}});
     let bs = BigStruct(a4, b4, c4);
 }

--- a/tests/mir-opt/dataflow-const-prop/terminator.rs
+++ b/tests/mir-opt/dataflow-const-prop/terminator.rs
@@ -1,12 +1,14 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 
 fn foo(n: i32) {}
 
 // EMIT_MIR terminator.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
     let a = 1;
     // Checks that we propagate into terminators.
+    // CHECK: {{_[0-9]+}} = foo(const 2_i32) -> [return: {{bb[0-9]+}}, unwind continue];
     foo(a + 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/terminator.rs
+++ b/tests/mir-opt/dataflow-const-prop/terminator.rs
@@ -5,10 +5,10 @@ fn foo(n: i32) {}
 
 // EMIT_MIR terminator.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     let a = 1;
     // Checks that we propagate into terminators.
-    // CHECK: {{_[0-9]+}} = foo(const 2_i32) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: {{_.*}} = foo(const 2_i32) -> [return: {{bb.*}}, unwind continue];
     foo(a + 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -1,13 +1,27 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR tuple.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_[0-9]+]];
+    // CHECK: debug b => [[b:_[0-9]+]];
+    // CHECK: debug c => [[c:_[0-9]+]];
+    // CHECK: debug d => [[d:_[0-9]+]];
+
+    // CHECK: [[a]] = const (1_i32, 2_i32);
     let mut a = (1, 2);
+
+    // CHECK: [[b]] = const 6_i32;
     let b = a.0 + a.1 + 3;
+
+    // CHECK: [[a]] = const (2_i32, 3_i32);
     a = (2, 3);
+
+    // CHECK: [[c]] = const 11_i32;
     let c = a.0 + a.1 + b;
 
+    // CHECK: [[d]] = (const 6_i32, const (2_i32, 3_i32), const 11_i32);
     let d = (b, a, c);
 }

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -3,12 +3,12 @@
 
 // EMIT_MIR tuple.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug a => [[a:_[0-9]+]];
-    // CHECK: debug b => [[b:_[0-9]+]];
-    // CHECK: debug c => [[c:_[0-9]+]];
-    // CHECK: debug d => [[d:_[0-9]+]];
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: debug d => [[d:_.*]];
 
     // CHECK: [[a]] = const (1_i32, 2_i32);
     let mut a = (1, 2);

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
@@ -1,0 +1,12 @@
+error[E0038]: the trait `Copy` cannot be made into an object
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
+   |
+LL | fn id<F>(f: Copy) -> usize {
+   |             ^^^^ `Copy` cannot be made into an object
+   |
+   = note: the trait cannot be made into an object because it requires `Self: Sized`
+   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
@@ -1,43 +1,33 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-2.rs:1:13
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `Copy` it is not object safe, so it can't be `dyn`
    = note: `#[warn(bare_trait_objects)]` on by default
-help: use a new generic type parameter, constrained by `Copy`
+help: use `dyn`
    |
-LL | fn id<F, T: Copy>(f: T) -> usize {
-   |        +++++++++     ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | fn id<F>(f: impl Copy) -> usize {
-   |             ++++
+LL | fn id<F>(f: dyn Copy) -> usize {
+   |             +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-2.rs:1:13
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `Copy` it is not object safe, so it can't be `dyn`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use a new generic type parameter, constrained by `Copy`
+help: use `dyn`
    |
-LL | fn id<F, T: Copy>(f: T) -> usize {
-   |        +++++++++     ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | fn id<F>(f: impl Copy) -> usize {
-   |             ++++
+LL | fn id<F>(f: dyn Copy) -> usize {
+   |             +++
 
 error[E0038]: the trait `Copy` cannot be made into an object
-  --> $DIR/avoid-ice-on-warning-2.rs:1:13
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^ `Copy` cannot be made into an object

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.rs
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.rs
@@ -1,9 +1,12 @@
+// revisions: old new
+//[old] edition:2015
+//[new] edition:2021
 fn id<F>(f: Copy) -> usize {
-//~^ WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-//~| ERROR the trait `Copy` cannot be made into an object
+//~^ ERROR the trait `Copy` cannot be made into an object
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     f()
 }
 fn main() {}

--- a/tests/ui/object-safety/avoid-ice-on-warning-3.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-3.new.stderr
@@ -1,0 +1,47 @@
+error[E0038]: the trait `A` cannot be made into an object
+  --> $DIR/avoid-ice-on-warning-3.rs:4:19
+   |
+LL | trait B { fn f(a: A) -> A; }
+   |                   ^ `A` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/avoid-ice-on-warning-3.rs:12:14
+   |
+LL | trait A { fn g(b: B) -> B; }
+   |       -      ^ ...because associated function `g` has no `self` parameter
+   |       |
+   |       this trait cannot be made into an object...
+help: consider turning `g` into a method by giving it a `&self` argument
+   |
+LL | trait A { fn g(&self, b: B) -> B; }
+   |                ++++++
+help: alternatively, consider constraining `g` so it does not apply to trait objects
+   |
+LL | trait A { fn g(b: B) -> B where Self: Sized; }
+   |                           +++++++++++++++++
+
+error[E0038]: the trait `B` cannot be made into an object
+  --> $DIR/avoid-ice-on-warning-3.rs:12:19
+   |
+LL | trait A { fn g(b: B) -> B; }
+   |                   ^ `B` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/avoid-ice-on-warning-3.rs:4:14
+   |
+LL | trait B { fn f(a: A) -> A; }
+   |       -      ^ ...because associated function `f` has no `self` parameter
+   |       |
+   |       this trait cannot be made into an object...
+help: consider turning `f` into a method by giving it a `&self` argument
+   |
+LL | trait B { fn f(&self, a: A) -> A; }
+   |                ++++++
+help: alternatively, consider constraining `f` so it does not apply to trait objects
+   |
+LL | trait B { fn f(a: A) -> A where Self: Sized; }
+   |                           +++++++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-3.old.stderr
@@ -1,93 +1,78 @@
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-3.rs:9:19
+  --> $DIR/avoid-ice-on-warning-3.rs:4:19
    |
-LL | trait A { fn g(b: B) -> B; }
+LL | trait B { fn f(a: A) -> A; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `B` it is not object safe, so it can't be `dyn`
    = note: `#[warn(bare_trait_objects)]` on by default
-help: use a new generic type parameter, constrained by `B`
+help: use `dyn`
    |
-LL | trait A { fn g<T: B>(b: T) -> B; }
-   |               ++++++    ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | trait A { fn g(b: impl B) -> B; }
-   |                   ++++
+LL | trait B { fn f(a: dyn A) -> A; }
+   |                   +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-3.rs:9:25
+  --> $DIR/avoid-ice-on-warning-3.rs:4:25
+   |
+LL | trait B { fn f(a: A) -> A; }
+   |                         ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL | trait B { fn f(a: A) -> dyn A; }
+   |                         +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/avoid-ice-on-warning-3.rs:12:19
+   |
+LL | trait A { fn g(b: B) -> B; }
+   |                   ^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: use `dyn`
+   |
+LL | trait A { fn g(b: dyn B) -> B; }
+   |                   +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/avoid-ice-on-warning-3.rs:12:25
    |
 LL | trait A { fn g(b: B) -> B; }
    |                         ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: `B` is not object safe, use `impl B` to return an opaque type, as long as you return a single underlying type
+help: use `dyn`
    |
-LL | trait A { fn g(b: B) -> impl B; }
-   |                         ++++
+LL | trait A { fn g(b: B) -> dyn B; }
+   |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-3.rs:1:19
+  --> $DIR/avoid-ice-on-warning-3.rs:4:19
    |
 LL | trait B { fn f(a: A) -> A; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `A` it is not object safe, so it can't be `dyn`
-help: use a new generic type parameter, constrained by `A`
-   |
-LL | trait B { fn f<T: A>(a: T) -> A; }
-   |               ++++++    ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | trait B { fn f(a: impl A) -> A; }
-   |                   ++++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-3.rs:1:25
-   |
-LL | trait B { fn f(a: A) -> A; }
-   |                         ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: `A` is not object safe, use `impl A` to return an opaque type, as long as you return a single underlying type
-   |
-LL | trait B { fn f(a: A) -> impl A; }
-   |                         ++++
-
-warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-3.rs:1:19
-   |
-LL | trait B { fn f(a: A) -> A; }
-   |                   ^
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `A` it is not object safe, so it can't be `dyn`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use a new generic type parameter, constrained by `A`
+help: use `dyn`
    |
-LL | trait B { fn f<T: A>(a: T) -> A; }
-   |               ++++++    ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | trait B { fn f(a: impl A) -> A; }
-   |                   ++++
+LL | trait B { fn f(a: dyn A) -> A; }
+   |                   +++
 
 error[E0038]: the trait `A` cannot be made into an object
-  --> $DIR/avoid-ice-on-warning-3.rs:1:19
+  --> $DIR/avoid-ice-on-warning-3.rs:4:19
    |
 LL | trait B { fn f(a: A) -> A; }
    |                   ^ `A` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/avoid-ice-on-warning-3.rs:9:14
+  --> $DIR/avoid-ice-on-warning-3.rs:12:14
    |
 LL | trait A { fn g(b: B) -> B; }
    |       -      ^ ...because associated function `g` has no `self` parameter
@@ -103,32 +88,27 @@ LL | trait A { fn g(b: B) -> B where Self: Sized; }
    |                           +++++++++++++++++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning-3.rs:9:19
+  --> $DIR/avoid-ice-on-warning-3.rs:12:19
    |
 LL | trait A { fn g(b: B) -> B; }
    |                   ^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-   = note: `B` it is not object safe, so it can't be `dyn`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: use a new generic type parameter, constrained by `B`
+help: use `dyn`
    |
-LL | trait A { fn g<T: B>(b: T) -> B; }
-   |               ++++++    ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | trait A { fn g(b: impl B) -> B; }
-   |                   ++++
+LL | trait A { fn g(b: dyn B) -> B; }
+   |                   +++
 
 error[E0038]: the trait `B` cannot be made into an object
-  --> $DIR/avoid-ice-on-warning-3.rs:9:19
+  --> $DIR/avoid-ice-on-warning-3.rs:12:19
    |
 LL | trait A { fn g(b: B) -> B; }
    |                   ^ `B` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/avoid-ice-on-warning-3.rs:1:14
+  --> $DIR/avoid-ice-on-warning-3.rs:4:14
    |
 LL | trait B { fn f(a: A) -> A; }
    |       -      ^ ...because associated function `f` has no `self` parameter

--- a/tests/ui/object-safety/avoid-ice-on-warning-3.rs
+++ b/tests/ui/object-safety/avoid-ice-on-warning-3.rs
@@ -1,17 +1,20 @@
+// revisions: old new
+//[old] edition:2015
+//[new] edition:2021
 trait B { fn f(a: A) -> A; }
-//~^ WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN this is accepted in the current edition
-//~| WARN this is accepted in the current edition
-//~| ERROR the trait `A` cannot be made into an object
+//~^ ERROR the trait `A` cannot be made into an object
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN this is accepted in the current edition
+//[old]~| WARN this is accepted in the current edition
+//[old]~| WARN this is accepted in the current edition
 trait A { fn g(b: B) -> B; }
-//~^ WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition
-//~| WARN this is accepted in the current edition
-//~| WARN this is accepted in the current edition
-//~| ERROR the trait `B` cannot be made into an object
+//~^ ERROR the trait `B` cannot be made into an object
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN this is accepted in the current edition
+//[old]~| WARN this is accepted in the current edition
+//[old]~| WARN this is accepted in the current edition
 fn main() {}

--- a/tests/ui/object-safety/avoid-ice-on-warning.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning.new.stderr
@@ -1,0 +1,15 @@
+error: return types are denoted using `->`
+  --> $DIR/avoid-ice-on-warning.rs:4:23
+   |
+LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
+   |                       ^ help: use `->` instead
+
+error[E0405]: cannot find trait `call_that` in this scope
+  --> $DIR/avoid-ice-on-warning.rs:4:36
+   |
+LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
+   |                                    ^^^^^^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0405`.

--- a/tests/ui/object-safety/avoid-ice-on-warning.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning.old.stderr
@@ -1,17 +1,17 @@
 error: return types are denoted using `->`
-  --> $DIR/avoid-ice-on-warning.rs:1:23
+  --> $DIR/avoid-ice-on-warning.rs:4:23
    |
 LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    |                       ^ help: use `->` instead
 
 error[E0405]: cannot find trait `call_that` in this scope
-  --> $DIR/avoid-ice-on-warning.rs:1:36
+  --> $DIR/avoid-ice-on-warning.rs:4:36
    |
 LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    |                                    ^^^^^^^^^ not found in this scope
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/avoid-ice-on-warning.rs:1:25
+  --> $DIR/avoid-ice-on-warning.rs:4:25
    |
 LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    |                         ^^^^^^^^^^^^^^^^^^^^
@@ -19,10 +19,10 @@ LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: `Fn(&str) + call_that` is not object safe, use `impl Fn(&str) + call_that` to return an opaque type, as long as you return a single underlying type
+help: use `dyn`
    |
-LL | fn call_this<F>(f: F) : impl Fn(&str) + call_that {}
-   |                         ++++
+LL | fn call_this<F>(f: F) : dyn Fn(&str) + call_that {}
+   |                         +++
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/object-safety/avoid-ice-on-warning.rs
+++ b/tests/ui/object-safety/avoid-ice-on-warning.rs
@@ -1,6 +1,9 @@
+// revisions: old new
+//[old] edition:2015
+//[new] edition:2021
 fn call_this<F>(f: F) : Fn(&str) + call_that {}
 //~^ ERROR return types are denoted using `->`
 //~| ERROR cannot find trait `call_that` in this scope
-//~| WARN trait objects without an explicit `dyn` are deprecated
-//~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+//[old]~| WARN trait objects without an explicit `dyn` are deprecated
+//[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
 fn main() {}

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.fixed
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.fixed
@@ -1,9 +1,0 @@
-// run-rustfix
-#![deny(bare_trait_objects)]
-fn ord_prefer_dot(s: String) -> impl Ord {
-    //~^ ERROR the trait `Ord` cannot be made into an object
-    (s.starts_with("."), s)
-}
-fn main() {
-    let _ = ord_prefer_dot(String::new());
-}

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.fixed
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.fixed
@@ -5,7 +5,7 @@
 // FIXME: the test suite tries to create a crate called `bare_trait_dont_suggest_dyn.new`
 #![crate_name="bare_trait_dont_suggest_dyn"]
 #![deny(bare_trait_objects)]
-fn ord_prefer_dot(s: String) -> Ord {
+fn ord_prefer_dot(s: String) -> impl Ord {
     //~^ ERROR the trait `Ord` cannot be made into an object
     //[old]~| ERROR trait objects without an explicit `dyn` are deprecated
     //[old]~| WARNING this is accepted in the current edition (Rust 2015)

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.stderr
@@ -1,0 +1,21 @@
+error[E0038]: the trait `Ord` cannot be made into an object
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:8:33
+   |
+LL | fn ord_prefer_dot(s: String) -> Ord {
+   |                                 ^^^ `Ord` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+  ::: $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+help: consider using an opaque type instead
+   |
+LL | fn ord_prefer_dot(s: String) -> impl Ord {
+   |                                 ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.old.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.old.stderr
@@ -1,5 +1,23 @@
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:8:33
+   |
+LL | fn ord_prefer_dot(s: String) -> Ord {
+   |                                 ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+note: the lint level is defined here
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:7:9
+   |
+LL | #![deny(bare_trait_objects)]
+   |         ^^^^^^^^^^^^^^^^^^
+help: use `dyn`
+   |
+LL | fn ord_prefer_dot(s: String) -> dyn Ord {
+   |                                 +++
+
 error[E0038]: the trait `Ord` cannot be made into an object
-  --> $DIR/bare-trait-dont-suggest-dyn.rs:3:33
+  --> $DIR/bare-trait-dont-suggest-dyn.rs:8:33
    |
 LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^ `Ord` cannot be made into an object
@@ -16,6 +34,6 @@ help: consider using an opaque type instead
 LL | fn ord_prefer_dot(s: String) -> impl Ord {
    |                                 ++++
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body.rs
+++ b/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body.rs
@@ -1,0 +1,9 @@
+// Issue #118164: recovery path leaving unemitted error behind
+fn bar() -> String {
+    #[cfg(feature = )]
+    [1, 2, 3].iter().map().collect::<String>() //~ ERROR expected `;`, found `#`
+    #[attr] //~ ERROR expected statement after outer attribute
+}
+fn main() {
+    let _ = bar();
+}

--- a/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body.stderr
+++ b/tests/ui/parser/attribute/properly-recover-from-trailing-outer-attribute-in-body.stderr
@@ -1,0 +1,27 @@
+error: expected `;`, found `#`
+  --> $DIR/properly-recover-from-trailing-outer-attribute-in-body.rs:4:47
+   |
+LL |     #[cfg(feature = )]
+   |     ------------------ only `;` terminated statements or tail expressions are allowed after this attribute
+LL |     [1, 2, 3].iter().map().collect::<String>()
+   |                                               ^ expected `;` here
+LL |     #[attr]
+   |     - unexpected token
+   |
+help: add `;` here
+   |
+LL |     [1, 2, 3].iter().map().collect::<String>();
+   |                                               +
+help: alternatively, consider surrounding the expression with a block
+   |
+LL |     { [1, 2, 3].iter().map().collect::<String>() }
+   |     +                                            +
+
+error: expected statement after outer attribute
+  --> $DIR/properly-recover-from-trailing-outer-attribute-in-body.rs:5:5
+   |
+LL |     #[attr]
+   |     ^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -7,18 +7,10 @@ LL | fn foo(_x: Foo + Send) {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: use a new generic type parameter, constrained by `Foo + Send`
+help: use `dyn`
    |
-LL | fn foo<T: Foo + Send>(_x: T) {
-   |       +++++++++++++++     ~
-help: you can also use an opaque type, but users won't be able to specify the type parameter when calling the `fn`, having to rely exclusively on type inference
-   |
-LL | fn foo(_x: impl Foo + Send) {
-   |            ++++
-help: alternatively, use a trait object to accept any type that implements `Foo + Send`, accessing its methods at runtime using dynamic dispatch
-   |
-LL | fn foo(_x: &(dyn Foo + Send)) {
-   |            +++++           +
+LL | fn foo(_x: dyn Foo + Send) {
+   |            +++
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:8

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -662,7 +662,6 @@ libs = [
     "@joshtriplett",
     "@Mark-Simulacrum",
     "@m-ou-se",
-    "@thomcc",
 ]
 bootstrap = [
     "@Mark-Simulacrum",
@@ -802,7 +801,7 @@ project-stable-mir = [
 "/library/panic_unwind" =                                ["libs"]
 "/library/proc_macro" =                                  ["@petrochenkov"]
 "/library/std" =                                         ["libs"]
-"/library/std/src/sys/pal/windows" =                     ["@ChrisDenton", "@thomcc"]
+"/library/std/src/sys/pal/windows" =                     ["@ChrisDenton"]
 "/library/stdarch" =                                     ["libs"]
 "/library/test" =                                        ["libs"]
 "/src/bootstrap" =                                       ["bootstrap"]


### PR DESCRIPTION
Successful merges:

 - #111379 (Boost iterator intersperse(_with) performance)
 - #118182 (Properly recover from trailing attr in body)
 - #119641 (Remove feature not required by `Ipv6Addr::to_cononical` doctest)
 - #119759 (Add FileCheck annotations to dataflow-const-prop tests)
 - #120275 (Avoid ICE in trait without `dyn` lint)
 - #120376 (Update codegen test for LLVM 18)
 - #120386 (ScopeTree: remove destruction_scopes as unused)
 - #120398 (Improve handling of numbers in `IntoDiagnosticArg`)
 - #120399 (Remove myself from review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=111379,118182,119641,119759,120275,120376,120386,120398,120399)
<!-- homu-ignore:end -->