### PR TITLE
add semantic modifier for logical not

### DIFF
--- a/src/tools/rust-analyzer/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/src/tools/rust-analyzer/crates/ide/src/syntax_highlighting/highlight.rs
@@ -106,7 +106,7 @@ fn punctuation(
         }
         (T![!], MACRO_CALL | MACRO_RULES) => HlPunct::MacroBang.into(),
         (T![!], NEVER_TYPE) => HlTag::BuiltinType.into(),
-        (T![!], PREFIX_EXPR) => HlOperator::Logical.into(),
+        (T![!], PREFIX_EXPR) => HlTag::Operator(HlOperator::Logical) | HlMod::Not,
         (T![*], PTR_TYPE) => HlTag::Keyword.into(),
         (T![*], PREFIX_EXPR) => {
             let is_raw_ptr = (|| {

--- a/src/tools/rust-analyzer/crates/ide/src/syntax_highlighting/tags.rs
+++ b/src/tools/rust-analyzer/crates/ide/src/syntax_highlighting/tags.rs
@@ -77,6 +77,8 @@ pub enum HlMod {
     Macro,
     /// Mutable binding.
     Mutable,
+    /// Operator `!`
+    Not,
     /// Used for public items.
     Public,
     /// Immutable reference.
@@ -220,6 +222,7 @@ impl HlMod {
         HlMod::Library,
         HlMod::Macro,
         HlMod::Mutable,
+        HlMod::Not,
         HlMod::Public,
         HlMod::Reference,
         HlMod::Static,
@@ -244,6 +247,7 @@ impl HlMod {
             HlMod::Library => "library",
             HlMod::Macro => "macro",
             HlMod::Mutable => "mutable",
+            HlMod::Not => "not",
             HlMod::Public => "public",
             HlMod::Reference => "reference",
             HlMod::Static => "static",

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/semantic_tokens.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/semantic_tokens.rs
@@ -144,6 +144,7 @@ define_semantic_token_modifiers![
         (LIBRARY, "library"),
         (MACRO_MODIFIER, "macro"),
         (MUTABLE, "mutable"),
+        (NOT, "not"),
         (PUBLIC, "public"),
         (REFERENCE, "reference"),
         (TRAIT_MODIFIER, "trait"),

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -721,6 +721,7 @@ fn semantic_token_type_and_modifiers(
             HlMod::Library => semantic_tokens::LIBRARY,
             HlMod::Macro => semantic_tokens::MACRO_MODIFIER,
             HlMod::Mutable => semantic_tokens::MUTABLE,
+            HlMod::Not => semantic_tokens::NOT,
             HlMod::Public => semantic_tokens::PUBLIC,
             HlMod::Reference => semantic_tokens::REFERENCE,
             HlMod::Static => semantic_tokens::STATIC,


### PR DESCRIPTION
By having a modifier for `!`, I'll be able to highlight it in vscode with more noticable color without affecting the other logical operators.