### PR TITLE
never patterns: It is correct to lower `!` to `_`.

### DIFF
--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -680,8 +680,9 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
                     cx.pattern_arena.alloc_from_iter(pats.into_iter().map(|p| self.lower_pat(p)))
             }
             PatKind::Never => {
-                // FIXME(never_patterns): handle `!` in exhaustiveness. This is a sane default
-                // in the meantime.
+                // A never pattern matches all the values of its type (namely none). Moreover it
+                // must be compatible with other constructors, since we can use `!` on a type like
+                // `Result<!, !>` which has other constructors. Hence we lower it as a wildcard.
                 ctor = Wildcard;
                 fields = &[];
             }


### PR DESCRIPTION
This is just a comment update but a non-trivial one: it is correct to lower `!` patterns as `_`. The reasoning is that `!` matches all the possible values of the type, since the type is empty. Moreover, we do want to warn that the `Err` is redundant in:
```rust
match x {
  !,
  Err(!),
}
```
which is consistent with `!` behaving like a wildcard.

I did try to introduce `Constructor::Never` and it ended up needing to behave exactly like `Constructor::Wildcard`.

r? @compiler-errors 