### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -509,6 +509,7 @@ pub enum StashKey {
     MaybeForgetReturn,
     /// Query cycle detected, stashing in favor of a better error.
     Cycle,
+    UndeterminedMacroResolution,
 }
 
 fn default_track_diagnostic(diag: Diagnostic, f: &mut dyn FnMut(Diagnostic)) {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1,10 +1,9 @@
 //! A bunch of methods and structures more or less related to resolving macros and
 //! interface provided by `Resolver` to macro expander.
 
-use crate::errors::{
-    self, AddAsNonDerive, CannotDetermineMacroResolution, CannotFindIdentInThisScope,
-    MacroExpectedFound, RemoveSurroundingDerive,
-};
+use crate::errors::CannotDetermineMacroResolution;
+use crate::errors::{self, AddAsNonDerive, CannotFindIdentInThisScope};
+use crate::errors::{MacroExpectedFound, RemoveSurroundingDerive};
 use crate::Namespace::*;
 use crate::{BuiltinMacroState, Determinacy, MacroData};
 use crate::{DeriveData, Finalize, ParentScope, ResolutionError, Resolver, ScopeSet};
@@ -15,6 +14,7 @@ use rustc_ast_pretty::pprust;
 use rustc_attr::StabilityLevel;
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::sync::Lrc;
+use rustc_errors::StashKey;
 use rustc_errors::{struct_span_code_err, Applicability};
 use rustc_expand::base::{Annotatable, DeriveResolutions, Indeterminate, ResolverExpand};
 use rustc_expand::base::{SyntaxExtension, SyntaxExtensionKind};
@@ -25,9 +25,8 @@ use rustc_hir::def_id::{CrateNum, DefId, LocalDefId};
 use rustc_middle::middle::stability;
 use rustc_middle::ty::RegisteredTools;
 use rustc_middle::ty::{TyCtxt, Visibility};
-use rustc_session::lint::builtin::{
-    LEGACY_DERIVE_HELPERS, SOFT_UNSTABLE, UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-};
+use rustc_session::lint::builtin::UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES;
+use rustc_session::lint::builtin::{LEGACY_DERIVE_HELPERS, SOFT_UNSTABLE};
 use rustc_session::lint::builtin::{UNUSED_MACROS, UNUSED_MACRO_RULES};
 use rustc_session::lint::BuiltinLintDiagnostics;
 use rustc_session::parse::feature_err;
@@ -703,21 +702,21 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                     // situations should be reported as errors, so this is a bug.
                     this.dcx().span_delayed_bug(span, "inconsistent resolution for a macro");
                 }
-            } else {
+            } else if this.tcx.dcx().has_errors().is_none() && this.privacy_errors.is_empty() {
                 // It's possible that the macro was unresolved (indeterminate) and silently
                 // expanded into a dummy fragment for recovery during expansion.
                 // Now, post-expansion, the resolution may succeed, but we can't change the
                 // past and need to report an error.
                 // However, non-speculative `resolve_path` can successfully return private items
                 // even if speculative `resolve_path` returned nothing previously, so we skip this
-                // less informative error if the privacy error is reported elsewhere.
-                if this.privacy_errors.is_empty() {
-                    this.dcx().emit_err(CannotDetermineMacroResolution {
-                        span,
-                        kind: kind.descr(),
-                        path: Segment::names_to_string(path),
-                    });
-                }
+                // less informative error if no other error is reported elsewhere.
+
+                let err = this.dcx().create_err(CannotDetermineMacroResolution {
+                    span,
+                    kind: kind.descr(),
+                    path: Segment::names_to_string(path),
+                });
+                err.stash(span, StashKey::UndeterminedMacroResolution);
             }
         };
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -938,8 +938,11 @@ impl<T, A: Allocator> Rc<T, A> {
     /// it is guaranteed that exactly one of the calls returns the inner value.
     /// This means in particular that the inner value is not dropped.
     ///
-    /// This is equivalent to `Rc::try_unwrap(this).ok()`. (Note that these are not equivalent for
-    /// [`Arc`](crate::sync::Arc), due to race conditions that do not apply to `Rc`.)
+    /// [`Rc::try_unwrap`] is conceptually similar to `Rc::into_inner`.
+    /// And while they are meant for different use-cases, `Rc::into_inner(this)`
+    /// is in fact equivalent to <code>[Rc::try_unwrap]\(this).[ok][Result::ok]()</code>.
+    /// (Note that the same kind of equivalence does **not** hold true for
+    /// [`Arc`](crate::sync::Arc), due to race conditions that do not apply to `Rc`!)
     #[inline]
     #[stable(feature = "rc_into_inner", since = "1.70.0")]
     pub fn into_inner(this: Self) -> Option<T> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -983,9 +983,13 @@ impl<T, A: Allocator> Arc<T, A> {
     /// it is guaranteed that exactly one of the calls returns the inner value.
     /// This means in particular that the inner value is not dropped.
     ///
-    /// The similar expression `Arc::try_unwrap(this).ok()` does not
-    /// offer such a guarantee. See the last example below
-    /// and the documentation of [`Arc::try_unwrap`].
+    /// [`Arc::try_unwrap`] is conceptually similar to `Arc::into_inner`, but it
+    /// is meant for different use-cases. If used as a direct replacement
+    /// for `Arc::into_inner` anyway, such as with the expression
+    /// <code>[Arc::try_unwrap]\(this).[ok][Result::ok]()</code>, then it does
+    /// **not** give the same guarantee as described in the previous paragraph.
+    /// For more information, see the examples below and read the documentation
+    /// of [`Arc::try_unwrap`].
     ///
     /// # Examples
     ///

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1397,7 +1397,11 @@ mod prim_usize {}
 /// which violates any of these properties.
 ///
 /// * `t` is aligned to `align_of_val(t)`
-/// * `t` refers to a single [allocated object]
+/// * `t` is dereferenceable for `size_of_val(t)` many bytes
+///
+///  Being "dereferenceable" for N bytes means that the memory range beginning
+/// at the address `t` points to and ending N bytes later is all contained within a
+/// single [allocated object].
 ///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1389,6 +1389,18 @@ mod prim_usize {}
 /// work on references as well as they do on owned values! The implementations described here are
 /// meant for generic contexts, where the final type `T` is a type parameter or otherwise not
 /// locally known.
+///
+/// # Safety
+///
+/// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, unsafe code may assume that
+/// the following properties hold. It is undefined behavior to produce a `t: &T` or `t: &mut T`
+/// which violates any of these properties.
+///
+/// * `t` is aligned to `align_of_val(t)`
+/// * `t` refers to a valid instance of `T`
+/// * `t` refers to a single [allocated object]
+///
+/// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_ref {}
 

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1393,8 +1393,9 @@ mod prim_usize {}
 /// # Safety
 ///
 /// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, unsafe code may assume that
-/// the following properties hold. It is undefined behavior to produce a `t: &T` or `t: &mut T`
-/// which violates any of these properties.
+/// the following properties hold. Rust programmers must assume that, unless explicitly stated
+/// otherwise, any Rust code they did not author themselves may rely on these properties, and that
+/// violating them may cause that code to exhibit undefined behavior.
 ///
 /// * `t` is aligned to `align_of_val(t)`
 /// * `t` is dereferenceable for `size_of_val(t)` many bytes

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1399,9 +1399,8 @@ mod prim_usize {}
 /// * `t` is aligned to `align_of_val(t)`
 /// * `t` is dereferenceable for `size_of_val(t)` many bytes
 ///
-///  Being "dereferenceable" for N bytes means that the memory range beginning
-/// at the address `t` points to and ending N bytes later is all contained within a
-/// single [allocated object].
+/// If `t` points at address `a`, being "dereferenceable" for N bytes means that the memory range
+/// `[a, a + N)` is all contained within a single [allocated object].
 ///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1397,7 +1397,6 @@ mod prim_usize {}
 /// which violates any of these properties.
 ///
 /// * `t` is aligned to `align_of_val(t)`
-/// * `t` refers to a valid instance of `T`
 /// * `t` refers to a single [allocated object]
 ///
 /// [allocated object]: ptr#allocated-object

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1392,10 +1392,8 @@ mod prim_usize {}
 ///
 /// # Safety
 ///
-/// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, unsafe code may assume that
-/// the following properties hold. Rust programmers must assume that, unless explicitly stated
-/// otherwise, any Rust code they did not author themselves may rely on these properties, and that
-/// violating them may cause that code to exhibit undefined behavior.
+/// For all types, `T: ?Sized`, and for all `t: &T` or `t: &mut T`, when such values cross an API
+/// boundary, the following invariants must generally be upheld:
 ///
 /// * `t` is aligned to `align_of_val(t)`
 /// * `t` is dereferenceable for `size_of_val(t)` many bytes
@@ -1403,9 +1401,16 @@ mod prim_usize {}
 /// If `t` points at address `a`, being "dereferenceable" for N bytes means that the memory range
 /// `[a, a + N)` is all contained within a single [allocated object].
 ///
-/// Note that the precise validity invariants for reference types are a work in progress. In the
-/// future, new guarantees may be added. However, the guarantees documented in this section will
-/// never be removed.
+/// For instance, this means that unsafe code in a safe function may assume these invariants are
+/// ensured of arguments passed by the caller, and it may assume that these invariants are ensured
+/// of return values from any safe functions it calls. In most cases, the inverse is also true:
+/// unsafe code must not violate these invariants when passing arguments to safe functions or
+/// returning values from safe functions; such violations may result in undefined behavior. Where
+/// exceptions to this latter requirement exist, they will be called out explicitly in documentation.
+///
+/// It is not decided yet whether unsafe code may violate these invariants temporarily on internal
+/// data. As a consequence, unsafe code which violates these invariants temporarily on internal data
+/// may become unsound in future versions of Rust depending on how this question is decided.
 ///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1403,6 +1403,10 @@ mod prim_usize {}
 /// If `t` points at address `a`, being "dereferenceable" for N bytes means that the memory range
 /// `[a, a + N)` is all contained within a single [allocated object].
 ///
+/// Note that the precise validity invariants for reference types are a work in progress. In the
+/// future, new guarantees may be added. However, the guarantees documented in this section will
+/// never be removed.
+///
 /// [allocated object]: ptr#allocated-object
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_ref {}

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -12,7 +12,8 @@ fn main() {
         return;
     }
 
-    let target = env::var("TARGET").expect("TARGET was not set");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV was not set");
     let cfg = &mut cc::Build::new();
 
     // FIXME: `rerun-if-changed` directives are not currently emitted and the build script
@@ -40,7 +41,7 @@ fn main() {
         "InstrProfilingBiasVar.c",
     ];
 
-    if target.contains("msvc") {
+    if target_env == "msvc" {
         // Don't pull in extra libraries on MSVC
         cfg.flag("/Zl");
         profile_sources.push("WindowsMMap.c");
@@ -55,7 +56,7 @@ fn main() {
         cfg.flag("-fno-builtin");
         cfg.flag("-fomit-frame-pointer");
         cfg.define("VISIBILITY_HIDDEN", None);
-        if !target.contains("windows") {
+        if target_os != "windows" {
             cfg.flag("-fvisibility=hidden");
             cfg.define("COMPILER_RT_HAS_UNAME", Some("1"));
         } else {

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -2,41 +2,46 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    let target = env::var("TARGET").expect("TARGET was not set");
-    if target.contains("linux")
-        || target.contains("netbsd")
-        || target.contains("dragonfly")
-        || target.contains("openbsd")
-        || target.contains("freebsd")
-        || target.contains("solaris")
-        || target.contains("illumos")
-        || target.contains("apple-darwin")
-        || target.contains("apple-ios")
-        || target.contains("apple-tvos")
-        || target.contains("apple-watchos")
-        || target.contains("uwp")
-        || target.contains("windows")
-        || target.contains("fuchsia")
-        || (target.contains("sgx") && target.contains("fortanix"))
-        || target.contains("hermit")
-        || target.contains("l4re")
-        || target.contains("redox")
-        || target.contains("haiku")
-        || target.contains("vxworks")
-        || target.contains("wasm32")
-        || target.contains("wasm64")
-        || target.contains("espidf")
-        || target.contains("solid")
-        || target.contains("nintendo-3ds")
-        || target.contains("vita")
-        || target.contains("aix")
-        || target.contains("nto")
-        || target.contains("xous")
-        || target.contains("hurd")
-        || target.contains("uefi")
-        || target.contains("teeos")
-        || target.contains("zkvm")
-        // See src/bootstrap/synthetic_targets.rs
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH was not set");
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");
+    let target_vendor =
+        env::var("CARGO_CFG_TARGET_VENDOR").expect("CARGO_CFG_TARGET_VENDOR was not set");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV was not set");
+
+    if target_os == "linux"
+        || target_os == "netbsd"
+        || target_os == "dragonfly"
+        || target_os == "openbsd"
+        || target_os == "freebsd"
+        || target_os == "solaris"
+        || target_os == "illumos"
+        || target_os == "macos"
+        || target_os == "ios"
+        || target_os == "tvos"
+        || target_os == "watchos"
+        || target_os == "windows"
+        || target_os == "fuchsia"
+        || (target_vendor == "fortranix" && target_env == "sgx")
+        || target_os == "hermit"
+        || target_os == "l4re"
+        || target_os == "redox"
+        || target_os == "haiku"
+        || target_os == "vxworks"
+        || target_arch == "wasm32"
+        || target_arch == "wasm64"
+        || target_os == "espidf"
+        || target_os.starts_with("solid")
+        || (target_vendor == "nintendo" && target_env == "newlib")
+        || target_os == "vita"
+        || target_os == "aix"
+        || target_os == "nto"
+        || target_os == "xous"
+        || target_os == "hurd"
+        || target_os == "uefi"
+        || target_os == "teeos"
+        || target_os == "zkvm"
+
+        // See src/bootstrap/src/core/build_steps/synthetic_targets.rs
         || env::var("RUSTC_BOOTSTRAP_SYNTHETIC_TARGET").is_ok()
     {
         // These platforms don't have any special requirements.
@@ -48,7 +53,7 @@ fn main() {
         // - mipsel-sony-psp
         // - nvptx64-nvidia-cuda
         // - arch=avr
-        // - JSON targets
+        // - JSON targets not describing an excluded target above.
         // - Any new targets that have not been explicitly added above.
         println!("cargo:rustc-cfg=feature=\"restricted-std\"");
     }

--- a/library/std/src/sys/pal/unix/locks/pthread_mutex.rs
+++ b/library/std/src/sys/pal/unix/locks/pthread_mutex.rs
@@ -1,4 +1,5 @@
 use crate::cell::UnsafeCell;
+use crate::io::Error;
 use crate::mem::{forget, MaybeUninit};
 use crate::sys::cvt_nz;
 use crate::sys_common::lazy_box::{LazyBox, LazyInit};
@@ -103,8 +104,24 @@ impl Mutex {
 
     #[inline]
     pub unsafe fn lock(&self) {
+        #[cold]
+        #[inline(never)]
+        fn fail() -> ! {
+            let error = Error::last_os_error();
+            panic!("failed to lock mutex: {error}");
+        }
+
         let r = libc::pthread_mutex_lock(raw(self));
-        debug_assert_eq!(r, 0);
+        // As we set the mutex type to `PTHREAD_MUTEX_NORMAL` above, we expect
+        // the lock call to never fail. Unfortunately however, some platforms
+        // (Solaris) do not conform to the standard, and instead always provide
+        // deadlock detection. How kind of them! Unfortunately that means that
+        // we need to check the error code here. To save us from UB on other
+        // less well-behaved platforms in the future, we do it even on "good"
+        // platforms like macOS. See #120147 for more context.
+        if r != 0 {
+            fail()
+        }
     }
 
     #[inline]

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -1096,7 +1096,7 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
                 first: Some(wfd),
             })
         } else {
-            Err(Error::last_os_error())
+            Err(last_error)
         }
     }
 }

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -1081,9 +1081,9 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
         //
         // See issue #120040: https://github.com/rust-lang/rust/issues/120040.
         let last_error = Error::last_os_error();
-        if last_error.raw_os_error().unwrap() == c::ERROR_FILE_NOT_FOUND && p.exists() {
+        if last_error.raw_os_error().unwrap() == c::ERROR_FILE_NOT_FOUND as i32 && p.exists() {
             return Ok(ReadDir {
-                handle: FindNextFileHandle(file_handle),
+                handle: FindNextFileHandle(find_handle),
                 root: Arc::new(root),
                 first: None,
             });

--- a/tests/ui/derives/issue-36617.rs
+++ b/tests/ui/derives/issue-36617.rs
@@ -1,16 +1,16 @@
-#![derive(Copy)] //~ ERROR cannot determine resolution for the attribute macro `derive`
+#![derive(Copy)]
 //~^ ERROR `derive` attribute cannot be used at crate level
 
-#![test]//~ ERROR cannot determine resolution for the attribute macro `test`
+#![test]
 //~^ ERROR `test` attribute cannot be used at crate level
 
-#![test_case]//~ ERROR cannot determine resolution for the attribute macro `test_case`
+#![test_case]
 //~^ ERROR `test_case` attribute cannot be used at crate level
 
-#![bench]//~ ERROR cannot determine resolution for the attribute macro `bench`
+#![bench]
 //~^ ERROR `bench` attribute cannot be used at crate level
 
-#![global_allocator]//~ ERROR cannot determine resolution for the attribute macro `global_allocator`
+#![global_allocator]
 //~^ ERROR `global_allocator` attribute cannot be used at crate level
 
 fn main() {}

--- a/tests/ui/derives/issue-36617.stderr
+++ b/tests/ui/derives/issue-36617.stderr
@@ -1,43 +1,3 @@
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/issue-36617.rs:1:4
-   |
-LL | #![derive(Copy)]
-   |    ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-36617.rs:4:4
-   |
-LL | #![test]
-   |    ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `test_case`
-  --> $DIR/issue-36617.rs:7:4
-   |
-LL | #![test_case]
-   |    ^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `bench`
-  --> $DIR/issue-36617.rs:10:4
-   |
-LL | #![bench]
-   |    ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `global_allocator`
-  --> $DIR/issue-36617.rs:13:4
-   |
-LL | #![global_allocator]
-   |    ^^^^^^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `derive` attribute cannot be used at crate level
   --> $DIR/issue-36617.rs:1:1
    |
@@ -113,5 +73,5 @@ LL - #![global_allocator]
 LL + #[global_allocator]
    |
 
-error: aborting due to 10 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/extenv/issue-55897.rs
+++ b/tests/ui/extenv/issue-55897.rs
@@ -4,7 +4,6 @@ mod unresolved_env {
     use env; //~ ERROR unresolved import `env`
 
     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
-    //~^ ERROR cannot determine resolution for the macro `env`
 }
 
 mod nonexistent_env {

--- a/tests/ui/extenv/issue-55897.stderr
+++ b/tests/ui/extenv/issue-55897.stderr
@@ -1,5 +1,5 @@
 error: environment variable `NON_EXISTENT` not defined at compile time
-  --> $DIR/issue-55897.rs:11:22
+  --> $DIR/issue-55897.rs:10:22
    |
 LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: suffixes on string literals are invalid
-  --> $DIR/issue-55897.rs:16:22
+  --> $DIR/issue-55897.rs:15:22
    |
 LL |     include!(concat!("NON_EXISTENT"suffix, "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^ invalid suffix `suffix`
@@ -33,14 +33,6 @@ help: consider importing this module instead
 LL |     use std::env;
    |         ~~~~~~~~
 
-error: cannot determine resolution for the macro `env`
-  --> $DIR/issue-55897.rs:6:22
-   |
-LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
-   |                      ^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-bench.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-bench.rs
@@ -5,6 +5,5 @@
 #![feature(custom_inner_attributes)]
 
 #![bench                   = "4100"]
-//~^ ERROR cannot determine resolution for the attribute macro `bench`
-//~^^ ERROR `bench` attribute cannot be used at crate level
+//~^ ERROR `bench` attribute cannot be used at crate level
 fn main() {}

--- a/tests/ui/feature-gates/issue-43106-gating-of-bench.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-bench.stderr
@@ -1,17 +1,9 @@
-error: cannot determine resolution for the attribute macro `bench`
-  --> $DIR/issue-43106-gating-of-bench.rs:7:4
-   |
-LL | #![bench                   = "4100"]
-   |    ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `bench` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-bench.rs:7:1
    |
 LL | #![bench                   = "4100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+LL |
 LL | fn main() {}
    |    ---- the inner attribute doesn't annotate this function
    |
@@ -21,5 +13,5 @@ LL - #![bench                   = "4100"]
 LL + #[bench                   = "4100"]
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-test.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-test.rs
@@ -2,6 +2,5 @@
 
 #![allow(soft_unstable)]
 #![test                    = "4200"]
-//~^ ERROR cannot determine resolution for the attribute macro `test`
-//~^^ ERROR `test` attribute cannot be used at crate level
+//~^ ERROR `test` attribute cannot be used at crate level
 fn main() {}

--- a/tests/ui/feature-gates/issue-43106-gating-of-test.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-test.stderr
@@ -1,17 +1,9 @@
-error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-43106-gating-of-test.rs:4:4
-   |
-LL | #![test                    = "4200"]
-   |    ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `test` attribute cannot be used at crate level
   --> $DIR/issue-43106-gating-of-test.rs:4:1
    |
 LL | #![test                    = "4200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+LL |
 LL | fn main() {}
    |    ---- the inner attribute doesn't annotate this function
    |
@@ -21,5 +13,5 @@ LL - #![test                    = "4200"]
 LL + #[test                    = "4200"]
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-28134.rs
+++ b/tests/ui/imports/issue-28134.rs
@@ -1,5 +1,5 @@
 // compile-flags: --test
 
 #![allow(soft_unstable)]
-#![test] //~ ERROR cannot determine resolution for the attribute macro `test`
+#![test]
 //~^ ERROR 4:1: 4:9: `test` attribute cannot be used at crate level

--- a/tests/ui/imports/issue-28134.stderr
+++ b/tests/ui/imports/issue-28134.stderr
@@ -1,11 +1,3 @@
-error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-28134.rs:4:4
-   |
-LL | #![test]
-   |    ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `test` attribute cannot be used at crate level
   --> $DIR/issue-28134.rs:4:1
    |
@@ -18,5 +10,5 @@ LL - #![test]
 LL + #[test]
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-55457.rs
+++ b/tests/ui/imports/issue-55457.rs
@@ -1,10 +1,9 @@
 use NonExistent; //~ ERROR unresolved import `NonExistent`
 use non_existent::non_existent; //~ ERROR unresolved import `non_existent`
 
-#[non_existent] //~ ERROR cannot determine resolution for the attribute macro `non_existent`
-#[derive(NonExistent)] //~ ERROR cannot determine resolution for the derive macro `NonExistent`
-                       //~| ERROR cannot determine resolution for the derive macro `NonExistent`
-                       //~| ERROR cannot determine resolution for the derive macro `NonExistent`
+#[non_existent]
+#[derive(NonExistent)]
+
 struct S;
 
 fn main() {}

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -15,40 +15,6 @@ LL | use non_existent::non_existent;
    |
    = help: consider adding `extern crate non_existent` to use the `non_existent` crate
 
-error: cannot determine resolution for the derive macro `NonExistent`
-  --> $DIR/issue-55457.rs:5:10
-   |
-LL | #[derive(NonExistent)]
-   |          ^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the attribute macro `non_existent`
-  --> $DIR/issue-55457.rs:4:3
-   |
-LL | #[non_existent]
-   |   ^^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the derive macro `NonExistent`
-  --> $DIR/issue-55457.rs:5:10
-   |
-LL | #[derive(NonExistent)]
-   |          ^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: cannot determine resolution for the derive macro `NonExistent`
-  --> $DIR/issue-55457.rs:5:10
-   |
-LL | #[derive(NonExistent)]
-   |          ^^^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 6 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/imports/issue-59764.rs
+++ b/tests/ui/imports/issue-59764.rs
@@ -128,7 +128,6 @@ use issue_59764::foo::makro;
 //~^ ERROR unresolved import `issue_59764::foo::makro` [E0432]
 
 makro!(bar);
-//~^ ERROR cannot determine resolution for the macro `makro`
 
 fn main() {
     bar();

--- a/tests/ui/imports/issue-59764.stderr
+++ b/tests/ui/imports/issue-59764.stderr
@@ -226,21 +226,13 @@ help: a macro with this name exists at the root of the crate
 LL | use issue_59764::makro;
    |     ~~~~~~~~~~~~~~~~~~
 
-error: cannot determine resolution for the macro `makro`
-  --> $DIR/issue-59764.rs:130:1
-   |
-LL | makro!(bar);
-   | ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/issue-59764.rs:134:5
+  --> $DIR/issue-59764.rs:133:5
    |
 LL |     bar();
    |     ^^^ not found in this scope
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 
 Some errors have detailed explanations: E0425, E0432.
 For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/proc-macro/derive-helper-legacy-spurious.rs
+++ b/tests/ui/proc-macro/derive-helper-legacy-spurious.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 extern crate test_macros;
 
-#[derive(Empty)] //~ ERROR cannot determine resolution for the attribute macro `derive`
+#[derive(Empty)]
 #[empty_helper] //~ ERROR cannot find attribute `empty_helper` in this scope
 struct Foo {}
 

--- a/tests/ui/proc-macro/derive-helper-legacy-spurious.stderr
+++ b/tests/ui/proc-macro/derive-helper-legacy-spurious.stderr
@@ -4,19 +4,11 @@ error: cannot find attribute `dummy` in this scope
 LL | #![dummy]
    |    ^^^^^
 
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/derive-helper-legacy-spurious.rs:8:3
-   |
-LL | #[derive(Empty)]
-   |   ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: cannot find attribute `empty_helper` in this scope
   --> $DIR/derive-helper-legacy-spurious.rs:9:3
    |
 LL | #[empty_helper]
    |   ^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/proc-macro/issue-118455-skip-err-builtin.rs
+++ b/tests/ui/proc-macro/issue-118455-skip-err-builtin.rs
@@ -1,0 +1,6 @@
+#![some_nonexistent_attribute]
+//~^ ERROR cannot find attribute `some_nonexistent_attribute` in this scope
+#[derive(Debug)]
+pub struct SomeUserCode;
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-118455-skip-err-builtin.stderr
+++ b/tests/ui/proc-macro/issue-118455-skip-err-builtin.stderr
@@ -1,0 +1,8 @@
+error: cannot find attribute `some_nonexistent_attribute` in this scope
+  --> $DIR/issue-118455-skip-err-builtin.rs:1:4
+   |
+LL | #![some_nonexistent_attribute]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.fixed
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.fixed
@@ -1,0 +1,6 @@
+// run-rustfix
+
+#[derive(Debug)] //~ ERROR `derive` attribute cannot be used at crate level
+struct Test {}
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.rs
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.rs
@@ -1,0 +1,6 @@
+// run-rustfix
+
+#![derive(Debug)] //~ ERROR `derive` attribute cannot be used at crate level
+struct Test {}
+
+fn main() {}

--- a/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.stderr
+++ b/tests/ui/proc-macro/issue-89566-suggest-fix-invalid-top-level-macro-attr.stderr
@@ -1,0 +1,16 @@
+error: `derive` attribute cannot be used at crate level
+  --> $DIR/issue-89566-suggest-fix-invalid-top-level-macro-attr.rs:3:1
+   |
+LL | #![derive(Debug)]
+   | ^^^^^^^^^^^^^^^^^
+LL | struct Test {}
+   |        ---- the inner attribute doesn't annotate this struct
+   |
+help: perhaps you meant to use an outer attribute
+   |
+LL - #![derive(Debug)]
+LL + #[derive(Debug)]
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/reserved/reserved-attr-on-macro.rs
+++ b/tests/ui/reserved/reserved-attr-on-macro.rs
@@ -7,5 +7,5 @@ macro_rules! foo {
 }
 
 fn main() {
-    foo!(); //~ ERROR cannot determine resolution for the macro `foo`
+    foo!();
 }

--- a/tests/ui/reserved/reserved-attr-on-macro.stderr
+++ b/tests/ui/reserved/reserved-attr-on-macro.stderr
@@ -4,19 +4,11 @@ error: attributes starting with `rustc` are reserved for use by the `rustc` comp
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: cannot determine resolution for the macro `foo`
-  --> $DIR/reserved-attr-on-macro.rs:10:5
-   |
-LL |     foo!();
-   |     ^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: cannot find attribute `rustc_attribute_should_be_reserved` in this scope
   --> $DIR/reserved-attr-on-macro.rs:1:3
    |
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/rust-2018/issue-54006.rs
+++ b/tests/ui/rust-2018/issue-54006.rs
@@ -8,6 +8,5 @@ use alloc::vec;
 
 pub fn foo() {
     let mut xs = vec![];
-    //~^ ERROR cannot determine resolution for the macro `vec`
     xs.push(0);
 }

--- a/tests/ui/rust-2018/issue-54006.stderr
+++ b/tests/ui/rust-2018/issue-54006.stderr
@@ -4,14 +4,6 @@ error[E0432]: unresolved import `alloc`
 LL | use alloc::vec;
    |     ^^^^^ help: a similar path exists: `core::alloc`
 
-error: cannot determine resolution for the macro `vec`
-  --> $DIR/issue-54006.rs:10:18
-   |
-LL |     let mut xs = vec![];
-   |                  ^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/span/issue-43927-non-ADT-derive.rs
+++ b/tests/ui/span/issue-43927-non-ADT-derive.rs
@@ -1,6 +1,5 @@
 #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-//~^ ERROR cannot determine resolution for the attribute macro `derive`
-//~^^ ERROR `derive` attribute cannot be used at crate level
+//~^ ERROR `derive` attribute cannot be used at crate level
 struct DerivedOn;
 
 fn main() {}

--- a/tests/ui/span/issue-43927-non-ADT-derive.stderr
+++ b/tests/ui/span/issue-43927-non-ADT-derive.stderr
@@ -1,17 +1,9 @@
-error: cannot determine resolution for the attribute macro `derive`
-  --> $DIR/issue-43927-non-ADT-derive.rs:1:4
-   |
-LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-   |    ^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
 error: `derive` attribute cannot be used at crate level
   --> $DIR/issue-43927-non-ADT-derive.rs:1:1
    |
 LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+LL |
 LL | struct DerivedOn;
    |        --------- the inner attribute doesn't annotate this struct
    |
@@ -21,5 +13,5 @@ LL - #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
 LL + #[derive(Debug, PartialEq, Eq)] // should be an outer attribute!
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - #116677 (References refer to allocated objects)
 - #118533 (Suppress unhelpful diagnostics for unresolved top level attributes)
 - #120232 (Add support for custom JSON targets when using build-std.)
 - #120238 (Always check the result of `pthread_mutex_lock`)
 - #120266 (Improve documentation for [A]Rc::into_inner)
 - #120373 (Adjust Behaviour of `read_dir` and `ReadDir` in Windows Implementation: Check Whether Path to Search In Exists)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=116677,118533,120232,120238,120266,120373)
<!-- homu-ignore:end -->