### PR TITLE
[PERF Experiment] Only create the self-profile infra if the profiler is actually enabled (only if `-Z self-profile`)

### DIFF
--- a/compiler/rustc_session/src/utils.rs
+++ b/compiler/rustc_session/src/utils.rs
@@ -9,7 +9,11 @@ impl Session {
     }
     /// Used by `-Z self-profile`.
     pub fn time<R>(&self, what: &'static str, f: impl FnOnce() -> R) -> R {
-        self.prof.verbose_generic_activity(what).run(f)
+        if self.prof.enabled() {
+            return self.prof.verbose_generic_activity(what).run(f)
+        } else {
+            return f()
+        }
     }
 }
 

--- a/compiler/rustc_session/src/utils.rs
+++ b/compiler/rustc_session/src/utils.rs
@@ -10,9 +10,9 @@ impl Session {
     /// Used by `-Z self-profile`.
     pub fn time<R>(&self, what: &'static str, f: impl FnOnce() -> R) -> R {
         if self.prof.enabled() {
-            return self.prof.verbose_generic_activity(what).run(f)
+            return self.prof.verbose_generic_activity(what).run(f);
         } else {
-            return f()
+            return f();
         }
     }
 }


### PR DESCRIPTION
Previously, we would use the [`Session::time`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/struct.Session.html#method.time) and this would just call `verbose_generic_activity(...)`, which would create an activity and all that... But all this effort would go unnoticed if the user didn't use the `-Z self-profile` feature.

So, this PR checks for the profiler before trying to profile. From my benchmarks on a server, this should be a great performance improvement (Note: I tested this with a 12-thread custom multithreaded rustc-perf clone to mimick a compiler that a user might use, the results may change by using the single-threaded rustc-perf that bors currently uses)