### PR TITLE
Improve `io::Read::read_buf_exact` error case

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -994,7 +994,10 @@ pub trait Read {
             }
 
             if cursor.written() == prev_written {
-                return Err(Error::new(ErrorKind::UnexpectedEof, "failed to fill buffer"));
+                return Err(error::const_io_error!(
+                    ErrorKind::UnexpectedEof,
+                    "failed to fill whole buffer"
+                ));
             }
         }
 


### PR DESCRIPTION
- Use `const_io_error` instead of `Error::new`
- Use the same message as `read_exact`