### PR TITLE
 Transforms match into an assignment statement

### DIFF
--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -85,6 +85,12 @@ impl SwitchTargets {
         self.values.push(value);
         self.targets.insert(self.targets.len() - 1, bb);
     }
+
+    /// Returns true if all targets (including the fallback target) are distinct.
+    #[inline]
+    pub fn is_distinct(&self) -> bool {
+        self.targets.iter().collect::<FxHashSet<_>>().len() == self.targets.len()
+    }
 }
 
 pub struct SwitchTargetsIter<'a> {

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -1,6 +1,6 @@
 use rustc_index::IndexVec;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{ParamEnv, Ty, TyCtxt};
+use rustc_middle::ty::{ParamEnv, ScalarInt, Ty, TyCtxt};
 use std::iter;
 
 use super::simplify::simplify_cfg;
@@ -38,6 +38,11 @@ impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
                 should_cleanup = true;
                 continue;
             }
+            if SimplifyToExp::default().simplify(tcx, &mut body.local_decls, bbs, bb_idx, param_env)
+            {
+                should_cleanup = true;
+                continue;
+            }
         }
 
         if should_cleanup {
@@ -47,8 +52,10 @@ impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
 }
 
 trait SimplifyMatch<'tcx> {
+    /// Simplifies a match statement, returning true if the simplification succeeds, false otherwise.
+    /// Generic code is written here, and we generally don't need a custom implementation.
     fn simplify(
-        &self,
+        &mut self,
         tcx: TyCtxt<'tcx>,
         local_decls: &mut IndexVec<Local, LocalDecl<'tcx>>,
         bbs: &mut IndexVec<BasicBlock, BasicBlockData<'tcx>>,
@@ -72,9 +79,7 @@ trait SimplifyMatch<'tcx> {
         let source_info = bbs[switch_bb_idx].terminator().source_info;
         let discr_local = local_decls.push(LocalDecl::new(discr_ty, source_info.span));
 
-        // We already checked that first and second are different blocks,
-        // and bb_idx has a different terminator from both of them.
-        let new_stmts = self.new_stmts(tcx, targets, param_env, bbs, discr_local.clone(), discr_ty);
+        let new_stmts = self.new_stmts(tcx, targets, param_env, bbs, discr_local, discr_ty);
         let (_, first) = targets.iter().next().unwrap();
         let (from, first) = bbs.pick2_mut(switch_bb_idx, first);
         from.statements
@@ -90,8 +95,11 @@ trait SimplifyMatch<'tcx> {
         true
     }
 
+    /// Check that the BBs to be simplified satisfies all distinct and
+    /// that the terminator are the same.
+    /// There are also conditions for different ways of simplification.
     fn can_simplify(
-        &self,
+        &mut self,
         tcx: TyCtxt<'tcx>,
         targets: &SwitchTargets,
         param_env: ParamEnv<'tcx>,
@@ -144,7 +152,7 @@ struct SimplifyToIf;
 /// ```
 impl<'tcx> SimplifyMatch<'tcx> for SimplifyToIf {
     fn can_simplify(
-        &self,
+        &mut self,
         tcx: TyCtxt<'tcx>,
         targets: &SwitchTargets,
         param_env: ParamEnv<'tcx>,
@@ -247,6 +255,214 @@ impl<'tcx> SimplifyMatch<'tcx> for SimplifyToIf {
                 _ => unreachable!(),
             }
         });
+        new_stmts.collect()
+    }
+}
+
+#[derive(Default)]
+struct SimplifyToExp {
+    transfrom_types: Vec<TransfromType>,
+}
+
+#[derive(Clone, Copy)]
+enum CompareType<'tcx, 'a> {
+    Same(&'a StatementKind<'tcx>),
+    Eq(&'a Place<'tcx>, Ty<'tcx>, ScalarInt),
+    Discr(&'a Place<'tcx>, Ty<'tcx>),
+}
+
+enum TransfromType {
+    Same,
+    Eq,
+    Discr,
+}
+
+impl From<CompareType<'_, '_>> for TransfromType {
+    fn from(compare_type: CompareType<'_, '_>) -> Self {
+        match compare_type {
+            CompareType::Same(_) => TransfromType::Same,
+            CompareType::Eq(_, _, _) => TransfromType::Eq,
+            CompareType::Discr(_, _) => TransfromType::Discr,
+        }
+    }
+}
+
+/// If we find that the value of match is the same as the assignment,
+/// merge a target block statements into the source block,
+/// using cast to transform different integer types.
+///
+/// For example:
+///
+/// ```ignore (MIR)
+/// bb0: {
+///     switchInt(_1) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
+/// }
+///
+/// bb1: {
+///     unreachable;
+/// }
+///
+/// bb2: {
+///     _0 = const 1_i16;
+///     goto -> bb5;
+/// }
+///
+/// bb3: {
+///     _0 = const 2_i16;
+///     goto -> bb5;
+/// }
+///
+/// bb4: {
+///     _0 = const 3_i16;
+///     goto -> bb5;
+/// }
+/// ```
+///
+/// into:
+///
+/// ```ignore (MIR)
+/// bb0: {
+///    _0 = _3 as i16 (IntToInt);
+///    goto -> bb5;
+/// }
+/// ```
+impl<'tcx> SimplifyMatch<'tcx> for SimplifyToExp {
+    fn can_simplify(
+        &mut self,
+        tcx: TyCtxt<'tcx>,
+        targets: &SwitchTargets,
+        param_env: ParamEnv<'tcx>,
+        bbs: &IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+    ) -> bool {
+        if targets.iter().len() < 2 || targets.iter().len() > 64 {
+            return false;
+        }
+        // We require that the possible target blocks all be distinct.
+        if !targets.is_distinct() {
+            return false;
+        }
+        if !bbs[targets.otherwise()].is_empty_unreachable() {
+            return false;
+        }
+        let mut target_iter = targets.iter();
+        let (first_val, first_target) = target_iter.next().unwrap();
+        let first_terminator_kind = &bbs[first_target].terminator().kind;
+        // Check that destinations are identical, and if not, then don't optimize this block
+        if !targets
+            .iter()
+            .all(|(_, other_target)| first_terminator_kind == &bbs[other_target].terminator().kind)
+        {
+            return false;
+        }
+
+        let first_stmts = &bbs[first_target].statements;
+        let (second_val, second_target) = target_iter.next().unwrap();
+        let second_stmts = &bbs[second_target].statements;
+        if first_stmts.len() != second_stmts.len() {
+            return false;
+        }
+
+        let mut compare_types = Vec::new();
+        for (f, s) in iter::zip(first_stmts, second_stmts) {
+            let compare_type = match (&f.kind, &s.kind) {
+                // If two statements are exactly the same, we can optimize.
+                (f_s, s_s) if f_s == s_s => CompareType::Same(f_s),
+
+                // If two statements are assignments with the match values to the same place, we can optimize.
+                (
+                    StatementKind::Assign(box (lhs_f, Rvalue::Use(Operand::Constant(f_c)))),
+                    StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(s_c)))),
+                ) if lhs_f == lhs_s
+                    && f_c.const_.ty() == s_c.const_.ty()
+                    && f_c.const_.ty().is_integral() =>
+                {
+                    match (
+                        f_c.const_.try_eval_scalar_int(tcx, param_env),
+                        s_c.const_.try_eval_scalar_int(tcx, param_env),
+                    ) {
+                        (Some(f), Some(s)) if f == s => CompareType::Eq(lhs_f, f_c.const_.ty(), f),
+                        (Some(f), Some(s))
+                            if Some(f) == ScalarInt::try_from_uint(first_val, f.size())
+                                && Some(s) == ScalarInt::try_from_uint(second_val, s.size()) =>
+                        {
+                            CompareType::Discr(lhs_f, f_c.const_.ty())
+                        }
+                        _ => return false,
+                    }
+                }
+
+                // Otherwise we cannot optimize. Try another block.
+                _ => return false,
+            };
+            compare_types.push(compare_type);
+        }
+
+        // All remaining BBs need to fulfill the same pattern as the two BBs from the previous step.
+        for (other_val, other_target) in target_iter {
+            let other_stmts = &bbs[other_target].statements;
+            if compare_types.len() != other_stmts.len() {
+                return false;
+            }
+            for (f, s) in iter::zip(&compare_types, other_stmts) {
+                match (*f, &s.kind) {
+                    (CompareType::Same(f_s), s_s) if f_s == s_s => {}
+                    (
+                        CompareType::Eq(lhs_f, f_ty, val),
+                        StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(s_c)))),
+                    ) if lhs_f == lhs_s
+                        && s_c.const_.ty() == f_ty
+                        && s_c.const_.try_eval_scalar_int(tcx, param_env) == Some(val) => {}
+                    (
+                        CompareType::Discr(lhs_f, f_ty),
+                        StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(s_c)))),
+                    ) if lhs_f == lhs_s && s_c.const_.ty() == f_ty => {
+                        let Some(f) = s_c.const_.try_eval_scalar_int(tcx, param_env) else {
+                            return false;
+                        };
+                        if Some(f) != ScalarInt::try_from_uint(other_val, f.size()) {
+                            return false;
+                        }
+                    }
+                    _ => return false,
+                }
+            }
+        }
+        self.transfrom_types = compare_types.into_iter().map(|c| c.into()).collect();
+        true
+    }
+
+    fn new_stmts(
+        &self,
+        _tcx: TyCtxt<'tcx>,
+        targets: &SwitchTargets,
+        _param_env: ParamEnv<'tcx>,
+        bbs: &IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+        discr_local: Local,
+        discr_ty: Ty<'tcx>,
+    ) -> Vec<Statement<'tcx>> {
+        let (_, first) = targets.iter().next().unwrap();
+        let first = &bbs[first];
+
+        let new_stmts =
+            iter::zip(&self.transfrom_types, &first.statements).map(|(t, s)| match (t, &s.kind) {
+                (TransfromType::Same, _) | (TransfromType::Eq, _) => (*s).clone(),
+                (
+                    TransfromType::Discr,
+                    StatementKind::Assign(box (lhs, Rvalue::Use(Operand::Constant(f_c)))),
+                ) => {
+                    let operand = Operand::Copy(Place::from(discr_local));
+                    let r_val = if f_c.const_.ty() == discr_ty {
+                        Rvalue::Use(operand)
+                    } else {
+                        Rvalue::Cast(CastKind::IntToInt, operand, f_c.const_.ty())
+                    };
+                    Statement {
+                        source_info: s.source_info,
+                        kind: StatementKind::Assign(Box::new((*lhs, r_val))),
+                    }
+                }
+                _ => unreachable!(),
+            });
         new_stmts.collect()
     }
 }

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -1,10 +1,115 @@
+use rustc_index::IndexVec;
 use rustc_middle::mir::*;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{ParamEnv, Ty, TyCtxt};
 use std::iter;
 
 use super::simplify::simplify_cfg;
 
 pub struct MatchBranchSimplification;
+
+impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
+    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        sess.mir_opt_level() >= 1
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let def_id = body.source.def_id();
+        let param_env = tcx.param_env_reveal_all_normalized(def_id);
+
+        let bbs = body.basic_blocks.as_mut();
+        let mut should_cleanup = false;
+        for bb_idx in bbs.indices() {
+            if !tcx.consider_optimizing(|| format!("MatchBranchSimplification {def_id:?} ")) {
+                continue;
+            }
+
+            match bbs[bb_idx].terminator().kind {
+                TerminatorKind::SwitchInt {
+                    discr: ref _discr @ (Operand::Copy(_) | Operand::Move(_)),
+                    ref targets,
+                    ..
+                    // We require that the possible target blocks don't contain this block.
+                } if !targets.all_targets().contains(&bb_idx) => {}
+                // Only optimize switch int statements
+                _ => continue,
+            };
+
+            if SimplifyToIf.simplify(tcx, &mut body.local_decls, bbs, bb_idx, param_env) {
+                should_cleanup = true;
+                continue;
+            }
+        }
+
+        if should_cleanup {
+            simplify_cfg(body);
+        }
+    }
+}
+
+trait SimplifyMatch<'tcx> {
+    fn simplify(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        local_decls: &mut IndexVec<Local, LocalDecl<'tcx>>,
+        bbs: &mut IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+        switch_bb_idx: BasicBlock,
+        param_env: ParamEnv<'tcx>,
+    ) -> bool {
+        let (discr, targets) = match bbs[switch_bb_idx].terminator().kind {
+            TerminatorKind::SwitchInt { ref discr, ref targets, .. } => (discr, targets),
+            _ => unreachable!(),
+        };
+
+        if !self.can_simplify(tcx, targets, param_env, bbs) {
+            return false;
+        }
+
+        // Take ownership of items now that we know we can optimize.
+        let discr = discr.clone();
+        let discr_ty = discr.ty(local_decls, tcx);
+
+        // Introduce a temporary for the discriminant value.
+        let source_info = bbs[switch_bb_idx].terminator().source_info;
+        let discr_local = local_decls.push(LocalDecl::new(discr_ty, source_info.span));
+
+        // We already checked that first and second are different blocks,
+        // and bb_idx has a different terminator from both of them.
+        let new_stmts = self.new_stmts(tcx, targets, param_env, bbs, discr_local.clone(), discr_ty);
+        let (_, first) = targets.iter().next().unwrap();
+        let (from, first) = bbs.pick2_mut(switch_bb_idx, first);
+        from.statements
+            .push(Statement { source_info, kind: StatementKind::StorageLive(discr_local) });
+        from.statements.push(Statement {
+            source_info,
+            kind: StatementKind::Assign(Box::new((Place::from(discr_local), Rvalue::Use(discr)))),
+        });
+        from.statements.extend(new_stmts);
+        from.statements
+            .push(Statement { source_info, kind: StatementKind::StorageDead(discr_local) });
+        from.terminator_mut().kind = first.terminator().kind.clone();
+        true
+    }
+
+    fn can_simplify(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        targets: &SwitchTargets,
+        param_env: ParamEnv<'tcx>,
+        bbs: &IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+    ) -> bool;
+
+    fn new_stmts(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        targets: &SwitchTargets,
+        param_env: ParamEnv<'tcx>,
+        bbs: &IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+        discr_local: Local,
+        discr_ty: Ty<'tcx>,
+    ) -> Vec<Statement<'tcx>>;
+}
+
+struct SimplifyToIf;
 
 /// If a source block is found that switches between two blocks that are exactly
 /// the same modulo const bool assignments (e.g., one assigns true another false
@@ -37,144 +142,111 @@ pub struct MatchBranchSimplification;
 ///    goto -> bb3;
 /// }
 /// ```
+impl<'tcx> SimplifyMatch<'tcx> for SimplifyToIf {
+    fn can_simplify(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        targets: &SwitchTargets,
+        param_env: ParamEnv<'tcx>,
+        bbs: &IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+    ) -> bool {
+        if targets.iter().len() != 1 {
+            return false;
+        }
+        // We require that the possible target blocks all be distinct.
+        let (_, first) = targets.iter().next().unwrap();
+        let second = targets.otherwise();
+        if first == second {
+            return false;
+        }
+        // Check that destinations are identical, and if not, then don't optimize this block
+        if bbs[first].terminator().kind != bbs[second].terminator().kind {
+            return false;
+        }
 
-impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() >= 1
+        // Check that blocks are assignments of consts to the same place or same statement,
+        // and match up 1-1, if not don't optimize this block.
+        let first_stmts = &bbs[first].statements;
+        let second_stmts = &bbs[second].statements;
+        if first_stmts.len() != second_stmts.len() {
+            return false;
+        }
+        for (f, s) in iter::zip(first_stmts, second_stmts) {
+            match (&f.kind, &s.kind) {
+                // If two statements are exactly the same, we can optimize.
+                (f_s, s_s) if f_s == s_s => {}
+
+                // If two statements are const bool assignments to the same place, we can optimize.
+                (
+                    StatementKind::Assign(box (lhs_f, Rvalue::Use(Operand::Constant(f_c)))),
+                    StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(s_c)))),
+                ) if lhs_f == lhs_s
+                    && f_c.const_.ty().is_bool()
+                    && s_c.const_.ty().is_bool()
+                    && f_c.const_.try_eval_bool(tcx, param_env).is_some()
+                    && s_c.const_.try_eval_bool(tcx, param_env).is_some() => {}
+
+                // Otherwise we cannot optimize. Try another block.
+                _ => return false,
+            }
+        }
+        true
     }
 
-    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        let def_id = body.source.def_id();
-        let param_env = tcx.param_env_reveal_all_normalized(def_id);
+    fn new_stmts(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        targets: &SwitchTargets,
+        param_env: ParamEnv<'tcx>,
+        bbs: &IndexVec<BasicBlock, BasicBlockData<'tcx>>,
+        discr_local: Local,
+        discr_ty: Ty<'tcx>,
+    ) -> Vec<Statement<'tcx>> {
+        let (val, first) = targets.iter().next().unwrap();
+        let second = targets.otherwise();
+        // We already checked that first and second are different blocks,
+        // and bb_idx has a different terminator from both of them.
+        let first = &bbs[first];
+        let second = &bbs[second];
 
-        let bbs = body.basic_blocks.as_mut();
-        let mut should_cleanup = false;
-        'outer: for bb_idx in bbs.indices() {
-            if !tcx.consider_optimizing(|| format!("MatchBranchSimplification {def_id:?} ")) {
-                continue;
-            }
+        let new_stmts = iter::zip(&first.statements, &second.statements).map(|(f, s)| {
+            match (&f.kind, &s.kind) {
+                (f_s, s_s) if f_s == s_s => (*f).clone(),
 
-            let (discr, val, first, second) = match bbs[bb_idx].terminator().kind {
-                TerminatorKind::SwitchInt {
-                    discr: ref discr @ (Operand::Copy(_) | Operand::Move(_)),
-                    ref targets,
-                    ..
-                } if targets.iter().len() == 1 => {
-                    let (value, target) = targets.iter().next().unwrap();
-                    // We require that this block and the two possible target blocks all be
-                    // distinct.
-                    if target == targets.otherwise()
-                        || bb_idx == target
-                        || bb_idx == targets.otherwise()
-                    {
-                        continue;
-                    }
-                    (discr, value, target, targets.otherwise())
-                }
-                // Only optimize switch int statements
-                _ => continue,
-            };
-
-            // Check that destinations are identical, and if not, then don't optimize this block
-            if bbs[first].terminator().kind != bbs[second].terminator().kind {
-                continue;
-            }
-
-            // Check that blocks are assignments of consts to the same place or same statement,
-            // and match up 1-1, if not don't optimize this block.
-            let first_stmts = &bbs[first].statements;
-            let scnd_stmts = &bbs[second].statements;
-            if first_stmts.len() != scnd_stmts.len() {
-                continue;
-            }
-            for (f, s) in iter::zip(first_stmts, scnd_stmts) {
-                match (&f.kind, &s.kind) {
-                    // If two statements are exactly the same, we can optimize.
-                    (f_s, s_s) if f_s == s_s => {}
-
-                    // If two statements are const bool assignments to the same place, we can optimize.
-                    (
-                        StatementKind::Assign(box (lhs_f, Rvalue::Use(Operand::Constant(f_c)))),
-                        StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(s_c)))),
-                    ) if lhs_f == lhs_s
-                        && f_c.const_.ty().is_bool()
-                        && s_c.const_.ty().is_bool()
-                        && f_c.const_.try_eval_bool(tcx, param_env).is_some()
-                        && s_c.const_.try_eval_bool(tcx, param_env).is_some() => {}
-
-                    // Otherwise we cannot optimize. Try another block.
-                    _ => continue 'outer,
-                }
-            }
-            // Take ownership of items now that we know we can optimize.
-            let discr = discr.clone();
-            let discr_ty = discr.ty(&body.local_decls, tcx);
-
-            // Introduce a temporary for the discriminant value.
-            let source_info = bbs[bb_idx].terminator().source_info;
-            let discr_local = body.local_decls.push(LocalDecl::new(discr_ty, source_info.span));
-
-            // We already checked that first and second are different blocks,
-            // and bb_idx has a different terminator from both of them.
-            let (from, first, second) = bbs.pick3_mut(bb_idx, first, second);
-
-            let new_stmts = iter::zip(&first.statements, &second.statements).map(|(f, s)| {
-                match (&f.kind, &s.kind) {
-                    (f_s, s_s) if f_s == s_s => (*f).clone(),
-
-                    (
-                        StatementKind::Assign(box (lhs, Rvalue::Use(Operand::Constant(f_c)))),
-                        StatementKind::Assign(box (_, Rvalue::Use(Operand::Constant(s_c)))),
-                    ) => {
-                        // From earlier loop we know that we are dealing with bool constants only:
-                        let f_b = f_c.const_.try_eval_bool(tcx, param_env).unwrap();
-                        let s_b = s_c.const_.try_eval_bool(tcx, param_env).unwrap();
-                        if f_b == s_b {
-                            // Same value in both blocks. Use statement as is.
-                            (*f).clone()
-                        } else {
-                            // Different value between blocks. Make value conditional on switch condition.
-                            let size = tcx.layout_of(param_env.and(discr_ty)).unwrap().size;
-                            let const_cmp = Operand::const_from_scalar(
-                                tcx,
-                                discr_ty,
-                                rustc_const_eval::interpret::Scalar::from_uint(val, size),
-                                rustc_span::DUMMY_SP,
-                            );
-                            let op = if f_b { BinOp::Eq } else { BinOp::Ne };
-                            let rhs = Rvalue::BinaryOp(
-                                op,
-                                Box::new((Operand::Copy(Place::from(discr_local)), const_cmp)),
-                            );
-                            Statement {
-                                source_info: f.source_info,
-                                kind: StatementKind::Assign(Box::new((*lhs, rhs))),
-                            }
+                (
+                    StatementKind::Assign(box (lhs, Rvalue::Use(Operand::Constant(f_c)))),
+                    StatementKind::Assign(box (_, Rvalue::Use(Operand::Constant(s_c)))),
+                ) => {
+                    // From earlier loop we know that we are dealing with bool constants only:
+                    let f_b = f_c.const_.try_eval_bool(tcx, param_env).unwrap();
+                    let s_b = s_c.const_.try_eval_bool(tcx, param_env).unwrap();
+                    if f_b == s_b {
+                        // Same value in both blocks. Use statement as is.
+                        (*f).clone()
+                    } else {
+                        // Different value between blocks. Make value conditional on switch condition.
+                        let size = tcx.layout_of(param_env.and(discr_ty)).unwrap().size;
+                        let const_cmp = Operand::const_from_scalar(
+                            tcx,
+                            discr_ty,
+                            rustc_const_eval::interpret::Scalar::from_uint(val, size),
+                            rustc_span::DUMMY_SP,
+                        );
+                        let op = if f_b { BinOp::Eq } else { BinOp::Ne };
+                        let rhs = Rvalue::BinaryOp(
+                            op,
+                            Box::new((Operand::Copy(Place::from(discr_local)), const_cmp)),
+                        );
+                        Statement {
+                            source_info: f.source_info,
+                            kind: StatementKind::Assign(Box::new((*lhs, rhs))),
                         }
                     }
-
-                    _ => unreachable!(),
                 }
-            });
 
-            from.statements
-                .push(Statement { source_info, kind: StatementKind::StorageLive(discr_local) });
-            from.statements.push(Statement {
-                source_info,
-                kind: StatementKind::Assign(Box::new((
-                    Place::from(discr_local),
-                    Rvalue::Use(discr),
-                ))),
-            });
-            from.statements.extend(new_stmts);
-            from.statements
-                .push(Statement { source_info, kind: StatementKind::StorageDead(discr_local) });
-            from.terminator_mut().kind = first.terminator().kind.clone();
-            should_cleanup = true;
-        }
-
-        if should_cleanup {
-            simplify_cfg(body);
-        }
+                _ => unreachable!(),
+            }
+        });
+        new_stmts.collect()
     }
 }

--- a/tests/codegen/match-optimized.rs
+++ b/tests/codegen/match-optimized.rs
@@ -26,12 +26,12 @@ pub fn exhaustive_match(e: E) -> u8 {
 // CHECK-NEXT: store i8 1, ptr %_0, align 1
 // CHECK-NEXT: br label %[[EXIT]]
 // CHECK: [[C]]:
-// CHECK-NEXT: store i8 2, ptr %_0, align 1
+// CHECK-NEXT: store i8 3, ptr %_0, align 1
 // CHECK-NEXT: br label %[[EXIT]]
     match e {
         E::A => 0,
         E::B => 1,
-        E::C => 2,
+        E::C => 3,
     }
 }
 

--- a/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
@@ -1,0 +1,42 @@
+- // MIR for `match_i128_u128` before MatchBranchSimplification
++ // MIR for `match_i128_u128` after MatchBranchSimplification
+  
+  fn match_i128_u128(_1: EnumAi128) -> u128 {
+      debug i => _1;
+      let mut _0: u128;
+      let mut _2: i128;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const core::num::<impl u128>::MAX;
+          goto -> bb6;
+      }
+  
+      bb3: {
+          _0 = const 1_u128;
+          goto -> bb6;
+      }
+  
+      bb4: {
+          _0 = const 2_u128;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _0 = const 3_u128;
+          goto -> bb6;
+      }
+  
+      bb6: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
@@ -5,37 +5,42 @@
       debug i => _1;
       let mut _0: u128;
       let mut _2: i128;
++     let mut _3: i128;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const core::num::<impl u128>::MAX;
-          goto -> bb6;
-      }
-  
-      bb3: {
-          _0 = const 1_u128;
-          goto -> bb6;
-      }
-  
-      bb4: {
-          _0 = const 2_u128;
-          goto -> bb6;
-      }
-  
-      bb5: {
-          _0 = const 3_u128;
-          goto -> bb6;
-      }
-  
-      bb6: {
+-         switchInt(move _2) -> [1: bb3, 2: bb4, 3: bb5, 340282366920938463463374607431768211455: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const core::num::<impl u128>::MAX;
+-         goto -> bb6;
+-     }
+- 
+-     bb3: {
+-         _0 = const 1_u128;
+-         goto -> bb6;
+-     }
+- 
+-     bb4: {
+-         _0 = const 2_u128;
+-         goto -> bb6;
+-     }
+- 
+-     bb5: {
+-         _0 = const 3_u128;
+-         goto -> bb6;
+-     }
+- 
+-     bb6: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as u128 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_i16_i8` before MatchBranchSimplification
++ // MIR for `match_i16_i8` after MatchBranchSimplification
+  
+  fn match_i16_i8(_1: EnumAi16) -> i8 {
+      debug i => _1;
+      let mut _0: i8;
+      let mut _2: i16;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [65535: bb3, 2: bb4, 65533: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const -3_i8;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const -1_i8;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i8;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
@@ -5,32 +5,37 @@
       debug i => _1;
       let mut _0: i8;
       let mut _2: i16;
++     let mut _3: i16;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [65535: bb3, 2: bb4, 65533: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const -3_i8;
-          goto -> bb5;
-      }
-  
-      bb3: {
-          _0 = const -1_i8;
-          goto -> bb5;
-      }
-  
-      bb4: {
-          _0 = const 2_i8;
-          goto -> bb5;
-      }
-  
-      bb5: {
+-         switchInt(move _2) -> [65535: bb3, 2: bb4, 65533: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const -3_i8;
+-         goto -> bb5;
+-     }
+- 
+-     bb3: {
+-         _0 = const -1_i8;
+-         goto -> bb5;
+-     }
+- 
+-     bb4: {
+-         _0 = const 2_i8;
+-         goto -> bb5;
+-     }
+- 
+-     bb5: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as i8 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_i8_i16` before MatchBranchSimplification
++ // MIR for `match_i8_i16` after MatchBranchSimplification
+  
+  fn match_i8_i16(_1: EnumAi8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+      let mut _2: i8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const -3_i16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const -1_i16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i16;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
@@ -5,32 +5,37 @@
       debug i => _1;
       let mut _0: i16;
       let mut _2: i8;
++     let mut _3: i8;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const -3_i16;
-          goto -> bb5;
-      }
-  
-      bb3: {
-          _0 = const -1_i16;
-          goto -> bb5;
-      }
-  
-      bb4: {
-          _0 = const 2_i16;
-          goto -> bb5;
-      }
-  
-      bb5: {
+-         switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const -3_i16;
+-         goto -> bb5;
+-     }
+- 
+-     bb3: {
+-         _0 = const -1_i16;
+-         goto -> bb5;
+-     }
+- 
+-     bb4: {
+-         _0 = const 2_i16;
+-         goto -> bb5;
+-     }
+- 
+-     bb5: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as i16 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_i8_i16_failed.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_i8_i16_failed` before MatchBranchSimplification
++ // MIR for `match_i8_i16_failed` after MatchBranchSimplification
+  
+  fn match_i8_i16_failed(_1: EnumAi8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+      let mut _2: i8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [255: bb3, 2: bb4, 253: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 3_i16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const -1_i16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_i16;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
@@ -1,0 +1,32 @@
+- // MIR for `match_u8_i16` before MatchBranchSimplification
++ // MIR for `match_u8_i16` after MatchBranchSimplification
+  
+  fn match_u8_i16(_1: EnumAu8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+      let mut _2: u8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 2_i16;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _0 = const 1_i16;
+          goto -> bb4;
+      }
+  
+      bb4: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
@@ -5,27 +5,32 @@
       debug i => _1;
       let mut _0: i16;
       let mut _2: u8;
++     let mut _3: u8;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const 2_i16;
-          goto -> bb4;
-      }
-  
-      bb3: {
-          _0 = const 1_i16;
-          goto -> bb4;
-      }
-  
-      bb4: {
+-         switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const 2_i16;
+-         goto -> bb4;
+-     }
+- 
+-     bb3: {
+-         _0 = const 1_i16;
+-         goto -> bb4;
+-     }
+- 
+-     bb4: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as i16 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16_2.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16_2.MatchBranchSimplification.diff
@@ -1,0 +1,26 @@
+- // MIR for `match_u8_i16_2` before MatchBranchSimplification
++ // MIR for `match_u8_i16_2` after MatchBranchSimplification
+  
+  fn match_u8_i16_2(_1: EnumAu8) -> i16 {
+      let mut _0: i16;
+      let mut _2: u8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(_2) -> [1: bb3, 2: bb1, otherwise: bb2];
+      }
+  
+      bb1: {
+          _0 = const 2_i16;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          unreachable;
+      }
+  
+      bb3: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16_failed.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16_failed.MatchBranchSimplification.diff
@@ -1,0 +1,32 @@
+- // MIR for `match_u8_i16_failed` before MatchBranchSimplification
++ // MIR for `match_u8_i16_failed` after MatchBranchSimplification
+  
+  fn match_u8_i16_failed(_1: EnumAu8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+      let mut _2: u8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [1: bb3, 2: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 3_i16;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _0 = const 1_i16;
+          goto -> bb4;
+      }
+  
+      bb4: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i16_fallback.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i16_fallback.MatchBranchSimplification.diff
@@ -1,0 +1,31 @@
+- // MIR for `match_u8_i16_fallback` before MatchBranchSimplification
++ // MIR for `match_u8_i16_fallback` after MatchBranchSimplification
+  
+  fn match_u8_i16_fallback(_1: u8) -> i16 {
+      debug i => _1;
+      let mut _0: i16;
+  
+      bb0: {
+          switchInt(_1) -> [1: bb2, 2: bb3, otherwise: bb1];
+      }
+  
+      bb1: {
+          _0 = const 3_i16;
+          goto -> bb4;
+      }
+  
+      bb2: {
+          _0 = const 1_i16;
+          goto -> bb4;
+      }
+  
+      bb3: {
+          _0 = const 2_i16;
+          goto -> bb4;
+      }
+  
+      bb4: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_u8_u16` before MatchBranchSimplification
++ // MIR for `match_u8_u16` after MatchBranchSimplification
+  
+  fn match_u8_u16(_1: EnumBu8) -> u16 {
+      debug i => _1;
+      let mut _0: u16;
+      let mut _2: u8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(move _2) -> [1: bb3, 2: bb4, 5: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          unreachable;
+      }
+  
+      bb2: {
+          _0 = const 5_u16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const 1_u16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_u16;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
@@ -5,32 +5,37 @@
       debug i => _1;
       let mut _0: u16;
       let mut _2: u8;
++     let mut _3: u8;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [1: bb3, 2: bb4, 5: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const 5_u16;
-          goto -> bb5;
-      }
-  
-      bb3: {
-          _0 = const 1_u16;
-          goto -> bb5;
-      }
-  
-      bb4: {
-          _0 = const 2_u16;
-          goto -> bb5;
-      }
-  
-      bb5: {
+-         switchInt(move _2) -> [1: bb3, 2: bb4, 5: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const 5_u16;
+-         goto -> bb5;
+-     }
+- 
+-     bb3: {
+-         _0 = const 1_u16;
+-         goto -> bb5;
+-     }
+- 
+-     bb4: {
+-         _0 = const 2_u16;
+-         goto -> bb5;
+-     }
+- 
+-     bb5: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as u16 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }

--- a/tests/mir-opt/matches_reduce_branches.match_u8_u16_2.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_u16_2.MatchBranchSimplification.diff
@@ -1,0 +1,37 @@
+- // MIR for `match_u8_u16_2` before MatchBranchSimplification
++ // MIR for `match_u8_u16_2` after MatchBranchSimplification
+  
+  fn match_u8_u16_2(_1: EnumBu8) -> i16 {
+      let mut _0: i16;
+      let mut _2: u8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+          switchInt(_2) -> [1: bb1, 2: bb2, 5: bb3, otherwise: bb4];
+      }
+  
+      bb1: {
+          _0 = const 1_i16;
+          goto -> bb5;
+      }
+  
+      bb2: {
+          _0 = const 2_i16;
+          goto -> bb5;
+      }
+  
+      bb3: {
+          _0 = const 5_i16;
+          _0 = const 5_i16;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          unreachable;
+      }
+  
+      bb5: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -75,7 +75,9 @@ enum EnumAu8 {
 // EMIT_MIR matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
 fn match_u8_i16(i: EnumAu8) -> i16 {
     // CHECK-LABEL: fn match_u8_i16(
-    // CHECK: switchInt
+    // CHECK-NOT: switchInt
+    // CHECK: _0 = _3 as i16 (IntToInt);
+    // CHECH: return
     match i {
         EnumAu8::A => 1,
         EnumAu8::B => 2,
@@ -144,7 +146,9 @@ enum EnumBu8 {
 // EMIT_MIR matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
 fn match_u8_u16(i: EnumBu8) -> u16 {
     // CHECK-LABEL: fn match_u8_u16(
-    // CHECK: switchInt
+    // CHECK-NOT: switchInt
+    // CHECK: _0 = _3 as u16 (IntToInt);
+    // CHECH: return
     match i {
         EnumBu8::A => 1,
         EnumBu8::B => 2,
@@ -248,7 +252,9 @@ enum EnumAi128 {
 // EMIT_MIR matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
 fn match_i128_u128(i: EnumAi128) -> u128 {
     // CHECK-LABEL: fn match_i128_u128(
-    // CHECK: switchInt
+    // CHECK-NOT: switchInt
+    // CHECK: _0 = _3 as u128 (IntToInt);
+    // CHECH: return
     match i {
         EnumAi128::A => 1,
         EnumAi128::B => 2,

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -1,18 +1,28 @@
-// skip-filecheck
 //@ unit-test: MatchBranchSimplification
 
+#![feature(repr128)]
+#![feature(core_intrinsics)]
+#![feature(custom_mir)]
+
+use std::intrinsics::mir::*;
 
 // EMIT_MIR matches_reduce_branches.foo.MatchBranchSimplification.diff
-// EMIT_MIR matches_reduce_branches.bar.MatchBranchSimplification.diff
-// EMIT_MIR matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
-
 fn foo(bar: Option<()>) {
+    // CHECK-LABEL: fn foo(
+    // CHECK: = Eq(
+    // CHECK: switchInt
+    // CHECK-NOT: switchInt
     if matches!(bar, None) {
         ()
     }
 }
 
+// EMIT_MIR matches_reduce_branches.bar.MatchBranchSimplification.diff
 fn bar(i: i32) -> (bool, bool, bool, bool) {
+    // CHECK-LABEL: fn bar(
+    // CHECK: = Ne(
+    // CHECK: = Eq(
+    // CHECK-NOT: switchInt
     let a;
     let b;
     let c;
@@ -38,7 +48,10 @@ fn bar(i: i32) -> (bool, bool, bool, bool) {
     (a, b, c, d)
 }
 
+// EMIT_MIR matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
 fn match_nested_if() -> bool {
+    // CHECK-LABEL: fn match_nested_if(
+    // CHECK-NOT: switchInt
     let val = match () {
         () if if if if true { true } else { false } { true } else { false } {
             true
@@ -53,9 +66,211 @@ fn match_nested_if() -> bool {
     val
 }
 
+#[repr(u8)]
+enum EnumAu8 {
+    A = 1,
+    B = 2,
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_i16.MatchBranchSimplification.diff
+fn match_u8_i16(i: EnumAu8) -> i16 {
+    // CHECK-LABEL: fn match_u8_i16(
+    // CHECK: switchInt
+    match i {
+        EnumAu8::A => 1,
+        EnumAu8::B => 2,
+    }
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_i16_2.MatchBranchSimplification.diff
+// Check for different instruction lengths
+#[custom_mir(dialect = "built")]
+fn match_u8_i16_2(i: EnumAu8) -> i16 {
+    // CHECK-LABEL: fn match_u8_i16_2(
+    // CHECK: switchInt
+    mir!(
+        {
+            let a = Discriminant(i);
+            match a {
+                1 => bb1,
+                2 => bb2,
+                _ => unreachable_bb,
+            }
+        }
+        bb1 = {
+            Goto(ret)
+        }
+        bb2 = {
+            RET = 2;
+            Goto(ret)
+        }
+        unreachable_bb = {
+            Unreachable()
+        }
+        ret = {
+            Return()
+        }
+    )
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_i16_failed.MatchBranchSimplification.diff
+fn match_u8_i16_failed(i: EnumAu8) -> i16 {
+    // CHECK-LABEL: fn match_u8_i16_failed(
+    // CHECK: switchInt
+    match i {
+        EnumAu8::A => 1,
+        EnumAu8::B => 3,
+    }
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_i16_fallback.MatchBranchSimplification.diff
+fn match_u8_i16_fallback(i: u8) -> i16 {
+    // CHECK-LABEL: fn match_u8_i16_fallback(
+    // CHECK: switchInt
+    match i {
+        1 => 1,
+        2 => 2,
+        _ => 3,
+    }
+}
+
+#[repr(u8)]
+enum EnumBu8 {
+    A = 1,
+    B = 2,
+    C = 5,
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_u16.MatchBranchSimplification.diff
+fn match_u8_u16(i: EnumBu8) -> u16 {
+    // CHECK-LABEL: fn match_u8_u16(
+    // CHECK: switchInt
+    match i {
+        EnumBu8::A => 1,
+        EnumBu8::B => 2,
+        EnumBu8::C => 5,
+    }
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_u16_2.MatchBranchSimplification.diff
+// Check for different instruction lengths
+#[custom_mir(dialect = "built")]
+fn match_u8_u16_2(i: EnumBu8) -> i16 {
+    // CHECK-LABEL: fn match_u8_u16_2(
+    // CHECK: switchInt
+    mir!(
+        {
+            let a = Discriminant(i);
+            match a {
+                1 => bb1,
+                2 => bb2,
+                5 => bb5,
+                _ => unreachable_bb,
+            }
+        }
+        bb1 = {
+            RET = 1;
+            Goto(ret)
+        }
+        bb2 = {
+            RET = 2;
+            Goto(ret)
+        }
+        bb5 = {
+            RET = 5;
+            RET = 5;
+            Goto(ret)
+        }
+        unreachable_bb = {
+            Unreachable()
+        }
+        ret = {
+            Return()
+        }
+    )
+}
+
+#[repr(i8)]
+enum EnumAi8 {
+    A = -1,
+    B = 2,
+    C = -3,
+}
+
+// EMIT_MIR matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
+fn match_i8_i16(i: EnumAi8) -> i16 {
+    // CHECK-LABEL: fn match_i8_i16(
+    // CHECK: switchInt
+    match i {
+        EnumAi8::A => -1,
+        EnumAi8::B => 2,
+        EnumAi8::C => -3,
+    }
+}
+
+// EMIT_MIR matches_reduce_branches.match_i8_i16_failed.MatchBranchSimplification.diff
+fn match_i8_i16_failed(i: EnumAi8) -> i16 {
+    // CHECK-LABEL: fn match_i8_i16_failed(
+    // CHECK: switchInt
+    match i {
+        EnumAi8::A => -1,
+        EnumAi8::B => 2,
+        EnumAi8::C => 3,
+    }
+}
+
+#[repr(i16)]
+enum EnumAi16 {
+    A = -1,
+    B = 2,
+    C = -3,
+}
+
+// EMIT_MIR matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
+fn match_i16_i8(i: EnumAi16) -> i8 {
+    // CHECK-LABEL: fn match_i16_i8(
+    // CHECK: switchInt
+    match i {
+        EnumAi16::A => -1,
+        EnumAi16::B => 2,
+        EnumAi16::C => -3,
+    }
+}
+
+#[repr(i128)]
+enum EnumAi128 {
+    A = 1,
+    B = 2,
+    C = 3,
+    D = -1,
+}
+
+// EMIT_MIR matches_reduce_branches.match_i128_u128.MatchBranchSimplification.diff
+fn match_i128_u128(i: EnumAi128) -> u128 {
+    // CHECK-LABEL: fn match_i128_u128(
+    // CHECK: switchInt
+    match i {
+        EnumAi128::A => 1,
+        EnumAi128::B => 2,
+        EnumAi128::C => 3,
+        EnumAi128::D => u128::MAX,
+    }
+}
+
 fn main() {
     let _ = foo(None);
     let _ = foo(Some(()));
     let _ = bar(0);
     let _ = match_nested_if();
+    let _ = match_u8_i16(EnumAu8::A);
+    let _ = match_u8_i16_2(EnumAu8::A);
+    let _ = match_u8_i16_failed(EnumAu8::A);
+    let _ = match_u8_i16_fallback(1);
+    let _ = match_u8_u16(EnumBu8::A);
+    let _ = match_u8_u16_2(EnumBu8::A);
+    let _ = match_i8_i16(EnumAi8::A);
+    let _ = match_i8_i16_failed(EnumAi8::A);
+    let _ = match_i8_i16(EnumAi8::A);
+    let _ = match_i16_i8(EnumAi16::A);
+    let _ = match_i128_u128(EnumAi128::A);
 }

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -204,7 +204,9 @@ enum EnumAi8 {
 // EMIT_MIR matches_reduce_branches.match_i8_i16.MatchBranchSimplification.diff
 fn match_i8_i16(i: EnumAi8) -> i16 {
     // CHECK-LABEL: fn match_i8_i16(
-    // CHECK: switchInt
+    // CHECK-NOT: switchInt
+    // CHECK: _0 = _3 as i16 (IntToInt);
+    // CHECH: return
     match i {
         EnumAi8::A => -1,
         EnumAi8::B => 2,
@@ -233,7 +235,9 @@ enum EnumAi16 {
 // EMIT_MIR matches_reduce_branches.match_i16_i8.MatchBranchSimplification.diff
 fn match_i16_i8(i: EnumAi16) -> i8 {
     // CHECK-LABEL: fn match_i16_i8(
-    // CHECK: switchInt
+    // CHECK-NOT: switchInt
+    // CHECK: _0 = _3 as i8 (IntToInt);
+    // CHECH: return
     match i {
         EnumAi16::A => -1,
         EnumAi16::B => 2,

--- a/tests/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
@@ -5,27 +5,32 @@
       debug e => _1;
       let mut _0: u8;
       let mut _2: isize;
++     let mut _3: isize;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const 1_u8;
-          goto -> bb4;
-      }
-  
-      bb3: {
-          _0 = const 0_u8;
-          goto -> bb4;
-      }
-  
-      bb4: {
+-         switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const 1_u8;
+-         goto -> bb4;
+-     }
+- 
+-     bb3: {
+-         _0 = const 0_u8;
+-         goto -> bb4;
+-     }
+- 
+-     bb4: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as u8 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }

--- a/tests/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
@@ -5,27 +5,32 @@
       debug e => _1;
       let mut _0: i8;
       let mut _2: isize;
++     let mut _3: isize;
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
-      }
-  
-      bb1: {
-          unreachable;
-      }
-  
-      bb2: {
-          _0 = const 1_i8;
-          goto -> bb4;
-      }
-  
-      bb3: {
-          _0 = const 0_i8;
-          goto -> bb4;
-      }
-  
-      bb4: {
+-         switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
+-     }
+- 
+-     bb1: {
+-         unreachable;
+-     }
+- 
+-     bb2: {
+-         _0 = const 1_i8;
+-         goto -> bb4;
+-     }
+- 
+-     bb3: {
+-         _0 = const 0_i8;
+-         goto -> bb4;
+-     }
+- 
+-     bb4: {
++         StorageLive(_3);
++         _3 = move _2;
++         _0 = _3 as i8 (IntToInt);
++         StorageDead(_3);
           return;
       }
   }


### PR DESCRIPTION
Fixes #106459.

We should be able to do some similar transformations, like `enum` to `enum`.

r? mir-opt