### PR TITLE
raw pointer metadata API: data address -> data pointer

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -285,7 +285,7 @@ impl<T: ?Sized> *const T {
         self.with_addr(f(self.addr()))
     }
 
-    /// Decompose a (possibly wide) pointer into its address and metadata components.
+    /// Decompose a (possibly wide) pointer into its data pointer and metadata components.
     ///
     /// The pointer can be later reconstructed with [`from_raw_parts`].
     #[unstable(feature = "ptr_metadata", issue = "81513")]

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -39,13 +39,13 @@ use crate::hash::{Hash, Hasher};
 ///
 /// # Usage
 ///
-/// Raw pointers can be decomposed into the data address and metadata components
+/// Raw pointers can be decomposed into the data pointer and metadata components
 /// with their [`to_raw_parts`] method.
 ///
 /// Alternatively, metadata alone can be extracted with the [`metadata`] function.
 /// A reference can be passed to [`metadata`] and implicitly coerced.
 ///
-/// A (possibly-wide) pointer can be put back together from its address and metadata
+/// A (possibly-wide) pointer can be put back together from its data pointer and metadata
 /// with [`from_raw_parts`] or [`from_raw_parts_mut`].
 ///
 /// [`to_raw_parts`]: *const::to_raw_parts
@@ -98,7 +98,7 @@ pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
     unsafe { PtrRepr { const_ptr: ptr }.components.metadata }
 }
 
-/// Forms a (possibly-wide) raw pointer from a data address and metadata.
+/// Forms a (possibly-wide) raw pointer from a data pointer and metadata.
 ///
 /// This function is safe but the returned pointer is not necessarily safe to dereference.
 /// For slices, see the documentation of [`slice::from_raw_parts`] for safety requirements.
@@ -109,13 +109,13 @@ pub const fn metadata<T: ?Sized>(ptr: *const T) -> <T as Pointee>::Metadata {
 #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]
 pub const fn from_raw_parts<T: ?Sized>(
-    data_address: *const (),
+    data_pointer: *const (),
     metadata: <T as Pointee>::Metadata,
 ) -> *const T {
     // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
     // and PtrComponents<T> have the same memory layouts. Only std can make this
     // guarantee.
-    unsafe { PtrRepr { components: PtrComponents { data_address, metadata } }.const_ptr }
+    unsafe { PtrRepr { components: PtrComponents { data_pointer, metadata } }.const_ptr }
 }
 
 /// Performs the same functionality as [`from_raw_parts`], except that a
@@ -126,13 +126,13 @@ pub const fn from_raw_parts<T: ?Sized>(
 #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
 #[inline]
 pub const fn from_raw_parts_mut<T: ?Sized>(
-    data_address: *mut (),
+    data_pointer: *mut (),
     metadata: <T as Pointee>::Metadata,
 ) -> *mut T {
     // SAFETY: Accessing the value from the `PtrRepr` union is safe since *const T
     // and PtrComponents<T> have the same memory layouts. Only std can make this
     // guarantee.
-    unsafe { PtrRepr { components: PtrComponents { data_address, metadata } }.mut_ptr }
+    unsafe { PtrRepr { components: PtrComponents { data_pointer, metadata } }.mut_ptr }
 }
 
 #[repr(C)]
@@ -144,7 +144,7 @@ union PtrRepr<T: ?Sized> {
 
 #[repr(C)]
 struct PtrComponents<T: ?Sized> {
-    data_address: *const (),
+    data_pointer: *const (),
     metadata: <T as Pointee>::Metadata,
 }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -292,7 +292,7 @@ impl<T: ?Sized> *mut T {
         self.with_addr(f(self.addr()))
     }
 
-    /// Decompose a (possibly wide) pointer into its address and metadata components.
+    /// Decompose a (possibly wide) pointer into its data pointer and metadata components.
     ///
     /// The pointer can be later reconstructed with [`from_raw_parts_mut`].
     #[unstable(feature = "ptr_metadata", issue = "81513")]

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -259,16 +259,16 @@ impl<T: ?Sized> NonNull<T> {
     #[rustc_const_unstable(feature = "ptr_metadata", issue = "81513")]
     #[inline]
     pub const fn from_raw_parts(
-        data_address: NonNull<()>,
+        data_pointer: NonNull<()>,
         metadata: <T as super::Pointee>::Metadata,
     ) -> NonNull<T> {
-        // SAFETY: The result of `ptr::from::raw_parts_mut` is non-null because `data_address` is.
+        // SAFETY: The result of `ptr::from::raw_parts_mut` is non-null because `data_pointer` is.
         unsafe {
-            NonNull::new_unchecked(super::from_raw_parts_mut(data_address.as_ptr(), metadata))
+            NonNull::new_unchecked(super::from_raw_parts_mut(data_pointer.as_ptr(), metadata))
         }
     }
 
-    /// Decompose a (possibly wide) pointer into its address and metadata components.
+    /// Decompose a (possibly wide) pointer into its data pointer and metadata components.
     ///
     /// The pointer can be later reconstructed with [`NonNull::from_raw_parts`].
     #[unstable(feature = "ptr_metadata", issue = "81513")]

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -42,7 +42,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
                                 debug self => _8;
                             }
                             scope 15 (inlined std::ptr::from_raw_parts_mut::<[u32]>) {
-                                debug data_address => _9;
+                                debug data_pointer => _9;
                                 debug metadata => _6;
                                 let mut _10: *const ();
                                 let mut _11: std::ptr::metadata::PtrComponents<[u32]>;
@@ -90,7 +90,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
         StorageLive(_11);
         StorageLive(_10);
         _10 = _9 as *const () (PointerCoercion(MutToConstPointer));
-        _11 = std::ptr::metadata::PtrComponents::<[u32]> { data_address: move _10, metadata: _6 };
+        _11 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: move _10, metadata: _6 };
         StorageDead(_10);
         _12 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _11 };
         StorageDead(_11);

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -42,7 +42,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
                                 debug self => _8;
                             }
                             scope 15 (inlined std::ptr::from_raw_parts_mut::<[u32]>) {
-                                debug data_address => _9;
+                                debug data_pointer => _9;
                                 debug metadata => _6;
                                 let mut _10: *const ();
                                 let mut _11: std::ptr::metadata::PtrComponents<[u32]>;
@@ -90,7 +90,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
         StorageLive(_11);
         StorageLive(_10);
         _10 = _9 as *const () (PointerCoercion(MutToConstPointer));
-        _11 = std::ptr::metadata::PtrComponents::<[u32]> { data_address: move _10, metadata: _6 };
+        _11 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: move _10, metadata: _6 };
         StorageDead(_10);
         _12 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _11 };
         StorageDead(_11);

--- a/tests/ui/union/issue-81199.rs
+++ b/tests/ui/union/issue-81199.rs
@@ -9,7 +9,7 @@ union PtrRepr<T: ?Sized> {
 
 #[repr(C)]
 struct PtrComponents<T: Pointee + ?Sized> {
-    data_address: *const (),
+    data_pointer: *const (),
     metadata: <T as Pointee>::Metadata,
 }
 


### PR DESCRIPTION
A pointer consists of [more than just an address](https://github.com/rust-lang/rfcs/pull/3559), so let's not equate "pointer" and "address" in these docs.