### PR TITLE
Suggest changing type to const parameters if we encounter a type in the trait bound position

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -289,6 +289,9 @@ resolve_underscore_lifetime_name_cannot_be_used_here =
     `'_` cannot be used here
     .note = `'_` is a reserved lifetime name
 
+resolve_unexpected_res_change_ty_to_const_param_sugg =
+    you might have meant to write a const parameter here
+
 resolve_unreachable_label =
     use of unreachable label `{$name}`
     .label = unreachable label `{$name}`

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1,4 +1,4 @@
-use rustc_errors::codes::*;
+use rustc_errors::{codes::*, Applicability};
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_span::{
     symbol::{Ident, Symbol},
@@ -786,4 +786,17 @@ pub(crate) struct IsNotDirectlyImportable {
     #[label]
     pub(crate) span: Span,
     pub(crate) target: Ident,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion(
+    resolve_unexpected_res_change_ty_to_const_param_sugg,
+    code = "const ",
+    style = "verbose"
+)]
+pub(crate) struct UnexpectedResChangeTyToConstParamSugg {
+    #[primary_span]
+    pub span: Span,
+    #[applicability]
+    pub applicability: Applicability,
 }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -594,9 +594,9 @@ struct DiagnosticMetadata<'ast> {
     /// The current trait (used to suggest).
     current_item: Option<&'ast Item>,
 
-    /// When processing generics and encountering a type not found, suggest introducing a type
-    /// param.
-    currently_processing_generics: bool,
+    /// When processing generic arguments and encountering an unresolved ident not found,
+    /// suggest introducing a type or const param depending on the context.
+    currently_processing_generic_args: bool,
 
     /// The current enclosing (non-closure) function (used for better errors).
     current_function: Option<(FnKind<'ast>, Span)>,
@@ -1069,7 +1069,7 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
 
     fn visit_generic_arg(&mut self, arg: &'ast GenericArg) {
         debug!("visit_generic_arg({:?})", arg);
-        let prev = replace(&mut self.diagnostic_metadata.currently_processing_generics, true);
+        let prev = replace(&mut self.diagnostic_metadata.currently_processing_generic_args, true);
         match arg {
             GenericArg::Type(ref ty) => {
                 // We parse const arguments as path types as we cannot distinguish them during
@@ -1100,7 +1100,7 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
                                 },
                             );
 
-                            self.diagnostic_metadata.currently_processing_generics = prev;
+                            self.diagnostic_metadata.currently_processing_generic_args = prev;
                             return;
                         }
                     }
@@ -1113,7 +1113,7 @@ impl<'a: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast,
                 self.resolve_anon_const(ct, AnonConstKind::ConstArg(IsRepeatExpr::No))
             }
         }
-        self.diagnostic_metadata.currently_processing_generics = prev;
+        self.diagnostic_metadata.currently_processing_generic_args = prev;
     }
 
     fn visit_assoc_constraint(&mut self, constraint: &'ast AssocConstraint) {

--- a/tests/ui/resolve/change-ty-to-const-param-sugg-0.rs
+++ b/tests/ui/resolve/change-ty-to-const-param-sugg-0.rs
@@ -1,0 +1,10 @@
+fn make<N: u32>() {}
+//~^ ERROR expected trait, found builtin type `u32`
+//~| HELP you might have meant to write a const parameter here
+
+struct Array<N: usize>([bool; N]);
+//~^ ERROR expected trait, found builtin type `usize`
+//~| HELP you might have meant to write a const parameter here
+//~| ERROR expected value, found type parameter `N`
+
+fn main() {}

--- a/tests/ui/resolve/change-ty-to-const-param-sugg-0.stderr
+++ b/tests/ui/resolve/change-ty-to-const-param-sugg-0.stderr
@@ -1,0 +1,34 @@
+error[E0404]: expected trait, found builtin type `u32`
+  --> $DIR/change-ty-to-const-param-sugg-0.rs:1:12
+   |
+LL | fn make<N: u32>() {}
+   |            ^^^ not a trait
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | fn make<const N: u32>() {}
+   |         +++++
+
+error[E0404]: expected trait, found builtin type `usize`
+  --> $DIR/change-ty-to-const-param-sugg-0.rs:5:17
+   |
+LL | struct Array<N: usize>([bool; N]);
+   |                 ^^^^^ not a trait
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | struct Array<const N: usize>([bool; N]);
+   |              +++++
+
+error[E0423]: expected value, found type parameter `N`
+  --> $DIR/change-ty-to-const-param-sugg-0.rs:5:31
+   |
+LL | struct Array<N: usize>([bool; N]);
+   |              -                ^ not a value
+   |              |
+   |              found this type parameter
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0404, E0423.
+For more information about an error, try `rustc --explain E0404`.

--- a/tests/ui/resolve/change-ty-to-const-param-sugg-1.rs
+++ b/tests/ui/resolve/change-ty-to-const-param-sugg-1.rs
@@ -1,0 +1,24 @@
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy;
+
+struct Tagged<T: Tag, O: Options>;
+//~^ ERROR expected trait, found enum `Tag`
+//~| HELP you might have meant to write a const parameter here
+//~| ERROR expected trait, found struct `Options`
+//~| HELP you might have meant to write a const parameter here
+
+#[derive(PartialEq, Eq, ConstParamTy)]
+enum Tag {
+    One,
+    Two,
+}
+
+#[derive(PartialEq, Eq, ConstParamTy)]
+struct Options {
+    verbose: bool,
+    safe: bool,
+}
+
+fn main() {}

--- a/tests/ui/resolve/change-ty-to-const-param-sugg-1.stderr
+++ b/tests/ui/resolve/change-ty-to-const-param-sugg-1.stderr
@@ -1,0 +1,25 @@
+error[E0404]: expected trait, found enum `Tag`
+  --> $DIR/change-ty-to-const-param-sugg-1.rs:6:18
+   |
+LL | struct Tagged<T: Tag, O: Options>;
+   |                  ^^^ not a trait
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | struct Tagged<const T: Tag, O: Options>;
+   |               +++++
+
+error[E0404]: expected trait, found struct `Options`
+  --> $DIR/change-ty-to-const-param-sugg-1.rs:6:26
+   |
+LL | struct Tagged<T: Tag, O: Options>;
+   |                          ^^^^^^^ not a trait
+   |
+help: you might have meant to write a const parameter here
+   |
+LL | struct Tagged<T: Tag, const O: Options>;
+   |                       +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0404`.


### PR DESCRIPTION
The first commit is just drive-by cleanup.

Provide a structured suggestion if the user forgot to prefix a “const parameter” with `const`, e.g., in `struct Tagged<TAG: u64>;`. This happens to me from time to time. Maybe C++ devs are also prone to this mistake given template syntax looks like `template<typename T, uint32_t N>`.