### PR TITLE
rustdoc: Correctly handle attribute merge if this is a glob reexport

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -147,6 +147,17 @@ pub(crate) fn clean_doc_module<'tcx>(doc: &DocModule<'tcx>, cx: &mut DocContext<
     )
 }
 
+fn is_glob_import(tcx: TyCtxt<'_>, import_id: LocalDefId) -> bool {
+    if let Some(node) = tcx.opt_hir_node_by_def_id(import_id)
+        && let hir::Node::Item(item) = node
+        && let hir::ItemKind::Use(_, use_kind) = item.kind
+    {
+        use_kind == hir::UseKind::Glob
+    } else {
+        false
+    }
+}
+
 fn generate_item_with_correct_attrs(
     cx: &mut DocContext<'_>,
     kind: ItemKind,
@@ -157,10 +168,17 @@ fn generate_item_with_correct_attrs(
 ) -> Item {
     let target_attrs = inline::load_attrs(cx, def_id);
     let attrs = if let Some(import_id) = import_id {
+        // glob reexports are treated the same as `#[doc(inline)]` items.
+        //
+        // For glob re-exports the item may or may not exist to be re-exported (potentially the cfgs
+        // on the path up until the glob can be removed, and only cfgs on the globbed item itself
+        // matter), for non-inlined re-exports see #85043.
         let is_inline = inline::load_attrs(cx, import_id.to_def_id())
             .lists(sym::doc)
             .get_word_attr(sym::inline)
-            .is_some();
+            .is_some()
+            || (is_glob_import(cx.tcx, import_id)
+                && (cx.render_options.document_hidden || !cx.tcx.is_doc_hidden(def_id)));
         let mut attrs = get_all_import_attributes(cx, import_id, def_id, is_inline);
         add_without_unwanted_attributes(&mut attrs, target_attrs, is_inline, None);
         attrs

--- a/tests/rustdoc/glob-reexport-attribute-merge-120487.rs
+++ b/tests/rustdoc/glob-reexport-attribute-merge-120487.rs
@@ -1,0 +1,32 @@
+// This test ensures that non-glob reexports don't get their attributes merge with
+// the reexported item whereas glob reexports do.
+// Regression test for <https://github.com/rust-lang/rust/issues/120487>.
+
+#![crate_name = "foo"]
+#![feature(doc_cfg)]
+
+// @has 'foo/index.html'
+// There are two items.
+// @count - '//*[@class="item-table"]//div[@class="item-name"]' 2
+// Only one of them should have an attribute.
+// @count - '//*[@class="item-table"]//div[@class="item-name"]/*[@class="stab portability"]' 1
+
+mod a {
+    #[doc(cfg(not(feature = "a")))]
+    #[cfg(not(feature = "a"))]
+    pub struct Test1;
+}
+
+mod b {
+    #[doc(cfg(not(feature = "a")))]
+    #[cfg(not(feature = "a"))]
+    pub struct Test2;
+}
+
+// @has 'foo/struct.Test1.html'
+// @count - '//*[@id="main-content"]/*[@class="item-info"]' 1
+// @has - '//*[@id="main-content"]/*[@class="item-info"]' 'Available on non-crate feature a only.'
+pub use a::*;
+// @has 'foo/struct.Test2.html'
+// @count - '//*[@id="main-content"]/*[@class="item-info"]' 0
+pub use b::Test2;


### PR DESCRIPTION
Fixes #120487.

The regression was introduced in https://github.com/rust-lang/rust/pull/113091. Only non-glob reexports should have been impacted.

cc @Nemo157 
r? @notriddle 