### PR TITLE
i586_unknown_netbsd: use inline stack probes

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i586_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/targets/i586_unknown_netbsd.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     let mut base = base::netbsd::opts();
     base.cpu = "pentium".into();
     base.max_atomic_width = Some(64);
-    base.stack_probes = StackProbeType::Call;
+    base.stack_probes = StackProbeType::Inline;
 
     Target {
         llvm_target: "i586-unknown-netbsdelf".into(),


### PR DESCRIPTION
This is one of the last two targets still using "call" stack probes.

I don't believe that this target uses call stack probes for any particular reason--inline stack probes are used on [`i686_unknown_netbsd`](https://github.com/rust-lang/rust/blob/b362939be16f9324dd9e6e36e22b606020068d75/compiler/rustc_target/src/spec/targets/i686_unknown_netbsd.rs#L8), suggesting they work on netbsd; and on [`i586_unknown_linux_gnu`](https://github.com/rust-lang/rust/blob/b362939be16f9324dd9e6e36e22b606020068d75/compiler/rustc_target/src/spec/targets/i586_unknown_linux_gnu.rs#L4) (via the base [`i686_unknown_linux_gnu`](https://github.com/rust-lang/rust/blob/b362939be16f9324dd9e6e36e22b606020068d75/compiler/rustc_target/src/spec/targets/i686_unknown_linux_gnu.rs#L9)), suggesting they work with `cpu = "pentium"`.

...although I don't have a netbsd system to test this on.

(cc @he32)