### PR TITLE
coverage: Use normal `edition:` headers in coverage tests

### DIFF
--- a/tests/coverage/bad_counter_ids.cov-map
+++ b/tests/coverage/bad_counter_ids.cov-map
@@ -1,81 +1,81 @@
 Function name: bad_counter_ids::eq_bad
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 23, 01, 02, 1f, 00, 03, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 24, 01, 02, 1f, 00, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 35, 1) to (start + 2, 31)
+- Code(Counter(0)) at (prev + 36, 1) to (start + 2, 31)
 - Code(Zero) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::eq_bad_message
-Raw bytes (21): 0x[01, 01, 01, 01, 00, 03, 01, 28, 01, 02, 0f, 02, 02, 20, 00, 2b, 00, 01, 01, 00, 02]
+Raw bytes (21): 0x[01, 01, 01, 01, 00, 03, 01, 29, 01, 02, 0f, 02, 02, 20, 00, 2b, 00, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Zero
 Number of file 0 mappings: 3
-- Code(Counter(0)) at (prev + 40, 1) to (start + 2, 15)
+- Code(Counter(0)) at (prev + 41, 1) to (start + 2, 15)
 - Code(Expression(0, Sub)) at (prev + 2, 32) to (start + 0, 43)
     = (c0 - Zero)
 - Code(Zero) at (prev + 1, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::eq_good
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0f, 01, 02, 1f, 05, 03, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 10, 01, 02, 1f, 05, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 15, 1) to (start + 2, 31)
+- Code(Counter(0)) at (prev + 16, 1) to (start + 2, 31)
 - Code(Counter(1)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::eq_good_message
-Raw bytes (19): 0x[01, 01, 00, 03, 01, 14, 01, 02, 0f, 00, 02, 20, 00, 2b, 05, 01, 01, 00, 02]
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 15, 01, 02, 0f, 00, 02, 20, 00, 2b, 05, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 3
-- Code(Counter(0)) at (prev + 20, 1) to (start + 2, 15)
+- Code(Counter(0)) at (prev + 21, 1) to (start + 2, 15)
 - Code(Zero) at (prev + 2, 32) to (start + 0, 43)
 - Code(Counter(1)) at (prev + 1, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::ne_bad
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 2d, 01, 02, 1f, 00, 03, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 2e, 01, 02, 1f, 00, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 45, 1) to (start + 2, 31)
+- Code(Counter(0)) at (prev + 46, 1) to (start + 2, 31)
 - Code(Zero) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::ne_bad_message
-Raw bytes (19): 0x[01, 01, 00, 03, 01, 32, 01, 02, 0f, 05, 02, 20, 00, 2b, 00, 01, 01, 00, 02]
+Raw bytes (19): 0x[01, 01, 00, 03, 01, 33, 01, 02, 0f, 05, 02, 20, 00, 2b, 00, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 3
-- Code(Counter(0)) at (prev + 50, 1) to (start + 2, 15)
+- Code(Counter(0)) at (prev + 51, 1) to (start + 2, 15)
 - Code(Counter(1)) at (prev + 2, 32) to (start + 0, 43)
 - Code(Zero) at (prev + 1, 1) to (start + 0, 2)
 
 Function name: bad_counter_ids::ne_good
-Raw bytes (16): 0x[01, 01, 01, 01, 00, 02, 01, 19, 01, 02, 1f, 02, 03, 01, 00, 02]
+Raw bytes (16): 0x[01, 01, 01, 01, 00, 02, 01, 1a, 01, 02, 1f, 02, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Zero
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 25, 1) to (start + 2, 31)
+- Code(Counter(0)) at (prev + 26, 1) to (start + 2, 31)
 - Code(Expression(0, Sub)) at (prev + 3, 1) to (start + 0, 2)
     = (c0 - Zero)
 
 Function name: bad_counter_ids::ne_good_message
-Raw bytes (21): 0x[01, 01, 01, 01, 00, 03, 01, 1e, 01, 02, 0f, 00, 02, 20, 00, 2b, 02, 01, 01, 00, 02]
+Raw bytes (21): 0x[01, 01, 01, 01, 00, 03, 01, 1f, 01, 02, 0f, 00, 02, 20, 00, 2b, 02, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Zero
 Number of file 0 mappings: 3
-- Code(Counter(0)) at (prev + 30, 1) to (start + 2, 15)
+- Code(Counter(0)) at (prev + 31, 1) to (start + 2, 15)
 - Code(Zero) at (prev + 2, 32) to (start + 0, 43)
 - Code(Expression(0, Sub)) at (prev + 1, 1) to (start + 0, 2)
     = (c0 - Zero)

--- a/tests/coverage/bad_counter_ids.coverage
+++ b/tests/coverage/bad_counter_ids.coverage
@@ -1,5 +1,6 @@
    LL|       |#![feature(coverage_attribute)]
-   LL|       |// compile-flags: --edition=2021 -Copt-level=0 -Zmir-opt-level=3
+   LL|       |// edition: 2021
+   LL|       |// compile-flags: -Copt-level=0 -Zmir-opt-level=3
    LL|       |
    LL|       |// Regression test for <https://github.com/rust-lang/rust/issues/117012>.
    LL|       |//

--- a/tests/coverage/bad_counter_ids.rs
+++ b/tests/coverage/bad_counter_ids.rs
@@ -1,5 +1,6 @@
 #![feature(coverage_attribute)]
-// compile-flags: --edition=2021 -Copt-level=0 -Zmir-opt-level=3
+// edition: 2021
+// compile-flags: -Copt-level=0 -Zmir-opt-level=3
 
 // Regression test for <https://github.com/rust-lang/rust/issues/117012>.
 //

--- a/tests/coverage/closure_macro.coverage
+++ b/tests/coverage/closure_macro.coverage
@@ -1,5 +1,5 @@
-   LL|       |// compile-flags: --edition=2018
    LL|       |#![feature(coverage_attribute)]
+   LL|       |// edition: 2018
    LL|       |
    LL|       |macro_rules! bail {
    LL|       |    ($msg:literal $(,)?) => {

--- a/tests/coverage/closure_macro.rs
+++ b/tests/coverage/closure_macro.rs
@@ -1,5 +1,5 @@
-// compile-flags: --edition=2018
 #![feature(coverage_attribute)]
+// edition: 2018
 
 macro_rules! bail {
     ($msg:literal $(,)?) => {

--- a/tests/coverage/fn_sig_into_try.coverage
+++ b/tests/coverage/fn_sig_into_try.coverage
@@ -1,5 +1,5 @@
    LL|       |#![feature(coverage_attribute)]
-   LL|       |// compile-flags: --edition=2021
+   LL|       |// edition: 2021
    LL|       |
    LL|       |// Regression test for inconsistent handling of function signature spans that
    LL|       |// are followed by code using the `?` operator.

--- a/tests/coverage/fn_sig_into_try.rs
+++ b/tests/coverage/fn_sig_into_try.rs
@@ -1,5 +1,5 @@
 #![feature(coverage_attribute)]
-// compile-flags: --edition=2021
+// edition: 2021
 
 // Regression test for inconsistent handling of function signature spans that
 // are followed by code using the `?` operator.

--- a/tests/coverage/issue-93054.cov-map
+++ b/tests/coverage/issue-93054.cov-map
@@ -1,24 +1,24 @@
 Function name: issue_93054::foo2 (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 01, 00, 1d]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 15, 01, 00, 1d]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 22, 1) to (start + 0, 29)
+- Code(Zero) at (prev + 21, 1) to (start + 0, 29)
 
 Function name: issue_93054::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 1e, 01, 00, 0d]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 1d, 01, 00, 0d]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 30, 1) to (start + 0, 13)
+- Code(Counter(0)) at (prev + 29, 1) to (start + 0, 13)
 
 Function name: issue_93054::make (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 1a, 01, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 19, 01, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 26, 1) to (start + 2, 2)
+- Code(Zero) at (prev + 25, 1) to (start + 2, 2)
 

--- a/tests/coverage/issue-93054.coverage
+++ b/tests/coverage/issue-93054.coverage
@@ -1,10 +1,9 @@
    LL|       |#![allow(dead_code, unreachable_code)]
+   LL|       |// edition: 2021
    LL|       |
    LL|       |// Regression test for #93054: Functions using uninhabited types often only have a single,
    LL|       |// unreachable basic block which doesn't get instrumented. This should not cause llvm-cov to fail.
    LL|       |// Since these kinds functions can't be invoked anyway, it's ok to not have coverage data for them.
-   LL|       |
-   LL|       |// compile-flags: --edition=2021
    LL|       |
    LL|       |enum Never {}
    LL|       |

--- a/tests/coverage/issue-93054.rs
+++ b/tests/coverage/issue-93054.rs
@@ -1,10 +1,9 @@
 #![allow(dead_code, unreachable_code)]
+// edition: 2021
 
 // Regression test for #93054: Functions using uninhabited types often only have a single,
 // unreachable basic block which doesn't get instrumented. This should not cause llvm-cov to fail.
 // Since these kinds functions can't be invoked anyway, it's ok to not have coverage data for them.
-
-// compile-flags: --edition=2021
 
 enum Never {}
 

--- a/tests/coverage/long_and_wide.coverage
+++ b/tests/coverage/long_and_wide.coverage
@@ -1,4 +1,4 @@
-   LL|       |// compile-flags: --edition=2021
+   LL|       |// edition: 2021
    LL|       |// ignore-tidy-linelength
    LL|       |
    LL|       |// This file deliberately contains line and column numbers larger than 127,

--- a/tests/coverage/long_and_wide.rs
+++ b/tests/coverage/long_and_wide.rs
@@ -1,4 +1,4 @@
-// compile-flags: --edition=2021
+// edition: 2021
 // ignore-tidy-linelength
 
 // This file deliberately contains line and column numbers larger than 127,

--- a/tests/coverage/sort_groups.coverage
+++ b/tests/coverage/sort_groups.coverage
@@ -1,4 +1,4 @@
-   LL|       |// compile-flags: --edition=2021
+   LL|       |// edition: 2021
    LL|       |
    LL|       |// Demonstrate that `sort_subviews.py` can sort instantiation groups into a
    LL|       |// predictable order, while preserving their heterogeneous contents.

--- a/tests/coverage/sort_groups.rs
+++ b/tests/coverage/sort_groups.rs
@@ -1,4 +1,4 @@
-// compile-flags: --edition=2021
+// edition: 2021
 
 // Demonstrate that `sort_subviews.py` can sort instantiation groups into a
 // predictable order, while preserving their heterogeneous contents.

--- a/tests/coverage/trivial.coverage
+++ b/tests/coverage/trivial.coverage
@@ -1,4 +1,4 @@
-   LL|       |// compile-flags: --edition=2021
+   LL|       |// edition: 2021
    LL|       |
    LL|      1|fn main() {}
 

--- a/tests/coverage/trivial.rs
+++ b/tests/coverage/trivial.rs
@@ -1,3 +1,3 @@
-// compile-flags: --edition=2021
+// edition: 2021
 
 fn main() {}

--- a/tests/coverage/unreachable.coverage
+++ b/tests/coverage/unreachable.coverage
@@ -1,6 +1,6 @@
    LL|       |#![feature(core_intrinsics)]
    LL|       |#![feature(coverage_attribute)]
-   LL|       |// compile-flags: --edition=2021
+   LL|       |// edition: 2021
    LL|       |
    LL|       |// <https://github.com/rust-lang/rust/issues/116171>
    LL|       |// If we instrument a function for coverage, but all of its counter-increment

--- a/tests/coverage/unreachable.rs
+++ b/tests/coverage/unreachable.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(coverage_attribute)]
-// compile-flags: --edition=2021
+// edition: 2021
 
 // <https://github.com/rust-lang/rust/issues/116171>
 // If we instrument a function for coverage, but all of its counter-increment


### PR DESCRIPTION
Some of these tests were originally written as part of a custom `run-make` test, so at that time they weren't able to use the normal compiletest header directive parser.

Now that they're properly integrated, there's no need for them to use `compile-flags` to specify the edition, since they can use `edition` instead.

In most cases the `.cov-map` snapshot isn't affected at all, but in a few cases we add or remove a line, which slightly disturbs the first line number in each instrumented function.
