### PR TITLE
Update Android in CI

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -395,7 +395,7 @@
 #metrics = false
 
 # Specify the location of the Android NDK. Used when targeting Android.
-#android-ndk = "/path/to/android-ndk-r25b"
+#android-ndk = "/path/to/android-ndk-r26d"
 
 # =============================================================================
 # General install configuration options

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -247,10 +247,8 @@ pub(crate) fn ndk_compiler(compiler: Language, triple: &str, ndk: &Path) -> Path
         triple.to_string()
     };
 
-    // API 19 is the earliest API level supported by NDK r25b but AArch64 and x86_64 support
-    // begins at API level 21.
-    let api_level =
-        if triple.contains("aarch64") || triple.contains("x86_64") { "21" } else { "19" };
+    // The earliest API supported by NDK r26d is 21.
+    let api_level = "21";
     let compiler = format!("{}{}-{}", triple_translated, api_level, compiler.clang());
     let host_tag = if cfg!(target_os = "macos") {
         // The NDK uses universal binaries, so this is correct even on ARM.
@@ -258,7 +256,7 @@ pub(crate) fn ndk_compiler(compiler: Language, triple: &str, ndk: &Path) -> Path
     } else if cfg!(target_os = "windows") {
         "windows-x86_64"
     } else {
-        // NDK r25b only has official releases for macOS, Windows and Linux.
+        // NDK r26d only has official releases for macOS, Windows and Linux.
         // Try the Linux directory everywhere else, on the assumption that the OS has an
         // emulation layer that can cope (e.g. BSDs).
         "linux-x86_64"

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -210,4 +210,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "the `wasm-component-ld` tool is now built as part of `build.extended` and can be a member of `build.tools`",
     },
+    ChangeInfo {
+        change_id: 120593,
+        severity: ChangeSeverity::Info,
+        summary: "Removed android-ndk r25b support in favor of android-ndk r26d.",
+    },
 ];

--- a/src/ci/docker/host-x86_64/arm-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/arm-android/Dockerfile
@@ -6,7 +6,7 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r25b-linux.zip
+    download_ndk android-ndk-r26d-linux.zip
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \

--- a/src/ci/docker/host-x86_64/arm-android/android-sdk.lock
+++ b/src/ci/docker/host-x86_64/arm-android/android-sdk.lock
@@ -1,6 +1,6 @@
 emulator emulator-linux-5264690.zip 48c1cda2bdf3095d9d9d5c010fbfb3d6d673e3ea
 patcher;v4 3534162-studio.sdk-patcher.zip 046699c5e2716ae11d77e0bad814f7f33fab261e
-platform-tools platform-tools_r28.0.2-linux.zip 46a4c02a9b8e4e2121eddf6025da3c979bf02e28
-platforms;android-18 android-18_r03.zip e6b09b3505754cbbeb4a5622008b907262ee91cb
-system-images;android-18;default;armeabi-v7a sys-img/android/armeabi-v7a-18_r05.zip 580b583720f7de671040d5917c8c9db0c7aa03fd
+platform-tools platform-tools_r34.0.5-linux.zip 96097475cf7b279fdd8f218f5d043ffe94104ec3
+platforms;android-21 android-21_r02.zip 53536556059bb29ae82f414fd2e14bc335a4eb4c
+system-images;android-21;default;armeabi-v7a sys-img/android/armeabi-v7a-21_r04.zip 8c606f81306564b65e41303d2603e4c42ded0d10
 tools sdk-tools-linux-4333796.zip 8c7c28554a32318461802c1291d76fccfafde054

--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -6,7 +6,7 @@ RUN sh /scripts/android-base-apt-get.sh
 # ndk
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_ndk android-ndk-r25b-linux.zip
+    download_ndk android-ndk-r26d-linux.zip
 
 # env
 ENV TARGETS=arm-linux-androideabi

--- a/src/ci/docker/scripts/android-start-emulator.sh
+++ b/src/ci/docker/scripts/android-start-emulator.sh
@@ -10,7 +10,7 @@ export SHELL=/bin/bash
 # the emulator date is set to unix epoch (in armeabi-v7a-18 image). Using
 # classic engine the emulator starts with the current date and the tests run
 # fine. If another image is used, this need to be evaluated again.
-nohup nohup emulator @armeabi-v7a-18 \
+nohup nohup emulator @armeabi-v7a-21 \
     -engine classic -no-window -partition-size 2047 0<&- &>/dev/null &
 
 exec "$@"


### PR DESCRIPTION
We are currently using a 10+ year old Android image, and it has caused trouble when working on #120326.

Our current NDK (25) only supports API 19+, so we were already out of spec. This PR:

1. Bumps the API used by the emulator in CI to 21, as per [NDK-26's release notes](https://github.com/android/ndk/wiki/Changelog-r26) deprecating 19 and 20 as targets.
2. Bumps the NDK to 26b

try-job: arm-android