### PR TITLE
Relax the Sized requirement on the Error impl for Box.

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2438,7 +2438,7 @@ impl<'a> From<Cow<'a, str>> for Box<dyn Error> {
 }
 
 #[stable(feature = "box_error", since = "1.8.0")]
-impl<T: core::error::Error> core::error::Error for Box<T> {
+impl<T: core::error::Error + ?Sized> core::error::Error for Box<T> {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         core::error::Error::description(&**self)


### PR DESCRIPTION
This is already the case for Arc and ThinBox, so I'm guessing this was just an oversight? This will be insta-stable, and probably needs an FCP.