### PR TITLE
Store SHOULD_CAPTURE as AtomicU8

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -5,7 +5,7 @@
 use crate::any::Any;
 use crate::collections;
 use crate::panicking;
-use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::atomic::{AtomicU8, Ordering};
 use crate::sync::{Mutex, RwLock};
 use crate::thread::Result;
 
@@ -228,7 +228,7 @@ impl BacktraceStyle {
         if cfg!(feature = "backtrace") { Some(BacktraceStyle::Full) } else { None }
     }
 
-    fn as_usize(self) -> usize {
+    fn as_u8(self) -> u8 {
         match self {
             BacktraceStyle::Short => 1,
             BacktraceStyle::Full => 2,
@@ -236,7 +236,7 @@ impl BacktraceStyle {
         }
     }
 
-    fn from_usize(s: usize) -> Option<Self> {
+    fn from_u8(s: u8) -> Option<Self> {
         Some(match s {
             0 => return None,
             1 => BacktraceStyle::Short,
@@ -251,7 +251,7 @@ impl BacktraceStyle {
 // that backtrace.
 //
 // Internally stores equivalent of an Option<BacktraceStyle>.
-static SHOULD_CAPTURE: AtomicUsize = AtomicUsize::new(0);
+static SHOULD_CAPTURE: AtomicU8 = AtomicU8::new(0);
 
 /// Configure whether the default panic hook will capture and display a
 /// backtrace.
@@ -264,7 +264,7 @@ pub fn set_backtrace_style(style: BacktraceStyle) {
         // If the `backtrace` feature of this crate isn't enabled, skip setting.
         return;
     }
-    SHOULD_CAPTURE.store(style.as_usize(), Ordering::Release);
+    SHOULD_CAPTURE.store(style.as_u8(), Ordering::Release);
 }
 
 /// Checks whether the standard library's panic hook will capture and print a
@@ -296,7 +296,7 @@ pub fn get_backtrace_style() -> Option<BacktraceStyle> {
         // to optimize away callers.
         return None;
     }
-    if let Some(style) = BacktraceStyle::from_usize(SHOULD_CAPTURE.load(Ordering::Acquire)) {
+    if let Some(style) = BacktraceStyle::from_u8(SHOULD_CAPTURE.load(Ordering::Acquire)) {
         return Some(style);
     }
 


### PR DESCRIPTION
`BacktraceStyle` easily fits into a u8, so `SHOULD_CAPTURE`, which is just `Atomic<Option<BacktraceStyle>>`, should be stored as `AtomicU8`