### PR TITLE
std::thread::available_parallelism merging linux/android/freebsd version

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -153,6 +153,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             target_os = "hurd",
             target_os = "linux",
             target_os = "aix",
+            target_os = "freebsd",
             target_vendor = "apple",
             target_os = "cygwin",
         ) => {
@@ -163,9 +164,17 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             #[cfg(any(target_os = "android", target_os = "linux"))]
             {
                 quota = cgroups::quota().max(1);
-                let mut set: libc::cpu_set_t = unsafe { mem::zeroed() };
+            }
+
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
+            {
+                #[cfg(not(target_os = "freebsd"))]
+                type Cpuset = libc::cpu_set_t;
+                #[cfg(target_os = "freebsd")]
+                type Cpuset = libc::cpuset_t;
+                let mut set: Cpuset = unsafe { mem::zeroed() };
                 unsafe {
-                    if libc::sched_getaffinity(0, size_of::<libc::cpu_set_t>(), &mut set) == 0 {
+                    if libc::sched_getaffinity(0, mem::size_of::<Cpuset>(), &mut set) == 0 {
                         let count = libc::CPU_COUNT(&set) as usize;
                         let count = count.min(quota);
 
@@ -191,31 +200,11 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             }
         }
         any(
-           target_os = "freebsd",
            target_os = "dragonfly",
            target_os = "openbsd",
            target_os = "netbsd",
         ) => {
             use crate::ptr;
-
-            #[cfg(target_os = "freebsd")]
-            {
-                let mut set: libc::cpuset_t = unsafe { mem::zeroed() };
-                unsafe {
-                    if libc::cpuset_getaffinity(
-                        libc::CPU_LEVEL_WHICH,
-                        libc::CPU_WHICH_PID,
-                        -1,
-                        size_of::<libc::cpuset_t>(),
-                        &mut set,
-                    ) == 0 {
-                        let count = libc::CPU_COUNT(&set) as usize;
-                        if count > 0 {
-                            return Ok(NonZero::new_unchecked(count));
-                        }
-                    }
-                }
-            }
 
             #[cfg(target_os = "netbsd")]
             {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/120589)*
<!-- homu-ignore:end -->

FreeBSD 13.1 had introduced a sched cpu affinity compatibility layer with Linux. 13.0 and even 13.1 being EOL, we can simplify here.