### PR TITLE
Fix footnote handling in rustdoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3005,11 +3005,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "memchr",
  "unicase",
 ]

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 bitflags = "2.4.1"
-pulldown-cmark = { version = "0.9.3", default-features = false }
+pulldown-cmark = { version = "0.9.6", default-features = false }
 rustc_arena = { path = "../rustc_arena" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }

--- a/tests/rustdoc/footnote-definition-without-blank-line-100638.rs
+++ b/tests/rustdoc/footnote-definition-without-blank-line-100638.rs
@@ -1,0 +1,15 @@
+#![crate_name = "foo"]
+
+//! Reference to footnotes A[^1], B[^2] and C[^3].
+//!
+//! [^1]: Footnote A.
+//! [^2]: Footnote B.
+//! [^3]: Footnote C.
+
+// @has 'foo/index.html'
+// @has - '//*[@class="docblock"]/*[@class="footnotes"]/ol/li[@id="fn1"]/p' 'Footnote A'
+// @has - '//li[@id="fn1"]/p/a/@href' '#fnref1'
+// @has - '//*[@class="docblock"]/*[@class="footnotes"]/ol/li[@id="fn2"]/p' 'Footnote B'
+// @has - '//li[@id="fn2"]/p/a/@href' '#fnref2'
+// @has - '//*[@class="docblock"]/*[@class="footnotes"]/ol/li[@id="fn3"]/p' 'Footnote C'
+// @has - '//li[@id="fn3"]/p/a/@href' '#fnref3'


### PR DESCRIPTION
Fixes #100638.

You can now declare footnotes like this:

```rust
//! Reference to footnotes A[^1], B[^2] and C[^3].
//!
//! [^1]: Footnote A.
//! [^2]: Footnote B.
//! [^3]: Footnote C.
```

r? @notriddle 