### PR TITLE
rustc_monomorphize: fix outdated comment in partition

### DIFF
--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -156,7 +156,7 @@ where
         placed
     };
 
-    // Merge until we have at most `max_cgu_count` codegen units.
+    // Merge until we don't exceed the max CGU count.
     // `merge_codegen_units` is responsible for updating the CGU size
     // estimates.
     {


### PR DESCRIPTION
`max_cgu_count` was removed in https://github.com/rust-lang/rust/commit/51821515b3ccd7dd8f42ffd6a2eee536dcf7ddb0, but not comment (usage in `merge_codegen_units` was removed earlier).

r? @nnethercote 