### PR TITLE
add test for try-block-in-match-arm

### DIFF
--- a/tests/ui/try-block/try-block-in-match-arm.rs
+++ b/tests/ui/try-block/try-block-in-match-arm.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags: --edition 2018
+
+#![feature(try_blocks)]
+
+fn main() {
+    let _ = match 1 {
+        1 => try {}
+        _ => Ok::<(), ()>(()),
+    };
+}


### PR DESCRIPTION
This is noted as an implementation concern under the tracking issue for `?` and `try` blocks. (Issue 31436)

Refs: https://github.com/rust-lang/rust/issues/31436