### PR TITLE
miri: normalize struct tail in ABI compat check

### DIFF
--- a/src/tools/miri/tests/pass/issues/issue-miri-3282-struct-tail-normalize.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-3282-struct-tail-normalize.rs
@@ -1,0 +1,20 @@
+// regression test for an ICE: https://github.com/rust-lang/miri/issues/3282
+
+trait Id {
+    type Assoc: ?Sized;
+}
+
+impl<T: ?Sized> Id for T {
+    type Assoc = T;
+}
+
+#[repr(transparent)]
+struct Foo<T: ?Sized> {
+    field: <T as Id>::Assoc,
+}
+
+fn main() {
+    let x = unsafe { std::mem::transmute::<fn(&str), fn(&Foo<str>)>(|_| ()) };
+    let foo: &Foo<str> = unsafe { &*("uwu" as *const str as *const Foo<str>) };
+    x(foo);
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/miri/issues/3282
extracted from https://github.com/rust-lang/rust/pull/120354, see https://github.com/rust-lang/rust/pull/120354#discussion_r1469154220 for context

r? @RalfJung