### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -909,6 +909,7 @@ impl<'ll> CodegenCx<'ll, '_> {
         ifn!("llvm.is.constant.isize", fn(t_isize) -> i1);
         ifn!("llvm.is.constant.f32", fn(t_f32) -> i1);
         ifn!("llvm.is.constant.f64", fn(t_f64) -> i1);
+        ifn!("llvm.is.constant.ptr", fn(ptr) -> i1);
 
         ifn!("llvm.expect.i1", fn(i1, i1) -> i1);
         ifn!("llvm.eh.typeid.for", fn(ptr) -> t_i32);

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -119,10 +119,18 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
             sym::likely => {
                 self.call_intrinsic("llvm.expect.i1", &[args[0].immediate(), self.const_bool(true)])
             }
-            sym::is_val_statically_known => self.call_intrinsic(
-                &format!("llvm.is.constant.{:?}", args[0].layout.immediate_llvm_type(self.cx)),
-                &[args[0].immediate()],
-            ),
+            sym::is_val_statically_known => {
+                let intrinsic_type = args[0].layout.immediate_llvm_type(self.cx);
+                match self.type_kind(intrinsic_type) {
+                    TypeKind::Pointer | TypeKind::Integer | TypeKind::Float | TypeKind::Double => {
+                        self.call_intrinsic(
+                            &format!("llvm.is.constant.{:?}", intrinsic_type),
+                            &[args[0].immediate()],
+                        )
+                    }
+                    _ => self.const_bool(false),
+                }
+            }
             sym::unlikely => self
                 .call_intrinsic("llvm.expect.i1", &[args[0].immediate(), self.const_bool(false)]),
             kw::Try => {

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -648,6 +648,7 @@ impl OpaqueId {
 /// `specialize_constructor` returns the list of fields corresponding to a pattern, given a
 /// constructor. `Constructor::apply` reconstructs the pattern from a pair of `Constructor` and
 /// `Fields`.
+#[derive(Debug)]
 pub enum Constructor<Cx: TypeCx> {
     /// Tuples and structs.
     Struct,
@@ -713,33 +714,6 @@ impl<Cx: TypeCx> Clone for Constructor<Cx> {
             Constructor::NonExhaustive => Constructor::NonExhaustive,
             Constructor::Hidden => Constructor::Hidden,
             Constructor::Missing => Constructor::Missing,
-        }
-    }
-}
-
-impl<Cx: TypeCx> fmt::Debug for Constructor<Cx> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Constructor::Struct => f.debug_tuple("Struct").finish(),
-            Constructor::Variant(idx) => f.debug_tuple("Variant").field(idx).finish(),
-            Constructor::Ref => f.debug_tuple("Ref").finish(),
-            Constructor::Slice(slice) => f.debug_tuple("Slice").field(slice).finish(),
-            Constructor::UnionField => f.debug_tuple("UnionField").finish(),
-            Constructor::Bool(b) => f.debug_tuple("Bool").field(b).finish(),
-            Constructor::IntRange(range) => f.debug_tuple("IntRange").field(range).finish(),
-            Constructor::F32Range(lo, hi, end) => {
-                f.debug_tuple("F32Range").field(lo).field(hi).field(end).finish()
-            }
-            Constructor::F64Range(lo, hi, end) => {
-                f.debug_tuple("F64Range").field(lo).field(hi).field(end).finish()
-            }
-            Constructor::Str(value) => f.debug_tuple("Str").field(value).finish(),
-            Constructor::Opaque(inner) => f.debug_tuple("Opaque").field(inner).finish(),
-            Constructor::Or => f.debug_tuple("Or").finish(),
-            Constructor::Wildcard => f.debug_tuple("Wildcard").finish(),
-            Constructor::NonExhaustive => f.debug_tuple("NonExhaustive").finish(),
-            Constructor::Hidden => f.debug_tuple("Hidden").finish(),
-            Constructor::Missing => f.debug_tuple("Missing").finish(),
         }
     }
 }

--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -151,7 +151,6 @@
 use std::cmp::{self, max, min, Ordering};
 use std::fmt;
 use std::iter::once;
-use std::mem;
 
 use smallvec::SmallVec;
 
@@ -742,47 +741,6 @@ impl<Cx: TypeCx> fmt::Debug for Constructor<Cx> {
             Constructor::Hidden => f.debug_tuple("Hidden").finish(),
             Constructor::Missing => f.debug_tuple("Missing").finish(),
         }
-    }
-}
-
-impl<Cx: TypeCx> PartialEq for Constructor<Cx> {
-    fn eq(&self, other: &Self) -> bool {
-        (mem::discriminant(self) == mem::discriminant(other))
-            && match (self, other) {
-                (Constructor::Struct, Constructor::Struct) => true,
-                (Constructor::Variant(self_variant), Constructor::Variant(other_variant)) => {
-                    self_variant == other_variant
-                }
-                (Constructor::Ref, Constructor::Ref) => true,
-                (Constructor::Slice(self_slice), Constructor::Slice(other_slice)) => {
-                    self_slice == other_slice
-                }
-                (Constructor::UnionField, Constructor::UnionField) => true,
-                (Constructor::Bool(self_b), Constructor::Bool(other_b)) => self_b == other_b,
-                (Constructor::IntRange(self_range), Constructor::IntRange(other_range)) => {
-                    self_range == other_range
-                }
-                (
-                    Constructor::F32Range(self_lo, self_hi, self_end),
-                    Constructor::F32Range(other_lo, other_hi, other_end),
-                ) => self_lo == other_lo && self_hi == other_hi && self_end == other_end,
-                (
-                    Constructor::F64Range(self_lo, self_hi, self_end),
-                    Constructor::F64Range(other_lo, other_hi, other_end),
-                ) => self_lo == other_lo && self_hi == other_hi && self_end == other_end,
-                (Constructor::Str(self_value), Constructor::Str(other_value)) => {
-                    self_value == other_value
-                }
-                (Constructor::Opaque(self_inner), Constructor::Opaque(other_inner)) => {
-                    self_inner == other_inner
-                }
-                (Constructor::Or, Constructor::Or) => true,
-                (Constructor::Wildcard, Constructor::Wildcard) => true,
-                (Constructor::NonExhaustive, Constructor::NonExhaustive) => true,
-                (Constructor::Hidden, Constructor::Hidden) => true,
-                (Constructor::Missing, Constructor::Missing) => true,
-                _ => unreachable!(),
-            }
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -298,6 +298,7 @@ impl<'p, Cx: TypeCx> fmt::Debug for PatOrWild<'p, Cx> {
 
 /// Same idea as `DeconstructedPat`, except this is a fictitious pattern built up for diagnostics
 /// purposes. As such they don't use interning and can be cloned.
+#[derive(Debug)]
 pub struct WitnessPat<Cx: TypeCx> {
     ctor: Constructor<Cx>,
     pub(crate) fields: Vec<WitnessPat<Cx>>,
@@ -307,16 +308,6 @@ pub struct WitnessPat<Cx: TypeCx> {
 impl<Cx: TypeCx> Clone for WitnessPat<Cx> {
     fn clone(&self) -> Self {
         Self { ctor: self.ctor.clone(), fields: self.fields.clone(), ty: self.ty.clone() }
-    }
-}
-
-impl<Cx: TypeCx> fmt::Debug for WitnessPat<Cx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("WitnessPat")
-            .field("ctor", &self.ctor)
-            .field("fields", &self.fields)
-            .field("ty", &self.ty)
-            .finish()
     }
 }
 

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -680,8 +680,9 @@ impl<'p, 'tcx> RustcMatchCheckCtxt<'p, 'tcx> {
                     cx.pattern_arena.alloc_from_iter(pats.into_iter().map(|p| self.lower_pat(p)))
             }
             PatKind::Never => {
-                // FIXME(never_patterns): handle `!` in exhaustiveness. This is a sane default
-                // in the meantime.
+                // A never pattern matches all the values of its type (namely none). Moreover it
+                // must be compatible with other constructors, since we can use `!` on a type like
+                // `Result<!, !>` which has other constructors. Hence we lower it as a wildcard.
                 ctor = Wildcard;
                 fields = &[];
             }

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -1198,17 +1198,12 @@ impl<'p, Cx: TypeCx> fmt::Debug for Matrix<'p, Cx> {
 /// The final `Pair(Some(_), true)` is then the resulting witness.
 ///
 /// See the top of the file for more detailed explanations and examples.
+#[derive(Debug)]
 struct WitnessStack<Cx: TypeCx>(Vec<WitnessPat<Cx>>);
 
 impl<Cx: TypeCx> Clone for WitnessStack<Cx> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
-    }
-}
-
-impl<Cx: TypeCx> fmt::Debug for WitnessStack<Cx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_tuple("WitnessStack").field(&self.0).finish()
     }
 }
 
@@ -1256,17 +1251,12 @@ impl<Cx: TypeCx> WitnessStack<Cx> {
 ///
 /// Just as the `Matrix` starts with a single column, by the end of the algorithm, this has a single
 /// column, which contains the patterns that are missing for the match to be exhaustive.
+#[derive(Debug)]
 struct WitnessMatrix<Cx: TypeCx>(Vec<WitnessStack<Cx>>);
 
 impl<Cx: TypeCx> Clone for WitnessMatrix<Cx> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
-    }
-}
-
-impl<Cx: TypeCx> fmt::Debug for WitnessMatrix<Cx> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_tuple("WitnessMatrix").field(&self.0).finish()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2641,10 +2641,6 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 if let Some(e) = self.tainted_by_errors() {
                     return e;
                 }
-                if let Some(e) = self.dcx().has_errors() {
-                    // no need to overload user in such cases
-                    return e;
-                }
                 let SubtypePredicate { a_is_expected: _, a, b } = data;
                 // both must be type variables, or the other would've been instantiated
                 assert!(a.is_ty_var() && b.is_ty_var());

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2720,10 +2720,6 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 if let Some(e) = self.tainted_by_errors() {
                     return e;
                 }
-                if let Some(e) = self.dcx().has_errors() {
-                    // no need to overload user in such cases
-                    return e;
-                }
                 struct_span_code_err!(
                     self.dcx(),
                     span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2624,9 +2624,6 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 if let Some(e) = self.tainted_by_errors() {
                     return e;
                 }
-                if let Some(e) = self.dcx().has_errors() {
-                    return e;
-                }
 
                 self.emit_inference_failure_err(
                     obligation.cause.body_id,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -448,8 +448,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         // FIXME(effects)
                         let predicate_is_const = false;
 
-                        if let Some(guar) = self.dcx().has_errors()
-                            && trait_predicate.references_error()
+                        if let Err(guar) = trait_predicate.error_reported()
                         {
                             return guar;
                         }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -994,7 +994,10 @@ pub trait Read {
             }
 
             if cursor.written() == prev_written {
-                return Err(Error::new(ErrorKind::UnexpectedEof, "failed to fill buffer"));
+                return Err(error::const_io_error!(
+                    ErrorKind::UnexpectedEof,
+                    "failed to fill whole buffer"
+                ));
             }
         }
 

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -5,7 +5,7 @@
 use crate::any::Any;
 use crate::collections;
 use crate::panicking;
-use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::atomic::{AtomicU8, Ordering};
 use crate::sync::{Mutex, RwLock};
 use crate::thread::Result;
 
@@ -228,7 +228,7 @@ impl BacktraceStyle {
         if cfg!(feature = "backtrace") { Some(BacktraceStyle::Full) } else { None }
     }
 
-    fn as_usize(self) -> usize {
+    fn as_u8(self) -> u8 {
         match self {
             BacktraceStyle::Short => 1,
             BacktraceStyle::Full => 2,
@@ -236,7 +236,7 @@ impl BacktraceStyle {
         }
     }
 
-    fn from_usize(s: usize) -> Option<Self> {
+    fn from_u8(s: u8) -> Option<Self> {
         Some(match s {
             0 => return None,
             1 => BacktraceStyle::Short,
@@ -251,7 +251,7 @@ impl BacktraceStyle {
 // that backtrace.
 //
 // Internally stores equivalent of an Option<BacktraceStyle>.
-static SHOULD_CAPTURE: AtomicUsize = AtomicUsize::new(0);
+static SHOULD_CAPTURE: AtomicU8 = AtomicU8::new(0);
 
 /// Configure whether the default panic hook will capture and display a
 /// backtrace.
@@ -264,7 +264,7 @@ pub fn set_backtrace_style(style: BacktraceStyle) {
         // If the `backtrace` feature of this crate isn't enabled, skip setting.
         return;
     }
-    SHOULD_CAPTURE.store(style.as_usize(), Ordering::Release);
+    SHOULD_CAPTURE.store(style.as_u8(), Ordering::Release);
 }
 
 /// Checks whether the standard library's panic hook will capture and print a
@@ -296,7 +296,7 @@ pub fn get_backtrace_style() -> Option<BacktraceStyle> {
         // to optimize away callers.
         return None;
     }
-    if let Some(style) = BacktraceStyle::from_usize(SHOULD_CAPTURE.load(Ordering::Acquire)) {
+    if let Some(style) = BacktraceStyle::from_u8(SHOULD_CAPTURE.load(Ordering::Acquire)) {
         return Some(style);
     }
 

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
@@ -128,7 +128,8 @@ q6_arch=v65
 g0_lib_path=${sdk_libs}/${q6_arch}/G0
 pic_lib_path=${sdk_libs}/${q6_arch}/G0/pic
 
-cargo build --target=hexagon-unknown-none-elf -Zbuild-std
+build_cfg=release
+cargo build --target=hexagon-unknown-none-elf -Zbuild-std --release
 
 # Builds an executable against "hexagon standalone OS" suitable for emulation:
 ${cc} --target=hexagon-unknown-none-elf -o testit \
@@ -142,12 +143,12 @@ ${cc} --target=hexagon-unknown-none-elf -o testit \
     -L${sdk_libs}/${q6_arch}/ \
     -L${sdk_libs}/ \
     testit.c \
-    target/hexagon-unknown-none-elf/debug/libmin_ex_lib_lin.rlib \
-    target/hexagon-unknown-none-elf/debug/deps/libcore-*.rlib \
-    target/hexagon-unknown-none-elf/debug/deps/libcompiler_builtins-*.rlib \
+    target/hexagon-unknown-none-elf/${build_cfg}/libdemo1_hexagon.rlib \
+    target/hexagon-unknown-none-elf/${build_cfg}/deps/libcore-*.rlib \
+    target/hexagon-unknown-none-elf/${build_cfg}/deps/libcompiler_builtins-*.rlib \
     -Wl,--start-group \
     -Wl,--defsym,_SDA_BASE_=0,--defsym,__sbss_start=0,--defsym,__sbss_end=0 \
-    -lstandalone \
+    ${g0_lib_path}/libstandalone.a \
     ${g0_lib_path}/libc.a \
     -lgcc \
     -lc_eh \
@@ -248,9 +249,9 @@ ${cc} --target=hexagon-unknown-none-elf -o testit.so \
       -Wl,--wrap=memalign \
     -m${q6_arch} \
     testit.c \
-    target/hexagon-unknown-none-elf/debug/libmin_ex_lib_lin.rlib \
-    target/hexagon-unknown-none-elf/debug/deps/libcore-*.rlib \
-    target/hexagon-unknown-none-elf/debug/deps/libcompiler_builtins-*.rlib \
+    target/hexagon-unknown-none-elf/${build_cfg}/libdemo2_hexagon.rlib \
+    target/hexagon-unknown-none-elf/${build_cfg}/deps/libcore-*.rlib \
+    target/hexagon-unknown-none-elf/${build_cfg}/deps/libcompiler_builtins-*.rlib \
     -Wl,-soname=testit \
     ${pic_lib_path}/libc.so
 

--- a/tests/codegen/is_val_statically_known.rs
+++ b/tests/codegen/is_val_statically_known.rs
@@ -46,3 +46,41 @@ pub fn _bool_false(b: bool) -> i32 {
     // CHECK: ret i32 2
     _bool(b)
 }
+
+#[inline]
+pub fn _iref(a: &u8) -> i32 {
+    if unsafe { is_val_statically_known(a) } { 5 } else { 4 }
+}
+
+// CHECK-LABEL: @_iref_borrow(
+#[no_mangle]
+pub fn _iref_borrow() -> i32 {
+    // CHECK: ret i32 4
+    _iref(&0)
+}
+
+// CHECK-LABEL: @_iref_arg(
+#[no_mangle]
+pub fn _iref_arg(a: &u8) -> i32 {
+    // CHECK: ret i32 4
+    _iref(a)
+}
+
+#[inline]
+pub fn _slice_ref(a: &[u8]) -> i32 {
+    if unsafe { is_val_statically_known(a) } { 7 } else { 6 }
+}
+
+// CHECK-LABEL: @_slice_ref_borrow(
+#[no_mangle]
+pub fn _slice_ref_borrow() -> i32 {
+    // CHECK: ret i32 6
+    _slice_ref(&[0;3])
+}
+
+// CHECK-LABEL: @_slice_ref_arg(
+#[no_mangle]
+pub fn _slice_ref_arg(a: &[u8]) -> i32 {
+    // CHECK: ret i32 6
+    _slice_ref(a)
+}

--- a/tests/run-make/rust-lld-custom-target/custom-target.json
+++ b/tests/run-make/rust-lld-custom-target/custom-target.json
@@ -2,7 +2,7 @@
   "arch": "x86_64",
   "cpu": "x86-64",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "dynamic-linking": true,
   "env": "gnu",
   "has-rpath": true,

--- a/tests/run-make/rustdoc-target-spec-json-path/target.json
+++ b/tests/run-make/rustdoc-target-spec-json-path/target.json
@@ -2,7 +2,7 @@
   "arch": "x86_64",
   "cpu": "x86-64",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "dynamic-linking": true,
   "env": "gnu",
   "executables": true,

--- a/tests/run-make/target-specs/my-awesome-platform.json
+++ b/tests/run-make/target-specs/my-awesome-platform.json
@@ -1,5 +1,5 @@
 {
-    "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128",
+    "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
     "linker-flavor": "gcc",
     "llvm-target": "i686-unknown-linux-gnu",
     "target-endian": "little",

--- a/tests/run-make/target-specs/my-x86_64-unknown-linux-gnu-platform.json
+++ b/tests/run-make/target-specs/my-x86_64-unknown-linux-gnu-platform.json
@@ -1,6 +1,6 @@
 {
     "pre-link-args": {"gcc": ["-m64"]},
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "linker-flavor": "gcc",
     "llvm-target": "x86_64-unknown-linux-gnu",
     "target-endian": "little",

--- a/tests/ui/closures/issue-78720.rs
+++ b/tests/ui/closures/issue-78720.rs
@@ -1,6 +1,7 @@
 fn server() -> impl {
 //~^ ERROR at least one trait must be specified
     ().map2(|| "")
+    //~^ ERROR type annotations needed
 }
 
 trait FilterBase2 {

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -5,7 +5,7 @@ LL | fn server() -> impl {
    |                ^^^^
 
 error[E0412]: cannot find type `F` in this scope
-  --> $DIR/issue-78720.rs:13:12
+  --> $DIR/issue-78720.rs:14:12
    |
 LL |     _func: F,
    |            ^
@@ -22,8 +22,14 @@ help: you might be missing a type parameter
 LL | struct Map2<Segment2, F> {
    |                     +++
 
+error[E0282]: type annotations needed
+  --> $DIR/issue-78720.rs:3:5
+   |
+LL |     ().map2(|| "")
+   |     ^^^^^^^^^^^^^^ cannot infer type
+
 error[E0308]: mismatched types
-  --> $DIR/issue-78720.rs:7:39
+  --> $DIR/issue-78720.rs:8:39
    |
 LL |     fn map2<F>(self, f: F) -> Map2<F> {}
    |                                       ^^ expected `Map2<F>`, found `()`
@@ -32,7 +38,7 @@ LL |     fn map2<F>(self, f: F) -> Map2<F> {}
            found unit type `()`
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-78720.rs:7:16
+  --> $DIR/issue-78720.rs:8:16
    |
 LL |     fn map2<F>(self, f: F) -> Map2<F> {}
    |                ^^^^ doesn't have a size known at compile-time
@@ -47,7 +53,7 @@ help: function arguments must have a statically known size, borrowed types alway
 LL |     fn map2<F>(&self, f: F) -> Map2<F> {}
    |                +
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0277, E0308, E0412.
+Some errors have detailed explanations: E0277, E0282, E0308, E0412.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.rs
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.rs
@@ -25,6 +25,6 @@ fn owo() -> impl Traitor {
 
 fn main() {
     rawr();
-    uwu();
+    uwu(); //~ ERROR: type annotations needed
     owo();
 }

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -31,6 +31,18 @@ LL |     1_u64
    |
    = help: the trait `Traitor<1, 2>` is implemented for `u64`
 
-error: aborting due to 3 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/rp_impl_trait_fail.rs:28:5
+   |
+LL |     uwu();
+   |     ^^^ cannot infer the value of the const parameter `N` declared on the function `uwu`
+   |
+help: consider specifying the generic argument
+   |
+LL |     uwu::<N>();
+   |        +++++
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0282.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-62504.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-62504.full.stderr
@@ -15,6 +15,18 @@ LL |         ArrayHolder([0; Self::SIZE])
    |
    = help: try adding a `where` bound using this expression: `where [(); Self::SIZE]:`
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed for `ArrayHolder<X>`
+  --> $DIR/issue-62504.rs:26:9
+   |
+LL |     let mut array = ArrayHolder::new();
+   |         ^^^^^^^^^
+   |
+help: consider giving `array` an explicit type, where the value of const parameter `X` is specified
+   |
+LL |     let mut array: ArrayHolder<X> = ArrayHolder::new();
+   |                  ++++++++++++++++
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-62504.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-62504.min.stderr
@@ -22,6 +22,18 @@ note: tuple struct defined here
 LL | struct ArrayHolder<const X: usize>([u32; X]);
    |        ^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed for `ArrayHolder<X>`
+  --> $DIR/issue-62504.rs:26:9
+   |
+LL |     let mut array = ArrayHolder::new();
+   |         ^^^^^^^^^
+   |
+help: consider giving `array` an explicit type, where the value of const parameter `X` is specified
+   |
+LL |     let mut array: ArrayHolder<X> = ArrayHolder::new();
+   |                  ++++++++++++++++
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-62504.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-62504.rs
@@ -24,4 +24,5 @@ impl<const X: usize> ArrayHolder<X> {
 
 fn main() {
     let mut array = ArrayHolder::new();
+    //~^ ERROR: type annotations needed
 }

--- a/tests/ui/consts/issue-104609.rs
+++ b/tests/ui/consts/issue-104609.rs
@@ -5,6 +5,7 @@ fn foo() {
 
 unsafe fn bar() {
     std::mem::transmute::<_, *mut _>(1_u8);
+    //~^ ERROR: type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/consts/issue-104609.stderr
+++ b/tests/ui/consts/issue-104609.stderr
@@ -4,6 +4,13 @@ error[E0425]: cannot find value `oops` in this scope
 LL |     oops;
    |     ^^^^ not found in this scope
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-104609.rs:7:5
+   |
+LL |     std::mem::transmute::<_, *mut _>(1_u8);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `Dst` declared on the function `transmute`
 
-For more information about this error, try `rustc --explain E0425`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0425.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/generic-const-items/parameter-defaults.stderr
+++ b/tests/ui/generic-const-items/parameter-defaults.stderr
@@ -8,7 +8,7 @@ error[E0282]: type annotations needed for `Option<T>`
   --> $DIR/parameter-defaults.rs:13:9
    |
 LL |     let _ = NONE;
-   |         ^
+   |         ^   ---- type must be known at this point
    |
 help: consider giving this pattern a type, where the type for type parameter `T` is specified
    |

--- a/tests/ui/inference/need_type_info/type-alias.rs
+++ b/tests/ui/inference/need_type_info/type-alias.rs
@@ -15,7 +15,7 @@ fn direct_alias() {
 
 type IndirectAlias<T> = Ty<Box<T>>;
 fn indirect_alias() {
-    IndirectAlias::new();
+    IndirectAlias::new(); //~ ERROR: type annotations needed
     // FIXME: This should also emit an error.
     //
     // Added it separately as `type-alias-indirect.rs`

--- a/tests/ui/inference/need_type_info/type-alias.stderr
+++ b/tests/ui/inference/need_type_info/type-alias.stderr
@@ -5,11 +5,17 @@ LL |     DirectAlias::new()
    |     ^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
 error[E0282]: type annotations needed
+  --> $DIR/type-alias.rs:18:5
+   |
+LL |     IndirectAlias::new();
+   |     ^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the type alias `IndirectAlias`
+
+error[E0282]: type annotations needed
   --> $DIR/type-alias.rs:32:5
    |
 LL |     DirectButWithDefaultAlias::new();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/parser/issues/issue-89574.rs
+++ b/tests/ui/parser/issues/issue-89574.rs
@@ -1,4 +1,6 @@
 fn main() {
     const EMPTY_ARRAY = [];
     //~^ missing type for `const` item
+    //~| ERROR type annotations needed
+    //~| ERROR type annotations needed
 }

--- a/tests/ui/parser/issues/issue-89574.stderr
+++ b/tests/ui/parser/issues/issue-89574.stderr
@@ -1,8 +1,23 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-89574.rs:2:25
+   |
+LL |     const EMPTY_ARRAY = [];
+   |                         ^^ cannot infer type
+
 error: missing type for `const` item
   --> $DIR/issue-89574.rs:2:22
    |
 LL |     const EMPTY_ARRAY = [];
    |                      ^ help: provide a type for the item: `: <type>`
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-89574.rs:2:25
+   |
+LL |     const EMPTY_ARRAY = [];
+   |                         ^^ cannot infer type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
@@ -41,7 +41,7 @@ error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:7:7
    |
 LL |   let v : Vec<(u32,_) = vec![];
-   |       ^
+   |       ^                 ------ type must be known at this point
    |
 help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |
@@ -52,7 +52,7 @@ error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:18:7
    |
 LL |   let v : Vec<'a = vec![];
-   |       ^
+   |       ^            ------ type must be known at this point
    |
 help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |

--- a/tests/ui/traits/next-solver/specialization-transmute.rs
+++ b/tests/ui/traits/next-solver/specialization-transmute.rs
@@ -14,6 +14,7 @@ impl<T> Default for T {
     default type Id = T; //~ ERROR type annotations needed
     // This will be fixed by #111994
     fn intu(&self) -> &Self::Id {
+        //~^ ERROR type annotations needed
         self
     }
 }

--- a/tests/ui/traits/next-solver/specialization-transmute.stderr
+++ b/tests/ui/traits/next-solver/specialization-transmute.stderr
@@ -10,12 +10,19 @@ LL | #![feature(specialization)]
 
 error: cannot normalize `<T as Default>::Id`
 
+error[E0284]: type annotations needed: cannot satisfy `<T as Default>::Id == _`
+  --> $DIR/specialization-transmute.rs:16:23
+   |
+LL |     fn intu(&self) -> &Self::Id {
+   |                       ^^^^^^^^^ cannot satisfy `<T as Default>::Id == _`
+
 error[E0282]: type annotations needed
   --> $DIR/specialization-transmute.rs:14:23
    |
 LL |     default type Id = T;
    |                       ^ cannot infer type for associated type `<T as Default>::Id`
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0282`.
+Some errors have detailed explanations: E0282, E0284.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/typeck/issue-104510-ice.rs
+++ b/tests/ui/typeck/issue-104510-ice.rs
@@ -6,7 +6,7 @@ struct W<T: ?Sized>(Oops);
 
 unsafe fn test() {
     let j = W(());
-    let pointer = &j as *const _;
+    let pointer = &j as *const _; //~ ERROR type annotations needed
     core::arch::asm!(
         "nop",
         in("eax") pointer,

--- a/tests/ui/typeck/issue-104510-ice.stderr
+++ b/tests/ui/typeck/issue-104510-ice.stderr
@@ -4,6 +4,18 @@ error[E0412]: cannot find type `Oops` in this scope
 LL | struct W<T: ?Sized>(Oops);
    |                     ^^^^ not found in this scope
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed for `*const W<T>`
+  --> $DIR/issue-104510-ice.rs:9:9
+   |
+LL |     let pointer = &j as *const _;
+   |         ^^^^^^^
+   |
+help: consider giving `pointer` an explicit type, where the type for type parameter `T` is specified
+   |
+LL |     let pointer: *const W<T> = &j as *const _;
+   |                +++++++++++++
 
-For more information about this error, try `rustc --explain E0412`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0412.
+For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
Successful merges:

 - #120484 (Avoid ICE when is_val_statically_known is not of a supported type)
 - #120516 (pattern_analysis: cleanup manual impls)
 - #120517 (never patterns: It is correct to lower `!` to `_`.)
 - #120523 (Improve `io::Read::read_buf_exact` error case)
 - #120528 (Store SHOULD_CAPTURE as AtomicU8)
 - #120529 (Update data layouts in custom target tests for LLVM 18)
 - #120531 (Remove a bunch of `has_errors` checks that have no meaningful or the wrong effect)
 - #120533 (Correct paths for hexagon-unknown-none-elf platform doc)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=120484,120516,120517,120523,120528,120529,120531,120533)
<!-- homu-ignore:end -->