### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0091.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0091.md
@@ -1,11 +1,11 @@
-An unnecessary type or const parameter was given in a type alias.
+An unnecessary type parameter was given in a type alias.
 
 Erroneous code example:
 
 ```compile_fail,E0091
-type Foo<T> = u32; // error: type parameter `T` is unused
+type Foo<T> = u32; // error: type parameter `T` is never used
 // or:
-type Foo<A,B> = Box<A>; // error: type parameter `B` is unused
+type Foo<A, B> = Box<A>; // error: type parameter `B` is never used
 ```
 
 Please check you didn't write too many parameters. Example:

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -378,7 +378,7 @@ impl From<Cow<'static, str>> for DiagnosticMessage {
     }
 }
 
-/// A workaround for "good path" ICEs when formatting types in disabled lints.
+/// A workaround for good_path_delayed_bug ICEs when formatting types in disabled lints.
 ///
 /// Delays formatting until `.into(): DiagnosticMessage` is used.
 pub struct DelayDm<F>(pub F);

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -85,7 +85,11 @@ fn source_string(file: Lrc<SourceFile>, line: &Line) -> String {
 /// Maps `Diagnostic::Level` to `snippet::AnnotationType`
 fn annotation_type_for_level(level: Level) -> AnnotationType {
     match level {
-        Level::Bug | Level::DelayedBug(_) | Level::Fatal | Level::Error => AnnotationType::Error,
+        Level::Bug
+        | Level::Fatal
+        | Level::Error
+        | Level::DelayedBug
+        | Level::GoodPathDelayedBug => AnnotationType::Error,
         Level::ForceWarning(_) | Level::Warning => AnnotationType::Warning,
         Level::Note | Level::OnceNote => AnnotationType::Note,
         Level::Help | Level::OnceHelp => AnnotationType::Help,

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -1,8 +1,7 @@
 use crate::snippet::Style;
 use crate::{
-    CodeSuggestion, DelayedBugKind, DiagnosticBuilder, DiagnosticMessage, EmissionGuarantee,
-    ErrCode, Level, MultiSpan, SubdiagnosticMessage, Substitution, SubstitutionPart,
-    SuggestionStyle,
+    CodeSuggestion, DiagnosticBuilder, DiagnosticMessage, EmissionGuarantee, ErrCode, Level,
+    MultiSpan, SubdiagnosticMessage, Substitution, SubstitutionPart, SuggestionStyle,
 };
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_error_messages::fluent_value_from_str_list_sep_by_and;
@@ -235,14 +234,11 @@ impl Diagnostic {
 
     pub fn is_error(&self) -> bool {
         match self.level {
-            Level::Bug
-            | Level::DelayedBug(DelayedBugKind::Normal)
-            | Level::Fatal
-            | Level::Error => true,
+            Level::Bug | Level::Fatal | Level::Error | Level::DelayedBug => true,
 
-            Level::ForceWarning(_)
+            Level::GoodPathDelayedBug
+            | Level::ForceWarning(_)
             | Level::Warning
-            | Level::DelayedBug(DelayedBugKind::GoodPath)
             | Level::Note
             | Level::OnceNote
             | Level::Help
@@ -306,11 +302,11 @@ impl Diagnostic {
     #[track_caller]
     pub fn downgrade_to_delayed_bug(&mut self) {
         assert!(
-            matches!(self.level, Level::Error | Level::DelayedBug(_)),
+            matches!(self.level, Level::Error | Level::DelayedBug),
             "downgrade_to_delayed_bug: cannot downgrade {:?} to DelayedBug: not an error",
             self.level
         );
-        self.level = Level::DelayedBug(DelayedBugKind::Normal);
+        self.level = Level::DelayedBug;
     }
 
     /// Appends a labeled span to the diagnostic.

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -306,7 +306,7 @@ impl Diagnostic {
     #[track_caller]
     pub fn downgrade_to_delayed_bug(&mut self) {
         assert!(
-            self.is_error(),
+            matches!(self.level, Level::Error | Level::DelayedBug(_)),
             "downgrade_to_delayed_bug: cannot downgrade {:?} to DelayedBug: not an error",
             self.level
         );

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -238,8 +238,7 @@ impl Diagnostic {
             Level::Bug
             | Level::DelayedBug(DelayedBugKind::Normal)
             | Level::Fatal
-            | Level::Error
-            | Level::FailureNote => true,
+            | Level::Error => true,
 
             Level::ForceWarning(_)
             | Level::Warning
@@ -248,6 +247,7 @@ impl Diagnostic {
             | Level::OnceNote
             | Level::Help
             | Level::OnceHelp
+            | Level::FailureNote
             | Level::Allow
             | Level::Expect(_) => false,
         }

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2118,6 +2118,7 @@ impl HumanEmitter {
                 }
                 if !self.short_message {
                     for child in children {
+                        assert!(child.level.can_be_top_or_sub().1);
                         let span = &child.span;
                         if let Err(err) = self.emit_messages_default_inner(
                             span,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1545,6 +1545,8 @@ pub enum Level {
     ///
     /// The [`LintExpectationId`] is used for expected lint diagnostics. In all other cases this
     /// should be `None`.
+    ///
+    /// Its `EmissionGuarantee` is `()`.
     ForceWarning(Option<LintExpectationId>),
 
     /// A warning about the code being compiled. Does not prevent compilation from finishing.
@@ -1574,7 +1576,8 @@ pub enum Level {
     /// Its `EmissionGuarantee` is `()`.
     OnceHelp,
 
-    /// Similar to `Note`, but used in cases where compilation has failed. Rare.
+    /// Similar to `Note`, but used in cases where compilation has failed. When printed for human
+    /// consumption, it doesn't have any kind of `note:` label. Rare.
     ///
     /// Its `EmissionGuarantee` is `()`.
     FailureNote,

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -440,7 +440,7 @@ struct DiagCtxtInner {
     has_printed: bool,
 
     emitter: Box<DynEmitter>,
-    span_delayed_bugs: Vec<DelayedDiagnostic>,
+    delayed_bugs: Vec<DelayedDiagnostic>,
     good_path_delayed_bugs: Vec<DelayedDiagnostic>,
     /// This flag indicates that an expected diagnostic was emitted and suppressed.
     /// This is used for the `good_path_delayed_bugs` check.
@@ -524,8 +524,7 @@ fn default_track_diagnostic(diag: Diagnostic, f: &mut dyn FnMut(Diagnostic)) {
 pub static TRACK_DIAGNOSTIC: AtomicRef<fn(Diagnostic, &mut dyn FnMut(Diagnostic))> =
     AtomicRef::new(&(default_track_diagnostic as _));
 
-#[derive(Copy, PartialEq, Eq, Clone, Hash, Debug, Encodable, Decodable)]
-pub enum DelayedBugKind {
+enum DelayedBugKind {
     Normal,
     GoodPath,
 }
@@ -558,11 +557,6 @@ impl Drop for DiagCtxtInner {
             self.flush_delayed(DelayedBugKind::Normal)
         }
 
-        // FIXME(eddyb) this explains what `good_path_delayed_bugs` are!
-        // They're `span_delayed_bugs` but for "require some diagnostic happened"
-        // instead of "require some error happened". Sadly that isn't ideal, as
-        // lints can be `#[allow]`'d, potentially leading to this triggering.
-        // Also, "good path" should be replaced with a better naming.
         if !self.has_printed && !self.suppressed_expected_diag && !std::thread::panicking() {
             self.flush_delayed(DelayedBugKind::GoodPath);
         }
@@ -609,7 +603,7 @@ impl DiagCtxt {
                 deduplicated_warn_count: 0,
                 has_printed: false,
                 emitter,
-                span_delayed_bugs: Vec::new(),
+                delayed_bugs: Vec::new(),
                 good_path_delayed_bugs: Vec::new(),
                 suppressed_expected_diag: false,
                 taught_diagnostics: Default::default(),
@@ -665,7 +659,7 @@ impl DiagCtxt {
         inner.has_printed = false;
 
         // actually free the underlying memory (which `clear` would not do)
-        inner.span_delayed_bugs = Default::default();
+        inner.delayed_bugs = Default::default();
         inner.good_path_delayed_bugs = Default::default();
         inner.taught_diagnostics = Default::default();
         inner.emitted_diagnostic_codes = Default::default();
@@ -866,8 +860,7 @@ impl DiagCtxt {
     /// directly).
     #[track_caller]
     pub fn delayed_bug(&self, msg: impl Into<DiagnosticMessage>) -> ErrorGuaranteed {
-        DiagnosticBuilder::<ErrorGuaranteed>::new(self, DelayedBug(DelayedBugKind::Normal), msg)
-            .emit()
+        DiagnosticBuilder::<ErrorGuaranteed>::new(self, DelayedBug, msg).emit()
     }
 
     /// Like `delayed_bug`, but takes an additional span.
@@ -880,15 +873,12 @@ impl DiagCtxt {
         sp: impl Into<MultiSpan>,
         msg: impl Into<DiagnosticMessage>,
     ) -> ErrorGuaranteed {
-        DiagnosticBuilder::<ErrorGuaranteed>::new(self, DelayedBug(DelayedBugKind::Normal), msg)
-            .with_span(sp)
-            .emit()
+        DiagnosticBuilder::<ErrorGuaranteed>::new(self, DelayedBug, msg).with_span(sp).emit()
     }
 
-    // FIXME(eddyb) note the comment inside `impl Drop for DiagCtxtInner`, that's
-    // where the explanation of what "good path" is (also, it should be renamed).
+    /// Ensures that a diagnostic is printed. See `Level::GoodPathDelayedBug`.
     pub fn good_path_delayed_bug(&self, msg: impl Into<DiagnosticMessage>) {
-        DiagnosticBuilder::<()>::new(self, DelayedBug(DelayedBugKind::GoodPath), msg).emit()
+        DiagnosticBuilder::<()>::new(self, GoodPathDelayedBug, msg).emit()
     }
 
     #[track_caller]
@@ -962,7 +952,7 @@ impl DiagCtxt {
     pub fn has_errors_or_lint_errors_or_delayed_bugs(&self) -> Option<ErrorGuaranteed> {
         let inner = self.inner.borrow();
         let result =
-            inner.has_errors() || inner.lint_err_count > 0 || !inner.span_delayed_bugs.is_empty();
+            inner.has_errors() || inner.lint_err_count > 0 || !inner.delayed_bugs.is_empty();
         result.then(|| {
             #[allow(deprecated)]
             ErrorGuaranteed::unchecked_claim_error_was_emitted()
@@ -1248,6 +1238,8 @@ impl DiagCtxtInner {
     }
 
     fn emit_diagnostic(&mut self, mut diagnostic: Diagnostic) -> Option<ErrorGuaranteed> {
+        assert!(diagnostic.level.can_be_top_or_sub().0);
+
         if let Some(expectation_id) = diagnostic.level.get_expectation_id() {
             // The `LintExpectationId` can be stable or unstable depending on when it was created.
             // Diagnostics created before the definition of `HirId`s are unstable and can not yet
@@ -1264,32 +1256,33 @@ impl DiagCtxtInner {
             self.future_breakage_diagnostics.push(diagnostic.clone());
         }
 
-        if matches!(diagnostic.level, DelayedBug(_)) && self.flags.eagerly_emit_delayed_bugs {
+        if matches!(diagnostic.level, DelayedBug | GoodPathDelayedBug)
+            && self.flags.eagerly_emit_delayed_bugs
+        {
             diagnostic.level = Error;
         }
 
         match diagnostic.level {
-            // This must come after the possible promotion of `DelayedBug` to `Error` above.
+            // This must come after the possible promotion of `DelayedBug`/`GoodPathDelayedBug` to
+            // `Error` above.
             Fatal | Error if self.treat_next_err_as_bug() => {
                 diagnostic.level = Bug;
             }
-            DelayedBug(DelayedBugKind::Normal) => {
+            DelayedBug => {
                 // FIXME(eddyb) this should check for `has_errors` and stop pushing
-                // once *any* errors were emitted (and truncate `span_delayed_bugs`
+                // once *any* errors were emitted (and truncate `delayed_bugs`
                 // when an error is first emitted, also), but maybe there's a case
                 // in which that's not sound? otherwise this is really inefficient.
                 let backtrace = std::backtrace::Backtrace::capture();
-                self.span_delayed_bugs
+                self.delayed_bugs
                     .push(DelayedDiagnostic::with_backtrace(diagnostic.clone(), backtrace));
-
                 #[allow(deprecated)]
                 return Some(ErrorGuaranteed::unchecked_claim_error_was_emitted());
             }
-            DelayedBug(DelayedBugKind::GoodPath) => {
+            GoodPathDelayedBug => {
                 let backtrace = std::backtrace::Backtrace::capture();
                 self.good_path_delayed_bugs
                     .push(DelayedDiagnostic::with_backtrace(diagnostic.clone(), backtrace));
-
                 return None;
             }
             Warning if !self.flags.can_emit_warnings => {
@@ -1395,12 +1388,12 @@ impl DiagCtxtInner {
     fn flush_delayed(&mut self, kind: DelayedBugKind) {
         let (bugs, note1) = match kind {
             DelayedBugKind::Normal => (
-                std::mem::take(&mut self.span_delayed_bugs),
-                "no errors encountered even though `span_delayed_bug` issued",
+                std::mem::take(&mut self.delayed_bugs),
+                "no errors encountered even though delayed bugs were created",
             ),
             DelayedBugKind::GoodPath => (
                 std::mem::take(&mut self.good_path_delayed_bugs),
-                "no warnings or errors encountered even though `good_path_delayed_bugs` issued",
+                "no warnings or errors encountered even though good path delayed bugs were created",
             ),
         };
         let note2 = "those delayed bugs will now be shown as internal compiler errors";
@@ -1439,8 +1432,8 @@ impl DiagCtxtInner {
             let mut bug =
                 if backtrace || self.ice_file.is_none() { bug.decorate() } else { bug.inner };
 
-            // "Undelay" the `DelayedBug`s (into plain `Bug`s).
-            if !matches!(bug.level, DelayedBug(_)) {
+            // "Undelay" the delayed bugs (into plain `Bug`s).
+            if !matches!(bug.level, DelayedBug | GoodPathDelayedBug) {
                 // NOTE(eddyb) not panicking here because we're already producing
                 // an ICE, and the more information the merrier.
                 bug.subdiagnostic(InvalidFlushedDelayedDiagnosticLevel {
@@ -1506,85 +1499,89 @@ impl DelayedDiagnostic {
     }
 }
 
+/// Level              is_error  EmissionGuarantee         Top-level  Sub   Lint-only
+/// -----              --------  -----------------         ---------  ---   ---------
+/// Bug                yes       BugAbort                  yes        -     -
+/// Fatal              yes       FatalAbort/FatalError(*)  yes        -     -
+/// Error              yes       ErrorGuaranteed           yes        -     -
+/// DelayedBug         yes       ErrorGuaranteed           yes        -     -
+/// GoodPathDelayedBug -         ()                        yes        -     -
+/// ForceWarning       -         ()                        yes        -     yes
+/// Warning            -         ()                        yes        yes   -
+/// Note               -         ()                        rare       yes   -
+/// OnceNote           -         ()                        -          rare  -
+/// Help               -         ()                        rare       yes   -
+/// OnceHelp           -         ()                        -          rare  -
+/// FailureNote        -         ()                        rare       -     -
+/// Allow              -         ()                        yes        -     yes
+/// Expect             -         ()                        yes        -     yes
+///
+/// (*) `FatalAbort` normally, `FatalError` in the non-aborting "almost fatal" case that is
+///     occasionally used.
+///
 #[derive(Copy, PartialEq, Eq, Clone, Hash, Debug, Encodable, Decodable)]
 pub enum Level {
     /// For bugs in the compiler. Manifests as an ICE (internal compiler error) panic.
-    ///
-    /// Its `EmissionGuarantee` is `BugAbort`.
     Bug,
+
+    /// An error that causes an immediate abort. Used for things like configuration errors,
+    /// internal overflows, some file operation errors.
+    Fatal,
+
+    /// An error in the code being compiled, which prevents compilation from finishing. This is the
+    /// most common case.
+    Error,
 
     /// This is a strange one: lets you register an error without emitting it. If compilation ends
     /// without any other errors occurring, this will be emitted as a bug. Otherwise, it will be
     /// silently dropped. I.e. "expect other errors are emitted" semantics. Useful on code paths
     /// that should only be reached when compiling erroneous code.
-    ///
-    /// Its `EmissionGuarantee` is `ErrorGuaranteed` for `Normal` delayed bugs, and `()` for
-    /// `GoodPath` delayed bugs.
-    DelayedBug(DelayedBugKind),
+    DelayedBug,
 
-    /// An error that causes an immediate abort. Used for things like configuration errors,
-    /// internal overflows, some file operation errors.
+    /// Like `DelayedBug`, but weaker: lets you register an error without emitting it. If
+    /// compilation ends without any other diagnostics being emitted (and without an expected lint
+    /// being suppressed), this will be emitted as a bug. Otherwise, it will be silently dropped.
+    /// I.e. "expect other diagnostics are emitted (or suppressed)" semantics. Useful on code paths
+    /// that should only be reached when emitting diagnostics, e.g. for expensive one-time
+    /// diagnostic formatting operations.
     ///
-    /// Its `EmissionGuarantee` is `FatalAbort`, except in the non-aborting "almost fatal" case
-    /// that is occasionally used, where it is `FatalError`.
-    Fatal,
-
-    /// An error in the code being compiled, which prevents compilation from finishing. This is the
-    /// most common case.
-    ///
-    /// Its `EmissionGuarantee` is `ErrorGuaranteed`.
-    Error,
+    /// FIXME(nnethercote) good path delayed bugs are semantically strange: if printed they produce
+    /// an ICE, but they don't satisfy `is_error` and they don't guarantee an error is emitted.
+    /// Plus there's the extra complication with expected (suppressed) lints. They have limited
+    /// use, and are used in very few places, and "good path" isn't a good name. It would be good
+    /// to remove them.
+    GoodPathDelayedBug,
 
     /// A `force-warn` lint warning about the code being compiled. Does not prevent compilation
     /// from finishing.
     ///
     /// The [`LintExpectationId`] is used for expected lint diagnostics. In all other cases this
     /// should be `None`.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
     ForceWarning(Option<LintExpectationId>),
 
     /// A warning about the code being compiled. Does not prevent compilation from finishing.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
     Warning,
 
-    /// A message giving additional context. Rare, because notes are more commonly attached to other
-    /// diagnostics such as errors.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
+    /// A message giving additional context.
     Note,
 
-    /// A note that is only emitted once. Rare, mostly used in circumstances relating to lints.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
+    /// A note that is only emitted once.
     OnceNote,
 
-    /// A message suggesting how to fix something. Rare, because help messages are more commonly
-    /// attached to other diagnostics such as errors.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
+    /// A message suggesting how to fix something.
     Help,
 
-    /// A help that is only emitted once. Rare.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
+    /// A help that is only emitted once.
     OnceHelp,
 
     /// Similar to `Note`, but used in cases where compilation has failed. When printed for human
-    /// consumption, it doesn't have any kind of `note:` label. Rare.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
+    /// consumption, it doesn't have any kind of `note:` label.
     FailureNote,
 
     /// Only used for lints.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
     Allow,
 
     /// Only used for lints.
-    ///
-    /// Its `EmissionGuarantee` is `()`.
     Expect(LintExpectationId),
 }
 
@@ -1598,7 +1595,7 @@ impl Level {
     fn color(self) -> ColorSpec {
         let mut spec = ColorSpec::new();
         match self {
-            Bug | DelayedBug(_) | Fatal | Error => {
+            Bug | Fatal | Error | DelayedBug | GoodPathDelayedBug => {
                 spec.set_fg(Some(Color::Red)).set_intense(true);
             }
             ForceWarning(_) | Warning => {
@@ -1618,7 +1615,7 @@ impl Level {
 
     pub fn to_str(self) -> &'static str {
         match self {
-            Bug | DelayedBug(_) => "error: internal compiler error",
+            Bug | DelayedBug | GoodPathDelayedBug => "error: internal compiler error",
             Fatal | Error => "error",
             ForceWarning(_) | Warning => "warning",
             Note | OnceNote => "note",
@@ -1636,6 +1633,19 @@ impl Level {
         match self {
             Expect(id) | ForceWarning(Some(id)) => Some(*id),
             _ => None,
+        }
+    }
+
+    // Can this level be used in a top-level diagnostic message and/or a
+    // subdiagnostic message?
+    fn can_be_top_or_sub(&self) -> (bool, bool) {
+        match self {
+            Bug | DelayedBug | Fatal | Error | GoodPathDelayedBug | ForceWarning(_)
+            | FailureNote | Allow | Expect(_) => (true, false),
+
+            Warning | Note | Help => (true, true),
+
+            OnceNote | OnceHelp => (false, true),
         }
     }
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -496,7 +496,7 @@ declare_features! (
     /// Allow anonymous constants from an inline `const` block
     (unstable, inline_const, "1.49.0", Some(76001)),
     /// Allow anonymous constants from an inline `const` block in pattern position
-    (incomplete, inline_const_pat, "1.58.0", Some(76001)),
+    (unstable, inline_const_pat, "1.58.0", Some(76001)),
     /// Allows using `pointer` and `reference` in intra-doc links
     (unstable, intra_doc_pointers, "1.51.0", Some(80896)),
     // Allows setting the threshold for the `large_assignments` lint.

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -434,6 +434,17 @@ hir_analysis_unused_associated_type_bounds =
     .note = this associated type has a `where Self: Sized` bound. Thus, while the associated type can be specified, it cannot be used in any way, because trait objects are not `Sized`.
     .suggestion = remove this bound
 
+hir_analysis_unused_generic_parameter =
+    {$param_def_kind} `{$param_name}` is never used
+    .label = unused {$param_def_kind}
+    .const_param_help = if you intended `{$param_name}` to be a const parameter, use `const {$param_name}: /* Type */` instead
+hir_analysis_unused_generic_parameter_adt_help =
+    consider removing `{$param_name}`, referring to it in a field, or using a marker such as `{$phantom_data}`
+hir_analysis_unused_generic_parameter_adt_no_phantom_data_help =
+    consider removing `{$param_name}` or referring to it in a field
+hir_analysis_unused_generic_parameter_ty_alias_help =
+    consider removing `{$param_name}` or referring to it in the body of the type alias
+
 hir_analysis_value_of_associated_struct_already_specified =
     the value of the associated type `{$item_name}` in trait `{$def_path}` is already specified
     .label = re-bound here

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1511,3 +1511,27 @@ pub struct NotSupportedDelegation<'a> {
     #[label]
     pub callee_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_unused_generic_parameter)]
+pub(crate) struct UnusedGenericParameter {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub param_name: Ident,
+    pub param_def_kind: &'static str,
+    #[subdiagnostic]
+    pub help: UnusedGenericParameterHelp,
+    #[help(hir_analysis_const_param_help)]
+    pub const_param_help: Option<()>,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum UnusedGenericParameterHelp {
+    #[help(hir_analysis_unused_generic_parameter_adt_help)]
+    Adt { param_name: Ident, phantom_data: String },
+    #[help(hir_analysis_unused_generic_parameter_adt_no_phantom_data_help)]
+    AdtNoPhantomData { param_name: Ident },
+    #[help(hir_analysis_unused_generic_parameter_ty_alias_help)]
+    TyAlias { param_name: Ident },
+}

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -261,6 +261,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             expr.kind
             && let Some(recv_ty) = self.typeck_results.borrow().expr_ty_opt(recv_expr)
             && self.can_coerce(recv_ty, expected)
+            && let name = method.name.as_str()
+            && (name.starts_with("to_") || name.starts_with("as_") || name == "into")
         {
             let span = if let Some(recv_span) = recv_expr.span.find_ancestor_inside(expr.span) {
                 expr.span.with_lo(recv_span.hi())

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3010,7 +3010,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     }
                 }
                 let mut a = "a";
-                let mut this = "this";
+                let mut this = "this bound";
                 let mut note = None;
                 let mut help = None;
                 if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
@@ -3036,7 +3036,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             .any(|param| tcx.def_span(param.def_id) == span)
                         {
                             a = "an implicit `Sized`";
-                            this = "the implicit `Sized` requirement on this";
+                            this = "the implicit `Sized` requirement on this type parameter";
                         }
                         if let Some(hir::Node::TraitItem(hir::TraitItem {
                             ident,
@@ -3106,7 +3106,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 };
                 let descr = format!("required by {a} bound in `{item_name}`");
                 if span.is_visible(sm) {
-                    let msg = format!("required by {this} bound in `{short_item_name}`");
+                    let msg = format!("required by {this} in `{short_item_name}`");
                     multispan.push_span_label(span, msg);
                     err.span_note(multispan, descr);
                 } else {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3009,35 +3009,44 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         );
                     }
                 }
-                let descr = format!("required by a bound in `{item_name}`");
-                if span.is_visible(sm) {
-                    let msg = format!("required by this bound in `{short_item_name}`");
-                    multispan.push_span_label(span, msg);
-                    err.span_note(multispan, descr);
-                    if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
-                        && let ty::ClauseKind::Trait(trait_pred) = clause
-                    {
-                        let def_id = trait_pred.def_id();
-                        let visible_item = if let Some(local) = def_id.as_local() {
-                            // Check for local traits being reachable.
-                            let vis = &tcx.resolutions(()).effective_visibilities;
-                            // Account for non-`pub` traits in the root of the local crate.
-                            let is_locally_reachable = tcx.parent(def_id).is_crate_root();
-                            vis.is_reachable(local) || is_locally_reachable
-                        } else {
-                            // Check for foreign traits being reachable.
-                            tcx.visible_parent_map(()).get(&def_id).is_some()
-                        };
-                        if Some(def_id) == tcx.lang_items().sized_trait()
-                            && let Some(hir::Node::TraitItem(hir::TraitItem {
-                                ident,
-                                kind: hir::TraitItemKind::Type(bounds, None),
-                                ..
-                            })) = tcx.hir().get_if_local(item_def_id)
-                            // Do not suggest relaxing if there is an explicit `Sized` obligation.
-                            && !bounds.iter()
-                                .filter_map(|bound| bound.trait_ref())
-                                .any(|tr| tr.trait_def_id() == tcx.lang_items().sized_trait())
+                let mut a = "a";
+                let mut this = "this";
+                let mut note = None;
+                let mut help = None;
+                if let ty::PredicateKind::Clause(clause) = predicate.kind().skip_binder()
+                    && let ty::ClauseKind::Trait(trait_pred) = clause
+                {
+                    let def_id = trait_pred.def_id();
+                    let visible_item = if let Some(local) = def_id.as_local() {
+                        // Check for local traits being reachable.
+                        let vis = &tcx.resolutions(()).effective_visibilities;
+                        // Account for non-`pub` traits in the root of the local crate.
+                        let is_locally_reachable = tcx.parent(def_id).is_crate_root();
+                        vis.is_reachable(local) || is_locally_reachable
+                    } else {
+                        // Check for foreign traits being reachable.
+                        tcx.visible_parent_map(()).get(&def_id).is_some()
+                    };
+                    if Some(def_id) == tcx.lang_items().sized_trait() {
+                        // Check if this is an implicit bound, even in foreign crates.
+                        if tcx
+                            .generics_of(item_def_id)
+                            .params
+                            .iter()
+                            .any(|param| tcx.def_span(param.def_id) == span)
+                        {
+                            a = "an implicit `Sized`";
+                            this = "the implicit `Sized` requirement on this";
+                        }
+                        if let Some(hir::Node::TraitItem(hir::TraitItem {
+                            ident,
+                            kind: hir::TraitItemKind::Type(bounds, None),
+                            ..
+                        })) = tcx.hir().get_if_local(item_def_id)
+                        // Do not suggest relaxing if there is an explicit `Sized` obligation.
+                        && !bounds.iter()
+                            .filter_map(|bound| bound.trait_ref())
+                            .any(|tr| tr.trait_def_id() == tcx.lang_items().sized_trait())
                         {
                             let (span, separator) = if let [.., last] = bounds {
                                 (last.span().shrink_to_hi(), " +")
@@ -3051,51 +3060,63 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                                 Applicability::MachineApplicable,
                             );
                         }
-                        if let DefKind::Trait = tcx.def_kind(item_def_id)
-                            && !visible_item
-                        {
-                            err.note(format!(
-                                "`{short_item_name}` is a \"sealed trait\", because to implement \
-                                 it you also need to implement `{}`, which is not accessible; \
-                                 this is usually done to force you to use one of the provided \
-                                 types that already implement it",
-                                with_no_trimmed_paths!(tcx.def_path_str(def_id)),
-                            ));
-                            let impls_of = tcx.trait_impls_of(def_id);
-                            let impls = impls_of
-                                .non_blanket_impls()
-                                .values()
-                                .flatten()
-                                .chain(impls_of.blanket_impls().iter())
+                    }
+                    if let DefKind::Trait = tcx.def_kind(item_def_id)
+                        && !visible_item
+                    {
+                        note = Some(format!(
+                            "`{short_item_name}` is a \"sealed trait\", because to implement it \
+                             you also need to implement `{}`, which is not accessible; this is \
+                             usually done to force you to use one of the provided types that \
+                             already implement it",
+                            with_no_trimmed_paths!(tcx.def_path_str(def_id)),
+                        ));
+                        let impls_of = tcx.trait_impls_of(def_id);
+                        let impls = impls_of
+                            .non_blanket_impls()
+                            .values()
+                            .flatten()
+                            .chain(impls_of.blanket_impls().iter())
+                            .collect::<Vec<_>>();
+                        if !impls.is_empty() {
+                            let len = impls.len();
+                            let mut types = impls
+                                .iter()
+                                .map(|t| {
+                                    with_no_trimmed_paths!(format!(
+                                        "  {}",
+                                        tcx.type_of(*t).instantiate_identity(),
+                                    ))
+                                })
                                 .collect::<Vec<_>>();
-                            if !impls.is_empty() {
-                                let len = impls.len();
-                                let mut types = impls
-                                    .iter()
-                                    .map(|t| {
-                                        with_no_trimmed_paths!(format!(
-                                            "  {}",
-                                            tcx.type_of(*t).instantiate_identity(),
-                                        ))
-                                    })
-                                    .collect::<Vec<_>>();
-                                let post = if types.len() > 9 {
-                                    types.truncate(8);
-                                    format!("\nand {} others", len - 8)
-                                } else {
-                                    String::new()
-                                };
-                                err.help(format!(
-                                    "the following type{} implement{} the trait:\n{}{post}",
-                                    pluralize!(len),
-                                    if len == 1 { "s" } else { "" },
-                                    types.join("\n"),
-                                ));
-                            }
+                            let post = if types.len() > 9 {
+                                types.truncate(8);
+                                format!("\nand {} others", len - 8)
+                            } else {
+                                String::new()
+                            };
+                            help = Some(format!(
+                                "the following type{} implement{} the trait:\n{}{post}",
+                                pluralize!(len),
+                                if len == 1 { "s" } else { "" },
+                                types.join("\n"),
+                            ));
                         }
                     }
+                };
+                let descr = format!("required by {a} bound in `{item_name}`");
+                if span.is_visible(sm) {
+                    let msg = format!("required by {this} bound in `{short_item_name}`");
+                    multispan.push_span_label(span, msg);
+                    err.span_note(multispan, descr);
                 } else {
                     err.span_note(tcx.def_span(item_def_id), descr);
+                }
+                if let Some(note) = note {
+                    err.note(note);
+                }
+                if let Some(help) = help {
+                    err.help(help);
                 }
             }
             ObligationCauseCode::Coercion { source, target } => {

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -559,10 +559,10 @@ trait TraitAddBuiltinBoundToMethodTypeParameter {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(except="hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
     #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -9,8 +9,13 @@ fn main() {
     // CHECK: let mut [[array_lit:_.*]]: [u32; 4];
     // CHECK:     debug x => [[x:_.*]];
 
-    let x: u32 = [0, 1, 2, 3][2];
     // CHECK:       [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
-    // CHECK-LABEL: assert(const true,
-    // CHECK:     [[x]] = [[array_lit]][2 of 3];
+    // CHECK-NOT:   {{_.*}} = Len(
+    // CHECK-NOT:   {{_.*}} = Lt(
+    // CHECK-NOT:   assert(move _
+    // CHECK:       {{_.*}} = const 4_usize;
+    // CHECK:       {{_.*}} = const true;
+    // CHECK-LABEL: assert(const true
+    // CHECK:       [[x]] = [[array_lit]][2 of 3];
+    let x: u32 = [0, 1, 2, 3][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -10,10 +10,7 @@ fn main() {
     // CHECK:     debug x => [[x:_.*]];
 
     let x: u32 = [0, 1, 2, 3][2];
-    // CHECK: bb{{[0-9]+}}: {
-    // CHECK:     [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
-    // CHECK:     [[index:_.*]] = const 2_usize;
-    // CHECK: bb{{[0-9]+}}: {
-    // CHECK-NOT: [[x]] = [[array_lit]][[[index]]];
+    // CHECK:       [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
+    // CHECK-LABEL: assert(const true,
     // CHECK:     [[x]] = [[array_lit]][2 of 3];
 }

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -1,9 +1,19 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR array_index.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main() -> () {
 fn main() {
+    // CHECK: let mut [[array_lit:_.*]]: [u32; 4];
+    // CHECK:     debug x => [[x:_.*]];
+
     let x: u32 = [0, 1, 2, 3][2];
+    // CHECK: bb{{[0-9]+}}: {
+    // CHECK:     [[array_lit]] = [const 0_u32, const 1_u32, const 2_u32, const 3_u32];
+    // CHECK:     [[index:_.*]] = const 2_usize;
+    // CHECK: bb{{[0-9]+}}: {
+    // CHECK-NOT: [[x]] = [[array_lit]][[[index]]];
+    // CHECK:     [[x]] = [[array_lit]][2 of 3];
 }

--- a/tests/mir-opt/dataflow-const-prop/array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/array_index.rs
@@ -15,7 +15,7 @@ fn main() {
     // CHECK-NOT:   assert(move _
     // CHECK:       {{_.*}} = const 4_usize;
     // CHECK:       {{_.*}} = const true;
-    // CHECK-LABEL: assert(const true
+    // CHECK:       assert(const true
     // CHECK:       [[x]] = [[array_lit]][2 of 3];
     let x: u32 = [0, 1, 2, 3][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
+++ b/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
@@ -1,11 +1,14 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR boolean_identities.test.DataflowConstProp.diff
+
+// CHECK-LABEL: fn test(
 pub fn test(x: bool, y: bool) -> bool {
     (y | true) & (x & false)
+    // CHECK: _0 = const false;
 }
 
+// CHECK-LABEL: fn main(
 fn main() {
     test(true, false);
 }

--- a/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
+++ b/tests/mir-opt/dataflow-const-prop/boolean_identities.rs
@@ -4,8 +4,12 @@
 
 // CHECK-LABEL: fn test(
 pub fn test(x: bool, y: bool) -> bool {
+    // CHECK-NOT: BitAnd(
+    // CHECK-NOT: BitOr(
     (y | true) & (x & false)
     // CHECK: _0 = const false;
+    // CHECK-NOT: BitAnd(
+    // CHECK-NOT: BitOr(
 }
 
 // CHECK-LABEL: fn main(

--- a/tests/mir-opt/dataflow-const-prop/cast.rs
+++ b/tests/mir-opt/dataflow-const-prop/cast.rs
@@ -1,8 +1,14 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR cast.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main(
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+
+    // CHECK: [[a]] = const 257_i32;
     let a = 257;
+    // CHECK: [[b]] = const 2_u8;
     let b = a as u8 + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -1,15 +1,30 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // compile-flags: -Coverflow-checks=on
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
 // EMIT_MIR checked.main.DataflowConstProp.diff
 #[allow(arithmetic_overflow)]
+
+// CHECK-LABEL: fn main(
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: debug d => [[d:_.*]];
+    // CHECK: debug e => [[e:_.*]];
+
+    // CHECK: [[a]] = const 1_i32;
     let a = 1;
+
+    // CHECK: [[b]] = const 2_i32;
     let b = 2;
+
+    // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
+    // CHECK: [[d]] = const _;
     let d = i32::MAX;
+
+    // CHECK: [[e]] = const i32::MIN;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -19,12 +19,14 @@ fn main() {
     // CHECK: [[b]] = const 2_i32;
     let b = 2;
 
+    // CHECK-LABEL: assert(!const false,
     // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
     // CHECK: [[d]] = const _;
     let d = i32::MAX;
 
+    // CHECK-LABEL: assert(!const true,
     // CHECK: [[e]] = const i32::MIN;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/checked.rs
+++ b/tests/mir-opt/dataflow-const-prop/checked.rs
@@ -19,14 +19,14 @@ fn main() {
     // CHECK: [[b]] = const 2_i32;
     let b = 2;
 
-    // CHECK-LABEL: assert(!const false,
+    // CHECK: assert(!const false,
     // CHECK: [[c]] = const 3_i32;
     let c = a + b;
 
     // CHECK: [[d]] = const _;
     let d = i32::MAX;
 
-    // CHECK-LABEL: assert(!const true,
+    // CHECK: assert(!const true,
     // CHECK: [[e]] = const i32::MIN;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+GVN,+Inline
 // ignore-debug assertions change the output MIR
@@ -11,8 +10,20 @@ struct A {
 
 // EMIT_MIR default_boxed_slice.main.GVN.diff
 // EMIT_MIR default_boxed_slice.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main(
 fn main() {
     // ConstProp will create a constant of type `Box<[bool]>`.
     // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
+
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: scope {{[0-9]+}} (inlined <Box<[bool]> as Default>::default) {
+    // CHECK: scope {{[0-9]+}} (inlined Unique::<[bool; 0]>::dangling) {
+    // CHECK: scope {{[0-9]+}} (inlined NonNull::<[bool; 0]>::dangling) {
+    // We may check other inlined functions as well...
+
+    // CHECK: bb{{[0-9]+}}: {
+    // CHECK: [[box_obj:_.*]] = Box::<[bool]>(_3, const std::alloc::Global);
+    // CHECK: [[a]] = A { foo: move [[box_obj]] };
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -17,13 +17,10 @@ fn main() {
     // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
 
     // CHECK: debug a => [[a:_.*]];
-    // CHECK: scope {{[0-9]+}} (inlined <Box<[bool]> as Default>::default) {
-    // CHECK: scope {{[0-9]+}} (inlined Unique::<[bool; 0]>::dangling) {
-    // CHECK: scope {{[0-9]+}} (inlined NonNull::<[bool; 0]>::dangling) {
     // We may check other inlined functions as well...
 
-    // CHECK: bb{{[0-9]+}}: {
     // CHECK: [[box_obj:_.*]] = Box::<[bool]>(_3, const std::alloc::Global);
     // CHECK: [[a]] = A { foo: move [[box_obj]] };
+    // FIXME: we do not have `const Box::<[bool]>` after constprop right now.
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -4,6 +4,8 @@
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
+// This test is to check ICE in issue [#115789](https://github.com/rust-lang/rust/issues/115789).
+
 struct A {
     foo: Box<[bool]>,
 }
@@ -14,13 +16,14 @@ struct A {
 // CHECK-LABEL: fn main(
 fn main() {
     // ConstProp will create a constant of type `Box<[bool]>`.
+    // FIXME: it is not yet a constant.
+
     // Verify that `DataflowConstProp` does not ICE trying to dereference it directly.
 
     // CHECK: debug a => [[a:_.*]];
     // We may check other inlined functions as well...
 
-    // CHECK: [[box_obj:_.*]] = Box::<[bool]>(_3, const std::alloc::Global);
-    // CHECK: [[a]] = A { foo: move [[box_obj]] };
-    // FIXME: we do not have `const Box::<[bool]>` after constprop right now.
+    // CHECK-LABEL: _.* = Box::<[bool]>(
+    // FIXME: should be `_.* = const Box::<[bool]>`
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.rs
@@ -23,7 +23,7 @@ fn main() {
     // CHECK: debug a => [[a:_.*]];
     // We may check other inlined functions as well...
 
-    // CHECK-LABEL: _.* = Box::<[bool]>(
-    // FIXME: should be `_.* = const Box::<[bool]>`
+    // CHECK: {{_.*}} = Box::<[bool]>(
+    // FIXME: should be `{{_.*}} = const Box::<[bool]>`
     let a: A = A { foo: Box::default() };
 }

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.32bit.diff
@@ -14,7 +14,7 @@
           let _6: u8;
           let _8: u8;
           scope 2 {
-              debug x => _6;
+              debug x2 => _6;
               let _9: u8;
               scope 4 {
                   debug y => _9;

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.64bit.diff
@@ -14,7 +14,7 @@
           let _6: u8;
           let _8: u8;
           scope 2 {
-              debug x => _6;
+              debug x2 => _6;
               let _9: u8;
               scope 4 {
                   debug y => _9;

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -118,6 +118,7 @@ fn multiple(x: bool, i: u8) {
     // CHECK: debug x => [[x:_.*]];
     // CHECK: debug e => [[e:_.*]];
     // CHECK: debug x2 => [[x2:_.*]];
+    // CHECK: debug y => [[y:_.*]];
     let e = if x {
         // CHECK: [[e]] = Option::<u8>::Some(move {{_.*}});
         Some(i)
@@ -128,10 +129,18 @@ fn multiple(x: bool, i: u8) {
     // The dataflow state must have:
     //   discriminant(e) => Top
     //   (e as Some).0 => Top
+    // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[x2]] = const 0_u8;
-    // CHECK: [[x2]] = {{_.*}};
+    // CHECK-NOT: [[x2]] = const 5
+    // CHECK: [[some:_.*]] = (({{_.*}} as Some
+    // CHECK: [[x2]] = [[some]];
     let x2 = match e { Some(i) => i, None => 0 };
+
     // Therefore, `x2` should be `Top` here, and no replacement shall happen.
+
+    // CHECK-NOT: [[y]] = const
+    // CHECK: [[y]] = [[x2]];
+    // CHECK-NOT: [[y]] = const
     let y = x2;
 }
 

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -129,9 +129,7 @@ fn multiple(x: bool, i: u8) {
     // The dataflow state must have:
     //   discriminant(e) => Top
     //   (e as Some).0 => Top
-    // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[x2]] = const 0_u8;
-    // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[some:_.*]] = (({{_.*}} as Some).0: u8)
     // CHECK: [[x2]] = [[some]];
     let x2 = match e { Some(i) => i, None => 0 };

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -132,7 +132,7 @@ fn multiple(x: bool, i: u8) {
     // CHECK-NOT: [[x2]] = const 5
     // CHECK: [[x2]] = const 0_u8;
     // CHECK-NOT: [[x2]] = const 5
-    // CHECK: [[some:_.*]] = (({{_.*}} as Some
+    // CHECK: [[some:_.*]] = (({{_.*}} as Some).0: u8)
     // CHECK: [[x2]] = [[some]];
     let x2 = match e { Some(i) => i, None => 0 };
 

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
@@ -14,10 +14,10 @@
               debug x => _2;
           }
           scope 3 {
-              debug x => _4;
+              debug x1 => _4;
           }
           scope 4 {
-              debug x => _5;
+              debug x2 => _5;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
@@ -9,34 +9,34 @@
       let mut _8: &&E;
       let mut _10: isize;
       scope 1 {
-          debug e => _1;
+          debug e1 => _1;
           let _3: i32;
           let _5: i32;
           let _6: i32;
           scope 2 {
-              debug x => _3;
+              debug x1 => _3;
               let _7: &E;
               scope 5 {
-                  debug e => _7;
+                  debug e2 => _7;
                   let _9: &i32;
                   let _11: &i32;
                   let _12: &i32;
                   scope 6 {
-                      debug x => _9;
+                      debug x2 => _9;
                   }
                   scope 7 {
-                      debug x => _11;
+                      debug x21 => _11;
                   }
                   scope 8 {
-                      debug x => _12;
+                      debug x22 => _12;
                   }
               }
           }
           scope 3 {
-              debug x => _5;
+              debug x11 => _5;
           }
           scope 4 {
-              debug x => _6;
+              debug x12 => _6;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
@@ -9,34 +9,34 @@
       let mut _8: &&E;
       let mut _10: isize;
       scope 1 {
-          debug e => _1;
+          debug e1 => _1;
           let _3: i32;
           let _5: i32;
           let _6: i32;
           scope 2 {
-              debug x => _3;
+              debug x1 => _3;
               let _7: &E;
               scope 5 {
-                  debug e => _7;
+                  debug e2 => _7;
                   let _9: &i32;
                   let _11: &i32;
                   let _12: &i32;
                   scope 6 {
-                      debug x => _9;
+                      debug x2 => _9;
                   }
                   scope 7 {
-                      debug x => _11;
+                      debug x21 => _11;
                   }
                   scope 8 {
-                      debug x => _12;
+                      debug x22 => _12;
                   }
               }
           }
           scope 3 {
-              debug x => _5;
+              debug x11 => _5;
           }
           scope 4 {
-              debug x => _6;
+              debug x12 => _6;
           }
       }
   

--- a/tests/mir-opt/dataflow-const-prop/if.rs
+++ b/tests/mir-opt/dataflow-const-prop/if.rs
@@ -10,16 +10,14 @@ fn main() {
 
     let a = 1;
 
-    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_first_true:bb[0-9]+]]];
-    // CHECK: [[bb_first_true]]: {
+    // CHECK: switchInt(const true) -> [0: {{bb.*}}, otherwise: {{bb.*}}];
     // CHECK: [[b]] = const 2_i32;
     let b = if a == 1 { 2 } else { 3 };
 
     // CHECK: [[c]] = const 3_i32;
     let c = b + 1;
 
-    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_second_true:bb[0-9]+]]];
-    // CHECK: [[bb_second_true]]: {
+    // CHECK: switchInt(const true) -> [0: {{bb.*}}, otherwise: {{bb.*}}];
     // CHECK: [[d]] = const 1_i32;
     let d = if a == 1 { a } else { a + 1 };
 

--- a/tests/mir-opt/dataflow-const-prop/if.rs
+++ b/tests/mir-opt/dataflow-const-prop/if.rs
@@ -1,12 +1,28 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR if.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main(
 fn main() {
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: debug d => [[d:_.*]];
+    // CHECK: debug e => [[e:_.*]];
+
     let a = 1;
+
+    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_first_true:bb[0-9]+]]];
+    // CHECK: [[bb_first_true]]: {
+    // CHECK: [[b]] = const 2_i32;
     let b = if a == 1 { 2 } else { 3 };
+
+    // CHECK: [[c]] = const 3_i32;
     let c = b + 1;
 
+    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: [[bb_second_true:bb[0-9]+]]];
+    // CHECK: [[bb_second_true]]: {
+    // CHECK: [[d]] = const 1_i32;
     let d = if a == 1 { a } else { a + 1 };
+
+    // CHECK: [[e]] = const 2_i32;
     let e = d + 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
@@ -1,11 +1,14 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+Inline
 
 // EMIT_MIR inherit_overflow.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main(
 fn main() {
     // After inlining, this will contain a `CheckedBinaryOp`.
     // Propagating the overflow is ok as codegen will just skip emitting the panic.
+
+    // CHECK: {{_.*}} = const (0_u8, true);
+    // CHECK-LABEL: assert(!const true,
     let _ = <u8 as std::ops::Add>::add(255, 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
+++ b/tests/mir-opt/dataflow-const-prop/inherit_overflow.rs
@@ -9,6 +9,6 @@ fn main() {
     // Propagating the overflow is ok as codegen will just skip emitting the panic.
 
     // CHECK: {{_.*}} = const (0_u8, true);
-    // CHECK-LABEL: assert(!const true,
+    // CHECK: assert(!const true,
     let _ = <u8 as std::ops::Add>::add(255, 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/issue_81605.rs
+++ b/tests/mir-opt/dataflow-const-prop/issue_81605.rs
@@ -2,9 +2,15 @@
 
 // EMIT_MIR issue_81605.f.DataflowConstProp.diff
 
-// CHECK-LABEL: fn f
+// Plese find the original issue [here](https://github.com/rust-lang/rust/issues/81605).
+// This test program comes directly from the issue. Prior to this issue,
+// the compiler cannot simplify the return value of `f` into 2. This was
+// solved by adding a new MIR constant propagation based on dataflow
+// analysis in [#101168](https://github.com/rust-lang/rust/pull/101168).
+
+// CHECK-LABEL: fn f(
 fn f() -> usize {
-    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: {{bb[0-9]+}}];
+    // CHECK: switchInt(const true) -> [0: {{bb.*}}, otherwise: {{bb.*}}];
     1 + if true { 1 } else { 2 }
     // CHECK: _0 = const 2_usize;
 }

--- a/tests/mir-opt/dataflow-const-prop/issue_81605.rs
+++ b/tests/mir-opt/dataflow-const-prop/issue_81605.rs
@@ -1,9 +1,12 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR issue_81605.f.DataflowConstProp.diff
+
+// CHECK-LABEL: fn f
 fn f() -> usize {
+    // CHECK: switchInt(const true) -> [0: {{bb[0-9]+}}, otherwise: {{bb[0-9]+}}];
     1 + if true { 1 } else { 2 }
+    // CHECK: _0 = const 2_usize;
 }
 
 fn main() {

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -4,7 +4,7 @@
 
 // EMIT_MIR large_array_index.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // check that we don't propagate this, because it's too large
 

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -1,10 +1,18 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR large_array_index.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
     // check that we don't propagate this, because it's too large
+
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: [[array_lit:_.*]] = [const 0_u8; 5000];
+    // CHECK: {{_.*}} = const 5000_usize;
+    // CHECK: {{_.*}} = const true;
+    // CHECK-LABEL: assert(const true
+    // CHECK: [[x]] = [[array_lit]][2 of 3];
     let x: u8 = [0_u8; 5000][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/large_array_index.rs
+++ b/tests/mir-opt/dataflow-const-prop/large_array_index.rs
@@ -12,7 +12,7 @@ fn main() {
     // CHECK: [[array_lit:_.*]] = [const 0_u8; 5000];
     // CHECK: {{_.*}} = const 5000_usize;
     // CHECK: {{_.*}} = const true;
-    // CHECK-LABEL: assert(const true
+    // CHECK: assert(const true
     // CHECK: [[x]] = [[array_lit]][2 of 3];
     let x: u8 = [0_u8; 5000][2];
 }

--- a/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
+++ b/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
@@ -1,9 +1,10 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR mult_by_zero.test.DataflowConstProp.diff
+// CHECK-LABEL: fn test
 fn test(x : i32) -> i32 {
   x * 0
+  // CHECK: _0 = const 0_i32;
 }
 
 fn main() {

--- a/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
+++ b/tests/mir-opt/dataflow-const-prop/mult_by_zero.rs
@@ -1,7 +1,7 @@
 // unit-test: DataflowConstProp
 
 // EMIT_MIR mult_by_zero.test.DataflowConstProp.diff
-// CHECK-LABEL: fn test
+// CHECK-LABEL: fn test(
 fn test(x : i32) -> i32 {
   x * 0
   // CHECK: _0 = const 0_i32;

--- a/tests/mir-opt/dataflow-const-prop/offset_of.rs
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
@@ -29,18 +28,46 @@ struct Delta<T> {
 }
 
 // EMIT_MIR offset_of.concrete.DataflowConstProp.diff
+
+// CHECK-LABEL: fn concrete
 fn concrete() {
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: debug y => [[y:_.*]];
+    // CHECK: debug z0 => [[z0:_.*]];
+    // CHECK: debug z1 => [[z1:_.*]];
+
+    // CHECK: [[x]] = must_use::<usize>(const 4_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let x = offset_of!(Alpha, x);
+
+    // CHECK: [[y]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let y = offset_of!(Alpha, y);
+
+    // CHECK: [[z0]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let z0 = offset_of!(Alpha, z.0);
+
+    // CHECK: [[z1]] = must_use::<usize>(const 3_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let z1 = offset_of!(Alpha, z.1);
 }
 
 // EMIT_MIR offset_of.generic.DataflowConstProp.diff
+
+// CHECK-LABEL: generic
 fn generic<T>() {
+    // CHECK: debug gx => [[gx:_.*]];
+    // CHECK: debug gy => [[gy:_.*]];
+    // CHECK: debug dx => [[dx:_.*]];
+    // CHECK: debug dy => [[dy:_.*]];
+
+    // CHECK: [[gx]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
     let gx = offset_of!(Gamma<T>, x);
+
+    // CHECK: [[gy]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
     let gy = offset_of!(Gamma<T>, y);
+
+    // CHECK: [[dx]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let dx = offset_of!(Delta<T>, x);
+
+    // CHECK: [[dy]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
     let dy = offset_of!(Delta<T>, y);
 }
 

--- a/tests/mir-opt/dataflow-const-prop/offset_of.rs
+++ b/tests/mir-opt/dataflow-const-prop/offset_of.rs
@@ -29,45 +29,45 @@ struct Delta<T> {
 
 // EMIT_MIR offset_of.concrete.DataflowConstProp.diff
 
-// CHECK-LABEL: fn concrete
+// CHECK-LABEL: fn concrete(
 fn concrete() {
     // CHECK: debug x => [[x:_.*]];
     // CHECK: debug y => [[y:_.*]];
     // CHECK: debug z0 => [[z0:_.*]];
     // CHECK: debug z1 => [[z1:_.*]];
 
-    // CHECK: [[x]] = must_use::<usize>(const 4_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[x]] = must_use::<usize>(const 4_usize) -> {{.*}}
     let x = offset_of!(Alpha, x);
 
-    // CHECK: [[y]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[y]] = must_use::<usize>(const 0_usize) -> {{.*}}
     let y = offset_of!(Alpha, y);
 
-    // CHECK: [[z0]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[z0]] = must_use::<usize>(const 2_usize) -> {{.*}}
     let z0 = offset_of!(Alpha, z.0);
 
-    // CHECK: [[z1]] = must_use::<usize>(const 3_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[z1]] = must_use::<usize>(const 3_usize) -> {{.*}}
     let z1 = offset_of!(Alpha, z.1);
 }
 
 // EMIT_MIR offset_of.generic.DataflowConstProp.diff
 
-// CHECK-LABEL: generic
+// CHECK-LABEL: fn generic(
 fn generic<T>() {
     // CHECK: debug gx => [[gx:_.*]];
     // CHECK: debug gy => [[gy:_.*]];
     // CHECK: debug dx => [[dx:_.*]];
     // CHECK: debug dy => [[dy:_.*]];
 
-    // CHECK: [[gx]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[gx]] = must_use::<usize>(move {{_.*}}) -> {{.*}}
     let gx = offset_of!(Gamma<T>, x);
 
-    // CHECK: [[gy]] = must_use::<usize>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[gy]] = must_use::<usize>(move {{_.*}}) -> {{.*}}
     let gy = offset_of!(Gamma<T>, y);
 
-    // CHECK: [[dx]] = must_use::<usize>(const 0_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[dx]] = must_use::<usize>(const 0_usize) -> {{.*}}
     let dx = offset_of!(Delta<T>, x);
 
-    // CHECK: [[dy]] = must_use::<usize>(const 2_usize) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: [[dy]] = must_use::<usize>(const 2_usize) -> {{.*}}
     let dy = offset_of!(Delta<T>, y);
 }
 

--- a/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
+++ b/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
@@ -8,21 +8,23 @@ fn escape<T>(x: &T) {}
 fn some_function() {}
 
 // EMIT_MIR ref_without_sb.main.DataflowConstProp.diff
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug a => [[a:_.*]];
     // CHECK: debug b => [[b:_.*]];
 
     let mut a = 0;
 
-    // CHECK: {{_[0-9]+}} = escape::<i32>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: {{_.*}} = escape::<i32>(move {{_.*}}) ->  {{.*}}
     escape(&a);
     a = 1;
 
-    // CHECK: {{_[0-9]+}} = some_function() -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: {{_.*}} = some_function() ->  {{.*}}
     some_function();
     // This should currently not be propagated.
 
+    // CHECK-NOT: [[b]] = const
     // CHECK: [[b]] = [[a]];
+    // CHECK-NOT: [[b]] = const
     let b = a;
 }

--- a/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
+++ b/tests/mir-opt/dataflow-const-prop/ref_without_sb.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 
@@ -9,11 +8,21 @@ fn escape<T>(x: &T) {}
 fn some_function() {}
 
 // EMIT_MIR ref_without_sb.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+
     let mut a = 0;
+
+    // CHECK: {{_[0-9]+}} = escape::<i32>(move {{_[0-9]+}}) -> [return: {{bb[0-9]+}}, unwind continue];
     escape(&a);
     a = 1;
+
+    // CHECK: {{_[0-9]+}} = some_function() -> [return: {{bb[0-9]+}}, unwind continue];
     some_function();
     // This should currently not be propagated.
+
+    // CHECK: [[b]] = [[a]];
     let b = a;
 }

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -3,15 +3,19 @@
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR repeat.main.DataflowConstProp.diff
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug x => [[x:_.*]];
 
-    // CHECK: {{_[0-9]+}} = const 8_usize;
-    // CHECK: {{_[0-9]+}} = const true;
+    // CHECK: [[array_lit:_.*]] = [const 42_u32; 8];
+    // CHECK-NOT: {{_.*}} = Len(
+    // CHECK-NOT: {{_.*}} = Lt(
+    // CHECK: {{_.*}} = const 8_usize;
+    // CHECK: {{_.*}} = const true;
     // CHECK-LABEL: assert(const true
 
-    // CHECK: {{_[0-9]+}} = {{_[0-9]+}}[2 of 3];
-    // CHECK: [[x]] = Add(move {{_[0-9]+}}, const 0_u32);
+    // CHECK-NOT: [[t:_.*]] = [[array_lit]][_
+    // CHECK: [[t:_.*]] = [[array_lit]][2 of 3];
+    // CHECK: [[x]] = Add(move [[t]], const 0_u32);
     let x: u32 = [42; 8][2] + 0;
 }

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -1,9 +1,17 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR repeat.main.DataflowConstProp.diff
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug x => [[x:_.*]];
+
+    // CHECK: {{_[0-9]+}} = const 8_usize;
+    // CHECK: {{_[0-9]+}} = const true;
+    // CHECK-LABEL: assert(const true
+
+    // CHECK: {{_[0-9]+}} = {{_[0-9]+}}[2 of 3];
+    // CHECK: [[x]] = Add(move {{_[0-9]+}}, const 0_u32);
     let x: u32 = [42; 8][2] + 0;
 }

--- a/tests/mir-opt/dataflow-const-prop/repeat.rs
+++ b/tests/mir-opt/dataflow-const-prop/repeat.rs
@@ -12,7 +12,7 @@ fn main() {
     // CHECK-NOT: {{_.*}} = Lt(
     // CHECK: {{_.*}} = const 8_usize;
     // CHECK: {{_.*}} = const true;
-    // CHECK-LABEL: assert(const true
+    // CHECK: assert(const true
 
     // CHECK-NOT: [[t:_.*]] = [[array_lit]][_
     // CHECK: [[t:_.*]] = [[array_lit]][2 of 3];

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // The struct has scalar ABI, but is not a scalar type.
@@ -7,7 +6,15 @@
 struct I32(i32);
 
 // EMIT_MIR repr_transparent.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug x => [[x:_.*]];
+    // CHECK: debug y => [[y:_.*]];
+
+    // CHECK: [[x]] = const I32(0_i32);
     let x = I32(0);
+
+    // CHECK: [[y]] = const I32(0_i32);
     let y = I32(x.0 + x.0);
 }

--- a/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
+++ b/tests/mir-opt/dataflow-const-prop/repr_transparent.rs
@@ -7,7 +7,7 @@ struct I32(i32);
 
 // EMIT_MIR repr_transparent.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug x => [[x:_.*]];
     // CHECK: debug y => [[y:_.*]];

--- a/tests/mir-opt/dataflow-const-prop/self_assign.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign.rs
@@ -2,25 +2,25 @@
 
 // EMIT_MIR self_assign.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug a => [[a:_.*]];
     // CHECK: debug b => [[b:_.*]];
 
     let mut a = 0;
 
-    // CHECK: [[a]] = Add(move {{_[0-9]+}}, const 1_i32);
+    // CHECK: [[a]] = Add(move {{_.*}}, const 1_i32);
     a = a + 1;
 
-    // CHECK: [[a]] = move {{_[0-9]+}};
+    // CHECK: [[a]] = move {{_.*}};
     a = a;
 
     // CHECK: [[b]] = &[[a]];
     let mut b = &a;
 
-    // CHECK: [[b]] = move {{_[0-9]+}};
+    // CHECK: [[b]] = move {{_.*}};
     b = b;
 
-    // CHECK: [[a]] = move {{_[0-9]+}};
+    // CHECK: [[a]] = move {{_.*}};
     a = *b;
 }

--- a/tests/mir-opt/dataflow-const-prop/self_assign.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign.rs
@@ -1,13 +1,26 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR self_assign.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+
     let mut a = 0;
+
+    // CHECK: [[a]] = Add(move {{_[0-9]+}}, const 1_i32);
     a = a + 1;
+
+    // CHECK: [[a]] = move {{_[0-9]+}};
     a = a;
 
+    // CHECK: [[b]] = &[[a]];
     let mut b = &a;
+
+    // CHECK: [[b]] = move {{_[0-9]+}};
     b = b;
+
+    // CHECK: [[a]] = move {{_[0-9]+}};
     a = *b;
 }

--- a/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
@@ -1,9 +1,15 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 
 // EMIT_MIR self_assign_add.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_.*]];
     let mut a = 0;
+
+    // CHECK: [[a]] = const 1_i32;
     a += 1;
+
+    // CHECK: [[a]] = const 2_i32;
     a += 1;
 }

--- a/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
+++ b/tests/mir-opt/dataflow-const-prop/self_assign_add.rs
@@ -2,7 +2,7 @@
 
 // EMIT_MIR self_assign_add.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     // CHECK: debug a => [[a:_.*]];
     let mut a = 0;

--- a/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
+++ b/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // This attempts to modify `x.1` via a pointer derived from `addr_of_mut!(x.0)`.
 // According to Miri, that is UB. However, T-opsem has not finalized that
@@ -10,11 +9,17 @@
 // unit-test: DataflowConstProp
 
 // EMIT_MIR sibling_ptr.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug x1 => [[x1:_[0-9]+]];
+
     let mut x: (u8, u8) = (0, 0);
     unsafe {
         let p = std::ptr::addr_of_mut!(x.0);
         *p.add(1) = 1;
     }
+
+    // CHECK: [[x1]] = ({{_[0-9]+}}.1: u8);
     let x1 = x.1; // should not be propagated
 }

--- a/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
+++ b/tests/mir-opt/dataflow-const-prop/sibling_ptr.rs
@@ -10,9 +10,9 @@
 
 // EMIT_MIR sibling_ptr.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug x1 => [[x1:_[0-9]+]];
+    // CHECK: debug x1 => [[x1:_.*]];
 
     let mut x: (u8, u8) = (0, 0);
     unsafe {
@@ -20,6 +20,6 @@ fn main() {
         *p.add(1) = 1;
     }
 
-    // CHECK: [[x1]] = ({{_[0-9]+}}.1: u8);
+    // CHECK: [[x1]] = ({{_.*}}.1: u8);
     let x1 = x.1; // should not be propagated
 }

--- a/tests/mir-opt/dataflow-const-prop/slice_len.rs
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.rs
@@ -1,13 +1,23 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 // compile-flags: -Zmir-enable-passes=+InstSimplify
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR slice_len.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug local => [[local:_[0-9]+]];
+    // CHECK: debug constant => [[constant:_[0-9]+]];
+
+    // CHECK: {{_[0-9]+}} = const 3_usize;
+    // CHECK: {{_[0-9]+}} = const true;
+
+    // CHECK: [[local]] = (*{{_[0-9]+}})[1 of 2];
     let local = (&[1u32, 2, 3] as &[u32])[1];
 
     const SLICE: &[u32] = &[1, 2, 3];
+
+    // CHECK: [[constant]] = (*{{_[0-9]+}})[1 of 2];
     let constant = SLICE[1];
 }

--- a/tests/mir-opt/dataflow-const-prop/slice_len.rs
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.rs
@@ -5,19 +5,30 @@
 
 // EMIT_MIR slice_len.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug local => [[local:_[0-9]+]];
-    // CHECK: debug constant => [[constant:_[0-9]+]];
+    // CHECK: debug local => [[local:_.*]];
+    // CHECK: debug constant => [[constant:_.*]];
 
-    // CHECK: {{_[0-9]+}} = const 3_usize;
-    // CHECK: {{_[0-9]+}} = const true;
+    // CHECK-NOT: {{_.*}} = Len(
+    // CHECK-NOT: {{_.*}} = Lt(
+    // CHECK-NOT: assert(move _
+    // CHECK: {{_.*}} = const 3_usize;
+    // CHECK: {{_.*}} = const true;
+    // CHECK: assert(const true,
 
-    // CHECK: [[local]] = (*{{_[0-9]+}})[1 of 2];
+    // CHECK: [[local]] = (*{{_.*}})[1 of 2];
     let local = (&[1u32, 2, 3] as &[u32])[1];
 
+    // CHECK-NOT: {{_.*}} = Len(
+    // CHECK-NOT: {{_.*}} = Lt(
+    // CHECK-NOT: assert(move _
     const SLICE: &[u32] = &[1, 2, 3];
+    // CHECK: {{_.*}} = const 3_usize;
+    // CHECK: {{_.*}} = const true;
+    // CHECK: assert(const true,
 
-    // CHECK: [[constant]] = (*{{_[0-9]+}})[1 of 2];
+    // CHECK-NOT: [[constant]] = (*{{_.*}})[_
+    // CHECK: [[constant]] = (*{{_.*}})[1 of 2];
     let constant = SLICE[1];
 }

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.32bit.diff
@@ -37,16 +37,16 @@
                   let _8: std::option::Option<S>;
                   let _9: &[f32];
                   scope 4 {
-                      debug a => _7;
-                      debug b => _8;
-                      debug c => _9;
+                      debug a1 => _7;
+                      debug b1 => _8;
+                      debug c1 => _9;
                       let _11: f32;
                       let _12: std::option::Option<S>;
                       let _13: &[f32];
                       scope 5 {
-                          debug a => _11;
-                          debug b => _12;
-                          debug c => _13;
+                          debug a2 => _11;
+                          debug b2 => _12;
+                          debug c2 => _13;
                           let _15: SmallStruct;
                           scope 6 {
                               debug ss => _15;
@@ -54,16 +54,16 @@
                               let _20: std::option::Option<S>;
                               let _21: &[f32];
                               scope 7 {
-                                  debug a => _19;
-                                  debug b => _20;
-                                  debug c => _21;
+                                  debug a3 => _19;
+                                  debug b3 => _20;
+                                  debug c3 => _21;
                                   let _23: f32;
                                   let _24: std::option::Option<S>;
                                   let _25: &[f32];
                                   scope 8 {
-                                      debug a => _23;
-                                      debug b => _24;
-                                      debug c => _25;
+                                      debug a4 => _23;
+                                      debug b4 => _24;
+                                      debug c4 => _25;
                                       let _27: BigStruct;
                                       scope 9 {
                                           debug bs => _27;

--- a/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/struct.main.DataflowConstProp.64bit.diff
@@ -37,16 +37,16 @@
                   let _8: std::option::Option<S>;
                   let _9: &[f32];
                   scope 4 {
-                      debug a => _7;
-                      debug b => _8;
-                      debug c => _9;
+                      debug a1 => _7;
+                      debug b1 => _8;
+                      debug c1 => _9;
                       let _11: f32;
                       let _12: std::option::Option<S>;
                       let _13: &[f32];
                       scope 5 {
-                          debug a => _11;
-                          debug b => _12;
-                          debug c => _13;
+                          debug a2 => _11;
+                          debug b2 => _12;
+                          debug c2 => _13;
                           let _15: SmallStruct;
                           scope 6 {
                               debug ss => _15;
@@ -54,16 +54,16 @@
                               let _20: std::option::Option<S>;
                               let _21: &[f32];
                               scope 7 {
-                                  debug a => _19;
-                                  debug b => _20;
-                                  debug c => _21;
+                                  debug a3 => _19;
+                                  debug b3 => _20;
+                                  debug c3 => _21;
                                   let _23: f32;
                                   let _24: std::option::Option<S>;
                                   let _25: &[f32];
                                   scope 8 {
-                                      debug a => _23;
-                                      debug b => _24;
-                                      debug c => _25;
+                                      debug a4 => _23;
+                                      debug b4 => _24;
+                                      debug c4 => _25;
                                       let _27: BigStruct;
                                       scope 9 {
                                           debug bs => _27;

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
@@ -12,27 +11,69 @@ struct SmallStruct(f32, Option<S>, &'static [f32]);
 struct BigStruct(f32, Option<S>, &'static [f32]);
 
 // EMIT_MIR struct.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug s => [[s:_[0-9]+]];
+    // CHECK: debug a => [[a:_[0-9]+]];
+    // CHECK: debug b => [[b:_[0-9]+]];
+    // CHECK: debug a1 => [[a1:_[0-9]+]];
+    // CHECK: debug b1 => [[b1:_[0-9]+]];
+    // CHECK: debug c1 => [[c1:_[0-9]+]];
+    // CHECK: debug a2 => [[a2:_[0-9]+]];
+    // CHECK: debug b2 => [[b2:_[0-9]+]];
+    // CHECK: debug c2 => [[c2:_[0-9]+]];
+    // CHECK: debug ss => [[ss:_[0-9]+]];
+    // CHECK: debug a3 => [[a3:_[0-9]+]];
+    // CHECK: debug b3 => [[b3:_[0-9]+]];
+    // CHECK: debug c3 => [[c3:_[0-9]+]];
+    // CHECK: debug a4 => [[a4:_[0-9]+]];
+    // CHECK: debug b4 => [[b4:_[0-9]+]];
+    // CHECK: debug c4 => [[c4:_[0-9]+]];
+    // CHECK: debug bs => [[bs:_[0-9]+]];
+
+    // CHECK: [[s]] = const S(1_i32);
     let mut s = S(1);
+
+    // CHECK: [[a]] = const 3_i32;
     let a = s.0 + 2;
     s.0 = 3;
+
+    // CHECK: [[b]] = const 6_i32;
     let b = a + s.0;
 
     const SMALL_VAL: SmallStruct = SmallStruct(4., Some(S(1)), &[]);
-    let SmallStruct(a, b, c) = SMALL_VAL;
+
+    // CHECK: [[a1]] = const 4f32;
+    // CHECK: [[b1]] = const Option::<S>::Some(S(1_i32));
+    // CHECK: [[c1]] = ({{_[0-9]+}}.2: &[f32]);
+    let SmallStruct(a1, b1, c1) = SMALL_VAL;
 
     static SMALL_STAT: &SmallStruct = &SmallStruct(9., None, &[13.]);
-    let SmallStruct(a, b, c) = *SMALL_STAT;
 
-    let ss = SmallStruct(a, b, c);
+    // CHECK: [[a2]] = const 9f32;
+    // CHECK: [[b2]] = ((*{{_[0-9]+}}).1: std::option::Option<S>);
+    // CHECK: [[c2]] = ((*{{_[0-9]+}}).2: &[f32]);
+    let SmallStruct(a2, b2, c2) = *SMALL_STAT;
+
+    // CHECK: [[ss]] = SmallStruct(const 9f32, move {{_[0-9]+}}, move {{_[0-9]+}});
+    let ss = SmallStruct(a2, b2, c2);
 
     const BIG_VAL: BigStruct = BigStruct(25., None, &[]);
-    let BigStruct(a, b, c) = BIG_VAL;
+
+    // CHECK: [[a3]] = const 25f32;
+    // CHECK: [[b3]] = ({{_[0-9]+}}.1: std::option::Option<S>);
+    // CHECK: [[c3]] = ({{_[0-9]+}}.2: &[f32]);
+    let BigStruct(a3, b3, c3) = BIG_VAL;
 
     static BIG_STAT: &BigStruct = &BigStruct(82., Some(S(35)), &[45., 72.]);
-    let BigStruct(a, b, c) = *BIG_STAT;
+    // CHECK: [[a4]] = const 82f32;
+    // CHECK: [[b4]] = const Option::<S>::Some(S(35_i32));
+    // CHECK: [[c4]] = ((*{{_[0-9]+}}).2: &[f32]);
+    let BigStruct(a4, b4, c4) = *BIG_STAT;
 
     // We arbitrarily limit the size of synthetized values to 4 pointers.
     // `BigStruct` can be read, but we will keep a MIR aggregate for this.
-    let bs = BigStruct(a, b, c);
+    // CHECK: [[bs]] = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move {{_[0-9]+}});
+    let bs = BigStruct(a4, b4, c4);
 }

--- a/tests/mir-opt/dataflow-const-prop/struct.rs
+++ b/tests/mir-opt/dataflow-const-prop/struct.rs
@@ -12,25 +12,25 @@ struct BigStruct(f32, Option<S>, &'static [f32]);
 
 // EMIT_MIR struct.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug s => [[s:_[0-9]+]];
-    // CHECK: debug a => [[a:_[0-9]+]];
-    // CHECK: debug b => [[b:_[0-9]+]];
-    // CHECK: debug a1 => [[a1:_[0-9]+]];
-    // CHECK: debug b1 => [[b1:_[0-9]+]];
-    // CHECK: debug c1 => [[c1:_[0-9]+]];
-    // CHECK: debug a2 => [[a2:_[0-9]+]];
-    // CHECK: debug b2 => [[b2:_[0-9]+]];
-    // CHECK: debug c2 => [[c2:_[0-9]+]];
-    // CHECK: debug ss => [[ss:_[0-9]+]];
-    // CHECK: debug a3 => [[a3:_[0-9]+]];
-    // CHECK: debug b3 => [[b3:_[0-9]+]];
-    // CHECK: debug c3 => [[c3:_[0-9]+]];
-    // CHECK: debug a4 => [[a4:_[0-9]+]];
-    // CHECK: debug b4 => [[b4:_[0-9]+]];
-    // CHECK: debug c4 => [[c4:_[0-9]+]];
-    // CHECK: debug bs => [[bs:_[0-9]+]];
+    // CHECK: debug s => [[s:_.*]];
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug a1 => [[a1:_.*]];
+    // CHECK: debug b1 => [[b1:_.*]];
+    // CHECK: debug c1 => [[c1:_.*]];
+    // CHECK: debug a2 => [[a2:_.*]];
+    // CHECK: debug b2 => [[b2:_.*]];
+    // CHECK: debug c2 => [[c2:_.*]];
+    // CHECK: debug ss => [[ss:_.*]];
+    // CHECK: debug a3 => [[a3:_.*]];
+    // CHECK: debug b3 => [[b3:_.*]];
+    // CHECK: debug c3 => [[c3:_.*]];
+    // CHECK: debug a4 => [[a4:_.*]];
+    // CHECK: debug b4 => [[b4:_.*]];
+    // CHECK: debug c4 => [[c4:_.*]];
+    // CHECK: debug bs => [[bs:_.*]];
 
     // CHECK: [[s]] = const S(1_i32);
     let mut s = S(1);
@@ -46,34 +46,34 @@ fn main() {
 
     // CHECK: [[a1]] = const 4f32;
     // CHECK: [[b1]] = const Option::<S>::Some(S(1_i32));
-    // CHECK: [[c1]] = ({{_[0-9]+}}.2: &[f32]);
+    // CHECK: [[c1]] = ({{_.*}}.2: &[f32]);
     let SmallStruct(a1, b1, c1) = SMALL_VAL;
 
     static SMALL_STAT: &SmallStruct = &SmallStruct(9., None, &[13.]);
 
     // CHECK: [[a2]] = const 9f32;
-    // CHECK: [[b2]] = ((*{{_[0-9]+}}).1: std::option::Option<S>);
-    // CHECK: [[c2]] = ((*{{_[0-9]+}}).2: &[f32]);
+    // CHECK: [[b2]] = ((*{{_.*}}).1: std::option::Option<S>);
+    // CHECK: [[c2]] = ((*{{_.*}}).2: &[f32]);
     let SmallStruct(a2, b2, c2) = *SMALL_STAT;
 
-    // CHECK: [[ss]] = SmallStruct(const 9f32, move {{_[0-9]+}}, move {{_[0-9]+}});
+    // CHECK: [[ss]] = SmallStruct(const 9f32, move {{_.*}}, move {{_.*}});
     let ss = SmallStruct(a2, b2, c2);
 
     const BIG_VAL: BigStruct = BigStruct(25., None, &[]);
 
     // CHECK: [[a3]] = const 25f32;
-    // CHECK: [[b3]] = ({{_[0-9]+}}.1: std::option::Option<S>);
-    // CHECK: [[c3]] = ({{_[0-9]+}}.2: &[f32]);
+    // CHECK: [[b3]] = ({{_.*}}.1: std::option::Option<S>);
+    // CHECK: [[c3]] = ({{_.*}}.2: &[f32]);
     let BigStruct(a3, b3, c3) = BIG_VAL;
 
     static BIG_STAT: &BigStruct = &BigStruct(82., Some(S(35)), &[45., 72.]);
     // CHECK: [[a4]] = const 82f32;
     // CHECK: [[b4]] = const Option::<S>::Some(S(35_i32));
-    // CHECK: [[c4]] = ((*{{_[0-9]+}}).2: &[f32]);
+    // CHECK: [[c4]] = ((*{{_.*}}).2: &[f32]);
     let BigStruct(a4, b4, c4) = *BIG_STAT;
 
     // We arbitrarily limit the size of synthetized values to 4 pointers.
     // `BigStruct` can be read, but we will keep a MIR aggregate for this.
-    // CHECK: [[bs]] = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move {{_[0-9]+}});
+    // CHECK: [[bs]] = BigStruct(const 82f32, const Option::<S>::Some(S(35_i32)), move {{_.*}});
     let bs = BigStruct(a4, b4, c4);
 }

--- a/tests/mir-opt/dataflow-const-prop/terminator.rs
+++ b/tests/mir-opt/dataflow-const-prop/terminator.rs
@@ -1,12 +1,14 @@
-// skip-filecheck
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // unit-test: DataflowConstProp
 
 fn foo(n: i32) {}
 
 // EMIT_MIR terminator.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
     let a = 1;
     // Checks that we propagate into terminators.
+    // CHECK: {{_[0-9]+}} = foo(const 2_i32) -> [return: {{bb[0-9]+}}, unwind continue];
     foo(a + 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/terminator.rs
+++ b/tests/mir-opt/dataflow-const-prop/terminator.rs
@@ -5,10 +5,10 @@ fn foo(n: i32) {}
 
 // EMIT_MIR terminator.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
     let a = 1;
     // Checks that we propagate into terminators.
-    // CHECK: {{_[0-9]+}} = foo(const 2_i32) -> [return: {{bb[0-9]+}}, unwind continue];
+    // CHECK: {{_.*}} = foo(const 2_i32) -> [return: {{bb.*}}, unwind continue];
     foo(a + 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/terminator.rs
+++ b/tests/mir-opt/dataflow-const-prop/terminator.rs
@@ -9,6 +9,6 @@ fn foo(n: i32) {}
 fn main() {
     let a = 1;
     // Checks that we propagate into terminators.
-    // CHECK: {{_.*}} = foo(const 2_i32) -> [return: {{bb.*}}, unwind continue];
+    // CHECK: {{_.*}} = foo(const 2_i32) -> [return: {{bb.*}}, unwind
     foo(a + 1);
 }

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -1,13 +1,27 @@
-// skip-filecheck
 // unit-test: DataflowConstProp
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR tuple.main.DataflowConstProp.diff
+
+// CHECK-LABEL: fn main
 fn main() {
+    // CHECK: debug a => [[a:_[0-9]+]];
+    // CHECK: debug b => [[b:_[0-9]+]];
+    // CHECK: debug c => [[c:_[0-9]+]];
+    // CHECK: debug d => [[d:_[0-9]+]];
+
+    // CHECK: [[a]] = const (1_i32, 2_i32);
     let mut a = (1, 2);
+
+    // CHECK: [[b]] = const 6_i32;
     let b = a.0 + a.1 + 3;
+
+    // CHECK: [[a]] = const (2_i32, 3_i32);
     a = (2, 3);
+
+    // CHECK: [[c]] = const 11_i32;
     let c = a.0 + a.1 + b;
 
+    // CHECK: [[d]] = (const 6_i32, const (2_i32, 3_i32), const 11_i32);
     let d = (b, a, c);
 }

--- a/tests/mir-opt/dataflow-const-prop/tuple.rs
+++ b/tests/mir-opt/dataflow-const-prop/tuple.rs
@@ -3,12 +3,12 @@
 
 // EMIT_MIR tuple.main.DataflowConstProp.diff
 
-// CHECK-LABEL: fn main
+// CHECK-LABEL: fn main(
 fn main() {
-    // CHECK: debug a => [[a:_[0-9]+]];
-    // CHECK: debug b => [[b:_[0-9]+]];
-    // CHECK: debug c => [[c:_[0-9]+]];
-    // CHECK: debug d => [[d:_[0-9]+]];
+    // CHECK: debug a => [[a:_.*]];
+    // CHECK: debug b => [[b:_.*]];
+    // CHECK: debug c => [[c:_.*]];
+    // CHECK: debug d => [[d:_.*]];
 
     // CHECK: [[a]] = const (1_i32, 2_i32);
     let mut a = (1, 2);

--- a/tests/ui/associated-types/defaults-wf.stderr
+++ b/tests/ui/associated-types/defaults-wf.stderr
@@ -5,7 +5,7 @@ LL |     type Ty = Vec<[u8]>;
    |               ^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -4,11 +4,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
    |                                                 ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `From`
+note: required by an implicit `Sized` bound in `From`
   --> $DIR/issue-20005.rs:1:12
    |
 LL | trait From<Src> {
-   |            ^^^ required by this bound in `From`
+   |            ^^^ required by the implicit `Sized` requirement on this bound in `From`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -8,7 +8,7 @@ note: required by an implicit `Sized` bound in `From`
   --> $DIR/issue-20005.rs:1:12
    |
 LL | trait From<Src> {
-   |            ^^^ required by the implicit `Sized` requirement on this bound in `From`
+   |            ^^^ required by the implicit `Sized` requirement on this type parameter in `From`
 help: consider further restricting `Self`
    |
 LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {

--- a/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/tests/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -4,7 +4,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> {}
    |                      ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Add`
+note: required by an implicit `Sized` bound in `Add`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: consider further restricting `Self`
    |

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -17,7 +17,7 @@ LL |         println!("{:?}", foo);
    |                   required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn Foo`
-note: required by a bound in `core::fmt::rt::Argument::<'a>::new_debug`
+note: required by an implicit `Sized` bound in `core::fmt::rt::Argument::<'a>::new_debug`
   --> $SRC_DIR/core/src/fmt/rt.rs:LL:COL
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
@@ -10,14 +10,14 @@ error: expected identifier, found reserved identifier `_`
 LL | fn bad_infer_fn<_>() {}
    |                 ^ expected identifier, found reserved identifier
 
-error[E0392]: parameter `_` is never used
+error[E0392]: type parameter `_` is never used
   --> $DIR/infer-arg-test.rs:7:17
    |
 LL | struct BadInfer<_>;
-   |                 ^ unused parameter
+   |                 ^ unused type parameter
    |
    = help: consider removing `_`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `_` to be a const parameter, use `const _: usize` instead
+   = help: if you intended `_` to be a const parameter, use `const _: /* Type */` instead
 
 error[E0107]: struct takes 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/infer-arg-test.rs:18:10

--- a/tests/ui/const-generics/issue-46511.stderr
+++ b/tests/ui/const-generics/issue-46511.stderr
@@ -7,11 +7,11 @@ LL |     _a: [u8; std::mem::size_of::<&'a mut u8>()]
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-46511.rs:3:12
    |
 LL | struct Foo<'a>
-   |            ^^ unused parameter
+   |            ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/const-generics/issues/issue-67375.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67375.min.stderr
@@ -7,14 +7,14 @@ LL |     inner: [(); { [|_: &T| {}; 0].len() }],
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-67375.rs:5:12
    |
 LL | struct Bug<T> {
-   |            ^ unused parameter
+   |            ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-67945-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-1.min.stderr
@@ -16,14 +16,14 @@ LL |         let b = &*(&x as *const _ as *const S);
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0392]: parameter `S` is never used
+error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-1.rs:7:12
    |
 LL | struct Bug<S> {
-   |            ^ unused parameter
+   |            ^ unused type parameter
    |
    = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `S` to be a const parameter, use `const S: usize` instead
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/issues/issue-67945-3.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-3.min.stderr
@@ -7,14 +7,14 @@ LL |         let x: Option<S> = None;
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0392]: parameter `S` is never used
+error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-3.rs:9:12
    |
 LL | struct Bug<S> {
-   |            ^ unused parameter
+   |            ^ unused type parameter
    |
    = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `S` to be a const parameter, use `const S: usize` instead
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-67945-4.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-4.min.stderr
@@ -7,14 +7,14 @@ LL |         let x: Option<Box<S>> = None;
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0392]: parameter `S` is never used
+error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-4.rs:8:12
    |
 LL | struct Bug<S> {
-   |            ^ unused parameter
+   |            ^ unused type parameter
    |
    = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `S` to be a const parameter, use `const S: usize` instead
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/unused-type-param-suggestion.rs
+++ b/tests/ui/const-generics/unused-type-param-suggestion.rs
@@ -1,4 +1,27 @@
 #![crate_type="lib"]
 
-struct Example<N>;
-//~^ ERROR parameter
+struct S<N>;
+//~^ ERROR type parameter `N` is never used
+//~| HELP consider removing `N`
+//~| HELP if you intended `N` to be a const parameter
+
+// Ensure that we don't emit the const param suggestion here:
+struct T<N: Copy>;
+//~^ ERROR type parameter `N` is never used
+//~| HELP consider removing `N`
+
+type A<N> = ();
+//~^ ERROR type parameter `N` is never used
+//~| HELP consider removing `N`
+//~| HELP if you intended `N` to be a const parameter
+
+// Ensure that we don't emit the const param suggestion here:
+type B<N: Copy> = ();
+//~^ ERROR type parameter `N` is never used
+//~| HELP consider removing `N`
+type C<N: Sized> = ();
+//~^ ERROR type parameter `N` is never used
+//~| HELP consider removing `N`
+type D<N: ?Sized> = ();
+//~^ ERROR type parameter `N` is never used
+//~| HELP consider removing `N`

--- a/tests/ui/const-generics/unused-type-param-suggestion.stderr
+++ b/tests/ui/const-generics/unused-type-param-suggestion.stderr
@@ -1,12 +1,54 @@
-error[E0392]: parameter `N` is never used
-  --> $DIR/unused-type-param-suggestion.rs:3:16
+error[E0392]: type parameter `N` is never used
+  --> $DIR/unused-type-param-suggestion.rs:3:10
    |
-LL | struct Example<N>;
-   |                ^ unused parameter
+LL | struct S<N>;
+   |          ^ unused type parameter
    |
    = help: consider removing `N`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `N` to be a const parameter, use `const N: usize` instead
+   = help: if you intended `N` to be a const parameter, use `const N: /* Type */` instead
 
-error: aborting due to 1 previous error
+error[E0392]: type parameter `N` is never used
+  --> $DIR/unused-type-param-suggestion.rs:9:10
+   |
+LL | struct T<N: Copy>;
+   |          ^ unused type parameter
+   |
+   = help: consider removing `N`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0392`.
+error[E0091]: type parameter `N` is never used
+  --> $DIR/unused-type-param-suggestion.rs:13:8
+   |
+LL | type A<N> = ();
+   |        ^ unused type parameter
+   |
+   = help: consider removing `N` or referring to it in the body of the type alias
+   = help: if you intended `N` to be a const parameter, use `const N: /* Type */` instead
+
+error[E0091]: type parameter `N` is never used
+  --> $DIR/unused-type-param-suggestion.rs:19:8
+   |
+LL | type B<N: Copy> = ();
+   |        ^ unused type parameter
+   |
+   = help: consider removing `N` or referring to it in the body of the type alias
+
+error[E0091]: type parameter `N` is never used
+  --> $DIR/unused-type-param-suggestion.rs:22:8
+   |
+LL | type C<N: Sized> = ();
+   |        ^ unused type parameter
+   |
+   = help: consider removing `N` or referring to it in the body of the type alias
+
+error[E0091]: type parameter `N` is never used
+  --> $DIR/unused-type-param-suggestion.rs:25:8
+   |
+LL | type D<N: ?Sized> = ();
+   |        ^ unused type parameter
+   |
+   = help: consider removing `N` or referring to it in the body of the type alias
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0091, E0392.
+For more information about an error, try `rustc --explain E0091`.

--- a/tests/ui/consts/invalid-inline-const-in-match-arm.rs
+++ b/tests/ui/consts/invalid-inline-const-in-match-arm.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 
 fn main() {

--- a/tests/ui/consts/invalid-inline-const-in-match-arm.stderr
+++ b/tests/ui/consts/invalid-inline-const-in-match-arm.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const closure in constants
-  --> $DIR/invalid-inline-const-in-match-arm.rs:6:17
+  --> $DIR/invalid-inline-const-in-match-arm.rs:5:17
    |
 LL |         const { (|| {})() } => {}
    |                 ^^^^^^^^^

--- a/tests/ui/coroutine/sized-yield.stderr
+++ b/tests/ui/coroutine/sized-yield.stderr
@@ -18,7 +18,7 @@ LL |     Pin::new(&mut gen).resume(());
    |                        ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `CoroutineState`
+note: required by an implicit `Sized` bound in `CoroutineState`
   --> $SRC_DIR/core/src/ops/coroutine.rs:LL:COL
 
 error: aborting due to 2 previous errors

--- a/tests/ui/dst/dst-sized-trait-param.stderr
+++ b/tests/ui/dst/dst-sized-trait-param.stderr
@@ -5,11 +5,11 @@ LL | impl Foo<[isize]> for usize { }
    |      ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[isize]`
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/dst-sized-trait-param.rs:5:11
    |
 LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
-   |           ^ required by this bound in `Foo`
+   |           ^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Foo<T: ?Sized> : Sized { fn take(self, x: &T) { } } // Note: T is sized

--- a/tests/ui/dst/dst-sized-trait-param.stderr
+++ b/tests/ui/dst/dst-sized-trait-param.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/dst-sized-trait-param.rs:5:11
    |
 LL | trait Foo<T> : Sized { fn take(self, x: &T) { } } // Note: T is sized
-   |           ^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Foo<T: ?Sized> : Sized { fn take(self, x: &T) { } } // Note: T is sized

--- a/tests/ui/enum-discriminant/issue-70453-generics-in-discr-ice.stderr
+++ b/tests/ui/enum-discriminant/issue-70453-generics-in-discr-ice.stderr
@@ -6,14 +6,14 @@ LL |     Some = std::mem::size_of::<T>(),
    |
    = note: type parameters may not be used in enum discriminant values
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-70453-generics-in-discr-ice.rs:7:20
    |
 LL | enum MyWeirdOption<T> {
-   |                    ^ unused parameter
+   |                    ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/enum/issue-67945-1.stderr
+++ b/tests/ui/enum/issue-67945-1.stderr
@@ -6,14 +6,14 @@ LL |         let x: S = 0;
    |
    = note: type parameters may not be used in enum discriminant values
 
-error[E0392]: parameter `S` is never used
+error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-1.rs:1:10
    |
 LL | enum Bug<S> {
-   |          ^ unused parameter
+   |          ^ unused type parameter
    |
    = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `S` to be a const parameter, use `const S: usize` instead
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/enum/issue-67945-2.stderr
+++ b/tests/ui/enum/issue-67945-2.stderr
@@ -6,14 +6,14 @@ LL |     Var = type_ascribe!(0, S),
    |
    = note: type parameters may not be used in enum discriminant values
 
-error[E0392]: parameter `S` is never used
+error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-2.rs:3:10
    |
 LL | enum Bug<S> {
-   |          ^ unused parameter
+   |          ^ unused type parameter
    |
    = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `S` to be a const parameter, use `const S: usize` instead
+   = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0091.stderr
+++ b/tests/ui/error-codes/E0091.stderr
@@ -1,14 +1,20 @@
-error[E0091]: type parameter `T` is unused
+error[E0091]: type parameter `T` is never used
   --> $DIR/E0091.rs:1:10
    |
 LL | type Foo<T> = u32;
    |          ^ unused type parameter
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-error[E0091]: type parameter `B` is unused
+error[E0091]: type parameter `B` is never used
   --> $DIR/E0091.rs:2:14
    |
 LL | type Foo2<A, B> = Box<A>;
    |              ^ unused type parameter
+   |
+   = help: consider removing `B` or referring to it in the body of the type alias
+   = help: if you intended `B` to be a const parameter, use `const B: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0392.stderr
+++ b/tests/ui/error-codes/E0392.stderr
@@ -1,11 +1,11 @@
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/E0392.rs:1:10
    |
 LL | enum Foo<T> { Bar }
-   |          ^ unused parameter
+   |          ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -5,11 +5,11 @@ LL |     assert_sized::<A>();
    |                    ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `A`
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -27,11 +27,11 @@ note: required because it appears within the type `Foo`
    |
 LL | struct Foo {
    |        ^^^
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -49,11 +49,11 @@ note: required because it appears within the type `Bar<A>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -71,11 +71,11 @@ note: required because it appears within the type `Bar<A>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
-note: required by a bound in `assert_sized`
+note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}

--- a/tests/ui/extern/extern-types-unsized.stderr
+++ b/tests/ui/extern/extern-types-unsized.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -31,7 +31,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -53,7 +53,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}
@@ -75,7 +75,7 @@ note: required by an implicit `Sized` bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |
 LL | fn assert_sized<T>() {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `assert_sized`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `assert_sized`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn assert_sized<T: ?Sized>() {}

--- a/tests/ui/feature-gates/feature-gate-never_type.rs
+++ b/tests/ui/feature-gates/feature-gate-never_type.rs
@@ -13,5 +13,14 @@ impl Foo for Meeshka {
     type Wub = !; //~ ERROR type is experimental
 }
 
+fn look_ma_no_feature_gate<F: FnOnce() -> !>() {} //~ ERROR type is experimental
+fn tadam(f: &dyn Fn() -> !) {} //~ ERROR type is experimental
+fn panic() -> ! {
+    panic!();
+}
+fn toudoum() -> impl Fn() -> ! { //~ ERROR type is experimental
+    panic
+}
+
 fn main() {
 }

--- a/tests/ui/feature-gates/feature-gate-never_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_type.stderr
@@ -48,6 +48,36 @@ LL |     type Wub = !;
    = help: add `#![feature(never_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 5 previous errors
+error[E0658]: the `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:16:43
+   |
+LL | fn look_ma_no_feature_gate<F: FnOnce() -> !>() {}
+   |                                           ^
+   |
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:17:26
+   |
+LL | fn tadam(f: &dyn Fn() -> !) {}
+   |                          ^
+   |
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `!` type is experimental
+  --> $DIR/feature-gate-never_type.rs:21:30
+   |
+LL | fn toudoum() -> impl Fn() -> ! {
+   |                              ^
+   |
+   = note: see issue #35121 <https://github.com/rust-lang/rust/issues/35121> for more information
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/generic-associated-types/issue-88287.stderr
+++ b/tests/ui/generic-associated-types/issue-88287.stderr
@@ -11,7 +11,7 @@ note: required by an implicit `Sized` bound in `<T as SearchableResourceExt<Crit
   --> $DIR/issue-88287.rs:24:6
    |
 LL | impl<T, Criteria> SearchableResourceExt<Criteria> for T
-   |      ^ required by the implicit `Sized` requirement on this bound in `<T as SearchableResourceExt<Criteria>>`
+   |      ^ required by the implicit `Sized` requirement on this type parameter in `<T as SearchableResourceExt<Criteria>>`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL -     A: SearchableResource<B> + ?Sized + 'f,

--- a/tests/ui/generic-associated-types/issue-88287.stderr
+++ b/tests/ui/generic-associated-types/issue-88287.stderr
@@ -7,11 +7,11 @@ LL | type SearchFutureTy<'f, A, B: 'f>
 LL |         async move { todo!() }
    |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `<T as SearchableResourceExt<Criteria>>`
+note: required by an implicit `Sized` bound in `<T as SearchableResourceExt<Criteria>>`
   --> $DIR/issue-88287.rs:24:6
    |
 LL | impl<T, Criteria> SearchableResourceExt<Criteria> for T
-   |      ^ required by this bound in `<T as SearchableResourceExt<Criteria>>`
+   |      ^ required by the implicit `Sized` requirement on this bound in `<T as SearchableResourceExt<Criteria>>`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL -     A: SearchableResource<B> + ?Sized + 'f,

--- a/tests/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/tests/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -6,10 +6,10 @@ LL | impl Tsized for () {}
    |
    = help: the trait `Sized` is not implemented for `[()]`
 note: required by a bound in `Tsized`
-  --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:14
+  --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:17
    |
 LL | trait Tsized<P: Sized = [Self]> {}
-   |              ^^^^^^^^^^^^^^^^^ required by this bound in `Tsized`
+   |                 ^^^^^ required by this bound in `Tsized`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/half-open-range-patterns/range_pat_interactions0.rs
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions0.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![allow(incomplete_features)]
 #![feature(exclusive_range_pattern)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/impl-trait/equality-in-canonical-query.clone.stderr
+++ b/tests/ui/impl-trait/equality-in-canonical-query.clone.stderr
@@ -1,4 +1,4 @@
-note: no errors encountered even though `span_delayed_bug` issued
+note: no errors encountered even though delayed bugs were created
 
 note: those delayed bugs will now be shown as internal compiler errors
 

--- a/tests/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -5,7 +5,7 @@ LL |     fn nya() -> impl Wf<Vec<[u8]>>;
    |                      ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
@@ -15,11 +15,11 @@ LL |     fn nya2() -> impl Wf<[u8]>;
    |                       ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Wf`
+note: required by an implicit `Sized` bound in `Wf`
   --> $DIR/wf-bounds.rs:7:10
    |
 LL | trait Wf<T> {
-   |          ^ required by this bound in `Wf`
+   |          ^ required by the implicit `Sized` requirement on this bound in `Wf`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Wf<T: ?Sized> {
@@ -32,7 +32,7 @@ LL |     fn nya3() -> impl Wf<(), Output = impl Wf<Vec<[u8]>>>;
    |                                            ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: `T` doesn't implement `std::fmt::Display`

--- a/tests/ui/impl-trait/in-trait/wf-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/wf-bounds.stderr
@@ -19,7 +19,7 @@ note: required by an implicit `Sized` bound in `Wf`
   --> $DIR/wf-bounds.rs:7:10
    |
 LL | trait Wf<T> {
-   |          ^ required by the implicit `Sized` requirement on this bound in `Wf`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `Wf`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Wf<T: ?Sized> {

--- a/tests/ui/inline-const/const-match-pat-generic.rs
+++ b/tests/ui/inline-const/const-match-pat-generic.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter

--- a/tests/ui/inline-const/const-match-pat-generic.stderr
+++ b/tests/ui/inline-const/const-match-pat-generic.stderr
@@ -1,11 +1,11 @@
 error: constant pattern depends on a generic parameter
-  --> $DIR/const-match-pat-generic.rs:8:9
+  --> $DIR/const-match-pat-generic.rs:7:9
    |
 LL |         const { V } => {},
    |         ^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/const-match-pat-generic.rs:20:9
+  --> $DIR/const-match-pat-generic.rs:19:9
    |
 LL |         const { f(V) } => {},
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/inline-const/const-match-pat-inference.rs
+++ b/tests/ui/inline-const/const-match-pat-inference.rs
@@ -1,7 +1,6 @@
 // check-pass
 
 #![feature(inline_const_pat)]
-#![allow(incomplete_features)]
 
 fn main() {
     match 1u64 {

--- a/tests/ui/inline-const/const-match-pat-lifetime-err.rs
+++ b/tests/ui/inline-const/const-match-pat-lifetime-err.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/inline-const/const-match-pat-lifetime-err.stderr
+++ b/tests/ui/inline-const/const-match-pat-lifetime-err.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `y` does not live long enough
-  --> $DIR/const-match-pat-lifetime-err.rs:29:29
+  --> $DIR/const-match-pat-lifetime-err.rs:28:29
    |
 LL | fn match_invariant_ref<'a>() {
    |                        -- lifetime `'a` defined here
@@ -15,7 +15,7 @@ LL | }
    | - `y` dropped here while still borrowed
 
 error: lifetime may not live long enough
-  --> $DIR/const-match-pat-lifetime-err.rs:39:12
+  --> $DIR/const-match-pat-lifetime-err.rs:38:12
    |
 LL | fn match_covariant_ref<'a>() {
    |                        -- lifetime `'a` defined here

--- a/tests/ui/inline-const/const-match-pat-lifetime.rs
+++ b/tests/ui/inline-const/const-match-pat-lifetime.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(const_mut_refs)]
 #![feature(inline_const)]
 #![feature(inline_const_pat)]

--- a/tests/ui/inline-const/const-match-pat-range.rs
+++ b/tests/ui/inline-const/const-match-pat-range.rs
@@ -1,6 +1,5 @@
 // build-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const_pat, exclusive_range_pattern)]
 
 fn main() {

--- a/tests/ui/inline-const/const-match-pat.rs
+++ b/tests/ui/inline-const/const-match-pat.rs
@@ -1,6 +1,5 @@
 // run-pass
 
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 const MMIO_BIT1: u8 = 4;
 const MMIO_BIT2: u8 = 5;

--- a/tests/ui/inline-const/pat-match-fndef.rs
+++ b/tests/ui/inline-const/pat-match-fndef.rs
@@ -1,5 +1,4 @@
 #![feature(inline_const_pat)]
-//~^ WARN the feature `inline_const_pat` is incomplete
 
 fn uwu() {}
 

--- a/tests/ui/inline-const/pat-match-fndef.stderr
+++ b/tests/ui/inline-const/pat-match-fndef.stderr
@@ -1,17 +1,8 @@
-warning: the feature `inline_const_pat` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/pat-match-fndef.rs:1:12
-   |
-LL | #![feature(inline_const_pat)]
-   |            ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
-   = note: `#[warn(incomplete_features)]` on by default
-
 error: `fn() {uwu}` cannot be used in patterns
-  --> $DIR/pat-match-fndef.rs:9:9
+  --> $DIR/pat-match-fndef.rs:8:9
    |
 LL |         const { uwu } => {}
    |         ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/pat-unsafe-err.rs
+++ b/tests/ui/inline-const/pat-unsafe-err.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(inline_const_pat)]
 
 const unsafe fn require_unsafe() -> usize {

--- a/tests/ui/inline-const/pat-unsafe-err.stderr
+++ b/tests/ui/inline-const/pat-unsafe-err.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `require_unsafe` is unsafe and requires unsafe function or block
-  --> $DIR/pat-unsafe-err.rs:11:13
+  --> $DIR/pat-unsafe-err.rs:10:13
    |
 LL |             require_unsafe();
    |             ^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |             require_unsafe();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `require_unsafe` is unsafe and requires unsafe function or block
-  --> $DIR/pat-unsafe-err.rs:18:13
+  --> $DIR/pat-unsafe-err.rs:17:13
    |
 LL |             require_unsafe()
    |             ^^^^^^^^^^^^^^^^ call to unsafe function

--- a/tests/ui/inline-const/pat-unsafe.rs
+++ b/tests/ui/inline-const/pat-unsafe.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![allow(incomplete_features)]
 #![warn(unused_unsafe)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/inline-const/pat-unsafe.stderr
+++ b/tests/ui/inline-const/pat-unsafe.stderr
@@ -1,17 +1,17 @@
 warning: unnecessary `unsafe` block
-  --> $DIR/pat-unsafe.rs:16:17
+  --> $DIR/pat-unsafe.rs:15:17
    |
 LL |                 unsafe {}
    |                 ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
-  --> $DIR/pat-unsafe.rs:4:9
+  --> $DIR/pat-unsafe.rs:3:9
    |
 LL | #![warn(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
 warning: unnecessary `unsafe` block
-  --> $DIR/pat-unsafe.rs:23:17
+  --> $DIR/pat-unsafe.rs:22:17
    |
 LL |                 unsafe {}
    |                 ^^^^^^ unnecessary `unsafe` block

--- a/tests/ui/inner-static-type-parameter.stderr
+++ b/tests/ui/inner-static-type-parameter.stderr
@@ -6,14 +6,14 @@ LL | fn foo<T>() {
 LL |     static a: Bar<T> = Bar::What;
    |                   ^ use of generic parameter from outer item
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/inner-static-type-parameter.rs:3:10
    |
 LL | enum Bar<T> { What }
-   |          ^ unused parameter
+   |          ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-10412.stderr
+++ b/tests/ui/issues/issue-10412.stderr
@@ -62,7 +62,7 @@ note: required by an implicit `Sized` bound in `Serializable`
   --> $DIR/issue-10412.rs:1:27
    |
 LL | trait Serializable<'self, T> {
-   |                           ^ required by the implicit `Sized` requirement on this bound in `Serializable`
+   |                           ^ required by the implicit `Sized` requirement on this type parameter in `Serializable`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Serializable<'self, T: ?Sized> {

--- a/tests/ui/issues/issue-10412.stderr
+++ b/tests/ui/issues/issue-10412.stderr
@@ -58,11 +58,11 @@ LL | impl<'self> Serializable<str> for &'self str {
    |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `Serializable`
+note: required by an implicit `Sized` bound in `Serializable`
   --> $DIR/issue-10412.rs:1:27
    |
 LL | trait Serializable<'self, T> {
-   |                           ^ required by this bound in `Serializable`
+   |                           ^ required by the implicit `Sized` requirement on this bound in `Serializable`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Serializable<'self, T: ?Sized> {

--- a/tests/ui/issues/issue-17904-2.stderr
+++ b/tests/ui/issues/issue-17904-2.stderr
@@ -1,8 +1,8 @@
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-17904-2.rs:4:12
    |
 LL | struct Foo<T> where T: Copy;
-   |            ^ unused parameter
+   |            ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/issues/issue-17994.rs
+++ b/tests/ui/issues/issue-17994.rs
@@ -1,3 +1,3 @@
 trait Tr {}
-type Huh<T> where T: Tr = isize; //~  ERROR type parameter `T` is unused
+type Huh<T> where T: Tr = isize; //~ ERROR type parameter `T` is never used
 fn main() {}

--- a/tests/ui/issues/issue-17994.stderr
+++ b/tests/ui/issues/issue-17994.stderr
@@ -1,8 +1,10 @@
-error[E0091]: type parameter `T` is unused
+error[E0091]: type parameter `T` is never used
   --> $DIR/issue-17994.rs:2:10
    |
 LL | type Huh<T> where T: Tr = isize;
    |          ^ unused type parameter
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-18919.stderr
+++ b/tests/ui/issues/issue-18919.stderr
@@ -5,11 +5,11 @@ LL | fn ho_func(f: Option<FuncType>) {
    |               ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn for<'a> Fn(&'a isize) -> isize`
-note: required by a bound in `Option`
+note: required by an implicit `Sized` bound in `Option`
   --> $DIR/issue-18919.rs:7:13
    |
 LL | enum Option<T> {
-   |             ^ required by this bound in `Option`
+   |             ^ required by the implicit `Sized` requirement on this bound in `Option`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-18919.rs:7:13
    |

--- a/tests/ui/issues/issue-18919.stderr
+++ b/tests/ui/issues/issue-18919.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `Option`
   --> $DIR/issue-18919.rs:7:13
    |
 LL | enum Option<T> {
-   |             ^ required by the implicit `Sized` requirement on this bound in `Option`
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Option`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-18919.rs:7:13
    |

--- a/tests/ui/issues/issue-20413.stderr
+++ b/tests/ui/issues/issue-20413.stderr
@@ -1,11 +1,11 @@
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-20413.rs:6:15
    |
 LL | struct NoData<T>;
-   |               ^ unused parameter
+   |               ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<...>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:9:36

--- a/tests/ui/issues/issue-20433.stderr
+++ b/tests/ui/issues/issue-20433.stderr
@@ -5,7 +5,7 @@ LL |     fn iceman(c: Vec<[i32]>) {}
    |                  ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-23281.stderr
+++ b/tests/ui/issues/issue-23281.stderr
@@ -5,11 +5,11 @@ LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/issue-23281.rs:8:12
    |
 LL | struct Vec<T> {
-   |            ^ required by this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-23281.rs:8:12
    |

--- a/tests/ui/issues/issue-23281.stderr
+++ b/tests/ui/issues/issue-23281.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/issue-23281.rs:8:12
    |
 LL | struct Vec<T> {
-   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-23281.rs:8:12
    |

--- a/tests/ui/issues/issue-30236.rs
+++ b/tests/ui/issues/issue-30236.rs
@@ -1,5 +1,5 @@
 type Foo<
-    Unused //~ ERROR type parameter `Unused` is unused
+    Unused //~ ERROR type parameter `Unused` is never used
     > = u8;
 
 fn main() {

--- a/tests/ui/issues/issue-30236.stderr
+++ b/tests/ui/issues/issue-30236.stderr
@@ -1,8 +1,11 @@
-error[E0091]: type parameter `Unused` is unused
+error[E0091]: type parameter `Unused` is never used
   --> $DIR/issue-30236.rs:2:5
    |
 LL |     Unused
    |     ^^^^^^ unused type parameter
+   |
+   = help: consider removing `Unused` or referring to it in the body of the type alias
+   = help: if you intended `Unused` to be a const parameter, use `const Unused: /* Type */` instead
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-31910.stderr
+++ b/tests/ui/issues/issue-31910.stderr
@@ -4,11 +4,11 @@ error[E0308]: mismatched types
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected `isize`, found `i32`
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-31910.rs:1:11
    |
 LL | enum Enum<T: Trait> {
-   |           ^ unused parameter
+   |           ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -45,14 +45,14 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo(_: T) where Self: Sized {}
    |                  +++++++++++++++++
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-34373.rs:7:16
    |
 LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ unused parameter
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-36299.stderr
+++ b/tests/ui/issues/issue-36299.stderr
@@ -1,19 +1,19 @@
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-36299.rs:1:12
    |
 LL | struct Foo<'a, A> {}
-   |            ^^ unused parameter
+   |            ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `A` is never used
+error[E0392]: type parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
    |
 LL | struct Foo<'a, A> {}
-   |                ^ unused parameter
+   |                ^ unused type parameter
    |
    = help: consider removing `A`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `A` to be a const parameter, use `const A: usize` instead
+   = help: if you intended `A` to be a const parameter, use `const A: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-37534.stderr
+++ b/tests/ui/issues/issue-37534.stderr
@@ -15,11 +15,11 @@ warning: relaxing a default bound only does something for `?Sized`; all other tr
 LL | struct Foo<T: ?Hash> {}
    |               ^^^^^
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/issue-37534.rs:1:12
    |
 LL | struct Foo<T: ?Hash> {}
-   |            ^ unused parameter
+   |            ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/issues/issue-87199.stderr
+++ b/tests/ui/issues/issue-87199.stderr
@@ -27,7 +27,7 @@ note: required by an implicit `Sized` bound in `ref_arg`
   --> $DIR/issue-87199.rs:10:12
    |
 LL | fn ref_arg<T: ?Send>(_: &T) {}
-   |            ^ required by the implicit `Sized` requirement on this bound in `ref_arg`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `ref_arg`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn ref_arg<T: ?Send + ?Sized>(_: &T) {}

--- a/tests/ui/issues/issue-87199.stderr
+++ b/tests/ui/issues/issue-87199.stderr
@@ -23,11 +23,11 @@ LL |     ref_arg::<[i32]>(&[5]);
    |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by a bound in `ref_arg`
+note: required by an implicit `Sized` bound in `ref_arg`
   --> $DIR/issue-87199.rs:10:12
    |
 LL | fn ref_arg<T: ?Send>(_: &T) {}
-   |            ^ required by this bound in `ref_arg`
+   |            ^ required by the implicit `Sized` requirement on this bound in `ref_arg`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn ref_arg<T: ?Send + ?Sized>(_: &T) {}

--- a/tests/ui/iterators/collect-into-slice.rs
+++ b/tests/ui/iterators/collect-into-slice.rs
@@ -8,7 +8,7 @@ fn main() {
     //~| ERROR the size for values of type `[i32]` cannot be known at compilation time
     //~| ERROR a slice of type `[i32]` cannot be built since `[i32]` has no definite size
     //~| NOTE try explicitly collecting into a `Vec<{integer}>`
-    //~| NOTE required by a bound in `collect`
+    //~| NOTE required by an implicit `Sized` bound in `collect`
     //~| NOTE required by a bound in `collect`
     //~| NOTE all local variables must have a statically known size
     //~| NOTE doesn't have a size known at compile-time

--- a/tests/ui/iterators/collect-into-slice.stderr
+++ b/tests/ui/iterators/collect-into-slice.stderr
@@ -25,7 +25,7 @@ LL |     let some_generated_vec = (0..10).collect();
    |                                      ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i32]`
-note: required by a bound in `collect`
+note: required by an implicit `Sized` bound in `collect`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0277]: a slice of type `&[i32]` cannot be built since we need to store the elements somewhere

--- a/tests/ui/lang-items/lang-item-generic-requirements.stderr
+++ b/tests/ui/lang-items/lang-item-generic-requirements.stderr
@@ -50,23 +50,23 @@ LL |
 LL | fn start(_: *const u8, _: isize, _: *const *const u8) -> isize {
    |         - this function has 0 generic arguments
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/lang-item-generic-requirements.rs:24:22
    |
 LL | struct MyPhantomData<T, U>;
-   |                      ^ unused parameter
+   |                      ^ unused type parameter
    |
    = help: consider removing `T` or referring to it in a field
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-error[E0392]: parameter `U` is never used
+error[E0392]: type parameter `U` is never used
   --> $DIR/lang-item-generic-requirements.rs:24:25
    |
 LL | struct MyPhantomData<T, U>;
-   |                         ^ unused parameter
+   |                         ^ unused type parameter
    |
    = help: consider removing `U` or referring to it in a field
-   = help: if you intended `U` to be a const parameter, use `const U: usize` instead
+   = help: if you intended `U` to be a const parameter, use `const U: /* Type */` instead
 
 error[E0369]: cannot add `{integer}` to `{integer}`
   --> $DIR/lang-item-generic-requirements.rs:44:7

--- a/tests/ui/lazy-type-alias/unused-generic-parameters.rs
+++ b/tests/ui/lazy-type-alias/unused-generic-parameters.rs
@@ -1,0 +1,22 @@
+// Check that we reject bivariant generic parameters as unused.
+// Furthermore, check that we only emit a single diagnostic for unused type parameters:
+// Previously, we would emit *two* errors, namely E0392 and E0091.
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type A<'a> = ();
+//~^ ERROR lifetime parameter `'a` is never used
+//~| HELP consider removing `'a`
+
+type B<T> = ();
+//~^ ERROR type parameter `T` is never used
+//~| HELP consider removing `T`
+//~| HELP if you intended `T` to be a const parameter
+
+// Check that we don't emit the const param help message here:
+type C<T: Copy> = ();
+//~^ ERROR type parameter `T` is never used
+//~| HELP consider removing `T`
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/unused-generic-parameters.stderr
+++ b/tests/ui/lazy-type-alias/unused-generic-parameters.stderr
@@ -1,0 +1,28 @@
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/unused-generic-parameters.rs:8:8
+   |
+LL | type A<'a> = ();
+   |        ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a` or referring to it in the body of the type alias
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/unused-generic-parameters.rs:12:8
+   |
+LL | type B<T> = ();
+   |        ^ unused type parameter
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/unused-generic-parameters.rs:18:8
+   |
+LL | type C<T: Copy> = ();
+   |        ^ unused type parameter
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0392`.

--- a/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
+++ b/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
@@ -13,19 +13,19 @@ error: generic `Self` types are currently not permitted in anonymous constants
 LL |     array: [(); size_of::<&Self>()],
    |                            ^^^^
 
-error[E0392]: parameter `'s` is never used
+error[E0392]: lifetime parameter `'s` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:3:12
    |
 LL | struct Foo<'s> {
-   |            ^^ unused parameter
+   |            ^^ unused lifetime parameter
    |
    = help: consider removing `'s`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:15:12
    |
 LL | struct Bar<'a> {
-   |            ^^ unused parameter
+   |            ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/lint/dead-code/anon-const-in-pat.rs
+++ b/tests/ui/lint/dead-code/anon-const-in-pat.rs
@@ -1,6 +1,5 @@
 // check-pass
 #![feature(inline_const_pat)]
-#![allow(incomplete_features)]
 #![deny(dead_code)]
 
 const fn one() -> i32 {

--- a/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
+++ b/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
@@ -64,7 +64,7 @@ note: required by an implicit `Sized` bound in `A`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |
 LL | struct A<B>(B);
-   |          ^ required by the implicit `Sized` requirement on this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `A`
 help: you could relax the implicit `Sized` bound on `B` if it were used through indirection like `&B` or `Box<B>`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |

--- a/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
+++ b/tests/ui/malformed/do-not-ice-on-note_and_explain.stderr
@@ -60,11 +60,11 @@ LL | impl<B>A<B>{fn d(){fn d(){Self(1)}}}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `A`
+note: required by an implicit `Sized` bound in `A`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |
 LL | struct A<B>(B);
-   |          ^ required by this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this bound in `A`
 help: you could relax the implicit `Sized` bound on `B` if it were used through indirection like `&B` or `Box<B>`
   --> $DIR/do-not-ice-on-note_and_explain.rs:1:10
    |

--- a/tests/ui/match/issue-112438.rs
+++ b/tests/ui/match/issue-112438.rs
@@ -1,7 +1,6 @@
 // run-pass
 #![feature(inline_const_pat)]
 #![allow(dead_code)]
-#![allow(incomplete_features)]
 fn foo<const V: usize>() {
     match 0 {
         const { 1 << 5 } | _ => {}

--- a/tests/ui/match/validate-range-endpoints.rs
+++ b/tests/ui/match/validate-range-endpoints.rs
@@ -1,6 +1,5 @@
 #![feature(exclusive_range_pattern)]
 #![feature(inline_const_pat)]
-#![allow(incomplete_features)]
 #![allow(overlapping_range_endpoints)]
 
 fn main() {

--- a/tests/ui/match/validate-range-endpoints.stderr
+++ b/tests/ui/match/validate-range-endpoints.stderr
@@ -1,59 +1,59 @@
 error: literal out of range for `u8`
-  --> $DIR/validate-range-endpoints.rs:9:12
+  --> $DIR/validate-range-endpoints.rs:8:12
    |
 LL |         1..257 => {}
    |            ^^^ this value does not fit into the type `u8` whose range is `0..=255`
 
 error: literal out of range for `u8`
-  --> $DIR/validate-range-endpoints.rs:11:13
+  --> $DIR/validate-range-endpoints.rs:10:13
    |
 LL |         1..=256 => {}
    |             ^^^ this value does not fit into the type `u8` whose range is `0..=255`
 
 error[E0030]: lower range bound must be less than or equal to upper
-  --> $DIR/validate-range-endpoints.rs:20:9
+  --> $DIR/validate-range-endpoints.rs:19:9
    |
 LL |         1..=TOO_BIG => {}
    |         ^^^^^^^^^^^ lower bound larger than upper bound
 
 error[E0030]: lower range bound must be less than or equal to upper
-  --> $DIR/validate-range-endpoints.rs:22:9
+  --> $DIR/validate-range-endpoints.rs:21:9
    |
 LL |         1..=const { 256 } => {}
    |         ^^^^^^^^^^^^^^^^^ lower bound larger than upper bound
 
 error: literal out of range for `u64`
-  --> $DIR/validate-range-endpoints.rs:28:32
+  --> $DIR/validate-range-endpoints.rs:27:32
    |
 LL |         10000000000000000000..=99999999999999999999 => {}
    |                                ^^^^^^^^^^^^^^^^^^^^ this value does not fit into the type `u64` whose range is `0..=18446744073709551615`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:34:12
+  --> $DIR/validate-range-endpoints.rs:33:12
    |
 LL |         0..129 => {}
    |            ^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:36:13
+  --> $DIR/validate-range-endpoints.rs:35:13
    |
 LL |         0..=128 => {}
    |             ^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:38:9
+  --> $DIR/validate-range-endpoints.rs:37:9
    |
 LL |         -129..0 => {}
    |         ^^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error: literal out of range for `i8`
-  --> $DIR/validate-range-endpoints.rs:40:9
+  --> $DIR/validate-range-endpoints.rs:39:9
    |
 LL |         -10000..=-20 => {}
    |         ^^^^^^ this value does not fit into the type `i8` whose range is `-128..=127`
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=-17_i8` and `1_i8..=i8::MAX` not covered
-  --> $DIR/validate-range-endpoints.rs:51:11
+  --> $DIR/validate-range-endpoints.rs:50:11
    |
 LL |     match 0i8 {
    |           ^^^ patterns `i8::MIN..=-17_i8` and `1_i8..=i8::MAX` not covered
@@ -66,7 +66,7 @@ LL +         i8::MIN..=-17_i8 | 1_i8..=i8::MAX => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=-17_i8` not covered
-  --> $DIR/validate-range-endpoints.rs:55:11
+  --> $DIR/validate-range-endpoints.rs:54:11
    |
 LL |     match 0i8 {
    |           ^^^ pattern `i8::MIN..=-17_i8` not covered

--- a/tests/ui/methods/issues/issue-61525.stderr
+++ b/tests/ui/methods/issues/issue-61525.stderr
@@ -7,11 +7,11 @@ LL |         1.query::<dyn ToString>("")
    |           required by a bound introduced by this call
    |
    = help: the trait `Sized` is not implemented for `dyn ToString`
-note: required by a bound in `Example::query`
+note: required by an implicit `Sized` bound in `Example::query`
   --> $DIR/issue-61525.rs:2:14
    |
 LL |     fn query<Q>(self, q: Q);
-   |              ^ required by this bound in `Example::query`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Example::query`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     fn query<Q: ?Sized>(self, q: Q);

--- a/tests/ui/methods/issues/issue-61525.stderr
+++ b/tests/ui/methods/issues/issue-61525.stderr
@@ -11,7 +11,7 @@ note: required by an implicit `Sized` bound in `Example::query`
   --> $DIR/issue-61525.rs:2:14
    |
 LL |     fn query<Q>(self, q: Q);
-   |              ^ required by the implicit `Sized` requirement on this bound in `Example::query`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Example::query`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL |     fn query<Q: ?Sized>(self, q: Q);

--- a/tests/ui/never_type/never-type-in-nested-fn-decl.rs
+++ b/tests/ui/never_type/never-type-in-nested-fn-decl.rs
@@ -1,0 +1,7 @@
+// build-pass
+
+trait X<const N: i32> {}
+
+fn hello<T: X<{ fn hello() -> ! { loop {} } 1 }>>() {}
+
+fn main() {}

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -26,7 +26,7 @@ note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
    |
 LL | trait Bar<T> {
-   |           ^ required by the implicit `Sized` requirement on this bound in `Bar`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `Bar`
 help: consider further restricting `Self`
    |
 LL | trait Baz : Bar<Self> + Sized {

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -22,11 +22,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | trait Baz : Bar<Self> {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Bar`
+note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/object-safety-supertrait-mentions-Self.rs:4:11
    |
 LL | trait Bar<T> {
-   |           ^ required by this bound in `Bar`
+   |           ^ required by the implicit `Sized` requirement on this bound in `Bar`
 help: consider further restricting `Self`
    |
 LL | trait Baz : Bar<Self> + Sized {

--- a/tests/ui/parser/item-free-type-bounds-semantic-fail.rs
+++ b/tests/ui/parser/item-free-type-bounds-semantic-fail.rs
@@ -13,8 +13,8 @@ fn semantics() {
     //~| ERROR free type alias without body
     type E<_T>: Ord = u8;
     //~^ ERROR bounds on `type`s in this context have no effect
-    //~| ERROR type parameter `_T` is unused
+    //~| ERROR type parameter `_T` is never used
     type F<_T>: Ord where 'static: 'static = u8;
     //~^ ERROR bounds on `type`s in this context have no effect
-    //~| ERROR type parameter `_T` is unused
+    //~| ERROR type parameter `_T` is never used
 }

--- a/tests/ui/parser/item-free-type-bounds-semantic-fail.stderr
+++ b/tests/ui/parser/item-free-type-bounds-semantic-fail.stderr
@@ -50,17 +50,23 @@ error: bounds on `type`s in this context have no effect
 LL |     type F<_T>: Ord where 'static: 'static = u8;
    |                 ^^^
 
-error[E0091]: type parameter `_T` is unused
+error[E0091]: type parameter `_T` is never used
   --> $DIR/item-free-type-bounds-semantic-fail.rs:14:12
    |
 LL |     type E<_T>: Ord = u8;
    |            ^^ unused type parameter
+   |
+   = help: consider removing `_T` or referring to it in the body of the type alias
+   = help: if you intended `_T` to be a const parameter, use `const _T: /* Type */` instead
 
-error[E0091]: type parameter `_T` is unused
+error[E0091]: type parameter `_T` is never used
   --> $DIR/item-free-type-bounds-semantic-fail.rs:17:12
    |
 LL |     type F<_T>: Ord where 'static: 'static = u8;
    |            ^^ unused type parameter
+   |
+   = help: consider removing `_T` or referring to it in the body of the type alias
+   = help: if you intended `_T` to be a const parameter, use `const _T: /* Type */` instead
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/pattern/non-structural-match-types.rs
+++ b/tests/ui/pattern/non-structural-match-types.rs
@@ -1,6 +1,5 @@
 // edition:2021
 
-#![allow(incomplete_features)]
 #![allow(unreachable_code)]
 #![feature(const_async_blocks)]
 #![feature(inline_const_pat)]

--- a/tests/ui/pattern/non-structural-match-types.stderr
+++ b/tests/ui/pattern/non-structural-match-types.stderr
@@ -1,11 +1,11 @@
-error: `{closure@$DIR/non-structural-match-types.rs:10:17: 10:19}` cannot be used in patterns
-  --> $DIR/non-structural-match-types.rs:10:9
+error: `{closure@$DIR/non-structural-match-types.rs:9:17: 9:19}` cannot be used in patterns
+  --> $DIR/non-structural-match-types.rs:9:9
    |
 LL |         const { || {} } => {}
    |         ^^^^^^^^^^^^^^^
 
-error: `{async block@$DIR/non-structural-match-types.rs:13:17: 13:25}` cannot be used in patterns
-  --> $DIR/non-structural-match-types.rs:13:9
+error: `{async block@$DIR/non-structural-match-types.rs:12:17: 12:25}` cannot be used in patterns
+  --> $DIR/non-structural-match-types.rs:12:9
    |
 LL |         const { async {} } => {}
    |         ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/range/range-1.stderr
+++ b/tests/ui/range/range-1.stderr
@@ -30,7 +30,7 @@ LL |     let range = *arr..;
    |                 ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[{integer}]`
-note: required by a bound in `RangeFrom`
+note: required by an implicit `Sized` bound in `RangeFrom`
   --> $SRC_DIR/core/src/ops/range.rs:LL:COL
 
 error: aborting due to 3 previous errors

--- a/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -21,11 +21,11 @@ note: but lifetime parameter must outlive the lifetime `'a` as defined here
 LL | struct Foo<'a,'b,'c> {
    |            ^^
 
-error[E0392]: parameter `'c` is never used
+error[E0392]: lifetime parameter `'c` is never used
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:18
    |
 LL | struct Foo<'a,'b,'c> {
-   |                  ^^ unused parameter
+   |                  ^^ unused lifetime parameter
    |
    = help: consider removing `'c`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -272,11 +272,11 @@ LL |     type Type<T: ~const Trait> = ();
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/tilde-const-invalid-places.rs:11:19
    |
 LL | struct UnitStruct<T: ~const Trait>;
-   |                   ^ unused parameter
+   |                   ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/self/self_type_keyword.stderr
+++ b/tests/ui/self/self_type_keyword.stderr
@@ -72,11 +72,11 @@ note: unit struct `foo::Self` exists but is inaccessible
 LL |   struct Self;
    |   ^^^^^^^^^^^^ not accessible
 
-error[E0392]: parameter `'Self` is never used
+error[E0392]: lifetime parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:6:12
    |
 LL | struct Bar<'Self>;
-   |            ^^^^^ unused parameter
+   |            ^^^^^ unused lifetime parameter
    |
    = help: consider removing `'Self`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -5,11 +5,11 @@ LL |     s[1..2] = bot();
    |               ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-note: required by a bound in `bot`
+note: required by an implicit `Sized` bound in `bot`
   --> $DIR/str-mut-idx.rs:1:8
    |
 LL | fn bot<T>() -> T { loop {} }
-   |        ^ required by this bound in `bot`
+   |        ^ required by the implicit `Sized` requirement on this bound in `bot`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn bot<T: ?Sized>() -> T { loop {} }

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `bot`
   --> $DIR/str-mut-idx.rs:1:8
    |
 LL | fn bot<T>() -> T { loop {} }
-   |        ^ required by the implicit `Sized` requirement on this bound in `bot`
+   |        ^ required by the implicit `Sized` requirement on this type parameter in `bot`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn bot<T: ?Sized>() -> T { loop {} }

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -6,11 +6,11 @@ LL | struct Struct5<T: ?Sized>{
 LL |     _t: X<T>,
    |         ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `X`
+note: required by an implicit `Sized` bound in `X`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
 LL | struct X<T>(T);
-   |          ^ required by this bound in `X`
+   |          ^ required by the implicit `Sized` requirement on this bound in `X`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
@@ -30,11 +30,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func1() -> Struct1<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct1`
+note: required by an implicit `Sized` bound in `Struct1`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:8:16
    |
 LL | struct Struct1<T>{
-   |                ^ required by this bound in `Struct1`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Struct1`
 help: consider further restricting `Self`
    |
 LL |     fn func1() -> Struct1<Self> where Self: Sized;
@@ -50,11 +50,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func2<'a>() -> Struct2<'a, Self>;
    |                       ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct2`
+note: required by an implicit `Sized` bound in `Struct2`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:11:20
    |
 LL | struct Struct2<'a, T>{
-   |                    ^ required by this bound in `Struct2`
+   |                    ^ required by the implicit `Sized` requirement on this bound in `Struct2`
 help: consider further restricting `Self`
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self> where Self: Sized;
@@ -70,11 +70,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func3() -> Struct3<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct3`
+note: required by an implicit `Sized` bound in `Struct3`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
 LL | struct Struct3<T>{
-   |                ^ required by this bound in `Struct3`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Struct3`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
@@ -93,11 +93,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     fn func4() -> Struct4<Self>;
    |                   ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Struct4`
+note: required by an implicit `Sized` bound in `Struct4`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:20:16
    |
 LL | struct Struct4<T>{
-   |                ^ required by this bound in `Struct4`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Struct4`
 help: consider further restricting `Self`
    |
 LL |     fn func4() -> Struct4<Self> where Self: Sized;

--- a/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/tests/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `X`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
 LL | struct X<T>(T);
-   |          ^ required by the implicit `Sized` requirement on this bound in `X`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `X`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:18:10
    |
@@ -34,7 +34,7 @@ note: required by an implicit `Sized` bound in `Struct1`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:8:16
    |
 LL | struct Struct1<T>{
-   |                ^ required by the implicit `Sized` requirement on this bound in `Struct1`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Struct1`
 help: consider further restricting `Self`
    |
 LL |     fn func1() -> Struct1<Self> where Self: Sized;
@@ -54,7 +54,7 @@ note: required by an implicit `Sized` bound in `Struct2`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:11:20
    |
 LL | struct Struct2<'a, T>{
-   |                    ^ required by the implicit `Sized` requirement on this bound in `Struct2`
+   |                    ^ required by the implicit `Sized` requirement on this type parameter in `Struct2`
 help: consider further restricting `Self`
    |
 LL |     fn func2<'a>() -> Struct2<'a, Self> where Self: Sized;
@@ -74,7 +74,7 @@ note: required by an implicit `Sized` bound in `Struct3`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
 LL | struct Struct3<T>{
-   |                ^ required by the implicit `Sized` requirement on this bound in `Struct3`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Struct3`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:14:16
    |
@@ -97,7 +97,7 @@ note: required by an implicit `Sized` bound in `Struct4`
   --> $DIR/adt-param-with-implicit-sized-bound.rs:20:16
    |
 LL | struct Struct4<T>{
-   |                ^ required by the implicit `Sized` requirement on this bound in `Struct4`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Struct4`
 help: consider further restricting `Self`
    |
 LL |     fn func4() -> Struct4<Self> where Self: Sized;

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -76,7 +76,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -89,7 +89,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -102,7 +102,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -115,7 +115,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |
@@ -128,7 +128,7 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL |     const SIZE: usize = core::mem::size_of::<Self>();
    |                                              ^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider further restricting `Self`
    |

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -57,10 +57,10 @@ LL |     f_sized(*ref_cl);
    |
    = help: the trait `Sized` is not implemented for `dyn Fn()`
 note: required by a bound in `f_sized`
-  --> $DIR/issue-84973-blacklist.rs:9:12
+  --> $DIR/issue-84973-blacklist.rs:9:15
    |
 LL | fn f_sized<T: Sized>(t: T) {}
-   |            ^ required by this bound in `f_sized`
+   |               ^^^^^ required by this bound in `f_sized`
 
 error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/issue-84973-blacklist.rs:27:12

--- a/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
+++ b/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
@@ -5,11 +5,11 @@ LL | struct B(A<[u8]>);
    |          ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `A`
+note: required by an implicit `Sized` bound in `A`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |
 LL | struct A<T>(T) where T: Send;
-   |          ^ required by this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this bound in `A`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |

--- a/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
+++ b/tests/ui/suggestions/issue-85943-no-suggest-unsized-indirection-in-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by an implicit `Sized` bound in `A`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |
 LL | struct A<T>(T) where T: Send;
-   |          ^ required by the implicit `Sized` requirement on this bound in `A`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `A`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/issue-85943-no-suggest-unsized-indirection-in-where-clause.rs:4:10
    |

--- a/tests/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.stderr
+++ b/tests/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.stderr
@@ -8,10 +8,10 @@ LL | fn bar() { foo(""); }
    |
    = help: the trait `Sized` is not implemented for `str`
 note: required by a bound in `foo`
-  --> $DIR/issue-85945-check-where-clause-before-suggesting-unsized.rs:3:8
+  --> $DIR/issue-85945-check-where-clause-before-suggesting-unsized.rs:3:27
    |
 LL | fn foo<T>(_: &T) where T: Sized {}
-   |        ^ required by this bound in `foo`
+   |                           ^^^^^ required by this bound in `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/only-suggest-removal-of-conversion-method-calls.fixed
+++ b/tests/ui/suggestions/only-suggest-removal-of-conversion-method-calls.fixed
@@ -1,0 +1,16 @@
+// run-rustfix
+use std::io::stdin;
+
+fn get_name() -> String {
+    let mut your_name = String::new();
+    stdin()
+        .read_line(&mut your_name)
+        .expect("Failed to read the line for some reason");
+    your_name.trim().to_string() //~ ERROR E0308
+}
+
+fn main() {
+    println!("Hello, What is your name? ");
+    let your_name = get_name();
+    println!("Hello, {}", your_name)
+}

--- a/tests/ui/suggestions/only-suggest-removal-of-conversion-method-calls.rs
+++ b/tests/ui/suggestions/only-suggest-removal-of-conversion-method-calls.rs
@@ -1,0 +1,16 @@
+// run-rustfix
+use std::io::stdin;
+
+fn get_name() -> String {
+    let mut your_name = String::new();
+    stdin()
+        .read_line(&mut your_name)
+        .expect("Failed to read the line for some reason");
+    your_name.trim() //~ ERROR E0308
+}
+
+fn main() {
+    println!("Hello, What is your name? ");
+    let your_name = get_name();
+    println!("Hello, {}", your_name)
+}

--- a/tests/ui/suggestions/only-suggest-removal-of-conversion-method-calls.stderr
+++ b/tests/ui/suggestions/only-suggest-removal-of-conversion-method-calls.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/only-suggest-removal-of-conversion-method-calls.rs:9:5
+   |
+LL | fn get_name() -> String {
+   |                  ------ expected `String` because of return type
+...
+LL |     your_name.trim()
+   |     ^^^^^^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
+   |     |
+   |     expected `String`, found `&str`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -39,7 +39,7 @@ note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -64,7 +64,7 @@ note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |

--- a/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/tests/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -6,11 +6,11 @@ LL | fn foo<T>(foo: Wrapper<T>)
    |        |
    |        this type parameter needs to be `Sized`
    |
-note: required by a bound in `Wrapper`
+note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -35,11 +35,11 @@ LL | fn bar<T>(foo: Wrapper<T>)
    |        |
    |        this type parameter needs to be `Sized`
    |
-note: required by a bound in `Wrapper`
+note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
@@ -60,11 +60,11 @@ LL | fn qux<T>(foo: Wrapper<T>)
    |        |
    |        this type parameter needs to be `Sized`
    |
-note: required by a bound in `Wrapper`
+note: required by an implicit `Sized` bound in `Wrapper`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |
 LL | struct Wrapper<T>(T);
-   |                ^ required by this bound in `Wrapper`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Wrapper`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:1:16
    |

--- a/tests/ui/tag-type-args.stderr
+++ b/tests/ui/tag-type-args.stderr
@@ -14,14 +14,14 @@ help: add missing generic argument
 LL | fn foo(c: Quux<T>) { assert!((false)); }
    |               +++
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/tag-type-args.rs:1:11
    |
 LL | enum Quux<T> { Bar }
-   |           ^ unused parameter
+   |           ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -11,7 +11,7 @@ note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
@@ -50,7 +50,7 @@ note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
@@ -100,7 +100,7 @@ note: required by an implicit `Sized` bound in `Trait2`
   --> $DIR/unsized-bound.rs:9:14
    |
 LL | trait Trait2<A> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait2`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
@@ -138,7 +138,7 @@ note: required by an implicit `Sized` bound in `Trait3`
   --> $DIR/unsized-bound.rs:13:14
    |
 LL | trait Trait3<A> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait3`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait3`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A> Trait3<A> for A where A: ?Sized {}
@@ -161,7 +161,7 @@ note: required by an implicit `Sized` bound in `Trait4`
   --> $DIR/unsized-bound.rs:16:14
    |
 LL | trait Trait4<A> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait4`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized> Trait4<A> for A {}
@@ -184,7 +184,7 @@ note: required by an implicit `Sized` bound in `Trait5`
   --> $DIR/unsized-bound.rs:19:14
    |
 LL | trait Trait5<A, B> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait5`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
@@ -207,7 +207,7 @@ note: required by an implicit `Sized` bound in `Trait6`
   --> $DIR/unsized-bound.rs:22:14
    |
 LL | trait Trait6<A, B> {}
-   |              ^ required by the implicit `Sized` requirement on this bound in `Trait6`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait6`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized, Y> Trait6<X, Y> for X {}
@@ -230,7 +230,7 @@ note: required by an implicit `Sized` bound in `Trait7`
   --> $DIR/unsized-bound.rs:25:17
    |
 LL | trait Trait7<A, B> {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait7`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `Trait7`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
@@ -253,7 +253,7 @@ note: required by an implicit `Sized` bound in `Trait8`
   --> $DIR/unsized-bound.rs:28:17
    |
 LL | trait Trait8<A, B> {}
-   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait8`
+   |                 ^ required by the implicit `Sized` requirement on this type parameter in `Trait8`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y: ?Sized> Trait8<X, Y> for X {}

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -7,11 +7,11 @@ LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
    |         this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
-note: required by a bound in `Trait`
+note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
@@ -46,11 +46,11 @@ LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Size
    |                    this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B, C)`
-note: required by a bound in `Trait`
+note: required by an implicit `Sized` bound in `Trait`
   --> $DIR/unsized-bound.rs:1:13
    |
 LL | trait Trait<A> {}
-   |             ^ required by this bound in `Trait`
+   |             ^ required by the implicit `Sized` requirement on this bound in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
@@ -96,11 +96,11 @@ LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |                 this type parameter needs to be `Sized`
    |
    = note: required because it appears within the type `(A, B)`
-note: required by a bound in `Trait2`
+note: required by an implicit `Sized` bound in `Trait2`
   --> $DIR/unsized-bound.rs:9:14
    |
 LL | trait Trait2<A> {}
-   |              ^ required by this bound in `Trait2`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
@@ -134,11 +134,11 @@ LL | impl<A> Trait3<A> for A where A: ?Sized {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait3`
+note: required by an implicit `Sized` bound in `Trait3`
   --> $DIR/unsized-bound.rs:13:14
    |
 LL | trait Trait3<A> {}
-   |              ^ required by this bound in `Trait3`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait3`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A> Trait3<A> for A where A: ?Sized {}
@@ -157,11 +157,11 @@ LL | impl<A: ?Sized> Trait4<A> for A {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait4`
+note: required by an implicit `Sized` bound in `Trait4`
   --> $DIR/unsized-bound.rs:16:14
    |
 LL | trait Trait4<A> {}
-   |              ^ required by this bound in `Trait4`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized> Trait4<A> for A {}
@@ -180,11 +180,11 @@ LL | impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait5`
+note: required by an implicit `Sized` bound in `Trait5`
   --> $DIR/unsized-bound.rs:19:14
    |
 LL | trait Trait5<A, B> {}
-   |              ^ required by this bound in `Trait5`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
@@ -203,11 +203,11 @@ LL | impl<X: ?Sized, Y> Trait6<X, Y> for X {}
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait6`
+note: required by an implicit `Sized` bound in `Trait6`
   --> $DIR/unsized-bound.rs:22:14
    |
 LL | trait Trait6<A, B> {}
-   |              ^ required by this bound in `Trait6`
+   |              ^ required by the implicit `Sized` requirement on this bound in `Trait6`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized, Y> Trait6<X, Y> for X {}
@@ -226,11 +226,11 @@ LL | impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait7`
+note: required by an implicit `Sized` bound in `Trait7`
   --> $DIR/unsized-bound.rs:25:17
    |
 LL | trait Trait7<A, B> {}
-   |                 ^ required by this bound in `Trait7`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait7`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
@@ -249,11 +249,11 @@ LL | impl<X, Y: ?Sized> Trait8<X, Y> for X {}
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Trait8`
+note: required by an implicit `Sized` bound in `Trait8`
   --> $DIR/unsized-bound.rs:28:17
    |
 LL | trait Trait8<A, B> {}
-   |                 ^ required by this bound in `Trait8`
+   |                 ^ required by the implicit `Sized` requirement on this bound in `Trait8`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y: ?Sized> Trait8<X, Y> for X {}

--- a/tests/ui/traits/bad-sized.stderr
+++ b/tests/ui/traits/bad-sized.stderr
@@ -16,7 +16,7 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |            ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
@@ -36,7 +36,7 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    |                                     ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 
 error: aborting due to 4 previous errors

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -25,11 +25,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | pub trait Bar: Foo<Assoc=()> {
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: consider further restricting `Self`
    |
 LL | pub trait Bar: Foo<Assoc=()> + Sized {
@@ -45,11 +45,11 @@ error[E0277]: the size for values of type `Self` cannot be known at compilation 
 LL | pub trait Bar: Foo<Assoc=()> {
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: consider further restricting `Self`
    |
 LL |     ) where Self: Sized;

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -29,7 +29,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider further restricting `Self`
    |
 LL | pub trait Bar: Foo<Assoc=()> + Sized {
@@ -49,7 +49,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/issue-28576.rs:1:15
    |
 LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: consider further restricting `Self`
    |
 LL |     ) where Self: Sized;

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.rs
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.rs
@@ -8,11 +8,9 @@ use core::marker::PhantomData;
 fn main() {
     test::<MaskedStorage<GenericComp<Pos>>>(make());
     //~^ ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-    //~| ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
 
     test::<MaskedStorage<GenericComp2<Pos>>>(make());
     //~^ ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-    //~| ERROR evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
 }
 
 #[rustc_evaluate_where_clauses]

--- a/tests/ui/traits/issue-85360-eval-obligation-ice.stderr
+++ b/tests/ui/traits/issue-85360-eval-obligation-ice.stderr
@@ -5,28 +5,10 @@ LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | fn test<T: Sized>(_: T) {}
-   |         - predicate
-
-error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOk)
-  --> $DIR/issue-85360-eval-obligation-ice.rs:9:5
-   |
-LL |     test::<MaskedStorage<GenericComp<Pos>>>(make());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
 error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
-   |
-LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | fn test<T: Sized>(_: T) {}
-   |         - predicate
-
-error: evaluate(Binder { value: TraitPredicate(<MaskedStorage<GenericComp2<Pos>> as std::marker::Sized>, polarity:Positive), bound_vars: [] }) = Ok(EvaluatedToOkModuloRegions)
-  --> $DIR/issue-85360-eval-obligation-ice.rs:13:5
+  --> $DIR/issue-85360-eval-obligation-ice.rs:12:5
    |
 LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,5 +16,5 @@ LL |     test::<MaskedStorage<GenericComp2<Pos>>>(make());
 LL | fn test<T: Sized>(_: T) {}
    |            ----- predicate
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/mutual-recursion-issue-75860.stderr
+++ b/tests/ui/traits/mutual-recursion-issue-75860.stderr
@@ -5,7 +5,7 @@ LL |     iso(left, right)
    |     ^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`mutual_recursion_issue_75860`)
-note: required by a bound in `Option`
+note: required by an implicit `Sized` bound in `Option`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.stderr
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization-2.stderr
@@ -26,11 +26,11 @@ LL |     needs_bar::<T::Assoc1>();
    |                 ^^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization_2`)
-note: required by a bound in `needs_bar`
+note: required by an implicit `Sized` bound in `needs_bar`
   --> $DIR/recursive-self-normalization-2.rs:12:14
    |
 LL | fn needs_bar<S: Bar>() {}
-   |              ^ required by this bound in `needs_bar`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `needs_bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn needs_bar<S: Bar + ?Sized>() {}

--- a/tests/ui/traits/next-solver/overflow/recursive-self-normalization.stderr
+++ b/tests/ui/traits/next-solver/overflow/recursive-self-normalization.stderr
@@ -26,11 +26,11 @@ LL |     needs_bar::<T::Assoc>();
    |                 ^^^^^^^^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_self_normalization`)
-note: required by a bound in `needs_bar`
+note: required by an implicit `Sized` bound in `needs_bar`
   --> $DIR/recursive-self-normalization.rs:8:14
    |
 LL | fn needs_bar<S: Bar>() {}
-   |              ^ required by this bound in `needs_bar`
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `needs_bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn needs_bar<S: Bar + ?Sized>() {}

--- a/tests/ui/traits/suggest-where-clause.stderr
+++ b/tests/ui/traits/suggest-where-clause.stderr
@@ -7,7 +7,7 @@ LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
    |
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
@@ -29,7 +29,7 @@ note: required because it appears within the type `Misc<U>`
    |
 LL | struct Misc<T:?Sized>(T);
    |        ^^^^
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
@@ -72,7 +72,7 @@ LL |     mem::size_of::<[T]>();
    |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[T]`
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error[E0277]: the size for values of type `[&U]` cannot be known at compilation time
@@ -82,7 +82,7 @@ LL |     mem::size_of::<[&U]>();
    |                    ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[&U]`
-note: required by a bound in `std::mem::size_of`
+note: required by an implicit `Sized` bound in `std::mem::size_of`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 7 previous errors

--- a/tests/ui/try-block/try-block-in-match-arm.rs
+++ b/tests/ui/try-block/try-block-in-match-arm.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags: --edition 2018
+
+#![feature(try_blocks)]
+
+fn main() {
+    let _ = match 1 {
+        1 => try {}
+        _ => Ok::<(), ()>(()),
+    };
+}

--- a/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
+++ b/tests/ui/type-alias-impl-trait/rpit_tait_equality_in_canonical_query.current.stderr
@@ -1,4 +1,4 @@
-note: no errors encountered even though `span_delayed_bug` issued
+note: no errors encountered even though delayed bugs were created
 
 note: those delayed bugs will now be shown as internal compiler errors
 

--- a/tests/ui/unsafe/const_pat_in_layout_restricted.rs
+++ b/tests/ui/unsafe/const_pat_in_layout_restricted.rs
@@ -2,7 +2,6 @@
 // unsafe because they're within a pattern for a layout constrained stuct.
 // check-pass
 
-#![allow(incomplete_features)]
 #![feature(rustc_attrs)]
 #![feature(inline_const_pat)]
 

--- a/tests/ui/unsized/unsized-bare-typaram.stderr
+++ b/tests/ui/unsized/unsized-bare-typaram.stderr
@@ -7,10 +7,10 @@ LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        this type parameter needs to be `Sized`
    |
 note: required by a bound in `bar`
-  --> $DIR/unsized-bare-typaram.rs:1:8
+  --> $DIR/unsized-bare-typaram.rs:1:11
    |
 LL | fn bar<T: Sized>() { }
-   |        ^ required by this bound in `bar`
+   |           ^^^^^ required by this bound in `bar`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo<T: ?Sized>() { bar::<T>() }

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -6,11 +6,11 @@ LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-enum.rs:4:10
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   |          ^ required by this bound in `Foo`
+   |          ^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: you could relax the implicit `Sized` bound on `U` if it were used through indirection like `&U` or `Box<U>`
   --> $DIR/unsized-enum.rs:4:10
    |

--- a/tests/ui/unsized/unsized-enum.stderr
+++ b/tests/ui/unsized/unsized-enum.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-enum.rs:4:10
    |
 LL | enum Foo<U> { FooSome(U), FooNone }
-   |          ^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: you could relax the implicit `Sized` bound on `U` if it were used through indirection like `&U` or `Box<U>`
   --> $DIR/unsized-enum.rs:4:10
    |

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |

--- a/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized> S5<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `S5`
+note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11
    |

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -6,11 +6,11 @@ LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         |
    |         this type parameter needs to be `Sized`
    |
-note: required by a bound in `Foo`
+note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-struct.rs:4:12
    |
 LL | struct Foo<T> { data: T }
-   |            ^ required by this bound in `Foo`
+   |            ^ required by the implicit `Sized` requirement on this bound in `Foo`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/unsized-struct.rs:4:12
    |
@@ -38,10 +38,10 @@ note: required because it appears within the type `Bar<T>`
 LL | struct Bar<T: ?Sized> { data: T }
    |        ^^^
 note: required by a bound in `is_sized`
-  --> $DIR/unsized-struct.rs:1:13
+  --> $DIR/unsized-struct.rs:1:15
    |
 LL | fn is_sized<T:Sized>() { }
-   |             ^ required by this bound in `is_sized`
+   |               ^^^^^ required by this bound in `is_sized`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }

--- a/tests/ui/unsized/unsized-struct.stderr
+++ b/tests/ui/unsized/unsized-struct.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `Foo`
   --> $DIR/unsized-struct.rs:4:12
    |
 LL | struct Foo<T> { data: T }
-   |            ^ required by the implicit `Sized` requirement on this bound in `Foo`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `Foo`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/unsized-struct.rs:4:12
    |

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this type parameter in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |

--- a/tests/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `S5`
+note: required by an implicit `Sized` bound in `S5`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |
 LL | struct S5<Y>(Y);
-   |           ^ required by this bound in `S5`
+   |           ^ required by the implicit `Sized` requirement on this bound in `S5`
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11
    |

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `T2`
+note: required by an implicit `Sized` bound in `T2`
   --> $DIR/unsized-trait-impl-trait-arg.rs:4:10
    |
 LL | trait T2<Z> {
-   |          ^ required by this bound in `T2`
+   |          ^ required by the implicit `Sized` requirement on this bound in `T2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T2<X> for S4<X> {

--- a/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/tests/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `T2`
   --> $DIR/unsized-trait-impl-trait-arg.rs:4:10
    |
 LL | trait T2<Z> {
-   |          ^ required by the implicit `Sized` requirement on this bound in `T2`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `T2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T2<X> for S4<X> {

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `f2`
   --> $DIR/unsized3.rs:10:7
    |
 LL | fn f2<X>(x: &X) {
-   |       ^ required by the implicit `Sized` requirement on this bound in `f2`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<X: ?Sized>(x: &X) {
@@ -33,7 +33,7 @@ note: required by an implicit `Sized` bound in `f4`
   --> $DIR/unsized3.rs:21:7
    |
 LL | fn f4<X: T>(x: &X) {
-   |       ^ required by the implicit `Sized` requirement on this bound in `f4`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized + T>(x: &X) {
@@ -63,7 +63,7 @@ note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
@@ -135,7 +135,7 @@ note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -6,11 +6,11 @@ LL | fn f1<X: ?Sized>(x: &X) {
 LL |     f2::<X>(x);
    |          ^ doesn't have a size known at compile-time
    |
-note: required by a bound in `f2`
+note: required by an implicit `Sized` bound in `f2`
   --> $DIR/unsized3.rs:10:7
    |
 LL | fn f2<X>(x: &X) {
-   |       ^ required by this bound in `f2`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<X: ?Sized>(x: &X) {
@@ -29,11 +29,11 @@ LL | fn f3<X: ?Sized + T>(x: &X) {
 LL |     f4::<X>(x);
    |          ^ doesn't have a size known at compile-time
    |
-note: required by a bound in `f4`
+note: required by an implicit `Sized` bound in `f4`
   --> $DIR/unsized3.rs:21:7
    |
 LL | fn f4<X: T>(x: &X) {
-   |       ^ required by this bound in `f4`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f4`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized + T>(x: &X) {
@@ -59,11 +59,11 @@ note: required because it appears within the type `S<X>`
    |
 LL | struct S<X: ?Sized> {
    |        ^
-note: required by a bound in `f5`
+note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
@@ -131,11 +131,11 @@ note: required because it appears within the type `S<X>`
 LL | struct S<X: ?Sized> {
    |        ^
    = note: required because it appears within the type `({integer}, S<X>)`
-note: required by a bound in `f5`
+note: required by an implicit `Sized` bound in `f5`
   --> $DIR/unsized3.rs:24:7
    |
 LL | fn f5<Y>(x: &Y) {}
-   |       ^ required by this bound in `f5`
+   |       ^ required by the implicit `Sized` requirement on this bound in `f5`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -10,7 +10,7 @@ note: required by an implicit `Sized` bound in `T1`
   --> $DIR/unsized7.rs:7:10
    |
 LL | trait T1<Z: T> {
-   |          ^ required by the implicit `Sized` requirement on this bound in `T1`
+   |          ^ required by the implicit `Sized` requirement on this type parameter in `T1`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized + T> T1<X> for S3<X> {

--- a/tests/ui/unsized/unsized7.stderr
+++ b/tests/ui/unsized/unsized7.stderr
@@ -6,11 +6,11 @@ LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      |
    |      this type parameter needs to be `Sized`
    |
-note: required by a bound in `T1`
+note: required by an implicit `Sized` bound in `T1`
   --> $DIR/unsized7.rs:7:10
    |
 LL | trait T1<Z: T> {
-   |          ^ required by this bound in `T1`
+   |          ^ required by the implicit `Sized` requirement on this bound in `T1`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized + T> T1<X> for S3<X> {

--- a/tests/ui/variance/variance-regions-unused-direct.stderr
+++ b/tests/ui/variance/variance-regions-unused-direct.stderr
@@ -1,16 +1,16 @@
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/variance-regions-unused-direct.rs:5:18
    |
 LL | struct Bivariant<'a>;
-   |                  ^^ unused parameter
+   |                  ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `'d` is never used
+error[E0392]: lifetime parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
    |
 LL | struct Struct<'a, 'd> {
-   |                   ^^ unused parameter
+   |                   ^^ unused lifetime parameter
    |
    = help: consider removing `'d`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/variance/variance-regions-unused-indirect.stderr
+++ b/tests/ui/variance/variance-regions-unused-indirect.stderr
@@ -21,19 +21,19 @@ LL | enum Bar<'a> {
 LL ~     Bar1(Box<Foo<'a>>)
    |
 
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:3:10
    |
 LL | enum Foo<'a> {
-   |          ^^ unused parameter
+   |          ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:8:10
    |
 LL | enum Bar<'a> {
-   |          ^^ unused parameter
+   |          ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/variance/variance-unused-region-param.stderr
+++ b/tests/ui/variance/variance-unused-region-param.stderr
@@ -1,16 +1,16 @@
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:3:19
    |
 LL | struct SomeStruct<'a> { x: u32 }
-   |                   ^^ unused parameter
+   |                   ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `'a` is never used
+error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
    |
 LL | enum SomeEnum<'a> { Nothing }
-   |               ^^ unused parameter
+   |               ^^ unused lifetime parameter
    |
    = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/variance/variance-unused-type-param.stderr
+++ b/tests/ui/variance/variance-unused-type-param.stderr
@@ -1,51 +1,51 @@
-error[E0392]: parameter `A` is never used
+error[E0392]: type parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:6:19
    |
 LL | struct SomeStruct<A> { x: u32 }
-   |                   ^ unused parameter
+   |                   ^ unused type parameter
    |
    = help: consider removing `A`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `A` to be a const parameter, use `const A: usize` instead
+   = help: if you intended `A` to be a const parameter, use `const A: /* Type */` instead
 
-error[E0392]: parameter `A` is never used
+error[E0392]: type parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
    |
 LL | enum SomeEnum<A> { Nothing }
-   |               ^ unused parameter
+   |               ^ unused type parameter
    |
    = help: consider removing `A`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `A` to be a const parameter, use `const A: usize` instead
+   = help: if you intended `A` to be a const parameter, use `const A: /* Type */` instead
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
    |
 LL | enum ListCell<T> {
-   |               ^ unused parameter
+   |               ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:19:19
    |
 LL | struct WithBounds<T: Sized> {}
-   |                   ^ unused parameter
+   |                   ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:22:24
    |
 LL | struct WithWhereBounds<T> where T: Sized {}
-   |                        ^ unused parameter
+   |                        ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: parameter `T` is never used
+error[E0392]: type parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:25:27
    |
 LL | struct WithOutlivesBounds<T: 'static> {}
-   |                           ^ unused parameter
+   |                           ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 

--- a/tests/ui/wf/hir-wf-canonicalized.stderr
+++ b/tests/ui/wf/hir-wf-canonicalized.stderr
@@ -29,11 +29,11 @@ LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Callback<Bar<'a, T>, for<'b, 'c, 'd> Output = ()> + 'static)`
-note: required by a bound in `Bar`
+note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/hir-wf-canonicalized.rs:9:16
    |
 LL | struct Bar<'a, T> {
-   |                ^ required by this bound in `Bar`
+   |                ^ required by the implicit `Sized` requirement on this bound in `Bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | struct Bar<'a, T: ?Sized> {

--- a/tests/ui/wf/hir-wf-canonicalized.stderr
+++ b/tests/ui/wf/hir-wf-canonicalized.stderr
@@ -33,7 +33,7 @@ note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/hir-wf-canonicalized.rs:9:16
    |
 LL | struct Bar<'a, T> {
-   |                ^ required by the implicit `Sized` requirement on this bound in `Bar`
+   |                ^ required by the implicit `Sized` requirement on this type parameter in `Bar`
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | struct Bar<'a, T: ?Sized> {

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -34,7 +34,7 @@ note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |
 LL | struct Vec<T> {
-   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this type parameter in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -30,11 +30,11 @@ LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
-note: required by a bound in `Vec`
+note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |
 LL | struct Vec<T> {
-   |            ^ required by this bound in `Vec`
+   |            ^ required by the implicit `Sized` requirement on this bound in `Vec`
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |

--- a/tests/ui/wf/wf-impl-self-type.stderr
+++ b/tests/ui/wf/wf-impl-self-type.stderr
@@ -5,7 +5,7 @@ LL | impl Foo for Option<[u8]> {}
    |              ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-note: required by a bound in `Option`
+note: required by an implicit `Sized` bound in `Option`
   --> $SRC_DIR/core/src/option.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -652,6 +652,7 @@ compiler-team = [
     "@davidtwco",
     "@estebank",
     "@oli-obk",
+    "@pnkfelix",
     "@wesleywiser",
     "@michaelwoerister",
 ]


### PR DESCRIPTION
Successful merges:

 - #119759 (Add FileCheck annotations to dataflow-const-prop tests)
 - #120323 (On E0277 be clearer about implicit `Sized` bounds on type params and assoc types)
 - #120473 (Only suggest removal of `as_*` and `to_` conversion methods on E0308)
 - #120520 (Some cleanups around diagnostic levels.)
 - #120540 (add test for try-block-in-match-arm)
 - #120547 (`#![feature(inline_const_pat)]` is no longer incomplete)
 - #120552 (Correctly check `never_type` feature gating)
 - #120555 (put pnkfelix (me) back on the review queue.)
 - #120556 (Improve the diagnostics for unused generic parameters)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119759,120323,120473,120520,120540,120547,120552,120555,120556)
<!-- homu-ignore:end -->