### PR TITLE
fix #120603 by adding a check in default_read_buf

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -578,8 +578,13 @@ where
     F: FnOnce(&mut [u8]) -> Result<usize>,
 {
     let n = read(cursor.ensure_init().init_mut())?;
+    assert!(
+        n <= cursor.capacity(),
+        "read should not return more bytes than there is capacity for in the read buffer"
+    );
     unsafe {
-        // SAFETY: we initialised using `ensure_init` so there is no uninit data to advance to.
+        // SAFETY: we initialised using `ensure_init` so there is no uninit data to advance to
+        // and we have checked that the read amount is not over capacity (see #120603)
         cursor.advance(n);
     }
     Ok(())

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -1,6 +1,6 @@
 use super::{repeat, BorrowedBuf, Cursor, SeekFrom};
 use crate::cmp::{self, min};
-use crate::io::{self, IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut, DEFAULT_BUF_SIZE};
 use crate::io::{BufRead, BufReader, Read, Seek, Write};
 use crate::mem::MaybeUninit;
 use crate::ops::Deref;
@@ -666,5 +666,18 @@ fn read_buf_broken_read() {
         }
     }
 
-    BufReader::new(MalformedRead).read(&mut [0; 4]).unwrap();
+    let _ = BufReader::new(MalformedRead).fill_buf();
+}
+
+#[test]
+fn read_buf_full_read() {
+    struct FullRead;
+
+    impl Read for FullRead {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+    }
+
+    assert_eq!(BufReader::new(FullRead).fill_buf().unwrap().len(), DEFAULT_BUF_SIZE);
 }


### PR DESCRIPTION
Fixes #120603 by checking the returned read n is in-bounds of the cursor.

Interestingly, I noticed that `BorrowedBuf` side-steps this issue by using checked accesses. Maybe this can be switched to unchecked to mirror what BufReader does https://github.com/rust-lang/rust/blob/bf3c6c5bed498f41ad815641319a1ad9bcecb8e8/library/core/src/io/borrowed_buf.rs#L95