### PR TITLE
Provide more context on derived obligation error primary label

### DIFF
--- a/tests/ui/associated-consts/issue-58022.stderr
+++ b/tests/ui/associated-consts/issue-58022.stderr
@@ -13,7 +13,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     fn new(slice: &[u8; Self::SIZE]) -> Self {
    |                                         ^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Bar<[u8]>`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `Bar<[u8]>`, the trait `Sized` is not implemented for `[u8]`, which is required by `Bar<[u8]>: Sized`
 note: required because it appears within the type `Bar<[u8]>`
   --> $DIR/issue-58022.rs:8:12
    |

--- a/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/basic.without.stderr
@@ -13,7 +13,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo::<T>());
    |             ^^^^^^^^^^ future returned by `foo` is not `Send`
    |
-   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>> { <T as Foo>::method() }`
+   = help: within `impl Future<Output = Result<(), ()>>`, the trait `Send` is not implemented for `impl Future<Output = Result<(), ()>> { <T as Foo>::method() }`, which is required by `impl Future<Output = Result<(), ()>>: Send`
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/basic.rs:13:5
    |

--- a/tests/ui/associated-types/defaults-suitability.stderr
+++ b/tests/ui/associated-types/defaults-suitability.stderr
@@ -39,7 +39,7 @@ error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:28:23
    |
 LL |     type Bar: Clone = Vec<T>;
-   |                       ^^^^^^ the trait `Clone` is not implemented for `T`
+   |                       ^^^^^^ the trait `Clone` is not implemented for `T`, which is required by `Vec<T>: Clone`
    |
    = note: required for `Vec<T>` to implement `Clone`
 note: required by a bound in `Foo::Bar`
@@ -88,7 +88,7 @@ error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:65:23
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
-   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`
+   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`, which is required by `Vec<<Self as Foo2<T>>::Baz>: Clone`
    |
    = note: required for `Vec<<Self as Foo2<T>>::Baz>` to implement `Clone`
 note: required by a bound in `Foo2::Bar`
@@ -105,7 +105,7 @@ error[E0277]: the trait bound `<Self as Foo25<T>>::Baz: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:74:23
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
-   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`
+   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`, which is required by `Vec<<Self as Foo25<T>>::Baz>: Clone`
    |
    = note: required for `Vec<<Self as Foo25<T>>::Baz>` to implement `Clone`
 note: required by a bound in `Foo25::Bar`

--- a/tests/ui/associated-types/hr-associated-type-bound-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-1.rs:12:14
    |
 LL |     type U = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <i32 as X<'b>>::U: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-1.rs:14:14
    |
 LL |     type V = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <u8 as Y<'b, u8>>::V: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `Y`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-2.rs:15:14
    |
 LL |     type W = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <u16 as Z<'b, u16>>::W: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `Z`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-3.rs:13:14
    |
 LL |     type U = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <(T,) as X<'b, (T,)>>::U: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-4.rs:13:14
    |
 LL |     type U = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <(T,) as X<'b, T>>::U: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `X`

--- a/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-5.rs:26:14
    |
 LL |     type U = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <<Vec<T> as Cycle>::Next as X<'b, <Vec<T> as Cycle>::Next>>::U: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `X`
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `str: Clone` is not satisfied
   --> $DIR/hr-associated-type-bound-param-5.rs:31:14
    |
 LL |     type U = str;
-   |              ^^^ the trait `Clone` is not implemented for `str`
+   |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <<Box<T> as Cycle>::Next as X<'b, <Box<T> as Cycle>::Next>>::U: Clone`
    |
    = help: the trait `Clone` is implemented for `String`
 note: required by a bound in `X`

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:17
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:38:1
    |
 LL | pub enum ColumnInsertValue<Col, Expr> where
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -45,7 +45,7 @@ LL | |     Col: Column,
 ...  |
 LL | |     Default(Col),
 LL | | }
-   | |_^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   | |_^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -63,7 +63,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:10
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -82,7 +82,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:10
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -102,7 +102,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:10
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -117,7 +117,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:10
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -133,7 +133,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:17
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -153,7 +153,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:23
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -172,7 +172,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:23
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -192,7 +192,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:23
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -207,7 +207,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:23
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -223,7 +223,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:10
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -239,7 +239,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:10
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -255,7 +255,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:23
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18
@@ -271,7 +271,7 @@ error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not sat
   --> $DIR/issue-38821.rs:23:23
    |
 LL | #[derive(Debug, Copy, Clone)]
-   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
    |
 note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
   --> $DIR/issue-38821.rs:9:18

--- a/tests/ui/associated-types/issue-43784-associated-type.stderr
+++ b/tests/ui/associated-types/issue-43784-associated-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-43784-associated-type.rs:14:18
    |
 LL |     type Assoc = T;
-   |                  ^ the trait `Copy` is not implemented for `T`
+   |                  ^ the trait `Copy` is not implemented for `T`, which is required by `<T as Complete>::Assoc: Partial<T>`
    |
 note: required for `<T as Complete>::Assoc` to implement `Partial<T>`
   --> $DIR/issue-43784-associated-type.rs:1:11

--- a/tests/ui/associated-types/issue-65774-1.stderr
+++ b/tests/ui/associated-types/issue-65774-1.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `T: MyDisplay` is not satisfied
   --> $DIR/issue-65774-1.rs:44:76
    |
 LL |         let closure = |config: &mut <S as MPU>::MpuConfig| writer.my_write(&config);
-   |                                                                            ^^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |                                                                            ^^^^^^^ the trait `MyDisplay` is not implemented for `T`, which is required by `&mut T: MyDisplay`
    |
    = help: the trait `MyDisplay` is implemented for `&'a mut T`
 note: required for `&mut T` to implement `MyDisplay`

--- a/tests/ui/associated-types/substs-ppaux.normal.stderr
+++ b/tests/ui/associated-types/substs-ppaux.normal.stderr
@@ -76,7 +76,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
 LL |     <str as Foo<u8>>::bar;
    |      ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `str`
+   = help: the trait `Sized` is not implemented for `str`, which is required by `str: Foo<'_, '_, u8>`
 note: required for `str` to implement `Foo<'_, '_, u8>`
   --> $DIR/substs-ppaux.rs:11:17
    |

--- a/tests/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/tests/ui/associated-types/substs-ppaux.verbose.stderr
@@ -76,7 +76,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
 LL |     <str as Foo<u8>>::bar;
    |      ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `str`
+   = help: the trait `Sized` is not implemented for `str`, which is required by `str: Foo<'?0, '?1, u8>`
 note: required for `str` to implement `Foo<'?0, '?1, u8>`
   --> $DIR/substs-ppaux.rs:11:17
    |

--- a/tests/ui/async-await/async-await-let-else.stderr
+++ b/tests/ui/async-await/async-await-let-else.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo(Some(true)));
    |             ^^^^^^^^^^^^^^^ future returned by `foo` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:8:15
    |
@@ -29,7 +29,7 @@ LL |     is_send(foo2(Some(true)));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`, which is required by `impl Future<Output = ()>: Send`
 note: required because it's used within this `async` fn body
   --> $DIR/async-await-let-else.rs:24:29
    |
@@ -61,7 +61,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo3(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo3` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:30:29
    |
@@ -81,7 +81,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo4(Some(true)));
    |             ^^^^^^^^^^^^^^^^ future returned by `foo4` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-await-let-else.rs:38:15
    |

--- a/tests/ui/async-await/async-fn-nonsend.stderr
+++ b/tests/ui/async-await/async-fn-nonsend.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(non_send_temporary_in_match());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_send_temporary_in_match` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<()>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:33:26
    |
@@ -24,7 +24,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(non_sync_with_method_call());
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ future returned by `non_sync_with_method_call` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `dyn std::fmt::Write`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/async-fn-nonsend.rs:46:15
    |

--- a/tests/ui/async-await/async-is-unwindsafe.stderr
+++ b/tests/ui/async-await/async-is-unwindsafe.stderr
@@ -15,7 +15,7 @@ LL | ||     });
    |  |_____|
    |        within this `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`
    |
-   = help: within `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`, the trait `UnwindSafe` is not implemented for `&mut Context<'_>`
+   = help: within `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}`, the trait `UnwindSafe` is not implemented for `&mut Context<'_>`, which is required by `{async block@$DIR/async-is-unwindsafe.rs:12:19: 29:6}: UnwindSafe`
    = note: `UnwindSafe` is implemented for `&Context<'_>`, but not for `&mut Context<'_>`
 note: future does not implement `UnwindSafe` as this value is used across an await
   --> $DIR/async-is-unwindsafe.rs:25:18

--- a/tests/ui/async-await/debug-ice-attempted-to-add-with-overflow.stderr
+++ b/tests/ui/async-await/debug-ice-attempted-to-add-with-overflow.stderr
@@ -7,7 +7,7 @@ LL |     [0usize; 0xffff_ffff_ffff_ffff].await;
    |                                    |`[usize; usize::MAX]` is not a future
    |                                    help: remove the `.await`
    |
-   = help: the trait `Future` is not implemented for `[usize; usize::MAX]`
+   = help: the trait `Future` is not implemented for `[usize; usize::MAX]`, which is required by `[usize; usize::MAX]: IntoFuture`
    = note: [usize; usize::MAX] must be a future or must implement `IntoFuture` to be awaited
    = note: required for `[usize; usize::MAX]` to implement `IntoFuture`
 

--- a/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
+++ b/tests/ui/async-await/drop-track-bad-field-in-fru.stderr
@@ -15,7 +15,7 @@ LL |     None { value: (), ..Default::default() }.await;
    |                                             |`Option<_>` is not a future
    |                                             help: remove the `.await`
    |
-   = help: the trait `Future` is not implemented for `Option<_>`
+   = help: the trait `Future` is not implemented for `Option<_>`, which is required by `Option<_>: IntoFuture`
    = note: Option<_> must be a future or must implement `IntoFuture` to be awaited
    = note: required for `Option<_>` to implement `IntoFuture`
 

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.stderr
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/drop-track-field-assign-nonsend.rs:20:39
    |

--- a/tests/ui/async-await/field-assign-nonsend.stderr
+++ b/tests/ui/async-await/field-assign-nonsend.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     assert_send(agent.handle());
    |                 ^^^^^^^^^^^^^^ future returned by `handle` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Rc<String>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/field-assign-nonsend.rs:20:39
    |

--- a/tests/ui/async-await/in-trait/missing-send-bound.stderr
+++ b/tests/ui/async-await/in-trait/missing-send-bound.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     assert_is_send(test::<T>());
    |                    ^^^^^^^^^^^ future returned by `test` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `impl Future<Output = ()>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/missing-send-bound.rs:9:5
    |

--- a/tests/ui/async-await/issue-101715.stderr
+++ b/tests/ui/async-await/issue-101715.stderr
@@ -7,7 +7,7 @@ LL |         .await
    |         |`()` is not a future
    |         help: remove the `.await`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 

--- a/tests/ui/async-await/issue-64130-1-sync.stderr
+++ b/tests/ui/async-await/issue-64130-1-sync.stderr
@@ -4,7 +4,7 @@ error: future cannot be shared between threads safely
 LL |     is_sync(bar());
    |             ^^^^^ future returned by `bar` is not `Sync`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`
+   = help: within `impl Future<Output = ()>`, the trait `Sync` is not implemented for `Foo`, which is required by `impl Future<Output = ()>: Sync`
 note: future is not `Sync` as this value is used across an await
   --> $DIR/issue-64130-1-sync.rs:15:11
    |

--- a/tests/ui/async-await/issue-64130-2-send.stderr
+++ b/tests/ui/async-await/issue-64130-2-send.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(bar());
    |             ^^^^^ future returned by `bar` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Foo`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `Foo`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-2-send.rs:15:11
    |

--- a/tests/ui/async-await/issue-64130-3-other.stderr
+++ b/tests/ui/async-await/issue-64130-3-other.stderr
@@ -5,7 +5,7 @@ LL | async fn bar() {
    | -------------- within this `impl Future<Output = ()>`
 ...
 LL |     is_qux(bar());
-   |            ^^^^^ within `impl Future<Output = ()>`, the trait `Qux` is not implemented for `Foo`
+   |            ^^^^^ within `impl Future<Output = ()>`, the trait `Qux` is not implemented for `Foo`, which is required by `impl Future<Output = ()>: Qux`
    |
 note: future does not implement `Qux` as this value is used across an await
   --> $DIR/issue-64130-3-other.rs:18:11

--- a/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
+++ b/tests/ui/async-await/issue-64130-non-send-future-diags.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     is_send(foo());
    |             ^^^^^ future returned by `foo` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, u32>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-64130-non-send-future-diags.rs:17:11
    |

--- a/tests/ui/async-await/issue-67252-unnamed-future.stderr
+++ b/tests/ui/async-await/issue-67252-unnamed-future.stderr
@@ -8,7 +8,7 @@ LL | |         let _a = a;
 LL | |     });
    | |______^ future created by async block is not `Send`
    |
-   = help: within `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 22:6}`, the trait `Send` is not implemented for `*mut ()`
+   = help: within `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 22:6}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-67252-unnamed-future.rs:18:11: 22:6}: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-67252-unnamed-future.rs:20:17
    |

--- a/tests/ui/async-await/issue-68112.stderr
+++ b/tests/ui/async-await/issue-68112.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:29:20: 33:6}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:31:17
@@ -23,7 +23,7 @@ error: future cannot be sent between threads safely
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:39:20: 42:6}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: future is not `Send` as it awaits another future which is not `Send`
   --> $DIR/issue-68112.rs:40:17
@@ -42,7 +42,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
 LL |     require_send(send_fut);
    |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{async block@$DIR/issue-68112.rs:57:20: 61:6}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this `async` fn body

--- a/tests/ui/async-await/issue-70935-complex-spans.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
 LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:17:5: 21:6}: Send`
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`

--- a/tests/ui/async-await/issue-71137.stderr
+++ b/tests/ui/async-await/issue-71137.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |   fake_spawn(wrong_mutex());
    |              ^^^^^^^^^^^^^ future returned by `wrong_mutex` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, i32>`, which is required by `impl Future<Output = ()>: Send`
 note: future is not `Send` as this value is used across an await
   --> $DIR/issue-71137.rs:14:26
    |

--- a/tests/ui/async-await/issue-72590-type-error-sized.stderr
+++ b/tests/ui/async-await/issue-72590-type-error-sized.stderr
@@ -16,7 +16,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
 LL |     async fn frob(self) {}
    |                   ^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Foo`, the trait `Sized` is not implemented for `str`
+   = help: within `Foo`, the trait `Sized` is not implemented for `str`, which is required by `Foo: Sized`
 note: required because it appears within the type `Foo`
   --> $DIR/issue-72590-type-error-sized.rs:5:8
    |

--- a/tests/ui/async-await/issues/issue-67893.stderr
+++ b/tests/ui/async-await/issues/issue-67893.stderr
@@ -11,7 +11,7 @@ LL |     g(issue_67893::run())
 LL | pub async fn run() {
    | ------------------ within this `impl Future<Output = ()>`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `MutexGuard<'_, ()>`, which is required by `impl Future<Output = ()>: Send`
    = note: required because it captures the following types: `Arc<Mutex<()>>`, `MutexGuard<'_, ()>`, `impl Future<Output = ()>`
 note: required because it's used within this `async` fn body
   --> $DIR/auxiliary/issue_67893.rs:9:20

--- a/tests/ui/async-await/partial-drop-partial-reinit.stderr
+++ b/tests/ui/async-await/partial-drop-partial-reinit.stderr
@@ -9,7 +9,7 @@ LL |     gimme_send(foo());
 LL | async fn foo() {
    | -------------- within this `impl Future<Output = ()>`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `NotSend`, which is required by `impl Future<Output = ()>: Send`
    = note: required because it appears within the type `(NotSend,)`
    = note: required because it captures the following types: `(NotSend,)`, `impl Future<Output = ()>`
 note: required because it's used within this `async` fn body

--- a/tests/ui/async-await/pin-needed-to-poll-2.stderr
+++ b/tests/ui/async-await/pin-needed-to-poll-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/pin-needed-to-poll-2.rs:43:18
    |
 LL |         Pin::new(&mut self.sleep).poll(cx)
-   |         -------- ^^^^^^^^^^^^^^^ within `Sleep`, the trait `Unpin` is not implemented for `PhantomPinned`
+   |         -------- ^^^^^^^^^^^^^^^ within `Sleep`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `Sleep: Unpin`
    |         |
    |         required by a bound introduced by this call
    |

--- a/tests/ui/async-await/unnecessary-await.stderr
+++ b/tests/ui/async-await/unnecessary-await.stderr
@@ -6,7 +6,7 @@ LL |     boo().await;
    |     |
    |     this call returns `()`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 help: remove the `.await`
@@ -28,7 +28,7 @@ LL |     e!().await;
    |         |`()` is not a future
    |         help: remove the `.await`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 
@@ -44,7 +44,7 @@ LL |         $expr.await
 LL |     f!(());
    |     ------ in this macro invocation
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
    = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -58,7 +58,7 @@ LL |     for x in [] {}.await
    |                   |`()` is not a future
    |                   help: remove the `.await`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Foo<T, U>` cannot be sent between threads safely
 LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `Foo<T, U>`
+   = help: the trait `Send` is not implemented for `Foo<T, U>`, which is required by `Foo<T, U>: WithAssoc`
 note: required for `Foo<T, U>` to implement `WithAssoc`
   --> $DIR/issue-83857-ub.rs:15:15
    |

--- a/tests/ui/auto-traits/str-contains-slice-conceptually.stderr
+++ b/tests/ui/auto-traits/str-contains-slice-conceptually.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `[u8]: AutoTrait` is not satisfied in `str`
   --> $DIR/str-contains-slice-conceptually.rs:11:22
    |
 LL |   needs_auto_trait::<str>();
-   |                      ^^^ within `str`, the trait `AutoTrait` is not implemented for `[u8]`
+   |                      ^^^ within `str`, the trait `AutoTrait` is not implemented for `[u8]`, which is required by `str: AutoTrait`
    |
    = note: `str` is considered to contain a `[u8]` slice for auto trait purposes
 note: required by a bound in `needs_auto_trait`

--- a/tests/ui/auto-traits/typeck-default-trait-impl-constituent-types-2.stderr
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-constituent-types-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied in `(MyS2, MyS)`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:17:18
    |
 LL |     is_mytrait::<(MyS2, MyS)>();
-   |                  ^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`
+   |                  ^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`, which is required by `(MyS2, MyS): MyTrait`
    |
    = note: required because it appears within the type `(MyS2, MyS)`
 note: required by a bound in `is_mytrait`

--- a/tests/ui/auto-traits/typeck-default-trait-impl-precedence.stderr
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-precedence.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: Signed` is not satisfied
   --> $DIR/typeck-default-trait-impl-precedence.rs:19:20
    |
 LL |     is_defaulted::<&'static u32>();
-   |                    ^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`
+   |                    ^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`, which is required by `&'static u32: Defaulted`
    |
 note: required for `&'static u32` to implement `Defaulted`
   --> $DIR/typeck-default-trait-impl-precedence.rs:10:19

--- a/tests/ui/binop/binary-op-suggest-deref.stderr
+++ b/tests/ui/binop/binary-op-suggest-deref.stderr
@@ -27,7 +27,7 @@ error[E0277]: can't compare `&{integer}` with `{integer}`
 LL |     _ = foo == &0;
    |             ^^ no implementation for `&{integer} == {integer}`
    |
-   = help: the trait `PartialEq<{integer}>` is not implemented for `&{integer}`
+   = help: the trait `PartialEq<{integer}>` is not implemented for `&{integer}`, which is required by `&&{integer}: PartialEq<&{integer}>`
    = note: required for `&&{integer}` to implement `PartialEq<&{integer}>`
 help: consider dereferencing here
    |
@@ -65,7 +65,7 @@ error[E0277]: can't compare `&&{integer}` with `{integer}`
 LL |     _ = &&foo == &&0;
    |               ^^ no implementation for `&&{integer} == {integer}`
    |
-   = help: the trait `PartialEq<{integer}>` is not implemented for `&&{integer}`
+   = help: the trait `PartialEq<{integer}>` is not implemented for `&&{integer}`, which is required by `&&&&{integer}: PartialEq<&&{integer}>`
    = note: required for `&&&{integer}` to implement `PartialEq<&{integer}>`
    = note: 1 redundant requirement hidden
    = note: required for `&&&&{integer}` to implement `PartialEq<&&{integer}>`
@@ -119,7 +119,7 @@ error[E0277]: can't compare `{integer}` with `&{integer}`
 LL |     _ = &0 == foo;
    |            ^^ no implementation for `{integer} == &{integer}`
    |
-   = help: the trait `PartialEq<&{integer}>` is not implemented for `{integer}`
+   = help: the trait `PartialEq<&{integer}>` is not implemented for `{integer}`, which is required by `&{integer}: PartialEq<&&{integer}>`
    = note: required for `&{integer}` to implement `PartialEq<&&{integer}>`
 help: consider dereferencing here
    |
@@ -157,7 +157,7 @@ error[E0277]: can't compare `{integer}` with `&&{integer}`
 LL |     _ = &&0 == &&foo;
    |             ^^ no implementation for `{integer} == &&{integer}`
    |
-   = help: the trait `PartialEq<&&{integer}>` is not implemented for `{integer}`
+   = help: the trait `PartialEq<&&{integer}>` is not implemented for `{integer}`, which is required by `&&{integer}: PartialEq<&&&&{integer}>`
    = note: required for `&{integer}` to implement `PartialEq<&&&{integer}>`
    = note: 1 redundant requirement hidden
    = note: required for `&&{integer}` to implement `PartialEq<&&&&{integer}>`
@@ -173,7 +173,7 @@ error[E0277]: can't compare `Box<Box<{integer}>>` with `&&{integer}`
 LL |     _ = &Box::new(Box::new(42)) == &foo;
    |                                 ^^ no implementation for `Box<Box<{integer}>> == &&{integer}`
    |
-   = help: the trait `PartialEq<&&{integer}>` is not implemented for `Box<Box<{integer}>>`
+   = help: the trait `PartialEq<&&{integer}>` is not implemented for `Box<Box<{integer}>>`, which is required by `&Box<Box<{integer}>>: PartialEq<&&&{integer}>`
    = note: required for `&Box<Box<{integer}>>` to implement `PartialEq<&&&{integer}>`
 help: consider dereferencing both sides of the expression
    |
@@ -187,7 +187,7 @@ error[E0277]: can't compare `Box<{integer}>` with `&&{integer}`
 LL |     _ = &Box::new(42) == &foo;
    |                       ^^ no implementation for `Box<{integer}> == &&{integer}`
    |
-   = help: the trait `PartialEq<&&{integer}>` is not implemented for `Box<{integer}>`
+   = help: the trait `PartialEq<&&{integer}>` is not implemented for `Box<{integer}>`, which is required by `&Box<{integer}>: PartialEq<&&&{integer}>`
    = note: required for `&Box<{integer}>` to implement `PartialEq<&&&{integer}>`
 help: consider dereferencing both sides of the expression
    |
@@ -201,7 +201,7 @@ error[E0277]: can't compare `Box<Box<Box<Box<{integer}>>>>` with `&&{integer}`
 LL |     _ = &Box::new(Box::new(Box::new(Box::new(42)))) == &foo;
    |                                                     ^^ no implementation for `Box<Box<Box<Box<{integer}>>>> == &&{integer}`
    |
-   = help: the trait `PartialEq<&&{integer}>` is not implemented for `Box<Box<Box<Box<{integer}>>>>`
+   = help: the trait `PartialEq<&&{integer}>` is not implemented for `Box<Box<Box<Box<{integer}>>>>`, which is required by `&Box<Box<Box<Box<{integer}>>>>: PartialEq<&&&{integer}>`
    = note: required for `&Box<Box<Box<Box<{integer}>>>>` to implement `PartialEq<&&&{integer}>`
 help: consider dereferencing both sides of the expression
    |
@@ -215,7 +215,7 @@ error[E0277]: can't compare `&&{integer}` with `Box<Box<Box<Box<{integer}>>>>`
 LL |     _ = &foo == &Box::new(Box::new(Box::new(Box::new(42))));
    |              ^^ no implementation for `&&{integer} == Box<Box<Box<Box<{integer}>>>>`
    |
-   = help: the trait `PartialEq<Box<Box<Box<Box<{integer}>>>>>` is not implemented for `&&{integer}`
+   = help: the trait `PartialEq<Box<Box<Box<Box<{integer}>>>>>` is not implemented for `&&{integer}`, which is required by `&&&{integer}: PartialEq<&Box<Box<Box<Box<{integer}>>>>>`
    = note: required for `&&&{integer}` to implement `PartialEq<&Box<Box<Box<Box<{integer}>>>>>`
 help: consider dereferencing both sides of the expression
    |

--- a/tests/ui/block-result/issue-22645.stderr
+++ b/tests/ui/block-result/issue-22645.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `{integer}: Scalar` is not satisfied
   --> $DIR/issue-22645.rs:15:5
    |
 LL |   b + 3
-   |     ^ the trait `Scalar` is not implemented for `{integer}`
+   |     ^ the trait `Scalar` is not implemented for `{integer}`, which is required by `Bob: Add<_>`
    |
    = help: the trait `Scalar` is implemented for `f64`
 note: required for `Bob` to implement `Add<{integer}>`

--- a/tests/ui/closures/closure-move-sync.stderr
+++ b/tests/ui/closures/closure-move-sync.stderr
@@ -10,7 +10,7 @@ LL | |
 LL | |     });
    | |_____^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
+   = help: the trait `Sync` is not implemented for `std::sync::mpsc::Receiver<()>`, which is required by `{closure@$DIR/closure-move-sync.rs:6:27: 6:29}: Send`
    = note: required for `&std::sync::mpsc::Receiver<()>` to implement `Send`
 note: required because it's used within this closure
   --> $DIR/closure-move-sync.rs:6:27

--- a/tests/ui/closures/closure-return-type-must-be-sized.stderr
+++ b/tests/ui/closures/closure-return-type-must-be-sized.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     a::foo::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
@@ -13,7 +13,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     a::bar::<fn() -> dyn A, _>();
    |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 note: required by a bound in `a::bar`
   --> $DIR/closure-return-type-must-be-sized.rs:14:19
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     a::baz::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
@@ -36,7 +36,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     b::foo::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
@@ -45,7 +45,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     b::bar::<fn() -> dyn A, _>();
    |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: Fn()`
    = note: required because it appears within the type `fn() -> dyn A`
 note: required by a bound in `b::bar`
   --> $DIR/closure-return-type-must-be-sized.rs:28:19
@@ -59,7 +59,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     b::baz::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
@@ -68,7 +68,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     c::foo::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error[E0277]: the size for values of type `dyn A` cannot be known at compilation time
@@ -77,7 +77,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     c::bar::<fn() -> dyn A, _>();
    |              ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnMut()`
    = note: required because it appears within the type `fn() -> dyn A`
 note: required by a bound in `c::bar`
   --> $DIR/closure-return-type-must-be-sized.rs:42:19
@@ -91,7 +91,7 @@ error[E0277]: the size for values of type `dyn A` cannot be known at compilation
 LL |     c::baz::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`
+   = help: within `fn() -> dyn A`, the trait `Sized` is not implemented for `dyn A`, which is required by `fn() -> dyn A: FnOnce()`
    = note: required because it appears within the type `fn() -> dyn A`
 
 error: aborting due to 9 previous errors

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad_empty_array.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_bad_empty_array.rs:10:13
    |
 LL |     check::<[NotParam; 0]>();
-   |             ^^^^^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`, which is required by `[NotParam; 0]: ConstParamTy`
    |
    = note: required for `[NotParam; 0]` to implement `ConstParamTy`
 note: required by a bound in `check`

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_generic_bounds_do_not_hold.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:10:13
    |
 LL |     check::<&NotParam>();
-   |             ^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`, which is required by `&NotParam: ConstParamTy`
    |
    = note: required for `&NotParam` to implement `ConstParamTy`
 note: required by a bound in `check`
@@ -15,7 +15,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:11:13
    |
 LL |     check::<[NotParam]>();
-   |             ^^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`, which is required by `[NotParam]: ConstParamTy`
    |
    = note: required for `[NotParam]` to implement `ConstParamTy`
 note: required by a bound in `check`
@@ -28,7 +28,7 @@ error[E0277]: `NotParam` can't be used as a const parameter type
   --> $DIR/const_param_ty_generic_bounds_do_not_hold.rs:12:13
    |
 LL |     check::<[NotParam; 17]>();
-   |             ^^^^^^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`
+   |             ^^^^^^^^^^^^^^ the trait `ConstParamTy` is not implemented for `NotParam`, which is required by `[NotParam; 17]: ConstParamTy`
    |
    = note: required for `[NotParam; 17]` to implement `ConstParamTy`
 note: required by a bound in `check`

--- a/tests/ui/const-generics/generic_const_exprs/issue-85848.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-85848.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): _Contains<&C>` is not satisfied
   --> $DIR/issue-85848.rs:24:29
    |
 LL |     writes_to_specific_path(&cap);
-   |     ----------------------- ^^^^ the trait `_Contains<&C>` is not implemented for `()`
+   |     ----------------------- ^^^^ the trait `_Contains<&C>` is not implemented for `()`, which is required by `&C: Delegates<()>`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/const-generics/issues/issue-67185-2.stderr
+++ b/tests/ui/const-generics/issues/issue-67185-2.stderr
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `[u16; 3]: Bar` is not satisfied
   --> $DIR/issue-67185-2.rs:21:6
    |
 LL | impl Foo for FooImpl {}
-   |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`
+   |      ^^^ the trait `Bar` is not implemented for `[u16; 3]`, which is required by `<u8 as Baz>::Quaks: Bar`
    |
    = help: the following other types implement trait `Bar`:
              [u16; 4]
@@ -44,7 +44,7 @@ error[E0277]: the trait bound `[[u16; 3]; 2]: Bar` is not satisfied
   --> $DIR/issue-67185-2.rs:21:6
    |
 LL | impl Foo for FooImpl {}
-   |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`
+   |      ^^^ the trait `Bar` is not implemented for `[[u16; 3]; 2]`, which is required by `[<u8 as Baz>::Quaks; 2]: Bar`
    |
    = help: the following other types implement trait `Bar`:
              [u16; 4]

--- a/tests/ui/consts/const-blocks/fn-call-in-non-const.stderr
+++ b/tests/ui/consts/const-blocks/fn-call-in-non-const.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Bar: Copy` is not satisfied
   --> $DIR/fn-call-in-non-const.rs:14:32
    |
 LL |     let _: [Option<Bar>; 2] = [no_copy(); 2];
-   |                                ^^^^^^^^^ the trait `Copy` is not implemented for `Bar`
+   |                                ^^^^^^^^^ the trait `Copy` is not implemented for `Bar`, which is required by `Option<Bar>: Copy`
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array

--- a/tests/ui/consts/const-blocks/migrate-fail.stderr
+++ b/tests/ui/consts/const-blocks/migrate-fail.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Bar: Copy` is not satisfied
   --> $DIR/migrate-fail.rs:11:38
    |
 LL |         let arr: [Option<Bar>; 2] = [x; 2];
-   |                                      ^ the trait `Copy` is not implemented for `Bar`
+   |                                      ^ the trait `Copy` is not implemented for `Bar`, which is required by `Option<Bar>: Copy`
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `Bar: Copy` is not satisfied
   --> $DIR/migrate-fail.rs:17:38
    |
 LL |         let arr: [Option<Bar>; 2] = [x; 2];
-   |                                      ^ the trait `Copy` is not implemented for `Bar`
+   |                                      ^ the trait `Copy` is not implemented for `Bar`, which is required by `Option<Bar>: Copy`
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array

--- a/tests/ui/consts/const-blocks/nll-fail.stderr
+++ b/tests/ui/consts/const-blocks/nll-fail.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Bar: Copy` is not satisfied
   --> $DIR/nll-fail.rs:11:38
    |
 LL |         let arr: [Option<Bar>; 2] = [x; 2];
-   |                                      ^ the trait `Copy` is not implemented for `Bar`
+   |                                      ^ the trait `Copy` is not implemented for `Bar`, which is required by `Option<Bar>: Copy`
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
@@ -18,7 +18,7 @@ error[E0277]: the trait bound `Bar: Copy` is not satisfied
   --> $DIR/nll-fail.rs:17:38
    |
 LL |         let arr: [Option<Bar>; 2] = [x; 2];
-   |                                      ^ the trait `Copy` is not implemented for `Bar`
+   |                                      ^ the trait `Copy` is not implemented for `Bar`, which is required by `Option<Bar>: Copy`
    |
    = note: required for `Option<Bar>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array

--- a/tests/ui/consts/const-blocks/trait-error.stderr
+++ b/tests/ui/consts/const-blocks/trait-error.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/trait-error.rs:5:6
    |
 LL |     [Foo(String::new()); 4];
-   |      ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |      ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`, which is required by `Foo<String>: Copy`
    |
 note: required for `Foo<String>` to implement `Copy`
   --> $DIR/trait-error.rs:1:10

--- a/tests/ui/consts/const-fn-in-vec.stderr
+++ b/tests/ui/consts/const-fn-in-vec.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/const-fn-in-vec.rs:1:47
    |
 LL | static _MAYBE_STRINGS: [Option<String>; 5] = [None; 5];
-   |                                               ^^^^ the trait `Copy` is not implemented for `String`
+   |                                               ^^^^ the trait `Copy` is not implemented for `String`, which is required by `Option<String>: Copy`
    |
    = note: required for `Option<String>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/const-fn-in-vec.rs:9:48
    |
 LL |     let _maybe_strings: [Option<String>; 5] = [None; 5];
-   |                                                ^^^^ the trait `Copy` is not implemented for `String`
+   |                                                ^^^^ the trait `Copy` is not implemented for `String`, which is required by `Option<String>: Copy`
    |
    = note: required for `Option<String>` to implement `Copy`
    = note: the `Copy` trait is required because this value will be copied for each element of the array

--- a/tests/ui/coroutine/clone-impl.stderr
+++ b/tests/ui/coroutine/clone-impl.stderr
@@ -5,7 +5,7 @@ LL |     let gen_clone_0 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}: Copy`
    |
 note: captured value does not implement `Copy`
   --> $DIR/clone-impl.rs:40:14
@@ -25,7 +25,7 @@ LL |     let gen_clone_0 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<char>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}`, the trait `Copy` is not implemented for `Vec<char>`, which is required by `{coroutine@$DIR/clone-impl.rs:36:23: 36:30}: Copy`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
   --> $DIR/clone-impl.rs:38:9
@@ -47,7 +47,7 @@ LL |     let gen_clone_1 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<u32>`, which is required by `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}: Copy`
    |
 note: captured value does not implement `Copy`
   --> $DIR/clone-impl.rs:56:14
@@ -67,7 +67,7 @@ LL |     let gen_clone_1 = move || {
    |                       ------- within this `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<char>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}`, the trait `Copy` is not implemented for `Vec<char>`, which is required by `{coroutine@$DIR/clone-impl.rs:46:23: 46:30}: Copy`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
   --> $DIR/clone-impl.rs:52:9
@@ -90,7 +90,7 @@ LL |     let gen_non_clone = move || {
    |                         ------- within this `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`
 ...
 LL |     check_copy(&gen_non_clone);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Copy` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Copy` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}: Copy`
    |
 note: captured value does not implement `Copy`
   --> $DIR/clone-impl.rs:64:14
@@ -115,7 +115,7 @@ LL |     let gen_non_clone = move || {
    |                         ------- within this `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`
 ...
 LL |     check_clone(&gen_non_clone);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Clone` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}`, the trait `Clone` is not implemented for `NonClone`, which is required by `{coroutine@$DIR/clone-impl.rs:62:25: 62:32}: Clone`
    |
 note: captured value does not implement `Clone`
   --> $DIR/clone-impl.rs:64:14

--- a/tests/ui/coroutine/drop-tracking-parent-expression.stderr
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.stderr
@@ -13,7 +13,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `derived_drop::Client`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `derived_drop::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:21:22
    |
@@ -53,7 +53,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `significant_drop::Client`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `significant_drop::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:21:22
    |
@@ -93,7 +93,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `insignificant_dtor::Client`, which is required by `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:21: 17:28}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-tracking-parent-expression.rs:21:22
    |

--- a/tests/ui/coroutine/drop-yield-twice.stderr
+++ b/tests/ui/coroutine/drop-yield-twice.stderr
@@ -9,7 +9,7 @@ LL | |         yield;
 LL | |     })
    | |______^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/drop-yield-twice.rs:7:17: 7:19}`, the trait `Send` is not implemented for `Foo`
+   = help: within `{coroutine@$DIR/drop-yield-twice.rs:7:17: 7:19}`, the trait `Send` is not implemented for `Foo`, which is required by `{coroutine@$DIR/drop-yield-twice.rs:7:17: 7:19}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/drop-yield-twice.rs:9:9
    |

--- a/tests/ui/coroutine/issue-105084.stderr
+++ b/tests/ui/coroutine/issue-105084.stderr
@@ -29,7 +29,7 @@ LL |     let mut g = || {
    |                 -- within this `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`
 ...
 LL |     let mut h = copy(g);
-   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`, the trait `Copy` is not implemented for `Box<(i32, ())>`
+   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}`, the trait `Copy` is not implemented for `Box<(i32, ())>`, which is required by `{coroutine@$DIR/issue-105084.rs:14:17: 14:19}: Copy`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
   --> $DIR/issue-105084.rs:21:22

--- a/tests/ui/coroutine/issue-68112.stderr
+++ b/tests/ui/coroutine/issue-68112.stderr
@@ -4,7 +4,7 @@ error: coroutine cannot be sent between threads safely
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^^^^^^^^^^^ coroutine is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{coroutine@$DIR/issue-68112.rs:33:20: 33:22}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/issue-68112.rs:36:9
@@ -26,7 +26,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{coroutine@$DIR/issue-68112.rs:60:20: 60:22}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this coroutine

--- a/tests/ui/coroutine/not-send-sync.stderr
+++ b/tests/ui/coroutine/not-send-sync.stderr
@@ -9,7 +9,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{coroutine@$DIR/not-send-sync.rs:14:17: 14:19}`, the trait `Sync` is not implemented for `NotSync`
+   = help: within `{coroutine@$DIR/not-send-sync.rs:14:17: 14:19}`, the trait `Sync` is not implemented for `NotSync`, which is required by `{coroutine@$DIR/not-send-sync.rs:14:17: 14:19}: Sync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/not-send-sync.rs:17:9
    |
@@ -34,7 +34,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/not-send-sync.rs:21:17: 21:19}`, the trait `Send` is not implemented for `NotSend`
+   = help: within `{coroutine@$DIR/not-send-sync.rs:21:17: 21:19}`, the trait `Send` is not implemented for `NotSend`, which is required by `{coroutine@$DIR/not-send-sync.rs:21:17: 21:19}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/not-send-sync.rs:24:9
    |

--- a/tests/ui/coroutine/parent-expression.stderr
+++ b/tests/ui/coroutine/parent-expression.stderr
@@ -13,7 +13,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `derived_drop::Client`
+   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `derived_drop::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:21:22
    |
@@ -53,7 +53,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `significant_drop::Client`
+   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `significant_drop::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:21:22
    |
@@ -93,7 +93,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+   = help: within `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}`, the trait `Send` is not implemented for `insignificant_dtor::Client`, which is required by `{coroutine@$DIR/parent-expression.rs:17:21: 17:28}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/parent-expression.rs:21:22
    |

--- a/tests/ui/coroutine/print/coroutine-print-verbose-1.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-1.stderr
@@ -4,7 +4,7 @@ error: coroutine cannot be sent between threads safely
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^^^^^^^^^^^ coroutine is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{test1::{closure#0} upvar_tys=() witness={test1::{closure#0}}}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-1.rs:35:9
@@ -25,7 +25,7 @@ error[E0277]: `RefCell<i32>` cannot be shared between threads safely
 LL |     require_send(send_gen);
    |     ^^^^^^^^^^^^^^^^^^^^^^ `RefCell<i32>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `RefCell<i32>`
+   = help: the trait `Sync` is not implemented for `RefCell<i32>`, which is required by `{test2::{closure#0} upvar_tys=() witness={test2::{closure#0}}}: Send`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Arc<RefCell<i32>>` to implement `Send`
 note: required because it's used within this coroutine

--- a/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
+++ b/tests/ui/coroutine/print/coroutine-print-verbose-2.stderr
@@ -9,7 +9,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Sync`
    |
-   = help: within `{main::{closure#0} upvar_tys=() witness={main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`
+   = help: within `{main::{closure#0} upvar_tys=() witness={main::{closure#0}}}`, the trait `Sync` is not implemented for `NotSync`, which is required by `{main::{closure#0} upvar_tys=() witness={main::{closure#0}}}: Sync`
 note: coroutine is not `Sync` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:20:9
    |
@@ -34,7 +34,7 @@ LL | |         drop(a);
 LL | |     });
    | |______^ coroutine is not `Send`
    |
-   = help: within `{main::{closure#1} upvar_tys=() witness={main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`
+   = help: within `{main::{closure#1} upvar_tys=() witness={main::{closure#1}}}`, the trait `Send` is not implemented for `NotSend`, which is required by `{main::{closure#1} upvar_tys=() witness={main::{closure#1}}}: Send`
 note: coroutine is not `Send` as this value is used across a yield
   --> $DIR/coroutine-print-verbose-2.rs:27:9
    |

--- a/tests/ui/coroutine/ref-upvar-not-send.stderr
+++ b/tests/ui/coroutine/ref-upvar-not-send.stderr
@@ -10,7 +10,7 @@ LL | |         let _x = x;
 LL | |     });
    | |_____^ coroutine is not `Send`
    |
-   = help: the trait `Sync` is not implemented for `*mut ()`
+   = help: the trait `Sync` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:15:17: 15:24}: Send`
 note: captured value is not `Send` because `&` references cannot be sent unless their referent is `Sync`
   --> $DIR/ref-upvar-not-send.rs:19:18
    |
@@ -34,7 +34,7 @@ LL | |         let _y = y;
 LL | |     });
    | |_____^ coroutine is not `Send`
    |
-   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}`, the trait `Send` is not implemented for `*mut ()`
+   = help: within `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}`, the trait `Send` is not implemented for `*mut ()`, which is required by `{coroutine@$DIR/ref-upvar-not-send.rs:23:17: 23:24}: Send`
 note: captured value is not `Send` because `&mut` references cannot be sent unless their referent is `Send`
   --> $DIR/ref-upvar-not-send.rs:27:18
    |

--- a/tests/ui/coroutine/unresolved-ct-var.stderr
+++ b/tests/ui/coroutine/unresolved-ct-var.stderr
@@ -8,7 +8,7 @@ LL |         let s = std::array::from_fn(|_| ()).await;
    |                 |                          help: remove the `.await`
    |                 this call returns `[(); _]`
    |
-   = help: the trait `Future` is not implemented for `[(); _]`
+   = help: the trait `Future` is not implemented for `[(); _]`, which is required by `[(); _]: IntoFuture`
    = note: [(); _] must be a future or must implement `IntoFuture` to be awaited
    = note: required for `[(); _]` to implement `IntoFuture`
 

--- a/tests/ui/coroutine/yield-outside-coroutine-issue-78653.stderr
+++ b/tests/ui/coroutine/yield-outside-coroutine-issue-78653.stderr
@@ -10,7 +10,7 @@ error[E0277]: `{integer}` is not an iterator
 LL |     yield || for i in 0 { }
    |                       ^ `{integer}` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `{integer}`
+   = help: the trait `Iterator` is not implemented for `{integer}`, which is required by `{integer}: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `{integer}` to implement `IntoIterator`
 

--- a/tests/ui/derives/derives-span-Debug-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Debug-enum-struct-variant.stderr
@@ -7,7 +7,7 @@ LL | #[derive(Debug)]
 LL |      x: Error
    |      ^^^^^^^^ `Error` cannot be formatted using `{:?}`
    |
-   = help: the trait `Debug` is not implemented for `Error`
+   = help: the trait `Debug` is not implemented for `Error`, which is required by `&Error: Debug`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`

--- a/tests/ui/derives/derives-span-Debug-enum.stderr
+++ b/tests/ui/derives/derives-span-Debug-enum.stderr
@@ -7,7 +7,7 @@ LL | #[derive(Debug)]
 LL |      Error
    |      ^^^^^ `Error` cannot be formatted using `{:?}`
    |
-   = help: the trait `Debug` is not implemented for `Error`
+   = help: the trait `Debug` is not implemented for `Error`, which is required by `&Error: Debug`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`

--- a/tests/ui/derives/derives-span-Debug-struct.stderr
+++ b/tests/ui/derives/derives-span-Debug-struct.stderr
@@ -7,7 +7,7 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ `Error` cannot be formatted using `{:?}`
    |
-   = help: the trait `Debug` is not implemented for `Error`
+   = help: the trait `Debug` is not implemented for `Error`, which is required by `&Error: Debug`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`

--- a/tests/ui/derives/derives-span-Debug-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Debug-tuple-struct.stderr
@@ -7,7 +7,7 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ `Error` cannot be formatted using `{:?}`
    |
-   = help: the trait `Debug` is not implemented for `Error`
+   = help: the trait `Debug` is not implemented for `Error`, which is required by `&Error: Debug`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`

--- a/tests/ui/deriving/issue-103157.stderr
+++ b/tests/ui/deriving/issue-103157.stderr
@@ -5,7 +5,7 @@ LL | #[derive(PartialEq, Eq)]
    |                     -- in this derive macro expansion
 ...
 LL |     Float(Option<f64>),
-   |           ^^^^^^^^^^^ the trait `Eq` is not implemented for `f64`
+   |           ^^^^^^^^^^^ the trait `Eq` is not implemented for `f64`, which is required by `Option<f64>: Eq`
    |
    = help: the following other types implement trait `Eq`:
              isize

--- a/tests/ui/dst/dst-bad-deep-2.stderr
+++ b/tests/ui/dst/dst-bad-deep-2.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `[isize]` cannot be known at compilati
 LL |     let h: &(([isize],),) = &(*g,);
    |                              ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(([isize],),)`, the trait `Sized` is not implemented for `[isize]`
+   = help: within `(([isize],),)`, the trait `Sized` is not implemented for `[isize]`, which is required by `(([isize],),): Sized`
    = note: required because it appears within the type `([isize],)`
    = note: required because it appears within the type `(([isize],),)`
    = note: tuples must have a statically known size to be initialized

--- a/tests/ui/dst/dst-bad-deep.stderr
+++ b/tests/ui/dst/dst-bad-deep.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `[isize]` cannot be known at compilati
 LL |     let h: &Fat<Fat<[isize]>> = &Fat { ptr: *g };
    |                                  ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Fat<Fat<[isize]>>`, the trait `Sized` is not implemented for `[isize]`
+   = help: within `Fat<Fat<[isize]>>`, the trait `Sized` is not implemented for `[isize]`, which is required by `Fat<Fat<[isize]>>: Sized`
 note: required because it appears within the type `Fat<[isize]>`
   --> $DIR/dst-bad-deep.rs:6:8
    |

--- a/tests/ui/error-codes/E0277-2.stderr
+++ b/tests/ui/error-codes/E0277-2.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*const u8` cannot be sent between threads safely
 LL |     is_send::<Foo>();
    |               ^^^ `*const u8` cannot be sent between threads safely
    |
-   = help: within `Foo`, the trait `Send` is not implemented for `*const u8`
+   = help: within `Foo`, the trait `Send` is not implemented for `*const u8`, which is required by `Foo: Send`
 note: required because it appears within the type `Baz`
   --> $DIR/E0277-2.rs:9:8
    |

--- a/tests/ui/error-codes/E0277.stderr
+++ b/tests/ui/error-codes/E0277.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL | fn f(p: Path) { }
    |      ^ doesn't have a size known at compile-time
    |
-   = help: within `Path`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`
   --> $SRC_DIR/std/src/path.rs:LL:COL
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:53:46
    |
 LL |     want(Wrapper { value: Burrito { filling: q } });
-   |     ----                                     ^ the trait `T3` is not implemented for `Q`
+   |     ----                                     ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<Burrito<Q>>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -38,7 +38,7 @@ LL |     want(Some(()));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Iterator` is not implemented for `()`
+   = help: the trait `Iterator` is not implemented for `()`, which is required by `Option<()>: T1`
    = help: the trait `T1` is implemented for `Option<It>`
 note: required for `Option<()>` to implement `T1`
   --> $DIR/blame-trait-error.rs:21:20
@@ -109,7 +109,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:65:45
    |
 LL |     want(&ExampleTuple::ExampleTupleVariant(q));
-   |     ----                                    ^ the trait `T3` is not implemented for `Q`
+   |     ----                                    ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleTuple<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -134,7 +134,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:68:31
    |
 LL |     want(&ExampleTupleVariant(q));
-   |     ----                      ^ the trait `T3` is not implemented for `Q`
+   |     ----                      ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleTuple<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -159,7 +159,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:71:50
    |
 LL |     want(&ExampleOtherTuple::ExampleTupleVariant(q));
-   |     ----                                         ^ the trait `T3` is not implemented for `Q`
+   |     ----                                         ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleTuple<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -184,7 +184,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:74:44
    |
 LL |     want(&ExampleDifferentTupleVariantName(q));
-   |     ----                                   ^ the trait `T3` is not implemented for `Q`
+   |     ----                                   ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleTuple<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -209,7 +209,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:77:45
    |
 LL |     want(&ExampleYetAnotherTupleVariantName(q));
-   |     ----                                    ^ the trait `T3` is not implemented for `Q`
+   |     ----                                    ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleTuple<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -234,7 +234,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:80:56
    |
 LL |     want(&ExampleStruct::ExampleStructVariant { field: q });
-   |     ---- required by a bound introduced by this call   ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call   ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleStruct<Q>: T1`
    |
 note: required for `ExampleStruct<Q>` to implement `T1`
   --> $DIR/blame-trait-error.rs:45:9
@@ -257,7 +257,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:83:41
    |
 LL |     want(&ExampleStructVariant { field: q });
-   |     ----                                ^ the trait `T3` is not implemented for `Q`
+   |     ----                                ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleStruct<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -282,7 +282,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:86:61
    |
 LL |     want(&ExampleOtherStruct::ExampleStructVariant { field: q });
-   |     ---- required by a bound introduced by this call        ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call        ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleStruct<Q>: T1`
    |
 note: required for `ExampleStruct<Q>` to implement `T1`
   --> $DIR/blame-trait-error.rs:45:9
@@ -305,7 +305,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:89:54
    |
 LL |     want(&ExampleDifferentStructVariantName { field: q });
-   |     ---- required by a bound introduced by this call ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleStruct<Q>: T1`
    |
 note: required for `ExampleStruct<Q>` to implement `T1`
   --> $DIR/blame-trait-error.rs:45:9
@@ -328,7 +328,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:92:55
    |
 LL |     want(&ExampleYetAnotherStructVariantName { field: q });
-   |     ---- required by a bound introduced by this call  ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call  ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleStruct<Q>: T1`
    |
 note: required for `ExampleStruct<Q>` to implement `T1`
   --> $DIR/blame-trait-error.rs:45:9
@@ -351,7 +351,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:95:38
    |
 LL |     want(&ExampleActuallyTupleStruct(q, 0));
-   |     ----                             ^ the trait `T3` is not implemented for `Q`
+   |     ----                             ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleActuallyTupleStruct<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -376,7 +376,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error.rs:98:43
    |
 LL |     want(&ExampleActuallyTupleStructOther(q, 0));
-   |     ----                                  ^ the trait `T3` is not implemented for `Q`
+   |     ----                                  ^ the trait `T3` is not implemented for `Q`, which is required by `&ExampleActuallyTupleStruct<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/errors/traits/blame-trait-error-spans-on-exprs.stderr
+++ b/tests/ui/errors/traits/blame-trait-error-spans-on-exprs.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:81:60
    |
 LL |     want(Wrapper { value: Burrito { spicy: false, filling: q } });
-   |     ---- required by a bound introduced by this call       ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call       ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<Burrito<Q>>: T1`
    |
 note: required for `Burrito<Q>` to implement `T2`
   --> $DIR/blame-trait-error-spans-on-exprs.rs:22:13
@@ -32,7 +32,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:85:84
    |
 LL |     want(Wrapper { value: BurritoKinds::SmallBurrito { spicy: true, small_filling: q } });
-   |     ---- required by a bound introduced by this call                               ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call                               ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<BurritoKinds<Q>>: T1`
    |
 note: required for `BurritoKinds<Q>` to implement `T2`
   --> $DIR/blame-trait-error-spans-on-exprs.rs:32:13
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:89:39
    |
 LL |     want(Wrapper { value: Taco(false, q) });
-   |     ----                              ^ the trait `T3` is not implemented for `Q`
+   |     ----                              ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<Taco<Q>>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -94,7 +94,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:93:53
    |
 LL |     want(Wrapper { value: TacoKinds::OneTaco(false, q) });
-   |     ----                                            ^ the trait `T3` is not implemented for `Q`
+   |     ----                                            ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<TacoKinds<Q>>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -126,7 +126,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:97:74
    |
 LL |     want(Wrapper { value: GenericBurrito { spiciness: NotSpicy, filling: q } });
-   |     ---- required by a bound introduced by this call                     ^ the trait `T3` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call                     ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<GenericBurrito<NotSpicy, Q>>: T1`
    |
 note: required for `GenericBurrito<NotSpicy, Q>` to implement `T2`
   --> $DIR/blame-trait-error-spans-on-exprs.rs:47:16
@@ -156,7 +156,7 @@ error[E0277]: the trait bound `Q: T2` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:101:14
    |
 LL |     want((3, q));
-   |     ----     ^ the trait `T2` is not implemented for `Q`
+   |     ----     ^ the trait `T2` is not implemented for `Q`, which is required by `({integer}, Q): T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -181,7 +181,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:105:31
    |
 LL |     want(Wrapper { value: (3, q) });
-   |     ----                      ^ the trait `T3` is not implemented for `Q`
+   |     ----                      ^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<({integer}, Q)>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -213,7 +213,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:109:15
    |
 LL |     want(((3, q), 5));
-   |     ----      ^ the trait `T3` is not implemented for `Q`
+   |     ----      ^ the trait `T3` is not implemented for `Q`, which is required by `(({integer}, Q), {integer}): T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -245,7 +245,7 @@ error[E0277]: the trait bound `Q: T1` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:112:49
    |
 LL |     want(DoubleWrapper { item: Wrapper { value: q } });
-   |     ----                                        ^ the trait `T1` is not implemented for `Q`
+   |     ----                                        ^ the trait `T1` is not implemented for `Q`, which is required by `DoubleWrapper<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -270,7 +270,7 @@ error[E0277]: the trait bound `Q: T1` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:115:88
    |
 LL |     want(DoubleWrapper { item: Wrapper { value: DoubleWrapper { item: Wrapper { value: q } } } });
-   |     ---- required by a bound introduced by this call                                   ^ the trait `T1` is not implemented for `Q`
+   |     ---- required by a bound introduced by this call                                   ^ the trait `T1` is not implemented for `Q`, which is required by `DoubleWrapper<DoubleWrapper<Q>>: T1`
    |
 note: required for `DoubleWrapper<Q>` to implement `T1`
   --> $DIR/blame-trait-error-spans-on-exprs.rs:72:13
@@ -295,7 +295,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:119:27
    |
 LL |     want(Wrapper { value: AliasBurrito { spiciness: q, filling: q } });
-   |     ----                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `T3` is not implemented for `Q`
+   |     ----                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `T3` is not implemented for `Q`, which is required by `Wrapper<GenericBurrito<Q, Q>>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -327,7 +327,7 @@ error[E0277]: the trait bound `Q: T1` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:122:35
    |
 LL |     want(Two { a: Two { a: (), b: q }, b: () });
-   |     ----                          ^ the trait `T1` is not implemented for `Q`
+   |     ----                          ^ the trait `T1` is not implemented for `Q`, which is required by `Two<Two<(), Q>, ()>: T1`
    |     |
    |     required by a bound introduced by this call
    |
@@ -354,7 +354,7 @@ error[E0277]: the trait bound `Q: T1` is not satisfied
 LL |     want(
    |     ---- required by a bound introduced by this call
 LL |         Two { a: Two { a: (), b: Two { a: Two { a: (), b: q }, b: () } }, b: () },
-   |                                                           ^ the trait `T1` is not implemented for `Q`
+   |                                                           ^ the trait `T1` is not implemented for `Q`, which is required by `Two<Two<(), Two<Two<(), Q>, ()>>, ()>: T1`
    |
 note: required for `Two<Two<(), Q>, ()>` to implement `T1`
   --> $DIR/blame-trait-error-spans-on-exprs.rs:66:19
@@ -379,7 +379,7 @@ error[E0277]: the trait bound `Q: T3` is not satisfied
   --> $DIR/blame-trait-error-spans-on-exprs.rs:133:44
    |
 LL |     want(&Burrito { spicy: false, filling: q });
-   |     ----                                   ^ the trait `T3` is not implemented for `Q`
+   |     ----                                   ^ the trait `T3` is not implemented for `Q`, which is required by `&Burrito<Q>: T1`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -21,7 +21,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL |     assert_sized::<Foo>();
    |                    ^^^ doesn't have a size known at compile-time
    |
-   = help: within `Foo`, the trait `Sized` is not implemented for `A`
+   = help: within `Foo`, the trait `Sized` is not implemented for `A`, which is required by `Foo: Sized`
 note: required because it appears within the type `Foo`
   --> $DIR/extern-types-unsized.rs:9:8
    |
@@ -43,7 +43,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL |     assert_sized::<Bar<A>>();
    |                    ^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Bar<A>`, the trait `Sized` is not implemented for `A`
+   = help: within `Bar<A>`, the trait `Sized` is not implemented for `A`, which is required by `Bar<A>: Sized`
 note: required because it appears within the type `Bar<A>`
   --> $DIR/extern-types-unsized.rs:14:8
    |
@@ -65,7 +65,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
 LL |     assert_sized::<Bar<Bar<A>>>();
    |                    ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Bar<Bar<A>>`, the trait `Sized` is not implemented for `A`
+   = help: within `Bar<Bar<A>>`, the trait `Sized` is not implemented for `A`, which is required by `Bar<Bar<A>>: Sized`
 note: required because it appears within the type `Bar<A>`
   --> $DIR/extern-types-unsized.rs:14:8
    |

--- a/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -94,7 +94,7 @@ error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at
 LL | fn unsized_local() where Dst<dyn A>: Sized {
    |                          ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Dst<(dyn A + 'static)>`, the trait `Sized` is not implemented for `(dyn A + 'static)`
+   = help: within `Dst<(dyn A + 'static)>`, the trait `Sized` is not implemented for `(dyn A + 'static)`, which is required by `Dst<(dyn A + 'static)>: Sized`
 note: required because it appears within the type `Dst<(dyn A + 'static)>`
   --> $DIR/feature-gate-trivial_bounds.rs:48:8
    |

--- a/tests/ui/fmt/ifmt-unimpl.stderr
+++ b/tests/ui/fmt/ifmt-unimpl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `str: UpperHex` is not satisfied
   --> $DIR/ifmt-unimpl.rs:2:21
    |
 LL |     format!("{:X}", "3");
-   |              ----   ^^^ the trait `UpperHex` is not implemented for `str`
+   |              ----   ^^^ the trait `UpperHex` is not implemented for `str`, which is required by `&str: UpperHex`
    |              |
    |              required by a bound introduced by this call
    |

--- a/tests/ui/fmt/send-sync.stderr
+++ b/tests/ui/fmt/send-sync.stderr
@@ -6,7 +6,7 @@ LL |     send(format_args!("{:?}", c));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `[core::fmt::rt::Argument<'_>]`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
+   = help: within `[core::fmt::rt::Argument<'_>]`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`, which is required by `Arguments<'_>: Send`
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `core::fmt::rt::Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
@@ -28,7 +28,7 @@ LL |     sync(format_args!("{:?}", c));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`
+   = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::rt::Opaque`, which is required by `Arguments<'_>: Sync`
    = note: required because it appears within the type `&core::fmt::rt::Opaque`
 note: required because it appears within the type `core::fmt::rt::Argument<'_>`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL

--- a/tests/ui/for/for-c-in-str.stderr
+++ b/tests/ui/for/for-c-in-str.stderr
@@ -4,7 +4,7 @@ error[E0277]: `&str` is not an iterator
 LL |     for c in "asdf" {
    |              ^^^^^^ `&str` is not an iterator; try calling `.chars()` or `.bytes()`
    |
-   = help: the trait `Iterator` is not implemented for `&str`
+   = help: the trait `Iterator` is not implemented for `&str`, which is required by `&str: IntoIterator`
    = note: required for `&str` to implement `IntoIterator`
 
 error: aborting due to 1 previous error

--- a/tests/ui/for/for-loop-bogosity.stderr
+++ b/tests/ui/for/for-loop-bogosity.stderr
@@ -4,7 +4,7 @@ error[E0277]: `MyStruct` is not an iterator
 LL |     for x in bogus {
    |              ^^^^^ `MyStruct` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `MyStruct`
+   = help: the trait `Iterator` is not implemented for `MyStruct`, which is required by `MyStruct: IntoIterator`
    = note: required for `MyStruct` to implement `IntoIterator`
 
 error: aborting due to 1 previous error

--- a/tests/ui/function-pointer/unsized-ret.stderr
+++ b/tests/ui/function-pointer/unsized-ret.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
 LL |     foo::<fn() -> str, _>(None, ());
    |           ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> str`, the trait `Sized` is not implemented for `str`
+   = help: within `fn() -> str`, the trait `Sized` is not implemented for `str`, which is required by `fn() -> str: Fn<_>`
    = note: required because it appears within the type `fn() -> str`
 note: required by a bound in `foo`
   --> $DIR/unsized-ret.rs:5:11
@@ -18,7 +18,7 @@ error[E0277]: the size for values of type `(dyn std::fmt::Display + 'a)` cannot 
 LL |     foo::<for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a), _>(None, (&(),));
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`, the trait `for<'a> Sized` is not implemented for `(dyn std::fmt::Display + 'a)`
+   = help: within `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`, the trait `for<'a> Sized` is not implemented for `(dyn std::fmt::Display + 'a)`, which is required by `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a): Fn<_>`
    = note: required because it appears within the type `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`
 note: required by a bound in `foo`
   --> $DIR/unsized-ret.rs:5:11

--- a/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.stderr
+++ b/tests/ui/generic-associated-types/assume-gat-normalization-for-nested-goals.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `<Self as Foo>::Bar<()>: Eq<i32>` is not satisfied
   --> $DIR/assume-gat-normalization-for-nested-goals.rs:6:30
    |
 LL |     type Bar<T>: Baz<Self> = i32;
-   |                              ^^^ the trait `Eq<i32>` is not implemented for `<Self as Foo>::Bar<()>`
+   |                              ^^^ the trait `Eq<i32>` is not implemented for `<Self as Foo>::Bar<()>`, which is required by `i32: Baz<Self>`
    |
 note: required for `i32` to implement `Baz<Self>`
   --> $DIR/assume-gat-normalization-for-nested-goals.rs:13:23

--- a/tests/ui/generic-associated-types/impl_bounds.stderr
+++ b/tests/ui/generic-associated-types/impl_bounds.stderr
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/impl_bounds.rs:18:33
    |
 LL |     type C = String where Self: Copy;
-   |                                 ^^^^ the trait `Copy` is not implemented for `T`
+   |                                 ^^^^ the trait `Copy` is not implemented for `T`, which is required by `Fooy<T>: Copy`
    |
 note: required for `Fooy<T>` to implement `Copy`
   --> $DIR/impl_bounds.rs:10:10
@@ -50,7 +50,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/impl_bounds.rs:20:24
    |
 LL |     fn d() where Self: Copy {}
-   |                        ^^^^ the trait `Copy` is not implemented for `T`
+   |                        ^^^^ the trait `Copy` is not implemented for `T`, which is required by `Fooy<T>: Copy`
    |
 note: required for `Fooy<T>` to implement `Copy`
   --> $DIR/impl_bounds.rs:10:10

--- a/tests/ui/generic-associated-types/issue-101020.stderr
+++ b/tests/ui/generic-associated-types/issue-101020.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a> &'a mut (): Foo<&'a mut ()>` is not satis
   --> $DIR/issue-101020.rs:31:22
    |
 LL |     (&mut EmptyIter).consume(());
-   |                      ^^^^^^^ the trait `for<'a> Foo<&'a mut ()>` is not implemented for `&'a mut ()`
+   |                      ^^^^^^^ the trait `for<'a> Foo<&'a mut ()>` is not implemented for `&'a mut ()`, which is required by `for<'a> &'a mut (): FuncInput<'a, &'a mut ()>`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-101020.rs:28:1

--- a/tests/ui/generic-associated-types/issue-74824.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.stderr
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/issue-74824.rs:6:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
-   |                          ^^^^^^ the trait `Clone` is not implemented for `T`
+   |                          ^^^^^^ the trait `Clone` is not implemented for `T`, which is required by `<Self as UnsafeCopy>::Copy<T>: Copy`
    |
    = note: required for `Box<T>` to implement `Clone`
    = note: required for `<Self as UnsafeCopy>::Copy<T>` to implement `Copy`

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
   --> $DIR/issue-89118.rs:19:8
    |
 LL |     C: StackContext,
-   |        ^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
+   |        ^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`, which is required by `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-89118.rs:1:1
@@ -29,7 +29,7 @@ error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
   --> $DIR/issue-89118.rs:29:9
    |
 LL | impl<C> EthernetWorker<C> {}
-   |         ^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
+   |         ^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`, which is required by `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-89118.rs:1:1
@@ -56,7 +56,7 @@ error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
   --> $DIR/issue-89118.rs:22:20
    |
 LL |     type Handler = Ctx<C::Dispatcher>;
-   |                    ^^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
+   |                    ^^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`, which is required by `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-89118.rs:1:1

--- a/tests/ui/impl-trait/auto-trait-leak2.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak2.stderr
@@ -9,7 +9,7 @@ LL |     send(before());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
+   = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`, which is required by `impl Fn(i32): Send`
 note: required because it's used within this closure
   --> $DIR/auto-trait-leak2.rs:10:5
    |
@@ -37,7 +37,7 @@ LL |     send(after());
 LL | fn after() -> impl Fn(i32) {
    |               ------------ within this `impl Fn(i32)`
    |
-   = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`
+   = help: within `impl Fn(i32)`, the trait `Send` is not implemented for `Rc<Cell<i32>>`, which is required by `impl Fn(i32): Send`
 note: required because it's used within this closure
   --> $DIR/auto-trait-leak2.rs:38:5
    |

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -16,7 +16,7 @@ LL | fn fuz() -> (usize, Trait) { (42, Struct) }
    |             |
    |             doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`, which is required by `(usize, (dyn Trait + 'static)): Sized`
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
    = note: the return type of a function must have a statically known size
 
@@ -38,7 +38,7 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |             |
    |             doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`, which is required by `(usize, (dyn Trait + 'static)): Sized`
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
    = note: the return type of a function must have a statically known size
 

--- a/tests/ui/impl-trait/impl_trait_projections.stderr
+++ b/tests/ui/impl-trait/impl_trait_projections.stderr
@@ -32,7 +32,7 @@ error[E0277]: the trait bound `impl Debug: Step` is not satisfied
   --> $DIR/impl_trait_projections.rs:26:8
    |
 LL |     -> <::std::ops::Range<impl Debug> as Iterator>::Item
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Step` is not implemented for `impl Debug`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Step` is not implemented for `impl Debug`, which is required by `std::ops::Range<impl Debug>: Iterator`
    |
    = help: the following other types implement trait `Step`:
              char
@@ -53,7 +53,7 @@ LL | / {
 LL | |
 LL | |     (1i32..100).next().unwrap()
 LL | | }
-   | |_^ the trait `Step` is not implemented for `impl Debug`
+   | |_^ the trait `Step` is not implemented for `impl Debug`, which is required by `std::ops::Range<impl Debug>: Iterator`
    |
    = help: the following other types implement trait `Step`:
              char

--- a/tests/ui/impl-trait/issue-55872-1.stderr
+++ b/tests/ui/impl-trait/issue-55872-1.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `S: Copy` is not satisfied in `(S, T)`
   --> $DIR/issue-55872-1.rs:12:29
    |
 LL |     fn foo<T: Default>() -> Self::E {
-   |                             ^^^^^^^ within `(S, T)`, the trait `Copy` is not implemented for `S`
+   |                             ^^^^^^^ within `(S, T)`, the trait `Copy` is not implemented for `S`, which is required by `(S, T): Copy`
    |
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound
@@ -23,7 +23,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied in `(S, T)`
   --> $DIR/issue-55872-1.rs:12:29
    |
 LL |     fn foo<T: Default>() -> Self::E {
-   |                             ^^^^^^^ within `(S, T)`, the trait `Copy` is not implemented for `T`
+   |                             ^^^^^^^ within `(S, T)`, the trait `Copy` is not implemented for `T`, which is required by `(S, T): Copy`
    |
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound

--- a/tests/ui/impl-trait/nested_impl_trait.stderr
+++ b/tests/ui/impl-trait/nested_impl_trait.stderr
@@ -46,7 +46,7 @@ error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfie
   --> $DIR/nested_impl_trait.rs:6:46
    |
 LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
-   |                                              ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
+   |                                              ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`, which is required by `impl Into<u32>: Into<impl Debug>`
    |
    = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
@@ -55,7 +55,7 @@ error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfie
   --> $DIR/nested_impl_trait.rs:19:34
    |
 LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
-   |                                  ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
+   |                                  ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`, which is required by `impl Into<u32>: Into<impl Debug>`
    |
    = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `[{integer}]` cannot be indexed by `i32`
 LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
+   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`, which is required by `Vec<{integer}>: Index<_>`
    = help: the trait `SliceIndex<[{integer}]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `[{integer}]` cannot be indexed by `u8`
 LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
+   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`, which is required by `[{integer}; 1]: Index<_>`
    = help: the trait `SliceIndex<[{integer}]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `[{integer}]` to implement `Index<u8>`

--- a/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
+++ b/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `String: Borrow<&str>` is not satisfied
   --> $DIR/point-at-index-for-obligation-failure.rs:5:9
    |
 LL |         &s
-   |         ^^ the trait `Borrow<&str>` is not implemented for `String`
+   |         ^^ the trait `Borrow<&str>` is not implemented for `String`, which is required by `HashMap<String, String>: Index<&_>`
    |
    = help: the trait `Borrow<str>` is implemented for `String`
    = help: for that trait implementation, expected `str`, found `&str`

--- a/tests/ui/integral-indexing.stderr
+++ b/tests/ui/integral-indexing.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `[isize]` cannot be indexed by `u8`
 LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`, which is required by `Vec<isize>: Index<_>`
    = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `Vec<isize>` to implement `Index<u8>`
@@ -15,7 +15,7 @@ error[E0277]: the type `[isize]` cannot be indexed by `i8`
 LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`, which is required by `Vec<isize>: Index<_>`
    = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i8`
    = note: required for `Vec<isize>` to implement `Index<i8>`
@@ -26,7 +26,7 @@ error[E0277]: the type `[isize]` cannot be indexed by `u32`
 LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`, which is required by `Vec<isize>: Index<_>`
    = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u32`
    = note: required for `Vec<isize>` to implement `Index<u32>`
@@ -37,7 +37,7 @@ error[E0277]: the type `[isize]` cannot be indexed by `i32`
 LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`, which is required by `Vec<isize>: Index<_>`
    = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `Vec<isize>` to implement `Index<i32>`
@@ -48,7 +48,7 @@ error[E0277]: the type `[u8]` cannot be indexed by `u8`
 LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`, which is required by `[u8]: Index<_>`
    = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `[u8]` to implement `Index<u8>`
@@ -59,7 +59,7 @@ error[E0277]: the type `[u8]` cannot be indexed by `i8`
 LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`, which is required by `[u8]: Index<_>`
    = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i8`
    = note: required for `[u8]` to implement `Index<i8>`
@@ -70,7 +70,7 @@ error[E0277]: the type `[u8]` cannot be indexed by `u32`
 LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`, which is required by `[u8]: Index<_>`
    = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u32`
    = note: required for `[u8]` to implement `Index<u32>`
@@ -81,7 +81,7 @@ error[E0277]: the type `[u8]` cannot be indexed by `i32`
 LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`, which is required by `[u8]: Index<_>`
    = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `[u8]` to implement `Index<i32>`

--- a/tests/ui/interior-mutability/interior-mutability.stderr
+++ b/tests/ui/interior-mutability/interior-mutability.stderr
@@ -6,7 +6,7 @@ LL |     catch_unwind(|| { x.set(23); });
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Cell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
+   = help: within `Cell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`, which is required by `{closure@$DIR/interior-mutability.rs:5:18: 5:20}: UnwindSafe`
 note: required because it appears within the type `Cell<i32>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `&Cell<i32>` to implement `UnwindSafe`

--- a/tests/ui/issues/issue-21763.stderr
+++ b/tests/ui/issues/issue-21763.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
 LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |           ^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
    |
-   = help: within `(Rc<()>, Rc<()>)`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `(Rc<()>, Rc<()>)`, the trait `Send` is not implemented for `Rc<()>`, which is required by `HashMap<Rc<()>, Rc<()>>: Send`
    = note: required because it appears within the type `(Rc<()>, Rc<()>)`
    = note: required for `hashbrown::raw::RawTable<(Rc<()>, Rc<()>)>` to implement `Send`
 note: required because it appears within the type `hashbrown::map::HashMap<Rc<()>, Rc<()>, RandomState>`

--- a/tests/ui/issues/issue-22872.stderr
+++ b/tests/ui/issues/issue-22872.stderr
@@ -4,7 +4,7 @@ error[E0277]: `<P as Process<'_>>::Item` is not an iterator
 LL |     let _: Box<dyn for<'b> Wrap<'b>> = Box::new(Wrapper(process));
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `<P as Process<'_>>::Item` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `<P as Process<'_>>::Item`
+   = help: the trait `Iterator` is not implemented for `<P as Process<'_>>::Item`, which is required by `for<'b> Wrapper<P>: Wrap<'b>`
 note: required for `Wrapper<P>` to implement `for<'b> Wrap<'b>`
   --> $DIR/issue-22872.rs:7:13
    |

--- a/tests/ui/issues/issue-40827.stderr
+++ b/tests/ui/issues/issue-40827.stderr
@@ -6,7 +6,7 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Bar`, the trait `Sync` is not implemented for `Rc<Foo>`
+   = help: within `Bar`, the trait `Sync` is not implemented for `Rc<Foo>`, which is required by `Foo: Send`
 note: required because it appears within the type `Bar`
   --> $DIR/issue-40827.rs:6:6
    |
@@ -32,7 +32,7 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Bar`, the trait `Send` is not implemented for `Rc<Foo>`
+   = help: within `Bar`, the trait `Send` is not implemented for `Rc<Foo>`, which is required by `Foo: Send`
 note: required because it appears within the type `Bar`
   --> $DIR/issue-40827.rs:6:6
    |

--- a/tests/ui/issues/issue-7364.stderr
+++ b/tests/ui/issues/issue-7364.stderr
@@ -4,7 +4,7 @@ error[E0277]: `RefCell<isize>` cannot be shared between threads safely
 LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
    |               ^^^^^^^^^^^^^^^^^^^ `RefCell<isize>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `RefCell<isize>`
+   = help: the trait `Sync` is not implemented for `RefCell<isize>`, which is required by `Box<RefCell<isize>>: Sync`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` instead
    = note: required for `Unique<RefCell<isize>>` to implement `Sync`
 note: required because it appears within the type `Box<RefCell<isize>>`

--- a/tests/ui/iterators/float_iterator_hint.stderr
+++ b/tests/ui/iterators/float_iterator_hint.stderr
@@ -4,7 +4,7 @@ error[E0277]: `{float}` is not an iterator
 LL |     for i in 0.2 {
    |              ^^^ `{float}` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `{float}`
+   = help: the trait `Iterator` is not implemented for `{float}`, which is required by `{float}: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `{float}` to implement `IntoIterator`
 

--- a/tests/ui/iterators/integral.stderr
+++ b/tests/ui/iterators/integral.stderr
@@ -4,7 +4,7 @@ error[E0277]: `{integer}` is not an iterator
 LL |     for _ in 42 {}
    |              ^^ `{integer}` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `{integer}`
+   = help: the trait `Iterator` is not implemented for `{integer}`, which is required by `{integer}: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `{integer}` to implement `IntoIterator`
 
@@ -14,7 +14,7 @@ error[E0277]: `u8` is not an iterator
 LL |     for _ in 42 as u8 {}
    |              ^^^^^^^^ `u8` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `u8`
+   = help: the trait `Iterator` is not implemented for `u8`, which is required by `u8: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `u8` to implement `IntoIterator`
 
@@ -24,7 +24,7 @@ error[E0277]: `i8` is not an iterator
 LL |     for _ in 42 as i8 {}
    |              ^^^^^^^^ `i8` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `i8`
+   = help: the trait `Iterator` is not implemented for `i8`, which is required by `i8: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `i8` to implement `IntoIterator`
 
@@ -34,7 +34,7 @@ error[E0277]: `u16` is not an iterator
 LL |     for _ in 42 as u16 {}
    |              ^^^^^^^^^ `u16` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `u16`
+   = help: the trait `Iterator` is not implemented for `u16`, which is required by `u16: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `u16` to implement `IntoIterator`
 
@@ -44,7 +44,7 @@ error[E0277]: `i16` is not an iterator
 LL |     for _ in 42 as i16 {}
    |              ^^^^^^^^^ `i16` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `i16`
+   = help: the trait `Iterator` is not implemented for `i16`, which is required by `i16: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `i16` to implement `IntoIterator`
 
@@ -54,7 +54,7 @@ error[E0277]: `u32` is not an iterator
 LL |     for _ in 42 as u32 {}
    |              ^^^^^^^^^ `u32` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `u32`
+   = help: the trait `Iterator` is not implemented for `u32`, which is required by `u32: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `u32` to implement `IntoIterator`
 
@@ -64,7 +64,7 @@ error[E0277]: `i32` is not an iterator
 LL |     for _ in 42 as i32 {}
    |              ^^^^^^^^^ `i32` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `i32`
+   = help: the trait `Iterator` is not implemented for `i32`, which is required by `i32: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `i32` to implement `IntoIterator`
 
@@ -74,7 +74,7 @@ error[E0277]: `u64` is not an iterator
 LL |     for _ in 42 as u64 {}
    |              ^^^^^^^^^ `u64` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `u64`
+   = help: the trait `Iterator` is not implemented for `u64`, which is required by `u64: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `u64` to implement `IntoIterator`
 
@@ -84,7 +84,7 @@ error[E0277]: `i64` is not an iterator
 LL |     for _ in 42 as i64 {}
    |              ^^^^^^^^^ `i64` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `i64`
+   = help: the trait `Iterator` is not implemented for `i64`, which is required by `i64: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `i64` to implement `IntoIterator`
 
@@ -94,7 +94,7 @@ error[E0277]: `usize` is not an iterator
 LL |     for _ in 42 as usize {}
    |              ^^^^^^^^^^^ `usize` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `usize`
+   = help: the trait `Iterator` is not implemented for `usize`, which is required by `usize: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `usize` to implement `IntoIterator`
 
@@ -104,7 +104,7 @@ error[E0277]: `isize` is not an iterator
 LL |     for _ in 42 as isize {}
    |              ^^^^^^^^^^^ `isize` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `isize`
+   = help: the trait `Iterator` is not implemented for `isize`, which is required by `isize: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `isize` to implement `IntoIterator`
 
@@ -114,7 +114,7 @@ error[E0277]: `{float}` is not an iterator
 LL |     for _ in 42.0 {}
    |              ^^^^ `{float}` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `{float}`
+   = help: the trait `Iterator` is not implemented for `{float}`, which is required by `{float}: IntoIterator`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: required for `{float}` to implement `IntoIterator`
 

--- a/tests/ui/iterators/issue-28098.stderr
+++ b/tests/ui/iterators/issue-28098.stderr
@@ -14,7 +14,7 @@ error[E0277]: `bool` is not an iterator
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `bool`
+   = help: the trait `Iterator` is not implemented for `bool`, which is required by `bool: IntoIterator`
    = note: required for `bool` to implement `IntoIterator`
 
 error[E0277]: `()` is not an iterator
@@ -61,7 +61,7 @@ error[E0277]: `bool` is not an iterator
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `bool`
+   = help: the trait `Iterator` is not implemented for `bool`, which is required by `bool: IntoIterator`
    = note: required for `bool` to implement `IntoIterator`
 
 error[E0277]: `()` is not an iterator

--- a/tests/ui/iterators/ranges.stderr
+++ b/tests/ui/iterators/ranges.stderr
@@ -4,7 +4,7 @@ error[E0277]: `RangeTo<{integer}>` is not an iterator
 LL |     for _ in ..10 {}
    |              ^^^^ if you meant to iterate until a value, add a starting value
    |
-   = help: the trait `Iterator` is not implemented for `RangeTo<{integer}>`
+   = help: the trait `Iterator` is not implemented for `RangeTo<{integer}>`, which is required by `RangeTo<{integer}>: IntoIterator`
    = note: `..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a bounded `Range`: `0..end`
    = note: required for `RangeTo<{integer}>` to implement `IntoIterator`
 
@@ -14,7 +14,7 @@ error[E0277]: `RangeToInclusive<{integer}>` is not an iterator
 LL |     for _ in ..=10 {}
    |              ^^^^^ if you meant to iterate until a value (including it), add a starting value
    |
-   = help: the trait `Iterator` is not implemented for `RangeToInclusive<{integer}>`
+   = help: the trait `Iterator` is not implemented for `RangeToInclusive<{integer}>`, which is required by `RangeToInclusive<{integer}>: IntoIterator`
    = note: `..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant to have a bounded `RangeInclusive`: `0..=end`
    = note: required for `RangeToInclusive<{integer}>` to implement `IntoIterator`
 

--- a/tests/ui/iterators/string.stderr
+++ b/tests/ui/iterators/string.stderr
@@ -4,7 +4,7 @@ error[E0277]: `String` is not an iterator
 LL |     for _ in "".to_owned() {}
    |              ^^^^^^^^^^^^^ `String` is not an iterator; try calling `.chars()` or `.bytes()`
    |
-   = help: the trait `Iterator` is not implemented for `String`
+   = help: the trait `Iterator` is not implemented for `String`, which is required by `String: IntoIterator`
    = note: required for `String` to implement `IntoIterator`
 
 error[E0277]: `&str` is not an iterator
@@ -13,7 +13,7 @@ error[E0277]: `&str` is not an iterator
 LL |     for _ in "" {}
    |              ^^ `&str` is not an iterator; try calling `.chars()` or `.bytes()`
    |
-   = help: the trait `Iterator` is not implemented for `&str`
+   = help: the trait `Iterator` is not implemented for `&str`, which is required by `&str: IntoIterator`
    = note: required for `&str` to implement `IntoIterator`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Box<{integer}>: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params-2.rs:13:16
    |
 LL |     take_param(&x);
-   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`, which is required by `Box<{integer}>: Foo`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:16:13
    |
 LL |     let a = &t as &dyn Gettable<T>;
-   |             ^^ the trait `Copy` is not implemented for `T`
+   |             ^^ the trait `Copy` is not implemented for `T`, which is required by `S<T>: Gettable<T>`
    |
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
@@ -59,7 +59,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:23:31
    |
 LL |     let a: &dyn Gettable<T> = &t;
-   |                               ^^ the trait `Copy` is not implemented for `T`
+   |                               ^^ the trait `Copy` is not implemented for `T`, which is required by `S<T>: Gettable<T>`
    |
 note: required for `S<T>` to implement `Gettable<T>`
   --> $DIR/kindck-impl-type-params.rs:12:32
@@ -78,7 +78,7 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:35:13
    |
 LL |     let a = t as Box<dyn Gettable<String>>;
-   |             ^ the trait `Copy` is not implemented for `String`
+   |             ^ the trait `Copy` is not implemented for `String`, which is required by `S<String>: Gettable<String>`
    |
    = help: the trait `Gettable<T>` is implemented for `S<T>`
 note: required for `S<String>` to implement `Gettable<String>`
@@ -94,7 +94,7 @@ error[E0277]: the trait bound `Foo: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:43:37
    |
 LL |     let a: Box<dyn Gettable<Foo>> = t;
-   |                                     ^ the trait `Copy` is not implemented for `Foo`
+   |                                     ^ the trait `Copy` is not implemented for `Foo`, which is required by `S<Foo>: Gettable<Foo>`
    |
    = help: the trait `Gettable<T>` is implemented for `S<T>`
 note: required for `S<Foo>` to implement `Gettable<Foo>`

--- a/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Box<{integer}>: Copy` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL |     take_param(&x);
-   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`, which is required by `Box<{integer}>: Foo`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Box<{integer}>: Copy` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL |     take_param(&x);
-   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`
+   |     ---------- ^^ the trait `Copy` is not implemented for `Box<{integer}>`, which is required by `Box<{integer}>: Foo`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/kindck/kindck-nonsendable-1.stderr
+++ b/tests/ui/kindck/kindck-nonsendable-1.stderr
@@ -8,7 +8,7 @@ LL |     bar(move|| foo(x));
    |     |   within this `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`
    |     required by a bound introduced by this call
    |
-   = help: within `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`, the trait `Send` is not implemented for `Rc<usize>`
+   = help: within `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}`, the trait `Send` is not implemented for `Rc<usize>`, which is required by `{closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:15}: Send`
 note: required because it's used within this closure
   --> $DIR/kindck-nonsendable-1.rs:9:9
    |

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -4,7 +4,7 @@ error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
+   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`, which is required by `&'static (dyn Dummy + 'static): Send`
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object.rs:5:18
@@ -18,7 +18,7 @@ error[E0277]: `dyn Dummy` cannot be sent between threads safely
 LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `dyn Dummy`
+   = help: the trait `Send` is not implemented for `dyn Dummy`, which is required by `Box<dyn Dummy>: Send`
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -4,7 +4,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
 LL |     assert_send::<&'a dyn Dummy>();
    |                   ^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
+   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`, which is required by `&'a (dyn Dummy + 'a): Send`
    = note: required for `&'a (dyn Dummy + 'a)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object1.rs:5:18
@@ -18,7 +18,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
+   = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`, which is required by `Box<(dyn Dummy + 'a)>: Send`
    = note: required for `Unique<(dyn Dummy + 'a)>` to implement `Send`
 note: required because it appears within the type `Box<(dyn Dummy + 'a)>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -4,7 +4,7 @@ error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
 LL |     assert_send::<&'static dyn Dummy>();
    |                   ^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
+   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`, which is required by `&'static (dyn Dummy + 'static): Send`
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object2.rs:3:18
@@ -18,7 +18,7 @@ error[E0277]: `dyn Dummy` cannot be sent between threads safely
 LL |     assert_send::<Box<dyn Dummy>>();
    |                   ^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `dyn Dummy`
+   = help: the trait `Send` is not implemented for `dyn Dummy`, which is required by `Box<dyn Dummy>: Send`
    = note: required for `Unique<dyn Dummy>` to implement `Send`
 note: required because it appears within the type `Box<dyn Dummy>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/kindck/kindck-send-owned.stderr
+++ b/tests/ui/kindck/kindck-send-owned.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut u8` cannot be sent between threads safely
 LL |     assert_send::<Box<*mut u8>>();
    |                   ^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `*mut u8`
+   = help: the trait `Send` is not implemented for `*mut u8`, which is required by `Box<*mut u8>: Send`
    = note: required for `Unique<*mut u8>` to implement `Send`
 note: required because it appears within the type `Box<*mut u8>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL

--- a/tests/ui/modules/issue-107649.stderr
+++ b/tests/ui/modules/issue-107649.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Dummy` doesn't implement `Debug`
 105 |     dbg!(lib::Dummy);
     |     ^^^^^^^^^^^^^^^^ `Dummy` cannot be formatted using `{:?}`
     |
-    = help: the trait `Debug` is not implemented for `Dummy`
+    = help: the trait `Debug` is not implemented for `Dummy`, which is required by `&Dummy: Debug`
     = note: add `#[derive(Debug)]` to `Dummy` or manually `impl Debug for Dummy`
     = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Dummy` with `#[derive(Debug)]`

--- a/tests/ui/mut/mutable-enum-indirect.stderr
+++ b/tests/ui/mut/mutable-enum-indirect.stderr
@@ -6,7 +6,7 @@ LL |     bar(&x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`
+   = help: within `&Foo`, the trait `Sync` is not implemented for `NoSync`, which is required by `&Foo: Sync`
 note: required because it appears within the type `Foo`
   --> $DIR/mutable-enum-indirect.rs:11:6
    |

--- a/tests/ui/no-send-res-ports.stderr
+++ b/tests/ui/no-send-res-ports.stderr
@@ -13,7 +13,7 @@ LL | |         println!("{:?}", y);
 LL | |     });
    | |_____^ `Rc<()>` cannot be sent between threads safely
    |
-   = help: within `{closure@$DIR/no-send-res-ports.rs:25:19: 25:25}`, the trait `Send` is not implemented for `Rc<()>`
+   = help: within `{closure@$DIR/no-send-res-ports.rs:25:19: 25:25}`, the trait `Send` is not implemented for `Rc<()>`, which is required by `{closure@$DIR/no-send-res-ports.rs:25:19: 25:25}: Send`
 note: required because it appears within the type `Port<()>`
   --> $DIR/no-send-res-ports.rs:5:8
    |

--- a/tests/ui/no_send-enum.stderr
+++ b/tests/ui/no_send-enum.stderr
@@ -6,7 +6,7 @@ LL |     bar(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Foo`, the trait `Send` is not implemented for `NoSend`
+   = help: within `Foo`, the trait `Send` is not implemented for `NoSend`, which is required by `Foo: Send`
 note: required because it appears within the type `Foo`
   --> $DIR/no_send-enum.rs:8:6
    |

--- a/tests/ui/no_share-enum.stderr
+++ b/tests/ui/no_share-enum.stderr
@@ -6,7 +6,7 @@ LL |     bar(x);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Foo`, the trait `Sync` is not implemented for `NoSync`
+   = help: within `Foo`, the trait `Sync` is not implemented for `NoSync`, which is required by `Foo: Sync`
 note: required because it appears within the type `Foo`
   --> $DIR/no_share-enum.rs:8:6
    |

--- a/tests/ui/not-clone-closure.stderr
+++ b/tests/ui/not-clone-closure.stderr
@@ -5,7 +5,7 @@ LL |     let hello = move || {
    |                 ------- within this `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}`
 ...
 LL |     let hello = hello.clone();
-   |                       ^^^^^ within `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}`, the trait `Clone` is not implemented for `S`
+   |                       ^^^^^ within `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}`, the trait `Clone` is not implemented for `S`, which is required by `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}: Clone`
    |
 note: required because it's used within this closure
   --> $DIR/not-clone-closure.rs:7:17

--- a/tests/ui/not-panic/not-panic-safe-2.stderr
+++ b/tests/ui/not-panic/not-panic-safe-2.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
 LL |     assert::<Rc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`, which is required by `Rc<RefCell<i32>>: UnwindSafe`
 note: required because it appears within the type `RefCell<i32>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `Rc<RefCell<i32>>` to implement `UnwindSafe`
@@ -20,7 +20,7 @@ error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a
 LL |     assert::<Rc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`, which is required by `Rc<RefCell<i32>>: UnwindSafe`
 note: required because it appears within the type `Cell<isize>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
 note: required because it appears within the type `RefCell<i32>`

--- a/tests/ui/not-panic/not-panic-safe-3.stderr
+++ b/tests/ui/not-panic/not-panic-safe-3.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
 LL |     assert::<Arc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`, which is required by `Arc<RefCell<i32>>: UnwindSafe`
 note: required because it appears within the type `RefCell<i32>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `Arc<RefCell<i32>>` to implement `UnwindSafe`
@@ -20,7 +20,7 @@ error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a
 LL |     assert::<Arc<RefCell<i32>>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`, which is required by `Arc<RefCell<i32>>: UnwindSafe`
 note: required because it appears within the type `Cell<isize>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
 note: required because it appears within the type `RefCell<i32>`

--- a/tests/ui/not-panic/not-panic-safe-4.stderr
+++ b/tests/ui/not-panic/not-panic-safe-4.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
 LL |     assert::<&RefCell<i32>>();
    |              ^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`, which is required by `&RefCell<i32>: UnwindSafe`
 note: required because it appears within the type `RefCell<i32>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `&RefCell<i32>` to implement `UnwindSafe`
@@ -25,7 +25,7 @@ error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a
 LL |     assert::<&RefCell<i32>>();
    |              ^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`, which is required by `&RefCell<i32>: UnwindSafe`
 note: required because it appears within the type `Cell<isize>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
 note: required because it appears within the type `RefCell<i32>`

--- a/tests/ui/not-panic/not-panic-safe-5.stderr
+++ b/tests/ui/not-panic/not-panic-safe-5.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
 LL |     assert::<*const UnsafeCell<i32>>();
    |              ^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
+   = help: the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`, which is required by `*const UnsafeCell<i32>: UnwindSafe`
    = note: required for `*const UnsafeCell<i32>` to implement `UnwindSafe`
 note: required by a bound in `assert`
   --> $DIR/not-panic-safe-5.rs:6:14

--- a/tests/ui/not-panic/not-panic-safe-6.stderr
+++ b/tests/ui/not-panic/not-panic-safe-6.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `UnsafeCell<i32>` may contain interior mutability and a r
 LL |     assert::<*mut RefCell<i32>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<i32>`, which is required by `*mut RefCell<i32>: UnwindSafe`
 note: required because it appears within the type `RefCell<i32>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
    = note: required for `*mut RefCell<i32>` to implement `UnwindSafe`
@@ -20,7 +20,7 @@ error[E0277]: the type `UnsafeCell<isize>` may contain interior mutability and a
 LL |     assert::<*mut RefCell<i32>>();
    |              ^^^^^^^^^^^^^^^^^ `UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
-   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`
+   = help: within `RefCell<i32>`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<isize>`, which is required by `*mut RefCell<i32>: UnwindSafe`
 note: required because it appears within the type `Cell<isize>`
   --> $SRC_DIR/core/src/cell.rs:LL:COL
 note: required because it appears within the type `RefCell<i32>`

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -40,7 +40,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     offset_of!(Delta<Alpha>, z);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Alpha`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `Alpha`, the trait `Sized` is not implemented for `[u8]`, which is required by `Alpha: Sized`
 note: required because it appears within the type `Alpha`
   --> $DIR/offset-of-dst-field.rs:5:8
    |

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `[i32]` cannot be indexed by `i32`
 LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
+   = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`, which is required by `[i32]: Index<_>`
    = help: the trait `SliceIndex<[i32]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `[i32]` to implement `Index<i32>`
@@ -15,7 +15,7 @@ error[E0277]: the type `[i32]` cannot be indexed by `RangeTo<i32>`
 LL |     x[..1i32];
    |       ^^^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`
+   = help: the trait `SliceIndex<[i32]>` is not implemented for `RangeTo<i32>`, which is required by `[i32]: Index<_>`
    = help: the following other types implement trait `SliceIndex<T>`:
              <RangeTo<usize> as SliceIndex<str>>
              <RangeTo<usize> as SliceIndex<[T]>>

--- a/tests/ui/parser/struct-literal-in-for.stderr
+++ b/tests/ui/parser/struct-literal-in-for.stderr
@@ -23,7 +23,7 @@ LL | |         x: 3
 LL | |     }.hi() {
    | |__________^ `bool` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `bool`
+   = help: the trait `Iterator` is not implemented for `bool`, which is required by `bool: IntoIterator`
    = note: required for `bool` to implement `IntoIterator`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `bool: Step` is not satisfied
   --> $DIR/range-1.rs:9:14
    |
 LL |     for i in false..true {}
-   |              ^^^^^^^^^^^ the trait `Step` is not implemented for `bool`
+   |              ^^^^^^^^^^^ the trait `Step` is not implemented for `bool`, which is required by `std::ops::Range<bool>: IntoIterator`
    |
    = help: the following other types implement trait `Step`:
              char

--- a/tests/ui/recursion/recursive-requirements.stderr
+++ b/tests/ui/recursion/recursive-requirements.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*const Bar` cannot be shared between threads safely
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
    |
-   = help: within `Foo`, the trait `Sync` is not implemented for `*const Bar`
+   = help: within `Foo`, the trait `Sync` is not implemented for `*const Bar`, which is required by `Foo: Sync`
 note: required because it appears within the type `Foo`
   --> $DIR/recursive-requirements.rs:5:12
    |
@@ -22,7 +22,7 @@ error[E0277]: `*const Foo` cannot be shared between threads safely
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely
    |
-   = help: within `Foo`, the trait `Sync` is not implemented for `*const Foo`
+   = help: within `Foo`, the trait `Sync` is not implemented for `*const Foo`, which is required by `Foo: Sync`
 note: required because it appears within the type `Bar`
   --> $DIR/recursive-requirements.rs:10:12
    |

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `f32: Termination` is not satisfied
 LL | #[test]
    | ------- in this procedural macro expansion
 LL | fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Termination` is not implemented for `f32`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Termination` is not implemented for `f32`, which is required by `Result<f32, ParseFloatError>: Termination`
    |
    = note: required for `Result<f32, ParseFloatError>` to implement `Termination`
 note: required by a bound in `assert_test_result`

--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -4,7 +4,7 @@ error[E0277]: `NotDebug` doesn't implement `Debug`
 LL |     let _: NotDebug = dbg!(NotDebug);
    |                       ^^^^^^^^^^^^^^ `NotDebug` cannot be formatted using `{:?}`
    |
-   = help: the trait `Debug` is not implemented for `NotDebug`
+   = help: the trait `Debug` is not implemented for `NotDebug`, which is required by `&NotDebug: Debug`
    = note: add `#[derive(Debug)]` to `NotDebug` or manually `impl Debug for NotDebug`
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NotDebug` with `#[derive(Debug)]`

--- a/tests/ui/rfcs/rfc-2397-do-not-recommend/feature-gate-do_not_recommend.stderr
+++ b/tests/ui/rfcs/rfc-2397-do-not-recommend/feature-gate-do_not_recommend.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u8: Foo` is not satisfied
   --> $DIR/feature-gate-do_not_recommend.rs:19:11
    |
 LL |     stuff(1u8);
-   |     ----- ^^^ the trait `Foo` is not implemented for `u8`
+   |     ----- ^^^ the trait `Foo` is not implemented for `u8`, which is required by `u8: Bar`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `B: Clone` is not satisfied
   --> $DIR/issue-79224.rs:18:29
    |
 LL | impl<B: ?Sized> Display for Cow<'_, B> {
-   |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`
+   |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`, which is required by `B: ToOwned`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting this bound
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `B: Clone` is not satisfied
   --> $DIR/issue-79224.rs:20:5
    |
 LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`, which is required by `B: ToOwned`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting this bound
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `B: Clone` is not satisfied
   --> $DIR/issue-79224.rs:20:13
    |
 LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |             ^^^^ the trait `Clone` is not implemented for `B`
+   |             ^^^^ the trait `Clone` is not implemented for `B`, which is required by `B: ToOwned`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting this bound

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `str` cannot be indexed by `{integer}`
 LL |     let _: u8 = s[4];
    |                   ^ string indices are ranges of `usize`
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
+   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`, which is required by `str: Index<_>`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
    = help: the trait `SliceIndex<[_]>` is implemented for `usize`
@@ -49,7 +49,7 @@ error[E0277]: the type `str` cannot be indexed by `char`
 LL |     let _: u8 = s['c'];
    |                   ^^^ string indices are ranges of `usize`
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `char`
+   = help: the trait `SliceIndex<str>` is not implemented for `char`, which is required by `str: Index<_>`
    = note: required for `str` to implement `Index<char>`
 
 error: aborting due to 4 previous errors

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -30,7 +30,7 @@ error[E0277]: the type `str` cannot be indexed by `usize`
 LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `usize`, which is required by `str: Index<_>`
    = help: the trait `SliceIndex<[_]>` is implemented for `usize`
    = help: for that trait implementation, expected `[_]`, found `str`
    = note: required for `str` to implement `Index<usize>`
@@ -73,7 +73,7 @@ error[E0277]: the type `str` cannot be indexed by `char`
 LL |     s['c'];
    |       ^^^ string indices are ranges of `usize`
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `char`
+   = help: the trait `SliceIndex<str>` is not implemented for `char`, which is required by `str: Index<_>`
    = note: required for `str` to implement `Index<char>`
 
 error: aborting due to 6 previous errors

--- a/tests/ui/suggestions/derive-clone-for-eq.stderr
+++ b/tests/ui/suggestions/derive-clone-for-eq.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/derive-clone-for-eq.rs:4:17
    |
 LL | #[derive(Clone, Eq)]
-   |                 ^^ the trait `Clone` is not implemented for `T`
+   |                 ^^ the trait `Clone` is not implemented for `T`, which is required by `Struct<T>: PartialEq`
    |
 note: required for `Struct<T>` to implement `PartialEq`
   --> $DIR/derive-clone-for-eq.rs:7:19

--- a/tests/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/tests/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -6,7 +6,7 @@ LL |     #[derive(Debug)]
 LL |     struct Outer<T>(Inner<T>);
    |                     ^^^^^^^^ `a::Inner<T>` cannot be formatted using `{:?}`
    |
-   = help: the trait `Debug` is not implemented for `a::Inner<T>`
+   = help: the trait `Debug` is not implemented for `a::Inner<T>`, which is required by `&a::Inner<T>: Debug`
    = note: add `#[derive(Debug)]` to `a::Inner<T>` or manually `impl Debug for a::Inner<T>`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `a::Inner<T>` with `#[derive(Debug)]`
@@ -25,7 +25,7 @@ error[E0277]: the trait bound `T: c::Trait` is not satisfied
 LL |     #[derive(Debug)]
    |              ----- in this derive macro expansion
 LL |     struct Outer<T>(Inner<T>);
-   |                     ^^^^^^^^ the trait `c::Trait` is not implemented for `T`
+   |                     ^^^^^^^^ the trait `c::Trait` is not implemented for `T`, which is required by `&c::Inner<T>: Debug`
    |
 note: required for `c::Inner<T>` to implement `Debug`
   --> $DIR/derive-macro-missing-bounds.rs:34:28
@@ -49,7 +49,7 @@ error[E0277]: the trait bound `T: d::Trait` is not satisfied
 LL |     #[derive(Debug)]
    |              ----- in this derive macro expansion
 LL |     struct Outer<T>(Inner<T>);
-   |                     ^^^^^^^^ the trait `d::Trait` is not implemented for `T`
+   |                     ^^^^^^^^ the trait `d::Trait` is not implemented for `T`, which is required by `&d::Inner<T>: Debug`
    |
 note: required for `d::Inner<T>` to implement `Debug`
   --> $DIR/derive-macro-missing-bounds.rs:49:13
@@ -71,7 +71,7 @@ error[E0277]: the trait bound `T: e::Trait` is not satisfied
 LL |     #[derive(Debug)]
    |              ----- in this derive macro expansion
 LL |     struct Outer<T>(Inner<T>);
-   |                     ^^^^^^^^ the trait `e::Trait` is not implemented for `T`
+   |                     ^^^^^^^^ the trait `e::Trait` is not implemented for `T`, which is required by `&e::Inner<T>: Debug`
    |
 note: required for `e::Inner<T>` to implement `Debug`
   --> $DIR/derive-macro-missing-bounds.rs:64:13
@@ -93,7 +93,7 @@ error[E0277]: the trait bound `T: f::Trait` is not satisfied
 LL |     #[derive(Debug)]
    |              ----- in this derive macro expansion
 LL |     struct Outer<T>(Inner<T>);
-   |                     ^^^^^^^^ the trait `f::Trait` is not implemented for `T`
+   |                     ^^^^^^^^ the trait `f::Trait` is not implemented for `T`, which is required by `&f::Inner<T>: Debug`
    |
 note: required for `f::Inner<T>` to implement `Debug`
   --> $DIR/derive-macro-missing-bounds.rs:79:20

--- a/tests/ui/suggestions/into-str.stderr
+++ b/tests/ui/suggestions/into-str.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&str: From<String>` is not satisfied
   --> $DIR/into-str.rs:4:9
    |
 LL |     foo(String::new());
-   |     --- ^^^^^^^^^^^^^ the trait `From<String>` is not implemented for `&str`
+   |     --- ^^^^^^^^^^^^^ the trait `From<String>` is not implemented for `&str`, which is required by `String: Into<&str>`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&[i8]: From<&[u8]>` is not satisfied
   --> $DIR/issue-71394-no-from-impl.rs:8:25
    |
 LL |     let _: &[i8] = data.into();
-   |                         ^^^^ the trait `From<&[u8]>` is not implemented for `&[i8]`
+   |                         ^^^^ the trait `From<&[u8]>` is not implemented for `&[i8]`, which is required by `&[u8]: Into<_>`
    |
    = help: the following other types implement trait `From<T>`:
              <[bool; N] as From<Mask<T, N>>>

--- a/tests/ui/suggestions/issue-88696.stderr
+++ b/tests/ui/suggestions/issue-88696.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Result<u32, i32>: From<Result<u64, i32>>` is not 
   --> $DIR/issue-88696.rs:9:9
    |
 LL |     a().into()
-   |         ^^^^ the trait `From<Result<u64, i32>>` is not implemented for `Result<u32, i32>`
+   |         ^^^^ the trait `From<Result<u64, i32>>` is not implemented for `Result<u32, i32>`, which is required by `Result<u64, i32>: Into<_>`
    |
    = note: required for `Result<u64, i32>` to implement `Into<Result<u32, i32>>`
 

--- a/tests/ui/suggestions/issue-96223.stderr
+++ b/tests/ui/suggestions/issue-96223.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'de> EmptyBis<'de>: Foo<'_>` is not satisfied
   --> $DIR/issue-96223.rs:49:17
    |
 LL |     icey_bounds(&p);
-   |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
+   |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`, which is required by `Empty: Dummy<EmptyMarker>`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/suggestions/issue-96555.stderr
+++ b/tests/ui/suggestions/issue-96555.stderr
@@ -6,7 +6,7 @@ LL |     m::f1().await;
    |     |
    |     this call returns `()`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 help: remove the `.await`
@@ -27,7 +27,7 @@ LL |     m::f2().await;
    |     |
    |     this call returns `()`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 help: remove the `.await`
@@ -48,7 +48,7 @@ LL |     m::f3().await;
    |     |
    |     this call returns `()`
    |
-   = help: the trait `Future` is not implemented for `()`
+   = help: the trait `Future` is not implemented for `()`, which is required by `(): IntoFuture`
    = note: () must be a future or must implement `IntoFuture` to be awaited
    = note: required for `()` to implement `IntoFuture`
 help: remove the `.await`

--- a/tests/ui/suggestions/path-by-value.stderr
+++ b/tests/ui/suggestions/path-by-value.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL | fn f(p: Path) { }
    |      ^ doesn't have a size known at compile-time
    |
-   = help: within `Path`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`
   --> $SRC_DIR/std/src/path.rs:LL:COL
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/suggestions/path-display.stderr
+++ b/tests/ui/suggestions/path-display.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Path` doesn't implement `std::fmt::Display`
 LL |     println!("{}", path);
    |                    ^^^^ `Path` cannot be formatted with the default formatter; call `.display()` on it
    |
-   = help: the trait `std::fmt::Display` is not implemented for `Path`
+   = help: the trait `std::fmt::Display` is not implemented for `Path`, which is required by `&Path: std::fmt::Display`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -4,7 +4,7 @@ error[E0277]: the type `[{integer}]` cannot be indexed by `&usize`
 LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
+   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`, which is required by `[{integer}; 3]: Index<_>`
    = help: the trait `SliceIndex<[{integer}]>` is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `&usize`
    = note: required for `[{integer}]` to implement `Index<&usize>`

--- a/tests/ui/suggestions/suggest-pin-macro.stderr
+++ b/tests/ui/suggestions/suggest-pin-macro.stderr
@@ -2,7 +2,7 @@ error[E0277]: `PhantomPinned` cannot be unpinned
   --> $DIR/suggest-pin-macro.rs:22:17
    |
 LL |     dummy(test1.get_mut());
-   |                 ^^^^^^^ within `Test`, the trait `Unpin` is not implemented for `PhantomPinned`
+   |                 ^^^^^^^ within `Test`, the trait `Unpin` is not implemented for `PhantomPinned`, which is required by `Test: Unpin`
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope

--- a/tests/ui/suggestions/suggest-remove-refs-1.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-1.stderr
@@ -4,7 +4,7 @@ error[E0277]: `&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
 LL |     for (i, _) in &v.iter().enumerate() {
    |                   ^^^^^^^^^^^^^^^^^^^^^ `&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&Enumerate<std::slice::Iter<'_, {integer}>>`
+   = help: the trait `Iterator` is not implemented for `&Enumerate<std::slice::Iter<'_, {integer}>>`, which is required by `&Enumerate<std::slice::Iter<'_, {integer}>>: IntoIterator`
    = note: required for `&Enumerate<std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
 help: consider removing the leading `&`-reference
    |

--- a/tests/ui/suggestions/suggest-remove-refs-2.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-2.stderr
@@ -4,7 +4,7 @@ error[E0277]: `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterat
 LL |     for (i, _) in & & & & &v.iter().enumerate() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
+   = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`, which is required by `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>: IntoIterator`
    = note: required for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
 help: consider removing 5 leading `&`-references
    |

--- a/tests/ui/suggestions/suggest-remove-refs-3.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-3.stderr
@@ -8,7 +8,7 @@ LL | |         .iter()
 LL | |         .enumerate() {
    | |____________________^ `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`
+   = help: the trait `Iterator` is not implemented for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>`, which is required by `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>: IntoIterator`
    = note: required for `&&&&&Enumerate<std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
 help: consider removing 5 leading `&`-references
    |

--- a/tests/ui/suggestions/suggest-remove-refs-4.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-4.stderr
@@ -4,7 +4,7 @@ error[E0277]: `&&std::slice::Iter<'_, {integer}>` is not an iterator
 LL |     for _i in &foo {}
    |               ^^^^ `&&std::slice::Iter<'_, {integer}>` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&&std::slice::Iter<'_, {integer}>`
+   = help: the trait `Iterator` is not implemented for `&&std::slice::Iter<'_, {integer}>`, which is required by `&&std::slice::Iter<'_, {integer}>: IntoIterator`
    = note: required for `&&std::slice::Iter<'_, {integer}>` to implement `IntoIterator`
 help: consider removing 2 leading `&`-references
    |

--- a/tests/ui/suggestions/suggest-remove-refs-5.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-5.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Vec<i32>` is not an iterator
 LL |     for _ in &mut &mut v {}
    |              ^^^^^^^^^^^ `Vec<i32>` is not an iterator; try calling `.into_iter()` or `.iter()`
    |
-   = help: the trait `Iterator` is not implemented for `Vec<i32>`
+   = help: the trait `Iterator` is not implemented for `Vec<i32>`, which is required by `&mut &mut &mut &mut Vec<i32>: IntoIterator`
    = note: required for `&mut Vec<i32>` to implement `Iterator`
    = note: 3 redundant requirements hidden
    = note: required for `&mut &mut &mut &mut Vec<i32>` to implement `Iterator`
@@ -21,7 +21,7 @@ error[E0277]: `[u8; 1]` is not an iterator
 LL |     for _ in &mut v {}
    |              ^^^^^^ `[u8; 1]` is not an iterator; try calling `.into_iter()` or `.iter()`
    |
-   = help: the trait `Iterator` is not implemented for `[u8; 1]`
+   = help: the trait `Iterator` is not implemented for `[u8; 1]`, which is required by `&mut &mut &mut [u8; 1]: IntoIterator`
    = note: required for `&mut [u8; 1]` to implement `Iterator`
    = note: 2 redundant requirements hidden
    = note: required for `&mut &mut &mut [u8; 1]` to implement `Iterator`

--- a/tests/ui/sync/mutexguard-sync.stderr
+++ b/tests/ui/sync/mutexguard-sync.stderr
@@ -6,7 +6,7 @@ LL |     test_sync(guard);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Sync` is not implemented for `Cell<i32>`
+   = help: the trait `Sync` is not implemented for `Cell<i32>`, which is required by `MutexGuard<'_, Cell<i32>>: Sync`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock` or `std::sync::atomic::AtomicI32` instead
    = note: required for `MutexGuard<'_, Cell<i32>>` to implement `Sync`
 note: required by a bound in `test_sync`

--- a/tests/ui/traits/alias/cross-crate.stderr
+++ b/tests/ui/traits/alias/cross-crate.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Rc<u32>` cannot be sent between threads safely
 LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `Rc<u32>`
+   = help: the trait `Send` is not implemented for `Rc<u32>`, which is required by `Rc<u32>: SendSync`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17
@@ -18,7 +18,7 @@ error[E0277]: `Rc<u32>` cannot be shared between threads safely
 LL |     use_alias::<Rc<u32>>();
    |                 ^^^^^^^ `Rc<u32>` cannot be shared between threads safely
    |
-   = help: the trait `Sync` is not implemented for `Rc<u32>`
+   = help: the trait `Sync` is not implemented for `Rc<u32>`, which is required by `Rc<u32>: SendSync`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17

--- a/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.stderr
+++ b/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.stderr
@@ -6,7 +6,7 @@ LL |     f(())
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Iterator` is not implemented for `()`
+   = help: the trait `Iterator` is not implemented for `()`, which is required by `(): IteratorAlias`
    = note: required for `()` to implement `IteratorAlias`
 note: required by a bound in `f`
   --> $DIR/issue-108072-unmet-trait-alias-bound.rs:7:14

--- a/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
+++ b/tests/ui/traits/bound/assoc-fn-bound-root-obligation.stderr
@@ -4,7 +4,7 @@ error[E0277]: expected a `FnMut(char)` closure, found `u8`
 LL |     s.strip_suffix(b'\n').unwrap_or(s)
    |       ^^^^^^^^^^^^ expected an `FnMut(char)` closure, found `u8`
    |
-   = help: the trait `FnMut<(char,)>` is not implemented for `u8`
+   = help: the trait `FnMut<(char,)>` is not implemented for `u8`, which is required by `u8: Pattern<'_>`
    = help: the following other types implement trait `Pattern<'a>`:
              char
              [char; N]

--- a/tests/ui/traits/copy-impl-cannot-normalize.stderr
+++ b/tests/ui/traits/copy-impl-cannot-normalize.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: TraitFoo` is not satisfied
   --> $DIR/copy-impl-cannot-normalize.rs:22:18
    |
 LL | impl<T> Copy for Foo<T> {}
-   |                  ^^^^^^ the trait `TraitFoo` is not implemented for `T`
+   |                  ^^^^^^ the trait `TraitFoo` is not implemented for `T`, which is required by `Foo<T>: Clone`
    |
 note: required for `Foo<T>` to implement `Clone`
   --> $DIR/copy-impl-cannot-normalize.rs:12:9

--- a/tests/ui/traits/dont-autoderef-ty-with-escaping-var.stderr
+++ b/tests/ui/traits/dont-autoderef-ty-with-escaping-var.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `for<'a> &'a mut Vec<&'a u32>: Foo<'static, i32>` 
   --> $DIR/dont-autoderef-ty-with-escaping-var.rs:17:6
    |
 LL |     <i32 as RefFoo<i32>>::ref_foo(unknown);
-   |      ^^^ the trait `for<'a> Foo<'static, i32>` is not implemented for `&'a mut Vec<&'a u32>`
+   |      ^^^ the trait `for<'a> Foo<'static, i32>` is not implemented for `&'a mut Vec<&'a u32>`, which is required by `i32: RefFoo<i32>`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/dont-autoderef-ty-with-escaping-var.rs:3:1

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `NoClone: Copy` is not satisfied
   --> $DIR/supertrait-auto-trait.rs:16:23
    |
 LL |     let (a, b) = copy(NoClone);
-   |                  ---- ^^^^^^^ the trait `Copy` is not implemented for `NoClone`
+   |                  ---- ^^^^^^^ the trait `Copy` is not implemented for `NoClone`, which is required by `NoClone: Magic`
    |                  |
    |                  required by a bound introduced by this call
    |

--- a/tests/ui/traits/issue-43784-supertrait.stderr
+++ b/tests/ui/traits/issue-43784-supertrait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/issue-43784-supertrait.rs:8:22
    |
 LL | impl<T> Complete for T {}
-   |                      ^ the trait `Copy` is not implemented for `T`
+   |                      ^ the trait `Copy` is not implemented for `T`, which is required by `T: Partial`
    |
 note: required for `T` to implement `Partial`
   --> $DIR/issue-43784-supertrait.rs:1:11

--- a/tests/ui/traits/issue-7013.stderr
+++ b/tests/ui/traits/issue-7013.stderr
@@ -4,7 +4,7 @@ error[E0277]: `Rc<RefCell<A>>` cannot be sent between threads safely
 LL |     let a = A {v: Box::new(B{v: None}) as Box<dyn Foo + Send>};
    |                   ^^^^^^^^^^^^^^^^^^^^ `Rc<RefCell<A>>` cannot be sent between threads safely
    |
-   = help: within `B`, the trait `Send` is not implemented for `Rc<RefCell<A>>`
+   = help: within `B`, the trait `Send` is not implemented for `Rc<RefCell<A>>`, which is required by `B: Send`
 note: required because it appears within the type `Option<Rc<RefCell<A>>>`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 note: required because it appears within the type `B`

--- a/tests/ui/traits/issue-71036.stderr
+++ b/tests/ui/traits/issue-71036.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&'a T: Unsize<&'a U>` is not satisfied
   --> $DIR/issue-71036.rs:11:1
    |
 LL | impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Foo<'a, U>> for Foo<'a, T> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unsize<&'a U>` is not implemented for `&'a T`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Unsize<&'a U>` is not implemented for `&'a T`, which is required by `&'a &'a T: DispatchFromDyn<&'a &'a U>`
    |
    = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
    = note: required for `&'a &'a T` to implement `DispatchFromDyn<&'a &'a U>`

--- a/tests/ui/traits/issue-71136.stderr
+++ b/tests/ui/traits/issue-71136.stderr
@@ -5,7 +5,7 @@ LL | #[derive(Clone)]
    |          ----- in this derive macro expansion
 LL | struct FooHolster {
 LL |     the_foos: Vec<Foo>,
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Foo`
+   |     ^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Foo`, which is required by `Vec<Foo>: Clone`
    |
    = note: required for `Vec<Foo>` to implement `Clone`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/traits/issue-91594.stderr
+++ b/tests/ui/traits/issue-91594.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Foo: HasComponent<()>` is not satisfied
   --> $DIR/issue-91594.rs:10:19
    |
 LL | impl HasComponent<<Foo as Component<Foo>>::Interface> for Foo {}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasComponent<()>` is not implemented for `Foo`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasComponent<()>` is not implemented for `Foo`, which is required by `Foo: Component<Foo>`
    |
    = help: the trait `HasComponent<<Foo as Component<Foo>>::Interface>` is implemented for `Foo`
 note: required for `Foo` to implement `Component<Foo>`

--- a/tests/ui/traits/issue-97576.stderr
+++ b/tests/ui/traits/issue-97576.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `String: From<impl ToString>` is not satisfied
   --> $DIR/issue-97576.rs:8:22
    |
 LL |             bar: bar.into(),
-   |                      ^^^^ the trait `From<impl ToString>` is not implemented for `String`
+   |                      ^^^^ the trait `From<impl ToString>` is not implemented for `String`, which is required by `impl ToString: Into<_>`
    |
    = note: required for `impl ToString` to implement `Into<String>`
 

--- a/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
+++ b/tests/ui/traits/negative-impls/negated-auto-traits-error.stderr
@@ -49,7 +49,7 @@ LL |     is_send((8, TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`
+   = help: within `({integer}, dummy1c::TestType)`, the trait `Send` is not implemented for `dummy1c::TestType`, which is required by `({integer}, dummy1c::TestType): Send`
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
 note: required by a bound in `is_send`
   --> $DIR/negated-auto-traits-error.rs:16:15
@@ -87,7 +87,7 @@ LL |     is_send(Box::new(Outer2(TestType)));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`
+   = help: within `Outer2<dummy3::TestType>`, the trait `Send` is not implemented for `dummy3::TestType`, which is required by `Box<Outer2<dummy3::TestType>>: Send`
 note: required because it appears within the type `Outer2<dummy3::TestType>`
   --> $DIR/negated-auto-traits-error.rs:12:8
    |
@@ -110,7 +110,7 @@ LL |     is_sync(Outer2(TestType));
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Send` is not implemented for `main::TestType`
+   = help: the trait `Send` is not implemented for `main::TestType`, which is required by `Outer2<main::TestType>: Sync`
 note: required for `Outer2<main::TestType>` to implement `Sync`
   --> $DIR/negated-auto-traits-error.rs:14:22
    |

--- a/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
+++ b/tests/ui/traits/non_lifetime_binders/bad-sized-cond.stderr
@@ -29,7 +29,7 @@ error[E0277]: `V` is not an iterator
 LL |     bar();
    |     ^^^^^ `V` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `V`
+   = help: the trait `Iterator` is not implemented for `V`, which is required by `V: IntoIterator`
    = note: required for `V` to implement `IntoIterator`
 note: required by a bound in `bar`
   --> $DIR/bad-sized-cond.rs:12:15
@@ -46,7 +46,7 @@ error[E0277]: the size for values of type `V` cannot be known at compilation tim
 LL |     bar();
    |     ^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `V`
+   = help: the trait `Sized` is not implemented for `V`, which is required by `V: IntoIterator`
    = note: required for `V` to implement `IntoIterator`
 note: required by a bound in `bar`
   --> $DIR/bad-sized-cond.rs:12:15

--- a/tests/ui/traits/question-mark-result-err-mismatch.stderr
+++ b/tests/ui/traits/question-mark-result-err-mismatch.stderr
@@ -11,7 +11,7 @@ LL | |             e;
 LL | |         })
    | |__________- this can't be annotated with `?` because it has type `Result<_, ()>`
 LL |           .map(|()| "")?;
-   |                        ^ the trait `From<()>` is not implemented for `String`
+   |                        ^ the trait `From<()>` is not implemented for `String`, which is required by `Result<String, String>: FromResidual<Result<Infallible, ()>>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = note: required for `Result<String, String>` to implement `FromResidual<Result<Infallible, ()>>`
@@ -25,7 +25,7 @@ LL |     let x = foo();
    |             ----- this has type `Result<_, String>`
 ...
 LL |         .map_err(|_| ())?;
-   |          ---------------^ the trait `From<()>` is not implemented for `String`
+   |          ---------------^ the trait `From<()>` is not implemented for `String`, which is required by `Result<(), String>: FromResidual<Result<Infallible, ()>>`
    |          |
    |          this can't be annotated with `?` because it has type `Result<_, ()>`
    |
@@ -50,7 +50,7 @@ LL |           .ok_or_else(|| {
 LL | |             "Couldn't split the test string";
    | |                                             - help: remove this semicolon
 LL | |         })?;
-   | |          -^ the trait `From<()>` is not implemented for `String`
+   | |          -^ the trait `From<()>` is not implemented for `String`, which is required by `Result<String, String>: FromResidual<Result<Infallible, ()>>`
    | |__________|
    |            this can't be annotated with `?` because it has type `Result<_, ()>`
    |

--- a/tests/ui/traits/suggest-dereferences/dont-suggest-unsize-deref.stderr
+++ b/tests/ui/traits/suggest-dereferences/dont-suggest-unsize-deref.stderr
@@ -6,7 +6,7 @@ LL |     use_iterator(i);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Iterator` is not implemented for `&dyn IntoIterator<IntoIter = I, Item = i32>`
+   = help: the trait `Iterator` is not implemented for `&dyn IntoIterator<IntoIter = I, Item = i32>`, which is required by `&dyn IntoIterator<IntoIter = I, Item = i32>: IntoIterator`
    = note: required for `&dyn IntoIterator<IntoIter = I, Item = i32>` to implement `IntoIterator`
 note: required by a bound in `use_iterator`
   --> $DIR/dont-suggest-unsize-deref.rs:3:8

--- a/tests/ui/traits/suggest-dereferences/issue-39029.stderr
+++ b/tests/ui/traits/suggest-dereferences/issue-39029.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NoToSocketAddrs: ToSocketAddrs` is not satisfied
   --> $DIR/issue-39029.rs:16:38
    |
 LL |     let _errors = TcpListener::bind(&bad);
-   |                   -----------------  ^^^ the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`
+   |                   -----------------  ^^^ the trait `ToSocketAddrs` is not implemented for `NoToSocketAddrs`, which is required by `&NoToSocketAddrs: ToSocketAddrs`
    |                   |
    |                   required by a bound introduced by this call
    |

--- a/tests/ui/traits/suggest-dereferences/root-obligation.stderr
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.stderr
@@ -6,7 +6,7 @@ LL |         .filter(|c| "aeiou".contains(c))
    |                             |
    |                             required by a bound introduced by this call
    |
-   = help: the trait `Fn<(char,)>` is not implemented for `char`
+   = help: the trait `Fn<(char,)>` is not implemented for `char`, which is required by `&char: Pattern<'_>`
    = note: required for `&char` to implement `FnOnce<(char,)>`
    = note: required for `&char` to implement `Pattern<'_>`
 note: required by a bound in `core::str::<impl str>::contains`

--- a/tests/ui/traits/suggest-dereferences/suggest-dereferencing-receiver-argument.stderr
+++ b/tests/ui/traits/suggest-dereferences/suggest-dereferencing-receiver-argument.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `TargetStruct: From<&{integer}>` is not satisfied
   --> $DIR/suggest-dereferencing-receiver-argument.rs:13:30
    |
 LL |     let _b: TargetStruct = a.into();
-   |                              ^^^^ the trait `From<&{integer}>` is not implemented for `TargetStruct`
+   |                              ^^^^ the trait `From<&{integer}>` is not implemented for `TargetStruct`, which is required by `&{integer}: Into<_>`
    |
    = note: required for `&{integer}` to implement `Into<TargetStruct>`
 help: consider dereferencing here

--- a/tests/ui/traits/unsend-future.stderr
+++ b/tests/ui/traits/unsend-future.stderr
@@ -4,7 +4,7 @@ error: future cannot be sent between threads safely
 LL |     require_handler(handler)
    |                     ^^^^^^^ future returned by `handler` is not `Send`
    |
-   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`
+   = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i32`, which is required by `fn() -> impl Future<Output = ()> {handler}: Handler`
 note: future is not `Send` as this value is used across an await
   --> $DIR/unsend-future.rs:15:14
    |

--- a/tests/ui/try-block/try-block-bad-type.stderr
+++ b/tests/ui/try-block/try-block-bad-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: `?` couldn't convert the error to `TryFromSliceError`
   --> $DIR/try-block-bad-type.rs:7:16
    |
 LL |         Err("")?;
-   |         -------^ the trait `From<&str>` is not implemented for `TryFromSliceError`
+   |         -------^ the trait `From<&str>` is not implemented for `TryFromSliceError`, which is required by `Result<u32, TryFromSliceError>: FromResidual<Result<Infallible, &str>>`
    |         |
    |         this can't be annotated with `?` because it has type `Result<_, &str>`
    |

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -4,7 +4,7 @@ error[E0277]: `?` couldn't convert the error to `u8`
 LL | fn result_to_result() -> Result<u64, u8> {
    |                          --------------- expected `u8` because of this
 LL |     Ok(Err(123_i32)?)
-   |        ------------^ the trait `From<i32>` is not implemented for `u8`
+   |        ------------^ the trait `From<i32>` is not implemented for `u8`, which is required by `Result<u64, u8>: FromResidual<Result<Infallible, i32>>`
    |        |
    |        this can't be annotated with `?` because it has type `Result<_, i32>`
    |

--- a/tests/ui/try-trait/issue-32709.stderr
+++ b/tests/ui/try-trait/issue-32709.stderr
@@ -4,7 +4,7 @@ error[E0277]: `?` couldn't convert the error to `()`
 LL | fn a() -> Result<i32, ()> {
    |           --------------- expected `()` because of this
 LL |     Err(5)?;
-   |     ------^ the trait `From<{integer}>` is not implemented for `()`
+   |     ------^ the trait `From<{integer}>` is not implemented for `()`, which is required by `Result<i32, ()>: FromResidual<Result<Infallible, {integer}>>`
    |     |
    |     this can't be annotated with `?` because it has type `Result<_, {integer}>`
    |

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage2.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage2.stderr
@@ -9,7 +9,7 @@ LL |     is_send(m::foo());
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `Foo`, the trait `Send` is not implemented for `Rc<u32>`
+   = help: within `Foo`, the trait `Send` is not implemented for `Rc<u32>`, which is required by `Foo: Send`
 note: required because it appears within the type `Foo`
   --> $DIR/auto-trait-leakage2.rs:7:16
    |

--- a/tests/ui/type-alias-impl-trait/issue-90400-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-90400-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `B: Bar` is not satisfied
   --> $DIR/issue-90400-2.rs:25:9
    |
 LL |         MyBaz(bar)
-   |         ^^^^^^^^^^ the trait `Bar` is not implemented for `B`
+   |         ^^^^^^^^^^ the trait `Bar` is not implemented for `B`, which is required by `MyBaz<B>: Baz`
    |
 note: required for `MyBaz<B>` to implement `Baz`
   --> $DIR/issue-90400-2.rs:30:14

--- a/tests/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
+++ b/tests/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&'static B: From<&A>` is not satisfied
   --> $DIR/multiple-def-uses-in-one-fn.rs:9:45
    |
 LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
-   |                                             ^^^^^^^^^^^^^^^^^^ the trait `From<&A>` is not implemented for `&'static B`
+   |                                             ^^^^^^^^^^^^^^^^^^ the trait `From<&A>` is not implemented for `&'static B`, which is required by `&A: Into<&'static B>`
    |
    = note: required for `&A` to implement `Into<&'static B>`
 help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement

--- a/tests/ui/type-alias-impl-trait/underconstrained_generic.stderr
+++ b/tests/ui/type-alias-impl-trait/underconstrained_generic.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/underconstrained_generic.rs:22:5
    |
 LL |     ()
-   |     ^^ the trait `Trait` is not implemented for `T`
+   |     ^^ the trait `Trait` is not implemented for `T`, which is required by `(): ProofForConversion<T>`
    |
 note: required for `()` to implement `ProofForConversion<T>`
   --> $DIR/underconstrained_generic.rs:13:16

--- a/tests/ui/type/issue-58355.stderr
+++ b/tests/ui/type/issue-58355.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `dyn ToString` cannot be known at comp
 LL |     x = Some(Box::new(callback));
    |              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `fn() -> dyn ToString`, the trait `Sized` is not implemented for `dyn ToString`
+   = help: within `fn() -> dyn ToString`, the trait `Sized` is not implemented for `dyn ToString`, which is required by `fn() -> dyn ToString: Fn()`
    = note: required because it appears within the type `fn() -> dyn ToString`
    = note: required for the cast from `Box<fn() -> dyn ToString>` to `Box<dyn Fn() -> (dyn ToString + 'static)>`
 

--- a/tests/ui/typeck/bad-index-due-to-nested.stderr
+++ b/tests/ui/typeck/bad-index-due-to-nested.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `K: Hash` is not satisfied
   --> $DIR/bad-index-due-to-nested.rs:20:5
    |
 LL |     map[k]
-   |     ^^^ the trait `Hash` is not implemented for `K`
+   |     ^^^ the trait `Hash` is not implemented for `K`, which is required by `HashMap<_, _>: Index<&_>`
    |
 note: required for `HashMap<K, V>` to implement `Index<&K>`
   --> $DIR/bad-index-due-to-nested.rs:7:12
@@ -21,7 +21,7 @@ error[E0277]: the trait bound `V: Copy` is not satisfied
   --> $DIR/bad-index-due-to-nested.rs:20:5
    |
 LL |     map[k]
-   |     ^^^ the trait `Copy` is not implemented for `V`
+   |     ^^^ the trait `Copy` is not implemented for `V`, which is required by `HashMap<_, _>: Index<&_>`
    |
 note: required for `HashMap<K, V>` to implement `Index<&K>`
   --> $DIR/bad-index-due-to-nested.rs:7:12

--- a/tests/ui/typeck/issue-90101.stderr
+++ b/tests/ui/typeck/issue-90101.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `PathBuf: From<Cow<'_, str>>` is not satisfied
   --> $DIR/issue-90101.rs:6:10
    |
 LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
-   |     ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<Cow<'_, str>>` is not implemented for `PathBuf`
+   |     ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<Cow<'_, str>>` is not implemented for `PathBuf`, which is required by `Cow<'_, str>: Into<PathBuf>`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -17,7 +17,7 @@ error[E0277]: `UnsafeCell<u8>` cannot be shared between threads safely
 LL |     is_sync::<MyTypeWUnsafe>();
    |               ^^^^^^^^^^^^^ `UnsafeCell<u8>` cannot be shared between threads safely
    |
-   = help: within `MyTypeWUnsafe`, the trait `Sync` is not implemented for `UnsafeCell<u8>`
+   = help: within `MyTypeWUnsafe`, the trait `Sync` is not implemented for `UnsafeCell<u8>`, which is required by `MyTypeWUnsafe: Sync`
 note: required because it appears within the type `MyTypeWUnsafe`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:21:8
    |
@@ -35,7 +35,7 @@ error[E0277]: `Managed` cannot be shared between threads safely
 LL |     is_sync::<MyTypeManaged>();
    |               ^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
-   = help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`
+   = help: within `MyTypeManaged`, the trait `Sync` is not implemented for `Managed`, which is required by `MyTypeManaged: Sync`
 note: required because it appears within the type `MyTypeManaged`
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:25:8
    |

--- a/tests/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/tests/ui/typeck/typeck-unsafe-always-share.stderr
@@ -36,7 +36,7 @@ LL |     test(ms);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: within `MySync<NoSync>`, the trait `Sync` is not implemented for `UnsafeCell<NoSync>`
+   = help: within `MySync<NoSync>`, the trait `Sync` is not implemented for `UnsafeCell<NoSync>`, which is required by `MySync<NoSync>: Sync`
 note: required because it appears within the type `MySync<NoSync>`
   --> $DIR/typeck-unsafe-always-share.rs:8:8
    |

--- a/tests/ui/union/projection-as-union-type-error-2.stderr
+++ b/tests/ui/union/projection-as-union-type-error-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u8: NotImplemented` is not satisfied
   --> $DIR/projection-as-union-type-error-2.rs:18:8
    |
 LL |     a: <Foo as Identity>::Identity,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotImplemented` is not implemented for `u8`
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotImplemented` is not implemented for `u8`, which is required by `u8: Identity`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/projection-as-union-type-error-2.rs:9:1

--- a/tests/ui/unsized-locals/issue-50940-with-feature.stderr
+++ b/tests/ui/unsized-locals/issue-50940-with-feature.stderr
@@ -13,7 +13,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
 LL |     A as fn(str) -> A<str>;
    |     ^ doesn't have a size known at compile-time
    |
-   = help: within `A<str>`, the trait `Sized` is not implemented for `str`
+   = help: within `A<str>`, the trait `Sized` is not implemented for `str`, which is required by `A<str>: Sized`
 note: required because it appears within the type `A<str>`
   --> $DIR/issue-50940-with-feature.rs:5:12
    |

--- a/tests/ui/unsized-locals/rust-call.stderr
+++ b/tests/ui/unsized-locals/rust-call.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     f(*slice);
    |       ^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `([u8],)`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `([u8],)`, the trait `Sized` is not implemented for `[u8]`, which is required by `([u8],): Sized`
    = note: required because it appears within the type `([u8],)`
    = note: argument required to be sized due to `extern "rust-call"` ABI
 

--- a/tests/ui/unsized-locals/unsized-exprs.stderr
+++ b/tests/ui/unsized-locals/unsized-exprs.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     udrop::<(i32, [u8])>((42, *foo()));
    |                          ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `({integer}, [u8])`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `({integer}, [u8])`, the trait `Sized` is not implemented for `[u8]`, which is required by `({integer}, [u8]): Sized`
    = note: required because it appears within the type `({integer}, [u8])`
    = note: tuples must have a statically known size to be initialized
 
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     udrop::<A<[u8]>>(A { 0: *foo() });
    |                      ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `A<[u8]>`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `A<[u8]>`, the trait `Sized` is not implemented for `[u8]`, which is required by `A<[u8]>: Sized`
 note: required because it appears within the type `A<[u8]>`
   --> $DIR/unsized-exprs.rs:3:8
    |
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `[u8]` cannot be known at compilation 
 LL |     udrop::<A<[u8]>>(A(*foo()));
    |                      ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `A<[u8]>`, the trait `Sized` is not implemented for `[u8]`
+   = help: within `A<[u8]>`, the trait `Sized` is not implemented for `[u8]`, which is required by `A<[u8]>: Sized`
 note: required because it appears within the type `A<[u8]>`
   --> $DIR/unsized-exprs.rs:3:8
    |

--- a/tests/ui/unsized/unsized-enum2.stderr
+++ b/tests/ui/unsized/unsized-enum2.stderr
@@ -320,7 +320,7 @@ error[E0277]: the size for values of type `(dyn PathHelper1 + 'static)` cannot b
 LL |     VI(Path1),
    |        ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path1`, the trait `Sized` is not implemented for `(dyn PathHelper1 + 'static)`
+   = help: within `Path1`, the trait `Sized` is not implemented for `(dyn PathHelper1 + 'static)`, which is required by `Path1: Sized`
 note: required because it appears within the type `Path1`
   --> $DIR/unsized-enum2.rs:16:8
    |
@@ -343,7 +343,7 @@ error[E0277]: the size for values of type `(dyn PathHelper2 + 'static)` cannot b
 LL |     VJ{x: Path2},
    |           ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path2`, the trait `Sized` is not implemented for `(dyn PathHelper2 + 'static)`
+   = help: within `Path2`, the trait `Sized` is not implemented for `(dyn PathHelper2 + 'static)`, which is required by `Path2: Sized`
 note: required because it appears within the type `Path2`
   --> $DIR/unsized-enum2.rs:17:8
    |
@@ -366,7 +366,7 @@ error[E0277]: the size for values of type `(dyn PathHelper3 + 'static)` cannot b
 LL |     VK(isize, Path3),
    |               ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path3`, the trait `Sized` is not implemented for `(dyn PathHelper3 + 'static)`
+   = help: within `Path3`, the trait `Sized` is not implemented for `(dyn PathHelper3 + 'static)`, which is required by `Path3: Sized`
 note: required because it appears within the type `Path3`
   --> $DIR/unsized-enum2.rs:18:8
    |
@@ -389,7 +389,7 @@ error[E0277]: the size for values of type `(dyn PathHelper4 + 'static)` cannot b
 LL |     VL{u: isize, x: Path4},
    |                     ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path4`, the trait `Sized` is not implemented for `(dyn PathHelper4 + 'static)`
+   = help: within `Path4`, the trait `Sized` is not implemented for `(dyn PathHelper4 + 'static)`, which is required by `Path4: Sized`
 note: required because it appears within the type `Path4`
   --> $DIR/unsized-enum2.rs:19:8
    |

--- a/tests/ui/wf/hir-wf-check-erase-regions.stderr
+++ b/tests/ui/wf/hir-wf-check-erase-regions.stderr
@@ -4,7 +4,7 @@ error[E0277]: `&'a T` is not an iterator
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&'a T`
+   = help: the trait `Iterator` is not implemented for `&'a T`, which is required by `Flatten<std::slice::Iter<'a, T>>: Iterator`
    = help: the trait `Iterator` is implemented for `&mut I`
    = note: required for `Flatten<std::slice::Iter<'a, T>>` to implement `Iterator`
 note: required by a bound in `std::iter::IntoIterator::IntoIter`
@@ -16,7 +16,7 @@ error[E0277]: `&'a T` is not an iterator
 LL |     type IntoIter = std::iter::Flatten<std::slice::Iter<'a, T>>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&'a T`
+   = help: the trait `Iterator` is not implemented for `&'a T`, which is required by `&'a T: IntoIterator`
    = help: the trait `Iterator` is implemented for `&mut I`
    = note: required for `&'a T` to implement `IntoIterator`
 note: required by a bound in `Flatten`
@@ -28,7 +28,7 @@ error[E0277]: `&'a T` is not an iterator
 LL |     fn into_iter(self) -> Self::IntoIter {
    |                           ^^^^^^^^^^^^^^ `&'a T` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `&'a T`
+   = help: the trait `Iterator` is not implemented for `&'a T`, which is required by `&'a T: IntoIterator`
    = help: the trait `Iterator` is implemented for `&mut I`
    = note: required for `&'a T` to implement `IntoIterator`
 note: required by a bound in `Flatten`

--- a/tests/ui/wf/wf-const-type.stderr
+++ b/tests/ui/wf/wf-const-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:12
    |
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`, which is required by `Option<NotCopy>: Copy`
    |
    = note: required for `Option<NotCopy>` to implement `Copy`
 note: required by a bound in `IsCopy`
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:50
    |
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
-   |                                                  ^^^^ the trait `Copy` is not implemented for `NotCopy`
+   |                                                  ^^^^ the trait `Copy` is not implemented for `NotCopy`, which is required by `Option<NotCopy>: Copy`
    |
    = note: required for `Option<NotCopy>` to implement `Copy`
 note: required by a bound in `IsCopy`

--- a/tests/ui/wf/wf-static-type.stderr
+++ b/tests/ui/wf/wf-static-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:13
    |
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `NotCopy`, which is required by `Option<NotCopy>: Copy`
    |
    = note: required for `Option<NotCopy>` to implement `Copy`
 note: required by a bound in `IsCopy`
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `NotCopy: Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:51
    |
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
-   |                                                   ^^^^ the trait `Copy` is not implemented for `NotCopy`
+   |                                                   ^^^^ the trait `Copy` is not implemented for `NotCopy`, which is required by `Option<NotCopy>: Copy`
    |
    = note: required for `Option<NotCopy>` to implement `Copy`
 note: required by a bound in `IsCopy`


### PR DESCRIPTION
Expand the primary span of E0277 when the immediate unmet bound is not what the user wrote:

```
error[E0277]: the trait bound `i32: Bar` is not satisfied
 --> f100.rs:6:6
  |
6 |     <i32 as Foo>::foo();
  |      ^^^ the trait `Bar` is not implemented for `i32`, which is required by `i32: Foo`
  |
help: this trait has no implementations, consider adding one
 --> f100.rs:2:1
  |
2 | trait Bar {}
  | ^^^^^^^^^
note: required for `i32` to implement `Foo`
 --> f100.rs:3:14
  |
3 | impl<T: Bar> Foo for T {}
  |         ---  ^^^     ^
  |         |
  |         unsatisfied trait bound introduced here
```

Fix #40120.