### PR TITLE
Continue to borrowck even if there were previous errors

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -163,10 +163,6 @@ impl Lifetime {
             (LifetimeSuggestionPosition::Normal, self.ident.span)
         }
     }
-
-    pub fn is_static(&self) -> bool {
-        self.res == LifetimeName::Static
-    }
 }
 
 /// A `Path` is essentially Rust's notion of a name; for instance,

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -9,6 +9,8 @@ use rustc_middle::ty::{self, ImplTraitInTraitData, IsSuggestable, Ty, TyCtxt, Ty
 use rustc_span::symbol::Ident;
 use rustc_span::{Span, DUMMY_SP};
 
+use crate::errors::TypeofReservedKeywordUsed;
+
 use super::bad_placeholder;
 use super::ItemCtxt;
 pub use opaque::test_opaque_hidden_types;
@@ -39,8 +41,18 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
         {
             return tcx.types.usize;
         }
-        Node::Ty(&hir::Ty { kind: TyKind::Typeof(ref e), .. }) if e.hir_id == hir_id => {
-            return tcx.typeck(def_id).node_type(e.hir_id);
+        Node::Ty(&hir::Ty { kind: TyKind::Typeof(ref e), span, .. }) if e.hir_id == hir_id => {
+            let ty = tcx.typeck(def_id).node_type(e.hir_id);
+            let ty = tcx.fold_regions(ty, |r, _| {
+                if r.is_erased() { ty::Region::new_error_misc(tcx) } else { r }
+            });
+            let (ty, opt_sugg) = if let Some(ty) = ty.make_suggestable(tcx, false) {
+                (ty, Some((span, Applicability::MachineApplicable)))
+            } else {
+                (ty, None)
+            };
+            tcx.dcx().emit_err(TypeofReservedKeywordUsed { span, ty, opt_sugg });
+            return ty;
         }
         Node::Expr(&Expr { kind: ExprKind::InlineAsm(asm), .. })
         | Node::Item(&Item { kind: ItemKind::GlobalAsm(asm), .. })

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -209,7 +209,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
 
     tcx.ensure().check_unused_traits(());
 
-    if let Some(reported) = tcx.dcx().has_errors() { Err(reported) } else { Ok(()) }
+    Ok(())
 }
 
 /// A quasi-deprecated helper used in rustdoc and clippy to get

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -59,6 +59,7 @@ fn has_ffi_unwind_calls(tcx: TyCtxt<'_>, local_def_id: LocalDefId) -> bool {
         ty::Closure(..) => Abi::RustCall,
         ty::CoroutineClosure(..) => Abi::RustCall,
         ty::Coroutine(..) => Abi::Rust,
+        ty::Error(_) => return false,
         _ => span_bug!(body.span, "unexpected body ty: {:?}", body_ty),
     };
     let body_can_unwind = layout::fn_can_unwind(tcx, Some(def_id), body_abi);

--- a/src/tools/clippy/clippy_lints/src/lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/lifetimes.rs
@@ -176,7 +176,7 @@ fn check_fn_inner<'tcx>(
                             _ => None,
                         });
                         for bound in lifetimes {
-                            if !bound.is_static() && !bound.is_elided() {
+                            if bound.res != LifetimeName::Static && !bound.is_elided() {
                                 return;
                             }
                         }

--- a/tests/incremental/const-generics/issue-62536.rs
+++ b/tests/incremental/const-generics/issue-62536.rs
@@ -1,4 +1,7 @@
 // revisions:cfail1
+
+#![allow(unused_variables)]
+
 struct S<T, const N: usize>([T; N]);
 
 fn f<T, const N: usize>(x: T) -> S<T, {N}> { panic!() }

--- a/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-77708-1.rs
+++ b/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-77708-1.rs
@@ -1,6 +1,6 @@
 // revisions: cfail
 #![feature(generic_const_exprs)]
-#![allow(incomplete_features, unused_braces)]
+#![allow(incomplete_features, unused_braces, unused_variables)]
 
 trait Delegates<T> {}
 

--- a/tests/incremental/struct_change_field_name.rs
+++ b/tests/incremental/struct_change_field_name.rs
@@ -6,6 +6,7 @@
 // [cfail2] compile-flags: -Z query-dep-graph -Z assert-incr-state=loaded
 
 #![feature(rustc_attrs)]
+#![allow(unused_variables)]
 
 #[cfg(rpass1)]
 pub struct X {

--- a/tests/rustdoc-ui/issues/issue-102986.stderr
+++ b/tests/rustdoc-ui/issues/issue-102986.stderr
@@ -6,8 +6,8 @@ LL |     y: (typeof("hey"),),
    |
 help: consider replacing `typeof(...)` with an actual type
    |
-LL |     y: (&'static str,),
-   |         ~~~~~~~~~~~~
+LL |     y: (&str,),
+   |         ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/asm/bad-template.aarch64.stderr
+++ b/tests/ui/asm/bad-template.aarch64.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:27:15
+  --> $DIR/bad-template.rs:30:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:29:15
+  --> $DIR/bad-template.rs:32:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:29:21
+  --> $DIR/bad-template.rs:32:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:32:16
+  --> $DIR/bad-template.rs:35:16
    |
 LL |         asm!("{a}");
    |                ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:34:15
+  --> $DIR/bad-template.rs:37:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:37:15
+  --> $DIR/bad-template.rs:40:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:37:21
+  --> $DIR/bad-template.rs:40:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:44:15
+  --> $DIR/bad-template.rs:47:15
    |
 LL |         asm!("{}", in("x0") foo);
    |               ^^   ------------ explicit register argument
@@ -77,24 +77,24 @@ LL |         asm!("{}", in("x0") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:44:20
+  --> $DIR/bad-template.rs:47:20
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
 help: use the register name directly in the assembly code
-  --> $DIR/bad-template.rs:44:20
+  --> $DIR/bad-template.rs:47:20
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:46:17
+  --> $DIR/bad-template.rs:49:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:49:18
+  --> $DIR/bad-template.rs:52:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -104,7 +104,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:55:14
+  --> $DIR/bad-template.rs:58:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -112,7 +112,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:57:14
+  --> $DIR/bad-template.rs:60:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -120,7 +120,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:57:20
+  --> $DIR/bad-template.rs:60:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -128,13 +128,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:60:15
+  --> $DIR/bad-template.rs:63:15
    |
 LL | global_asm!("{a}");
    |               ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:62:14
+  --> $DIR/bad-template.rs:65:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -143,13 +143,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -157,7 +157,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:65:14
+  --> $DIR/bad-template.rs:68:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -165,7 +165,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:65:20
+  --> $DIR/bad-template.rs:68:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -173,13 +173,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:68:16
+  --> $DIR/bad-template.rs:71:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:70:17
+  --> $DIR/bad-template.rs:73:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -189,7 +189,7 @@ LL | global_asm!("", const FOO, const FOO);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 warning: formatting may not be suitable for sub-register argument
-  --> $DIR/bad-template.rs:46:15
+  --> $DIR/bad-template.rs:49:15
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument

--- a/tests/ui/asm/bad-template.rs
+++ b/tests/ui/asm/bad-template.rs
@@ -21,6 +21,9 @@ macro_rules! global_asm {
 #[lang = "sized"]
 trait Sized {}
 
+#[lang = "copy"]
+trait Copy {}
+
 fn main() {
     let mut foo = 0;
     unsafe {

--- a/tests/ui/asm/bad-template.x86_64.stderr
+++ b/tests/ui/asm/bad-template.x86_64.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:27:15
+  --> $DIR/bad-template.rs:30:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:29:15
+  --> $DIR/bad-template.rs:32:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:29:21
+  --> $DIR/bad-template.rs:32:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:32:16
+  --> $DIR/bad-template.rs:35:16
    |
 LL |         asm!("{a}");
    |                ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:34:15
+  --> $DIR/bad-template.rs:37:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:37:15
+  --> $DIR/bad-template.rs:40:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:37:21
+  --> $DIR/bad-template.rs:40:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:41:15
+  --> $DIR/bad-template.rs:44:15
    |
 LL |         asm!("{}", in("eax") foo);
    |               ^^   ------------- explicit register argument
@@ -77,24 +77,24 @@ LL |         asm!("{}", in("eax") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:41:20
+  --> $DIR/bad-template.rs:44:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 help: use the register name directly in the assembly code
-  --> $DIR/bad-template.rs:41:20
+  --> $DIR/bad-template.rs:44:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:46:17
+  --> $DIR/bad-template.rs:49:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:49:18
+  --> $DIR/bad-template.rs:52:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -104,7 +104,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:55:14
+  --> $DIR/bad-template.rs:58:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -112,7 +112,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:57:14
+  --> $DIR/bad-template.rs:60:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -120,7 +120,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:57:20
+  --> $DIR/bad-template.rs:60:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -128,13 +128,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:60:15
+  --> $DIR/bad-template.rs:63:15
    |
 LL | global_asm!("{a}");
    |               ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:62:14
+  --> $DIR/bad-template.rs:65:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -143,13 +143,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -157,7 +157,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:65:14
+  --> $DIR/bad-template.rs:68:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -165,7 +165,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:65:20
+  --> $DIR/bad-template.rs:68:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -173,13 +173,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:68:16
+  --> $DIR/bad-template.rs:71:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:70:17
+  --> $DIR/bad-template.rs:73:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -189,7 +189,7 @@ LL | global_asm!("", const FOO, const FOO);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 warning: formatting may not be suitable for sub-register argument
-  --> $DIR/bad-template.rs:46:15
+  --> $DIR/bad-template.rs:49:15
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument

--- a/tests/ui/asm/naked-functions.rs
+++ b/tests/ui/asm/naked-functions.rs
@@ -81,13 +81,15 @@ pub extern "C" fn missing_assembly() {
 #[naked]
 pub extern "C" fn too_many_asm_blocks() {
     //~^ ERROR naked functions must contain a single asm block
-    asm!("");
-    //~^ ERROR asm in naked functions must use `noreturn` option
-    asm!("");
-    //~^ ERROR asm in naked functions must use `noreturn` option
-    asm!("");
-    //~^ ERROR asm in naked functions must use `noreturn` option
-    asm!("", options(noreturn));
+    unsafe {
+        asm!("");
+        //~^ ERROR asm in naked functions must use `noreturn` option
+        asm!("");
+        //~^ ERROR asm in naked functions must use `noreturn` option
+        asm!("");
+        //~^ ERROR asm in naked functions must use `noreturn` option
+        asm!("", options(noreturn));
+    }
 }
 
 pub fn outer(x: u32) -> extern "C" fn(usize) -> usize {

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -1,23 +1,23 @@
 error: asm with the `pure` option must have at least one output
-  --> $DIR/naked-functions.rs:111:14
+  --> $DIR/naked-functions.rs:113:14
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:203:5
+  --> $DIR/naked-functions.rs:205:5
    |
 LL |     compile_error!("this is a user specified error")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:209:5
+  --> $DIR/naked-functions.rs:211:5
    |
 LL |     compile_error!("this is a user specified error");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/naked-functions.rs:216:10
+  --> $DIR/naked-functions.rs:218:10
    |
 LL |     asm!(invalid_syntax)
    |          ^^^^^^^^^^^^^^
@@ -142,37 +142,37 @@ LL | pub extern "C" fn missing_assembly() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:5
+  --> $DIR/naked-functions.rs:85:9
    |
-LL |     asm!("");
-   |     ^^^^^^^^
+LL |         asm!("");
+   |         ^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn));
-   |            +++++++++++++++++++
+LL |         asm!("", options(noreturn));
+   |                +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:86:5
+  --> $DIR/naked-functions.rs:87:9
    |
-LL |     asm!("");
-   |     ^^^^^^^^
+LL |         asm!("");
+   |         ^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn));
-   |            +++++++++++++++++++
+LL |         asm!("", options(noreturn));
+   |                +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:88:5
+  --> $DIR/naked-functions.rs:89:9
    |
-LL |     asm!("");
-   |     ^^^^^^^^
+LL |         asm!("");
+   |         ^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn));
-   |            +++++++++++++++++++
+LL |         asm!("", options(noreturn));
+   |                +++++++++++++++++++
 
 error[E0787]: naked functions must contain a single asm block
   --> $DIR/naked-functions.rs:82:1
@@ -180,17 +180,17 @@ error[E0787]: naked functions must contain a single asm block
 LL | pub extern "C" fn too_many_asm_blocks() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-LL |     asm!("");
-   |     -------- multiple asm blocks are unsupported in naked functions
+LL |         asm!("");
+   |         -------- multiple asm blocks are unsupported in naked functions
 LL |
-LL |     asm!("");
-   |     -------- multiple asm blocks are unsupported in naked functions
+LL |         asm!("");
+   |         -------- multiple asm blocks are unsupported in naked functions
 LL |
-LL |     asm!("", options(noreturn));
-   |     --------------------------- multiple asm blocks are unsupported in naked functions
+LL |         asm!("", options(noreturn));
+   |         --------------------------- multiple asm blocks are unsupported in naked functions
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:97:11
+  --> $DIR/naked-functions.rs:99:11
    |
 LL |         *&y
    |           ^
@@ -198,7 +198,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:95:5
+  --> $DIR/naked-functions.rs:97:5
    |
 LL |     pub extern "C" fn inner(y: usize) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,19 +207,19 @@ LL |         *&y
    |         --- non-asm is unsupported in naked functions
 
 error[E0787]: asm options unsupported in naked functions: `nomem`, `preserves_flags`
-  --> $DIR/naked-functions.rs:105:5
+  --> $DIR/naked-functions.rs:107:5
    |
 LL |     asm!("", options(nomem, preserves_flags, noreturn));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm options unsupported in naked functions: `nostack`, `pure`, `readonly`
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:113:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:113:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,13 +230,13 @@ LL |     asm!("", options(noreturn), options(readonly, nostack), options(pure));
    |            +++++++++++++++++++
 
 error[E0787]: asm options unsupported in naked functions: `may_unwind`
-  --> $DIR/naked-functions.rs:119:5
+  --> $DIR/naked-functions.rs:121:5
    |
 LL |     asm!("", options(noreturn, may_unwind));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:124:1
+  --> $DIR/naked-functions.rs:126:1
    |
 LL | pub unsafe fn default_abi() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,43 +244,43 @@ LL | pub unsafe fn default_abi() {
    = note: `#[warn(undefined_naked_function_abi)]` on by default
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:130:1
+  --> $DIR/naked-functions.rs:132:1
    |
 LL | pub unsafe fn rust_abi() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:170:1
+  --> $DIR/naked-functions.rs:172:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:177:1
+  --> $DIR/naked-functions.rs:179:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:184:1
+  --> $DIR/naked-functions.rs:186:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:191:1
+  --> $DIR/naked-functions.rs:193:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:193:1
+  --> $DIR/naked-functions.rs:195:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:195:1
+  --> $DIR/naked-functions.rs:197:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/associated-types/associated-types-eq-hr.rs
+++ b/tests/ui/associated-types/associated-types-eq-hr.rs
@@ -94,10 +94,18 @@ pub fn call_bar() {
 
 pub fn call_tuple_one() {
     tuple_one::<Tuple>();
+    //~^ ERROR not general enough
+    //~| ERROR not general enough
+    //~| ERROR not general enough
+    //~| ERROR not general enough
 }
 
 pub fn call_tuple_two() {
     tuple_two::<Tuple>();
+    //~^ ERROR not general enough
+    //~| ERROR not general enough
+    //~| ERROR mismatched types
+    //~| ERROR mismatched types
 }
 
 pub fn call_tuple_three() {
@@ -106,6 +114,8 @@ pub fn call_tuple_three() {
 
 pub fn call_tuple_four() {
     tuple_four::<Tuple>();
+    //~^ ERROR not general enough
+    //~| ERROR not general enough
 }
 
 fn main() {}

--- a/tests/ui/associated-types/associated-types-eq-hr.stderr
+++ b/tests/ui/associated-types/associated-types-eq-hr.stderr
@@ -42,6 +42,113 @@ LL | where
 LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `bar`
 
-error: aborting due to 2 previous errors
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
 
-For more information about this error, try `rustc --explain E0271`.
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected reference `&'x _`
+              found reference `&'y _`
+note: the lifetime requirement is introduced here
+  --> $DIR/associated-types-eq-hr.rs:66:53
+   |
+LL |     T: for<'x, 'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>,
+   |                                                     ^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected reference `&'x _`
+              found reference `&'y _`
+note: the lifetime requirement is introduced here
+  --> $DIR/associated-types-eq-hr.rs:66:53
+   |
+LL |     T: for<'x, 'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>,
+   |                                                     ^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:116:5
+   |
+LL |     tuple_four::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:116:5
+   |
+LL |     tuple_four::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/async-await/issue-70935-complex-spans.rs
+++ b/tests/ui/async-await/issue-70935-complex-spans.rs
@@ -14,6 +14,7 @@ async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
 
 fn foo(x: NotSync) -> impl Future + Send {
     //~^ ERROR `*mut ()` cannot be shared between threads safely
+    //~| ERROR `*mut ()` cannot be shared between threads safely
     async move {
         baz(|| async {
             foo(x.clone());

--- a/tests/ui/async-await/issue-70935-complex-spans.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
 LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:17:5: 21:6}: Send`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 22:6}: Send`
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`
@@ -14,7 +14,7 @@ LL | struct NotSync(PhantomData<*mut ()>);
    |        ^^^^^^^
    = note: required for `&NotSync` to implement `Send`
 note: required because it's used within this closure
-  --> $DIR/issue-70935-complex-spans.rs:18:13
+  --> $DIR/issue-70935-complex-spans.rs:19:13
    |
 LL |         baz(|| async {
    |             ^^
@@ -27,7 +27,7 @@ LL | | }
    | |_^
    = note: required because it captures the following types: `impl Future<Output = ()>`
 note: required because it's used within this `async` block
-  --> $DIR/issue-70935-complex-spans.rs:17:5
+  --> $DIR/issue-70935-complex-spans.rs:18:5
    |
 LL | /     async move {
 LL | |         baz(|| async {
@@ -36,6 +36,45 @@ LL | |         }).await;
 LL | |     }
    | |_____^
 
-error: aborting due to 1 previous error
+error[E0277]: `*mut ()` cannot be shared between threads safely
+  --> $DIR/issue-70935-complex-spans.rs:15:23
+   |
+LL | fn foo(x: NotSync) -> impl Future + Send {
+   |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
+   |
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 22:6}: Send`
+note: required because it appears within the type `PhantomData<*mut ()>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+note: required because it appears within the type `NotSync`
+  --> $DIR/issue-70935-complex-spans.rs:9:8
+   |
+LL | struct NotSync(PhantomData<*mut ()>);
+   |        ^^^^^^^
+   = note: required for `&NotSync` to implement `Send`
+note: required because it's used within this closure
+  --> $DIR/issue-70935-complex-spans.rs:19:13
+   |
+LL |         baz(|| async {
+   |             ^^
+note: required because it's used within this `async` fn body
+  --> $DIR/issue-70935-complex-spans.rs:12:67
+   |
+LL |   async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
+   |  ___________________________________________________________________^
+LL | | }
+   | |_^
+   = note: required because it captures the following types: `impl Future<Output = ()>`
+note: required because it's used within this `async` block
+  --> $DIR/issue-70935-complex-spans.rs:18:5
+   |
+LL | /     async move {
+LL | |         baz(|| async {
+LL | |             foo(x.clone());
+LL | |         }).await;
+LL | |     }
+   | |_____^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.rs
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.rs
@@ -6,6 +6,7 @@ auto trait Magic : Sized where Option<Self> : Magic {} //~ ERROR E0568
 impl<T:Magic> Magic for T {}
 
 fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+//~^ ERROR: use of moved value
 
 #[derive(Debug)]
 struct NoClone;

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -14,6 +14,21 @@ LL | auto trait Magic : Sized where Option<Self> : Magic {}
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
-error: aborting due to 2 previous errors
+error[E0382]: use of moved value: `x`
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:8:41
+   |
+LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+   |                   -                  -  ^ value used here after move
+   |                   |                  |
+   |                   |                  value moved here
+   |                   move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |
+help: consider further restricting this bound
+   |
+LL | fn copy<T: Magic + Copy>(x: T) -> (T, T) { (x, x) }
+   |                  ++++++
 
-For more information about this error, try `rustc --explain E0568`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0382, E0568.
+For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/binop/issue-77910-1.rs
+++ b/tests/ui/binop/issue-77910-1.rs
@@ -1,6 +1,6 @@
 fn foo(s: &i32) -> &i32 {
     let xs;
-    xs
+    xs //~ ERROR: isn't initialized
 }
 fn main() {
     let y;

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -22,7 +22,20 @@ LL |     assert_eq!(foo, y);
    = help: use parentheses to call this function: `foo(/* &i32 */)`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error[E0381]: used binding `xs` isn't initialized
+  --> $DIR/issue-77910-1.rs:3:5
+   |
+LL |     let xs;
+   |         -- binding declared here but left uninitialized
+LL |     xs
+   |     ^^ `xs` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let xs = todo!();
+   |            +++++++++
 
-Some errors have detailed explanations: E0277, E0369.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0369, E0381.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/binop/issue-77910-2.rs
+++ b/tests/ui/binop/issue-77910-2.rs
@@ -1,6 +1,6 @@
 fn foo(s: &i32) -> &i32 {
     let xs;
-    xs
+    xs //~ ERROR: isn't initialized
 }
 fn main() {
     let y;

--- a/tests/ui/binop/issue-77910-2.stderr
+++ b/tests/ui/binop/issue-77910-2.stderr
@@ -11,6 +11,20 @@ help: use parentheses to call this function
 LL |     if foo(/* &i32 */) == y {}
    |           ++++++++++++
 
-error: aborting due to 1 previous error
+error[E0381]: used binding `xs` isn't initialized
+  --> $DIR/issue-77910-2.rs:3:5
+   |
+LL |     let xs;
+   |         -- binding declared here but left uninitialized
+LL |     xs
+   |     ^^ `xs` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let xs = todo!();
+   |            +++++++++
 
-For more information about this error, try `rustc --explain E0369`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0369, E0381.
+For more information about an error, try `rustc --explain E0369`.

--- a/tests/ui/class-cast-to-trait.rs
+++ b/tests/ui/class-cast-to-trait.rs
@@ -1,5 +1,5 @@
 trait Noisy {
-  fn speak(&self);
+  fn speak(&mut self);
 }
 
 struct Cat {
@@ -10,7 +10,7 @@ struct Cat {
 }
 
 impl Cat {
-  pub fn eat(&self) -> bool {
+  pub fn eat(&mut self) -> bool {
     if self.how_hungry > 0 {
         println!("OM NOM NOM");
         self.how_hungry -= 2;
@@ -24,12 +24,12 @@ impl Cat {
 }
 
 impl Noisy for Cat {
-  fn speak(&self) { self.meow(); }
+  fn speak(&mut self) { self.meow(); }
 
 }
 
 impl Cat {
-    fn meow(&self) {
+    fn meow(&mut self) {
       println!("Meow");
       self.meows += 1;
       if self.meows % 5 == 0 {

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/borrowck/borrowck-4.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/borrowck/borrowck-4.rs
@@ -15,6 +15,6 @@ fn foo () -> impl FnMut()->() {
     c
 }
 fn main() {
-    let c = foo();
+    let mut c = foo();
     c();
 }

--- a/tests/ui/closures/binder/implicit-stuff.rs
+++ b/tests/ui/closures/binder/implicit-stuff.rs
@@ -24,4 +24,5 @@ fn main() {
                                                //~| ERROR `'_` cannot be used here
     let _ = for<'a> |x: &()| -> &'a () { x };  //~ ERROR `&` without an explicit lifetime name cannot be used here
     let _ = for<'a> |x: &'a ()| -> &() { x };  //~ ERROR `&` without an explicit lifetime name cannot be used here
+    //~^ ERROR: lifetime may not live long enough
 }

--- a/tests/ui/closures/binder/implicit-stuff.stderr
+++ b/tests/ui/closures/binder/implicit-stuff.stderr
@@ -102,6 +102,15 @@ LL |     let _ = for<'a> |x: &'a _, y, z: _| -> &'a _ {
    |             |
    |             `for<...>` is here
 
-error: aborting due to 15 previous errors
+error: lifetime may not live long enough
+  --> $DIR/implicit-stuff.rs:26:42
+   |
+LL |     let _ = for<'a> |x: &'a ()| -> &() { x };
+   |                 --                 -     ^ returning this value requires that `'a` must outlive `'1`
+   |                 |                  |
+   |                 |                  let's call the lifetime of this reference `'1`
+   |                 lifetime `'a` defined here
+
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0637`.

--- a/tests/ui/closures/issue-109188.rs
+++ b/tests/ui/closures/issue-109188.rs
@@ -7,13 +7,13 @@ struct X(Y);
 
 struct Y;
 
-fn consume_fnmut(f: &dyn FnMut()) {
+fn consume_fnmut(f: &mut dyn FnMut()) {
     f();
 }
 
 fn move_into_fnmut() {
     let x = move_into_fnmut();
-    consume_fnmut(&|| {
+    consume_fnmut(&mut || {
         let Either::One(_t) = x; //~ ERROR mismatched types
         let Either::Two(_t) = x; //~ ERROR mismatched types
     });

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.rs
@@ -2,8 +2,11 @@
 // needs-llvm-components: arm
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
-#[lang="sized"]
-trait Sized { }
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
 
 #[no_mangle]
 #[cmse_nonsecure_entry]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.stderr
@@ -1,5 +1,5 @@
 error[E0776]: `#[cmse_nonsecure_entry]` requires C ABI
-  --> $DIR/wrong-abi.rs:9:1
+  --> $DIR/wrong-abi.rs:12:1
    |
 LL | #[cmse_nonsecure_entry]
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -13,6 +13,7 @@ fn consume<T: 'static>(_val: T)
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
     //~^ overly complex generic constant
+    //~| ERROR: cannot call
 {
 }
 
@@ -20,6 +21,7 @@ fn test<T: 'static>()
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
     //~^ overly complex generic constant
+    //~| ERROR: cannot call
 {
 }
 

--- a/tests/ui/const-generics/issues/issue-90318.stderr
+++ b/tests/ui/const-generics/issues/issue-90318.stderr
@@ -10,7 +10,7 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = note: this operation may be supported in the future
 
 error: overly complex generic constant
-  --> $DIR/issue-90318.rs:21:8
+  --> $DIR/issue-90318.rs:22:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,5 +20,28 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error: aborting due to 2 previous errors
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/issue-90318.rs:14:10
+   |
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/issue-90318.rs:22:10
+   |
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
+++ b/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
@@ -13,5 +13,37 @@ LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error: aborting due to 2 previous errors
+error[E0391]: cycle detected when evaluating type-level constant
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `bug::{constant#0}`...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires caching mir of `bug::{constant#0}` for CTFE...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires elaborating drops for `bug::{constant#0}`...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires borrow-checking `bug::{constant#0}`...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `Binder { value: ConstEvaluatable(UnevaluatedConst { def: DefId(0:8 ~ late_bound_in_return_issue_77357[9394]::bug::{constant#0}), args: [T/#0] }: usize), bound_vars: [] }`...
+   = note: ...which again requires evaluating type-level constant, completing the cycle
+   = note: cycle used when normalizing `&dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]>`
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/consts/const-for-feature-gate.rs
+++ b/tests/ui/consts/const-for-feature-gate.rs
@@ -3,6 +3,9 @@
 const _: () = {
     for _ in 0..5 {}
     //~^ error: `for` is not allowed in a `const`
+    //~| ERROR: cannot convert
+    //~| ERROR: cannot call
+    //~| ERROR: mutable references
 };
 
 fn main() {}

--- a/tests/ui/consts/const-for-feature-gate.stderr
+++ b/tests/ui/consts/const-for-feature-gate.stderr
@@ -8,6 +8,37 @@ LL |     for _ in 0..5 {}
    = help: add `#![feature(const_for)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/const-try-feature-gate.rs
+++ b/tests/ui/consts/const-try-feature-gate.rs
@@ -3,6 +3,8 @@
 const fn t() -> Option<()> {
     Some(())?;
     //~^ error: `?` is not allowed in a `const fn`
+    //~| ERROR: cannot convert
+    //~| ERROR: cannot determine
     None
 }
 

--- a/tests/ui/consts/const-try-feature-gate.stderr
+++ b/tests/ui/consts/const-try-feature-gate.stderr
@@ -8,6 +8,29 @@ LL |     Some(())?;
    = help: add `#![feature(const_try)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0015]: `?` cannot determine the branch of `Option<()>` in constant functions
+  --> $DIR/const-try-feature-gate.rs:4:5
+   |
+LL |     Some(())?;
+   |     ^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0015]: `?` cannot convert from residual of `Option<()>` in constant functions
+  --> $DIR/const-try-feature-gate.rs:4:5
+   |
+LL |     Some(())?;
+   |     ^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/control-flow/loop.rs
+++ b/tests/ui/consts/control-flow/loop.rs
@@ -51,10 +51,16 @@ const _: i32 = {
     let mut x = 0;
 
     for i in 0..4 { //~ ERROR `for` is not allowed in a `const`
+        //~^ ERROR: cannot call
+        //~| ERROR: mutable references
+        //~| ERROR: cannot convert
         x += i;
     }
 
     for i in 0..4 { //~ ERROR `for` is not allowed in a `const`
+        //~^ ERROR: cannot call
+        //~| ERROR: mutable references
+        //~| ERROR: cannot convert
         x += i;
     }
 

--- a/tests/ui/consts/control-flow/loop.stderr
+++ b/tests/ui/consts/control-flow/loop.stderr
@@ -2,6 +2,9 @@ error[E0658]: `for` is not allowed in a `const`
   --> $DIR/loop.rs:53:5
    |
 LL | /     for i in 0..4 {
+LL | |
+LL | |
+LL | |
 LL | |         x += i;
 LL | |     }
    | |_____^
@@ -11,9 +14,12 @@ LL | |     }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `for` is not allowed in a `const`
-  --> $DIR/loop.rs:57:5
+  --> $DIR/loop.rs:60:5
    |
 LL | /     for i in 0..4 {
+LL | |
+LL | |
+LL | |
 LL | |         x += i;
 LL | |     }
    | |_____^
@@ -22,6 +28,67 @@ LL | |     }
    = help: add `#![feature(const_for)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
+  --> $DIR/loop.rs:53:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/loop.rs:53:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+  --> $DIR/loop.rs:53:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
+  --> $DIR/loop.rs:60:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/loop.rs:60:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+  --> $DIR/loop.rs:60:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/control-flow/try.rs
+++ b/tests/ui/consts/control-flow/try.rs
@@ -4,6 +4,8 @@
 const fn opt() -> Option<i32> {
     let x = Some(2);
     x?; //~ ERROR `?` is not allowed in a `const fn`
+    //~^ ERROR: cannot convert
+    //~| ERROR: cannot determine
     None
 }
 

--- a/tests/ui/consts/control-flow/try.stderr
+++ b/tests/ui/consts/control-flow/try.stderr
@@ -8,6 +8,29 @@ LL |     x?;
    = help: add `#![feature(const_try)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0015]: `?` cannot determine the branch of `Option<i32>` in constant functions
+  --> $DIR/try.rs:6:5
+   |
+LL |     x?;
+   |     ^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0015]: `?` cannot convert from residual of `Option<i32>` in constant functions
+  --> $DIR/try.rs:6:5
+   |
+LL |     x?;
+   |     ^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -74,6 +74,100 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 11 previous errors
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/fn_trait_refs.rs:17:5
+   |
+LL |     f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     T: ~const Fn<()> + ~const Destruct + ~const std::ops::Fn<()>,
+   |                                        +++++++++++++++++++++++++
 
-For more information about this error, try `rustc --explain E0635`.
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:13:23
+   |
+LL | const fn tester_fn<T>(f: T) -> T::Output
+   |                       ^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/fn_trait_refs.rs:24:5
+   |
+LL |     f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     T: ~const FnMut<()> + ~const Destruct + ~const std::ops::FnMut<()>,
+   |                                           ++++++++++++++++++++++++++++
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:20:27
+   |
+LL | const fn tester_fn_mut<T>(mut f: T) -> T::Output
+   |                           ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/fn_trait_refs.rs:31:5
+   |
+LL |     f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     T: ~const FnOnce<()> + ~const std::ops::FnOnce<()>,
+   |                          +++++++++++++++++++++++++++++
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:34:21
+   |
+LL | const fn test_fn<T>(mut f: T) -> (T::Output, T::Output, T::Output)
+   |                     ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:48:25
+   |
+LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
+   |                         ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/fn_trait_refs.rs:72:17
+   |
+LL |         assert!(test_one == (1, 1, 1));
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/fn_trait_refs.rs:75:17
+   |
+LL |         assert!(test_two == (2, 2));
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 20 previous errors
+
+Some errors have detailed explanations: E0015, E0493, E0635.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/promoted_const_call.stderr
+++ b/tests/ui/consts/promoted_const_call.stderr
@@ -7,26 +7,6 @@ LL |     let _: &'static _ = &id(&Panic);
    |                              the destructor for this type cannot be evaluated in constants
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:11:26
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:11:30
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
-   |            |                 |
-   |            |                 creates a temporary value which is freed while still in use
-   |            type annotation requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:17:26
    |
 LL |     let _: &'static _ = &id(&Panic);
@@ -68,7 +48,7 @@ LL |     let _: &'static _ = &&(Panic, 0).1;
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0493, E0716.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/promoted_const_call3.rs
+++ b/tests/ui/consts/promoted_const_call3.rs
@@ -2,13 +2,14 @@ pub const fn id<T>(x: T) -> T { x }
 pub const C: () = {
     let _: &'static _ = &String::new();
     //~^ ERROR: destructor of `String` cannot be evaluated at compile-time
-    //~| ERROR: temporary value dropped while borrowed
+};
 
+pub const _: () = {
     let _: &'static _ = &id(&String::new());
     //~^ ERROR: destructor of `String` cannot be evaluated at compile-time
-    //~| ERROR: temporary value dropped while borrowed
-    //~| ERROR: temporary value dropped while borrowed
+};
 
+pub const _: () = {
     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
     //~^ ERROR: temporary value dropped while borrowed
 };

--- a/tests/ui/consts/promoted_const_call3.stderr
+++ b/tests/ui/consts/promoted_const_call3.stderr
@@ -1,53 +1,22 @@
 error[E0493]: destructor of `String` cannot be evaluated at compile-time
-  --> $DIR/promoted_const_call3.rs:7:30
+  --> $DIR/promoted_const_call3.rs:3:26
+   |
+LL |     let _: &'static _ = &String::new();
+   |                          ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
+LL |
+LL | };
+   | - value is dropped here
+
+error[E0493]: destructor of `String` cannot be evaluated at compile-time
+  --> $DIR/promoted_const_call3.rs:8:30
    |
 LL |     let _: &'static _ = &id(&String::new());
    |                              ^^^^^^^^^^^^^ - value is dropped here
    |                              |
    |                              the destructor for this type cannot be evaluated in constants
 
-error[E0493]: destructor of `String` cannot be evaluated at compile-time
-  --> $DIR/promoted_const_call3.rs:3:26
-   |
-LL |     let _: &'static _ = &String::new();
-   |                          ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
-...
-LL | };
-   | - value is dropped here
-
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:3:26
-   |
-LL |     let _: &'static _ = &String::new();
-   |            ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:7:26
-   |
-LL |     let _: &'static _ = &id(&String::new());
-   |            ----------    ^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:7:30
-   |
-LL |     let _: &'static _ = &id(&String::new());
-   |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
-   |            |                 |
-   |            |                 creates a temporary value which is freed while still in use
-   |            type annotation requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:12:26
+  --> $DIR/promoted_const_call3.rs:13:26
    |
 LL |     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
    |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -58,7 +27,7 @@ LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:17:26
+  --> $DIR/promoted_const_call3.rs:18:26
    |
 LL |     let _: &'static _ = &String::new();
    |            ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -69,7 +38,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:20:26
+  --> $DIR/promoted_const_call3.rs:21:26
    |
 LL |     let _: &'static _ = &id(&String::new());
    |            ----------    ^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -80,7 +49,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:20:30
+  --> $DIR/promoted_const_call3.rs:21:30
    |
 LL |     let _: &'static _ = &id(&String::new());
    |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
@@ -89,7 +58,7 @@ LL |     let _: &'static _ = &id(&String::new());
    |            type annotation requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:24:26
+  --> $DIR/promoted_const_call3.rs:25:26
    |
 LL |     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
    |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -99,7 +68,7 @@ LL |
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 10 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0493, E0716.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/promoted_const_call5.rs
+++ b/tests/ui/consts/promoted_const_call5.rs
@@ -25,9 +25,9 @@ pub const fn new_manually_drop<T>(t: T) -> std::mem::ManuallyDrop<T>  {
 const C: () = {
     let _: &'static _ = &id(&new_string());
     //~^ ERROR destructor of `String` cannot be evaluated at compile-time
-    //~| ERROR: temporary value dropped while borrowed
-    //~| ERROR: temporary value dropped while borrowed
+};
 
+const _: () = {
     let _: &'static _ = &new_manually_drop(new_string());
     //~^ ERROR: temporary value dropped while borrowed
 };

--- a/tests/ui/consts/promoted_const_call5.stderr
+++ b/tests/ui/consts/promoted_const_call5.stderr
@@ -7,26 +7,6 @@ LL |     let _: &'static _ = &id(&new_string());
    |                              the destructor for this type cannot be evaluated in constants
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call5.rs:26:26
-   |
-LL |     let _: &'static _ = &id(&new_string());
-   |            ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call5.rs:26:30
-   |
-LL |     let _: &'static _ = &id(&new_string());
-   |                          ----^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |                          |   |
-   |                          |   creates a temporary value which is freed while still in use
-   |                          argument requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call5.rs:31:26
    |
 LL |     let _: &'static _ = &new_manually_drop(new_string());
@@ -68,7 +48,7 @@ LL |
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0493, E0716.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/transmute-size-mismatch-before-typeck.rs
+++ b/tests/ui/consts/transmute-size-mismatch-before-typeck.rs
@@ -5,7 +5,7 @@
 
 fn main() {
     match &b""[..] {
-        ZST => {}
+        ZST => {} //~ ERROR: could not evaluate constant pattern
     }
 }
 

--- a/tests/ui/consts/transmute-size-mismatch-before-typeck.stderr
+++ b/tests/ui/consts/transmute-size-mismatch-before-typeck.stderr
@@ -7,6 +7,12 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    = note: source type: `usize` (word size)
    = note: target type: `&[u8]` (2 * word size)
 
-error: aborting due to 1 previous error
+error: could not evaluate constant pattern
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:8:9
+   |
+LL |         ZST => {}
+   |         ^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0512`.

--- a/tests/ui/consts/try-operator.stderr
+++ b/tests/ui/consts/try-operator.stderr
@@ -4,6 +4,51 @@ error[E0635]: unknown feature `const_convert`
 LL | #![feature(const_convert)]
    |            ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: `?` cannot determine the branch of `Result<(), ()>` in constant functions
+  --> $DIR/try-operator.rs:10:9
+   |
+LL |         Err(())?;
+   |         ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0635`.
+error[E0015]: `?` cannot convert from residual of `Result<bool, ()>` in constant functions
+  --> $DIR/try-operator.rs:10:9
+   |
+LL |         Err(())?;
+   |         ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: `?` cannot determine the branch of `Option<()>` in constant functions
+  --> $DIR/try-operator.rs:18:9
+   |
+LL |         None?;
+   |         ^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: `?` cannot convert from residual of `Option<()>` in constant functions
+  --> $DIR/try-operator.rs:18:9
+   |
+LL |         None?;
+   |         ^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0015, E0635.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -4,5 +4,38 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
    |                                       ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/unstable-const-fn-in-libcore.rs:24:26
+   |
+LL |             Opt::None => f(),
+   |                          ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T + ~const std::ops::FnOnce<()>>(self, f: F) -> T {
+   |                                                     +++++++++++++++++++++++++++++
 
+error[E0493]: destructor of `F` cannot be evaluated at compile-time
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:60
+   |
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
+   |                                                            ^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
+
+error[E0493]: destructor of `Opt<T>` cannot be evaluated at compile-time
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:54
+   |
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
+   |                                                      ^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0015, E0493.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/diagnostic-width/tabs-trimming.rs
+++ b/tests/ui/diagnostic-width/tabs-trimming.rs
@@ -8,6 +8,7 @@
 						match money {
 							v @ 1 | 2 | 3 => panic!("You gave me too little money {}", v), // Long text here: TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
 							//~^ ERROR variable `v` is not bound in all patterns
+							//~| ERROR possibly-uninitialized
 							v => println!("Enough money {}", v),
 						}
 					}

--- a/tests/ui/diagnostic-width/tabs-trimming.stderr
+++ b/tests/ui/diagnostic-width/tabs-trimming.stderr
@@ -7,6 +7,18 @@ LL | ...   v @ 1 | 2 | 3 => panic!("You gave me too little money {}", v), // Lon
    |       |       pattern doesn't bind `v`
    |       variable not in all patterns
 
-error: aborting due to 1 previous error
+error[E0381]: used binding `v` is possibly-uninitialized
+  --> $DIR/tabs-trimming.rs:9:67
+   |
+LL | ...   v @ 1 | 2 | 3 => panic!("You gave me too little money {}", v), // Long text here: TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT...
+   |       -                                                          ^ `v` used here but it is possibly-uninitialized
+   |       |
+   |       binding initialized here in some conditions
+   |       binding declared here but left uninitialized
+   |
+   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0408`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0381, E0408.
+For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/enum/enum-and-module-in-same-scope.rs
+++ b/tests/ui/enum/enum-and-module-in-same-scope.rs
@@ -5,6 +5,7 @@ enum Foo {
 mod Foo { //~ ERROR the name `Foo` is defined multiple times
     pub static X: isize = 42;
     fn f() { f() } // Check that this does not result in a resolution error
+    //~^ WARN cannot return without recursing
 }
 
 fn main() {}

--- a/tests/ui/enum/enum-and-module-in-same-scope.stderr
+++ b/tests/ui/enum/enum-and-module-in-same-scope.stderr
@@ -9,6 +9,17 @@ LL | mod Foo {
    |
    = note: `Foo` must be defined only once in the type namespace of this module
 
-error: aborting due to 1 previous error
+warning: function cannot return without recursing
+  --> $DIR/enum-and-module-in-same-scope.rs:7:5
+   |
+LL |     fn f() { f() } // Check that this does not result in a resolution error
+   |     ^^^^^^   --- recursive call site
+   |     |
+   |     cannot return without recursing
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0428`.

--- a/tests/ui/error-codes/E0582.rs
+++ b/tests/ui/error-codes/E0582.rs
@@ -19,7 +19,7 @@ fn mk_unexpected_char_err<'a>() -> Option<&'a i32> {
 }
 
 fn foo<'a>(data: &mut Chars<'a>) {
-    bar(mk_unexpected_char_err)
+    bar(mk_unexpected_char_err) //~ ERROR mismatched types
 }
 
 fn bar<F>(t: F)

--- a/tests/ui/error-codes/E0582.stderr
+++ b/tests/ui/error-codes/E0582.stderr
@@ -10,6 +10,21 @@ error[E0582]: binding for associated type `Item` references lifetime `'a`, which
 LL |     where F: for<'a> Iterator<Item=&'a i32>
    |                               ^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/E0582.rs:22:5
+   |
+LL |     bar(mk_unexpected_char_err)
+   |     ^^^ one type is more general than the other
+   |
+   = note: expected enum `Option<&_>`
+              found enum `Option<&'a _>`
+note: the lifetime requirement is introduced here
+  --> $DIR/E0582.rs:28:30
+   |
+LL |     where F: for<'a> Fn() -> Option<&'a i32>
+   |                              ^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0582`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0582.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/error-codes/E0637.rs
+++ b/tests/ui/error-codes/E0637.rs
@@ -2,9 +2,9 @@ fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
     //~^ ERROR: `'_` cannot be used here [E0637]
     //~| ERROR: missing lifetime specifier
     if str1.len() > str2.len() {
-        str1
+        str1 //~ ERROR: lifetime may not live long enough
     } else {
-        str2
+        str2 //~ ERROR: lifetime may not live long enough
     }
 }
 

--- a/tests/ui/error-codes/E0637.stderr
+++ b/tests/ui/error-codes/E0637.stderr
@@ -27,7 +27,25 @@ help: consider introducing a higher-ranked lifetime here
 LL |     T: for<'a> Into<&'a u32>,
    |        +++++++       ++
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/E0637.rs:5:9
+   |
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                  - let's call the lifetime of this reference `'1`
+...
+LL |         str1
+   |         ^^^^ returning this value requires that `'1` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/E0637.rs:7:9
+   |
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                                 - let's call the lifetime of this reference `'2`
+...
+LL |         str2
+   |         ^^^^ returning this value requires that `'2` must outlive `'static`
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/explicit-tail-calls/return-mismatches.rs
+++ b/tests/ui/explicit-tail-calls/return-mismatches.rs
@@ -13,7 +13,7 @@ fn _f1() {
     become _g1(); //~ error: mismatched types
 }
 
-fn _g1() -> ! {
+fn _g1() -> ! { //~ WARN: cannot return without recursing
     become _g1();
 }
 

--- a/tests/ui/explicit-tail-calls/return-mismatches.stderr
+++ b/tests/ui/explicit-tail-calls/return-mismatches.stderr
@@ -22,6 +22,17 @@ error[E0308]: mismatched types
 LL |     become _g2();
    |     ^^^^^^^^^^^^ expected `u32`, found `u16`
 
-error: aborting due to 3 previous errors
+warning: function cannot return without recursing
+  --> $DIR/return-mismatches.rs:16:1
+   |
+LL | fn _g1() -> ! {
+   | ^^^^^^^^^^^^^ cannot return without recursing
+LL |     become _g1();
+   |            ----- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/expr/if/if-no-match-bindings.rs
+++ b/tests/ui/expr/if/if-no-match-bindings.rs
@@ -6,6 +6,7 @@
 
 fn b_ref<'a>() -> &'a bool { &true }
 fn b_mut_ref<'a>() -> &'a mut bool { &mut true }
+//~^ ERROR: cannot return reference to temporary
 
 fn main() {
     // This is OK:

--- a/tests/ui/expr/if/if-no-match-bindings.stderr
+++ b/tests/ui/expr/if/if-no-match-bindings.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:18:8
+  --> $DIR/if-no-match-bindings.rs:19:8
    |
 LL |     if b_ref() {}
    |        ^^^^^^^ expected `bool`, found `&bool`
@@ -10,7 +10,7 @@ LL |     if *b_ref() {}
    |        +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:19:8
+  --> $DIR/if-no-match-bindings.rs:20:8
    |
 LL |     if b_mut_ref() {}
    |        ^^^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -21,7 +21,7 @@ LL |     if *b_mut_ref() {}
    |        +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:20:8
+  --> $DIR/if-no-match-bindings.rs:21:8
    |
 LL |     if &true {}
    |        ^^^^^ expected `bool`, found `&bool`
@@ -33,7 +33,7 @@ LL +     if true {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:21:8
+  --> $DIR/if-no-match-bindings.rs:22:8
    |
 LL |     if &mut true {}
    |        ^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -45,7 +45,7 @@ LL +     if true {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:24:11
+  --> $DIR/if-no-match-bindings.rs:25:11
    |
 LL |     while b_ref() {}
    |           ^^^^^^^ expected `bool`, found `&bool`
@@ -56,7 +56,7 @@ LL |     while *b_ref() {}
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:25:11
+  --> $DIR/if-no-match-bindings.rs:26:11
    |
 LL |     while b_mut_ref() {}
    |           ^^^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -67,7 +67,7 @@ LL |     while *b_mut_ref() {}
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:26:11
+  --> $DIR/if-no-match-bindings.rs:27:11
    |
 LL |     while &true {}
    |           ^^^^^ expected `bool`, found `&bool`
@@ -79,7 +79,7 @@ LL +     while true {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:27:11
+  --> $DIR/if-no-match-bindings.rs:28:11
    |
 LL |     while &mut true {}
    |           ^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -90,6 +90,16 @@ LL -     while &mut true {}
 LL +     while true {}
    |
 
-error: aborting due to 8 previous errors
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/if-no-match-bindings.rs:8:38
+   |
+LL | fn b_mut_ref<'a>() -> &'a mut bool { &mut true }
+   |                                      ^^^^^----
+   |                                      |    |
+   |                                      |    temporary value created here
+   |                                      returns a reference to data owned by the current function
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0308, E0515.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
@@ -13,4 +13,5 @@ extern "C" {
 
 fn main() {
     assert_eq!(FOO, 3);
+    //~^ ERROR extern static is unsafe
 }

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
@@ -8,6 +8,15 @@ LL |     #[cfg_attr(target_thread_local, thread_local)]
    = help: add `#![feature(cfg_target_thread_local)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-cfg-target-thread-local.rs:15:16
+   |
+LL |     assert_eq!(FOO, 3);
+   |                ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0133, E0658.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/feature-gates/feature-gate-custom_mir.rs
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.rs
@@ -1,10 +1,15 @@
 #![feature(core_intrinsics)]
 
 extern crate core;
+use core::intrinsics::mir::*; //~ custom_mir
 
 #[custom_mir(dialect = "built")] //~ ERROR the `#[custom_mir]` attribute is just used for the Rust test suite
 pub fn foo(_x: i32) -> i32 {
-    0
+    mir! {
+        {
+            Return() //~ custom_mir
+        }
+    }
 }
 
 fn main() {

--- a/tests/ui/feature-gates/feature-gate-custom_mir.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the `#[custom_mir]` attribute is just used for the Rust test suite
-  --> $DIR/feature-gate-custom_mir.rs:5:1
+  --> $DIR/feature-gate-custom_mir.rs:6:1
    |
 LL | #[custom_mir(dialect = "built")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,6 +7,24 @@ LL | #[custom_mir(dialect = "built")]
    = help: add `#![feature(custom_mir)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0658]: use of unstable library feature 'custom_mir': MIR is an implementation detail and extremely unstable
+  --> $DIR/feature-gate-custom_mir.rs:4:5
+   |
+LL | use core::intrinsics::mir::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(custom_mir)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature 'custom_mir': MIR is an implementation detail and extremely unstable
+  --> $DIR/feature-gate-custom_mir.rs:10:13
+   |
+LL |             Return()
+   |             ^^^^^^
+   |
+   = help: add `#![feature(custom_mir)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -6,12 +6,14 @@ use std::arch::asm;
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
     asm!("", options(noreturn))
+    //~^ ERROR: requires unsafe
 }
 
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
     asm!("", options(noreturn))
+    //~^ ERROR: requires unsafe
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -9,7 +9,7 @@ LL | #[naked]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
-  --> $DIR/feature-gate-naked_functions.rs:11:1
+  --> $DIR/feature-gate-naked_functions.rs:12:1
    |
 LL | #[naked]
    | ^^^^^^^^
@@ -18,6 +18,23 @@ LL | #[naked]
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-naked_functions.rs:8:5
+   |
+LL |     asm!("", options(noreturn))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-naked_functions.rs:15:5
+   |
+LL |     asm!("", options(noreturn))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0133, E0658.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.rs
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.rs
@@ -8,7 +8,7 @@ fn main() {
         extern "rust-intrinsic" { //~ ERROR intrinsics are subject to change
             fn atomic_fence();
         }
-        atomic_fence();
+        atomic_fence(); //~ ERROR: is unsafe
         42
     });
 }

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
@@ -7,6 +7,15 @@ LL |         extern "rust-intrinsic" {
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0133]: call to unsafe function `main::atomic_fence` is unsafe and requires unsafe function or block
+  --> $DIR/feature-gated-feature-in-macro-arg.rs:11:9
+   |
+LL |         atomic_fence();
+   |         ^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0133, E0658.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/fn/suggest-return-closure.rs
+++ b/tests/ui/fn/suggest-return-closure.rs
@@ -17,10 +17,16 @@ fn fn_mut() -> _ {
     //~| SUGGESTION impl FnMut(char)
     //~| NOTE for more information on `Fn` traits and closure types
     let x = String::new();
-    |c| {
+    //~^ HELP: consider changing this to be mutable
+    |c| { //~ NOTE: value captured here
         x.push(c);
+        //~^ ERROR: does not live long enough
+        //~| NOTE: does not live long enough
+        //~| NOTE: cannot borrow as mutable
+        //~| ERROR: not declared as mutable
     }
-}
+} //~ NOTE: borrow later used here
+//~^ NOTE: dropped here
 
 fn fun() -> _ {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types [E0121]

--- a/tests/ui/fn/suggest-return-closure.stderr
+++ b/tests/ui/fn/suggest-return-closure.stderr
@@ -21,7 +21,7 @@ LL | fn fn_mut() -> _ {
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/suggest-return-closure.rs:25:13
+  --> $DIR/suggest-return-closure.rs:31:13
    |
 LL | fn fun() -> _ {
    |             ^
@@ -31,6 +31,29 @@ LL | fn fun() -> _ {
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
 
-error: aborting due to 3 previous errors
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/suggest-return-closure.rs:22:9
+   |
+LL |     let x = String::new();
+   |         - help: consider changing this to be mutable: `mut x`
+...
+LL |         x.push(c);
+   |         ^ cannot borrow as mutable
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0597]: `x` does not live long enough
+  --> $DIR/suggest-return-closure.rs:22:9
+   |
+LL |     |c| {
+   |     --- value captured here
+LL |         x.push(c);
+   |         ^ borrowed value does not live long enough
+...
+LL | }
+   | -- borrow later used here
+   | |
+   | `x` dropped here while still borrowed
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0121, E0596, E0597.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/generic-associated-types/extended/lending_iterator.base.stderr
+++ b/tests/ui/generic-associated-types/extended/lending_iterator.base.stderr
@@ -7,6 +7,12 @@ LL |     fn from_iter<T: for<'x> LendingIterator<Item<'x> = A>>(iter: T) -> Self
 LL |     fn from_iter<I: for<'x> LendingIterator<Item<'x> = A>>(mut iter: I) -> Self {
    |                                             ^^^^^^^^^^^^ impl has extra requirement `I: 'x`
 
-error: aborting due to 1 previous error
+error: `Self` does not live long enough
+  --> $DIR/lending_iterator.rs:34:9
+   |
+LL |         <B as FromLendingIterator<A>>::from_iter(self)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0276`.

--- a/tests/ui/generic-associated-types/extended/lending_iterator.rs
+++ b/tests/ui/generic-associated-types/extended/lending_iterator.rs
@@ -32,6 +32,7 @@ pub trait LendingIterator {
         Self: for<'q> LendingIterator<Item<'q> = A>,
     {
         <B as FromLendingIterator<A>>::from_iter(self)
+        //[base]~^ ERROR: does not live long enough
     }
 }
 

--- a/tests/ui/generic-associated-types/issue-70304.rs
+++ b/tests/ui/generic-associated-types/issue-70304.rs
@@ -52,4 +52,5 @@ fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
 pub fn main() {
     let doc = create_doc();
     let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
+    //~^ ERROR: `doc` does not live long enough
 }

--- a/tests/ui/generic-associated-types/issue-70304.stderr
+++ b/tests/ui/generic-associated-types/issue-70304.stderr
@@ -27,7 +27,21 @@ LL |     type Cursor<'a>: DocCursor<'a>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 3 previous errors
+error[E0597]: `doc` does not live long enough
+  --> $DIR/issue-70304.rs:54:59
+   |
+LL |     let doc = create_doc();
+   |         --- binding `doc` declared here
+LL |     let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
+   |                                               ------------^^^^-
+   |                                               |           |
+   |                                               |           borrowed value does not live long enough
+   |                                               argument requires that `doc` is borrowed for `'static`
+LL |
+LL | }
+   | - `doc` dropped here while still borrowed
 
-Some errors have detailed explanations: E0106, E0637.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0597, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/generic-associated-types/issue-74684-2.rs
+++ b/tests/ui/generic-associated-types/issue-74684-2.rs
@@ -10,7 +10,7 @@ impl <T> Fun for T {
 
 fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
     let a = [0; 1];
-    let x = T::identity(&a);
+    let x = T::identity(&a); //~ ERROR: does not live long enough
     todo!()
 }
 

--- a/tests/ui/generic-associated-types/issue-74684-2.stderr
+++ b/tests/ui/generic-associated-types/issue-74684-2.stderr
@@ -17,6 +17,23 @@ note: required by a bound in `bug`
 LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
    |                            ^^^^^^^^^^^^ required by this bound in `bug`
 
-error: aborting due to 1 previous error
+error[E0597]: `a` does not live long enough
+  --> $DIR/issue-74684-2.rs:13:25
+   |
+LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+   |        -- lifetime `'a` defined here
+LL |     let a = [0; 1];
+   |         - binding `a` declared here
+LL |     let x = T::identity(&a);
+   |             ------------^^-
+   |             |           |
+   |             |           borrowed value does not live long enough
+   |             argument requires that `a` is borrowed for `'a`
+LL |     todo!()
+LL | }
+   | - `a` dropped here while still borrowed
 
-For more information about this error, try `rustc --explain E0271`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0271, E0597.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -22,11 +22,12 @@ fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
   //~^ ERROR missing generics for associated type
 {
     for n in 0i16..100 {
-        *dst.test_mut() = n.into();
+        *dst.test_mut() = n.into(); //~ ERROR: cannot borrow
+        //~^ ERROR: borrowed data escapes outside of function
     }
 }
 
 fn main() {
     let mut t1: E<f32> = Default::default();
-    test_simpler(&mut t1);
+    test_simpler(&mut t1); //~ ERROR does not live long enough
 }

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -25,6 +25,43 @@ LL |     type Output<'a>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 2 previous errors
+error[E0499]: cannot borrow `*dst` as mutable more than once at a time
+  --> $DIR/issue-80433.rs:25:10
+   |
+LL |         *dst.test_mut() = n.into();
+   |          ^^^-----------
+   |          |
+   |          `*dst` was mutably borrowed here in the previous iteration of the loop
+   |          argument requires that `*dst` is borrowed for `'static`
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/issue-80433.rs:25:10
+   |
+LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
+   |                 --  --- `dst` is a reference that is only valid in the function body
+   |                 |
+   |                 lifetime `'a` defined here
+...
+LL |         *dst.test_mut() = n.into();
+   |          ^^^^^^^^^^^^^^
+   |          |
+   |          `dst` escapes the function body here
+   |          argument requires that `'a` must outlive `'static`
+
+error[E0597]: `t1` does not live long enough
+  --> $DIR/issue-80433.rs:32:18
+   |
+LL |     let mut t1: E<f32> = Default::default();
+   |         ------ binding `t1` declared here
+LL |     test_simpler(&mut t1);
+   |     -------------^^^^^^^-
+   |     |            |
+   |     |            borrowed value does not live long enough
+   |     argument requires that `t1` is borrowed for `'static`
+LL | }
+   | - `t1` dropped here while still borrowed
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0107, E0499, E0521, E0597.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/generics/generic-extern.rs
+++ b/tests/ui/generics/generic-extern.rs
@@ -3,5 +3,5 @@ extern "C" {
 }
 
 fn main() {
-    foo::<i32>();
+    foo::<i32>(); //~ ERROR requires unsafe
 }

--- a/tests/ui/generics/generic-extern.stderr
+++ b/tests/ui/generics/generic-extern.stderr
@@ -6,6 +6,15 @@ LL |     fn foo<T>();
    |
    = help: replace the type parameters with concrete types like `u32`
 
-error: aborting due to 1 previous error
+error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
+  --> $DIR/generic-extern.rs:6:5
+   |
+LL |     foo::<i32>();
+   |     ^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
 
-For more information about this error, try `rustc --explain E0044`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0044, E0133.
+For more information about an error, try `rustc --explain E0044`.

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.rs
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.rs
@@ -4,4 +4,5 @@ fn main() {
     let xs = [13, 1, 5, 2, 3, 1, 21, 8];
     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
     //~^ `X..` patterns in slices are experimental
+    //~| ERROR: refutable pattern
 }

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
@@ -8,6 +8,21 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0005]: refutable pattern in local binding
+  --> $DIR/feature-gate-half-open-range-patterns-in-slices.rs:5:9
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `[i32::MIN..=2_i32, ..]` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `[i32; 8]`
+help: you might want to use `let else` to handle the variant that isn't matched
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs else { todo!() };
+   |                                               ++++++++++++++++
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0005, E0658.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs
@@ -23,6 +23,7 @@ fn syntax2() {
     macro_rules! mac {
         ($e:expr) => {
             let ...$e; //~ ERROR range-to patterns with `...` are not allowed
+            //~^ ERROR refutable pattern in local binding
         }
     }
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
@@ -33,5 +33,24 @@ LL |     mac!(0);
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:25:17
+   |
+LL |             let ...$e;
+   |                 ^^^^^ pattern `1_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ...$e; { todo!() }
+   |             ++            +++++++++++
 
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0005`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.rs
@@ -1,6 +1,9 @@
 fn main() {
     let x = 42;
     match x {
+        //~^ ERROR: non-exhaustive patterns
+        //~| NOTE: not covered
+        //~| NOTE: matched value is of type
         0..=73 => {},
         74..=> {},
         //~^ ERROR unexpected `>` after inclusive range

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
@@ -1,5 +1,5 @@
 error: unexpected `>` after inclusive range
-  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:5:14
+  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:8:14
    |
 LL |         74..=> {},
    |           ---^
@@ -11,5 +11,19 @@ help: add a space between the pattern and `=>`
 LL |         74.. => {},
    |             +
 
-error: aborting due to 1 previous error
+error[E0004]: non-exhaustive patterns: `i32::MIN..=-1_i32` not covered
+  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:3:11
+   |
+LL |     match x {
+   |           ^ pattern `i32::MIN..=-1_i32` not covered
+   |
+   = note: the matched value is of type `i32`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         74..=> {},
+LL ~         i32::MIN..=-1_i32 => todo!(),
+   |
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.rs
@@ -16,7 +16,9 @@ fn bar() {
     macro_rules! mac {
         ($e:expr) => {
             let $e...; //~ ERROR inclusive range with no end
+            //~^ ERROR: refutable pattern
             let $e..=; //~ ERROR inclusive range with no end
+            //~^ ERROR: refutable pattern
         }
     }
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
@@ -43,7 +43,7 @@ LL |     mac!(0);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/half-open-range-pats-inclusive-no-end.rs:19:19
+  --> $DIR/half-open-range-pats-inclusive-no-end.rs:20:19
    |
 LL |             let $e..=;
    |                   ^^^ help: use `..` instead
@@ -54,6 +54,43 @@ LL |     mac!(0);
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/half-open-range-pats-inclusive-no-end.rs:18:17
+   |
+LL |             let $e...;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e...; { todo!() }
+   |             ++            +++++++++++
 
-For more information about this error, try `rustc --explain E0586`.
+error[E0005]: refutable pattern in local binding
+  --> $DIR/half-open-range-pats-inclusive-no-end.rs:20:17
+   |
+LL |             let $e..=;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e..=; { todo!() }
+   |             ++            +++++++++++
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0005, E0586.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.rs
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.rs
@@ -5,4 +5,5 @@ fn main() {
     //~^ `X..` patterns in slices are experimental
     //~| exclusive range pattern syntax is experimental
     //~| exclusive range pattern syntax is experimental
+    //~| ERROR: refutable pattern
 }

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
@@ -30,6 +30,21 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: use an inclusive range pattern, like N..=M
 
-error: aborting due to 3 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/slice_pattern_syntax_problem1.rs:4:9
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `[i32::MIN..=2_i32, ..]` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `[i32; 8]`
+help: you might want to use `let else` to handle the variant that isn't matched
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs else { todo!() };
+   |                                               ++++++++++++++++
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0005, E0658.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.rs
+++ b/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.rs
@@ -12,10 +12,12 @@ fn hr_subtype<'c>(f: for<'a, 'b> fn(Inv<'a>, Inv<'a>)) {
 
 fn simple1<'c>(x: (&'c i32,)) {
     let _x: (&'static i32,) = x;
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn simple2<'c>(x: (&'c i32,)) {
     let _: (&'static i32,) = x;
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn main() {

--- a/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.stderr
+++ b/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.stderr
@@ -9,6 +9,22 @@ LL |     let _: for<'a, 'b> fn(Inv<'a>, Inv<'b>) = sub;
    = note: expected fn pointer `for<'a, 'b> fn(Inv<'a>, Inv<'b>)`
               found fn pointer `for<'a> fn(Inv<'a>, Inv<'a>)`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/placeholder-pattern-fail.rs:14:13
+   |
+LL | fn simple1<'c>(x: (&'c i32,)) {
+   |            -- lifetime `'c` defined here
+LL |     let _x: (&'static i32,) = x;
+   |             ^^^^^^^^^^^^^^^ type annotation requires that `'c` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/placeholder-pattern-fail.rs:19:12
+   |
+LL | fn simple2<'c>(x: (&'c i32,)) {
+   |            -- lifetime `'c` defined here
+LL |     let _: (&'static i32,) = x;
+   |            ^^^^^^^^^^^^^^^ type annotation requires that `'c` must outlive `'static`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.rs
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.rs
@@ -18,7 +18,7 @@ fn want_foo_for_some_tcx<'x,F>(f: &'x F)
     want_foo_for_any_tcx(f); //~ ERROR not satisfied
 }
 
-fn want_foo_for_any_tcx<F>(f: &F)
+fn want_foo_for_any_tcx<F>(f: &F) //~ WARN cannot return without recursing
     where F : for<'tcx> Foo<'tcx>
 {
     want_foo_for_some_tcx(f);
@@ -35,7 +35,7 @@ fn want_bar_for_some_ccx<'x,B>(b: &B)
     want_bar_for_any_ccx(b); //~ ERROR not satisfied
 }
 
-fn want_bar_for_any_ccx<B>(b: &B)
+fn want_bar_for_any_ccx<B>(b: &B) //~ WARN cannot return without recursing
     where B : for<'ccx> Bar<'ccx>
 {
     want_foo_for_some_tcx(b);

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -38,6 +38,31 @@ help: consider further restricting this bound
 LL |     where B : Bar<'x> + for<'ccx> Bar<'ccx>
    |                       +++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+warning: function cannot return without recursing
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:21:1
+   |
+LL | / fn want_foo_for_any_tcx<F>(f: &F)
+LL | |     where F : for<'tcx> Foo<'tcx>
+   | |_________________________________^ cannot return without recursing
+...
+LL |       want_foo_for_any_tcx(f);
+   |       ----------------------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: function cannot return without recursing
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:38:1
+   |
+LL | / fn want_bar_for_any_ccx<B>(b: &B)
+LL | |     where B : for<'ccx> Bar<'ccx>
+   | |_________________________________^ cannot return without recursing
+...
+LL |       want_bar_for_any_ccx(b);
+   |       ----------------------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.rs
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.rs
@@ -16,12 +16,16 @@ fn foo<'a>(x: &i32) -> impl Copy + 'a { x }
 //~^ ERROR explicit lifetime required in the type of `x`
 
 fn elided3(x: &i32) -> Box<dyn Debug> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn explicit3<'a>(x: &'a i32) -> Box<dyn Debug> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn elided4(x: &i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn explicit4<'a>(x: &'a i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug) { (Box::new(x), x) }
 //~^ ERROR lifetime may not live long enough

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -67,7 +67,7 @@ LL | fn foo<'a>(x: &i32) -> impl Copy + 'a { x }
    |               help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 
 error: lifetime may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:26:55
+  --> $DIR/must_outlive_least_region_or_bound.rs:30:55
    |
 LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug) { (Box::new(x), x) }
    |               -                                       ^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
@@ -84,7 +84,7 @@ LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug + '_) { (Box::new(x), x)
    |                                                    ++++
 
 error: lifetime may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:32:69
+  --> $DIR/must_outlive_least_region_or_bound.rs:36:69
    |
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
    |               -- lifetime `'a` defined here                         ^ returning this value requires that `'a` must outlive `'static`
@@ -99,12 +99,12 @@ LL | fn with_bound<'a>(x: &'static i32) -> impl LifetimeTrait<'a> + 'static { x 
    |                      ~~~~~~~~~~~~
 
 error[E0700]: hidden type for `impl Fn(&'a u32)` captures lifetime that does not appear in bounds
-  --> $DIR/must_outlive_least_region_or_bound.rs:38:5
+  --> $DIR/must_outlive_least_region_or_bound.rs:42:5
    |
 LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) {
    |                              --                             ---------------- opaque type defined here
    |                              |
-   |                              hidden type `{closure@$DIR/must_outlive_least_region_or_bound.rs:38:5: 38:13}` captures the lifetime `'b` as defined here
+   |                              hidden type `{closure@$DIR/must_outlive_least_region_or_bound.rs:42:5: 42:13}` captures the lifetime `'b` as defined here
 LL |     move |_| println!("{}", y)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -114,7 +114,7 @@ LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32
    |                                                                              ++++
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:43:5
+  --> $DIR/must_outlive_least_region_or_bound.rs:47:5
    |
 LL |     x
    |     ^
@@ -127,7 +127,63 @@ help: consider adding an explicit lifetime bound
 LL | fn ty_param_wont_outlive_static<T:Debug + 'static>(x: T) -> impl Debug + 'static {
    |                                         +++++++++
 
-error: aborting due to 9 previous errors
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:18:41
+   |
+LL | fn elided3(x: &i32) -> Box<dyn Debug> { Box::new(x) }
+   |               -                         ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |               |
+   |               let's call the lifetime of this reference `'1`
+   |
+help: to declare that the trait object captures data from argument `x`, you can add an explicit `'_` lifetime bound
+   |
+LL | fn elided3(x: &i32) -> Box<dyn Debug + '_> { Box::new(x) }
+   |                                      ++++
+
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:21:50
+   |
+LL | fn explicit3<'a>(x: &'a i32) -> Box<dyn Debug> { Box::new(x) }
+   |              -- lifetime `'a` defined here       ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+   |
+help: to declare that the trait object captures data from argument `x`, you can add an explicit `'a` lifetime bound
+   |
+LL | fn explicit3<'a>(x: &'a i32) -> Box<dyn Debug + 'a> { Box::new(x) }
+   |                                               ++++
+
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:24:51
+   |
+LL | fn elided4(x: &i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |               -                                   ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |               |
+   |               let's call the lifetime of this reference `'1`
+   |
+help: consider changing the trait object's explicit `'static` bound to the lifetime of argument `x`
+   |
+LL | fn elided4(x: &i32) -> Box<dyn Debug + '_> { Box::new(x) }
+   |                                        ~~
+help: alternatively, add an explicit `'static` bound to this reference
+   |
+LL | fn elided4(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |               ~~~~~~~~~~~~
+
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:27:60
+   |
+LL | fn explicit4<'a>(x: &'a i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |              -- lifetime `'a` defined here                 ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+   |
+help: consider changing the trait object's explicit `'static` bound to the lifetime of argument `x`
+   |
+LL | fn explicit4<'a>(x: &'a i32) -> Box<dyn Debug + 'a> { Box::new(x) }
+   |                                                 ~~
+help: alternatively, add an explicit `'static` bound to this reference
+   |
+LL | fn explicit4<'a>(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |                     ~~~~~~~~~~~~
+
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0310, E0621, E0700.
 For more information about an error, try `rustc --explain E0310`.

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -4,5 +4,29 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
    |                                          ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/normalize-tait-in-const.rs:26:5
+   |
+LL |     fun(filter_positive());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct + ~const std::ops::Fn<(&Alias<'_>,)>>(fun: F) {
+   |                                                                              ++++++++++++++++++++++++++++++++++++
 
+error[E0493]: destructor of `F` cannot be evaluated at compile-time
+  --> $DIR/normalize-tait-in-const.rs:25:79
+   |
+LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
+   |                                                                               ^^^ the destructor for this type cannot be evaluated in constant functions
+LL |     fun(filter_positive());
+LL | }
+   | - value is dropped here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0493.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/infinite/infinite-tag-type-recursion.rs
+++ b/tests/ui/infinite/infinite-tag-type-recursion.rs
@@ -1,4 +1,5 @@
 enum MList { Cons(isize, MList), Nil }
 //~^ ERROR recursive type `MList` has infinite size
+//~| ERROR cycle
 
 fn main() { let a = MList::Cons(10, MList::Cons(11, MList::Nil)); }

--- a/tests/ui/infinite/infinite-tag-type-recursion.stderr
+++ b/tests/ui/infinite/infinite-tag-type-recursion.stderr
@@ -9,6 +9,17 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
 LL | enum MList { Cons(isize, Box<MList>), Nil }
    |                          ++++     +
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing when `MList` needs drop
+  --> $DIR/infinite-tag-type-recursion.rs:1:1
+   |
+LL | enum MList { Cons(isize, MList), Nil }
+   | ^^^^^^^^^^
+   |
+   = note: ...which immediately requires computing when `MList` needs drop again
+   = note: cycle used when computing whether `MList` needs drop
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-For more information about this error, try `rustc --explain E0072`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0072, E0391.
+For more information about an error, try `rustc --explain E0072`.

--- a/tests/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
+++ b/tests/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
@@ -26,5 +26,7 @@ fn main() {
     let _ = A(0);
     let _ = B(0);
     let _ = C(0);
-    let _ = E::X;
+    unsafe {
+        let _ = E::X;
+    }
 }

--- a/tests/ui/issues/issue-11374.rs
+++ b/tests/ui/issues/issue-11374.rs
@@ -18,6 +18,7 @@ impl<'a> Container<'a> {
 pub fn for_stdin<'a>() -> Container<'a> {
     let mut r = io::stdin();
     Container::wrap(&mut r as &mut dyn io::Read)
+    //~^ ERROR cannot return value referencing local variable
 }
 
 fn main() {

--- a/tests/ui/issues/issue-11374.stderr
+++ b/tests/ui/issues/issue-11374.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-11374.rs:26:15
+  --> $DIR/issue-11374.rs:27:15
    |
 LL |     c.read_to(v);
    |       ------- ^ expected `&mut [u8]`, found `Vec<_>`
@@ -18,6 +18,16 @@ help: consider mutably borrowing here
 LL |     c.read_to(&mut v);
    |               ++++
 
-error: aborting due to 1 previous error
+error[E0515]: cannot return value referencing local variable `r`
+  --> $DIR/issue-11374.rs:20:5
+   |
+LL |     Container::wrap(&mut r as &mut dyn io::Read)
+   |     ^^^^^^^^^^^^^^^^------^^^^^^^^^^^^^^^^^^^^^^
+   |     |               |
+   |     |               `r` is borrowed here
+   |     returns a value referencing data owned by the current function
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0515.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/issues/issue-13497.rs
+++ b/tests/ui/issues/issue-13497.rs
@@ -3,6 +3,7 @@ fn read_lines_borrowed1() -> Vec<
 > {
     let rawLines: Vec<String> = vec!["foo  ".to_string(), "  bar".to_string()];
     rawLines.iter().map(|l| l.trim()).collect()
+    //~^ ERROR: cannot return value referencing
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-13497.stderr
+++ b/tests/ui/issues/issue-13497.stderr
@@ -14,6 +14,16 @@ help: instead, you are more likely to want to return an owned value
 LL |     String
    |     ~~~~~~
 
-error: aborting due to 1 previous error
+error[E0515]: cannot return value referencing local variable `rawLines`
+  --> $DIR/issue-13497.rs:5:5
+   |
+LL |     rawLines.iter().map(|l| l.trim()).collect()
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     `rawLines` is borrowed here
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0515.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/issues/issue-2848.rs
+++ b/tests/ui/issues/issue-2848.rs
@@ -12,6 +12,7 @@ fn main() {
     use bar::foo::{alpha, charlie};
     match alpha {
       alpha | beta => {} //~  ERROR variable `beta` is not bound in all patterns
+      //~^ ERROR: `beta` is named the same as one of the variants
       charlie => {}
     }
 }

--- a/tests/ui/issues/issue-2848.stderr
+++ b/tests/ui/issues/issue-2848.stderr
@@ -6,6 +6,15 @@ LL |       alpha | beta => {}
    |       |
    |       pattern doesn't bind `beta`
 
-error: aborting due to 1 previous error
+error[E0170]: pattern binding `beta` is named the same as one of the variants of the type `bar::foo`
+  --> $DIR/issue-2848.rs:14:15
+   |
+LL |       alpha | beta => {}
+   |               ^^^^ help: to match on the variant, qualify the path: `bar::foo::beta`
+   |
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-For more information about this error, try `rustc --explain E0408`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0170, E0408.
+For more information about an error, try `rustc --explain E0170`.

--- a/tests/ui/issues/issue-28971.rs
+++ b/tests/ui/issues/issue-28971.rs
@@ -13,4 +13,5 @@ fn main(){
 
 fn foo<F>(f: F) where F: FnMut() {
     f();
+    //~^ ERROR: cannot borrow
 }

--- a/tests/ui/issues/issue-28971.stderr
+++ b/tests/ui/issues/issue-28971.stderr
@@ -10,6 +10,18 @@ LL |             Foo::Baz(..) => (),
    |                  variant or associated item not found in `Foo`
    |                  help: there is a variant with a similar name: `Bar`
 
-error: aborting due to 1 previous error
+error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+  --> $DIR/issue-28971.rs:15:5
+   |
+LL |     f();
+   |     ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn foo<F>(mut f: F) where F: FnMut() {
+   |           +++
 
-For more information about this error, try `rustc --explain E0599`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0596, E0599.
+For more information about an error, try `rustc --explain E0596`.

--- a/tests/ui/kindck/kindck-impl-type-params.rs
+++ b/tests/ui/kindck/kindck-impl-type-params.rs
@@ -28,6 +28,7 @@ fn g<T>(val: T) {
 fn foo<'a>() {
     let t: S<&'a isize> = S(marker::PhantomData);
     let a = &t as &dyn Gettable<&'a isize>;
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn foo2<'a>() {

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -75,7 +75,7 @@ LL | fn g<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
-  --> $DIR/kindck-impl-type-params.rs:35:13
+  --> $DIR/kindck-impl-type-params.rs:36:13
    |
 LL |     let a = t as Box<dyn Gettable<String>>;
    |             ^ the trait `Copy` is not implemented for `String`, which is required by `S<String>: Gettable<String>`
@@ -91,7 +91,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    = note: required for the cast from `Box<S<String>>` to `Box<dyn Gettable<String>>`
 
 error[E0277]: the trait bound `Foo: Copy` is not satisfied
-  --> $DIR/kindck-impl-type-params.rs:43:37
+  --> $DIR/kindck-impl-type-params.rs:44:37
    |
 LL |     let a: Box<dyn Gettable<Foo>> = t;
    |                                     ^ the trait `Copy` is not implemented for `Foo`, which is required by `S<Foo>: Gettable<Foo>`
@@ -111,6 +111,15 @@ LL +     #[derive(Copy)]
 LL |     struct Foo; // does not impl Copy
    |
 
-error: aborting due to 6 previous errors
+error: lifetime may not live long enough
+  --> $DIR/kindck-impl-type-params.rs:30:13
+   |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let t: S<&'a isize> = S(marker::PhantomData);
+LL |     let a = &t as &dyn Gettable<&'a isize>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/kindck/kindck-send-object1.rs
+++ b/tests/ui/kindck/kindck-send-object1.rs
@@ -12,6 +12,7 @@ fn test51<'a>() {
 }
 fn test52<'a>() {
     assert_send::<&'a (dyn Dummy + Sync)>();
+    //~^ ERROR: lifetime may not live long enough
 }
 
 // ...unless they are properly bounded

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -13,7 +13,7 @@ LL | fn assert_send<T:Send+'static>() { }
    |                  ^^^^ required by this bound in `assert_send`
 
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
-  --> $DIR/kindck-send-object1.rs:28:19
+  --> $DIR/kindck-send-object1.rs:29:19
    |
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
@@ -28,6 +28,14 @@ note: required by a bound in `assert_send`
 LL | fn assert_send<T:Send+'static>() { }
    |                  ^^^^ required by this bound in `assert_send`
 
-error: aborting due to 2 previous errors
+error: lifetime may not live long enough
+  --> $DIR/kindck-send-object1.rs:14:5
+   |
+LL | fn test52<'a>() {
+   |           -- lifetime `'a` defined here
+LL |     assert_send::<&'a (dyn Dummy + Sync)>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/lifetimes/issue-17728.rs
+++ b/tests/ui/lifetimes/issue-17728.rs
@@ -12,7 +12,7 @@ trait TraversesWorld {
         let direction = str_to_direction(directionStr);
         let maybe_room = room.direction_to_room.get(&direction);
         match maybe_room {
-            Some(entry) => Ok(entry),
+            Some(entry) => Ok(entry), //~ ERROR: lifetime may not live long enough
             _ => Err("Direction does not exist in room.")
         }
     }

--- a/tests/ui/lifetimes/issue-17728.stderr
+++ b/tests/ui/lifetimes/issue-17728.stderr
@@ -16,6 +16,22 @@ LL | |     }
    = note: expected enum `RoomDirection`
               found enum `Option<_>`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/issue-17728.rs:15:28
+   |
+LL |     fn attemptTraverse(&self, room: &Room, directionStr: &str) -> Result<&Room, &str> {
+   |                        -            - let's call the lifetime of this reference `'1`
+   |                        |
+   |                        let's call the lifetime of this reference `'2`
+...
+LL |             Some(entry) => Ok(entry),
+   |                            ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&Room, &str> {
+   |                       ++++  ++              ++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
@@ -1,5 +1,7 @@
 fn foo(x: &i32, y: &i32) -> &i32 { //~ ERROR missing lifetime
     if x > y { x } else { y }
+    //~^ ERROR: lifetime may not live long enough
+    //~| ERROR: lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -10,6 +10,22 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |       ++++     ++          ++          ++
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/ex1b-return-no-names-if-else.rs:2:16
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |           - let's call the lifetime of this reference `'1`
+LL |     if x > y { x } else { y }
+   |                ^ returning this value requires that `'1` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/ex1b-return-no-names-if-else.rs:2:27
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |                    - let's call the lifetime of this reference `'2`
+LL |     if x > y { x } else { y }
+   |                           ^ returning this value requires that `'2` must outlive `'static`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/liveness/liveness-forgot-ret.rs
+++ b/tests/ui/liveness/liveness-forgot-ret.rs
@@ -1,4 +1,5 @@
 fn god_exists(a: isize) -> bool { return god_exists(a); }
+//~^ WARN function cannot return without recursing
 
 fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
 //~^ ERROR mismatched types

--- a/tests/ui/liveness/liveness-forgot-ret.stderr
+++ b/tests/ui/liveness/liveness-forgot-ret.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/liveness-forgot-ret.rs:3:19
+  --> $DIR/liveness-forgot-ret.rs:4:19
    |
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected `isize`, found `()`
@@ -11,6 +11,17 @@ help: consider returning the local binding `a`
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; a }
    |                                                           +
 
-error: aborting due to 1 previous error
+warning: function cannot return without recursing
+  --> $DIR/liveness-forgot-ret.rs:1:1
+   |
+LL | fn god_exists(a: isize) -> bool { return god_exists(a); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ------------- recursive call site
+   | |
+   | cannot return without recursing
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/loops/loop-else-break-with-value.rs
+++ b/tests/ui/loops/loop-else-break-with-value.rs
@@ -1,6 +1,11 @@
 fn main() {
     let Some(1) = loop {
         //~^ NOTE `else` is attached to this loop
+        //~| ERROR refutable pattern in local binding
+        //~| NOTE not covered
+        //~| NOTE for more information
+        //~| NOTE matched value is of type
+        //~| NOTE require an "irrefutable pattern"
         break Some(1)
     } else {
         //~^ ERROR `loop...else` loops are not supported

--- a/tests/ui/loops/loop-else-break-with-value.stderr
+++ b/tests/ui/loops/loop-else-break-with-value.stderr
@@ -1,5 +1,5 @@
 error: `loop...else` loops are not supported
-  --> $DIR/loop-else-break-with-value.rs:5:7
+  --> $DIR/loop-else-break-with-value.rs:10:7
    |
 LL |       let Some(1) = loop {
    |                     ---- `else` is attached to this loop
@@ -14,5 +14,24 @@ LL | |     };
    |
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
-error: aborting due to 1 previous error
+error[E0005]: refutable pattern in local binding
+  --> $DIR/loop-else-break-with-value.rs:2:9
+   |
+LL |     let Some(1) = loop {
+   |         ^^^^^^^ pattern `None` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Option<i32>`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL ~     if let Some(1) = loop {
+LL |
+ ...
+LL |         return;
+LL ~     } { todo!() };
+   |
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0005`.

--- a/tests/ui/methods/assign-to-method.rs
+++ b/tests/ui/methods/assign-to-method.rs
@@ -6,7 +6,7 @@ struct Cat {
 }
 
 impl Cat {
-    pub fn speak(&self) { self.meows += 1; }
+    pub fn speak(&mut self) { self.meows += 1; }
 }
 
 fn cat(in_x : usize, in_y : isize) -> Cat {

--- a/tests/ui/mir/drop-elaboration-after-borrowck-error.rs
+++ b/tests/ui/mir/drop-elaboration-after-borrowck-error.rs
@@ -6,7 +6,6 @@ static A: () = {
     //~^ ERROR destructor of
     a[0] = String::new();
     //~^ ERROR destructor of
-    //~| ERROR binding `a` isn't initialized
 };
 
 struct B<T>([T; 1]);
@@ -17,7 +16,6 @@ impl<T> B<T> {
         //~^ ERROR destructor of
         self.0[0] = other;
         //~^ ERROR destructor of
-        //~| ERROR use of moved value
         self
     }
 }

--- a/tests/ui/mir/drop-elaboration-after-borrowck-error.stderr
+++ b/tests/ui/mir/drop-elaboration-after-borrowck-error.stderr
@@ -16,22 +16,8 @@ LL |     let a: [String; 1];
 LL | };
    | - value is dropped here
 
-error[E0381]: used binding `a` isn't initialized
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:7:5
-   |
-LL |     let a: [String; 1];
-   |         - binding declared here but left uninitialized
-LL |
-LL |     a[0] = String::new();
-   |     ^^^^ `a` used here but it isn't initialized
-   |
-help: consider assigning a value
-   |
-LL |     let a: [String; 1] = todo!();
-   |                        +++++++++
-
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:18:9
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:17:9
    |
 LL |         self.0[0] = other;
    |         ^^^^^^^^^
@@ -40,7 +26,7 @@ LL |         self.0[0] = other;
    |         value is dropped here
 
 error[E0493]: destructor of `B<T>` cannot be evaluated at compile-time
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:16:13
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:15:13
    |
 LL |         let _this = self;
    |             ^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -48,18 +34,6 @@ LL |         let _this = self;
 LL |     }
    |     - value is dropped here
 
-error[E0382]: use of moved value: `self.0`
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:18:9
-   |
-LL |     pub const fn f(mut self, other: T) -> Self {
-   |                    -------- move occurs because `self` has type `B<T>`, which does not implement the `Copy` trait
-LL |         let _this = self;
-   |                     ---- value moved here
-LL |
-LL |         self.0[0] = other;
-   |         ^^^^^^^^^ value used here after move
+error: aborting due to 4 previous errors
 
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0381, E0382, E0493.
-For more information about an error, try `rustc --explain E0381`.
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.rs
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.rs
@@ -8,4 +8,7 @@ fn main() {
 fn baz<F: Fn(*mut &u32)>(_: F) {}
 fn _test<'a>(f: fn(*mut &'a u32)) {
     baz(f);
+    //~^ ERROR: mismatched types
+    //~| ERROR: borrowed data escapes
+    //~| ERROR: not general enough
 }

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -41,6 +41,52 @@ LL |     a.iter().map(|_: (u16, u16)| 45);
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error: aborting due to 3 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/closure-arg-type-mismatch.rs:10:5
+   |
+LL | fn _test<'a>(f: fn(*mut &'a u32)) {
+   |          --  - `f` is a reference that is only valid in the function body
+   |          |
+   |          lifetime `'a` defined here
+LL |     baz(f);
+   |     ^^^^^^
+   |     |
+   |     `f` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+   |
+   = note: requirement occurs because of a mutable pointer to `&u32`
+   = note: mutable pointers are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+note: due to current limitations in the borrow checker, this implies a `'static` lifetime
+  --> $DIR/closure-arg-type-mismatch.rs:8:11
+   |
+LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
+   |           ^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0631`.
+error[E0308]: mismatched types
+  --> $DIR/closure-arg-type-mismatch.rs:10:5
+   |
+LL |     baz(f);
+   |     ^^^^^^ one type is more general than the other
+   |
+   = note: expected trait `for<'a> Fn(*mut &'a u32)`
+              found trait `Fn(*mut &u32)`
+note: the lifetime requirement is introduced here
+  --> $DIR/closure-arg-type-mismatch.rs:8:11
+   |
+LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
+   |           ^^^^^^^^^^^^^
+
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/closure-arg-type-mismatch.rs:10:5
+   |
+LL |     baz(f);
+   |     ^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: `fn(*mut &'2 u32)` must implement `FnOnce<(*mut &'1 u32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(*mut &'2 u32,)>`, for some specific lifetime `'2`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0521, E0631.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/nll/continue-after-missing-main.rs
+++ b/tests/ui/nll/continue-after-missing-main.rs
@@ -26,4 +26,6 @@ fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
     tableau: Tableau<'data_provider, AdaptedMatrixProvider<'original_data, MP>>,
 ) {
     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
+    //~^ ERROR: lifetime may not live long enough
+    //~| ERROR: `tableau` does not live long enough
 } //~ ERROR `main` function not found in crate

--- a/tests/ui/nll/continue-after-missing-main.stderr
+++ b/tests/ui/nll/continue-after-missing-main.stderr
@@ -1,9 +1,39 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:29:2
+  --> $DIR/continue-after-missing-main.rs:31:2
    |
 LL | }
    |  ^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/continue-after-missing-main.rs:28:12
+   |
+LL | fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
+   |                                 --------------  -------------- lifetime `'original_data` defined here
+   |                                 |
+   |                                 lifetime `'data_provider` defined here
+...
+LL |     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'data_provider` must outlive `'original_data`
+   |
+   = help: consider adding the following bound: `'data_provider: 'original_data`
 
-For more information about this error, try `rustc --explain E0601`.
+error[E0597]: `tableau` does not live long enough
+  --> $DIR/continue-after-missing-main.rs:28:56
+   |
+LL | fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
+   |                                                 -------------- lifetime `'original_data` defined here
+LL |     tableau: Tableau<'data_provider, AdaptedMatrixProvider<'original_data, MP>>,
+   |     ------- binding `tableau` declared here
+LL | ) {
+LL |     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
+   |            -----------------------------------------   ^^^^^^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `tableau` is borrowed for `'original_data`
+...
+LL | }
+   |  - `tableau` dropped here while still borrowed
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0597, E0601.
+For more information about an error, try `rustc --explain E0597`.

--- a/tests/ui/or-patterns/missing-bindings.rs
+++ b/tests/ui/or-patterns/missing-bindings.rs
@@ -17,8 +17,10 @@ fn check_handling_of_paths() {
 
     use bar::foo::{alpha, charlie};
     let (alpha | beta | charlie) = alpha; //~  ERROR variable `beta` is not bound in all patterns
-    match Some(alpha) {
+    //~^ ERROR: `beta` is named the same as one of the variants
+    match Some(alpha) { //~ ERROR `None` not covered
         Some(alpha | beta) => {} //~ ERROR variable `beta` is not bound in all patterns
+        //~^ ERROR: `beta` is named the same as one of the variants
     }
 }
 

--- a/tests/ui/or-patterns/missing-bindings.stderr
+++ b/tests/ui/or-patterns/missing-bindings.stderr
@@ -8,7 +8,7 @@ LL |     let (alpha | beta | charlie) = alpha;
    |          pattern doesn't bind `beta`
 
 error[E0408]: variable `beta` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:21:14
+  --> $DIR/missing-bindings.rs:22:14
    |
 LL |         Some(alpha | beta) => {}
    |              ^^^^^   ---- variable not in all patterns
@@ -16,7 +16,7 @@ LL |         Some(alpha | beta) => {}
    |              pattern doesn't bind `beta`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:33:20
+  --> $DIR/missing-bindings.rs:35:20
    |
 LL |     let (A(a, _) | _) = X;
    |            -       ^ pattern doesn't bind `a`
@@ -24,7 +24,7 @@ LL |     let (A(a, _) | _) = X;
    |            variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:34:10
+  --> $DIR/missing-bindings.rs:36:10
    |
 LL |     let (_ | B(a)) = X;
    |          ^     - variable not in all patterns
@@ -32,7 +32,7 @@ LL |     let (_ | B(a)) = X;
    |          pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:35:10
+  --> $DIR/missing-bindings.rs:37:10
    |
 LL |     let (A(..) | B(a)) = X;
    |          ^^^^^     - variable not in all patterns
@@ -40,7 +40,7 @@ LL |     let (A(..) | B(a)) = X;
    |          pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:36:20
+  --> $DIR/missing-bindings.rs:38:20
    |
 LL |     let (A(a, _) | B(_)) = X;
    |            -       ^^^^ pattern doesn't bind `a`
@@ -48,7 +48,7 @@ LL |     let (A(a, _) | B(_)) = X;
    |            variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:37:20
+  --> $DIR/missing-bindings.rs:39:20
    |
 LL |     let (A(_, a) | B(_)) = X;
    |               -    ^^^^ pattern doesn't bind `a`
@@ -56,7 +56,7 @@ LL |     let (A(_, a) | B(_)) = X;
    |               variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:38:20
+  --> $DIR/missing-bindings.rs:40:20
    |
 LL |     let (A(a, b) | B(a)) = X;
    |               -    ^^^^ pattern doesn't bind `b`
@@ -64,7 +64,7 @@ LL |     let (A(a, b) | B(a)) = X;
    |               variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:42:10
+  --> $DIR/missing-bindings.rs:44:10
    |
 LL |     let (A(A(..) | B(_), _) | B(a)) = Y;
    |          ^^^^^^^^^^^^^^^^^^     - variable not in all patterns
@@ -72,7 +72,7 @@ LL |     let (A(A(..) | B(_), _) | B(a)) = Y;
    |          pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:43:12
+  --> $DIR/missing-bindings.rs:45:12
    |
 LL |     let (A(A(..) | B(a), _) | B(A(a, _) | B(a))) = Y;
    |            ^^^^^     - variable not in all patterns
@@ -80,7 +80,7 @@ LL |     let (A(A(..) | B(a), _) | B(A(a, _) | B(a))) = Y;
    |            pattern doesn't bind `a`
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:12
+  --> $DIR/missing-bindings.rs:47:12
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |            ^^^^^^^     - variable not in all patterns
@@ -88,7 +88,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |            pattern doesn't bind `c`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:22
+  --> $DIR/missing-bindings.rs:47:22
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              -       ^^^^ pattern doesn't bind `a`
@@ -96,7 +96,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:22
+  --> $DIR/missing-bindings.rs:47:22
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 -    ^^^^ pattern doesn't bind `b`
@@ -104,7 +104,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 variable not in all patterns
 
 error[E0408]: variable `e` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:10
+  --> $DIR/missing-bindings.rs:47:10
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |          ^^^^^^^^^^^^^^^^^^^^     - variable not in all patterns
@@ -112,7 +112,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |          pattern doesn't bind `e`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              -                  ^^^^ pattern doesn't bind `a`
@@ -120,7 +120,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 -               ^^^^ pattern doesn't bind `b`
@@ -128,7 +128,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 variable not in all patterns
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                        -        ^^^^ pattern doesn't bind `c`
@@ -136,7 +136,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                        variable not in all patterns
 
 error[E0408]: variable `d` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                            -    ^^^^ pattern doesn't bind `d`
@@ -144,7 +144,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                            variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:61:29
+  --> $DIR/missing-bindings.rs:63:29
    |
 LL |                     Ok(a) | Err(_),
    |                        -    ^^^^^^ pattern doesn't bind `a`
@@ -152,7 +152,7 @@ LL |                     Ok(a) | Err(_),
    |                        variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:68:21
+  --> $DIR/missing-bindings.rs:70:21
    |
 LL |                     A(_, a) |
    |                     ^^^^^^^ pattern doesn't bind `b`
@@ -160,7 +160,7 @@ LL |                     B(b),
    |                       - variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:69:21
+  --> $DIR/missing-bindings.rs:71:21
    |
 LL |                     A(_, a) |
    |                          - variable not in all patterns
@@ -168,7 +168,7 @@ LL |                     B(b),
    |                     ^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:72:17
+  --> $DIR/missing-bindings.rs:74:17
    |
 LL |                     A(_, a) |
    |                          - variable not in all patterns
@@ -177,7 +177,7 @@ LL |                 B(_)
    |                 ^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:72:17
+  --> $DIR/missing-bindings.rs:74:17
    |
 LL |                     B(b),
    |                       - variable not in all patterns
@@ -186,7 +186,7 @@ LL |                 B(_)
    |                 ^^^^ pattern doesn't bind `b`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:57:13
+  --> $DIR/missing-bindings.rs:59:13
    |
 LL | /             V1(
 LL | |
@@ -204,7 +204,7 @@ LL |               V3(c),
    |               ^^^^^ pattern doesn't bind `b`
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:57:13
+  --> $DIR/missing-bindings.rs:59:13
    |
 LL | /             V1(
 LL | |
@@ -226,7 +226,7 @@ LL |               V3(c),
    |                  - variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:76:13
+  --> $DIR/missing-bindings.rs:78:13
    |
 LL |                 B(Ok(a) | Err(a))
    |                               - variable not in all patterns
@@ -237,6 +237,38 @@ LL |                     A(_, a) |
 LL |             V3(c),
    |             ^^^^^ pattern doesn't bind `a`
 
-error: aborting due to 26 previous errors
+error[E0170]: pattern binding `beta` is named the same as one of the variants of the type `check_handling_of_paths::bar::foo`
+  --> $DIR/missing-bindings.rs:19:18
+   |
+LL |     let (alpha | beta | charlie) = alpha;
+   |                  ^^^^
+   |
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-For more information about this error, try `rustc --explain E0408`.
+error[E0170]: pattern binding `beta` is named the same as one of the variants of the type `check_handling_of_paths::bar::foo`
+  --> $DIR/missing-bindings.rs:22:22
+   |
+LL |         Some(alpha | beta) => {}
+   |                      ^^^^ help: to match on the variant, qualify the path: `check_handling_of_paths::bar::foo::beta`
+
+error[E0004]: non-exhaustive patterns: `None` not covered
+  --> $DIR/missing-bindings.rs:21:11
+   |
+LL |     match Some(alpha) {
+   |           ^^^^^^^^^^^ pattern `None` not covered
+   |
+note: `Option<foo>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<foo>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL |         Some(alpha | beta) => {}, None => todo!()
+   |                                 +++++++++++++++++
+
+error: aborting due to 29 previous errors
+
+Some errors have detailed explanations: E0004, E0170, E0408.
+For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/parser/bad-let-else-statement.rs
+++ b/tests/ui/parser/bad-let-else-statement.rs
@@ -5,6 +5,7 @@
 
 fn a() {
     let foo = {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -23,6 +24,7 @@ fn b() {
 
 fn c() {
     let foo = if true {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         0
@@ -43,6 +45,7 @@ fn d() {
 
 fn e() {
     let foo = match true {
+        //~^ WARN irrefutable `let...else` pattern
         true => 1,
         false => 0
     } else {
@@ -54,6 +57,7 @@ fn e() {
 struct X {a: i32}
 fn f() {
     let foo = X {
+        //~^ WARN irrefutable `let...else` pattern
         a: 1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -72,6 +76,7 @@ fn g() {
 
 fn h() {
     let foo = const {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -81,6 +86,7 @@ fn h() {
 
 fn i() {
     let foo = &{
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -90,7 +96,8 @@ fn i() {
 
 fn j() {
     let bar = 0;
-    let foo = bar = {
+    let foo = bar = { //~ ERROR: cannot assign twice
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -100,6 +107,7 @@ fn j() {
 
 fn k() {
     let foo = 1 + {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -109,6 +117,7 @@ fn k() {
 
 fn l() {
     let foo = 1..{
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -118,6 +127,7 @@ fn l() {
 
 fn m() {
     let foo = return {
+        //~^ WARN irrefutable `let...else` pattern
         ()
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -127,6 +137,7 @@ fn m() {
 
 fn n() {
     let foo = -{
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -136,6 +147,7 @@ fn n() {
 
 fn o() -> Result<(), ()> {
     let foo = do yeet {
+        //~^ WARN irrefutable `let...else` pattern
         ()
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -145,6 +157,7 @@ fn o() -> Result<(), ()> {
 
 fn p() {
     let foo = become {
+        //~^ WARN irrefutable `let...else` pattern
         ()
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -154,6 +167,7 @@ fn p() {
 
 fn q() {
     let foo = |x: i32| {
+        //~^ WARN irrefutable `let...else` pattern
         x
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -163,14 +177,18 @@ fn q() {
 
 fn r() {
     let ok = format_args!("") else { return; };
+    //~^ WARN irrefutable `let...else` pattern
 
     let bad = format_args! {""} else { return; };
     //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
+    //~| WARN irrefutable `let...else` pattern
 }
 
 fn s() {
     macro_rules! a {
         () => { {} }
+        //~^ WARN irrefutable `let...else` pattern
+        //~| WARN irrefutable `let...else` pattern
     }
 
     macro_rules! b {

--- a/tests/ui/parser/bad-let-else-statement.stderr
+++ b/tests/ui/parser/bad-let-else-statement.stderr
@@ -1,5 +1,5 @@
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:9:5
+  --> $DIR/bad-let-else-statement.rs:10:5
    |
 LL |     } else {
    |     ^
@@ -7,12 +7,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = ({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: `for...else` loops are not supported
-  --> $DIR/bad-let-else-statement.rs:18:7
+  --> $DIR/bad-let-else-statement.rs:19:7
    |
 LL |       let foo = for i in 1..2 {
    |                 --- `else` is attached to this loop
@@ -27,7 +28,7 @@ LL | |     };
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:29:5
+  --> $DIR/bad-let-else-statement.rs:31:5
    |
 LL |     } else {
    |     ^
@@ -35,14 +36,14 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (if true {
-LL |         1
-LL |     } else {
+LL |
+ ...
 LL |         0
 LL ~     }) else {
    |
 
 error: `loop...else` loops are not supported
-  --> $DIR/bad-let-else-statement.rs:38:7
+  --> $DIR/bad-let-else-statement.rs:40:7
    |
 LL |       let foo = loop {
    |                 ---- `else` is attached to this loop
@@ -57,7 +58,7 @@ LL | |     };
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:48:5
+  --> $DIR/bad-let-else-statement.rs:51:5
    |
 LL |     } else {
    |     ^
@@ -65,13 +66,14 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (match true {
+LL |
 LL |         true => 1,
 LL |         false => 0
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:58:5
+  --> $DIR/bad-let-else-statement.rs:62:5
    |
 LL |     } else {
    |     ^
@@ -79,12 +81,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (X {
+LL |
 LL |         a: 1
 LL ~     }) else {
    |
 
 error: `while...else` loops are not supported
-  --> $DIR/bad-let-else-statement.rs:67:7
+  --> $DIR/bad-let-else-statement.rs:71:7
    |
 LL |       let foo = while false {
    |                 ----- `else` is attached to this loop
@@ -99,7 +102,7 @@ LL | |     };
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:76:5
+  --> $DIR/bad-let-else-statement.rs:81:5
    |
 LL |     } else {
    |     ^
@@ -107,12 +110,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (const {
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:85:5
+  --> $DIR/bad-let-else-statement.rs:91:5
    |
 LL |     } else {
    |     ^
@@ -120,12 +124,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = &({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:95:5
+  --> $DIR/bad-let-else-statement.rs:102:5
    |
 LL |     } else {
    |     ^
@@ -133,12 +138,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = bar = ({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:104:5
+  --> $DIR/bad-let-else-statement.rs:112:5
    |
 LL |     } else {
    |     ^
@@ -146,19 +152,7 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = 1 + ({
-LL |         1
-LL ~     }) else {
-   |
-
-error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:113:5
-   |
-LL |     } else {
-   |     ^
-   |
-help: wrap the expression in parentheses
-   |
-LL ~     let foo = 1..({
+LL |
 LL |         1
 LL ~     }) else {
    |
@@ -171,13 +165,28 @@ LL |     } else {
    |
 help: wrap the expression in parentheses
    |
+LL ~     let foo = 1..({
+LL |
+LL |         1
+LL ~     }) else {
+   |
+
+error: right curly brace `}` before `else` in a `let...else` statement not allowed
+  --> $DIR/bad-let-else-statement.rs:132:5
+   |
+LL |     } else {
+   |     ^
+   |
+help: wrap the expression in parentheses
+   |
 LL ~     let foo = return ({
+LL |
 LL |         ()
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:131:5
+  --> $DIR/bad-let-else-statement.rs:142:5
    |
 LL |     } else {
    |     ^
@@ -185,12 +194,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = -({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:140:5
+  --> $DIR/bad-let-else-statement.rs:152:5
    |
 LL |     } else {
    |     ^
@@ -198,12 +208,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = do yeet ({
+LL |
 LL |         ()
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:149:5
+  --> $DIR/bad-let-else-statement.rs:162:5
    |
 LL |     } else {
    |     ^
@@ -211,12 +222,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = become ({
+LL |
 LL |         ()
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:158:5
+  --> $DIR/bad-let-else-statement.rs:172:5
    |
 LL |     } else {
    |     ^
@@ -224,12 +236,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = |x: i32| ({
+LL |
 LL |         x
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:167:31
+  --> $DIR/bad-let-else-statement.rs:182:31
    |
 LL |     let bad = format_args! {""} else { return; };
    |                               ^
@@ -240,7 +253,7 @@ LL |     let bad = format_args! ("") else { return; };
    |                            ~  ~
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:181:25
+  --> $DIR/bad-let-else-statement.rs:199:25
    |
 LL |             let x = a! {} else { return; };
    |                         ^
@@ -254,5 +267,251 @@ help: use parentheses instead of braces for this macro
 LL |             let x = a! () else { return; };
    |                        ~~
 
-error: aborting due to 19 previous errors
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:7:5
+   |
+LL | /     let foo = {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
 
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:26:5
+   |
+LL | /     let foo = if true {
+LL | |
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:47:5
+   |
+LL | /     let foo = match true {
+LL | |
+LL | |         true => 1,
+LL | |         false => 0
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:59:5
+   |
+LL | /     let foo = X {
+LL | |
+LL | |         a: 1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:78:5
+   |
+LL | /     let foo = const {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:88:5
+   |
+LL | /     let foo = &{
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:99:5
+   |
+LL | /     let foo = bar = {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+error[E0384]: cannot assign twice to immutable variable `bar`
+  --> $DIR/bad-let-else-statement.rs:99:15
+   |
+LL |       let bar = 0;
+   |           ---
+   |           |
+   |           first assignment to `bar`
+   |           help: consider making this binding mutable: `mut bar`
+LL |       let foo = bar = {
+   |  _______________^
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^ cannot assign twice to immutable variable
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:109:5
+   |
+LL | /     let foo = 1 + {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:119:5
+   |
+LL | /     let foo = 1..{
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:129:5
+   |
+LL | /     let foo = return {
+LL | |
+LL | |         ()
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:139:5
+   |
+LL | /     let foo = -{
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:149:5
+   |
+LL | /     let foo = do yeet {
+LL | |
+LL | |         ()
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:159:5
+   |
+LL | /     let foo = become {
+LL | |
+LL | |         ()
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:169:5
+   |
+LL | /     let foo = |x: i32| {
+LL | |
+LL | |         x
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:179:5
+   |
+LL |     let ok = format_args!("") else { return; };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:182:5
+   |
+LL |     let bad = format_args! {""} else { return; };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:189:19
+   |
+LL |           () => { {} }
+   |  ___________________^
+LL | |
+LL | |
+LL | |     }
+...  |
+LL | |         (1) => {
+LL | |             let x = a!() else { return; };
+   | |____________^
+...
+LL |       b!(1); b!(2);
+   |       ----- in this macro invocation
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+   = note: this warning originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:189:19
+   |
+LL |           () => { {} }
+   |  ___________________^
+LL | |
+LL | |
+LL | |     }
+...  |
+LL | |         (2) => {
+LL | |             let x = a! {} else { return; };
+   | |____________^
+...
+LL |       b!(1); b!(2);
+   |              ----- in this macro invocation
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+   = note: this warning originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 20 previous errors; 18 warnings emitted
+
+For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/parser/issues/issue-35813-postfix-after-cast.rs
+++ b/tests/ui/parser/issues/issue-35813-postfix-after-cast.rs
@@ -129,6 +129,7 @@ pub fn inside_block() {
 
 static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
 //~^ ERROR: cast cannot be followed by indexing
+//~| ERROR: cannot call non-const operator in statics
 
 static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
 //~^ ERROR: expected one of

--- a/tests/ui/parser/issues/issue-35813-postfix-after-cast.stderr
+++ b/tests/ui/parser/issues/issue-35813-postfix-after-cast.stderr
@@ -235,13 +235,13 @@ LL | static bar: &[i32] = &((&[1,2,3] as &[i32])[0..1]);
    |                        +                  +
 
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:133:36
+  --> $DIR/issue-35813-postfix-after-cast.rs:134:36
    |
 LL | static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
    |                                    ^ expected one of `)`, `,`, `.`, `?`, or an operator
 
 error: cast cannot be followed by `?`
-  --> $DIR/issue-35813-postfix-after-cast.rs:138:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:139:5
    |
 LL |     Err(0u64) as Result<u64,u64>?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -252,13 +252,13 @@ LL |     (Err(0u64) as Result<u64,u64>)?;
    |     +                            +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:140:14
+  --> $DIR/issue-35813-postfix-after-cast.rs:141:14
    |
 LL |     Err(0u64): Result<u64,u64>?;
    |              ^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: expected identifier, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:152:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:153:13
    |
 LL |     drop_ptr: F();
    |             ^ expected identifier
@@ -266,13 +266,13 @@ LL |     drop_ptr: F();
    = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:159:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:160:13
    |
 LL |     drop_ptr: fn(u8);
    |             ^ expected one of 8 possible tokens
 
 error: cast cannot be followed by a function call
-  --> $DIR/issue-35813-postfix-after-cast.rs:165:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:166:5
    |
 LL |     drop as fn(u8)(0);
    |     ^^^^^^^^^^^^^^
@@ -283,13 +283,13 @@ LL |     (drop as fn(u8))(0);
    |     +              +
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:167:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:168:13
    |
 LL |     drop_ptr: fn(u8)(0);
    |             ^ expected one of 8 possible tokens
 
 error: cast cannot be followed by `.await`
-  --> $DIR/issue-35813-postfix-after-cast.rs:172:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:173:5
    |
 LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -300,13 +300,13 @@ LL |     (Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>).await;
    |     +                                                     +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:175:21
+  --> $DIR/issue-35813-postfix-after-cast.rs:176:21
    |
 LL |     Box::pin(noop()): Pin<Box<_>>.await;
    |                     ^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: cast cannot be followed by a field access
-  --> $DIR/issue-35813-postfix-after-cast.rs:187:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:188:5
    |
 LL |     Foo::default() as Foo.bar;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -317,7 +317,7 @@ LL |     (Foo::default() as Foo).bar;
    |     +                     +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:189:19
+  --> $DIR/issue-35813-postfix-after-cast.rs:190:19
    |
 LL |     Foo::default(): Foo.bar;
    |                   ^ expected one of `.`, `;`, `?`, `}`, or an operator
@@ -340,11 +340,22 @@ LL |         if true { 33 } else { 44 }: i32.max(0)
    |                                   ^ expected one of `,`, `.`, `?`, or an operator
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-35813-postfix-after-cast.rs:150:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:151:13
    |
 LL |     drop as F();
    |             ^^^ only `Fn` traits may use parentheses
 
-error: aborting due to 39 previous errors
+error[E0015]: cannot call non-const operator in statics
+  --> $DIR/issue-35813-postfix-after-cast.rs:130:42
+   |
+LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
+   |                                          ^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 40 previous errors
+
+Some errors have detailed explanations: E0015, E0214.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.rs
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.rs
@@ -37,9 +37,10 @@ fn g1() {
         //~| HELP: maybe write a path separator here
         _ => {}
     }
-    if let Foo:Bar = f() {
+    if let Foo:Bar = f() { //~ WARN: irrefutable `if let` pattern
     //~^ ERROR: expected one of
     //~| HELP: maybe write a path separator here
+    //~| HELP: consider replacing the `if let` with a `let`
     }
 }
 

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
@@ -64,7 +64,7 @@ LL |     if let Foo::Bar = f() {
    |               ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:48:16
+  --> $DIR/issue-87086-colon-path-sep.rs:49:16
    |
 LL |         ref qux: Foo::Baz => {}
    |                ^ -------- specifying the type of a pattern isn't supported
@@ -77,7 +77,7 @@ LL |         ref qux::Foo::Baz => {}
    |                ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:57:16
+  --> $DIR/issue-87086-colon-path-sep.rs:58:16
    |
 LL |         mut qux: Foo::Baz => {}
    |                ^ -------- specifying the type of a pattern isn't supported
@@ -90,7 +90,7 @@ LL |         mut qux::Foo::Baz => {}
    |                ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:68:12
+  --> $DIR/issue-87086-colon-path-sep.rs:69:12
    |
 LL |         Foo:Bar::Baz => {}
    |            ^-------- specifying the type of a pattern isn't supported
@@ -103,7 +103,7 @@ LL |         Foo::Bar::Baz => {}
    |            ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:74:12
+  --> $DIR/issue-87086-colon-path-sep.rs:75:12
    |
 LL |         Foo:Bar => {}
    |            ^--- specifying the type of a pattern isn't supported
@@ -115,5 +115,15 @@ help: maybe write a path separator here
 LL |         Foo::Bar => {}
    |            ~~
 
-error: aborting due to 9 previous errors
+warning: irrefutable `if let` pattern
+  --> $DIR/issue-87086-colon-path-sep.rs:40:8
+   |
+LL |     if let Foo:Bar = f() {
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `if let` is useless
+   = help: consider replacing the `if let` with a `let`
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+
+error: aborting due to 9 previous errors; 1 warning emitted
 

--- a/tests/ui/parser/recover/recover-range-pats.rs
+++ b/tests/ui/parser/recover/recover-range-pats.rs
@@ -134,10 +134,13 @@ fn with_macro_expr_var() {
     macro_rules! mac2 {
         ($e1:expr, $e2:expr) => {
             let $e1..$e2;
+            //~^ ERROR refutable pattern in local binding
             let $e1...$e2;
             //~^ ERROR `...` range patterns are deprecated
             //~| WARN this is accepted in the current edition
+            //~| ERROR refutable pattern in local binding
             let $e1..=$e2;
+            //~^ ERROR refutable pattern in local binding
         }
     }
 
@@ -146,12 +149,18 @@ fn with_macro_expr_var() {
     macro_rules! mac {
         ($e:expr) => {
             let ..$e;
+            //~^ ERROR refutable pattern in local binding
             let ...$e;
             //~^ ERROR range-to patterns with `...` are not allowed
+            //~| ERROR refutable pattern in local binding
             let ..=$e;
+            //~^ ERROR refutable pattern in local binding
             let $e..;
+            //~^ ERROR refutable pattern in local binding
             let $e...; //~ ERROR inclusive range with no end
+            //~^ ERROR refutable pattern in local binding
             let $e..=; //~ ERROR inclusive range with no end
+            //~^ ERROR refutable pattern in local binding
         }
     }
 

--- a/tests/ui/parser/recover/recover-range-pats.stderr
+++ b/tests/ui/parser/recover/recover-range-pats.stderr
@@ -159,7 +159,7 @@ LL |     if let ....3 = 0 {}
    |            ^^^ help: use `..=` instead
 
 error: range-to patterns with `...` are not allowed
-  --> $DIR/recover-range-pats.rs:149:17
+  --> $DIR/recover-range-pats.rs:153:17
    |
 LL |             let ...$e;
    |                 ^^^ help: use `..=` instead
@@ -170,7 +170,7 @@ LL |     mac!(0);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/recover-range-pats.rs:153:19
+  --> $DIR/recover-range-pats.rs:160:19
    |
 LL |             let $e...;
    |                   ^^^ help: use `..` instead
@@ -182,7 +182,7 @@ LL |     mac!(0);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/recover-range-pats.rs:154:19
+  --> $DIR/recover-range-pats.rs:162:19
    |
 LL |             let $e..=;
    |                   ^^^ help: use `..` instead
@@ -271,7 +271,7 @@ LL |     if let X... .0 = 0 {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
-  --> $DIR/recover-range-pats.rs:137:20
+  --> $DIR/recover-range-pats.rs:138:20
    |
 LL |             let $e1...$e2;
    |                    ^^^ help: use `..=` for an inclusive range
@@ -478,7 +478,169 @@ LL |     if let ....3 = 0 {}
    |               |
    |               expected integer, found floating-point number
 
-error: aborting due to 60 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:136:17
+   |
+LL |             let $e1..$e2;
+   |                 ^^^^^^^^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
+...
+LL |     mac2!(0, 1);
+   |     ----------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |             if let $e1..$e2; { todo!() }
+   |             ++               +++++++++++
 
-Some errors have detailed explanations: E0029, E0308, E0586.
-For more information about an error, try `rustc --explain E0029`.
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:138:17
+   |
+LL |             let $e1...$e2;
+   |                 ^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `2_i32..=i32::MAX` not covered
+...
+LL |     mac2!(0, 1);
+   |     ----------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |             if let $e1...$e2; { todo!() }
+   |             ++                +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:142:17
+   |
+LL |             let $e1..=$e2;
+   |                 ^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `2_i32..=i32::MAX` not covered
+...
+LL |     mac2!(0, 1);
+   |     ----------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |             if let $e1..=$e2; { todo!() }
+   |             ++                +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:151:17
+   |
+LL |             let ..$e;
+   |                 ^^^^ pattern `0_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ..$e; { todo!() }
+   |             ++           +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:153:17
+   |
+LL |             let ...$e;
+   |                 ^^^^^ pattern `1_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ...$e; { todo!() }
+   |             ++            +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:156:17
+   |
+LL |             let ..=$e;
+   |                 ^^^^^ pattern `1_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ..=$e; { todo!() }
+   |             ++            +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:158:17
+   |
+LL |             let $e..;
+   |                 ^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e..; { todo!() }
+   |             ++           +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:160:17
+   |
+LL |             let $e...;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e...; { todo!() }
+   |             ++            +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:162:17
+   |
+LL |             let $e..=;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e..=; { todo!() }
+   |             ++            +++++++++++
+
+error: aborting due to 69 previous errors
+
+Some errors have detailed explanations: E0005, E0029, E0308, E0586.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -34,10 +34,12 @@ extern "C" fn f3_3(..., x: isize) {}
 
 const unsafe extern "C" fn f4_1(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
+//~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_2(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
 //~| ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_3(..., x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
@@ -48,7 +50,7 @@ extern "C" {
     fn e_f1(...);
     //~^ ERROR C-variadic function must be declared with at least one named argument
     fn e_f2(..., x: isize);
-//~^ ERROR `...` must be the last argument of a C-variadic function
+    //~^ ERROR `...` must be the last argument of a C-variadic function
 }
 
 struct X;
@@ -68,6 +70,7 @@ impl X {
     const fn i_f5(x: isize, ...) {}
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
     //~| ERROR functions cannot be both `const` and C-variadic
+    //~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 }
 
 trait T {

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -83,25 +83,25 @@ LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
    | ^^^^^ `const` because of this             ^^^ C-variadic because of this
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:38:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:1
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    | ^^^^^ `const` because of this      ^^^ C-variadic because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:38:36
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    |                                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:42:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:42:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:1
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | ^^^^^                    ^^^            ^^^ C-variadic because of this
@@ -110,67 +110,67 @@ LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | `const` because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:42:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^            ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:48:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
    |
 LL |     fn e_f1(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:52:13
    |
 LL |     fn e_f2(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:57:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:23
    |
 LL |     fn i_f1(x: isize, ...) {}
    |                       ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:65:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:65:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:5
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:5
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |     ^^^^^                   ^^^ C-variadic because of this
@@ -178,70 +178,95 @@ LL |     const fn i_f5(x: isize, ...) {}
    |     `const` because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:29
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |                             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:74:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:77:23
    |
 LL |     fn t_f1(x: isize, ...) {}
    |                       ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:76:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:23
    |
 LL |     fn t_f2(x: isize, ...);
    |                       ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:78:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:78:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:90:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:90:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
-error: aborting due to 40 previous errors
+error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:43
+   |
+LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
+   |                                           ^^^   - value is dropped here
+   |                                           |
+   |                                           the destructor for this type cannot be evaluated in constant functions
 
+error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:36
+   |
+LL | const extern "C" fn f4_2(x: isize, ...) {}
+   |                                    ^^^   - value is dropped here
+   |                                    |
+   |                                    the destructor for this type cannot be evaluated in constant functions
+
+error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:29
+   |
+LL |     const fn i_f5(x: isize, ...) {}
+   |                             ^^^   - value is dropped here
+   |                             |
+   |                             the destructor for this type cannot be evaluated in constant functions
+
+error: aborting due to 43 previous errors
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.rs
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.rs
@@ -10,7 +10,7 @@ fn main() {
     match Ok(0) {
         Ok(a @ b @ a)
         //~^ ERROR identifier `a` is bound more than once in the same pattern
-        | Err(a @ b @ a)
+        | Err(a @ b @ a) //~ ERROR cannot assign twice to immutable variable `a`
         //~^ ERROR identifier `a` is bound more than once in the same pattern
         => {}
     }
@@ -20,7 +20,7 @@ fn main() {
     //~| ERROR identifier `a` is bound more than once in the same pattern
     let ref a @ ref a = ();
     //~^ ERROR identifier `a` is bound more than once in the same pattern
-    let ref mut a @ ref mut a = ();
+    let ref mut a @ ref mut a = (); //~ ERROR cannot borrow value as mutable more than once at a time
     //~^ ERROR identifier `a` is bound more than once in the same pattern
 
     let a @ (Ok(a) | Err(a)) = Ok(());

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
@@ -58,7 +58,27 @@ error[E0416]: identifier `a` is bound more than once in the same pattern
 LL |     let a @ (Ok(a) | Err(a)) = Ok(());
    |                          ^ used in a pattern more than once
 
-error: aborting due to 10 previous errors
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/pat-at-same-name-both.rs:23:9
+   |
+LL |     let ref mut a @ ref mut a = ();
+   |         ^^^^^^^^^   --------- value is mutably borrowed by `a` here
+   |         |
+   |         value is mutably borrowed by `a` here
 
-Some errors have detailed explanations: E0415, E0416.
-For more information about an error, try `rustc --explain E0415`.
+error[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/pat-at-same-name-both.rs:13:15
+   |
+LL |         Ok(a @ b @ a)
+   |                    -
+   |                    |
+   |                    first assignment to `a`
+   |                    help: consider making this binding mutable: `mut a`
+LL |
+LL |         | Err(a @ b @ a)
+   |               ^ cannot assign twice to immutable variable
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0384, E0415, E0416.
+For more information about an error, try `rustc --explain E0384`.

--- a/tests/ui/pattern/pattern-binding-disambiguation.rs
+++ b/tests/ui/pattern/pattern-binding-disambiguation.rs
@@ -26,7 +26,7 @@ fn main() {
     match doesnt_matter {
         BracedStruct => {} // OK, `BracedStruct` is a fresh binding
     }
-    match UnitVariant {
+    match UnitVariant { //~ ERROR: `E::TupleVariant` and `E::BracedVariant {  }` not covered
         UnitVariant => {} // OK, `UnitVariant` is a unit variant pattern
     }
     match doesnt_matter {
@@ -48,7 +48,7 @@ fn main() {
     let UnitStruct = UnitStruct; // OK, `UnitStruct` is a unit struct pattern
     let TupleStruct = doesnt_matter; //~ ERROR let bindings cannot shadow tuple structs
     let BracedStruct = doesnt_matter; // OK, `BracedStruct` is a fresh binding
-    let UnitVariant = UnitVariant; // OK, `UnitVariant` is a unit variant pattern
+    let UnitVariant = UnitVariant; //~ ERROR: refutable pattern in local binding
     let TupleVariant = doesnt_matter; //~ ERROR let bindings cannot shadow tuple variants
     let BracedVariant = doesnt_matter; // OK, `BracedVariant` is a fresh binding
     let CONST = CONST; // OK, `CONST` is a const pattern

--- a/tests/ui/pattern/pattern-binding-disambiguation.stderr
+++ b/tests/ui/pattern/pattern-binding-disambiguation.stderr
@@ -58,6 +58,53 @@ LL | static STATIC: () = ();
 LL |     let STATIC = doesnt_matter;
    |         ^^^^^^ cannot be named the same as a static
 
-error: aborting due to 6 previous errors
+error[E0004]: non-exhaustive patterns: `E::TupleVariant` and `E::BracedVariant {  }` not covered
+  --> $DIR/pattern-binding-disambiguation.rs:29:11
+   |
+LL |     match UnitVariant {
+   |           ^^^^^^^^^^^ patterns `E::TupleVariant` and `E::BracedVariant {  }` not covered
+   |
+note: `E` defined here
+  --> $DIR/pattern-binding-disambiguation.rs:5:6
+   |
+LL | enum E {
+   |      ^
+LL |     UnitVariant,
+LL |     TupleVariant(),
+   |     ------------ not covered
+LL |     BracedVariant{},
+   |     ------------- not covered
+   = note: the matched value is of type `E`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+   |
+LL |         UnitVariant => {}, E::TupleVariant | E::BracedVariant {  } => todo!() // OK, `UnitVariant` is a unit variant pattern
+   |                          ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-For more information about this error, try `rustc --explain E0530`.
+error[E0005]: refutable pattern in local binding
+  --> $DIR/pattern-binding-disambiguation.rs:51:9
+   |
+LL |     let UnitVariant = UnitVariant;
+   |         ^^^^^^^^^^^ patterns `E::TupleVariant` and `E::BracedVariant {  }` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+note: `E` defined here
+  --> $DIR/pattern-binding-disambiguation.rs:5:6
+   |
+LL | enum E {
+   |      ^
+LL |     UnitVariant,
+LL |     TupleVariant(),
+   |     ------------ not covered
+LL |     BracedVariant{},
+   |     ------------- not covered
+   = note: the matched value is of type `E`
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |     if let UnitVariant = UnitVariant { todo!() };
+   |     ++                               +++++++++++
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0004, E0005, E0530.
+For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.rs
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.rs
@@ -5,13 +5,13 @@ fn a<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) where 'b: 'a {
 
 fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y;
+    *x = *y; //~ ERROR: lifetime may not live long enough
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y);
+    a(x, y); //~ ERROR: lifetime may not live long enough
 }
 
 fn d() {

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -9,6 +9,35 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
                  found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:8:5
+   |
+LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     // Illegal now because there is no `'b:'a` declaration.
+LL |     *x = *y;
+   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:14:5
+   |
+LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |     a(x, y);
+   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of a mutable reference to `&isize`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.rs
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.rs
@@ -6,14 +6,14 @@ fn a<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) where 
 
 fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y;
+    *x = *y; //~ ERROR: lifetime may not live long enough
     *z = *y;
 }
 
 fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y, z);
+    a(x, y, z); //~ ERROR: lifetime may not live long enough
 }
 
 fn d() {

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -9,6 +9,35 @@ LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
    = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b _, &'c mut &'d _, &'e mut &'f _)`
                  found fn item `for<'a, 'b, 'c> fn(&'a mut &_, &'b mut &_, &'c mut &_) {a::<'_, '_, '_>}`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:9:5
+   |
+LL | fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     // Illegal now because there is no `'b:'a` declaration.
+LL |     *x = *y;
+   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:16:5
+   |
+LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |     a(x, y, z);
+   |     ^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of a mutable reference to `&isize`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.rs
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.rs
@@ -5,13 +5,13 @@ fn a<'a, 'b:'a>(x: &mut &'a isize, y: &mut &'b isize) {
 
 fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y;
+    *x = *y; //~ ERROR: lifetime may not live long enough
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y);
+    a(x, y); //~ ERROR: lifetime may not live long enough
 }
 
 fn d() {

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -9,6 +9,35 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
                  found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:8:5
+   |
+LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     // Illegal now because there is no `'b:'a` declaration.
+LL |     *x = *y;
+   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:14:5
+   |
+LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |     a(x, y);
+   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of a mutable reference to `&isize`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.rs
@@ -3,8 +3,9 @@ fn main() {}
 fn attr_in_guard() {
     match None::<u32> {
         Some(!) //~ ERROR `!` patterns are experimental
+        //~^ ERROR: mismatched types
             if #[deny(unused_mut)] //~ ERROR attributes on expressions are experimental
             false //~ ERROR a guard on a never pattern will never be run
     }
-    match false {}
+    match false {} //~ ERROR: `bool` is non-empty
 }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:6:16
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:7:16
    |
 LL |             if #[deny(unused_mut)]
    |                ^^^^^^^^^^^^^^^^^^^
@@ -19,11 +19,34 @@ LL |         Some(!)
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: a guard on a never pattern will never be run
-  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:7:13
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:8:13
    |
 LL |             false
    |             ^^^^^ help: remove this guard
 
-error: aborting due to 3 previous errors
+error: mismatched types
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14
+   |
+LL |         Some(!)
+   |              ^ a never pattern must be used on an uninhabited type
+   |
+   = note: the matched value is of type `u32`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0004]: non-exhaustive patterns: type `bool` is non-empty
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:10:11
+   |
+LL |     match false {}
+   |           ^^^^^
+   |
+   = note: the matched value is of type `bool`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match false {
+LL +         _ => todo!(),
+LL ~     }
+   |
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0004, E0658.
+For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
@@ -1,6 +1,7 @@
 #![feature(never_patterns)]
 #![allow(incomplete_features)]
 
+#[derive(Copy, Clone)]
 enum Void {}
 
 fn main() {

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
@@ -1,47 +1,47 @@
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:16:15
+  --> $DIR/bindings.rs:17:15
    |
 LL |         Err(&(_a, _b, !)),
    |               ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:16:19
+  --> $DIR/bindings.rs:17:19
    |
 LL |         Err(&(_a, _b, !)),
    |                   ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:21:25
+  --> $DIR/bindings.rs:22:25
    |
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
    |                         ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:21:29
+  --> $DIR/bindings.rs:22:29
    |
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
    |                             ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:34:10
+  --> $DIR/bindings.rs:35:10
    |
 LL |     let (_a, (! | !)) = (true, void);
    |          ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:38:9
+  --> $DIR/bindings.rs:39:9
    |
 LL |     let _a @ ! = void;
    |         ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:41:10
+  --> $DIR/bindings.rs:42:10
    |
 LL |     let (_a @ (), !) = ((), void);
    |          ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:44:14
+  --> $DIR/bindings.rs:45:14
    |
 LL |             (_b @ (_, !))) = (true, void);
    |              ^^ help: use a wildcard `_` instead

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.rs
@@ -15,18 +15,18 @@ fn no_arms_or_guards(x: Void) {
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
-    match None::<Void> {
+    match None::<Void> { //~ ERROR: `Some(_)` not covered
         Some(!) if true,
         //~^ ERROR guard on a never pattern
         None => {}
     }
-    match None::<Void> {
+    match None::<Void> { //~ ERROR: `Some(_)` not covered
         Some(!) if true => {}
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
     match None::<Void> {
-        Some(never!()) => {},
+        Some(never!()) => {}
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -25,11 +25,48 @@ LL |         Some(!) if true => {}
 error: a never pattern is always unreachable
   --> $DIR/check.rs:29:27
    |
-LL |         Some(never!()) => {},
+LL |         Some(never!()) => {}
    |                           ^^
    |                           |
    |                           this will never be executed
    |                           help: remove this expression
 
-error: aborting due to 4 previous errors
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+  --> $DIR/check.rs:18:11
+   |
+LL |     match None::<Void> {
+   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |
+note: `Option<Void>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<Void>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => {},
+LL +         Some(_) => todo!()
+   |
 
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+  --> $DIR/check.rs:23:11
+   |
+LL |     match None::<Void> {
+   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |
+note: `Option<Void>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<Void>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => {},
+LL +         Some(_) => todo!()
+   |
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
@@ -7,7 +7,9 @@ use std::arch::asm;
 //~^ ERROR `#[track_caller]` requires Rust ABI
 #[naked]
 extern "C" fn f() {
-    asm!("", options(noreturn));
+    unsafe {
+        asm!("", options(noreturn));
+    }
 }
 
 struct S;
@@ -17,7 +19,9 @@ impl S {
     //~^ ERROR `#[track_caller]` requires Rust ABI
     #[naked]
     extern "C" fn g() {
-        asm!("", options(noreturn));
+        unsafe {
+            asm!("", options(noreturn));
+        }
     }
 }
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.stderr
@@ -5,7 +5,7 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error[E0736]: cannot use `#[track_caller]` with `#[naked]`
-  --> $DIR/error-with-naked.rs:16:5
+  --> $DIR/error-with-naked.rs:18:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error[E0737]: `#[track_caller]` requires Rust ABI
-  --> $DIR/error-with-naked.rs:16:5
+  --> $DIR/error-with-naked.rs:18:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -12,7 +12,7 @@ fn call(f: impl Fn()) {
     f()
 }
 
-fn call_mut(f: impl FnMut()) {
+fn call_mut(mut f: impl FnMut()) {
     f()
 }
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -27,10 +27,10 @@ LL |     call_mut(foo);
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
-  --> $DIR/fn-traits.rs:15:21
+  --> $DIR/fn-traits.rs:15:25
    |
-LL | fn call_mut(f: impl FnMut()) {
-   |                     ^^^^^^^ required by this bound in `call_mut`
+LL | fn call_mut(mut f: impl FnMut()) {
+   |                         ^^^^^^^ required by this bound in `call_mut`
 
 error[E0277]: expected a `FnOnce()` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:26:15
@@ -80,10 +80,10 @@ LL |     call_mut(foo_unsafe);
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
-  --> $DIR/fn-traits.rs:15:21
+  --> $DIR/fn-traits.rs:15:25
    |
-LL | fn call_mut(f: impl FnMut()) {
-   |                     ^^^^^^^ required by this bound in `call_mut`
+LL | fn call_mut(mut f: impl FnMut()) {
+   |                         ^^^^^^^ required by this bound in `call_mut`
 
 error[E0277]: expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:32:15

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method-fail.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method-fail.stderr
@@ -4,5 +4,19 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
    |                                       ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closure-trait-method-fail.rs:15:5
+   |
+LL |     x(())
+   |     ^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const std::ops::FnOnce<((),)>>(x: T) -> i32 {
+   |                                                         ++++++++++++++++++++++++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method.stderr
@@ -4,5 +4,19 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
    |                                       ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closure-trait-method.rs:15:5
+   |
+LL |     x(())
+   |     ^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const std::ops::FnOnce<((),)>>(x: T) -> i32 {
+   |                                                         ++++++++++++++++++++++++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
@@ -22,5 +22,45 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn answer<F: ~const Fn() -> u8>(f: &F) -> u8 {
    |                           ^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:12:5
+   |
+LL |     f() * 7
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |         F: ~const FnOnce() -> u8 + ~const std::ops::Fn<()>,
+   |                                  +++++++++++++++++++++++++
 
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:24:5
+   |
+LL |     f() + f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
+   |                                      +++++++++++++++++++++++++
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:24:11
+   |
+LL |     f() + f()
+   |           ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
+   |                                      +++++++++++++++++++++++++
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.rs
@@ -30,8 +30,7 @@ fn non_const_context() {
 #[unstable(feature = "none", issue = "none")]
 const fn const_context() {
     Unstable::func();
-    // ^ This is okay regardless of whether the `unstable` feature is enabled, as this function is
-    // not const-stable.
+    //[stable]~^ ERROR not yet stable as a const fn
     Foo::func();
     //[unstable]~^ ERROR not yet stable as a const fn
     // ^ fails, because the `foo` feature is not active
@@ -42,8 +41,7 @@ const fn const_context() {
 pub const fn const_context_not_const_stable() {
     //[stable]~^ ERROR function has missing const stability attribute
     Unstable::func();
-    // ^ This is okay regardless of whether the `unstable` feature is enabled, as this function is
-    // not const-stable.
+    //[stable]~^ ERROR not yet stable as a const fn
     Foo::func();
     //[unstable]~^ ERROR not yet stable as a const fn
     // ^ fails, because the `foo` feature is not active
@@ -53,7 +51,7 @@ pub const fn const_context_not_const_stable() {
 #[rustc_const_stable(feature = "cheese", since = "1.0.0")]
 const fn stable_const_context() {
     Unstable::func();
-    //[unstable]~^ ERROR not yet stable as a const fn
+    //~^ ERROR not yet stable as a const fn
     Foo::func();
     //[unstable]~^ ERROR not yet stable as a const fn
     const_context_not_const_stable()

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.stable.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.stable.stderr
@@ -10,16 +10,40 @@ LL | | }
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
 
 error: function has missing const stability attribute
-  --> $DIR/staged-api.rs:42:1
+  --> $DIR/staged-api.rs:41:1
    |
 LL | / pub const fn const_context_not_const_stable() {
 LL | |
 LL | |     Unstable::func();
-LL | |     // ^ This is okay regardless of whether the `unstable` feature is enabled, as this function is
+LL | |
 ...  |
 LL | |     // ^ fails, because the `foo` feature is not active
 LL | | }
    | |_^
 
-error: aborting due to 2 previous errors
+error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
+  --> $DIR/staged-api.rs:32:5
+   |
+LL |     Unstable::func();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(unstable)]` to the crate attributes to enable
+
+error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
+  --> $DIR/staged-api.rs:43:5
+   |
+LL |     Unstable::func();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(unstable)]` to the crate attributes to enable
+
+error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
+  --> $DIR/staged-api.rs:53:5
+   |
+LL |     Unstable::func();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: const-stable functions can only call other const-stable functions
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.unstable.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.unstable.stderr
@@ -1,5 +1,5 @@
 error: `<Foo as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:35:5
+  --> $DIR/staged-api.rs:34:5
    |
 LL |     Foo::func();
    |     ^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     Foo::func();
    = help: add `#![feature(foo)]` to the crate attributes to enable
 
 error: `<Foo as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:47:5
+  --> $DIR/staged-api.rs:45:5
    |
 LL |     Foo::func();
    |     ^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     Foo::func();
    = help: add `#![feature(foo)]` to the crate attributes to enable
 
 error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:55:5
+  --> $DIR/staged-api.rs:53:5
    |
 LL |     Unstable::func();
    |     ^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     Unstable::func();
    = help: const-stable functions can only call other const-stable functions
 
 error: `<Foo as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:57:5
+  --> $DIR/staged-api.rs:55:5
    |
 LL |     Foo::func();
    |     ^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     Foo::func();
    = help: const-stable functions can only call other const-stable functions
 
 error: `const_context_not_const_stable` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:59:5
+  --> $DIR/staged-api.rs:57:5
    |
 LL |     const_context_not_const_stable()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/std-impl-gate.gated.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/std-impl-gate.gated.stderr
@@ -4,6 +4,16 @@ error[E0635]: unknown feature `const_default_impls`
 LL | #![cfg_attr(gated, feature(const_trait_impl, const_default_impls))]
    |                                              ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const fn `<Vec<usize> as Default>::default` in constant functions
+  --> $DIR/std-impl-gate.rs:13:5
+   |
+LL |     Default::default()
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0635`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0635.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/span/issue-23827.rs
+++ b/tests/ui/span/issue-23827.rs
@@ -2,6 +2,7 @@
 
 #![feature(fn_traits, unboxed_closures)]
 
+#[derive(Copy, Clone)]
 pub struct Prototype {
     pub target: u32
 }

--- a/tests/ui/span/issue-23827.stderr
+++ b/tests/ui/span/issue-23827.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `Output`
-  --> $DIR/issue-23827.rs:26:1
+  --> $DIR/issue-23827.rs:27:1
    |
 LL | impl<C: Component> FnOnce<(C,)> for Prototype {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation

--- a/tests/ui/span/issue-39698.rs
+++ b/tests/ui/span/issue-39698.rs
@@ -12,5 +12,6 @@ fn main() {
         //~| ERROR is not bound in all patterns
         //~| ERROR is not bound in all patterns
         //~| ERROR is not bound in all patterns
+        //~| ERROR `a` is possibly-uninitialized
     }
 }

--- a/tests/ui/span/issue-39698.stderr
+++ b/tests/ui/span/issue-39698.stderr
@@ -38,6 +38,19 @@ LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}
    |                  |          variable not in all patterns
    |                  variable not in all patterns
 
-error: aborting due to 4 previous errors
+error[E0381]: used binding `a` is possibly-uninitialized
+  --> $DIR/issue-39698.rs:10:79
+   |
+LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}", a); }
+   |               -                                      -                        ^ `a` used here but it is possibly-uninitialized
+   |               |                                      |
+   |               |                                      binding initialized here in some conditions
+   |               binding initialized here in some conditions
+   |               binding declared here but left uninitialized
+   |
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0408`.
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0381, E0408.
+For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/specialization/const_trait_impl.stderr
+++ b/tests/ui/specialization/const_trait_impl.stderr
@@ -16,5 +16,33 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | impl<T: ~const Default + ~const Sub> const A for T {
    |                ^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0015]: cannot call non-const fn `<() as A>::a` in constants
+  --> $DIR/const_trait_impl.rs:52:23
+   |
+LL | const _: () = assert!(<()>::a() == 42);
+   |                       ^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
 
+error[E0015]: cannot call non-const fn `<u8 as A>::a` in constants
+  --> $DIR/const_trait_impl.rs:53:23
+   |
+LL | const _: () = assert!(<u8>::a() == 3);
+   |                       ^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `<u16 as A>::a` in constants
+  --> $DIR/const_trait_impl.rs:54:23
+   |
+LL | const _: () = assert!(<u16>::a() == 2);
+   |                       ^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.rs
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.rs
@@ -14,3 +14,4 @@ pub const fn foobar() -> u32 {
 }
 
 const VAR: u32 = foobar();
+//~^ ERROR: `foobar` is not yet stable as a const fn

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
@@ -4,5 +4,13 @@ error: feature `const_bar` implying `const_foobar` does not exist
 LL | #[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_bar")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: `foobar` is not yet stable as a const fn
+  --> $DIR/const-stability-attribute-implies-missing.rs:16:18
+   |
+LL | const VAR: u32 = foobar();
+   |                  ^^^^^^^^
+   |
+   = help: add `#![feature(const_foobar)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/static/static-drop-scope.rs
+++ b/tests/ui/static/static-drop-scope.rs
@@ -6,11 +6,9 @@ impl Drop for WithDtor {
 
 static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
 //~^ ERROR destructor of
-//~| ERROR temporary value dropped while borrowed
 
 const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
 //~^ ERROR destructor of
-//~| ERROR temporary value dropped while borrowed
 
 static EARLY_DROP_S: i32 = (WithDtor, 0).1;
 //~^ ERROR destructor of

--- a/tests/ui/static/static-drop-scope.stderr
+++ b/tests/ui/static/static-drop-scope.stderr
@@ -6,36 +6,16 @@ LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
    |                                                            |
    |                                                            the destructor for this type cannot be evaluated in statics
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/static-drop-scope.rs:7:60
-   |
-LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                      ------^^^^^^^^-
-   |                                                      |     |       |
-   |                                                      |     |       temporary value is freed at the end of this statement
-   |                                                      |     creates a temporary value which is freed while still in use
-   |                                                      using this value as a static requires that borrow lasts for `'static`
-
 error[E0493]: destructor of `WithDtor` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:11:59
+  --> $DIR/static-drop-scope.rs:10:59
    |
 LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
    |                                                           ^^^^^^^^- value is dropped here
    |                                                           |
    |                                                           the destructor for this type cannot be evaluated in constants
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/static-drop-scope.rs:11:59
-   |
-LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                     ------^^^^^^^^-
-   |                                                     |     |       |
-   |                                                     |     |       temporary value is freed at the end of this statement
-   |                                                     |     creates a temporary value which is freed while still in use
-   |                                                     using this value as a constant requires that borrow lasts for `'static`
-
 error[E0493]: destructor of `(WithDtor, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:15:28
+  --> $DIR/static-drop-scope.rs:13:28
    |
 LL | static EARLY_DROP_S: i32 = (WithDtor, 0).1;
    |                            ^^^^^^^^^^^^^ - value is dropped here
@@ -43,7 +23,7 @@ LL | static EARLY_DROP_S: i32 = (WithDtor, 0).1;
    |                            the destructor for this type cannot be evaluated in statics
 
 error[E0493]: destructor of `(WithDtor, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:18:27
+  --> $DIR/static-drop-scope.rs:16:27
    |
 LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
    |                           ^^^^^^^^^^^^^ - value is dropped here
@@ -51,7 +31,7 @@ LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
    |                           the destructor for this type cannot be evaluated in constants
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:21:24
+  --> $DIR/static-drop-scope.rs:19:24
    |
 LL | const fn const_drop<T>(_: T) {}
    |                        ^      - value is dropped here
@@ -59,7 +39,7 @@ LL | const fn const_drop<T>(_: T) {}
    |                        the destructor for this type cannot be evaluated in constant functions
 
 error[E0493]: destructor of `(T, ())` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:25:5
+  --> $DIR/static-drop-scope.rs:23:5
    |
 LL |     (x, ()).1
    |     ^^^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -68,7 +48,7 @@ LL | }
    | - value is dropped here
 
 error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:29:34
+  --> $DIR/static-drop-scope.rs:27:34
    |
 LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
    |                                  ^^^^^^^^^^^^^^^^^^^ - value is dropped here
@@ -76,14 +56,13 @@ LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
    |                                  the destructor for this type cannot be evaluated in constants
 
 error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:34:43
+  --> $DIR/static-drop-scope.rs:32:43
    |
 LL | const EARLY_DROP_C_OPTION_CONSTANT: i32 = (HELPER, 0).1;
    |                                           ^^^^^^^^^^^ - value is dropped here
    |                                           |
    |                                           the destructor for this type cannot be evaluated in constants
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0493, E0716.
-For more information about an error, try `rustc --explain E0493`.
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/structs-enums/enum-rec/issue-17431-6.rs
+++ b/tests/ui/structs-enums/enum-rec/issue-17431-6.rs
@@ -1,7 +1,10 @@
+// ignore-macos: cycle error does not appear on apple
+
 use std::sync::Mutex;
 
 enum Foo { X(Mutex<Option<Foo>>) }
 //~^ ERROR recursive type `Foo` has infinite size
+//~| ERROR cycle detected
 
 impl Foo { fn bar(self) {} }
 

--- a/tests/ui/structs-enums/enum-rec/issue-17431-6.stderr
+++ b/tests/ui/structs-enums/enum-rec/issue-17431-6.stderr
@@ -1,5 +1,5 @@
 error[E0072]: recursive type `Foo` has infinite size
-  --> $DIR/issue-17431-6.rs:3:1
+  --> $DIR/issue-17431-6.rs:5:1
    |
 LL | enum Foo { X(Mutex<Option<Foo>>) }
    | ^^^^^^^^                  --- recursive without indirection
@@ -9,6 +9,17 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
 LL | enum Foo { X(Mutex<Option<Box<Foo>>>) }
    |                           ++++   +
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing when `Foo` needs drop
+  --> $DIR/issue-17431-6.rs:5:1
+   |
+LL | enum Foo { X(Mutex<Option<Foo>>) }
+   | ^^^^^^^^
+   |
+   = note: ...which immediately requires computing when `Foo` needs drop again
+   = note: cycle used when computing whether `Foo` needs drop
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-For more information about this error, try `rustc --explain E0072`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0072, E0391.
+For more information about an error, try `rustc --explain E0072`.

--- a/tests/ui/suggestions/derive-trait-for-method-call.rs
+++ b/tests/ui/suggestions/derive-trait-for-method-call.rs
@@ -19,7 +19,7 @@ struct CloneStruct {
 struct Foo<X, Y> (X, Y);
 impl<X: Clone + Default + , Y: Clone + Default> Foo<X, Y> {
     fn test(&self) -> (X, Y) {
-        (self.0, self.1)
+        (self.0.clone(), self.1.clone())
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs
@@ -64,6 +64,8 @@ mod bay {
 
     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
         val.use_self()
+        //~^ ERROR: cannot return value referencing function parameter `val`
+        //~| ERROR: borrowed data escapes outside of function
     }
 }
 
@@ -86,6 +88,7 @@ mod bax {
 
     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
         val.use_self()
+        //~^ ERROR: cannot return value referencing function parameter `val`
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
@@ -17,7 +17,7 @@ LL |         val.use_self()
    |         `val` is borrowed here
 
 error[E0515]: cannot return value referencing function parameter `val`
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:109:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:112:9
    |
 LL |         val.use_self()
    |         ---^^^^^^^^^^^
@@ -25,6 +25,50 @@ LL |         val.use_self()
    |         returns a value referencing data owned by the current function
    |         `val` is borrowed here
 
-error: aborting due to 3 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:66:9
+   |
+LL |     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:60:30
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait<Assoc = i32>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+LL |         fn use_self(&self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+help: consider relaxing the implicit `'static` requirement
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait<Assoc = i32> + '_> {
+   |                                                       ++++
 
-For more information about this error, try `rustc --explain E0515`.
+error[E0515]: cannot return value referencing function parameter `val`
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:66:9
+   |
+LL |         val.use_self()
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
+
+error[E0515]: cannot return value referencing function parameter `val`
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:90:9
+   |
+LL |         val.use_self()
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0515, E0521.
+For more information about an error, try `rustc --explain E0515`.

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.rs
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.rs
@@ -36,6 +36,7 @@ mod bar {
 
     fn use_it<'a>(val: &'a dyn ObjectTrait) -> &'a () {
         val.use_self()
+        //~^ ERROR: borrowed data escapes
     }
 }
 
@@ -53,6 +54,7 @@ mod baz {
 
     fn use_it<'a>(val: &'a Box<dyn ObjectTrait + 'a>) -> &'a () {
         val.use_self()
+        //~^ ERROR: borrowed data escapes
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -24,7 +24,7 @@ LL |     impl<T> MyTrait<T> for dyn ObjectTrait<T> + '_ {
    |                                               ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:70:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:72:9
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |               --  --- `val` is a reference that is only valid in the function body
@@ -37,7 +37,7 @@ LL |         val.use_self()
    |         argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:65:14
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:67:14
    |
 LL |     impl dyn ObjectTrait {
    |              ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
@@ -49,7 +49,7 @@ LL |     impl dyn ObjectTrait + '_ {
    |                          ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:90:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:92:9
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> {
    |               --  --- `val` is a reference that is only valid in the function body
@@ -62,7 +62,7 @@ LL |         val.use_self()
    |         argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:87:26
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:89:26
    |
 LL |         fn use_self(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
@@ -75,7 +75,7 @@ LL |     impl MyTrait for dyn ObjectTrait + '_ {}
    |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:110:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:112:9
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |               --  --- `val` is a reference that is only valid in the function body
@@ -88,7 +88,7 @@ LL |         MyTrait::use_self(val)
    |         argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:106:26
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:108:26
    |
 LL |         fn use_self(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
@@ -100,6 +100,56 @@ help: consider relaxing the implicit `'static` requirement
 LL |     impl MyTrait for dyn ObjectTrait + '_ {}
    |                                      ++++
 
-error: aborting due to 4 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:38:9
+   |
+LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> &'a () {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:32:26
+   |
+LL |     impl MyTrait for dyn ObjectTrait {
+   |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+LL |         fn use_self(&self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+help: consider relaxing the implicit `'static` requirement
+   |
+LL |     impl MyTrait for dyn ObjectTrait + '_ {
+   |                                      ++++
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:56:9
+   |
+LL |     fn use_it<'a>(val: &'a Box<dyn ObjectTrait + 'a>) -> &'a () {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:50:30
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait> {
+   |                              ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+LL |         fn use_self(&self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+help: consider relaxing the implicit `'static` requirement
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait + '_> {
+   |                                          ++++
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.rs
@@ -8,6 +8,7 @@ fn f(_: impl Iterator<Item = &'_ ()>) {}
 // But that lifetime does not participate in resolution.
 fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
 //~^ ERROR missing lifetime specifier
+//~| ERROR lifetime may not live long enough
 
 // This is understood as `fn foo<'_1>(_: impl Iterator<Item = &'_1 ()>) {}`.
 async fn h(_: impl Iterator<Item = &'_ ()>) {}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -20,7 +20,7 @@ LL + fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime.rs:16:60
+  --> $DIR/impl-trait-missing-lifetime.rs:17:60
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                            ^^ expected named lifetime parameter
@@ -41,13 +41,19 @@ LL + async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime.rs:16:69
+  --> $DIR/impl-trait-missing-lifetime.rs:17:69
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    | -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
    | |
    | return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime.rs:9:63
+   |
+LL | fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |      ----- has type `x`                                       ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/issue-102892.rs
+++ b/tests/ui/suggestions/issue-102892.rs
@@ -9,6 +9,7 @@ struct B;
 
 fn process_without_annot(arc: &Arc<(A, B)>) {
     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+    //~^ ERROR: cannot move out of an `Arc`
 }
 
 fn process_with_annot(arc: &Arc<(A, B)>) {

--- a/tests/ui/suggestions/issue-102892.stderr
+++ b/tests/ui/suggestions/issue-102892.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-102892.rs:15:26
+  --> $DIR/issue-102892.rs:16:26
    |
 LL |     let (a, b): (A, B) = &**arc; // suggests putting `&**arc` here too
    |                 ------   ^^^^^^ expected `(A, B)`, found `&(A, B)`
@@ -19,7 +19,7 @@ LL |     let (a, b): &(A, B) = &**arc; // suggests putting `&**arc` here too
    |                 +
 
 error[E0308]: mismatched types
-  --> $DIR/issue-102892.rs:20:32
+  --> $DIR/issue-102892.rs:21:32
    |
 LL |     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                                ^^^^^^^^^^^^^^ expected `(A, B)`, found `&mut (A, B)`
@@ -37,7 +37,7 @@ LL |     let (a, b): (&mut (A, B), A) = (&mut *mutation, &(**arc).0); // suggest
    |                  ++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-102892.rs:20:48
+  --> $DIR/issue-102892.rs:21:48
    |
 LL |     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                                                ^^^^^^^^^^ expected `A`, found `&A`
@@ -52,6 +52,23 @@ help: alternatively, consider changing the type annotation
 LL |     let (a, b): ((A, B), &A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                          +
 
-error: aborting due to 3 previous errors
+error[E0507]: cannot move out of an `Arc`
+  --> $DIR/issue-102892.rs:11:18
+   |
+LL |     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+   |          -  -    ^^^^^
+   |          |  |
+   |          |  ...and here
+   |          data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the dereference here
+   |
+LL -     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+LL +     let (a, b) = *arc; // suggests putting `&**arc` here; with that, fixed!
+   |
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0507.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/suggestions/issue-86667.rs
+++ b/tests/ui/suggestions/issue-86667.rs
@@ -4,14 +4,15 @@
 // compile-flags: --edition 2018
 
 async fn a(s1: &str, s2: &str) -> &str {
-//~^ ERROR: missing lifetime specifier [E0106]
+    //~^ ERROR: missing lifetime specifier [E0106]
     s1
-//~^ ERROR: lifetime may not live long enough
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn b(s1: &str, s2: &str) -> &str {
-//~^ ERROR: missing lifetime specifier [E0106]
+    //~^ ERROR: missing lifetime specifier [E0106]
     s1
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/suggestions/issue-86667.stderr
+++ b/tests/ui/suggestions/issue-86667.stderr
@@ -31,6 +31,15 @@ LL |
 LL |     s1
    |     ^^ returning this value requires that `'1` must outlive `'static`
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/issue-86667.rs:14:5
+   |
+LL | fn b(s1: &str, s2: &str) -> &str {
+   |          - let's call the lifetime of this reference `'1`
+LL |
+LL |     s1
+   |     ^^ returning this value requires that `'1` must outlive `'static`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -1,4 +1,6 @@
 // different number of duplicated diagnostics on different targets
+// only-x86_64
+// only-linux
 // compile-flags: -Zdeduplicate-diagnostics=yes
 
 #![allow(bare_trait_objects)]
@@ -18,21 +20,31 @@ pub union Qux<'t, 'k, I> {
 trait Tar<'t, 'k, I> {}
 
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
       //~^ ERROR missing lifetime specifiers
       //~| ERROR missing lifetime specifiers
 }
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
       //~^ ERROR missing lifetime specifiers
       //~| ERROR missing lifetime specifiers
 }
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR missing lifetime specifiers
     //~| ERROR missing lifetime specifiers
 }
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR missing lifetime specifiers
     //~| ERROR missing lifetime specifiers

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:21:44
+  --> $DIR/missing-lifetime-specifier.rs:25:44
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ expected 2 lifetime parameters
@@ -11,9 +11,11 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
    |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:21:44
+  --> $DIR/missing-lifetime-specifier.rs:25:44
    |
 LL | / thread_local! {
+LL | |
+LL | |
 LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    | |                                            ^^^ expected 2 lifetime parameters
 LL | |
@@ -24,7 +26,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:26:44
+  --> $DIR/missing-lifetime-specifier.rs:33:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    |                                            ^^^^ expected 2 lifetime parameters
@@ -38,9 +40,12 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>
    |                                             +++++++    ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:26:44
+  --> $DIR/missing-lifetime-specifier.rs:33:44
    |
 LL | / thread_local! {
+LL | |
+LL | |
+LL | |
 LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    | |                                            ^^^^ expected 2 lifetime parameters
    | |                                            |
@@ -53,7 +58,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:31:47
+  --> $DIR/missing-lifetime-specifier.rs:40:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    |                                               ^ expected 2 lifetime parameters
@@ -65,9 +70,11 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:31:47
+  --> $DIR/missing-lifetime-specifier.rs:40:47
    |
 LL | / thread_local! {
+LL | |
+LL | |
 LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    | |                                               ^ expected 2 lifetime parameters
 LL | |
@@ -78,7 +85,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:36:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^   ^ expected 2 lifetime parameters
@@ -92,9 +99,12 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i
    |                                             +++++++     +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:36:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL | / thread_local! {
+LL | |
+LL | |
+LL | |
 LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    | |                                            ^   ^ expected 2 lifetime parameters
    | |                                            |
@@ -107,7 +117,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:46:44
+  --> $DIR/missing-lifetime-specifier.rs:58:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -119,7 +129,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:46:44
+  --> $DIR/missing-lifetime-specifier.rs:58:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -133,7 +143,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:42:44
+  --> $DIR/missing-lifetime-specifier.rs:54:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ ------- supplied 1 lifetime argument
@@ -141,7 +151,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell:
    |                                            expected 2 lifetime arguments
    |
 note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:14:11
+  --> $DIR/missing-lifetime-specifier.rs:16:11
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
@@ -151,7 +161,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:46:45
+  --> $DIR/missing-lifetime-specifier.rs:58:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -159,7 +169,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell
    |                                             expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:18:7
+  --> $DIR/missing-lifetime-specifier.rs:20:7
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --
@@ -168,7 +178,199 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error: aborting due to 12 previous errors
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:22:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Foo<'1, '_>>>>>>>`
+   |   returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:22:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Foo<'_, '2>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:29:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
+   | |                                            - let's call the lifetime of this reference `'1`
+LL | |
+LL | |
+LL | | }
+   | |_^ returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
+   |                                                 ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:29:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Bar<'2, '_>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
+   |                                                 ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:29:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Bar<'_, '3>>>>>>>`
+   |   returning this value requires that `'3` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
+   |                                                 ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:37:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Qux<'1, '_, i32>>>>>>>`
+   |   returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:37:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Qux<'_, '2, i32>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:44:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
+   | |                                            - let's call the lifetime of this reference `'1`
+LL | |
+LL | |
+LL | | }
+   | |_^ returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
+   |                                                      ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:44:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'2, '_, i32>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
+   |                                                      ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:44:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'_, '3, i32>>>>>>>`
+   |   returning this value requires that `'3` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
+   |                                                      ++++
+
+error: aborting due to 22 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lt-for-hrtb.rs
+++ b/tests/ui/suggestions/missing-lt-for-hrtb.rs
@@ -8,6 +8,8 @@ fn main() {
     let x = S(&|x| {
         println!("hi");
         x
+        //~^ ERROR lifetime may not live long enough
+        //~| ERROR lifetime may not live long enough
     });
     x.0(&X(&()));
 }

--- a/tests/ui/suggestions/missing-lt-for-hrtb.stderr
+++ b/tests/ui/suggestions/missing-lt-for-hrtb.stderr
@@ -31,6 +31,28 @@ help: consider using one of the available lifetimes here
 LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &'lifetime X<'lifetime>);
    |                                         +++++++++  +++++++++++
 
-error: aborting due to 2 previous errors
+error: lifetime may not live long enough
+  --> $DIR/missing-lt-for-hrtb.rs:10:9
+   |
+LL |     let x = S(&|x| {
+   |                 -- return type of closure is &'2 X<'_>
+   |                 |
+   |                 has type `&'1 X<'_>`
+LL |         println!("hi");
+LL |         x
+   |         ^ returning this value requires that `'1` must outlive `'2`
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lt-for-hrtb.rs:10:9
+   |
+LL |     let x = S(&|x| {
+   |                 -- return type of closure is &X<'4>
+   |                 |
+   |                 has type `&X<'3>`
+LL |         println!("hi");
+LL |         x
+   |         ^ returning this value requires that `'3` must outlive `'4`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/traits/self-without-lifetime-constraint.rs
+++ b/tests/ui/traits/self-without-lifetime-constraint.rs
@@ -15,6 +15,7 @@ impl<'a> ValueRef<'a> {
         match *self {
             ValueRef::Text(t) => {
                 std::str::from_utf8(t).map_err(|_| FromSqlError::InvalidType).map(|x| (x, &x))
+                //~^ ERROR: cannot return value referencing function parameter `x`
             }
             _ => Err(FromSqlError::InvalidType),
         }

--- a/tests/ui/traits/self-without-lifetime-constraint.stderr
+++ b/tests/ui/traits/self-without-lifetime-constraint.stderr
@@ -1,5 +1,5 @@
 error: `impl` item signature doesn't match `trait` item signature
-  --> $DIR/self-without-lifetime-constraint.rs:45:5
+  --> $DIR/self-without-lifetime-constraint.rs:46:5
    |
 LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self, &Self>;
    |     -------------------------------------------------------------------- expected `fn(ValueRef<'1>) -> Result<(&'2 str, &'1 &'2 str), FromSqlError>`
@@ -10,10 +10,20 @@ LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<&str, &&str> {
    = note: expected signature `fn(ValueRef<'1>) -> Result<(&'2 str, &'1 &'2 str), FromSqlError>`
               found signature `fn(ValueRef<'1>) -> Result<(&'1 str, &'1 &'1 str), FromSqlError>`
 help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
-  --> $DIR/self-without-lifetime-constraint.rs:41:60
+  --> $DIR/self-without-lifetime-constraint.rs:42:60
    |
 LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self, &Self>;
    |                                                            ^^^^ consider borrowing this type parameter in the trait
 
-error: aborting due to 1 previous error
+error[E0515]: cannot return value referencing function parameter `x`
+  --> $DIR/self-without-lifetime-constraint.rs:17:87
+   |
+LL |                 std::str::from_utf8(t).map_err(|_| FromSqlError::InvalidType).map(|x| (x, &x))
+   |                                                                                       ^^^^--^
+   |                                                                                       |   |
+   |                                                                                       |   `x` is borrowed here
+   |                                                                                       returns a value referencing data owned by the current function
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0515`.

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.rs
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.rs
@@ -6,6 +6,7 @@ mod test_type_param_static {
     fn defining<A: 'static>(s: A) -> Ty<A> { s }
     fn assert_static<A: 'static>() {}
     fn test<A>() where Ty<A>: 'static { assert_static::<A>() }
+    //~^ ERROR: the parameter type `A` may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
@@ -12,6 +12,20 @@ help: consider adding an explicit lifetime bound
 LL |     type Ty<A: 'static> = impl Sized + 'static;
    |              +++++++++
 
-error: aborting due to 1 previous error
+error[E0310]: the parameter type `A` may not live long enough
+  --> $DIR/implied_lifetime_wf_check4_static.rs:8:41
+   |
+LL |     fn test<A>() where Ty<A>: 'static { assert_static::<A>() }
+   |                                         ^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         the parameter type `A` must be valid for the static lifetime...
+   |                                         ...so that the type `A` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL |     fn test<A: 'static>() where Ty<A>: 'static { assert_static::<A>() }
+   |              +++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -7,6 +7,7 @@ type Pointer<T> = impl std::ops::Deref<Target = T>;
 fn test() -> Pointer<_> {
     //~^ ERROR: the placeholder `_` is not allowed within types
     Box::new(1)
+    //~^ ERROR: expected generic type parameter, found `i32`
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Pointer<_> {
    |              help: replace with the correct return type: `Pointer<i32>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-77179.rs:17:25
+  --> $DIR/issue-77179.rs:18:25
    |
 LL |     fn bar() -> Pointer<_>;
    |                         ^
@@ -16,6 +16,16 @@ LL |     fn bar() -> Pointer<_>;
    |                         not allowed in type signatures
    |                         help: use type parameters instead: `T`
 
-error: aborting due to 2 previous errors
+error[E0792]: expected generic type parameter, found `i32`
+  --> $DIR/issue-77179.rs:9:5
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |              - this generic parameter must be used with a generic type parameter
+...
+LL |     Box::new(1)
+   |     ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0121, E0792.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
+++ b/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
@@ -14,5 +14,7 @@ mod foo {
 }
 
 fn main() {
-    let _: foo::Foo = std::mem::transmute(0u8);
+    unsafe {
+        let _: foo::Foo = std::mem::transmute(0u8);
+    }
 }

--- a/tests/ui/typeof/issue-100183.stderr
+++ b/tests/ui/typeof/issue-100183.stderr
@@ -6,8 +6,8 @@ LL |     y: (typeof("hey"),),
    |
 help: consider replacing `typeof(...)` with an actual type
    |
-LL |     y: (&'static str,),
-   |         ~~~~~~~~~~~~
+LL |     y: (&str,),
+   |         ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -33,6 +33,7 @@ fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
     //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
     // Here, the omitted lifetimes are expanded to distinct things.
     same_type(x, y)
+    //~^ ERROR borrowed data escapes outside of function
 }
 
 fn main() { }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -34,6 +34,22 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL | trait Foo<'a,T> {
    |       ^^^ --
 
-error: aborting due to 3 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/unboxed-closure-sugar-region.rs:35:5
+   |
+LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
+   |          -                                - `y` declared here, outside of the function body
+   |          |
+   |          `x` is a reference that is only valid in the function body
+   |          has type `&dyn Foo<'1, (isize,), Output = ()>`
+...
+LL |     same_type(x, y)
+   |     ^^^^^^^^^^^^^^^
+   |     |
+   |     `x` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0521.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.rs
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.rs
@@ -14,6 +14,7 @@ fn meh() -> Box<dyn for<'_> Meh<'_>> //~ ERROR cannot be used here
 }
 
 fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y } //~ ERROR missing lifetime specifier
+//~^ ERROR lifetime may not live long enough
 
 fn main() {
     let x = 5;

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -45,7 +45,15 @@ help: consider introducing a named lifetime parameter
 LL | fn foo2<'a>(_: &'a u8, y: &'a u8) -> &'a u8 { y }
    |        ++++     ~~         ~~         ~~
 
-error: aborting due to 5 previous errors
+error: lifetime may not live long enough
+  --> $DIR/underscore-lifetime-binders.rs:16:43
+   |
+LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
+   |                       -                   ^ returning this value requires that `'1` must outlive `'static`
+   |                       |
+   |                       let's call the lifetime of this reference `'1`
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
but only from the perspective of the whole compiler. Individual items should not get borrowcked if their MIR is tainted by errors.

r? @estebank @nnethercote 