### PR TITLE
Fix ICE on field access on a tainted type after const-eval failure

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -464,7 +464,11 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
                 self.lookup_and_handle_method(expr.hir_id);
             }
             hir::ExprKind::Field(ref lhs, ..) => {
-                self.handle_field_access(lhs, expr.hir_id);
+                if self.typeck_results().opt_field_index(expr.hir_id).is_some() {
+                    self.handle_field_access(lhs, expr.hir_id);
+                } else {
+                    self.tcx.dcx().span_delayed_bug(expr.span, "couldn't resolve index for field");
+                }
             }
             hir::ExprKind::Struct(qpath, fields, _) => {
                 let res = self.typeck_results().qpath_res(qpath, expr.hir_id);

--- a/tests/ui/consts/const-eval/field-access-after-const-eval-fail-in-ty.rs
+++ b/tests/ui/consts/const-eval/field-access-after-const-eval-fail-in-ty.rs
@@ -1,0 +1,5 @@
+// Regression test for issue #120615.
+
+fn main() {
+    [(); loop {}].field; //~ ERROR constant evaluation is taking a long time
+}

--- a/tests/ui/consts/const-eval/field-access-after-const-eval-fail-in-ty.stderr
+++ b/tests/ui/consts/const-eval/field-access-after-const-eval-fail-in-ty.stderr
@@ -1,0 +1,17 @@
+error: constant evaluation is taking a long time
+  --> $DIR/field-access-after-const-eval-fail-in-ty.rs:4:10
+   |
+LL |     [(); loop {}].field;
+   |          ^^^^^^^
+   |
+   = note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
+           If your compilation actually takes a long time, you can safely allow the lint.
+help: the constant being evaluated
+  --> $DIR/field-access-after-const-eval-fail-in-ty.rs:4:10
+   |
+LL |     [(); loop {}].field;
+   |          ^^^^^^^
+   = note: `#[deny(long_running_const_eval)]` on by default
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #120615.

r? oli-obk or compiler