### PR TITLE
Correctly check `never_type` feature gating

### DIFF
--- a/tests/ui/feature-gates/feature-gate-never_type.rs
+++ b/tests/ui/feature-gates/feature-gate-never_type.rs
@@ -13,5 +13,14 @@ impl Foo for Meeshka {
     type Wub = !; //~ ERROR type is experimental
 }
 
+fn look_ma_no_feature_gate<F: FnOnce() -> !>() {} //~ ERROR type is experimental
+fn tadam(f: &dyn Fn() -> !) {} //~ ERROR type is experimental
+fn panic() -> ! {
+    panic!();
+}
+fn toudoum() -> impl Fn() -> ! { //~ ERROR type is experimental
+    panic
+}
+
 fn main() {
 }

--- a/tests/ui/feature-gates/feature-gate-never_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_type.stderr
@@ -48,6 +48,36 @@ LL |     type Wub = !;
    = help: add `#![feature(never_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 5 previous errors
+error[E0658]: the `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:16:43
+   |
+LL | fn look_ma_no_feature_gate<F: FnOnce() -> !>() {}
+   |                                           ^
+   |
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:17:26
+   |
+LL | fn tadam(f: &dyn Fn() -> !) {}
+   |                          ^
+   |
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:21:30
+   |
+LL | fn toudoum() -> impl Fn() -> ! {
+   |                              ^
+   |
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/never_type/never-type-in-nested-fn-decl.rs
+++ b/tests/ui/never_type/never-type-in-nested-fn-decl.rs
@@ -1,0 +1,7 @@
+// build-pass
+
+trait X<const N: i32> {}
+
+fn hello<T: X<{ fn hello() -> ! { loop {} } 1 }>>() {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #120542.

The feature wasn't tested on return type of a generic function type, so it got under the radar in https://github.com/rust-lang/rust/pull/120316.

r? @compiler-errors 