### PR TITLE
rustdoc: Fix handling of doc_auto_cfg feature for cfg attributes on glob reexport

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/re-exports.md
+++ b/src/doc/rustdoc/src/write-documentation/re-exports.md
@@ -170,3 +170,32 @@ There are a few attributes which are not inlined though:
 
 All other attributes are inherited when inlined, so that the documentation matches the behavior if
 the inlined item was directly defined at the spot where it's shown.
+
+These rules also apply if the item is inlined with a glob re-export:
+
+```rust,ignore (inline)
+mod private_mod {
+    /// First
+    #[cfg(a)]
+    pub struct InPrivate;
+}
+
+#[cfg(c)]
+pub use self::private_mod::*;
+```
+
+Otherwise, the attributes displayed will be from the re-exported item and the attributes on the
+re-export itself will be ignored:
+
+```rust,ignore (inline)
+mod private_mod {
+    /// First
+    #[cfg(a)]
+    pub struct InPrivate;
+}
+
+#[cfg(c)]
+pub use self::private_mod::InPrivate;
+```
+
+In the above case, `cfg(c)` will not be displayed in the docs.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2722,7 +2722,7 @@ fn add_without_unwanted_attributes<'hir>(
                     if ident == sym::doc {
                         filter_doc_attr(normal, is_inline);
                         attrs.push((Cow::Owned(attr), import_parent));
-                    } else if ident != sym::cfg {
+                    } else if is_inline || ident != sym::cfg {
                         // If it's not a `cfg()` attribute, we keep it.
                         attrs.push((Cow::Owned(attr), import_parent));
                     }

--- a/tests/rustdoc/glob-reexport-attribute-merge-doc-auto-cfg.rs
+++ b/tests/rustdoc/glob-reexport-attribute-merge-doc-auto-cfg.rs
@@ -1,0 +1,29 @@
+// This test ensures that non-glob reexports don't get their attributes merge with
+// the reexported item whereas glob reexports do with the `doc_auto_cfg` feature.
+
+#![crate_name = "foo"]
+#![feature(doc_auto_cfg)]
+
+// @has 'foo/index.html'
+// There are two items.
+// @count - '//*[@class="item-table"]//div[@class="item-name"]' 2
+// Only one of them should have an attribute.
+// @count - '//*[@class="item-table"]//div[@class="item-name"]/*[@class="stab portability"]' 1
+
+mod a {
+    #[cfg(not(feature = "a"))]
+    pub struct Test1;
+}
+
+mod b {
+    #[cfg(not(feature = "a"))]
+    pub struct Test2;
+}
+
+// @has 'foo/struct.Test1.html'
+// @count - '//*[@id="main-content"]/*[@class="item-info"]' 1
+// @has - '//*[@id="main-content"]/*[@class="item-info"]' 'Available on non-crate feature a only.'
+pub use a::*;
+// @has 'foo/struct.Test2.html'
+// @count - '//*[@id="main-content"]/*[@class="item-info"]' 0
+pub use b::Test2;


### PR DESCRIPTION
This is a follow-up of #120501 and a part of https://github.com/rust-lang/rust/issues/120487.

r? @notriddle 