### PR TITLE
Stop bailing out from compilation just because there were incoherent traits

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1990,6 +1990,10 @@ pub(super) fn check_type_bounds<'tcx>(
     impl_ty: ty::AssocItem,
     impl_trait_ref: ty::TraitRef<'tcx>,
 ) -> Result<(), ErrorGuaranteed> {
+    // Avoid bogus "type annotations needed `Foo: Bar`" errors on `impl Bar for Foo` in case
+    // other `Foo` impls are incoherent.
+    tcx.ensure().coherent_trait(impl_trait_ref.def_id)?;
+
     let param_env = tcx.param_env(impl_ty.def_id);
     debug!(?param_env);
 

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -169,11 +169,11 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
 
     tcx.sess.time("coherence_checking", || {
         // Check impls constrain their parameters
-        let mut res =
+        let res =
             tcx.hir().try_par_for_each_module(|module| tcx.ensure().check_mod_impl_wf(module));
 
         for &trait_def_id in tcx.all_local_trait_impls(()).keys() {
-            res = res.and(tcx.ensure().coherent_trait(trait_def_id));
+            let _ = tcx.ensure().coherent_trait(trait_def_id);
         }
         // these queries are executed for side-effects (error reporting):
         res.and(tcx.ensure().crate_inherent_impls(()))

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -41,7 +41,7 @@ pub fn check_legal_trait_for_method_call(
     receiver: Option<Span>,
     expr_span: Span,
     trait_id: DefId,
-) {
+) -> Result<(), ErrorGuaranteed> {
     if tcx.lang_items().drop_trait() == Some(trait_id) {
         let sugg = if let Some(receiver) = receiver.filter(|s| !s.is_empty()) {
             errors::ExplicitDestructorCallSugg::Snippet {
@@ -51,8 +51,9 @@ pub fn check_legal_trait_for_method_call(
         } else {
             errors::ExplicitDestructorCallSugg::Empty(span)
         };
-        tcx.dcx().emit_err(errors::ExplicitDestructorCall { span, sugg });
+        return Err(tcx.dcx().emit_err(errors::ExplicitDestructorCall { span, sugg }));
     }
+    tcx.coherent_trait(trait_id)
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1105,13 +1105,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let container_id = assoc_item.container_id(tcx);
                 debug!(?def_id, ?container, ?container_id);
                 match container {
-                    ty::TraitContainer => callee::check_legal_trait_for_method_call(
-                        tcx,
-                        path_span,
-                        None,
-                        span,
-                        container_id,
-                    ),
+                    ty::TraitContainer => {
+                        if let Err(e) = callee::check_legal_trait_for_method_call(
+                            tcx,
+                            path_span,
+                            None,
+                            span,
+                            container_id,
+                        ) {
+                            self.set_tainted_by_errors(e);
+                        }
+                    }
                     ty::ImplContainer => {
                         if segments.len() == 1 {
                             // `<T>::assoc` will end up here, and so

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -630,13 +630,15 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
     fn enforce_illegal_method_limitations(&self, pick: &probe::Pick<'_>) {
         // Disallow calls to the method `drop` defined in the `Drop` trait.
         if let Some(trait_def_id) = pick.item.trait_container(self.tcx) {
-            callee::check_legal_trait_for_method_call(
+            if let Err(e) = callee::check_legal_trait_for_method_call(
                 self.tcx,
                 self.span,
                 Some(self.self_expr.span),
                 self.call_expr.span,
                 trait_def_id,
-            )
+            ) {
+                self.set_tainted_by_errors(e);
+            }
         }
     }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2364,6 +2364,12 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     return e;
                 }
 
+                if let Err(guar) = self.tcx.ensure().coherent_trait(trait_ref.def_id()) {
+                    // Avoid bogus "type annotations needed `Foo: Bar`" errors on `impl Bar for Foo` in case
+                    // other `Foo` impls are incoherent.
+                    return guar;
+                }
+
                 // This is kind of a hack: it frequently happens that some earlier
                 // error prevents types from being fully inferred, and then we get
                 // a bunch of uninteresting errors saying something like "<generic
@@ -2658,6 +2664,14 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 }
                 if let Some(e) = self.tainted_by_errors() {
                     return e;
+                }
+
+                if let Err(guar) =
+                    self.tcx.ensure().coherent_trait(self.tcx.parent(data.projection_ty.def_id))
+                {
+                    // Avoid bogus "type annotations needed `Foo: Bar`" errors on `impl Bar for Foo` in case
+                    // other `Foo` impls are incoherent.
+                    return guar;
                 }
                 let subst = data
                     .projection_ty

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -448,22 +448,6 @@ mod prim_unit {}
 #[doc(hidden)]
 impl () {}
 
-// Fake impl that's only really used for docs.
-#[cfg(doc)]
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Clone for () {
-    fn clone(&self) -> Self {
-        loop {}
-    }
-}
-
-// Fake impl that's only really used for docs.
-#[cfg(doc)]
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Copy for () {
-    // empty
-}
-
 #[rustc_doc_primitive = "pointer"]
 #[doc(alias = "ptr")]
 #[doc(alias = "*")]
@@ -1690,23 +1674,3 @@ mod prim_fn {}
 // See src/librustdoc/passes/collect_trait_impls.rs:collect_trait_impls
 #[doc(hidden)]
 impl<Ret, T> fn(T) -> Ret {}
-
-// Fake impl that's only really used for docs.
-#[cfg(doc)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(fake_variadic)]
-/// This trait is implemented on function pointers with any number of arguments.
-impl<Ret, T> Clone for fn(T) -> Ret {
-    fn clone(&self) -> Self {
-        loop {}
-    }
-}
-
-// Fake impl that's only really used for docs.
-#[cfg(doc)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(fake_variadic)]
-/// This trait is implemented on function pointers with any number of arguments.
-impl<Ret, T> Copy for fn(T) -> Ret {
-    // empty
-}

--- a/tests/ui/associated-consts/issue-105330.rs
+++ b/tests/ui/associated-consts/issue-105330.rs
@@ -14,5 +14,6 @@ fn foo<A: TraitWAssocConst<A=32>>() { //~ ERROR E0658
 
 fn main<A: TraitWAssocConst<A=32>>() {
     //~^ ERROR E0658
+    //~| ERROR E0131
     foo::<Demo>();
 }

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -43,7 +43,13 @@ LL | impl TraitWAssocConst for impl Demo {
    |
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
-error: aborting due to 5 previous errors
+error[E0131]: `main` function is not allowed to have generic parameters
+  --> $DIR/issue-105330.rs:15:8
+   |
+LL | fn main<A: TraitWAssocConst<A=32>>() {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `main` cannot have generic parameters
 
-Some errors have detailed explanations: E0404, E0562, E0658.
-For more information about an error, try `rustc --explain E0404`.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0131, E0404, E0562, E0658.
+For more information about an error, try `rustc --explain E0131`.

--- a/tests/ui/async-await/in-trait/coherence-constrained.rs
+++ b/tests/ui/async-await/in-trait/coherence-constrained.rs
@@ -12,7 +12,6 @@ impl Foo for Bar {
     type T = ();
 
     async fn foo(&self) {}
-    //~^ ERROR type annotations needed: cannot satisfy `<Bar as Foo>::T == ()`
 }
 
 impl Foo for Bar {
@@ -20,7 +19,6 @@ impl Foo for Bar {
     type T = ();
 
     async fn foo(&self) {}
-    //~^ ERROR type annotations needed: cannot satisfy `<Bar as Foo>::T == ()`
 }
 
 fn main() {}

--- a/tests/ui/async-await/in-trait/coherence-constrained.stderr
+++ b/tests/ui/async-await/in-trait/coherence-constrained.stderr
@@ -1,17 +1,5 @@
-error[E0284]: type annotations needed: cannot satisfy `<Bar as Foo>::T == ()`
-  --> $DIR/coherence-constrained.rs:14:5
-   |
-LL |     async fn foo(&self) {}
-   |     ^^^^^^^^^^^^^^^^^^^ cannot satisfy `<Bar as Foo>::T == ()`
-
-error[E0284]: type annotations needed: cannot satisfy `<Bar as Foo>::T == ()`
-  --> $DIR/coherence-constrained.rs:22:5
-   |
-LL |     async fn foo(&self) {}
-   |     ^^^^^^^^^^^^^^^^^^^ cannot satisfy `<Bar as Foo>::T == ()`
-
 error[E0119]: conflicting implementations of trait `Foo` for type `Bar`
-  --> $DIR/coherence-constrained.rs:18:1
+  --> $DIR/coherence-constrained.rs:17:1
    |
 LL | impl Foo for Bar {
    | ---------------- first implementation here
@@ -19,7 +7,6 @@ LL | impl Foo for Bar {
 LL | impl Foo for Bar {
    | ^^^^^^^^^^^^^^^^ conflicting implementation for `Bar`
 
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0119, E0284.
-For more information about an error, try `rustc --explain E0119`.
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/associated-type2.rs
+++ b/tests/ui/coherence/associated-type2.rs
@@ -1,0 +1,20 @@
+//! A regression test for #120343. The overlap error was previously
+//! silenced in coherence because projecting `<() as ToUnit>::Unit`
+//! failed. Then then silenced the missing items error in the `ToUnit`
+//! impl, causing us to not emit any errors and ICEing due to a
+//! `span_delay_bug`.
+
+trait ToUnit {
+    type Unit;
+}
+
+impl<T> ToUnit for *const T {}
+//~^ ERROR: not all trait items implemented
+
+trait Overlap<T> {}
+
+impl<T> Overlap<T> for T {}
+
+impl<T> Overlap<<*const T as ToUnit>::Unit> for T {}
+
+fn main() {}

--- a/tests/ui/coherence/associated-type2.stderr
+++ b/tests/ui/coherence/associated-type2.stderr
@@ -1,0 +1,12 @@
+error[E0046]: not all trait items implemented, missing: `Unit`
+  --> $DIR/associated-type2.rs:11:1
+   |
+LL |     type Unit;
+   |     --------- `Unit` from trait
+...
+LL | impl<T> ToUnit for *const T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Unit` in implementation
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0046`.

--- a/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.rs
+++ b/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.rs
@@ -22,6 +22,7 @@ struct MyType {
 impl MyTrait<MyType> for MyType {
 //~^ ERROR E0119
     fn get(&self) -> usize { (*self).clone() }
+    //~^ ERROR incompatible type
 }
 
 fn main() { }

--- a/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.stderr
+++ b/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.stderr
@@ -7,6 +7,24 @@ LL | impl<T> MyTrait<T> for T {
 LL | impl MyTrait<MyType> for MyType {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `MyType`
 
-error: aborting due to 1 previous error
+error[E0053]: method `get` has an incompatible type for trait
+  --> $DIR/coherence-blanket-conflicts-with-specific-multidispatch.rs:24:22
+   |
+LL |     fn get(&self) -> usize { (*self).clone() }
+   |                      ^^^^^
+   |                      |
+   |                      expected `MyType`, found `usize`
+   |                      help: change the output type to match the trait: `MyType`
+   |
+note: type in trait
+  --> $DIR/coherence-blanket-conflicts-with-specific-multidispatch.rs:8:22
+   |
+LL |     fn get(&self) -> T;
+   |                      ^
+   = note: expected signature `fn(&MyType) -> MyType`
+              found signature `fn(&MyType) -> usize`
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0053, E0119.
+For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/coherence/coherence-orphan.rs
+++ b/tests/ui/coherence/coherence-orphan.rs
@@ -9,10 +9,13 @@ struct TheType;
 
 impl TheTrait<usize> for isize { }
 //~^ ERROR E0117
+//~| ERROR not all trait items implemented
 
 impl TheTrait<TheType> for isize { }
+//~^ ERROR not all trait items implemented
 
 impl TheTrait<isize> for TheType { }
+//~^ ERROR not all trait items implemented
 
 impl !Send for Vec<isize> { } //~ ERROR E0117
 //~^ WARNING

--- a/tests/ui/coherence/coherence-orphan.stderr
+++ b/tests/ui/coherence/coherence-orphan.stderr
@@ -11,7 +11,7 @@ LL | impl TheTrait<usize> for isize { }
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
-  --> $DIR/coherence-orphan.rs:17:1
+  --> $DIR/coherence-orphan.rs:20:1
    |
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^----------
@@ -22,7 +22,7 @@ LL | impl !Send for Vec<isize> { }
    = note: define and implement a trait or new type instead
 
 warning: cross-crate traits with a default impl, like `Send`, should not be specialized
-  --> $DIR/coherence-orphan.rs:17:1
+  --> $DIR/coherence-orphan.rs:20:1
    |
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,6 +34,31 @@ note: try using the same sequence of generic parameters as the struct definition
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
    = note: `#[warn(suspicious_auto_trait_impls)]` on by default
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error[E0046]: not all trait items implemented, missing: `the_fn`
+  --> $DIR/coherence-orphan.rs:10:1
+   |
+LL | impl TheTrait<usize> for isize { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
+   |
+   = help: implement the missing item: `fn the_fn(&self) { todo!() }`
 
-For more information about this error, try `rustc --explain E0117`.
+error[E0046]: not all trait items implemented, missing: `the_fn`
+  --> $DIR/coherence-orphan.rs:14:1
+   |
+LL | impl TheTrait<TheType> for isize { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
+   |
+   = help: implement the missing item: `fn the_fn(&self) { todo!() }`
+
+error[E0046]: not all trait items implemented, missing: `the_fn`
+  --> $DIR/coherence-orphan.rs:17:1
+   |
+LL | impl TheTrait<isize> for TheType { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
+   |
+   = help: implement the missing item: `fn the_fn(&self) { todo!() }`
+
+error: aborting due to 5 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0046, E0117.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/coherence/deep-bad-copy-reason.rs
+++ b/tests/ui/coherence/deep-bad-copy-reason.rs
@@ -5,12 +5,15 @@ extern "Rust" {
 }
 
 pub struct ListS<T> {
+    //~^ NOTE: required because it appears within the type
     len: usize,
     data: [T; 0],
     opaque: OpaqueListContents,
 }
 
 pub struct Interned<'a, T>(&'a T);
+//~^ NOTE: required by an implicit `Sized`
+//~| NOTE: required by the implicit `Sized`
 
 impl<'a, T> Clone for Interned<'a, T> {
     fn clone(&self) -> Self {
@@ -23,6 +26,8 @@ impl<'a, T> Copy for Interned<'a, T> {}
 pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
 //~^ NOTE this field does not implement `Copy`
 //~| NOTE the `Copy` impl for `Interned<'tcx, ListS<T>>` requires that `OpaqueListContents: Sized`
+//~| NOTE: doesn't have a size known at compile-time
+//~| ERROR: cannot be known at compilation time
 
 impl<'tcx, T> Clone for List<'tcx, T> {
     fn clone(&self) -> Self {

--- a/tests/ui/coherence/deep-bad-copy-reason.stderr
+++ b/tests/ui/coherence/deep-bad-copy-reason.stderr
@@ -1,5 +1,5 @@
 error[E0204]: the trait `Copy` cannot be implemented for this type
-  --> $DIR/deep-bad-copy-reason.rs:33:24
+  --> $DIR/deep-bad-copy-reason.rs:38:24
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ------------------------ this field does not implement `Copy`
@@ -8,11 +8,34 @@ LL | impl<'tcx, T> Copy for List<'tcx, T> {}
    |                        ^^^^^^^^^^^^^
    |
 note: the `Copy` impl for `Interned<'tcx, ListS<T>>` requires that `OpaqueListContents: Sized`
-  --> $DIR/deep-bad-copy-reason.rs:23:26
+  --> $DIR/deep-bad-copy-reason.rs:26:26
    |
 LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `OpaqueListContents` cannot be known at compilation time
+  --> $DIR/deep-bad-copy-reason.rs:26:26
+   |
+LL | pub struct List<'tcx, T>(Interned<'tcx, ListS<T>>);
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `ListS<T>`, the trait `Sized` is not implemented for `OpaqueListContents`, which is required by `ListS<T>: Sized`
+note: required because it appears within the type `ListS<T>`
+  --> $DIR/deep-bad-copy-reason.rs:7:12
+   |
+LL | pub struct ListS<T> {
+   |            ^^^^^
+note: required by an implicit `Sized` bound in `Interned`
+  --> $DIR/deep-bad-copy-reason.rs:14:25
+   |
+LL | pub struct Interned<'a, T>(&'a T);
+   |                         ^ required by the implicit `Sized` requirement on this type parameter in `Interned`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub struct Interned<'a, T: ?Sized>(&'a T);
+   |                          ++++++++
 
-For more information about this error, try `rustc --explain E0204`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0204, E0277.
+For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Trait<Alias<_>>` for type `Alias<_>`
-  --> $DIR/opaques.rs:29:1
+  --> $DIR/opaques.rs:30:1
    |
 LL | impl<T> Trait<T> for T {
    | ---------------------- first implementation here
@@ -7,6 +7,13 @@ LL | impl<T> Trait<T> for T {
 LL | impl<T> Trait<T> for defining_scope::Alias<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Alias<_>`
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/opaques.rs:13:20
+   |
+LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
+   |                    ^ cannot infer type for struct `Container<Alias<T>, T>`
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0282.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/occurs-check/opaques.rs
+++ b/tests/ui/coherence/occurs-check/opaques.rs
@@ -11,6 +11,7 @@ mod defining_scope {
     pub type Alias<T> = impl Sized;
 
     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
+        //[next]~^ ERROR type annotations needed
         x
     }
 }

--- a/tests/ui/error-codes/E0117.rs
+++ b/tests/ui/error-codes/E0117.rs
@@ -1,4 +1,5 @@
 impl Drop for u32 {} //~ ERROR E0117
 //~| ERROR the `Drop` trait may only be implemented for local structs, enums, and unions
+//~| ERROR not all trait items implemented
 
 fn main() {}

--- a/tests/ui/error-codes/E0117.stderr
+++ b/tests/ui/error-codes/E0117.stderr
@@ -15,7 +15,15 @@ error[E0120]: the `Drop` trait may only be implemented for local structs, enums,
 LL | impl Drop for u32 {}
    |               ^^^ must be a struct, enum, or union in the current crate
 
-error: aborting due to 2 previous errors
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/E0117.rs:1:1
+   |
+LL | impl Drop for u32 {}
+   | ^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
 
-Some errors have detailed explanations: E0117, E0120.
-For more information about an error, try `rustc --explain E0117`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0046, E0117, E0120.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/error-codes/E0120.rs
+++ b/tests/ui/error-codes/E0120.rs
@@ -3,6 +3,7 @@ trait MyTrait { fn foo() {} }
 impl Drop for dyn MyTrait {
               //~^ ERROR E0120
     fn drop(&mut self) {}
+
 }
 
 fn main() {}

--- a/tests/ui/error-codes/E0374.rs
+++ b/tests/ui/error-codes/E0374.rs
@@ -1,7 +1,7 @@
 #![feature(coerce_unsized)]
 use std::ops::CoerceUnsized;
 
-struct Foo<T: ?Sized> {
+struct Foo<T: ?Sized> { //~ ERROR `T` is never used
     a: i32,
 }
 

--- a/tests/ui/error-codes/E0374.stderr
+++ b/tests/ui/error-codes/E0374.stderr
@@ -7,6 +7,15 @@ LL | |     where T: CoerceUnsized<U> {}
    |
    = note: expected a single field to be coerced, none found
 
-error: aborting due to 1 previous error
+error[E0392]: type parameter `T` is never used
+  --> $DIR/E0374.rs:4:12
+   |
+LL | struct Foo<T: ?Sized> {
+   |            ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0374`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0374, E0392.
+For more information about an error, try `rustc --explain E0374`.

--- a/tests/ui/error-codes/E0375.rs
+++ b/tests/ui/error-codes/E0375.rs
@@ -3,7 +3,7 @@ use std::ops::CoerceUnsized;
 
 struct Foo<T: ?Sized, U: ?Sized> {
     a: i32,
-    b: T,
+    b: T, //~ ERROR E0277
     c: U,
 }
 

--- a/tests/ui/error-codes/E0375.stderr
+++ b/tests/ui/error-codes/E0375.stderr
@@ -7,6 +7,32 @@ LL | impl<T, U> CoerceUnsized<Foo<U, T>> for Foo<T, U> {}
    = note: `CoerceUnsized` may only be implemented for a coercion between structures with one field being coerced
    = note: currently, 2 fields need coercions: `b` (`T` to `U`), `c` (`U` to `T`)
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/E0375.rs:6:8
+   |
+LL | struct Foo<T: ?Sized, U: ?Sized> {
+   |            - this type parameter needs to be `Sized`
+LL |     a: i32,
+LL |     b: T,
+   |        ^ doesn't have a size known at compile-time
+   |
+   = note: only the last field of a struct may have a dynamically sized type
+   = help: change the field's type to have a statically known size
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - struct Foo<T: ?Sized, U: ?Sized> {
+LL + struct Foo<T, U: ?Sized> {
+   |
+help: borrowed types always have a statically known size
+   |
+LL |     b: &T,
+   |        +
+help: the `Box` type always has a statically known size and allocates its contents in the heap
+   |
+LL |     b: Box<T>,
+   |        ++++ +
 
-For more information about this error, try `rustc --explain E0375`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0375.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-67535.rs
+++ b/tests/ui/issues/issue-67535.rs
@@ -2,21 +2,21 @@ fn main() {}
 
 impl std::ops::AddAssign for () {
     //~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
-    fn add_assign(&self, other: ()) -> () {
+    fn add_assign(&self, other: ()) -> () { //~ ERROR incompatible type
         ()
     }
 }
 
 impl std::ops::AddAssign for [(); 1] {
     //~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
-    fn add_assign(&self, other: [(); 1]) -> [(); 1] {
+    fn add_assign(&self, other: [(); 1]) -> [(); 1] { //~ ERROR incompatible type
         [()]
     }
 }
 
 impl std::ops::AddAssign for &[u8] {
     //~^ ERROR only traits defined in the current crate can be implemented for arbitrary types
-    fn add_assign(&self, other: &[u8]) -> &[u8] {
+    fn add_assign(&self, other: &[u8]) -> &[u8] { //~ ERROR incompatible type
         self
     }
 }

--- a/tests/ui/issues/issue-67535.stderr
+++ b/tests/ui/issues/issue-67535.stderr
@@ -34,6 +34,43 @@ LL | impl std::ops::AddAssign for &[u8] {
    |
    = note: define and implement a trait or new type instead
 
-error: aborting due to 3 previous errors
+error[E0053]: method `add_assign` has an incompatible type for trait
+  --> $DIR/issue-67535.rs:5:19
+   |
+LL |     fn add_assign(&self, other: ()) -> () {
+   |                   ^^^^^
+   |                   |
+   |                   types differ in mutability
+   |                   help: change the self-receiver type to match the trait: `&mut self`
+   |
+   = note: expected signature `fn(&mut (), ())`
+              found signature `fn(&(), ())`
 
-For more information about this error, try `rustc --explain E0117`.
+error[E0053]: method `add_assign` has an incompatible type for trait
+  --> $DIR/issue-67535.rs:12:19
+   |
+LL |     fn add_assign(&self, other: [(); 1]) -> [(); 1] {
+   |                   ^^^^^
+   |                   |
+   |                   types differ in mutability
+   |                   help: change the self-receiver type to match the trait: `&mut self`
+   |
+   = note: expected signature `fn(&mut _, _)`
+              found signature `fn(&_, _) -> [(); 1]`
+
+error[E0053]: method `add_assign` has an incompatible type for trait
+  --> $DIR/issue-67535.rs:19:19
+   |
+LL |     fn add_assign(&self, other: &[u8]) -> &[u8] {
+   |                   ^^^^^
+   |                   |
+   |                   types differ in mutability
+   |                   help: change the self-receiver type to match the trait: `&mut self`
+   |
+   = note: expected signature `fn(&mut &_, &_)`
+              found signature `fn(&&_, &_) -> &[u8]`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0053, E0117.
+For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/marker_trait_attr/override-item-on-marker-trait.rs
+++ b/tests/ui/marker_trait_attr/override-item-on-marker-trait.rs
@@ -3,7 +3,9 @@
 #[marker]
 trait Marker {
     const N: usize = 0;
+    //~^ ERROR marker traits cannot have associated items
     fn do_something() {}
+    //~^ ERROR marker traits cannot have associated items
 }
 
 struct OverrideConst;

--- a/tests/ui/marker_trait_attr/override-item-on-marker-trait.stderr
+++ b/tests/ui/marker_trait_attr/override-item-on-marker-trait.stderr
@@ -1,15 +1,28 @@
 error[E0715]: impls for marker traits cannot contain items
-  --> $DIR/override-item-on-marker-trait.rs:10:1
+  --> $DIR/override-item-on-marker-trait.rs:12:1
    |
 LL | impl Marker for OverrideConst {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0715]: impls for marker traits cannot contain items
-  --> $DIR/override-item-on-marker-trait.rs:16:1
+  --> $DIR/override-item-on-marker-trait.rs:18:1
    |
 LL | impl Marker for OverrideFn {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0714]: marker traits cannot have associated items
+  --> $DIR/override-item-on-marker-trait.rs:5:5
+   |
+LL |     const N: usize = 0;
+   |     ^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0715`.
+error[E0714]: marker traits cannot have associated items
+  --> $DIR/override-item-on-marker-trait.rs:7:5
+   |
+LL |     fn do_something() {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0714, E0715.
+For more information about an error, try `rustc --explain E0714`.

--- a/tests/ui/specialization/specialization-default-items-drop-coherence.next.stderr
+++ b/tests/ui/specialization/specialization-default-items-drop-coherence.next.stderr
@@ -7,6 +7,13 @@ LL | impl Overlap for u32 {
 LL | impl Overlap for <u32 as Default>::Id {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `u32`
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/specialization-default-items-drop-coherence.rs:18:23
+   |
+LL |     default type Id = T;
+   |                       ^ cannot infer type for associated type `<T as Default>::Id`
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0282.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/specialization/specialization-default-items-drop-coherence.rs
+++ b/tests/ui/specialization/specialization-default-items-drop-coherence.rs
@@ -11,25 +11,25 @@
 #![allow(incomplete_features)]
 
 trait Default {
-   type Id;
+    type Id;
 }
 
 impl<T> Default for T {
-   default type Id = T;
+    default type Id = T; //[next]~ ERROR type annotations needed
 }
 
 trait Overlap {
-   type Assoc;
+    type Assoc;
 }
 
 impl Overlap for u32 {
-   type Assoc = usize;
+    type Assoc = usize;
 }
 
 impl Overlap for <u32 as Default>::Id {
-   //[coherence]~^ ERROR conflicting implementations of trait `Overlap` for type `u32`
-   //[next]~^^ ERROR conflicting implementations of trait `Overlap` for type `u32`
-   type Assoc = Box<usize>;
+    //[coherence]~^ ERROR conflicting implementations of trait `Overlap` for type `u32`
+    //[next]~^^ ERROR conflicting implementations of trait `Overlap` for type `u32`
+    type Assoc = Box<usize>;
 }
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
@@ -8,8 +8,8 @@ pub struct Vector2<T: Debug + Copy + Clone>{
 }
 
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
-pub struct AABB<K: Copy + Debug>{
-    pub loc: Vector2<K>,
+pub struct AABB<K: Copy + Debug + std::fmt::Debug>{
+    pub loc: Vector2<K>, //~ ERROR `K` doesn't implement `Debug`
     pub size: Vector2<K>
 }
 

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
@@ -9,7 +9,7 @@ pub struct Vector2<T: Debug + Copy + Clone>{
 
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
 pub struct AABB<K: Copy>{
-    pub loc: Vector2<K>,
+    pub loc: Vector2<K>, //~ ERROR `K` doesn't implement `Debug`
     pub size: Vector2<K>
 }
 

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -18,6 +18,23 @@ help: consider further restricting this bound
 LL | pub struct AABB<K: Copy + Debug>{
    |                         +++++++
 
-error: aborting due to 1 previous error
+error[E0277]: `K` doesn't implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:12:14
+   |
+LL |     pub loc: Vector2<K>,
+   |              ^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+note: required by a bound in `Vector2`
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:5:23
+   |
+LL | pub struct Vector2<T: Debug + Copy + Clone>{
+   |                       ^^^^^ required by this bound in `Vector2`
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Copy + std::fmt::Debug>{
+   |                         +++++++++++++++++
 
-For more information about this error, try `rustc --explain E0204`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0204, E0277.
+For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.rs
@@ -9,6 +9,8 @@ pub struct Vector2<T: Debug + Copy + Clone>{
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
 pub struct AABB<K>{
     pub loc: Vector2<K>,
+    //~^ ERROR doesn't implement `Debug`
+    //~| ERROR `K: Copy` is not satisfied
     pub size: Vector2<K>
 }
 

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -18,6 +18,39 @@ help: consider restricting type parameter `K`
 LL | pub struct AABB<K: Debug>{
    |                  +++++++
 
-error: aborting due to 1 previous error
+error[E0277]: `K` doesn't implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:14
+   |
+LL |     pub loc: Vector2<K>,
+   |              ^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+note: required by a bound in `Vector2`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:4:23
+   |
+LL | pub struct Vector2<T: Debug + Copy + Clone>{
+   |                       ^^^^^ required by this bound in `Vector2`
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::fmt::Debug>{
+   |                  +++++++++++++++++
 
-For more information about this error, try `rustc --explain E0204`.
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:14
+   |
+LL |     pub loc: Vector2<K>,
+   |              ^^^^^^^^^^ the trait `Copy` is not implemented for `K`
+   |
+note: required by a bound in `Vector2`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:4:31
+   |
+LL | pub struct Vector2<T: Debug + Copy + Clone>{
+   |                               ^^^^ required by this bound in `Vector2`
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::marker::Copy>{
+   |                  +++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0204, E0277.
+For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/traits/issue-50480.rs
+++ b/tests/ui/traits/issue-50480.rs
@@ -5,11 +5,13 @@ struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~| ERROR cannot find type `NotDefined` in this scope
 //~| ERROR cannot find type `N` in this scope
 //~| ERROR cannot find type `N` in this scope
+//~| ERROR `i32` is not an iterator
 
 #[derive(Clone, Copy)]
 //~^ ERROR the trait `Copy` cannot be implemented for this type
 struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~^ ERROR cannot find type `NotDefined` in this scope
 //~| ERROR cannot find type `N` in this scope
+//~| ERROR `i32` is not an iterator
 
 fn main() {}

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -38,7 +38,7 @@ LL | struct Foo<NotDefined>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, St
    |           ++++++++++++
 
 error[E0412]: cannot find type `N` in this scope
-  --> $DIR/issue-50480.rs:11:18
+  --> $DIR/issue-50480.rs:12:18
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |            -     ^
@@ -55,7 +55,7 @@ LL | struct Bar<T, N>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, Strin
    |             +++
 
 error[E0412]: cannot find type `NotDefined` in this scope
-  --> $DIR/issue-50480.rs:11:21
+  --> $DIR/issue-50480.rs:12:21
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                     ^^^^^^^^^^ not found in this scope
@@ -74,7 +74,7 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` cannot be implemented for this type
-  --> $DIR/issue-50480.rs:9:17
+  --> $DIR/issue-50480.rs:10:17
    |
 LL | #[derive(Clone, Copy)]
    |                 ^^^^
@@ -86,7 +86,25 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 8 previous errors
+error[E0277]: `i32` is not an iterator
+  --> $DIR/issue-50480.rs:3:27
+   |
+LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
-Some errors have detailed explanations: E0204, E0412.
+error[E0277]: `i32` is not an iterator
+  --> $DIR/issue-50480.rs:12:33
+   |
+LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0204, E0277, E0412.
 For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/traits/issue-78372.rs
+++ b/tests/ui/traits/issue-78372.rs
@@ -6,8 +6,9 @@ impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {} //~ ERROR cannot find type `U` 
 //~| ERROR the trait `DispatchFromDyn` may only be implemented for a coercion between structures
 trait Foo: X<u32> {}
 trait X<T> {
-    fn foo(self: Smaht<Self, T>);
+    fn foo(self: Smaht<Self, T>); //~ ERROR: invalid `self`
 }
 trait Marker {}
 impl Marker for dyn Foo {}
+//~^ ERROR cannot be made into an object
 fn main() {}

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -61,7 +61,34 @@ error[E0378]: the trait `DispatchFromDyn` may only be implemented for a coercion
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/issue-78372.rs:12:17
+   |
+LL |     fn foo(self: Smaht<Self, T>);
+   |                  -------------- help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
+...
+LL | impl Marker for dyn Foo {}
+   |                 ^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-78372.rs:9:18
+   |
+LL | trait Foo: X<u32> {}
+   |       --- this trait cannot be made into an object...
+LL | trait X<T> {
+LL |     fn foo(self: Smaht<Self, T>);
+   |                  ^^^^^^^^^^^^^^ ...because method `foo`'s `self` parameter cannot be dispatched on
 
-Some errors have detailed explanations: E0378, E0412, E0658.
-For more information about an error, try `rustc --explain E0378`.
+error[E0307]: invalid `self` parameter type: Smaht<Self, T>
+  --> $DIR/issue-78372.rs:9:18
+   |
+LL |     fn foo(self: Smaht<Self, T>);
+   |                  ^^^^^^^^^^^^^^
+   |
+   = note: type of `self` must be `Self` or a type that dereferences to it
+   = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0038, E0307, E0378, E0412, E0658.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/next-solver/coherence/trait_ref_is_knowable-norm-overflow.rs
+++ b/tests/ui/traits/next-solver/coherence/trait_ref_is_knowable-norm-overflow.rs
@@ -8,6 +8,7 @@ trait Overflow {
 }
 impl<T> Overflow for T {
     type Assoc = <T as Overflow>::Assoc;
+    //~^ ERROR: overflow
 }
 
 

--- a/tests/ui/traits/next-solver/coherence/trait_ref_is_knowable-norm-overflow.stderr
+++ b/tests/ui/traits/next-solver/coherence/trait_ref_is_knowable-norm-overflow.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Trait` for type `<LocalTy as Overflow>::Assoc`
-  --> $DIR/trait_ref_is_knowable-norm-overflow.rs:17:1
+  --> $DIR/trait_ref_is_knowable-norm-overflow.rs:18:1
    |
 LL | impl<T: Copy> Trait for T {}
    | ------------------------- first implementation here
@@ -7,6 +7,24 @@ LL | struct LocalTy;
 LL | impl Trait for <LocalTy as Overflow>::Assoc {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `<LocalTy as Overflow>::Assoc`
 
-error: aborting due to 1 previous error
+error[E0275]: overflow evaluating the requirement `<T as Overflow>::Assoc: Sized`
+  --> $DIR/trait_ref_is_knowable-norm-overflow.rs:10:18
+   |
+LL |     type Assoc = <T as Overflow>::Assoc;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`trait_ref_is_knowable_norm_overflow`)
+note: required by a bound in `Overflow::Assoc`
+  --> $DIR/trait_ref_is_knowable-norm-overflow.rs:7:5
+   |
+LL |     type Assoc;
+   |     ^^^^^^^^^^^ required by this bound in `Overflow::Assoc`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     type Assoc: ?Sized;
+   |               ++++++++
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0275.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/traits/next-solver/issue-118950-root-region.rs
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.rs
@@ -12,6 +12,7 @@ trait ToUnit<'a> {
 trait Overlap<T> {}
 
 type Assoc<'a, T> = <*const T as ToUnit<'a>>::Unit;
+//~^ ERROR: not well-formed
 
 impl<T> Overlap<T> for T {}
 

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -1,5 +1,5 @@
 error[E0412]: cannot find type `Missing` in this scope
-  --> $DIR/issue-118950-root-region.rs:18:55
+  --> $DIR/issue-118950-root-region.rs:19:55
    |
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T> {}
    |                                                       ^^^^^^^ not found in this scope
@@ -22,7 +22,7 @@ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: 
 WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: Alias(Weak, AliasTy { args: [ReBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrNamed(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a), 'a) }), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc) })
 WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: Alias(Weak, AliasTy { args: [RePlaceholder(!1_BoundRegion { var: 0, kind: BrNamed(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a), 'a) }), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc) })
 error[E0119]: conflicting implementations of trait `Overlap<fn(_)>` for type `fn(_)`
-  --> $DIR/issue-118950-root-region.rs:18:1
+  --> $DIR/issue-118950-root-region.rs:19:1
    |
 LL | impl<T> Overlap<T> for T {}
    | ------------------------ first implementation here
@@ -30,7 +30,13 @@ LL |
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `fn(_)`
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: the type `<*const T as ToUnit<'a>>::Unit` is not well-formed
+  --> $DIR/issue-118950-root-region.rs:14:21
+   |
+LL | type Assoc<'a, T> = <*const T as ToUnit<'a>>::Unit;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0119, E0412.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -198,6 +198,7 @@ trait Qux {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
 }
 impl Qux for Struct {
+    //~^ ERROR not all trait items implemented, missing: `F`
     type A = _;
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for associated types
     type B = _;

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -29,7 +29,7 @@ LL | struct BadStruct2<_, T>(_, T);
    |                   ^ expected identifier, found reserved identifier
 
 error: associated constant in `impl` without body
-  --> $DIR/typeck_type_placeholder_item.rs:205:5
+  --> $DIR/typeck_type_placeholder_item.rs:206:5
    |
 LL |     const C: _;
    |     ^^^^^^^^^^-
@@ -411,7 +411,7 @@ LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:216:31
+  --> $DIR/typeck_type_placeholder_item.rs:217:31
    |
 LL | fn value() -> Option<&'static _> {
    |               ----------------^-
@@ -420,7 +420,7 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:221:10
+  --> $DIR/typeck_type_placeholder_item.rs:222:10
    |
 LL | const _: Option<_> = map(value);
    |          ^^^^^^^^^
@@ -429,7 +429,7 @@ LL | const _: Option<_> = map(value);
    |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:224:31
+  --> $DIR/typeck_type_placeholder_item.rs:225:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -438,13 +438,13 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:229:10
+  --> $DIR/typeck_type_placeholder_item.rs:230:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:229:29}>, {closure@typeck_type_placeholder_item.rs:229:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:229:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:230:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -631,25 +631,25 @@ LL |         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
    |                                         ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:201:14
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
    |
 LL |     type A = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:203:14
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
    |
 LL |     type B = _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:205:14
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
    |
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:208:14
+  --> $DIR/typeck_type_placeholder_item.rs:209:14
    |
 LL |     const D: _ = 42;
    |              ^
@@ -657,7 +657,16 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
 
-error: aborting due to 71 previous errors
+error[E0046]: not all trait items implemented, missing: `F`
+  --> $DIR/typeck_type_placeholder_item.rs:200:1
+   |
+LL |     type F: std::ops::Fn(_);
+   |     ----------------------- `F` from trait
+...
+LL | impl Qux for Struct {
+   | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
-Some errors have detailed explanations: E0121, E0282, E0403.
-For more information about an error, try `rustc --explain E0121`.
+error: aborting due to 72 previous errors
+
+Some errors have detailed explanations: E0046, E0121, E0282, E0403.
+For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
fixes #120343

but also has a lot of "type annotations needed" fallout. Some are fixed in the second commit.