### PR TITLE
`#![feature(inline_const_pat)]` is no longer incomplete

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -496,7 +496,7 @@ declare_features! (
     /// Allow anonymous constants from an inline `const` block
     (unstable, inline_const, "1.49.0", Some(76001)),
     /// Allow anonymous constants from an inline `const` block in pattern position
-    (incomplete, inline_const_pat, "1.58.0", Some(76001)),
+    (unstable, inline_const_pat, "1.58.0", Some(76001)),
     /// Allows using `pointer` and `reference` in intra-doc links
     (unstable, intra_doc_pointers, "1.51.0", Some(80896)),
     // Allows setting the threshold for the `large_assignments` lint.

--- a/tests/ui/consts/invalid-inline-const-in-match-arm.rs
+++ b/tests/ui/consts/invalid-inline-const-in-match-arm.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 
 fn main() {

--- a/tests/ui/consts/invalid-inline-const-in-match-arm.stderr
+++ b/tests/ui/consts/invalid-inline-const-in-match-arm.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const closure in constants
-  --> $DIR/invalid-inline-const-in-match-arm.rs:6:17
+  --> $DIR/invalid-inline-const-in-match-arm.rs:5:17
    |
 LL |         const { (|| {})() } => {}
    |                 ^^^^^^^^^

--- a/tests/ui/half-open-range-patterns/range_pat_interactions0.rs
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions0.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![allow(incomplete_features)]
 #![feature(exclusive_range_pattern)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/inline-const/const-match-pat-generic.rs
+++ b/tests/ui/inline-const/const-match-pat-generic.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter

--- a/tests/ui/inline-const/const-match-pat-generic.stderr
+++ b/tests/ui/inline-const/const-match-pat-generic.stderr
@@ -1,11 +1,11 @@
 error: constant pattern depends on a generic parameter
-  --> $DIR/const-match-pat-generic.rs:8:9
+  --> $DIR/const-match-pat-generic.rs:7:9
    |
 LL |         const { V } => {},
    |         ^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/const-match-pat-generic.rs:20:9
+  --> $DIR/const-match-pat-generic.rs:19:9
    |
 LL |         const { f(V) } => {},
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/inline-const/const-match-pat-inference.rs
+++ b/tests/ui/inline-const/const-match-pat-inference.rs
@@ -1,7 +1,6 @@
 // check-pass
 
 #![feature(inline_const_pat)]
-#![allow(incomplete_features)]
 
 fn main() {
     match 1u64 {

--- a/tests/ui/inline-const/const-match-pat-lifetime-err.rs
+++ b/tests/ui/inline-const/const-match-pat-lifetime-err.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/inline-const/const-match-pat-lifetime-err.stderr
+++ b/tests/ui/inline-const/const-match-pat-lifetime-err.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/const-match-pat-lifetime-err.rs:29:29
+  --> $DIR/const-match-pat-lifetime-err.rs:28:29
    |
 LL | fn match_invariant_ref<'a>() {
    |                        -- lifetime `'a` defined here
@@ -15,7 +15,7 @@ LL | }
    | - `y` dropped here while still borrowed
 
 error: lifetime may not live long enough
-  --> $DIR/const-match-pat-lifetime-err.rs:39:12
+  --> $DIR/const-match-pat-lifetime-err.rs:38:12
    |
 LL | fn match_covariant_ref<'a>() {
    |                        -- lifetime `'a` defined here

--- a/tests/ui/inline-const/const-match-pat-lifetime.rs
+++ b/tests/ui/inline-const/const-match-pat-lifetime.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
 #![feature(inline_const_pat)]

--- a/tests/ui/inline-const/const-match-pat-range.rs
+++ b/tests/ui/inline-const/const-match-pat-range.rs
@@ -1,6 +1,5 @@
 // build-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const_pat, exclusive_range_pattern)]
 
 fn main() {

--- a/tests/ui/inline-const/const-match-pat.rs
+++ b/tests/ui/inline-const/const-match-pat.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 const MMIO_BIT1: u8 = 4;
 const MMIO_BIT2: u8 = 5;

--- a/tests/ui/inline-const/pat-match-fndef.rs
+++ b/tests/ui/inline-const/pat-match-fndef.rs
@@ -1,5 +1,4 @@
 #![feature(inline_const_pat)]
-//~^ WARN the feature `inline_const_pat` is incomplete
 
 fn uwu() {}
 

--- a/tests/ui/inline-const/pat-match-fndef.stderr
+++ b/tests/ui/inline-const/pat-match-fndef.stderr
@@ -1,17 +1,8 @@
-warning: the feature `inline_const_pat` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/pat-match-fndef.rs:1:12
-   |
-LL | #![feature(inline_const_pat)]
-   |            ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
-   = note: `#[warn(incomplete_features)]` on by default
-
 error: `fn() {uwu}` cannot be used in patterns
-  --> $DIR/pat-match-fndef.rs:9:9
+  --> $DIR/pat-match-fndef.rs:8:9
    |
 LL |         const { uwu } => {}
    |         ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/pat-unsafe-err.rs
+++ b/tests/ui/inline-const/pat-unsafe-err.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 
 const unsafe fn require_unsafe() -> usize {

--- a/tests/ui/inline-const/pat-unsafe-err.stderr
+++ b/tests/ui/inline-const/pat-unsafe-err.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `require_unsafe` is unsafe and requires unsafe function or block
-  --> $DIR/pat-unsafe-err.rs:11:13
+  --> $DIR/pat-unsafe-err.rs:10:13
    |
 LL |             require_unsafe();
    |             ^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |             require_unsafe();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `require_unsafe` is unsafe and requires unsafe function or block
-  --> $DIR/pat-unsafe-err.rs:18:13
+  --> $DIR/pat-unsafe-err.rs:17:13
    |
 LL |             require_unsafe()
    |             ^^^^^^^^^^^^^^^^ call to unsafe function

--- a/tests/ui/inline-const/pat-unsafe.rs
+++ b/tests/ui/inline-const/pat-unsafe.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![allow(incomplete_features)]
 #![warn(unused_unsafe)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/inline-const/pat-unsafe.stderr
+++ b/tests/ui/inline-const/pat-unsafe.stderr
@@ -1,17 +1,17 @@
 warning: unnecessary `unsafe` block
-  --> $DIR/pat-unsafe.rs:16:17
+  --> $DIR/pat-unsafe.rs:15:17
    |
 LL |                 unsafe {}
    |                 ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
-  --> $DIR/pat-unsafe.rs:4:9
+  --> $DIR/pat-unsafe.rs:3:9
    |
 LL | #![warn(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
 warning: unnecessary `unsafe` block
-  --> $DIR/pat-unsafe.rs:23:17
+  --> $DIR/pat-unsafe.rs:22:17
    |
 LL |                 unsafe {}
    |                 ^^^^^^ unnecessary `unsafe` block

--- a/tests/ui/lint/dead-code/anon-const-in-pat.rs
+++ b/tests/ui/lint/dead-code/anon-const-in-pat.rs
@@ -1,6 +1,5 @@
 // check-pass
 #![feature(inline_const_pat)]
-#![allow(incomplete_features)]
 #![deny(dead_code)]
 
 const fn one() -> i32 {

--- a/tests/ui/match/issue-112438.rs
+++ b/tests/ui/match/issue-112438.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![feature(inline_const_pat)]
 #![allow(dead_code)]
-#![allow(incomplete_features)]
 fn foo<const V: usize>() {
     match 0 {
         const { 1 << 5 } | _ => {}

--- a/tests/ui/match/validate-range-endpoints.rs
+++ b/tests/ui/match/validate-range-endpoints.rs
@@ -1,6 +1,5 @@
 #![feature(exclusive_range_pattern)]
 #![feature(inline_const_pat)]
-#![allow(incomplete_features)]
 #![allow(overlapping_range_endpoints)]
 
 fn main() {

--- a/tests/ui/match/validate-range-endpoints.stderr
+++ b/tests/ui/match/validate-range-endpoints.stderr
@@ -1,59 +1,59 @@
 error: literal out of range for `u8`
-  --> $DIR/validate-range-endpoints.rs:9:12
+  --> $DIR/validate-range-endpoints.rs:8:12
    |
 LL |         1..257 => {}
    |            ^^^ this value does not fit into the type `u8` whose range is `0..=255`
 
 error: literal out of range for `u8`
-  --> $DIR/validate-range-endpoints.rs:11:13
+  --> $DIR/validate-range-endpoints.rs:10:13
    |
 LL |         1..=256 => {}
    |             ^^^ this value does not fit into the type `u8` whose range is `0..=255`
 
 error[E0030]: lower range bound must be less than or equal to upper
-  --> $DIR/validate-range-endpoints.rs:20:9
+  --> $DIR/validate-range-endpoints.rs:19:9
    |
 LL |         1..=TOO_BIG => {}
    |         ^^^^^^^^^^^ lower bound larger than upper bound
 
 error[E0030]: lower range bound must be less than or equal to upper
-  --> $DIR/validate-range-endpoints.rs:22:9
+  --> $DIR/validate-range-endpoints.rs:21:9
    |
 LL |         1..=const { 256 } => {}
    |         ^^^^^^^^^^^^^^^^^ lower bound larger than upper bound
 
 error: literal out of range for `u64`
-  --> $DIR/validate-range-endpoints.rs:28:32
+  --> $DIR/validate-range-endpoints.rs:27:32
    |
 LL |         10000000000000000000..=99999999999999999999 => {}
    |                                ^^^^^^^^^^^^^^^^^^^^ this value does not fit into the type `u64` whose range is `0..=18446744073709551615`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:34:12
+  --> $DIR/validate-range-endpoints.rs:33:12
    |
 LL |         0..129 => {}
    |            ^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:36:13
+  --> $DIR/validate-range-endpoints.rs:35:13
    |
 LL |         0..=128 => {}
    |             ^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:38:9
+  --> $DIR/validate-range-endpoints.rs:37:9
    |
 LL |         -129..0 => {}
    |         ^^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:40:9
+  --> $DIR/validate-range-endpoints.rs:39:9
    |
 LL |         -10000..=-20 => {}
    |         ^^^^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=-17_i8` and `1_i8..=i8::MAX` not covered
-  --> $DIR/validate-range-endpoints.rs:51:11
+  --> $DIR/validate-range-endpoints.rs:50:11
    |
 LL |     match 0i8 {
    |           ^^^ patterns `i8::MIN..=-17_i8` and `1_i8..=i8::MAX` not covered
@@ -66,7 +66,7 @@ LL +         i8::MIN..=-17_i8 | 1_i8..=i8::MAX => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=-17_i8` not covered
-  --> $DIR/validate-range-endpoints.rs:55:11
+  --> $DIR/validate-range-endpoints.rs:54:11
    |
 LL |     match 0i8 {
    |           ^^^ pattern `i8::MIN..=-17_i8` not covered

--- a/tests/ui/pattern/non-structural-match-types.rs
+++ b/tests/ui/pattern/non-structural-match-types.rs
@@ -1,6 +1,5 @@
 // edition:2021
 
-#![allow(incomplete_features)]
 #![allow(unreachable_code)]
 #![feature(const_async_blocks)]
 #![feature(inline_const_pat)]

--- a/tests/ui/pattern/non-structural-match-types.stderr
+++ b/tests/ui/pattern/non-structural-match-types.stderr
@@ -1,11 +1,11 @@
-error: `{closure@$DIR/non-structural-match-types.rs:10:17: 10:19}` cannot be used in patterns
-  --> $DIR/non-structural-match-types.rs:10:9
+error: `{closure@$DIR/non-structural-match-types.rs:9:17: 9:19}` cannot be used in patterns
+  --> $DIR/non-structural-match-types.rs:9:9
    |
 LL |         const { || {} } => {}
    |         ^^^^^^^^^^^^^^^
 
-error: `{async block@$DIR/non-structural-match-types.rs:13:17: 13:25}` cannot be used in patterns
-  --> $DIR/non-structural-match-types.rs:13:9
+error: `{async block@$DIR/non-structural-match-types.rs:12:17: 12:25}` cannot be used in patterns
+  --> $DIR/non-structural-match-types.rs:12:9
    |
 LL |         const { async {} } => {}
    |         ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/unsafe/const_pat_in_layout_restricted.rs
+++ b/tests/ui/unsafe/const_pat_in_layout_restricted.rs
@@ -2,7 +2,6 @@
 // unsafe because they're within a pattern for a layout constrained stuct.
 // check-pass
 
-#![allow(incomplete_features)]
 #![feature(rustc_attrs)]
 #![feature(inline_const_pat)]
 


### PR DESCRIPTION
Now that borrow checking and safety checking is implemented for inline constant patterns, the incomplete feature status is not necessary. Stabilizing this feature requires more testing and has some of the same unresolved questions as inline constants.

cc #76001