### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -110,14 +110,16 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> &BorrowCheckResult<'_> {
     let (input_body, promoted) = tcx.mir_promoted(def);
     debug!("run query mir_borrowck: {}", tcx.def_path_str(def));
 
-    if input_body.borrow().should_skip() {
-        debug!("Skipping borrowck because of injected body");
+    let input_body: &Body<'_> = &input_body.borrow();
+
+    if input_body.should_skip() || input_body.tainted_by_errors.is_some() {
+        debug!("Skipping borrowck because of injected body or tainted body");
         // Let's make up a borrowck result! Fun times!
         let result = BorrowCheckResult {
             concrete_opaque_types: FxIndexMap::default(),
             closure_requirements: None,
             used_mut_upvars: SmallVec::new(),
-            tainted_by_errors: None,
+            tainted_by_errors: input_body.tainted_by_errors,
         };
         return tcx.arena.alloc(result);
     }
@@ -126,7 +128,6 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> &BorrowCheckResult<'_> {
 
     let infcx =
         tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(hir_owner.def_id)).build();
-    let input_body: &Body<'_> = &input_body.borrow();
     let promoted: &IndexSlice<_, _> = &promoted.borrow();
     let opt_closure_req = do_mir_borrowck(&infcx, input_body, promoted, None).0;
     debug!("mir_borrowck done");

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -184,7 +184,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
 
     // Solve the region constraints.
     let (closure_region_requirements, nll_errors) =
-        regioncx.solve(infcx, param_env, body, polonius_output.clone());
+        regioncx.solve(infcx, body, polonius_output.clone());
 
     if !nll_errors.is_empty() {
         // Suppress unhelpful extra errors in `infer_opaque_types`.

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -217,7 +217,6 @@ pub(crate) fn type_check<'mir, 'tcx>(
                 CustomTypeOp::new(
                     |ocx| {
                         ocx.infcx.register_member_constraints(
-                            param_env,
                             opaque_type_key,
                             decl.hidden_type.ty,
                             decl.hidden_type.span,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -163,10 +163,6 @@ impl Lifetime {
             (LifetimeSuggestionPosition::Normal, self.ident.span)
         }
     }
-
-    pub fn is_static(&self) -> bool {
-        self.res == LifetimeName::Static
-    }
 }
 
 /// A `Path` is essentially Rust's notion of a name; for instance,

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -235,9 +235,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
         speculative: bool,
         dup_bindings: &mut FxHashMap<DefId, Span>,
         path_span: Span,
-        constness: ty::BoundConstness,
         only_self_bounds: OnlySelfBounds,
-        polarity: ty::ImplPolarity,
     ) -> Result<(), ErrorGuaranteed> {
         // Given something like `U: SomeTrait<T = X>`, we want to produce a
         // predicate like `<U as SomeTrait>::T = X`. This is somewhat

--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -16,7 +16,7 @@ use rustc_middle::ty::{
     self, GenericArgsRef, GenericParamDef, GenericParamDefKind, IsSuggestable, Ty, TyCtxt,
 };
 use rustc_session::lint::builtin::LATE_BOUND_LIFETIME_ARGUMENTS;
-use rustc_span::{symbol::kw, Span};
+use rustc_span::symbol::kw;
 use smallvec::SmallVec;
 
 /// Report an error that a generic argument did not match the generic parameter that was
@@ -404,7 +404,6 @@ pub fn create_args_for_parent_generic_args<'tcx: 'a, 'a>(
 /// Used specifically for function calls.
 pub fn check_generic_arg_count_for_call(
     tcx: TyCtxt<'_>,
-    span: Span,
     def_id: DefId,
     generics: &ty::Generics,
     seg: &hir::PathSegment<'_>,
@@ -418,17 +417,7 @@ pub fn check_generic_arg_count_for_call(
     };
     let has_self = generics.parent.is_none() && generics.has_self;
 
-    check_generic_arg_count(
-        tcx,
-        span,
-        def_id,
-        seg,
-        generics,
-        gen_args,
-        gen_pos,
-        has_self,
-        seg.infer_args,
-    )
+    check_generic_arg_count(tcx, def_id, seg, generics, gen_args, gen_pos, has_self, seg.infer_args)
 }
 
 /// Checks that the correct number of generic arguments have been provided.
@@ -436,7 +425,6 @@ pub fn check_generic_arg_count_for_call(
 #[instrument(skip(tcx, gen_pos), level = "debug")]
 pub(crate) fn check_generic_arg_count(
     tcx: TyCtxt<'_>,
-    span: Span,
     def_id: DefId,
     seg: &hir::PathSegment<'_>,
     gen_params: &ty::Generics,

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -12,7 +12,7 @@ use crate::astconv::errors::prohibit_assoc_ty_binding;
 use crate::astconv::generics::{check_generic_arg_count, create_args_for_parent_generic_args};
 use crate::bounds::Bounds;
 use crate::collect::HirPlaceholderCollector;
-use crate::errors::{AmbiguousLifetimeBound, TypeofReservedKeywordUsed};
+use crate::errors::AmbiguousLifetimeBound;
 use crate::middle::resolve_bound_vars as rbv;
 use crate::require_c_abi_if_c_variadic;
 use rustc_ast::TraitObjectSyntax;
@@ -30,8 +30,8 @@ use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::middle::stability::AllowUnstable;
 use rustc_middle::ty::{
-    self, Const, GenericArgKind, GenericArgsRef, GenericParamDefKind, IsSuggestable, ParamEnv, Ty,
-    TyCtxt, TypeVisitableExt,
+    self, Const, GenericArgKind, GenericArgsRef, GenericParamDefKind, ParamEnv, Ty, TyCtxt,
+    TypeVisitableExt,
 };
 use rustc_session::lint::builtin::AMBIGUOUS_ASSOCIATED_ITEMS;
 use rustc_span::edit_distance::find_best_match_for_name;
@@ -2537,21 +2537,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
                 Ty::new_array_with_const_len(tcx, self.ast_ty_to_ty(ty), length)
             }
-            hir::TyKind::Typeof(e) => {
-                let ty_erased = tcx.type_of(e.def_id).instantiate_identity();
-                let ty = tcx.fold_regions(ty_erased, |r, _| {
-                    if r.is_erased() { tcx.lifetimes.re_static } else { r }
-                });
-                let span = ast_ty.span;
-                let (ty, opt_sugg) = if let Some(ty) = ty.make_suggestable(tcx, false) {
-                    (ty, Some((span, Applicability::MachineApplicable)))
-                } else {
-                    (ty, None)
-                };
-                tcx.dcx().emit_err(TypeofReservedKeywordUsed { span, ty, opt_sugg });
-
-                ty
-            }
+            hir::TyKind::Typeof(e) => tcx.type_of(e.def_id).instantiate_identity(),
             hir::TyKind::Infer => {
                 // Infer also appears as the type of arguments or return
                 // values in an ExprKind::Closure, or as

--- a/compiler/rustc_hir_analysis/src/astconv/mod.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/mod.rs
@@ -25,7 +25,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Namespace, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{walk_generics, Visitor as _};
-use rustc_hir::{GenericArg, GenericArgs, OpaqueTyOrigin};
+use rustc_hir::{GenericArg, GenericArgs};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCause;
 use rustc_middle::middle::stability::AllowUnstable;
@@ -379,7 +379,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let mut arg_count = check_generic_arg_count(
             tcx,
-            span,
             def_id,
             seg,
             generics,
@@ -773,9 +772,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 speculative,
                 &mut dup_bindings,
                 binding.span,
-                constness,
                 only_self_bounds,
-                polarity,
             );
             // Okay to ignore `Err` because of `ErrorGuaranteed` (see above).
         }
@@ -2491,7 +2488,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let opaque_ty = tcx.hir().item(item_id);
 
                 match opaque_ty.kind {
-                    hir::ItemKind::OpaqueTy(&hir::OpaqueTy { origin, .. }) => {
+                    hir::ItemKind::OpaqueTy(&hir::OpaqueTy { .. }) => {
                         let local_def_id = item_id.owner_id.def_id;
                         // If this is an RPITIT and we are using the new RPITIT lowering scheme, we
                         // generate the def_id of an associated type for the trait and return as
@@ -2501,7 +2498,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         } else {
                             local_def_id.to_def_id()
                         };
-                        self.impl_trait_ty_to_ty(def_id, lifetimes, origin, in_trait)
+                        self.impl_trait_ty_to_ty(def_id, lifetimes, in_trait)
                     }
                     ref i => bug!("`impl Trait` pointed to non-opaque type?? {:#?}", i),
                 }
@@ -2571,7 +2568,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         &self,
         def_id: DefId,
         lifetimes: &[hir::GenericArg<'_>],
-        origin: OpaqueTyOrigin,
         in_trait: bool,
     ) -> Ty<'tcx> {
         debug!("impl_trait_ty_to_ty(def_id={:?}, lifetimes={:?})", def_id, lifetimes);

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -9,6 +9,8 @@ use rustc_middle::ty::{self, ImplTraitInTraitData, IsSuggestable, Ty, TyCtxt, Ty
 use rustc_span::symbol::Ident;
 use rustc_span::{Span, DUMMY_SP};
 
+use crate::errors::TypeofReservedKeywordUsed;
+
 use super::bad_placeholder;
 use super::ItemCtxt;
 pub use opaque::test_opaque_hidden_types;
@@ -39,8 +41,18 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
         {
             return tcx.types.usize;
         }
-        Node::Ty(&hir::Ty { kind: TyKind::Typeof(ref e), .. }) if e.hir_id == hir_id => {
-            return tcx.typeck(def_id).node_type(e.hir_id);
+        Node::Ty(&hir::Ty { kind: TyKind::Typeof(ref e), span, .. }) if e.hir_id == hir_id => {
+            let ty = tcx.typeck(def_id).node_type(e.hir_id);
+            let ty = tcx.fold_regions(ty, |r, _| {
+                if r.is_erased() { ty::Region::new_error_misc(tcx) } else { r }
+            });
+            let (ty, opt_sugg) = if let Some(ty) = ty.make_suggestable(tcx, false) {
+                (ty, Some((span, Applicability::MachineApplicable)))
+            } else {
+                (ty, None)
+            };
+            tcx.dcx().emit_err(TypeofReservedKeywordUsed { span, ty, opt_sugg });
+            return ty;
         }
         Node::Expr(&Expr { kind: ExprKind::InlineAsm(asm), .. })
         | Node::Item(&Item { kind: ItemKind::GlobalAsm(asm), .. })

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -209,7 +209,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
 
     tcx.ensure().check_unused_traits(());
 
-    if let Some(reported) = tcx.dcx().has_errors() { Err(reported) } else { Ok(()) }
+    Ok(())
 }
 
 /// A quasi-deprecated helper used in rustdoc and clippy to get

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -521,7 +521,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// We must not attempt to select obligations after this method has run, or risk query cycle
     /// ICE.
     #[instrument(level = "debug", skip(self))]
-    pub(in super::super) fn resolve_coroutine_interiors(&self, def_id: DefId) {
+    pub(in super::super) fn resolve_coroutine_interiors(&self) {
         // Try selecting all obligations that are not blocked on inference variables.
         // Once we start unifying coroutine witnesses, trying to select obligations on them will
         // trigger query cycle ICEs, as doing so requires MIR.
@@ -1175,14 +1175,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // parameter internally, but we don't allow users to specify the
             // parameter's value explicitly, so we have to do some error-
             // checking here.
-            let arg_count = check_generic_arg_count_for_call(
-                tcx,
-                span,
-                def_id,
-                generics,
-                seg,
-                IsMethodCall::No,
-            );
+            let arg_count =
+                check_generic_arg_count_for_call(tcx, def_id, generics, seg, IsMethodCall::No);
 
             if let ExplicitLateBound::Yes = arg_count.explicit_late_bound {
                 explicit_late_bound = ExplicitLateBound::Yes;

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -286,7 +286,7 @@ fn typeck_with_fallback<'tcx>(
     debug!(pending_obligations = ?fcx.fulfillment_cx.borrow().pending_obligations());
 
     // This must be the last thing before `report_ambiguity_errors`.
-    fcx.resolve_coroutine_interiors(def_id.to_def_id());
+    fcx.resolve_coroutine_interiors();
 
     debug!(pending_obligations = ?fcx.fulfillment_cx.borrow().pending_obligations());
 

--- a/compiler/rustc_hir_typeck/src/mem_categorization.rs
+++ b/compiler/rustc_hir_typeck/src/mem_categorization.rs
@@ -436,7 +436,8 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
     pub(crate) fn cat_rvalue(
         &self,
         hir_id: hir::HirId,
-        span: Span,
+        // FIXME: remove
+        _span: Span,
         expr_ty: Ty<'tcx>,
     ) -> PlaceWithHirId<'tcx> {
         PlaceWithHirId::new(hir_id, expr_ty, PlaceBase::Rvalue, Vec::new())

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -356,7 +356,6 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
 
         let arg_count_correct = check_generic_arg_count_for_call(
             self.tcx,
-            self.span,
             pick.item.def_id,
             generics,
             seg,

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -554,6 +554,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     "`count` is defined on `{iterator_trait}`, which `{rcvr_ty}` does not implement"
                 ));
             }
+        } else if !unsatisfied_predicates.is_empty() && matches!(rcvr_ty.kind(), ty::Param(_)) {
+            // We special case the situation where we are looking for `_` in
+            // `<TypeParam as _>::method` because otherwise the machinery will look for blanket
+            // implementations that have unsatisfied trait bounds to suggest, leading us to claim
+            // things like "we're looking for a trait with method `cmp`, both `Iterator` and `Ord`
+            // have one, in order to implement `Ord` you need to restrict `TypeParam: FnPtr` so
+            // that `impl<T: FnPtr> Ord for T` can apply", which is not what we want. We have a type
+            // parameter, we want to directly say "`Ord::cmp` and `Iterator::cmp` exist, restrict
+            // `TypeParam: Ord` or `TypeParam: Iterator`"". That is done further down when calling
+            // `self.suggest_traits_to_import`, so we ignore the `unsatisfied_predicates`
+            // suggestions.
         } else if !unsatisfied_predicates.is_empty() {
             let mut type_params = FxIndexMap::default();
 
@@ -1325,7 +1336,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
         self.note_derefed_ty_has_method(&mut err, source, rcvr_ty, item_name, expected);
-        return Some(err);
+        Some(err)
     }
 
     fn note_candidates_on_method_error(
@@ -2918,19 +2929,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // this isn't perfect (that is, there are cases when
                 // implementing a trait would be legal but is rejected
                 // here).
-                unsatisfied_predicates.iter().all(|(p, _, _)| {
-                    match p.kind().skip_binder() {
-                        // Hide traits if they are present in predicates as they can be fixed without
-                        // having to implement them.
-                        ty::PredicateKind::Clause(ty::ClauseKind::Trait(t)) => {
-                            t.def_id() == info.def_id
-                        }
-                        ty::PredicateKind::Clause(ty::ClauseKind::Projection(p)) => {
-                            p.projection_ty.def_id == info.def_id
-                        }
-                        _ => false,
-                    }
-                }) && (type_is_local || info.def_id.is_local())
+                (type_is_local || info.def_id.is_local())
                     && !self.tcx.trait_is_auto(info.def_id)
                     && self
                         .associated_value(info.def_id, item_name)
@@ -2978,6 +2977,20 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             item.visibility(self.tcx).is_public() || info.def_id.is_local()
                         })
                         .is_some()
+                    && (matches!(rcvr_ty.kind(), ty::Param(_))
+                        || unsatisfied_predicates.iter().all(|(p, _, _)| {
+                            match p.kind().skip_binder() {
+                                // Hide traits if they are present in predicates as they can be fixed without
+                                // having to implement them.
+                                ty::PredicateKind::Clause(ty::ClauseKind::Trait(t)) => {
+                                    t.def_id() == info.def_id
+                                }
+                                ty::PredicateKind::Clause(ty::ClauseKind::Projection(p)) => {
+                                    p.projection_ty.def_id == info.def_id
+                                }
+                                _ => false,
+                            }
+                        }))
             })
             .collect::<Vec<_>>();
         for span in &arbitrary_rcvr {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -540,6 +540,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let mut bound_spans: SortedMap<Span, Vec<String>> = Default::default();
         let mut restrict_type_params = false;
+        let mut suggested_derive = false;
         let mut unsatisfied_bounds = false;
         if item_name.name == sym::count && self.is_slice_ty(rcvr_ty, span) {
             let msg = "consider using `len` instead";
@@ -927,20 +928,22 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .enumerate()
                 .collect::<Vec<(usize, String)>>();
 
-            for ((span, add_where_or_comma), obligations) in type_params.into_iter() {
-                restrict_type_params = true;
-                // #74886: Sort here so that the output is always the same.
-                let obligations = obligations.into_sorted_stable_ord();
-                err.span_suggestion_verbose(
-                    span,
-                    format!(
-                        "consider restricting the type parameter{s} to satisfy the \
-                         trait bound{s}",
-                        s = pluralize!(obligations.len())
-                    ),
-                    format!("{} {}", add_where_or_comma, obligations.join(", ")),
-                    Applicability::MaybeIncorrect,
-                );
+            if !matches!(rcvr_ty.peel_refs().kind(), ty::Param(_)) {
+                for ((span, add_where_or_comma), obligations) in type_params.into_iter() {
+                    restrict_type_params = true;
+                    // #74886: Sort here so that the output is always the same.
+                    let obligations = obligations.into_sorted_stable_ord();
+                    err.span_suggestion_verbose(
+                        span,
+                        format!(
+                            "consider restricting the type parameter{s} to satisfy the trait \
+                             bound{s}",
+                            s = pluralize!(obligations.len())
+                        ),
+                        format!("{} {}", add_where_or_comma, obligations.join(", ")),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
             }
 
             bound_list.sort_by(|(_, a), (_, b)| a.cmp(b)); // Sort alphabetically.
@@ -988,7 +991,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         "the following trait bounds were not satisfied:\n{bound_list}"
                     ));
                 }
-                self.suggest_derive(&mut err, unsatisfied_predicates);
+                suggested_derive = self.suggest_derive(&mut err, unsatisfied_predicates);
 
                 unsatisfied_bounds = true;
             }
@@ -1211,7 +1214,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
         }
 
-        if rcvr_ty.is_numeric() && rcvr_ty.is_fresh() || restrict_type_params {
+        if rcvr_ty.is_numeric() && rcvr_ty.is_fresh() || restrict_type_params || suggested_derive {
         } else {
             self.suggest_traits_to_import(
                 &mut err,
@@ -1221,7 +1224,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 args.map(|args| args.len() + 1),
                 source,
                 no_match_data.out_of_scope_traits.clone(),
-                unsatisfied_predicates,
                 static_candidates,
                 unsatisfied_bounds,
                 expected.only_has_type(self),
@@ -2481,7 +2483,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Option<ty::Predicate<'tcx>>,
             Option<ObligationCause<'tcx>>,
         )],
-    ) {
+    ) -> bool {
         let mut derives = self.note_predicate_source_and_get_derives(err, unsatisfied_predicates);
         derives.sort();
         derives.dedup();
@@ -2506,6 +2508,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Applicability::MaybeIncorrect,
             );
         }
+        !derives_grouped.is_empty()
     }
 
     fn note_derefed_ty_has_method(
@@ -2708,11 +2711,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         inputs_len: Option<usize>,
         source: SelfSource<'tcx>,
         valid_out_of_scope_traits: Vec<DefId>,
-        unsatisfied_predicates: &[(
-            ty::Predicate<'tcx>,
-            Option<ty::Predicate<'tcx>>,
-            Option<ObligationCause<'tcx>>,
-        )],
         static_candidates: &[CandidateSource],
         unsatisfied_bounds: bool,
         return_type: Option<Ty<'tcx>>,
@@ -2977,20 +2975,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             item.visibility(self.tcx).is_public() || info.def_id.is_local()
                         })
                         .is_some()
-                    && (matches!(rcvr_ty.kind(), ty::Param(_))
-                        || unsatisfied_predicates.iter().all(|(p, _, _)| {
-                            match p.kind().skip_binder() {
-                                // Hide traits if they are present in predicates as they can be fixed without
-                                // having to implement them.
-                                ty::PredicateKind::Clause(ty::ClauseKind::Trait(t)) => {
-                                    t.def_id() == info.def_id
-                                }
-                                ty::PredicateKind::Clause(ty::ClauseKind::Projection(p)) => {
-                                    p.projection_ty.def_id == info.def_id
-                                }
-                                _ => false,
-                            }
-                        }))
             })
             .collect::<Vec<_>>();
         for span in &arbitrary_rcvr {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -862,7 +862,7 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     #[instrument(skip(self, snapshot), level = "debug")]
-    fn rollback_to(&self, cause: &str, snapshot: CombinedSnapshot<'tcx>) {
+    fn rollback_to(&self, snapshot: CombinedSnapshot<'tcx>) {
         let CombinedSnapshot { undo_snapshot, region_constraints_snapshot, universe } = snapshot;
 
         self.universe.set(universe);
@@ -894,7 +894,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 self.commit_from(snapshot);
             }
             Err(_) => {
-                self.rollback_to("commit_if_ok -- error", snapshot);
+                self.rollback_to(snapshot);
             }
         }
         r
@@ -908,7 +908,7 @@ impl<'tcx> InferCtxt<'tcx> {
     {
         let snapshot = self.start_snapshot();
         let r = f(&snapshot);
-        self.rollback_to("probe", snapshot);
+        self.rollback_to(snapshot);
         r
     }
 

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -327,7 +327,6 @@ impl<'tcx> InferCtxt<'tcx> {
     #[instrument(level = "debug", skip(self))]
     pub fn register_member_constraints(
         &self,
-        param_env: ty::ParamEnv<'tcx>,
         opaque_type_key: OpaqueTypeKey<'tcx>,
         concrete_ty: Ty<'tcx>,
         span: Span,

--- a/compiler/rustc_infer/src/infer/relate/combine.rs
+++ b/compiler/rustc_infer/src/infer/relate/combine.rs
@@ -225,11 +225,11 @@ impl<'tcx> InferCtxt<'tcx> {
             }
 
             (ty::ConstKind::Infer(InferConst::Var(vid)), _) => {
-                return self.unify_const_variable(vid, b, relation.param_env());
+                return self.unify_const_variable(vid, b);
             }
 
             (_, ty::ConstKind::Infer(InferConst::Var(vid))) => {
-                return self.unify_const_variable(vid, a, relation.param_env());
+                return self.unify_const_variable(vid, a);
             }
 
             (ty::ConstKind::Infer(InferConst::EffectVar(vid)), _) => {
@@ -310,7 +310,6 @@ impl<'tcx> InferCtxt<'tcx> {
         &self,
         target_vid: ty::ConstVid,
         ct: ty::Const<'tcx>,
-        param_env: ty::ParamEnv<'tcx>,
     ) -> RelateResult<'tcx, ty::Const<'tcx>> {
         let span = match self.inner.borrow_mut().const_unification_table().probe_value(target_vid) {
             ConstVariableValue::Known { value } => {

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -1038,7 +1038,6 @@ impl<'tcx> PatRangeBoundary<'tcx> {
                 a.partial_cmp(&b)
             }
             ty::Int(ity) => {
-                use rustc_middle::ty::layout::IntegerExt;
                 let size = rustc_target::abi::Integer::from_int_ty(&tcx, *ity).size();
                 let a = size.sign_extend(a) as i128;
                 let b = size.sign_extend(b) as i128;

--- a/compiler/rustc_middle/src/ty/_match.rs
+++ b/compiler/rustc_middle/src/ty/_match.rs
@@ -55,7 +55,7 @@ impl<'tcx> TypeRelation<'tcx> for MatchAgainstFreshVars<'tcx> {
     fn regions(
         &mut self,
         a: ty::Region<'tcx>,
-        b: ty::Region<'tcx>,
+        _b: ty::Region<'tcx>,
     ) -> RelateResult<'tcx, ty::Region<'tcx>> {
         Ok(a)
     }

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -675,8 +675,12 @@ fn construct_error(tcx: TyCtxt<'_>, def_id: LocalDefId, guar: ErrorGuaranteed) -
                         ))),
                     )
                 }
-                _ => {
-                    span_bug!(span, "expected type of closure body to be a closure or coroutine");
+                ty::Error(_) => (vec![closure_ty, closure_ty], closure_ty, None),
+                kind => {
+                    span_bug!(
+                        span,
+                        "expected type of closure body to be a closure or coroutine, got {kind:?}"
+                    );
                 }
             }
         }

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -541,12 +541,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
     }
 
     #[instrument(level = "trace", skip(self), ret)]
-    fn eval_rvalue(
-        &mut self,
-        rvalue: &Rvalue<'tcx>,
-        location: Location,
-        dest: &Place<'tcx>,
-    ) -> Option<()> {
+    fn eval_rvalue(&mut self, rvalue: &Rvalue<'tcx>, dest: &Place<'tcx>) -> Option<()> {
         if !dest.projection.is_empty() {
             return None;
         }
@@ -733,7 +728,7 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
             _ if place.is_indirect() => {}
             ConstPropMode::NoPropagation => self.ensure_not_propagated(place.local),
             ConstPropMode::OnlyInsideOwnBlock | ConstPropMode::FullConstProp => {
-                if self.eval_rvalue(rvalue, location, place).is_none() {
+                if self.eval_rvalue(rvalue, place).is_none() {
                     // Const prop failed, so erase the destination, ensuring that whatever happens
                     // from here on, does not know about the previous value.
                     // This is important in case we have

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -58,6 +58,7 @@ fn has_ffi_unwind_calls(tcx: TyCtxt<'_>, local_def_id: LocalDefId) -> bool {
         ty::FnDef(..) => body_ty.fn_sig(tcx).abi(),
         ty::Closure(..) => Abi::RustCall,
         ty::Coroutine(..) => Abi::Rust,
+        ty::Error(_) => return false,
         _ => span_bug!(body.span, "unexpected body ty: {:?}", body_ty),
     };
     let body_can_unwind = layout::fn_can_unwind(tcx, Some(def_id), body_abi);

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -123,6 +123,7 @@ enum LiveNodeKind {
     VarDefNode(Span, HirId),
     ClosureNode,
     ExitNode,
+    ErrNode,
 }
 
 fn live_node_kind_to_string(lnk: LiveNodeKind, tcx: TyCtxt<'_>) -> String {
@@ -133,6 +134,7 @@ fn live_node_kind_to_string(lnk: LiveNodeKind, tcx: TyCtxt<'_>) -> String {
         VarDefNode(s, _) => format!("Var def node [{}]", sm.span_to_diagnostic_string(s)),
         ClosureNode => "Closure node".to_owned(),
         ExitNode => "Exit node".to_owned(),
+        ErrNode => "Error node".to_owned(),
     }
 }
 
@@ -962,10 +964,10 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
                 // Now that we know the label we're going to,
                 // look it up in the continue loop nodes table
-                self.cont_ln
-                    .get(&sc)
-                    .cloned()
-                    .unwrap_or_else(|| span_bug!(expr.span, "continue to unknown label"))
+                self.cont_ln.get(&sc).cloned().unwrap_or_else(|| {
+                    self.ir.tcx.dcx().span_delayed_bug(expr.span, "continue to unknown label");
+                    self.ir.add_live_node(ErrNode)
+                })
             }
 
             hir::ExprKind::Assign(ref l, ref r, _) => {

--- a/compiler/rustc_pattern_analysis/src/lints.rs
+++ b/compiler/rustc_pattern_analysis/src/lints.rs
@@ -10,7 +10,7 @@ use crate::MatchArm;
 /// Traverse the patterns to collect any variants of a non_exhaustive enum that fail to be mentioned
 /// in a given column.
 #[instrument(level = "debug", skip(cx), ret)]
-fn collect_nonexhaustive_missing_variants<'a, 'p, 'tcx>(
+fn collect_nonexhaustive_missing_variants<'p, 'tcx>(
     cx: &RustcMatchCheckCtxt<'p, 'tcx>,
     column: &PatternColumn<'p, RustcMatchCheckCtxt<'p, 'tcx>>,
 ) -> Result<Vec<WitnessPat<'p, 'tcx>>, ErrorGuaranteed> {

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -52,7 +52,7 @@ impl From<DepNodeIndex> for QueryInvocationId {
     }
 }
 
-pub(crate) struct MarkFrame<'a> {
+pub struct MarkFrame<'a> {
     index: SerializedDepNodeIndex,
     parent: Option<&'a MarkFrame<'a>>,
 }
@@ -754,7 +754,6 @@ impl<D: Deps> DepGraphData<D> {
         &self,
         qcx: Qcx,
         parent_dep_node_index: SerializedDepNodeIndex,
-        dep_node: &DepNode,
         frame: Option<&MarkFrame<'_>>,
     ) -> Option<()> {
         let dep_dep_node_color = self.colors.get(parent_dep_node_index);
@@ -861,7 +860,7 @@ impl<D: Deps> DepGraphData<D> {
         let prev_deps = self.previous.edge_targets_from(prev_dep_node_index);
 
         for dep_dep_node_index in prev_deps {
-            self.try_mark_parent_green(qcx, dep_dep_node_index, dep_node, Some(&frame))?;
+            self.try_mark_parent_green(qcx, dep_dep_node_index, Some(&frame))?;
         }
 
         // If we got here without hitting a `return` that means that all

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1644,7 +1644,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             debug!(?rib.kind);
             match rib.kind {
                 LifetimeRibKind::AnonymousCreateParameter { binder, .. } => {
-                    let res = self.create_fresh_lifetime(lifetime.id, lifetime.ident, binder);
+                    let res = self.create_fresh_lifetime(lifetime.ident, binder);
                     self.record_lifetime_res(lifetime.id, res, elision_candidate);
                     return;
                 }
@@ -1736,7 +1736,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn create_fresh_lifetime(&mut self, id: NodeId, ident: Ident, binder: NodeId) -> LifetimeRes {
+    fn create_fresh_lifetime(&mut self, ident: Ident, binder: NodeId) -> LifetimeRes {
         debug_assert_eq!(ident.name, kw::UnderscoreLifetime);
         debug!(?ident.span);
 
@@ -1757,7 +1757,6 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
     #[instrument(level = "debug", skip(self))]
     fn resolve_elided_lifetimes_in_path(
         &mut self,
-        path_id: NodeId,
         partial_res: PartialRes,
         path: &[Segment],
         source: PathSource<'_>,
@@ -1890,7 +1889,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
                         // Group all suggestions into the first record.
                         let mut candidate = LifetimeElisionCandidate::Missing(missing_lifetime);
                         for id in node_ids {
-                            let res = self.create_fresh_lifetime(id, ident, binder);
+                            let res = self.create_fresh_lifetime(ident, binder);
                             self.record_lifetime_res(
                                 id,
                                 res,
@@ -3935,7 +3934,7 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
         if record_partial_res == RecordPartialRes::Yes {
             // Avoid recording definition of `A::B` in `<T as A>::B::C`.
             self.r.record_partial_res(node_id, partial_res);
-            self.resolve_elided_lifetimes_in_path(node_id, partial_res, path, source, path_span);
+            self.resolve_elided_lifetimes_in_path(partial_res, path, source, path_span);
         }
 
         partial_res

--- a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_gnu.rs
@@ -1,4 +1,6 @@
-use crate::spec::{base, CodeModel, Target, TargetOptions};
+use std::borrow::Cow;
+
+use crate::spec::{base, CodeModel, SplitDebuginfo, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -12,6 +14,7 @@ pub fn target() -> Target {
             features: "+m,+a,+f,+d,+c".into(),
             llvm_abiname: "ilp32d".into(),
             max_atomic_width: Some(32),
+            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
@@ -1,4 +1,6 @@
-use crate::spec::{base, CodeModel, Target, TargetOptions};
+use std::borrow::Cow;
+
+use crate::spec::{base, CodeModel, SplitDebuginfo, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -12,6 +14,7 @@ pub fn target() -> Target {
             features: "+m,+a,+f,+d,+c".into(),
             llvm_abiname: "ilp32d".into(),
             max_atomic_width: Some(32),
+            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_musl::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64_linux_android.rs
@@ -1,4 +1,6 @@
-use crate::spec::{base, CodeModel, SanitizerSet, Target, TargetOptions};
+use std::borrow::Cow;
+
+use crate::spec::{base, CodeModel, SanitizerSet, SplitDebuginfo, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -13,6 +15,7 @@ pub fn target() -> Target {
             llvm_abiname: "lp64d".into(),
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),
+            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::android::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_gnu.rs
@@ -1,4 +1,6 @@
-use crate::spec::{base, CodeModel, Target, TargetOptions};
+use std::borrow::Cow;
+
+use crate::spec::{base, CodeModel, SplitDebuginfo, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -12,6 +14,7 @@ pub fn target() -> Target {
             features: "+m,+a,+f,+d,+c".into(),
             llvm_abiname: "lp64d".into(),
             max_atomic_width: Some(64),
+            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_musl.rs
@@ -1,4 +1,6 @@
-use crate::spec::{base, CodeModel, Target, TargetOptions};
+use std::borrow::Cow;
+
+use crate::spec::{base, CodeModel, SplitDebuginfo, Target, TargetOptions};
 
 pub fn target() -> Target {
     Target {
@@ -12,6 +14,7 @@ pub fn target() -> Target {
             features: "+m,+a,+f,+d,+c".into(),
             llvm_abiname: "lp64d".into(),
             max_atomic_width: Some(64),
+            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_musl::opts()
         },
     }

--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -803,7 +803,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
     #[instrument(level = "debug", skip(self), ret)]
     pub(super) fn merge_candidates(
         &mut self,
-        mut candidates: Vec<Candidate<'tcx>>,
+        candidates: Vec<Candidate<'tcx>>,
     ) -> QueryResult<'tcx> {
         // First try merging all candidates. This is complete and fully sound.
         let responses = candidates.iter().map(|c| c.result).collect::<Vec<_>>();

--- a/compiler/rustc_trait_selection/src/solve/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/mod.rs
@@ -124,25 +124,6 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         }
     }
 
-    #[instrument(level = "debug", skip(self))]
-    fn compute_closure_kind_goal(
-        &mut self,
-        goal: Goal<'tcx, (DefId, ty::GenericArgsRef<'tcx>, ty::ClosureKind)>,
-    ) -> QueryResult<'tcx> {
-        let (_, args, expected_kind) = goal.predicate;
-        let found_kind = args.as_closure().kind_ty().to_opt_closure_kind();
-
-        let Some(found_kind) = found_kind else {
-            return self.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS);
-        };
-        if found_kind.extends(expected_kind) {
-            self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
-        } else {
-            Err(NoSolution)
-        }
-    }
-
-    #[instrument(level = "debug", skip(self))]
     fn compute_object_safe_goal(&mut self, trait_def_id: DefId) -> QueryResult<'tcx> {
         if self.tcx().check_is_object_safe(trait_def_id) {
             self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -483,7 +483,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // Instead, we select the right impl now but report "`Bar` does
         // not implement `Clone`".
         if candidates.len() == 1 {
-            return self.filter_reservation_impls(candidates.pop().unwrap(), stack.obligation);
+            return self.filter_reservation_impls(candidates.pop().unwrap());
         }
 
         // Winnow, but record the exact outcome of evaluation, which
@@ -557,7 +557,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         }
 
         // Just one candidate left.
-        self.filter_reservation_impls(candidates.pop().unwrap().candidate, stack.obligation)
+        self.filter_reservation_impls(candidates.pop().unwrap().candidate)
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1436,7 +1436,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     fn filter_reservation_impls(
         &mut self,
         candidate: SelectionCandidate<'tcx>,
-        obligation: &PolyTraitObligation<'tcx>,
     ) -> SelectionResult<'tcx, SelectionCandidate<'tcx>> {
         let tcx = self.tcx();
         // Treat reservation impls as ambiguity.

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -83,6 +83,90 @@ impl_zeroable_primitive!(isize);
 #[rustc_diagnostic_item = "NonZero"]
 pub struct NonZero<T: ZeroablePrimitive>(T);
 
+impl<T> NonZero<T>
+where
+    T: ZeroablePrimitive,
+{
+    /// Creates a non-zero if the given value is not zero.
+    #[stable(feature = "nonzero", since = "1.28.0")]
+    #[rustc_const_stable(feature = "const_nonzero_int_methods", since = "1.47.0")]
+    #[rustc_allow_const_fn_unstable(const_refs_to_cell)]
+    #[must_use]
+    #[inline]
+    pub const fn new(n: T) -> Option<Self> {
+        // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has
+        //         the same layout and size as `T`, with `0` representing `None`.
+        unsafe { crate::mem::transmute_copy(&n) }
+    }
+
+    /// Creates a non-zero without checking whether the value is non-zero.
+    /// This results in undefined behaviour if the value is zero.
+    ///
+    /// # Safety
+    ///
+    /// The value must not be zero.
+    #[stable(feature = "nonzero", since = "1.28.0")]
+    #[rustc_const_stable(feature = "nonzero", since = "1.28.0")]
+    #[must_use]
+    #[inline]
+    pub const unsafe fn new_unchecked(n: T) -> Self {
+        match Self::new(n) {
+            Some(n) => n,
+            None => {
+                // SAFETY: The caller guarantees that `n` is non-zero, so this is unreachable.
+                unsafe {
+                    crate::intrinsics::assert_unsafe_precondition!(
+                        "NonZero::new_unchecked requires the argument to be non-zero",
+                        () => false
+                    );
+
+                    crate::hint::unreachable_unchecked()
+                }
+            }
+        }
+    }
+
+    /// Converts a reference to a non-zero mutable reference
+    /// if the referenced value is not zero.
+    #[unstable(feature = "nonzero_from_mut", issue = "106290")]
+    #[must_use]
+    #[inline]
+    pub fn from_mut(n: &mut T) -> Option<&mut Self> {
+        // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has
+        //         the same layout and size as `T`, with `0` representing `None`.
+        let opt_n = unsafe { &mut *(n as *mut T as *mut Option<Self>) };
+
+        opt_n.as_mut()
+    }
+
+    /// Converts a mutable reference to a non-zero mutable reference
+    /// without checking whether the referenced value is non-zero.
+    /// This results in undefined behavior if the referenced value is zero.
+    ///
+    /// # Safety
+    ///
+    /// The referenced value must not be zero.
+    #[unstable(feature = "nonzero_from_mut", issue = "106290")]
+    #[must_use]
+    #[inline]
+    pub unsafe fn from_mut_unchecked(n: &mut T) -> &mut Self {
+        match Self::from_mut(n) {
+            Some(n) => n,
+            None => {
+                // SAFETY: The caller guarantees that `n` references a value that is non-zero, so this is unreachable.
+                unsafe {
+                    crate::intrinsics::assert_unsafe_precondition!(
+                      "NonZero::from_mut_unchecked requires the argument to dereference as non-zero",
+                        () => false
+                    );
+
+                    crate::hint::unreachable_unchecked()
+                }
+            }
+        }
+    }
+}
+
 macro_rules! impl_nonzero_fmt {
     ( #[$stability: meta] ( $( $Trait: ident ),+ ) for $Ty: ident ) => {
         $(
@@ -100,7 +184,6 @@ macro_rules! impl_nonzero_fmt {
 macro_rules! nonzero_integer {
     (
         #[$stability:meta]
-        #[$const_new_unchecked_stability:meta]
         Self = $Ty:ident,
         Primitive = $signedness:ident $Int:ident,
         $(UnsignedNonZero = $UnsignedNonZero:ident,)?
@@ -143,74 +226,6 @@ macro_rules! nonzero_integer {
         pub type $Ty = NonZero<$Int>;
 
         impl $Ty {
-            /// Creates a non-zero without checking whether the value is non-zero.
-            /// This results in undefined behaviour if the value is zero.
-            ///
-            /// # Safety
-            ///
-            /// The value must not be zero.
-            #[$stability]
-            #[$const_new_unchecked_stability]
-            #[must_use]
-            #[inline]
-            pub const unsafe fn new_unchecked(n: $Int) -> Self {
-                crate::panic::debug_assert_nounwind!(
-                    n != 0,
-                    concat!(stringify!($Ty), "::new_unchecked requires a non-zero argument")
-                );
-                // SAFETY: this is guaranteed to be safe by the caller.
-                unsafe {
-                    Self(n)
-                }
-            }
-
-            /// Creates a non-zero if the given value is not zero.
-            #[$stability]
-            #[rustc_const_stable(feature = "const_nonzero_int_methods", since = "1.47.0")]
-            #[must_use]
-            #[inline]
-            pub const fn new(n: $Int) -> Option<Self> {
-                if n != 0 {
-                    // SAFETY: we just checked that there's no `0`
-                    Some(unsafe { Self(n) })
-                } else {
-                    None
-                }
-            }
-
-            /// Converts a primitive mutable reference to a non-zero mutable reference
-            /// without checking whether the referenced value is non-zero.
-            /// This results in undefined behavior if `*n` is zero.
-            ///
-            /// # Safety
-            /// The referenced value must not be currently zero.
-            #[unstable(feature = "nonzero_from_mut", issue = "106290")]
-            #[must_use]
-            #[inline]
-            pub unsafe fn from_mut_unchecked(n: &mut $Int) -> &mut Self {
-                // SAFETY: Self is repr(transparent), and the value is assumed to be non-zero.
-                unsafe {
-                    let n_alias = &mut *n;
-                    core::intrinsics::assert_unsafe_precondition!(
-                        concat!(stringify!($Ty), "::from_mut_unchecked requires the argument to dereference as non-zero"),
-                        (n_alias: &mut $Int) => *n_alias != 0
-                    );
-                    &mut *(n as *mut $Int as *mut Self)
-                }
-            }
-
-            /// Converts a primitive mutable reference to a non-zero mutable reference
-            /// if the referenced integer is not zero.
-            #[unstable(feature = "nonzero_from_mut", issue = "106290")]
-            #[must_use]
-            #[inline]
-            pub fn from_mut(n: &mut $Int) -> Option<&mut Self> {
-                // SAFETY: Self is repr(transparent), and the value is non-zero.
-                // As long as the returned reference is alive,
-                // the user cannot `*n = 0` directly.
-                (*n != 0).then(|| unsafe { &mut *(n as *mut $Int as *mut Self) })
-            }
-
             /// Returns the value as a primitive type.
             #[$stability]
             #[inline]
@@ -724,7 +739,6 @@ macro_rules! nonzero_integer {
     (Self = $Ty:ident, Primitive = unsigned $Int:ident $(,)?) => {
         nonzero_integer! {
             #[stable(feature = "nonzero", since = "1.28.0")]
-            #[rustc_const_stable(feature = "nonzero", since = "1.28.0")]
             Self = $Ty,
             Primitive = unsigned $Int,
             UnsignedPrimitive = $Int,
@@ -735,7 +749,6 @@ macro_rules! nonzero_integer {
     (Self = $Ty:ident, Primitive = signed $Int:ident, $($rest:tt)*) => {
         nonzero_integer! {
             #[stable(feature = "signed_nonzero", since = "1.34.0")]
-            #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")]
             Self = $Ty,
             Primitive = signed $Int,
             $($rest)*

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -35,7 +35,7 @@ mod private {
 pub trait ZeroablePrimitive: Sized + Copy + private::Sealed {}
 
 macro_rules! impl_zeroable_primitive {
-    ($NonZero:ident ( $primitive:ty )) => {
+    ($primitive:ty) => {
         #[unstable(
             feature = "nonzero_internals",
             reason = "implementation detail which may disappear or be replaced at any time",
@@ -52,18 +52,18 @@ macro_rules! impl_zeroable_primitive {
     };
 }
 
-impl_zeroable_primitive!(NonZeroU8(u8));
-impl_zeroable_primitive!(NonZeroU16(u16));
-impl_zeroable_primitive!(NonZeroU32(u32));
-impl_zeroable_primitive!(NonZeroU64(u64));
-impl_zeroable_primitive!(NonZeroU128(u128));
-impl_zeroable_primitive!(NonZeroUsize(usize));
-impl_zeroable_primitive!(NonZeroI8(i8));
-impl_zeroable_primitive!(NonZeroI16(i16));
-impl_zeroable_primitive!(NonZeroI32(i32));
-impl_zeroable_primitive!(NonZeroI64(i64));
-impl_zeroable_primitive!(NonZeroI128(i128));
-impl_zeroable_primitive!(NonZeroIsize(isize));
+impl_zeroable_primitive!(u8);
+impl_zeroable_primitive!(u16);
+impl_zeroable_primitive!(u32);
+impl_zeroable_primitive!(u64);
+impl_zeroable_primitive!(u128);
+impl_zeroable_primitive!(usize);
+impl_zeroable_primitive!(i8);
+impl_zeroable_primitive!(i16);
+impl_zeroable_primitive!(i32);
+impl_zeroable_primitive!(i64);
+impl_zeroable_primitive!(i128);
+impl_zeroable_primitive!(isize);
 
 /// A value that is known not to equal zero.
 ///

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 use std::marker::PhantomData;
+use std::sync::atomic::AtomicU32;
 
 macro_rules! define_handles {
     (
@@ -12,8 +13,8 @@ macro_rules! define_handles {
         #[repr(C)]
         #[allow(non_snake_case)]
         pub struct HandleCounters {
-            $($oty: AtomicUsize,)*
-            $($ity: AtomicUsize,)*
+            $($oty: AtomicU32,)*
+            $($ity: AtomicU32,)*
         }
 
         impl HandleCounters {
@@ -21,8 +22,8 @@ macro_rules! define_handles {
             // a wrapper `fn` pointer, once `const fn` can reference `static`s.
             extern "C" fn get() -> &'static Self {
                 static COUNTERS: HandleCounters = HandleCounters {
-                    $($oty: AtomicUsize::new(1),)*
-                    $($ity: AtomicUsize::new(1),)*
+                    $($oty: AtomicU32::new(1),)*
+                    $($ity: AtomicU32::new(1),)*
                 };
                 &COUNTERS
             }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -16,7 +16,6 @@ use std::mem;
 use std::ops::Bound;
 use std::ops::Range;
 use std::panic;
-use std::sync::atomic::AtomicUsize;
 use std::sync::Once;
 use std::thread;
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -578,8 +578,13 @@ where
     F: FnOnce(&mut [u8]) -> Result<usize>,
 {
     let n = read(cursor.ensure_init().init_mut())?;
+    assert!(
+        n <= cursor.capacity(),
+        "read should not return more bytes than there is capacity for in the read buffer"
+    );
     unsafe {
-        // SAFETY: we initialised using `ensure_init` so there is no uninit data to advance to.
+        // SAFETY: we initialised using `ensure_init` so there is no uninit data to advance to
+        // and we have checked that the read amount is not over capacity (see #120603)
         cursor.advance(n);
     }
     Ok(())

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -1,6 +1,6 @@
 use super::{repeat, BorrowedBuf, Cursor, SeekFrom};
 use crate::cmp::{self, min};
-use crate::io::{self, IoSlice, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut, DEFAULT_BUF_SIZE};
 use crate::io::{BufRead, BufReader, Read, Seek, Write};
 use crate::mem::MaybeUninit;
 use crate::ops::Deref;
@@ -666,5 +666,18 @@ fn read_buf_broken_read() {
         }
     }
 
-    BufReader::new(MalformedRead).read(&mut [0; 4]).unwrap();
+    let _ = BufReader::new(MalformedRead).fill_buf();
+}
+
+#[test]
+fn read_buf_full_read() {
+    struct FullRead;
+
+    impl Read for FullRead {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+    }
+
+    assert_eq!(BufReader::new(FullRead).fill_buf().unwrap().len(), DEFAULT_BUF_SIZE);
 }

--- a/src/tools/clippy/clippy_lints/src/lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/lifetimes.rs
@@ -176,7 +176,7 @@ fn check_fn_inner<'tcx>(
                             _ => None,
                         });
                         for bound in lifetimes {
-                            if !bound.is_static() && !bound.is_elided() {
+                            if bound.res != LifetimeName::Static && !bound.is_elided() {
                                 return;
                             }
                         }

--- a/src/tools/miri/tests/pass/issues/issue-miri-3282-struct-tail-normalize.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-3282-struct-tail-normalize.rs
@@ -1,0 +1,20 @@
+// regression test for an ICE: https://github.com/rust-lang/miri/issues/3282
+
+trait Id {
+    type Assoc: ?Sized;
+}
+
+impl<T: ?Sized> Id for T {
+    type Assoc = T;
+}
+
+#[repr(transparent)]
+struct Foo<T: ?Sized> {
+    field: <T as Id>::Assoc,
+}
+
+fn main() {
+    let x = unsafe { std::mem::transmute::<fn(&str), fn(&Foo<str>)>(|_| ()) };
+    let foo: &Foo<str> = unsafe { &*("uwu" as *const str as *const Foo<str>) };
+    x(foo);
+}

--- a/tests/incremental/const-generics/issue-62536.rs
+++ b/tests/incremental/const-generics/issue-62536.rs
@@ -1,4 +1,7 @@
 // revisions:cfail1
+
+#![allow(unused_variables)]
+
 struct S<T, const N: usize>([T; N]);
 
 fn f<T, const N: usize>(x: T) -> S<T, {N}> { panic!() }

--- a/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-77708-1.rs
+++ b/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-77708-1.rs
@@ -1,6 +1,6 @@
 // revisions: cfail
 #![feature(generic_const_exprs)]
-#![allow(incomplete_features, unused_braces)]
+#![allow(incomplete_features, unused_braces, unused_variables)]
 
 trait Delegates<T> {}
 

--- a/tests/incremental/struct_change_field_name.rs
+++ b/tests/incremental/struct_change_field_name.rs
@@ -6,6 +6,7 @@
 // [cfail2] compile-flags: -Z query-dep-graph -Z assert-incr-state=loaded
 
 #![feature(rustc_attrs)]
+#![allow(unused_variables)]
 
 #[cfg(rpass1)]
 pub struct X {

--- a/tests/rustdoc-ui/issues/issue-102986.stderr
+++ b/tests/rustdoc-ui/issues/issue-102986.stderr
@@ -6,8 +6,8 @@ LL |     y: (typeof("hey"),),
    |
 help: consider replacing `typeof(...)` with an actual type
    |
-LL |     y: (&'static str,),
-   |         ~~~~~~~~~~~~
+LL |     y: (&str,),
+   |         ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/asm/bad-template.aarch64.stderr
+++ b/tests/ui/asm/bad-template.aarch64.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:27:15
+  --> $DIR/bad-template.rs:30:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:29:15
+  --> $DIR/bad-template.rs:32:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:29:21
+  --> $DIR/bad-template.rs:32:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:32:16
+  --> $DIR/bad-template.rs:35:16
    |
 LL |         asm!("{a}");
    |                ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:34:15
+  --> $DIR/bad-template.rs:37:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:37:15
+  --> $DIR/bad-template.rs:40:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:37:21
+  --> $DIR/bad-template.rs:40:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:44:15
+  --> $DIR/bad-template.rs:47:15
    |
 LL |         asm!("{}", in("x0") foo);
    |               ^^   ------------ explicit register argument
@@ -77,24 +77,24 @@ LL |         asm!("{}", in("x0") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:44:20
+  --> $DIR/bad-template.rs:47:20
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
 help: use the register name directly in the assembly code
-  --> $DIR/bad-template.rs:44:20
+  --> $DIR/bad-template.rs:47:20
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:46:17
+  --> $DIR/bad-template.rs:49:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:49:18
+  --> $DIR/bad-template.rs:52:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -104,7 +104,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:55:14
+  --> $DIR/bad-template.rs:58:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -112,7 +112,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:57:14
+  --> $DIR/bad-template.rs:60:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -120,7 +120,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:57:20
+  --> $DIR/bad-template.rs:60:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -128,13 +128,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:60:15
+  --> $DIR/bad-template.rs:63:15
    |
 LL | global_asm!("{a}");
    |               ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:62:14
+  --> $DIR/bad-template.rs:65:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -143,13 +143,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -157,7 +157,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:65:14
+  --> $DIR/bad-template.rs:68:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -165,7 +165,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:65:20
+  --> $DIR/bad-template.rs:68:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -173,13 +173,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:68:16
+  --> $DIR/bad-template.rs:71:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:70:17
+  --> $DIR/bad-template.rs:73:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -189,7 +189,7 @@ LL | global_asm!("", const FOO, const FOO);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 warning: formatting may not be suitable for sub-register argument
-  --> $DIR/bad-template.rs:46:15
+  --> $DIR/bad-template.rs:49:15
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument

--- a/tests/ui/asm/bad-template.rs
+++ b/tests/ui/asm/bad-template.rs
@@ -21,6 +21,9 @@ macro_rules! global_asm {
 #[lang = "sized"]
 trait Sized {}
 
+#[lang = "copy"]
+trait Copy {}
+
 fn main() {
     let mut foo = 0;
     unsafe {

--- a/tests/ui/asm/bad-template.x86_64.stderr
+++ b/tests/ui/asm/bad-template.x86_64.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:27:15
+  --> $DIR/bad-template.rs:30:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:29:15
+  --> $DIR/bad-template.rs:32:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:29:21
+  --> $DIR/bad-template.rs:32:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:32:16
+  --> $DIR/bad-template.rs:35:16
    |
 LL |         asm!("{a}");
    |                ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:34:15
+  --> $DIR/bad-template.rs:37:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:34:20
+  --> $DIR/bad-template.rs:37:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:37:15
+  --> $DIR/bad-template.rs:40:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:37:21
+  --> $DIR/bad-template.rs:40:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:41:15
+  --> $DIR/bad-template.rs:44:15
    |
 LL |         asm!("{}", in("eax") foo);
    |               ^^   ------------- explicit register argument
@@ -77,24 +77,24 @@ LL |         asm!("{}", in("eax") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:41:20
+  --> $DIR/bad-template.rs:44:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 help: use the register name directly in the assembly code
-  --> $DIR/bad-template.rs:41:20
+  --> $DIR/bad-template.rs:44:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:46:17
+  --> $DIR/bad-template.rs:49:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:49:18
+  --> $DIR/bad-template.rs:52:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -104,7 +104,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:55:14
+  --> $DIR/bad-template.rs:58:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -112,7 +112,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:57:14
+  --> $DIR/bad-template.rs:60:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -120,7 +120,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:57:20
+  --> $DIR/bad-template.rs:60:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -128,13 +128,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:60:15
+  --> $DIR/bad-template.rs:63:15
    |
 LL | global_asm!("{a}");
    |               ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:62:14
+  --> $DIR/bad-template.rs:65:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -143,13 +143,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:62:19
+  --> $DIR/bad-template.rs:65:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -157,7 +157,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:65:14
+  --> $DIR/bad-template.rs:68:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -165,7 +165,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:65:20
+  --> $DIR/bad-template.rs:68:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -173,13 +173,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:68:16
+  --> $DIR/bad-template.rs:71:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:70:17
+  --> $DIR/bad-template.rs:73:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -189,7 +189,7 @@ LL | global_asm!("", const FOO, const FOO);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 warning: formatting may not be suitable for sub-register argument
-  --> $DIR/bad-template.rs:46:15
+  --> $DIR/bad-template.rs:49:15
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument

--- a/tests/ui/asm/naked-functions.rs
+++ b/tests/ui/asm/naked-functions.rs
@@ -81,13 +81,15 @@ pub extern "C" fn missing_assembly() {
 #[naked]
 pub extern "C" fn too_many_asm_blocks() {
     //~^ ERROR naked functions must contain a single asm block
-    asm!("");
-    //~^ ERROR asm in naked functions must use `noreturn` option
-    asm!("");
-    //~^ ERROR asm in naked functions must use `noreturn` option
-    asm!("");
-    //~^ ERROR asm in naked functions must use `noreturn` option
-    asm!("", options(noreturn));
+    unsafe {
+        asm!("");
+        //~^ ERROR asm in naked functions must use `noreturn` option
+        asm!("");
+        //~^ ERROR asm in naked functions must use `noreturn` option
+        asm!("");
+        //~^ ERROR asm in naked functions must use `noreturn` option
+        asm!("", options(noreturn));
+    }
 }
 
 pub fn outer(x: u32) -> extern "C" fn(usize) -> usize {

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -1,23 +1,23 @@
 error: asm with the `pure` option must have at least one output
-  --> $DIR/naked-functions.rs:111:14
+  --> $DIR/naked-functions.rs:113:14
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:203:5
+  --> $DIR/naked-functions.rs:205:5
    |
 LL |     compile_error!("this is a user specified error")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:209:5
+  --> $DIR/naked-functions.rs:211:5
    |
 LL |     compile_error!("this is a user specified error");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/naked-functions.rs:216:10
+  --> $DIR/naked-functions.rs:218:10
    |
 LL |     asm!(invalid_syntax)
    |          ^^^^^^^^^^^^^^
@@ -142,37 +142,37 @@ LL | pub extern "C" fn missing_assembly() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:5
+  --> $DIR/naked-functions.rs:85:9
    |
-LL |     asm!("");
-   |     ^^^^^^^^
+LL |         asm!("");
+   |         ^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn));
-   |            +++++++++++++++++++
+LL |         asm!("", options(noreturn));
+   |                +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:86:5
+  --> $DIR/naked-functions.rs:87:9
    |
-LL |     asm!("");
-   |     ^^^^^^^^
+LL |         asm!("");
+   |         ^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn));
-   |            +++++++++++++++++++
+LL |         asm!("", options(noreturn));
+   |                +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:88:5
+  --> $DIR/naked-functions.rs:89:9
    |
-LL |     asm!("");
-   |     ^^^^^^^^
+LL |         asm!("");
+   |         ^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn));
-   |            +++++++++++++++++++
+LL |         asm!("", options(noreturn));
+   |                +++++++++++++++++++
 
 error[E0787]: naked functions must contain a single asm block
   --> $DIR/naked-functions.rs:82:1
@@ -180,17 +180,17 @@ error[E0787]: naked functions must contain a single asm block
 LL | pub extern "C" fn too_many_asm_blocks() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-LL |     asm!("");
-   |     -------- multiple asm blocks are unsupported in naked functions
+LL |         asm!("");
+   |         -------- multiple asm blocks are unsupported in naked functions
 LL |
-LL |     asm!("");
-   |     -------- multiple asm blocks are unsupported in naked functions
+LL |         asm!("");
+   |         -------- multiple asm blocks are unsupported in naked functions
 LL |
-LL |     asm!("", options(noreturn));
-   |     --------------------------- multiple asm blocks are unsupported in naked functions
+LL |         asm!("", options(noreturn));
+   |         --------------------------- multiple asm blocks are unsupported in naked functions
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:97:11
+  --> $DIR/naked-functions.rs:99:11
    |
 LL |         *&y
    |           ^
@@ -198,7 +198,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:95:5
+  --> $DIR/naked-functions.rs:97:5
    |
 LL |     pub extern "C" fn inner(y: usize) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,19 +207,19 @@ LL |         *&y
    |         --- non-asm is unsupported in naked functions
 
 error[E0787]: asm options unsupported in naked functions: `nomem`, `preserves_flags`
-  --> $DIR/naked-functions.rs:105:5
+  --> $DIR/naked-functions.rs:107:5
    |
 LL |     asm!("", options(nomem, preserves_flags, noreturn));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm options unsupported in naked functions: `nostack`, `pure`, `readonly`
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:113:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:113:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -230,13 +230,13 @@ LL |     asm!("", options(noreturn), options(readonly, nostack), options(pure));
    |            +++++++++++++++++++
 
 error[E0787]: asm options unsupported in naked functions: `may_unwind`
-  --> $DIR/naked-functions.rs:119:5
+  --> $DIR/naked-functions.rs:121:5
    |
 LL |     asm!("", options(noreturn, may_unwind));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:124:1
+  --> $DIR/naked-functions.rs:126:1
    |
 LL | pub unsafe fn default_abi() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -244,43 +244,43 @@ LL | pub unsafe fn default_abi() {
    = note: `#[warn(undefined_naked_function_abi)]` on by default
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:130:1
+  --> $DIR/naked-functions.rs:132:1
    |
 LL | pub unsafe fn rust_abi() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:170:1
+  --> $DIR/naked-functions.rs:172:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:177:1
+  --> $DIR/naked-functions.rs:179:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:184:1
+  --> $DIR/naked-functions.rs:186:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:191:1
+  --> $DIR/naked-functions.rs:193:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:193:1
+  --> $DIR/naked-functions.rs:195:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:195:1
+  --> $DIR/naked-functions.rs:197:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/associated-types/associated-types-eq-hr.rs
+++ b/tests/ui/associated-types/associated-types-eq-hr.rs
@@ -94,10 +94,18 @@ pub fn call_bar() {
 
 pub fn call_tuple_one() {
     tuple_one::<Tuple>();
+    //~^ ERROR not general enough
+    //~| ERROR not general enough
+    //~| ERROR not general enough
+    //~| ERROR not general enough
 }
 
 pub fn call_tuple_two() {
     tuple_two::<Tuple>();
+    //~^ ERROR not general enough
+    //~| ERROR not general enough
+    //~| ERROR mismatched types
+    //~| ERROR mismatched types
 }
 
 pub fn call_tuple_three() {
@@ -106,6 +114,8 @@ pub fn call_tuple_three() {
 
 pub fn call_tuple_four() {
     tuple_four::<Tuple>();
+    //~^ ERROR not general enough
+    //~| ERROR not general enough
 }
 
 fn main() {}

--- a/tests/ui/associated-types/associated-types-eq-hr.stderr
+++ b/tests/ui/associated-types/associated-types-eq-hr.stderr
@@ -42,6 +42,113 @@ LL | where
 LL |     T: for<'x> TheTrait<&'x isize, A = &'x usize>,
    |                                    ^^^^^^^^^^^^^ required by this bound in `bar`
 
-error: aborting due to 2 previous errors
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
 
-For more information about this error, try `rustc --explain E0271`.
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:96:5
+   |
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected reference `&'x _`
+              found reference `&'y _`
+note: the lifetime requirement is introduced here
+  --> $DIR/associated-types-eq-hr.rs:66:53
+   |
+LL |     T: for<'x, 'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>,
+   |                                                     ^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/associated-types-eq-hr.rs:104:5
+   |
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected reference `&'x _`
+              found reference `&'y _`
+note: the lifetime requirement is introduced here
+  --> $DIR/associated-types-eq-hr.rs:66:53
+   |
+LL |     T: for<'x, 'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>,
+   |                                                     ^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:116:5
+   |
+LL |     tuple_four::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+
+error: implementation of `TheTrait` is not general enough
+  --> $DIR/associated-types-eq-hr.rs:116:5
+   |
+LL |     tuple_four::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `TheTrait` is not general enough
+   |
+   = note: `Tuple` must implement `TheTrait<(&'0 isize, &'1 isize)>`, for any two lifetimes `'0` and `'1`...
+   = note: ...but it actually implements `TheTrait<(&'2 isize, &'2 isize)>`, for some specific lifetime `'2`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0271, E0308.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/async-await/issue-70935-complex-spans.rs
+++ b/tests/ui/async-await/issue-70935-complex-spans.rs
@@ -14,6 +14,7 @@ async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
 
 fn foo(x: NotSync) -> impl Future + Send {
     //~^ ERROR `*mut ()` cannot be shared between threads safely
+    //~| ERROR `*mut ()` cannot be shared between threads safely
     async move {
         baz(|| async {
             foo(x.clone());

--- a/tests/ui/async-await/issue-70935-complex-spans.stderr
+++ b/tests/ui/async-await/issue-70935-complex-spans.stderr
@@ -4,7 +4,7 @@ error[E0277]: `*mut ()` cannot be shared between threads safely
 LL | fn foo(x: NotSync) -> impl Future + Send {
    |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
    |
-   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:17:5: 21:6}: Send`
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 22:6}: Send`
 note: required because it appears within the type `PhantomData<*mut ()>`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
 note: required because it appears within the type `NotSync`
@@ -14,7 +14,7 @@ LL | struct NotSync(PhantomData<*mut ()>);
    |        ^^^^^^^
    = note: required for `&NotSync` to implement `Send`
 note: required because it's used within this closure
-  --> $DIR/issue-70935-complex-spans.rs:18:13
+  --> $DIR/issue-70935-complex-spans.rs:19:13
    |
 LL |         baz(|| async {
    |             ^^
@@ -27,7 +27,7 @@ LL | | }
    | |_^
    = note: required because it captures the following types: `impl Future<Output = ()>`
 note: required because it's used within this `async` block
-  --> $DIR/issue-70935-complex-spans.rs:17:5
+  --> $DIR/issue-70935-complex-spans.rs:18:5
    |
 LL | /     async move {
 LL | |         baz(|| async {
@@ -36,6 +36,45 @@ LL | |         }).await;
 LL | |     }
    | |_____^
 
-error: aborting due to 1 previous error
+error[E0277]: `*mut ()` cannot be shared between threads safely
+  --> $DIR/issue-70935-complex-spans.rs:15:23
+   |
+LL | fn foo(x: NotSync) -> impl Future + Send {
+   |                       ^^^^^^^^^^^^^^^^^^ `*mut ()` cannot be shared between threads safely
+   |
+   = help: within `NotSync`, the trait `Sync` is not implemented for `*mut ()`, which is required by `{async block@$DIR/issue-70935-complex-spans.rs:18:5: 22:6}: Send`
+note: required because it appears within the type `PhantomData<*mut ()>`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+note: required because it appears within the type `NotSync`
+  --> $DIR/issue-70935-complex-spans.rs:9:8
+   |
+LL | struct NotSync(PhantomData<*mut ()>);
+   |        ^^^^^^^
+   = note: required for `&NotSync` to implement `Send`
+note: required because it's used within this closure
+  --> $DIR/issue-70935-complex-spans.rs:19:13
+   |
+LL |         baz(|| async {
+   |             ^^
+note: required because it's used within this `async` fn body
+  --> $DIR/issue-70935-complex-spans.rs:12:67
+   |
+LL |   async fn baz<T>(_c: impl FnMut() -> T) where T: Future<Output=()> {
+   |  ___________________________________________________________________^
+LL | | }
+   | |_^
+   = note: required because it captures the following types: `impl Future<Output = ()>`
+note: required because it's used within this `async` block
+  --> $DIR/issue-70935-complex-spans.rs:18:5
+   |
+LL | /     async move {
+LL | |         baz(|| async {
+LL | |             foo(x.clone());
+LL | |         }).await;
+LL | |     }
+   | |_____^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.rs
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.rs
@@ -6,6 +6,7 @@ auto trait Magic : Sized where Option<Self> : Magic {} //~ ERROR E0568
 impl<T:Magic> Magic for T {}
 
 fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+//~^ ERROR: use of moved value
 
 #[derive(Debug)]
 struct NoClone;

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -14,6 +14,21 @@ LL | auto trait Magic : Sized where Option<Self> : Magic {}
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
-error: aborting due to 2 previous errors
+error[E0382]: use of moved value: `x`
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:8:41
+   |
+LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+   |                   -                  -  ^ value used here after move
+   |                   |                  |
+   |                   |                  value moved here
+   |                   move occurs because `x` has type `T`, which does not implement the `Copy` trait
+   |
+help: consider further restricting this bound
+   |
+LL | fn copy<T: Magic + Copy>(x: T) -> (T, T) { (x, x) }
+   |                  ++++++
 
-For more information about this error, try `rustc --explain E0568`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0382, E0568.
+For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/binop/issue-77910-1.rs
+++ b/tests/ui/binop/issue-77910-1.rs
@@ -1,6 +1,6 @@
 fn foo(s: &i32) -> &i32 {
     let xs;
-    xs
+    xs //~ ERROR: isn't initialized
 }
 fn main() {
     let y;

--- a/tests/ui/binop/issue-77910-1.stderr
+++ b/tests/ui/binop/issue-77910-1.stderr
@@ -22,7 +22,20 @@ LL |     assert_eq!(foo, y);
    = help: use parentheses to call this function: `foo(/* &i32 */)`
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error[E0381]: used binding `xs` isn't initialized
+  --> $DIR/issue-77910-1.rs:3:5
+   |
+LL |     let xs;
+   |         -- binding declared here but left uninitialized
+LL |     xs
+   |     ^^ `xs` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let xs = todo!();
+   |            +++++++++
 
-Some errors have detailed explanations: E0277, E0369.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0369, E0381.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/binop/issue-77910-2.rs
+++ b/tests/ui/binop/issue-77910-2.rs
@@ -1,6 +1,6 @@
 fn foo(s: &i32) -> &i32 {
     let xs;
-    xs
+    xs //~ ERROR: isn't initialized
 }
 fn main() {
     let y;

--- a/tests/ui/binop/issue-77910-2.stderr
+++ b/tests/ui/binop/issue-77910-2.stderr
@@ -11,6 +11,20 @@ help: use parentheses to call this function
 LL |     if foo(/* &i32 */) == y {}
    |           ++++++++++++
 
-error: aborting due to 1 previous error
+error[E0381]: used binding `xs` isn't initialized
+  --> $DIR/issue-77910-2.rs:3:5
+   |
+LL |     let xs;
+   |         -- binding declared here but left uninitialized
+LL |     xs
+   |     ^^ `xs` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let xs = todo!();
+   |            +++++++++
 
-For more information about this error, try `rustc --explain E0369`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0369, E0381.
+For more information about an error, try `rustc --explain E0369`.

--- a/tests/ui/box/unit/unique-object-noncopyable.stderr
+++ b/tests/ui/box/unit/unique-object-noncopyable.stderr
@@ -12,6 +12,9 @@ LL |     let _z = y.clone();
            which is required by `Box<dyn Foo>: Clone`
            `dyn Foo: Clone`
            which is required by `Box<dyn Foo>: Clone`
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `clone`, perhaps you need to implement it:
+           candidate #1: `Clone`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/box/unit/unique-pinned-nocopy.stderr
+++ b/tests/ui/box/unit/unique-pinned-nocopy.stderr
@@ -10,9 +10,6 @@ LL |     let _j = i.clone();
    = note: the following trait bounds were not satisfied:
            `R: Clone`
            which is required by `Box<R>: Clone`
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `clone`, perhaps you need to implement it:
-           candidate #1: `Clone`
 help: consider annotating `R` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/class-cast-to-trait.rs
+++ b/tests/ui/class-cast-to-trait.rs
@@ -1,5 +1,5 @@
 trait Noisy {
-  fn speak(&self);
+  fn speak(&mut self);
 }
 
 struct Cat {
@@ -10,7 +10,7 @@ struct Cat {
 }
 
 impl Cat {
-  pub fn eat(&self) -> bool {
+  pub fn eat(&mut self) -> bool {
     if self.how_hungry > 0 {
         println!("OM NOM NOM");
         self.how_hungry -= 2;
@@ -24,12 +24,12 @@ impl Cat {
 }
 
 impl Noisy for Cat {
-  fn speak(&self) { self.meow(); }
+  fn speak(&mut self) { self.meow(); }
 
 }
 
 impl Cat {
-    fn meow(&self) {
+    fn meow(&mut self) {
       println!("Meow");
       self.meows += 1;
       if self.meows % 5 == 0 {

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/borrowck/borrowck-4.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/borrowck/borrowck-4.rs
@@ -15,6 +15,6 @@ fn foo () -> impl FnMut()->() {
     c
 }
 fn main() {
-    let c = foo();
+    let mut c = foo();
     c();
 }

--- a/tests/ui/closures/binder/implicit-stuff.rs
+++ b/tests/ui/closures/binder/implicit-stuff.rs
@@ -24,4 +24,5 @@ fn main() {
                                                //~| ERROR `'_` cannot be used here
     let _ = for<'a> |x: &()| -> &'a () { x };  //~ ERROR `&` without an explicit lifetime name cannot be used here
     let _ = for<'a> |x: &'a ()| -> &() { x };  //~ ERROR `&` without an explicit lifetime name cannot be used here
+    //~^ ERROR: lifetime may not live long enough
 }

--- a/tests/ui/closures/binder/implicit-stuff.stderr
+++ b/tests/ui/closures/binder/implicit-stuff.stderr
@@ -102,6 +102,15 @@ LL |     let _ = for<'a> |x: &'a _, y, z: _| -> &'a _ {
    |             |
    |             `for<...>` is here
 
-error: aborting due to 15 previous errors
+error: lifetime may not live long enough
+  --> $DIR/implicit-stuff.rs:26:42
+   |
+LL |     let _ = for<'a> |x: &'a ()| -> &() { x };
+   |                 --                 -     ^ returning this value requires that `'a` must outlive `'1`
+   |                 |                  |
+   |                 |                  let's call the lifetime of this reference `'1`
+   |                 lifetime `'a` defined here
+
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0637`.

--- a/tests/ui/closures/issue-109188.rs
+++ b/tests/ui/closures/issue-109188.rs
@@ -7,13 +7,13 @@ struct X(Y);
 
 struct Y;
 
-fn consume_fnmut(f: &dyn FnMut()) {
+fn consume_fnmut(f: &mut dyn FnMut()) {
     f();
 }
 
 fn move_into_fnmut() {
     let x = move_into_fnmut();
-    consume_fnmut(&|| {
+    consume_fnmut(&mut || {
         let Either::One(_t) = x; //~ ERROR mismatched types
         let Either::Two(_t) = x; //~ ERROR mismatched types
     });

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.rs
@@ -2,8 +2,11 @@
 // needs-llvm-components: arm
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
-#[lang="sized"]
-trait Sized { }
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
 
 #[no_mangle]
 #[cmse_nonsecure_entry]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/wrong-abi.stderr
@@ -1,5 +1,5 @@
 error[E0776]: `#[cmse_nonsecure_entry]` requires C ABI
-  --> $DIR/wrong-abi.rs:9:1
+  --> $DIR/wrong-abi.rs:12:1
    |
 LL | #[cmse_nonsecure_entry]
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -13,6 +13,7 @@ fn consume<T: 'static>(_val: T)
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
     //~^ overly complex generic constant
+    //~| ERROR: cannot call
 {
 }
 
@@ -20,6 +21,7 @@ fn test<T: 'static>()
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
     //~^ overly complex generic constant
+    //~| ERROR: cannot call
 {
 }
 

--- a/tests/ui/const-generics/issues/issue-90318.stderr
+++ b/tests/ui/const-generics/issues/issue-90318.stderr
@@ -10,7 +10,7 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = note: this operation may be supported in the future
 
 error: overly complex generic constant
-  --> $DIR/issue-90318.rs:21:8
+  --> $DIR/issue-90318.rs:22:8
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,5 +20,28 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error: aborting due to 2 previous errors
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/issue-90318.rs:14:10
+   |
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/issue-90318.rs:22:10
+   |
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
+++ b/tests/ui/const-generics/late-bound-vars/late-bound-in-return-issue-77357.stderr
@@ -13,5 +13,37 @@ LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error: aborting due to 2 previous errors
+error[E0391]: cycle detected when evaluating type-level constant
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `bug::{constant#0}`...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires caching mir of `bug::{constant#0}` for CTFE...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires elaborating drops for `bug::{constant#0}`...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires borrow-checking `bug::{constant#0}`...
+  --> $DIR/late-bound-in-return-issue-77357.rs:9:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires normalizing `Binder { value: ConstEvaluatable(UnevaluatedConst { def: DefId(0:8 ~ late_bound_in_return_issue_77357[9394]::bug::{constant#0}), args: [T/#0] }: usize), bound_vars: [] }`...
+   = note: ...which again requires evaluating type-level constant, completing the cycle
+   = note: cycle used when normalizing `&dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]>`
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/consts/const-for-feature-gate.rs
+++ b/tests/ui/consts/const-for-feature-gate.rs
@@ -3,6 +3,9 @@
 const _: () = {
     for _ in 0..5 {}
     //~^ error: `for` is not allowed in a `const`
+    //~| ERROR: cannot convert
+    //~| ERROR: cannot call
+    //~| ERROR: mutable references
 };
 
 fn main() {}

--- a/tests/ui/consts/const-for-feature-gate.stderr
+++ b/tests/ui/consts/const-for-feature-gate.stderr
@@ -8,6 +8,37 @@ LL |     for _ in 0..5 {}
    = help: add `#![feature(const_for)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/const-try-feature-gate.rs
+++ b/tests/ui/consts/const-try-feature-gate.rs
@@ -3,6 +3,8 @@
 const fn t() -> Option<()> {
     Some(())?;
     //~^ error: `?` is not allowed in a `const fn`
+    //~| ERROR: cannot convert
+    //~| ERROR: cannot determine
     None
 }
 

--- a/tests/ui/consts/const-try-feature-gate.stderr
+++ b/tests/ui/consts/const-try-feature-gate.stderr
@@ -8,6 +8,29 @@ LL |     Some(())?;
    = help: add `#![feature(const_try)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0015]: `?` cannot determine the branch of `Option<()>` in constant functions
+  --> $DIR/const-try-feature-gate.rs:4:5
+   |
+LL |     Some(())?;
+   |     ^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0015]: `?` cannot convert from residual of `Option<()>` in constant functions
+  --> $DIR/const-try-feature-gate.rs:4:5
+   |
+LL |     Some(())?;
+   |     ^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/control-flow/loop.rs
+++ b/tests/ui/consts/control-flow/loop.rs
@@ -51,10 +51,16 @@ const _: i32 = {
     let mut x = 0;
 
     for i in 0..4 { //~ ERROR `for` is not allowed in a `const`
+        //~^ ERROR: cannot call
+        //~| ERROR: mutable references
+        //~| ERROR: cannot convert
         x += i;
     }
 
     for i in 0..4 { //~ ERROR `for` is not allowed in a `const`
+        //~^ ERROR: cannot call
+        //~| ERROR: mutable references
+        //~| ERROR: cannot convert
         x += i;
     }
 

--- a/tests/ui/consts/control-flow/loop.stderr
+++ b/tests/ui/consts/control-flow/loop.stderr
@@ -2,6 +2,9 @@ error[E0658]: `for` is not allowed in a `const`
   --> $DIR/loop.rs:53:5
    |
 LL | /     for i in 0..4 {
+LL | |
+LL | |
+LL | |
 LL | |         x += i;
 LL | |     }
    | |_____^
@@ -11,9 +14,12 @@ LL | |     }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `for` is not allowed in a `const`
-  --> $DIR/loop.rs:57:5
+  --> $DIR/loop.rs:60:5
    |
 LL | /     for i in 0..4 {
+LL | |
+LL | |
+LL | |
 LL | |         x += i;
 LL | |     }
    | |_____^
@@ -22,6 +28,67 @@ LL | |     }
    = help: add `#![feature(const_for)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
+  --> $DIR/loop.rs:53:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/loop.rs:53:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+  --> $DIR/loop.rs:53:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
+  --> $DIR/loop.rs:60:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error[E0658]: mutable references are not allowed in constants
+  --> $DIR/loop.rs:60:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+  --> $DIR/loop.rs:60:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/control-flow/try.rs
+++ b/tests/ui/consts/control-flow/try.rs
@@ -4,6 +4,8 @@
 const fn opt() -> Option<i32> {
     let x = Some(2);
     x?; //~ ERROR `?` is not allowed in a `const fn`
+    //~^ ERROR: cannot convert
+    //~| ERROR: cannot determine
     None
 }
 

--- a/tests/ui/consts/control-flow/try.stderr
+++ b/tests/ui/consts/control-flow/try.stderr
@@ -8,6 +8,29 @@ LL |     x?;
    = help: add `#![feature(const_try)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0015]: `?` cannot determine the branch of `Option<i32>` in constant functions
+  --> $DIR/try.rs:6:5
+   |
+LL |     x?;
+   |     ^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0015]: `?` cannot convert from residual of `Option<i32>` in constant functions
+  --> $DIR/try.rs:6:5
+   |
+LL |     x?;
+   |     ^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -74,6 +74,100 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 11 previous errors
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/fn_trait_refs.rs:17:5
+   |
+LL |     f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     T: ~const Fn<()> + ~const Destruct + ~const std::ops::Fn<()>,
+   |                                        +++++++++++++++++++++++++
 
-For more information about this error, try `rustc --explain E0635`.
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:13:23
+   |
+LL | const fn tester_fn<T>(f: T) -> T::Output
+   |                       ^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/fn_trait_refs.rs:24:5
+   |
+LL |     f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     T: ~const FnMut<()> + ~const Destruct + ~const std::ops::FnMut<()>,
+   |                                           ++++++++++++++++++++++++++++
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:20:27
+   |
+LL | const fn tester_fn_mut<T>(mut f: T) -> T::Output
+   |                           ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/fn_trait_refs.rs:31:5
+   |
+LL |     f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     T: ~const FnOnce<()> + ~const std::ops::FnOnce<()>,
+   |                          +++++++++++++++++++++++++++++
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:34:21
+   |
+LL | const fn test_fn<T>(mut f: T) -> (T::Output, T::Output, T::Output)
+   |                     ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/fn_trait_refs.rs:48:25
+   |
+LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
+   |                         ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/fn_trait_refs.rs:72:17
+   |
+LL |         assert!(test_one == (1, 1, 1));
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/fn_trait_refs.rs:75:17
+   |
+LL |         assert!(test_two == (2, 2));
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 20 previous errors
+
+Some errors have detailed explanations: E0015, E0493, E0635.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/promoted_const_call.stderr
+++ b/tests/ui/consts/promoted_const_call.stderr
@@ -7,26 +7,6 @@ LL |     let _: &'static _ = &id(&Panic);
    |                              the destructor for this type cannot be evaluated in constants
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:11:26
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:11:30
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
-   |            |                 |
-   |            |                 creates a temporary value which is freed while still in use
-   |            type annotation requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:17:26
    |
 LL |     let _: &'static _ = &id(&Panic);
@@ -68,7 +48,7 @@ LL |     let _: &'static _ = &&(Panic, 0).1;
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0493, E0716.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/promoted_const_call3.rs
+++ b/tests/ui/consts/promoted_const_call3.rs
@@ -2,13 +2,14 @@ pub const fn id<T>(x: T) -> T { x }
 pub const C: () = {
     let _: &'static _ = &String::new();
     //~^ ERROR: destructor of `String` cannot be evaluated at compile-time
-    //~| ERROR: temporary value dropped while borrowed
+};
 
+pub const _: () = {
     let _: &'static _ = &id(&String::new());
     //~^ ERROR: destructor of `String` cannot be evaluated at compile-time
-    //~| ERROR: temporary value dropped while borrowed
-    //~| ERROR: temporary value dropped while borrowed
+};
 
+pub const _: () = {
     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
     //~^ ERROR: temporary value dropped while borrowed
 };

--- a/tests/ui/consts/promoted_const_call3.stderr
+++ b/tests/ui/consts/promoted_const_call3.stderr
@@ -1,53 +1,22 @@
 error[E0493]: destructor of `String` cannot be evaluated at compile-time
-  --> $DIR/promoted_const_call3.rs:7:30
+  --> $DIR/promoted_const_call3.rs:3:26
+   |
+LL |     let _: &'static _ = &String::new();
+   |                          ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
+LL |
+LL | };
+   | - value is dropped here
+
+error[E0493]: destructor of `String` cannot be evaluated at compile-time
+  --> $DIR/promoted_const_call3.rs:8:30
    |
 LL |     let _: &'static _ = &id(&String::new());
    |                              ^^^^^^^^^^^^^ - value is dropped here
    |                              |
    |                              the destructor for this type cannot be evaluated in constants
 
-error[E0493]: destructor of `String` cannot be evaluated at compile-time
-  --> $DIR/promoted_const_call3.rs:3:26
-   |
-LL |     let _: &'static _ = &String::new();
-   |                          ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
-...
-LL | };
-   | - value is dropped here
-
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:3:26
-   |
-LL |     let _: &'static _ = &String::new();
-   |            ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:7:26
-   |
-LL |     let _: &'static _ = &id(&String::new());
-   |            ----------    ^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:7:30
-   |
-LL |     let _: &'static _ = &id(&String::new());
-   |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
-   |            |                 |
-   |            |                 creates a temporary value which is freed while still in use
-   |            type annotation requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:12:26
+  --> $DIR/promoted_const_call3.rs:13:26
    |
 LL |     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
    |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -58,7 +27,7 @@ LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:17:26
+  --> $DIR/promoted_const_call3.rs:18:26
    |
 LL |     let _: &'static _ = &String::new();
    |            ----------    ^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -69,7 +38,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:20:26
+  --> $DIR/promoted_const_call3.rs:21:26
    |
 LL |     let _: &'static _ = &id(&String::new());
    |            ----------    ^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -80,7 +49,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:20:30
+  --> $DIR/promoted_const_call3.rs:21:30
    |
 LL |     let _: &'static _ = &id(&String::new());
    |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
@@ -89,7 +58,7 @@ LL |     let _: &'static _ = &id(&String::new());
    |            type annotation requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call3.rs:24:26
+  --> $DIR/promoted_const_call3.rs:25:26
    |
 LL |     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
    |            ----------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
@@ -99,7 +68,7 @@ LL |
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 10 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0493, E0716.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/promoted_const_call5.rs
+++ b/tests/ui/consts/promoted_const_call5.rs
@@ -25,9 +25,9 @@ pub const fn new_manually_drop<T>(t: T) -> std::mem::ManuallyDrop<T>  {
 const C: () = {
     let _: &'static _ = &id(&new_string());
     //~^ ERROR destructor of `String` cannot be evaluated at compile-time
-    //~| ERROR: temporary value dropped while borrowed
-    //~| ERROR: temporary value dropped while borrowed
+};
 
+const _: () = {
     let _: &'static _ = &new_manually_drop(new_string());
     //~^ ERROR: temporary value dropped while borrowed
 };

--- a/tests/ui/consts/promoted_const_call5.stderr
+++ b/tests/ui/consts/promoted_const_call5.stderr
@@ -7,26 +7,6 @@ LL |     let _: &'static _ = &id(&new_string());
    |                              the destructor for this type cannot be evaluated in constants
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call5.rs:26:26
-   |
-LL |     let _: &'static _ = &id(&new_string());
-   |            ----------    ^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call5.rs:26:30
-   |
-LL |     let _: &'static _ = &id(&new_string());
-   |                          ----^^^^^^^^^^^^-- temporary value is freed at the end of this statement
-   |                          |   |
-   |                          |   creates a temporary value which is freed while still in use
-   |                          argument requires that borrow lasts for `'static`
-
-error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call5.rs:31:26
    |
 LL |     let _: &'static _ = &new_manually_drop(new_string());
@@ -68,7 +48,7 @@ LL |
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0493, E0716.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/transmute-size-mismatch-before-typeck.rs
+++ b/tests/ui/consts/transmute-size-mismatch-before-typeck.rs
@@ -5,7 +5,7 @@
 
 fn main() {
     match &b""[..] {
-        ZST => {}
+        ZST => {} //~ ERROR: could not evaluate constant pattern
     }
 }
 

--- a/tests/ui/consts/transmute-size-mismatch-before-typeck.stderr
+++ b/tests/ui/consts/transmute-size-mismatch-before-typeck.stderr
@@ -7,6 +7,12 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    = note: source type: `usize` (word size)
    = note: target type: `&[u8]` (2 * word size)
 
-error: aborting due to 1 previous error
+error: could not evaluate constant pattern
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:8:9
+   |
+LL |         ZST => {}
+   |         ^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0512`.

--- a/tests/ui/consts/try-operator.stderr
+++ b/tests/ui/consts/try-operator.stderr
@@ -4,6 +4,51 @@ error[E0635]: unknown feature `const_convert`
 LL | #![feature(const_convert)]
    |            ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: `?` cannot determine the branch of `Result<(), ()>` in constant functions
+  --> $DIR/try-operator.rs:10:9
+   |
+LL |         Err(())?;
+   |         ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0635`.
+error[E0015]: `?` cannot convert from residual of `Result<bool, ()>` in constant functions
+  --> $DIR/try-operator.rs:10:9
+   |
+LL |         Err(())?;
+   |         ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: `?` cannot determine the branch of `Option<()>` in constant functions
+  --> $DIR/try-operator.rs:18:9
+   |
+LL |         None?;
+   |         ^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: `?` cannot convert from residual of `Option<()>` in constant functions
+  --> $DIR/try-operator.rs:18:9
+   |
+LL |         None?;
+   |         ^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0015, E0635.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -4,5 +4,38 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
    |                                       ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/unstable-const-fn-in-libcore.rs:24:26
+   |
+LL |             Opt::None => f(),
+   |                          ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T + ~const std::ops::FnOnce<()>>(self, f: F) -> T {
+   |                                                     +++++++++++++++++++++++++++++
 
+error[E0493]: destructor of `F` cannot be evaluated at compile-time
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:60
+   |
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
+   |                                                            ^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
+
+error[E0493]: destructor of `Opt<T>` cannot be evaluated at compile-time
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:54
+   |
+LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
+   |                                                      ^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0015, E0493.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/derives/derive-assoc-type-not-impl.stderr
+++ b/tests/ui/derives/derive-assoc-type-not-impl.stderr
@@ -15,9 +15,6 @@ note: trait bound `NotClone: Clone` was not satisfied
    |
 LL | #[derive(Clone)]
    |          ^^^^^ unsatisfied trait bound introduced in this `derive` macro
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `clone`, perhaps you need to implement it:
-           candidate #1: `Clone`
 help: consider annotating `NotClone` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/diagnostic-width/tabs-trimming.rs
+++ b/tests/ui/diagnostic-width/tabs-trimming.rs
@@ -8,6 +8,7 @@
 						match money {
 							v @ 1 | 2 | 3 => panic!("You gave me too little money {}", v), // Long text here: TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
 							//~^ ERROR variable `v` is not bound in all patterns
+							//~| ERROR possibly-uninitialized
 							v => println!("Enough money {}", v),
 						}
 					}

--- a/tests/ui/diagnostic-width/tabs-trimming.stderr
+++ b/tests/ui/diagnostic-width/tabs-trimming.stderr
@@ -7,6 +7,18 @@ LL | ...   v @ 1 | 2 | 3 => panic!("You gave me too little money {}", v), // Lon
    |       |       pattern doesn't bind `v`
    |       variable not in all patterns
 
-error: aborting due to 1 previous error
+error[E0381]: used binding `v` is possibly-uninitialized
+  --> $DIR/tabs-trimming.rs:9:67
+   |
+LL | ...   v @ 1 | 2 | 3 => panic!("You gave me too little money {}", v), // Long text here: TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT...
+   |       -                                                          ^ `v` used here but it is possibly-uninitialized
+   |       |
+   |       binding initialized here in some conditions
+   |       binding declared here but left uninitialized
+   |
+   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0408`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0381, E0408.
+For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/enum/enum-and-module-in-same-scope.rs
+++ b/tests/ui/enum/enum-and-module-in-same-scope.rs
@@ -5,6 +5,7 @@ enum Foo {
 mod Foo { //~ ERROR the name `Foo` is defined multiple times
     pub static X: isize = 42;
     fn f() { f() } // Check that this does not result in a resolution error
+    //~^ WARN cannot return without recursing
 }
 
 fn main() {}

--- a/tests/ui/enum/enum-and-module-in-same-scope.stderr
+++ b/tests/ui/enum/enum-and-module-in-same-scope.stderr
@@ -9,6 +9,17 @@ LL | mod Foo {
    |
    = note: `Foo` must be defined only once in the type namespace of this module
 
-error: aborting due to 1 previous error
+warning: function cannot return without recursing
+  --> $DIR/enum-and-module-in-same-scope.rs:7:5
+   |
+LL |     fn f() { f() } // Check that this does not result in a resolution error
+   |     ^^^^^^   --- recursive call site
+   |     |
+   |     cannot return without recursing
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0428`.

--- a/tests/ui/error-codes/E0582.rs
+++ b/tests/ui/error-codes/E0582.rs
@@ -19,7 +19,7 @@ fn mk_unexpected_char_err<'a>() -> Option<&'a i32> {
 }
 
 fn foo<'a>(data: &mut Chars<'a>) {
-    bar(mk_unexpected_char_err)
+    bar(mk_unexpected_char_err) //~ ERROR mismatched types
 }
 
 fn bar<F>(t: F)

--- a/tests/ui/error-codes/E0582.stderr
+++ b/tests/ui/error-codes/E0582.stderr
@@ -10,6 +10,21 @@ error[E0582]: binding for associated type `Item` references lifetime `'a`, which
 LL |     where F: for<'a> Iterator<Item=&'a i32>
    |                               ^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/E0582.rs:22:5
+   |
+LL |     bar(mk_unexpected_char_err)
+   |     ^^^ one type is more general than the other
+   |
+   = note: expected enum `Option<&_>`
+              found enum `Option<&'a _>`
+note: the lifetime requirement is introduced here
+  --> $DIR/E0582.rs:28:30
+   |
+LL |     where F: for<'a> Fn() -> Option<&'a i32>
+   |                              ^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0582`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0582.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/error-codes/E0637.rs
+++ b/tests/ui/error-codes/E0637.rs
@@ -2,9 +2,9 @@ fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
     //~^ ERROR: `'_` cannot be used here [E0637]
     //~| ERROR: missing lifetime specifier
     if str1.len() > str2.len() {
-        str1
+        str1 //~ ERROR: lifetime may not live long enough
     } else {
-        str2
+        str2 //~ ERROR: lifetime may not live long enough
     }
 }
 

--- a/tests/ui/error-codes/E0637.stderr
+++ b/tests/ui/error-codes/E0637.stderr
@@ -27,7 +27,25 @@ help: consider introducing a higher-ranked lifetime here
 LL |     T: for<'a> Into<&'a u32>,
    |        +++++++       ++
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/E0637.rs:5:9
+   |
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                  - let's call the lifetime of this reference `'1`
+...
+LL |         str1
+   |         ^^^^ returning this value requires that `'1` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/E0637.rs:7:9
+   |
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                                 - let's call the lifetime of this reference `'2`
+...
+LL |         str2
+   |         ^^^^ returning this value requires that `'2` must outlive `'static`
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/explicit-tail-calls/return-mismatches.rs
+++ b/tests/ui/explicit-tail-calls/return-mismatches.rs
@@ -13,7 +13,7 @@ fn _f1() {
     become _g1(); //~ error: mismatched types
 }
 
-fn _g1() -> ! {
+fn _g1() -> ! { //~ WARN: cannot return without recursing
     become _g1();
 }
 

--- a/tests/ui/explicit-tail-calls/return-mismatches.stderr
+++ b/tests/ui/explicit-tail-calls/return-mismatches.stderr
@@ -22,6 +22,17 @@ error[E0308]: mismatched types
 LL |     become _g2();
    |     ^^^^^^^^^^^^ expected `u32`, found `u16`
 
-error: aborting due to 3 previous errors
+warning: function cannot return without recursing
+  --> $DIR/return-mismatches.rs:16:1
+   |
+LL | fn _g1() -> ! {
+   | ^^^^^^^^^^^^^ cannot return without recursing
+LL |     become _g1();
+   |            ----- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/expr/if/if-no-match-bindings.rs
+++ b/tests/ui/expr/if/if-no-match-bindings.rs
@@ -6,6 +6,7 @@
 
 fn b_ref<'a>() -> &'a bool { &true }
 fn b_mut_ref<'a>() -> &'a mut bool { &mut true }
+//~^ ERROR: cannot return reference to temporary
 
 fn main() {
     // This is OK:

--- a/tests/ui/expr/if/if-no-match-bindings.stderr
+++ b/tests/ui/expr/if/if-no-match-bindings.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:18:8
+  --> $DIR/if-no-match-bindings.rs:19:8
    |
 LL |     if b_ref() {}
    |        ^^^^^^^ expected `bool`, found `&bool`
@@ -10,7 +10,7 @@ LL |     if *b_ref() {}
    |        +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:19:8
+  --> $DIR/if-no-match-bindings.rs:20:8
    |
 LL |     if b_mut_ref() {}
    |        ^^^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -21,7 +21,7 @@ LL |     if *b_mut_ref() {}
    |        +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:20:8
+  --> $DIR/if-no-match-bindings.rs:21:8
    |
 LL |     if &true {}
    |        ^^^^^ expected `bool`, found `&bool`
@@ -33,7 +33,7 @@ LL +     if true {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:21:8
+  --> $DIR/if-no-match-bindings.rs:22:8
    |
 LL |     if &mut true {}
    |        ^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -45,7 +45,7 @@ LL +     if true {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:24:11
+  --> $DIR/if-no-match-bindings.rs:25:11
    |
 LL |     while b_ref() {}
    |           ^^^^^^^ expected `bool`, found `&bool`
@@ -56,7 +56,7 @@ LL |     while *b_ref() {}
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:25:11
+  --> $DIR/if-no-match-bindings.rs:26:11
    |
 LL |     while b_mut_ref() {}
    |           ^^^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -67,7 +67,7 @@ LL |     while *b_mut_ref() {}
    |           +
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:26:11
+  --> $DIR/if-no-match-bindings.rs:27:11
    |
 LL |     while &true {}
    |           ^^^^^ expected `bool`, found `&bool`
@@ -79,7 +79,7 @@ LL +     while true {}
    |
 
 error[E0308]: mismatched types
-  --> $DIR/if-no-match-bindings.rs:27:11
+  --> $DIR/if-no-match-bindings.rs:28:11
    |
 LL |     while &mut true {}
    |           ^^^^^^^^^ expected `bool`, found `&mut bool`
@@ -90,6 +90,16 @@ LL -     while &mut true {}
 LL +     while true {}
    |
 
-error: aborting due to 8 previous errors
+error[E0515]: cannot return reference to temporary value
+  --> $DIR/if-no-match-bindings.rs:8:38
+   |
+LL | fn b_mut_ref<'a>() -> &'a mut bool { &mut true }
+   |                                      ^^^^^----
+   |                                      |    |
+   |                                      |    temporary value created here
+   |                                      returns a reference to data owned by the current function
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0308, E0515.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
@@ -13,4 +13,5 @@ extern "C" {
 
 fn main() {
     assert_eq!(FOO, 3);
+    //~^ ERROR extern static is unsafe
 }

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
@@ -8,6 +8,15 @@ LL |     #[cfg_attr(target_thread_local, thread_local)]
    = help: add `#![feature(cfg_target_thread_local)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-cfg-target-thread-local.rs:15:16
+   |
+LL |     assert_eq!(FOO, 3);
+   |                ^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0133, E0658.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/feature-gates/feature-gate-custom_mir.rs
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.rs
@@ -5,6 +5,7 @@ extern crate core;
 #[custom_mir(dialect = "built")] //~ ERROR the `#[custom_mir]` attribute is just used for the Rust test suite
 pub fn foo(_x: i32) -> i32 {
     0
+    //~^ ERROR: Could not parse body
 }
 
 fn main() {

--- a/tests/ui/feature-gates/feature-gate-custom_mir.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.stderr
@@ -7,6 +7,12 @@ LL | #[custom_mir(dialect = "built")]
    = help: add `#![feature(custom_mir)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error: Could not parse body with block decls, found: "Literal { lit: Spanned { node: Int(Pu128(0), Unsuffixed), span: $DIR/feature-gate-custom_mir.rs:7:5: 7:6 (#0) }, neg: false }"
+  --> $DIR/feature-gate-custom_mir.rs:7:5
+   |
+LL |     0
+   |     ^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -6,12 +6,14 @@ use std::arch::asm;
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
     asm!("", options(noreturn))
+    //~^ ERROR: requires unsafe
 }
 
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
     asm!("", options(noreturn))
+    //~^ ERROR: requires unsafe
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -9,7 +9,7 @@ LL | #[naked]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
-  --> $DIR/feature-gate-naked_functions.rs:11:1
+  --> $DIR/feature-gate-naked_functions.rs:12:1
    |
 LL | #[naked]
    | ^^^^^^^^
@@ -18,6 +18,23 @@ LL | #[naked]
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-naked_functions.rs:8:5
+   |
+LL |     asm!("", options(noreturn))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-naked_functions.rs:15:5
+   |
+LL |     asm!("", options(noreturn))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0133, E0658.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.rs
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.rs
@@ -8,7 +8,7 @@ fn main() {
         extern "rust-intrinsic" { //~ ERROR intrinsics are subject to change
             fn atomic_fence();
         }
-        atomic_fence();
+        atomic_fence(); //~ ERROR: is unsafe
         42
     });
 }

--- a/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
+++ b/tests/ui/feature-gates/feature-gated-feature-in-macro-arg.stderr
@@ -7,6 +7,15 @@ LL |         extern "rust-intrinsic" {
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0133]: call to unsafe function `main::atomic_fence` is unsafe and requires unsafe function or block
+  --> $DIR/feature-gated-feature-in-macro-arg.rs:11:9
+   |
+LL |         atomic_fence();
+   |         ^^^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0133, E0658.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/fn/suggest-return-closure.rs
+++ b/tests/ui/fn/suggest-return-closure.rs
@@ -17,10 +17,16 @@ fn fn_mut() -> _ {
     //~| SUGGESTION impl FnMut(char)
     //~| NOTE for more information on `Fn` traits and closure types
     let x = String::new();
-    |c| {
+    //~^ HELP: consider changing this to be mutable
+    |c| { //~ NOTE: value captured here
         x.push(c);
+        //~^ ERROR: does not live long enough
+        //~| NOTE: does not live long enough
+        //~| NOTE: cannot borrow as mutable
+        //~| ERROR: not declared as mutable
     }
-}
+} //~ NOTE: borrow later used here
+//~^ NOTE: dropped here
 
 fn fun() -> _ {
     //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types [E0121]

--- a/tests/ui/fn/suggest-return-closure.stderr
+++ b/tests/ui/fn/suggest-return-closure.stderr
@@ -21,7 +21,7 @@ LL | fn fn_mut() -> _ {
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/suggest-return-closure.rs:25:13
+  --> $DIR/suggest-return-closure.rs:31:13
    |
 LL | fn fun() -> _ {
    |             ^
@@ -31,6 +31,29 @@ LL | fn fun() -> _ {
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
 
-error: aborting due to 3 previous errors
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/suggest-return-closure.rs:22:9
+   |
+LL |     let x = String::new();
+   |         - help: consider changing this to be mutable: `mut x`
+...
+LL |         x.push(c);
+   |         ^ cannot borrow as mutable
 
-For more information about this error, try `rustc --explain E0121`.
+error[E0597]: `x` does not live long enough
+  --> $DIR/suggest-return-closure.rs:22:9
+   |
+LL |     |c| {
+   |     --- value captured here
+LL |         x.push(c);
+   |         ^ borrowed value does not live long enough
+...
+LL | }
+   | -- borrow later used here
+   | |
+   | `x` dropped here while still borrowed
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0121, E0596, E0597.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/generic-associated-types/extended/lending_iterator.base.stderr
+++ b/tests/ui/generic-associated-types/extended/lending_iterator.base.stderr
@@ -7,6 +7,12 @@ LL |     fn from_iter<T: for<'x> LendingIterator<Item<'x> = A>>(iter: T) -> Self
 LL |     fn from_iter<I: for<'x> LendingIterator<Item<'x> = A>>(mut iter: I) -> Self {
    |                                             ^^^^^^^^^^^^ impl has extra requirement `I: 'x`
 
-error: aborting due to 1 previous error
+error: `Self` does not live long enough
+  --> $DIR/lending_iterator.rs:34:9
+   |
+LL |         <B as FromLendingIterator<A>>::from_iter(self)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0276`.

--- a/tests/ui/generic-associated-types/extended/lending_iterator.rs
+++ b/tests/ui/generic-associated-types/extended/lending_iterator.rs
@@ -32,6 +32,7 @@ pub trait LendingIterator {
         Self: for<'q> LendingIterator<Item<'q> = A>,
     {
         <B as FromLendingIterator<A>>::from_iter(self)
+        //[base]~^ ERROR: does not live long enough
     }
 }
 

--- a/tests/ui/generic-associated-types/issue-70304.rs
+++ b/tests/ui/generic-associated-types/issue-70304.rs
@@ -52,4 +52,5 @@ fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
 pub fn main() {
     let doc = create_doc();
     let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
+    //~^ ERROR: `doc` does not live long enough
 }

--- a/tests/ui/generic-associated-types/issue-70304.stderr
+++ b/tests/ui/generic-associated-types/issue-70304.stderr
@@ -27,7 +27,21 @@ LL |     type Cursor<'a>: DocCursor<'a>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 3 previous errors
+error[E0597]: `doc` does not live long enough
+  --> $DIR/issue-70304.rs:54:59
+   |
+LL |     let doc = create_doc();
+   |         --- binding `doc` declared here
+LL |     let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
+   |                                               ------------^^^^-
+   |                                               |           |
+   |                                               |           borrowed value does not live long enough
+   |                                               argument requires that `doc` is borrowed for `'static`
+LL |
+LL | }
+   | - `doc` dropped here while still borrowed
 
-Some errors have detailed explanations: E0106, E0637.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0597, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/generic-associated-types/issue-74684-2.rs
+++ b/tests/ui/generic-associated-types/issue-74684-2.rs
@@ -10,7 +10,7 @@ impl <T> Fun for T {
 
 fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
     let a = [0; 1];
-    let x = T::identity(&a);
+    let x = T::identity(&a); //~ ERROR: does not live long enough
     todo!()
 }
 

--- a/tests/ui/generic-associated-types/issue-74684-2.stderr
+++ b/tests/ui/generic-associated-types/issue-74684-2.stderr
@@ -17,6 +17,23 @@ note: required by a bound in `bug`
 LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
    |                            ^^^^^^^^^^^^ required by this bound in `bug`
 
-error: aborting due to 1 previous error
+error[E0597]: `a` does not live long enough
+  --> $DIR/issue-74684-2.rs:13:25
+   |
+LL | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+   |        -- lifetime `'a` defined here
+LL |     let a = [0; 1];
+   |         - binding `a` declared here
+LL |     let x = T::identity(&a);
+   |             ------------^^-
+   |             |           |
+   |             |           borrowed value does not live long enough
+   |             argument requires that `a` is borrowed for `'a`
+LL |     todo!()
+LL | }
+   | - `a` dropped here while still borrowed
 
-For more information about this error, try `rustc --explain E0271`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0271, E0597.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/generic-associated-types/issue-80433.rs
+++ b/tests/ui/generic-associated-types/issue-80433.rs
@@ -22,11 +22,12 @@ fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
   //~^ ERROR missing generics for associated type
 {
     for n in 0i16..100 {
-        *dst.test_mut() = n.into();
+        *dst.test_mut() = n.into(); //~ ERROR: cannot borrow
+        //~^ ERROR: borrowed data escapes outside of function
     }
 }
 
 fn main() {
     let mut t1: E<f32> = Default::default();
-    test_simpler(&mut t1);
+    test_simpler(&mut t1); //~ ERROR does not live long enough
 }

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -25,6 +25,43 @@ LL |     type Output<'a>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 2 previous errors
+error[E0499]: cannot borrow `*dst` as mutable more than once at a time
+  --> $DIR/issue-80433.rs:25:10
+   |
+LL |         *dst.test_mut() = n.into();
+   |          ^^^-----------
+   |          |
+   |          `*dst` was mutably borrowed here in the previous iteration of the loop
+   |          argument requires that `*dst` is borrowed for `'static`
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/issue-80433.rs:25:10
+   |
+LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output = &'a mut f32>)
+   |                 --  --- `dst` is a reference that is only valid in the function body
+   |                 |
+   |                 lifetime `'a` defined here
+...
+LL |         *dst.test_mut() = n.into();
+   |          ^^^^^^^^^^^^^^
+   |          |
+   |          `dst` escapes the function body here
+   |          argument requires that `'a` must outlive `'static`
+
+error[E0597]: `t1` does not live long enough
+  --> $DIR/issue-80433.rs:32:18
+   |
+LL |     let mut t1: E<f32> = Default::default();
+   |         ------ binding `t1` declared here
+LL |     test_simpler(&mut t1);
+   |     -------------^^^^^^^-
+   |     |            |
+   |     |            borrowed value does not live long enough
+   |     argument requires that `t1` is borrowed for `'static`
+LL | }
+   | - `t1` dropped here while still borrowed
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0107, E0499, E0521, E0597.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.rs
+++ b/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.rs
@@ -5,7 +5,7 @@ trait X {
     type Y<T>;
 }
 
-trait M {
+trait M { //~ NOTE
     fn f(&self) {}
 }
 

--- a/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.stderr
+++ b/tests/ui/generic-associated-types/method-unsatisfied-assoc-type-predicate.stderr
@@ -14,6 +14,12 @@ LL | impl<T: X<Y<i32> = i32>> M for T {}
    |           ^^^^^^^^^^^^   -     -
    |           |
    |           unsatisfied trait bound introduced here
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `M` defines an item `f`, perhaps you need to implement it
+  --> $DIR/method-unsatisfied-assoc-type-predicate.rs:8:1
+   |
+LL | trait M {
+   | ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-extern.rs
+++ b/tests/ui/generics/generic-extern.rs
@@ -3,5 +3,5 @@ extern "C" {
 }
 
 fn main() {
-    foo::<i32>();
+    foo::<i32>(); //~ ERROR requires unsafe
 }

--- a/tests/ui/generics/generic-extern.stderr
+++ b/tests/ui/generics/generic-extern.stderr
@@ -6,6 +6,15 @@ LL |     fn foo<T>();
    |
    = help: replace the type parameters with concrete types like `u32`
 
-error: aborting due to 1 previous error
+error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
+  --> $DIR/generic-extern.rs:6:5
+   |
+LL |     foo::<i32>();
+   |     ^^^^^^^^^^^^ call to unsafe function
+   |
+   = note: consult the function's documentation for information on how to avoid undefined behavior
 
-For more information about this error, try `rustc --explain E0044`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0044, E0133.
+For more information about an error, try `rustc --explain E0044`.

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.rs
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.rs
@@ -4,4 +4,5 @@ fn main() {
     let xs = [13, 1, 5, 2, 3, 1, 21, 8];
     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
     //~^ `X..` patterns in slices are experimental
+    //~| ERROR: refutable pattern
 }

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.stderr
@@ -8,6 +8,21 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0005]: refutable pattern in local binding
+  --> $DIR/feature-gate-half-open-range-patterns-in-slices.rs:5:9
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `[i32::MIN..=2_i32, ..]` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `[i32; 8]`
+help: you might want to use `let else` to handle the variant that isn't matched
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs else { todo!() };
+   |                                               ++++++++++++++++
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0005, E0658.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs
@@ -23,6 +23,7 @@ fn syntax2() {
     macro_rules! mac {
         ($e:expr) => {
             let ...$e; //~ ERROR range-to patterns with `...` are not allowed
+            //~^ ERROR refutable pattern in local binding
         }
     }
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
@@ -33,5 +33,24 @@ LL |     mac!(0);
    |
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/half-open-range-pats-inclusive-dotdotdot-bad-syntax.rs:25:17
+   |
+LL |             let ...$e;
+   |                 ^^^^^ pattern `1_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ...$e; { todo!() }
+   |             ++            +++++++++++
 
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0005`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.rs
@@ -1,6 +1,9 @@
 fn main() {
     let x = 42;
     match x {
+        //~^ ERROR: non-exhaustive patterns
+        //~| NOTE: not covered
+        //~| NOTE: matched value is of type
         0..=73 => {},
         74..=> {},
         //~^ ERROR unexpected `>` after inclusive range

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
@@ -1,5 +1,5 @@
 error: unexpected `>` after inclusive range
-  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:5:14
+  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:8:14
    |
 LL |         74..=> {},
    |           ---^
@@ -11,5 +11,19 @@ help: add a space between the pattern and `=>`
 LL |         74.. => {},
    |             +
 
-error: aborting due to 1 previous error
+error[E0004]: non-exhaustive patterns: `i32::MIN..=-1_i32` not covered
+  --> $DIR/half-open-range-pats-inclusive-match-arrow.rs:3:11
+   |
+LL |     match x {
+   |           ^ pattern `i32::MIN..=-1_i32` not covered
+   |
+   = note: the matched value is of type `i32`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         74..=> {},
+LL ~         i32::MIN..=-1_i32 => todo!(),
+   |
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.rs
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.rs
@@ -16,7 +16,9 @@ fn bar() {
     macro_rules! mac {
         ($e:expr) => {
             let $e...; //~ ERROR inclusive range with no end
+            //~^ ERROR: refutable pattern
             let $e..=; //~ ERROR inclusive range with no end
+            //~^ ERROR: refutable pattern
         }
     }
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
@@ -43,7 +43,7 @@ LL |     mac!(0);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/half-open-range-pats-inclusive-no-end.rs:19:19
+  --> $DIR/half-open-range-pats-inclusive-no-end.rs:20:19
    |
 LL |             let $e..=;
    |                   ^^^ help: use `..` instead
@@ -54,6 +54,43 @@ LL |     mac!(0);
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/half-open-range-pats-inclusive-no-end.rs:18:17
+   |
+LL |             let $e...;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e...; { todo!() }
+   |             ++            +++++++++++
 
-For more information about this error, try `rustc --explain E0586`.
+error[E0005]: refutable pattern in local binding
+  --> $DIR/half-open-range-pats-inclusive-no-end.rs:20:17
+   |
+LL |             let $e..=;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e..=; { todo!() }
+   |             ++            +++++++++++
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0005, E0586.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.rs
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.rs
@@ -5,4 +5,5 @@ fn main() {
     //~^ `X..` patterns in slices are experimental
     //~| exclusive range pattern syntax is experimental
     //~| exclusive range pattern syntax is experimental
+    //~| ERROR: refutable pattern
 }

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.stderr
@@ -30,6 +30,21 @@ LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: use an inclusive range pattern, like N..=M
 
-error: aborting due to 3 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/slice_pattern_syntax_problem1.rs:4:9
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `[i32::MIN..=2_i32, ..]` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `[i32; 8]`
+help: you might want to use `let else` to handle the variant that isn't matched
+   |
+LL |     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs else { todo!() };
+   |                                               ++++++++++++++++
 
-For more information about this error, try `rustc --explain E0658`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0005, E0658.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.rs
+++ b/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.rs
@@ -12,10 +12,12 @@ fn hr_subtype<'c>(f: for<'a, 'b> fn(Inv<'a>, Inv<'a>)) {
 
 fn simple1<'c>(x: (&'c i32,)) {
     let _x: (&'static i32,) = x;
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn simple2<'c>(x: (&'c i32,)) {
     let _: (&'static i32,) = x;
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn main() {

--- a/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.stderr
+++ b/tests/ui/higher-ranked/subtype/placeholder-pattern-fail.stderr
@@ -9,6 +9,22 @@ LL |     let _: for<'a, 'b> fn(Inv<'a>, Inv<'b>) = sub;
    = note: expected fn pointer `for<'a, 'b> fn(Inv<'a>, Inv<'b>)`
               found fn pointer `for<'a> fn(Inv<'a>, Inv<'a>)`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/placeholder-pattern-fail.rs:14:13
+   |
+LL | fn simple1<'c>(x: (&'c i32,)) {
+   |            -- lifetime `'c` defined here
+LL |     let _x: (&'static i32,) = x;
+   |             ^^^^^^^^^^^^^^^ type annotation requires that `'c` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/placeholder-pattern-fail.rs:19:12
+   |
+LL | fn simple2<'c>(x: (&'c i32,)) {
+   |            -- lifetime `'c` defined here
+LL |     let _: (&'static i32,) = x;
+   |            ^^^^^^^^^^^^^^^ type annotation requires that `'c` must outlive `'static`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.rs
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.rs
@@ -18,7 +18,7 @@ fn want_foo_for_some_tcx<'x,F>(f: &'x F)
     want_foo_for_any_tcx(f); //~ ERROR not satisfied
 }
 
-fn want_foo_for_any_tcx<F>(f: &F)
+fn want_foo_for_any_tcx<F>(f: &F) //~ WARN cannot return without recursing
     where F : for<'tcx> Foo<'tcx>
 {
     want_foo_for_some_tcx(f);
@@ -35,7 +35,7 @@ fn want_bar_for_some_ccx<'x,B>(b: &B)
     want_bar_for_any_ccx(b); //~ ERROR not satisfied
 }
 
-fn want_bar_for_any_ccx<B>(b: &B)
+fn want_bar_for_any_ccx<B>(b: &B) //~ WARN cannot return without recursing
     where B : for<'ccx> Bar<'ccx>
 {
     want_foo_for_some_tcx(b);

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits.stderr
@@ -38,6 +38,31 @@ help: consider further restricting this bound
 LL |     where B : Bar<'x> + for<'ccx> Bar<'ccx>
    |                       +++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+warning: function cannot return without recursing
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:21:1
+   |
+LL | / fn want_foo_for_any_tcx<F>(f: &F)
+LL | |     where F : for<'tcx> Foo<'tcx>
+   | |_________________________________^ cannot return without recursing
+...
+LL |       want_foo_for_any_tcx(f);
+   |       ----------------------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: function cannot return without recursing
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:38:1
+   |
+LL | / fn want_bar_for_any_ccx<B>(b: &B)
+LL | |     where B : for<'ccx> Bar<'ccx>
+   | |_________________________________^ cannot return without recursing
+...
+LL |       want_bar_for_any_ccx(b);
+   |       ----------------------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/higher-ranked/trait-bounds/issue-30786.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-30786.stderr
@@ -15,6 +15,12 @@ note: the following trait bounds were not satisfied:
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}
    |         ---------     -                          ^^^^^^ unsatisfied trait bound introduced here
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `StreamExt` defines an item `filterx`, perhaps you need to implement it
+  --> $DIR/issue-30786.rs:66:1
+   |
+LL | pub trait StreamExt
+   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, fn(&u64) -> &u64 {identity::<u64>}>, {closure@issue-30786.rs:131:30}>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:132:24
@@ -33,6 +39,12 @@ note: the following trait bounds were not satisfied:
    |
 LL | impl<T> StreamExt for T where for<'a> &'a mut T: Stream {}
    |         ---------     -                          ^^^^^^ unsatisfied trait bound introduced here
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `StreamExt` defines an item `countx`, perhaps you need to implement it
+  --> $DIR/issue-30786.rs:66:1
+   |
+LL | pub trait StreamExt
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.rs
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.rs
@@ -16,12 +16,16 @@ fn foo<'a>(x: &i32) -> impl Copy + 'a { x }
 //~^ ERROR explicit lifetime required in the type of `x`
 
 fn elided3(x: &i32) -> Box<dyn Debug> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn explicit3<'a>(x: &'a i32) -> Box<dyn Debug> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn elided4(x: &i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn explicit4<'a>(x: &'a i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+//~^ ERROR: lifetime may not live long enough
 
 fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug) { (Box::new(x), x) }
 //~^ ERROR lifetime may not live long enough

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -67,7 +67,7 @@ LL | fn foo<'a>(x: &i32) -> impl Copy + 'a { x }
    |               help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 
 error: lifetime may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:26:55
+  --> $DIR/must_outlive_least_region_or_bound.rs:30:55
    |
 LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug) { (Box::new(x), x) }
    |               -                                       ^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
@@ -84,7 +84,7 @@ LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug + '_) { (Box::new(x), x)
    |                                                    ++++
 
 error: lifetime may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:32:69
+  --> $DIR/must_outlive_least_region_or_bound.rs:36:69
    |
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
    |               -- lifetime `'a` defined here                         ^ returning this value requires that `'a` must outlive `'static`
@@ -99,12 +99,12 @@ LL | fn with_bound<'a>(x: &'static i32) -> impl LifetimeTrait<'a> + 'static { x 
    |                      ~~~~~~~~~~~~
 
 error[E0700]: hidden type for `impl Fn(&'a u32)` captures lifetime that does not appear in bounds
-  --> $DIR/must_outlive_least_region_or_bound.rs:38:5
+  --> $DIR/must_outlive_least_region_or_bound.rs:42:5
    |
 LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) {
    |                              --                             ---------------- opaque type defined here
    |                              |
-   |                              hidden type `{closure@$DIR/must_outlive_least_region_or_bound.rs:38:5: 38:13}` captures the lifetime `'b` as defined here
+   |                              hidden type `{closure@$DIR/must_outlive_least_region_or_bound.rs:42:5: 42:13}` captures the lifetime `'b` as defined here
 LL |     move |_| println!("{}", y)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -114,7 +114,7 @@ LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32
    |                                                                              ++++
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:43:5
+  --> $DIR/must_outlive_least_region_or_bound.rs:47:5
    |
 LL |     x
    |     ^
@@ -127,7 +127,63 @@ help: consider adding an explicit lifetime bound
 LL | fn ty_param_wont_outlive_static<T:Debug + 'static>(x: T) -> impl Debug + 'static {
    |                                         +++++++++
 
-error: aborting due to 9 previous errors
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:18:41
+   |
+LL | fn elided3(x: &i32) -> Box<dyn Debug> { Box::new(x) }
+   |               -                         ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |               |
+   |               let's call the lifetime of this reference `'1`
+   |
+help: to declare that the trait object captures data from argument `x`, you can add an explicit `'_` lifetime bound
+   |
+LL | fn elided3(x: &i32) -> Box<dyn Debug + '_> { Box::new(x) }
+   |                                      ++++
+
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:21:50
+   |
+LL | fn explicit3<'a>(x: &'a i32) -> Box<dyn Debug> { Box::new(x) }
+   |              -- lifetime `'a` defined here       ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+   |
+help: to declare that the trait object captures data from argument `x`, you can add an explicit `'a` lifetime bound
+   |
+LL | fn explicit3<'a>(x: &'a i32) -> Box<dyn Debug + 'a> { Box::new(x) }
+   |                                               ++++
+
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:24:51
+   |
+LL | fn elided4(x: &i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |               -                                   ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |               |
+   |               let's call the lifetime of this reference `'1`
+   |
+help: consider changing the trait object's explicit `'static` bound to the lifetime of argument `x`
+   |
+LL | fn elided4(x: &i32) -> Box<dyn Debug + '_> { Box::new(x) }
+   |                                        ~~
+help: alternatively, add an explicit `'static` bound to this reference
+   |
+LL | fn elided4(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |               ~~~~~~~~~~~~
+
+error: lifetime may not live long enough
+  --> $DIR/must_outlive_least_region_or_bound.rs:27:60
+   |
+LL | fn explicit4<'a>(x: &'a i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |              -- lifetime `'a` defined here                 ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'static`
+   |
+help: consider changing the trait object's explicit `'static` bound to the lifetime of argument `x`
+   |
+LL | fn explicit4<'a>(x: &'a i32) -> Box<dyn Debug + 'a> { Box::new(x) }
+   |                                                 ~~
+help: alternatively, add an explicit `'static` bound to this reference
+   |
+LL | fn explicit4<'a>(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |                     ~~~~~~~~~~~~
+
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0310, E0621, E0700.
 For more information about an error, try `rustc --explain E0310`.

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -4,5 +4,29 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
    |                                          ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/normalize-tait-in-const.rs:26:5
+   |
+LL |     fun(filter_positive());
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct + ~const std::ops::Fn<(&Alias<'_>,)>>(fun: F) {
+   |                                                                              ++++++++++++++++++++++++++++++++++++
 
+error[E0493]: destructor of `F` cannot be evaluated at compile-time
+  --> $DIR/normalize-tait-in-const.rs:25:79
+   |
+LL | const fn with_positive<F: ~const for<'a> Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
+   |                                                                               ^^^ the destructor for this type cannot be evaluated in constant functions
+LL |     fun(filter_positive());
+LL | }
+   | - value is dropped here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0015, E0493.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/infinite/infinite-tag-type-recursion.rs
+++ b/tests/ui/infinite/infinite-tag-type-recursion.rs
@@ -1,4 +1,5 @@
 enum MList { Cons(isize, MList), Nil }
 //~^ ERROR recursive type `MList` has infinite size
+//~| ERROR cycle
 
 fn main() { let a = MList::Cons(10, MList::Cons(11, MList::Nil)); }

--- a/tests/ui/infinite/infinite-tag-type-recursion.stderr
+++ b/tests/ui/infinite/infinite-tag-type-recursion.stderr
@@ -9,6 +9,17 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
 LL | enum MList { Cons(isize, Box<MList>), Nil }
    |                          ++++     +
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing when `MList` needs drop
+  --> $DIR/infinite-tag-type-recursion.rs:1:1
+   |
+LL | enum MList { Cons(isize, MList), Nil }
+   | ^^^^^^^^^^
+   |
+   = note: ...which immediately requires computing when `MList` needs drop again
+   = note: cycle used when computing whether `MList` needs drop
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-For more information about this error, try `rustc --explain E0072`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0072, E0391.
+For more information about an error, try `rustc --explain E0072`.

--- a/tests/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
+++ b/tests/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
@@ -26,5 +26,7 @@ fn main() {
     let _ = A(0);
     let _ = B(0);
     let _ = C(0);
-    let _ = E::X;
+    unsafe {
+        let _ = E::X;
+    }
 }

--- a/tests/ui/issues/issue-11374.rs
+++ b/tests/ui/issues/issue-11374.rs
@@ -18,6 +18,7 @@ impl<'a> Container<'a> {
 pub fn for_stdin<'a>() -> Container<'a> {
     let mut r = io::stdin();
     Container::wrap(&mut r as &mut dyn io::Read)
+    //~^ ERROR cannot return value referencing local variable
 }
 
 fn main() {

--- a/tests/ui/issues/issue-11374.stderr
+++ b/tests/ui/issues/issue-11374.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-11374.rs:26:15
+  --> $DIR/issue-11374.rs:27:15
    |
 LL |     c.read_to(v);
    |       ------- ^ expected `&mut [u8]`, found `Vec<_>`
@@ -18,6 +18,16 @@ help: consider mutably borrowing here
 LL |     c.read_to(&mut v);
    |               ++++
 
-error: aborting due to 1 previous error
+error[E0515]: cannot return value referencing local variable `r`
+  --> $DIR/issue-11374.rs:20:5
+   |
+LL |     Container::wrap(&mut r as &mut dyn io::Read)
+   |     ^^^^^^^^^^^^^^^^------^^^^^^^^^^^^^^^^^^^^^^
+   |     |               |
+   |     |               `r` is borrowed here
+   |     returns a value referencing data owned by the current function
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0515.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/issues/issue-13497.rs
+++ b/tests/ui/issues/issue-13497.rs
@@ -3,6 +3,7 @@ fn read_lines_borrowed1() -> Vec<
 > {
     let rawLines: Vec<String> = vec!["foo  ".to_string(), "  bar".to_string()];
     rawLines.iter().map(|l| l.trim()).collect()
+    //~^ ERROR: cannot return value referencing
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-13497.stderr
+++ b/tests/ui/issues/issue-13497.stderr
@@ -14,6 +14,16 @@ help: instead, you are more likely to want to return an owned value
 LL |     String
    |     ~~~~~~
 
-error: aborting due to 1 previous error
+error[E0515]: cannot return value referencing local variable `rawLines`
+  --> $DIR/issue-13497.rs:5:5
+   |
+LL |     rawLines.iter().map(|l| l.trim()).collect()
+   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     returns a value referencing data owned by the current function
+   |     `rawLines` is borrowed here
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0515.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/issues/issue-2848.rs
+++ b/tests/ui/issues/issue-2848.rs
@@ -12,6 +12,7 @@ fn main() {
     use bar::foo::{alpha, charlie};
     match alpha {
       alpha | beta => {} //~  ERROR variable `beta` is not bound in all patterns
+      //~^ ERROR: `beta` is named the same as one of the variants
       charlie => {}
     }
 }

--- a/tests/ui/issues/issue-2848.stderr
+++ b/tests/ui/issues/issue-2848.stderr
@@ -6,6 +6,15 @@ LL |       alpha | beta => {}
    |       |
    |       pattern doesn't bind `beta`
 
-error: aborting due to 1 previous error
+error[E0170]: pattern binding `beta` is named the same as one of the variants of the type `bar::foo`
+  --> $DIR/issue-2848.rs:14:15
+   |
+LL |       alpha | beta => {}
+   |               ^^^^ help: to match on the variant, qualify the path: `bar::foo::beta`
+   |
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-For more information about this error, try `rustc --explain E0408`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0170, E0408.
+For more information about an error, try `rustc --explain E0170`.

--- a/tests/ui/issues/issue-28971.rs
+++ b/tests/ui/issues/issue-28971.rs
@@ -13,4 +13,5 @@ fn main(){
 
 fn foo<F>(f: F) where F: FnMut() {
     f();
+    //~^ ERROR: cannot borrow
 }

--- a/tests/ui/issues/issue-28971.stderr
+++ b/tests/ui/issues/issue-28971.stderr
@@ -10,6 +10,18 @@ LL |             Foo::Baz(..) => (),
    |                  variant or associated item not found in `Foo`
    |                  help: there is a variant with a similar name: `Bar`
 
-error: aborting due to 1 previous error
+error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+  --> $DIR/issue-28971.rs:15:5
+   |
+LL |     f();
+   |     ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL | fn foo<F>(mut f: F) where F: FnMut() {
+   |           +++
 
-For more information about this error, try `rustc --explain E0599`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0596, E0599.
+For more information about an error, try `rustc --explain E0596`.

--- a/tests/ui/kindck/kindck-impl-type-params.rs
+++ b/tests/ui/kindck/kindck-impl-type-params.rs
@@ -28,6 +28,7 @@ fn g<T>(val: T) {
 fn foo<'a>() {
     let t: S<&'a isize> = S(marker::PhantomData);
     let a = &t as &dyn Gettable<&'a isize>;
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn foo2<'a>() {

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -75,7 +75,7 @@ LL | fn g<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++
 
 error[E0277]: the trait bound `String: Copy` is not satisfied
-  --> $DIR/kindck-impl-type-params.rs:35:13
+  --> $DIR/kindck-impl-type-params.rs:36:13
    |
 LL |     let a = t as Box<dyn Gettable<String>>;
    |             ^ the trait `Copy` is not implemented for `String`, which is required by `S<String>: Gettable<String>`
@@ -91,7 +91,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    = note: required for the cast from `Box<S<String>>` to `Box<dyn Gettable<String>>`
 
 error[E0277]: the trait bound `Foo: Copy` is not satisfied
-  --> $DIR/kindck-impl-type-params.rs:43:37
+  --> $DIR/kindck-impl-type-params.rs:44:37
    |
 LL |     let a: Box<dyn Gettable<Foo>> = t;
    |                                     ^ the trait `Copy` is not implemented for `Foo`, which is required by `S<Foo>: Gettable<Foo>`
@@ -111,6 +111,15 @@ LL +     #[derive(Copy)]
 LL |     struct Foo; // does not impl Copy
    |
 
-error: aborting due to 6 previous errors
+error: lifetime may not live long enough
+  --> $DIR/kindck-impl-type-params.rs:30:13
+   |
+LL | fn foo<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     let t: S<&'a isize> = S(marker::PhantomData);
+LL |     let a = &t as &dyn Gettable<&'a isize>;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/kindck/kindck-send-object1.rs
+++ b/tests/ui/kindck/kindck-send-object1.rs
@@ -12,6 +12,7 @@ fn test51<'a>() {
 }
 fn test52<'a>() {
     assert_send::<&'a (dyn Dummy + Sync)>();
+    //~^ ERROR: lifetime may not live long enough
 }
 
 // ...unless they are properly bounded

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -13,7 +13,7 @@ LL | fn assert_send<T:Send+'static>() { }
    |                  ^^^^ required by this bound in `assert_send`
 
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
-  --> $DIR/kindck-send-object1.rs:28:19
+  --> $DIR/kindck-send-object1.rs:29:19
    |
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |                   ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
@@ -28,6 +28,14 @@ note: required by a bound in `assert_send`
 LL | fn assert_send<T:Send+'static>() { }
    |                  ^^^^ required by this bound in `assert_send`
 
-error: aborting due to 2 previous errors
+error: lifetime may not live long enough
+  --> $DIR/kindck-send-object1.rs:14:5
+   |
+LL | fn test52<'a>() {
+   |           -- lifetime `'a` defined here
+LL |     assert_send::<&'a (dyn Dummy + Sync)>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/lifetimes/issue-17728.rs
+++ b/tests/ui/lifetimes/issue-17728.rs
@@ -12,7 +12,7 @@ trait TraversesWorld {
         let direction = str_to_direction(directionStr);
         let maybe_room = room.direction_to_room.get(&direction);
         match maybe_room {
-            Some(entry) => Ok(entry),
+            Some(entry) => Ok(entry), //~ ERROR: lifetime may not live long enough
             _ => Err("Direction does not exist in room.")
         }
     }

--- a/tests/ui/lifetimes/issue-17728.stderr
+++ b/tests/ui/lifetimes/issue-17728.stderr
@@ -16,6 +16,22 @@ LL | |     }
    = note: expected enum `RoomDirection`
               found enum `Option<_>`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/issue-17728.rs:15:28
+   |
+LL |     fn attemptTraverse(&self, room: &Room, directionStr: &str) -> Result<&Room, &str> {
+   |                        -            - let's call the lifetime of this reference `'1`
+   |                        |
+   |                        let's call the lifetime of this reference `'2`
+...
+LL |             Some(entry) => Ok(entry),
+   |                            ^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     fn attemptTraverse<'a>(&'a self, room: &'a Room, directionStr: &str) -> Result<&Room, &str> {
+   |                       ++++  ++              ++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
@@ -1,5 +1,7 @@
 fn foo(x: &i32, y: &i32) -> &i32 { //~ ERROR missing lifetime
     if x > y { x } else { y }
+    //~^ ERROR: lifetime may not live long enough
+    //~| ERROR: lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -10,6 +10,22 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |       ++++     ++          ++          ++
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/ex1b-return-no-names-if-else.rs:2:16
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |           - let's call the lifetime of this reference `'1`
+LL |     if x > y { x } else { y }
+   |                ^ returning this value requires that `'1` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/ex1b-return-no-names-if-else.rs:2:27
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |                    - let's call the lifetime of this reference `'2`
+LL |     if x > y { x } else { y }
+   |                           ^ returning this value requires that `'2` must outlive `'static`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/liveness/liveness-forgot-ret.rs
+++ b/tests/ui/liveness/liveness-forgot-ret.rs
@@ -1,4 +1,5 @@
 fn god_exists(a: isize) -> bool { return god_exists(a); }
+//~^ WARN function cannot return without recursing
 
 fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
 //~^ ERROR mismatched types

--- a/tests/ui/liveness/liveness-forgot-ret.stderr
+++ b/tests/ui/liveness/liveness-forgot-ret.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/liveness-forgot-ret.rs:3:19
+  --> $DIR/liveness-forgot-ret.rs:4:19
    |
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected `isize`, found `()`
@@ -11,6 +11,17 @@ help: consider returning the local binding `a`
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; a }
    |                                                           +
 
-error: aborting due to 1 previous error
+warning: function cannot return without recursing
+  --> $DIR/liveness-forgot-ret.rs:1:1
+   |
+LL | fn god_exists(a: isize) -> bool { return god_exists(a); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          ------------- recursive call site
+   | |
+   | cannot return without recursing
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/loops/loop-else-break-with-value.rs
+++ b/tests/ui/loops/loop-else-break-with-value.rs
@@ -1,6 +1,11 @@
 fn main() {
     let Some(1) = loop {
         //~^ NOTE `else` is attached to this loop
+        //~| ERROR refutable pattern in local binding
+        //~| NOTE not covered
+        //~| NOTE for more information
+        //~| NOTE matched value is of type
+        //~| NOTE require an "irrefutable pattern"
         break Some(1)
     } else {
         //~^ ERROR `loop...else` loops are not supported

--- a/tests/ui/loops/loop-else-break-with-value.stderr
+++ b/tests/ui/loops/loop-else-break-with-value.stderr
@@ -1,5 +1,5 @@
 error: `loop...else` loops are not supported
-  --> $DIR/loop-else-break-with-value.rs:5:7
+  --> $DIR/loop-else-break-with-value.rs:10:7
    |
 LL |       let Some(1) = loop {
    |                     ---- `else` is attached to this loop
@@ -14,5 +14,24 @@ LL | |     };
    |
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
-error: aborting due to 1 previous error
+error[E0005]: refutable pattern in local binding
+  --> $DIR/loop-else-break-with-value.rs:2:9
+   |
+LL |     let Some(1) = loop {
+   |         ^^^^^^^ pattern `None` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `Option<i32>`
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL ~     if let Some(1) = loop {
+LL |
+ ...
+LL |         return;
+LL ~     } { todo!() };
+   |
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0005`.

--- a/tests/ui/methods/assign-to-method.rs
+++ b/tests/ui/methods/assign-to-method.rs
@@ -6,7 +6,7 @@ struct Cat {
 }
 
 impl Cat {
-    pub fn speak(&self) { self.meows += 1; }
+    pub fn speak(&mut self) { self.meows += 1; }
 }
 
 fn cat(in_x : usize, in_y : isize) -> Cat {

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -63,8 +63,9 @@ LL | |      .take()
 note: the trait `Iterator` must be implemented
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `take`, perhaps you need to implement it:
-           candidate #1: `Iterator`
+   = note: the following traits define an item `take`, perhaps you need to implement one of them:
+           candidate #1: `std::io::Read`
+           candidate #2: `Iterator`
 
 error[E0061]: this method takes 3 arguments but 0 arguments were supplied
   --> $DIR/method-call-err-msg.rs:21:7

--- a/tests/ui/mir/drop-elaboration-after-borrowck-error.rs
+++ b/tests/ui/mir/drop-elaboration-after-borrowck-error.rs
@@ -6,7 +6,6 @@ static A: () = {
     //~^ ERROR destructor of
     a[0] = String::new();
     //~^ ERROR destructor of
-    //~| ERROR binding `a` isn't initialized
 };
 
 struct B<T>([T; 1]);
@@ -17,7 +16,6 @@ impl<T> B<T> {
         //~^ ERROR destructor of
         self.0[0] = other;
         //~^ ERROR destructor of
-        //~| ERROR use of moved value
         self
     }
 }

--- a/tests/ui/mir/drop-elaboration-after-borrowck-error.stderr
+++ b/tests/ui/mir/drop-elaboration-after-borrowck-error.stderr
@@ -16,22 +16,8 @@ LL |     let a: [String; 1];
 LL | };
    | - value is dropped here
 
-error[E0381]: used binding `a` isn't initialized
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:7:5
-   |
-LL |     let a: [String; 1];
-   |         - binding declared here but left uninitialized
-LL |
-LL |     a[0] = String::new();
-   |     ^^^^ `a` used here but it isn't initialized
-   |
-help: consider assigning a value
-   |
-LL |     let a: [String; 1] = todo!();
-   |                        +++++++++
-
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:18:9
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:17:9
    |
 LL |         self.0[0] = other;
    |         ^^^^^^^^^
@@ -40,7 +26,7 @@ LL |         self.0[0] = other;
    |         value is dropped here
 
 error[E0493]: destructor of `B<T>` cannot be evaluated at compile-time
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:16:13
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:15:13
    |
 LL |         let _this = self;
    |             ^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -48,18 +34,6 @@ LL |         let _this = self;
 LL |     }
    |     - value is dropped here
 
-error[E0382]: use of moved value: `self.0`
-  --> $DIR/drop-elaboration-after-borrowck-error.rs:18:9
-   |
-LL |     pub const fn f(mut self, other: T) -> Self {
-   |                    -------- move occurs because `self` has type `B<T>`, which does not implement the `Copy` trait
-LL |         let _this = self;
-   |                     ---- value moved here
-LL |
-LL |         self.0[0] = other;
-   |         ^^^^^^^^^ value used here after move
+error: aborting due to 4 previous errors
 
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0381, E0382, E0493.
-For more information about an error, try `rustc --explain E0381`.
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.rs
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.rs
@@ -8,4 +8,7 @@ fn main() {
 fn baz<F: Fn(*mut &u32)>(_: F) {}
 fn _test<'a>(f: fn(*mut &'a u32)) {
     baz(f);
+    //~^ ERROR: mismatched types
+    //~| ERROR: borrowed data escapes
+    //~| ERROR: not general enough
 }

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -41,6 +41,52 @@ LL |     a.iter().map(|_: (u16, u16)| 45);
 note: required by a bound in `map`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
-error: aborting due to 3 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/closure-arg-type-mismatch.rs:10:5
+   |
+LL | fn _test<'a>(f: fn(*mut &'a u32)) {
+   |          --  - `f` is a reference that is only valid in the function body
+   |          |
+   |          lifetime `'a` defined here
+LL |     baz(f);
+   |     ^^^^^^
+   |     |
+   |     `f` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+   |
+   = note: requirement occurs because of a mutable pointer to `&u32`
+   = note: mutable pointers are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+note: due to current limitations in the borrow checker, this implies a `'static` lifetime
+  --> $DIR/closure-arg-type-mismatch.rs:8:11
+   |
+LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
+   |           ^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0631`.
+error[E0308]: mismatched types
+  --> $DIR/closure-arg-type-mismatch.rs:10:5
+   |
+LL |     baz(f);
+   |     ^^^^^^ one type is more general than the other
+   |
+   = note: expected trait `for<'a> Fn(*mut &'a u32)`
+              found trait `Fn(*mut &u32)`
+note: the lifetime requirement is introduced here
+  --> $DIR/closure-arg-type-mismatch.rs:8:11
+   |
+LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
+   |           ^^^^^^^^^^^^^
+
+error: implementation of `FnOnce` is not general enough
+  --> $DIR/closure-arg-type-mismatch.rs:10:5
+   |
+LL |     baz(f);
+   |     ^^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: `fn(*mut &'2 u32)` must implement `FnOnce<(*mut &'1 u32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(*mut &'2 u32,)>`, for some specific lifetime `'2`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0308, E0521, E0631.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/nll/continue-after-missing-main.rs
+++ b/tests/ui/nll/continue-after-missing-main.rs
@@ -26,4 +26,6 @@ fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
     tableau: Tableau<'data_provider, AdaptedMatrixProvider<'original_data, MP>>,
 ) {
     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
+    //~^ ERROR: lifetime may not live long enough
+    //~| ERROR: `tableau` does not live long enough
 } //~ ERROR `main` function not found in crate

--- a/tests/ui/nll/continue-after-missing-main.stderr
+++ b/tests/ui/nll/continue-after-missing-main.stderr
@@ -1,9 +1,39 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:29:2
+  --> $DIR/continue-after-missing-main.rs:31:2
    |
 LL | }
    |  ^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/continue-after-missing-main.rs:28:12
+   |
+LL | fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
+   |                                 --------------  -------------- lifetime `'original_data` defined here
+   |                                 |
+   |                                 lifetime `'data_provider` defined here
+...
+LL |     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'data_provider` must outlive `'original_data`
+   |
+   = help: consider adding the following bound: `'data_provider: 'original_data`
 
-For more information about this error, try `rustc --explain E0601`.
+error[E0597]: `tableau` does not live long enough
+  --> $DIR/continue-after-missing-main.rs:28:56
+   |
+LL | fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
+   |                                                 -------------- lifetime `'original_data` defined here
+LL |     tableau: Tableau<'data_provider, AdaptedMatrixProvider<'original_data, MP>>,
+   |     ------- binding `tableau` declared here
+LL | ) {
+LL |     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
+   |            -----------------------------------------   ^^^^^^^ borrowed value does not live long enough
+   |            |
+   |            type annotation requires that `tableau` is borrowed for `'original_data`
+...
+LL | }
+   |  - `tableau` dropped here while still borrowed
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0597, E0601.
+For more information about an error, try `rustc --explain E0597`.

--- a/tests/ui/or-patterns/missing-bindings.rs
+++ b/tests/ui/or-patterns/missing-bindings.rs
@@ -17,8 +17,10 @@ fn check_handling_of_paths() {
 
     use bar::foo::{alpha, charlie};
     let (alpha | beta | charlie) = alpha; //~  ERROR variable `beta` is not bound in all patterns
-    match Some(alpha) {
+    //~^ ERROR: `beta` is named the same as one of the variants
+    match Some(alpha) { //~ ERROR `None` not covered
         Some(alpha | beta) => {} //~ ERROR variable `beta` is not bound in all patterns
+        //~^ ERROR: `beta` is named the same as one of the variants
     }
 }
 

--- a/tests/ui/or-patterns/missing-bindings.stderr
+++ b/tests/ui/or-patterns/missing-bindings.stderr
@@ -8,7 +8,7 @@ LL |     let (alpha | beta | charlie) = alpha;
    |          pattern doesn't bind `beta`
 
 error[E0408]: variable `beta` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:21:14
+  --> $DIR/missing-bindings.rs:22:14
    |
 LL |         Some(alpha | beta) => {}
    |              ^^^^^   ---- variable not in all patterns
@@ -16,7 +16,7 @@ LL |         Some(alpha | beta) => {}
    |              pattern doesn't bind `beta`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:33:20
+  --> $DIR/missing-bindings.rs:35:20
    |
 LL |     let (A(a, _) | _) = X;
    |            -       ^ pattern doesn't bind `a`
@@ -24,7 +24,7 @@ LL |     let (A(a, _) | _) = X;
    |            variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:34:10
+  --> $DIR/missing-bindings.rs:36:10
    |
 LL |     let (_ | B(a)) = X;
    |          ^     - variable not in all patterns
@@ -32,7 +32,7 @@ LL |     let (_ | B(a)) = X;
    |          pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:35:10
+  --> $DIR/missing-bindings.rs:37:10
    |
 LL |     let (A(..) | B(a)) = X;
    |          ^^^^^     - variable not in all patterns
@@ -40,7 +40,7 @@ LL |     let (A(..) | B(a)) = X;
    |          pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:36:20
+  --> $DIR/missing-bindings.rs:38:20
    |
 LL |     let (A(a, _) | B(_)) = X;
    |            -       ^^^^ pattern doesn't bind `a`
@@ -48,7 +48,7 @@ LL |     let (A(a, _) | B(_)) = X;
    |            variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:37:20
+  --> $DIR/missing-bindings.rs:39:20
    |
 LL |     let (A(_, a) | B(_)) = X;
    |               -    ^^^^ pattern doesn't bind `a`
@@ -56,7 +56,7 @@ LL |     let (A(_, a) | B(_)) = X;
    |               variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:38:20
+  --> $DIR/missing-bindings.rs:40:20
    |
 LL |     let (A(a, b) | B(a)) = X;
    |               -    ^^^^ pattern doesn't bind `b`
@@ -64,7 +64,7 @@ LL |     let (A(a, b) | B(a)) = X;
    |               variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:42:10
+  --> $DIR/missing-bindings.rs:44:10
    |
 LL |     let (A(A(..) | B(_), _) | B(a)) = Y;
    |          ^^^^^^^^^^^^^^^^^^     - variable not in all patterns
@@ -72,7 +72,7 @@ LL |     let (A(A(..) | B(_), _) | B(a)) = Y;
    |          pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:43:12
+  --> $DIR/missing-bindings.rs:45:12
    |
 LL |     let (A(A(..) | B(a), _) | B(A(a, _) | B(a))) = Y;
    |            ^^^^^     - variable not in all patterns
@@ -80,7 +80,7 @@ LL |     let (A(A(..) | B(a), _) | B(A(a, _) | B(a))) = Y;
    |            pattern doesn't bind `a`
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:12
+  --> $DIR/missing-bindings.rs:47:12
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |            ^^^^^^^     - variable not in all patterns
@@ -88,7 +88,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |            pattern doesn't bind `c`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:22
+  --> $DIR/missing-bindings.rs:47:22
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              -       ^^^^ pattern doesn't bind `a`
@@ -96,7 +96,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:22
+  --> $DIR/missing-bindings.rs:47:22
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 -    ^^^^ pattern doesn't bind `b`
@@ -104,7 +104,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 variable not in all patterns
 
 error[E0408]: variable `e` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:10
+  --> $DIR/missing-bindings.rs:47:10
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |          ^^^^^^^^^^^^^^^^^^^^     - variable not in all patterns
@@ -112,7 +112,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |          pattern doesn't bind `e`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              -                  ^^^^ pattern doesn't bind `a`
@@ -120,7 +120,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |              variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 -               ^^^^ pattern doesn't bind `b`
@@ -128,7 +128,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                 variable not in all patterns
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                        -        ^^^^ pattern doesn't bind `c`
@@ -136,7 +136,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                        variable not in all patterns
 
 error[E0408]: variable `d` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:45:33
+  --> $DIR/missing-bindings.rs:47:33
    |
 LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                            -    ^^^^ pattern doesn't bind `d`
@@ -144,7 +144,7 @@ LL |     let (A(A(a, b) | B(c), d) | B(e)) = Y;
    |                            variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:61:29
+  --> $DIR/missing-bindings.rs:63:29
    |
 LL |                     Ok(a) | Err(_),
    |                        -    ^^^^^^ pattern doesn't bind `a`
@@ -152,7 +152,7 @@ LL |                     Ok(a) | Err(_),
    |                        variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:68:21
+  --> $DIR/missing-bindings.rs:70:21
    |
 LL |                     A(_, a) |
    |                     ^^^^^^^ pattern doesn't bind `b`
@@ -160,7 +160,7 @@ LL |                     B(b),
    |                       - variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:69:21
+  --> $DIR/missing-bindings.rs:71:21
    |
 LL |                     A(_, a) |
    |                          - variable not in all patterns
@@ -168,7 +168,7 @@ LL |                     B(b),
    |                     ^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:72:17
+  --> $DIR/missing-bindings.rs:74:17
    |
 LL |                     A(_, a) |
    |                          - variable not in all patterns
@@ -177,7 +177,7 @@ LL |                 B(_)
    |                 ^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:72:17
+  --> $DIR/missing-bindings.rs:74:17
    |
 LL |                     B(b),
    |                       - variable not in all patterns
@@ -186,7 +186,7 @@ LL |                 B(_)
    |                 ^^^^ pattern doesn't bind `b`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:57:13
+  --> $DIR/missing-bindings.rs:59:13
    |
 LL | /             V1(
 LL | |
@@ -204,7 +204,7 @@ LL |               V3(c),
    |               ^^^^^ pattern doesn't bind `b`
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:57:13
+  --> $DIR/missing-bindings.rs:59:13
    |
 LL | /             V1(
 LL | |
@@ -226,7 +226,7 @@ LL |               V3(c),
    |                  - variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:76:13
+  --> $DIR/missing-bindings.rs:78:13
    |
 LL |                 B(Ok(a) | Err(a))
    |                               - variable not in all patterns
@@ -237,6 +237,38 @@ LL |                     A(_, a) |
 LL |             V3(c),
    |             ^^^^^ pattern doesn't bind `a`
 
-error: aborting due to 26 previous errors
+error[E0170]: pattern binding `beta` is named the same as one of the variants of the type `check_handling_of_paths::bar::foo`
+  --> $DIR/missing-bindings.rs:19:18
+   |
+LL |     let (alpha | beta | charlie) = alpha;
+   |                  ^^^^
+   |
+   = note: `#[deny(bindings_with_variant_name)]` on by default
 
-For more information about this error, try `rustc --explain E0408`.
+error[E0170]: pattern binding `beta` is named the same as one of the variants of the type `check_handling_of_paths::bar::foo`
+  --> $DIR/missing-bindings.rs:22:22
+   |
+LL |         Some(alpha | beta) => {}
+   |                      ^^^^ help: to match on the variant, qualify the path: `check_handling_of_paths::bar::foo::beta`
+
+error[E0004]: non-exhaustive patterns: `None` not covered
+  --> $DIR/missing-bindings.rs:21:11
+   |
+LL |     match Some(alpha) {
+   |           ^^^^^^^^^^^ pattern `None` not covered
+   |
+note: `Option<foo>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<foo>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL |         Some(alpha | beta) => {}, None => todo!()
+   |                                 +++++++++++++++++
+
+error: aborting due to 29 previous errors
+
+Some errors have detailed explanations: E0004, E0170, E0408.
+For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/parser/bad-let-else-statement.rs
+++ b/tests/ui/parser/bad-let-else-statement.rs
@@ -5,6 +5,7 @@
 
 fn a() {
     let foo = {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -23,6 +24,7 @@ fn b() {
 
 fn c() {
     let foo = if true {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         0
@@ -43,6 +45,7 @@ fn d() {
 
 fn e() {
     let foo = match true {
+        //~^ WARN irrefutable `let...else` pattern
         true => 1,
         false => 0
     } else {
@@ -54,6 +57,7 @@ fn e() {
 struct X {a: i32}
 fn f() {
     let foo = X {
+        //~^ WARN irrefutable `let...else` pattern
         a: 1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -72,6 +76,7 @@ fn g() {
 
 fn h() {
     let foo = const {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -81,6 +86,7 @@ fn h() {
 
 fn i() {
     let foo = &{
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -90,7 +96,8 @@ fn i() {
 
 fn j() {
     let bar = 0;
-    let foo = bar = {
+    let foo = bar = { //~ ERROR: cannot assign twice
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -100,6 +107,7 @@ fn j() {
 
 fn k() {
     let foo = 1 + {
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -109,6 +117,7 @@ fn k() {
 
 fn l() {
     let foo = 1..{
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -118,6 +127,7 @@ fn l() {
 
 fn m() {
     let foo = return {
+        //~^ WARN irrefutable `let...else` pattern
         ()
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -127,6 +137,7 @@ fn m() {
 
 fn n() {
     let foo = -{
+        //~^ WARN irrefutable `let...else` pattern
         1
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -136,6 +147,7 @@ fn n() {
 
 fn o() -> Result<(), ()> {
     let foo = do yeet {
+        //~^ WARN irrefutable `let...else` pattern
         ()
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -145,6 +157,7 @@ fn o() -> Result<(), ()> {
 
 fn p() {
     let foo = become {
+        //~^ WARN irrefutable `let...else` pattern
         ()
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -154,6 +167,7 @@ fn p() {
 
 fn q() {
     let foo = |x: i32| {
+        //~^ WARN irrefutable `let...else` pattern
         x
     } else {
         //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
@@ -163,14 +177,18 @@ fn q() {
 
 fn r() {
     let ok = format_args!("") else { return; };
+    //~^ WARN irrefutable `let...else` pattern
 
     let bad = format_args! {""} else { return; };
     //~^ ERROR right curly brace `}` before `else` in a `let...else` statement not allowed
+    //~| WARN irrefutable `let...else` pattern
 }
 
 fn s() {
     macro_rules! a {
         () => { {} }
+        //~^ WARN irrefutable `let...else` pattern
+        //~| WARN irrefutable `let...else` pattern
     }
 
     macro_rules! b {

--- a/tests/ui/parser/bad-let-else-statement.stderr
+++ b/tests/ui/parser/bad-let-else-statement.stderr
@@ -1,5 +1,5 @@
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:9:5
+  --> $DIR/bad-let-else-statement.rs:10:5
    |
 LL |     } else {
    |     ^
@@ -7,12 +7,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = ({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: `for...else` loops are not supported
-  --> $DIR/bad-let-else-statement.rs:18:7
+  --> $DIR/bad-let-else-statement.rs:19:7
    |
 LL |       let foo = for i in 1..2 {
    |                 --- `else` is attached to this loop
@@ -27,7 +28,7 @@ LL | |     };
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:29:5
+  --> $DIR/bad-let-else-statement.rs:31:5
    |
 LL |     } else {
    |     ^
@@ -35,14 +36,14 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (if true {
-LL |         1
-LL |     } else {
+LL |
+ ...
 LL |         0
 LL ~     }) else {
    |
 
 error: `loop...else` loops are not supported
-  --> $DIR/bad-let-else-statement.rs:38:7
+  --> $DIR/bad-let-else-statement.rs:40:7
    |
 LL |       let foo = loop {
    |                 ---- `else` is attached to this loop
@@ -57,7 +58,7 @@ LL | |     };
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:48:5
+  --> $DIR/bad-let-else-statement.rs:51:5
    |
 LL |     } else {
    |     ^
@@ -65,13 +66,14 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (match true {
+LL |
 LL |         true => 1,
 LL |         false => 0
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:58:5
+  --> $DIR/bad-let-else-statement.rs:62:5
    |
 LL |     } else {
    |     ^
@@ -79,12 +81,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (X {
+LL |
 LL |         a: 1
 LL ~     }) else {
    |
 
 error: `while...else` loops are not supported
-  --> $DIR/bad-let-else-statement.rs:67:7
+  --> $DIR/bad-let-else-statement.rs:71:7
    |
 LL |       let foo = while false {
    |                 ----- `else` is attached to this loop
@@ -99,7 +102,7 @@ LL | |     };
    = note: consider moving this `else` clause to a separate `if` statement and use a `bool` variable to control if it should run
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:76:5
+  --> $DIR/bad-let-else-statement.rs:81:5
    |
 LL |     } else {
    |     ^
@@ -107,12 +110,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = (const {
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:85:5
+  --> $DIR/bad-let-else-statement.rs:91:5
    |
 LL |     } else {
    |     ^
@@ -120,12 +124,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = &({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:95:5
+  --> $DIR/bad-let-else-statement.rs:102:5
    |
 LL |     } else {
    |     ^
@@ -133,12 +138,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = bar = ({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:104:5
+  --> $DIR/bad-let-else-statement.rs:112:5
    |
 LL |     } else {
    |     ^
@@ -146,19 +152,7 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = 1 + ({
-LL |         1
-LL ~     }) else {
-   |
-
-error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:113:5
-   |
-LL |     } else {
-   |     ^
-   |
-help: wrap the expression in parentheses
-   |
-LL ~     let foo = 1..({
+LL |
 LL |         1
 LL ~     }) else {
    |
@@ -171,13 +165,28 @@ LL |     } else {
    |
 help: wrap the expression in parentheses
    |
+LL ~     let foo = 1..({
+LL |
+LL |         1
+LL ~     }) else {
+   |
+
+error: right curly brace `}` before `else` in a `let...else` statement not allowed
+  --> $DIR/bad-let-else-statement.rs:132:5
+   |
+LL |     } else {
+   |     ^
+   |
+help: wrap the expression in parentheses
+   |
 LL ~     let foo = return ({
+LL |
 LL |         ()
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:131:5
+  --> $DIR/bad-let-else-statement.rs:142:5
    |
 LL |     } else {
    |     ^
@@ -185,12 +194,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = -({
+LL |
 LL |         1
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:140:5
+  --> $DIR/bad-let-else-statement.rs:152:5
    |
 LL |     } else {
    |     ^
@@ -198,12 +208,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = do yeet ({
+LL |
 LL |         ()
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:149:5
+  --> $DIR/bad-let-else-statement.rs:162:5
    |
 LL |     } else {
    |     ^
@@ -211,12 +222,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = become ({
+LL |
 LL |         ()
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:158:5
+  --> $DIR/bad-let-else-statement.rs:172:5
    |
 LL |     } else {
    |     ^
@@ -224,12 +236,13 @@ LL |     } else {
 help: wrap the expression in parentheses
    |
 LL ~     let foo = |x: i32| ({
+LL |
 LL |         x
 LL ~     }) else {
    |
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:167:31
+  --> $DIR/bad-let-else-statement.rs:182:31
    |
 LL |     let bad = format_args! {""} else { return; };
    |                               ^
@@ -240,7 +253,7 @@ LL |     let bad = format_args! ("") else { return; };
    |                            ~  ~
 
 error: right curly brace `}` before `else` in a `let...else` statement not allowed
-  --> $DIR/bad-let-else-statement.rs:181:25
+  --> $DIR/bad-let-else-statement.rs:199:25
    |
 LL |             let x = a! {} else { return; };
    |                         ^
@@ -254,5 +267,251 @@ help: use parentheses instead of braces for this macro
 LL |             let x = a! () else { return; };
    |                        ~~
 
-error: aborting due to 19 previous errors
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:7:5
+   |
+LL | /     let foo = {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
 
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:26:5
+   |
+LL | /     let foo = if true {
+LL | |
+LL | |         1
+LL | |     } else {
+LL | |         0
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:47:5
+   |
+LL | /     let foo = match true {
+LL | |
+LL | |         true => 1,
+LL | |         false => 0
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:59:5
+   |
+LL | /     let foo = X {
+LL | |
+LL | |         a: 1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:78:5
+   |
+LL | /     let foo = const {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:88:5
+   |
+LL | /     let foo = &{
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:99:5
+   |
+LL | /     let foo = bar = {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+error[E0384]: cannot assign twice to immutable variable `bar`
+  --> $DIR/bad-let-else-statement.rs:99:15
+   |
+LL |       let bar = 0;
+   |           ---
+   |           |
+   |           first assignment to `bar`
+   |           help: consider making this binding mutable: `mut bar`
+LL |       let foo = bar = {
+   |  _______________^
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^ cannot assign twice to immutable variable
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:109:5
+   |
+LL | /     let foo = 1 + {
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:119:5
+   |
+LL | /     let foo = 1..{
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:129:5
+   |
+LL | /     let foo = return {
+LL | |
+LL | |         ()
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:139:5
+   |
+LL | /     let foo = -{
+LL | |
+LL | |         1
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:149:5
+   |
+LL | /     let foo = do yeet {
+LL | |
+LL | |         ()
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:159:5
+   |
+LL | /     let foo = become {
+LL | |
+LL | |         ()
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:169:5
+   |
+LL | /     let foo = |x: i32| {
+LL | |
+LL | |         x
+LL | |     } else {
+   | |_____^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:179:5
+   |
+LL |     let ok = format_args!("") else { return; };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:182:5
+   |
+LL |     let bad = format_args! {""} else { return; };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:189:19
+   |
+LL |           () => { {} }
+   |  ___________________^
+LL | |
+LL | |
+LL | |     }
+...  |
+LL | |         (1) => {
+LL | |             let x = a!() else { return; };
+   | |____________^
+...
+LL |       b!(1); b!(2);
+   |       ----- in this macro invocation
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+   = note: this warning originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: irrefutable `let...else` pattern
+  --> $DIR/bad-let-else-statement.rs:189:19
+   |
+LL |           () => { {} }
+   |  ___________________^
+LL | |
+LL | |
+LL | |     }
+...  |
+LL | |         (2) => {
+LL | |             let x = a! {} else { return; };
+   | |____________^
+...
+LL |       b!(1); b!(2);
+   |              ----- in this macro invocation
+   |
+   = note: this pattern will always match, so the `else` clause is useless
+   = help: consider removing the `else` clause
+   = note: this warning originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 20 previous errors; 18 warnings emitted
+
+For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/parser/issues/issue-35813-postfix-after-cast.rs
+++ b/tests/ui/parser/issues/issue-35813-postfix-after-cast.rs
@@ -129,6 +129,7 @@ pub fn inside_block() {
 
 static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
 //~^ ERROR: cast cannot be followed by indexing
+//~| ERROR: cannot call non-const operator in statics
 
 static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
 //~^ ERROR: expected one of

--- a/tests/ui/parser/issues/issue-35813-postfix-after-cast.stderr
+++ b/tests/ui/parser/issues/issue-35813-postfix-after-cast.stderr
@@ -235,13 +235,13 @@ LL | static bar: &[i32] = &((&[1,2,3] as &[i32])[0..1]);
    |                        +                  +
 
 error: expected one of `)`, `,`, `.`, `?`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:133:36
+  --> $DIR/issue-35813-postfix-after-cast.rs:134:36
    |
 LL | static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
    |                                    ^ expected one of `)`, `,`, `.`, `?`, or an operator
 
 error: cast cannot be followed by `?`
-  --> $DIR/issue-35813-postfix-after-cast.rs:138:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:139:5
    |
 LL |     Err(0u64) as Result<u64,u64>?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -252,13 +252,13 @@ LL |     (Err(0u64) as Result<u64,u64>)?;
    |     +                            +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:140:14
+  --> $DIR/issue-35813-postfix-after-cast.rs:141:14
    |
 LL |     Err(0u64): Result<u64,u64>?;
    |              ^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: expected identifier, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:152:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:153:13
    |
 LL |     drop_ptr: F();
    |             ^ expected identifier
@@ -266,13 +266,13 @@ LL |     drop_ptr: F();
    = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:159:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:160:13
    |
 LL |     drop_ptr: fn(u8);
    |             ^ expected one of 8 possible tokens
 
 error: cast cannot be followed by a function call
-  --> $DIR/issue-35813-postfix-after-cast.rs:165:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:166:5
    |
 LL |     drop as fn(u8)(0);
    |     ^^^^^^^^^^^^^^
@@ -283,13 +283,13 @@ LL |     (drop as fn(u8))(0);
    |     +              +
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:167:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:168:13
    |
 LL |     drop_ptr: fn(u8)(0);
    |             ^ expected one of 8 possible tokens
 
 error: cast cannot be followed by `.await`
-  --> $DIR/issue-35813-postfix-after-cast.rs:172:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:173:5
    |
 LL |     Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>.await;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -300,13 +300,13 @@ LL |     (Box::pin(noop()) as Pin<Box<dyn Future<Output = ()>>>).await;
    |     +                                                     +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:175:21
+  --> $DIR/issue-35813-postfix-after-cast.rs:176:21
    |
 LL |     Box::pin(noop()): Pin<Box<_>>.await;
    |                     ^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: cast cannot be followed by a field access
-  --> $DIR/issue-35813-postfix-after-cast.rs:187:5
+  --> $DIR/issue-35813-postfix-after-cast.rs:188:5
    |
 LL |     Foo::default() as Foo.bar;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -317,7 +317,7 @@ LL |     (Foo::default() as Foo).bar;
    |     +                     +
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
-  --> $DIR/issue-35813-postfix-after-cast.rs:189:19
+  --> $DIR/issue-35813-postfix-after-cast.rs:190:19
    |
 LL |     Foo::default(): Foo.bar;
    |                   ^ expected one of `.`, `;`, `?`, `}`, or an operator
@@ -340,11 +340,22 @@ LL |         if true { 33 } else { 44 }: i32.max(0)
    |                                   ^ expected one of `,`, `.`, `?`, or an operator
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-35813-postfix-after-cast.rs:150:13
+  --> $DIR/issue-35813-postfix-after-cast.rs:151:13
    |
 LL |     drop as F();
    |             ^^^ only `Fn` traits may use parentheses
 
-error: aborting due to 39 previous errors
+error[E0015]: cannot call non-const operator in statics
+  --> $DIR/issue-35813-postfix-after-cast.rs:130:42
+   |
+LL | static bar: &[i32] = &(&[1,2,3] as &[i32][0..1]);
+   |                                          ^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
-For more information about this error, try `rustc --explain E0214`.
+error: aborting due to 40 previous errors
+
+Some errors have detailed explanations: E0015, E0214.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.rs
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.rs
@@ -37,9 +37,10 @@ fn g1() {
         //~| HELP: maybe write a path separator here
         _ => {}
     }
-    if let Foo:Bar = f() {
+    if let Foo:Bar = f() { //~ WARN: irrefutable `if let` pattern
     //~^ ERROR: expected one of
     //~| HELP: maybe write a path separator here
+    //~| HELP: consider replacing the `if let` with a `let`
     }
 }
 

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
@@ -64,7 +64,7 @@ LL |     if let Foo::Bar = f() {
    |               ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:48:16
+  --> $DIR/issue-87086-colon-path-sep.rs:49:16
    |
 LL |         ref qux: Foo::Baz => {}
    |                ^ -------- specifying the type of a pattern isn't supported
@@ -77,7 +77,7 @@ LL |         ref qux::Foo::Baz => {}
    |                ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:57:16
+  --> $DIR/issue-87086-colon-path-sep.rs:58:16
    |
 LL |         mut qux: Foo::Baz => {}
    |                ^ -------- specifying the type of a pattern isn't supported
@@ -90,7 +90,7 @@ LL |         mut qux::Foo::Baz => {}
    |                ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:68:12
+  --> $DIR/issue-87086-colon-path-sep.rs:69:12
    |
 LL |         Foo:Bar::Baz => {}
    |            ^-------- specifying the type of a pattern isn't supported
@@ -103,7 +103,7 @@ LL |         Foo::Bar::Baz => {}
    |            ~~
 
 error: expected one of `@` or `|`, found `:`
-  --> $DIR/issue-87086-colon-path-sep.rs:74:12
+  --> $DIR/issue-87086-colon-path-sep.rs:75:12
    |
 LL |         Foo:Bar => {}
    |            ^--- specifying the type of a pattern isn't supported
@@ -115,5 +115,15 @@ help: maybe write a path separator here
 LL |         Foo::Bar => {}
    |            ~~
 
-error: aborting due to 9 previous errors
+warning: irrefutable `if let` pattern
+  --> $DIR/issue-87086-colon-path-sep.rs:40:8
+   |
+LL |     if let Foo:Bar = f() {
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match, so the `if let` is useless
+   = help: consider replacing the `if let` with a `let`
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+
+error: aborting due to 9 previous errors; 1 warning emitted
 

--- a/tests/ui/parser/recover/recover-range-pats.rs
+++ b/tests/ui/parser/recover/recover-range-pats.rs
@@ -134,10 +134,13 @@ fn with_macro_expr_var() {
     macro_rules! mac2 {
         ($e1:expr, $e2:expr) => {
             let $e1..$e2;
+            //~^ ERROR refutable pattern in local binding
             let $e1...$e2;
             //~^ ERROR `...` range patterns are deprecated
             //~| WARN this is accepted in the current edition
+            //~| ERROR refutable pattern in local binding
             let $e1..=$e2;
+            //~^ ERROR refutable pattern in local binding
         }
     }
 
@@ -146,12 +149,18 @@ fn with_macro_expr_var() {
     macro_rules! mac {
         ($e:expr) => {
             let ..$e;
+            //~^ ERROR refutable pattern in local binding
             let ...$e;
             //~^ ERROR range-to patterns with `...` are not allowed
+            //~| ERROR refutable pattern in local binding
             let ..=$e;
+            //~^ ERROR refutable pattern in local binding
             let $e..;
+            //~^ ERROR refutable pattern in local binding
             let $e...; //~ ERROR inclusive range with no end
+            //~^ ERROR refutable pattern in local binding
             let $e..=; //~ ERROR inclusive range with no end
+            //~^ ERROR refutable pattern in local binding
         }
     }
 

--- a/tests/ui/parser/recover/recover-range-pats.stderr
+++ b/tests/ui/parser/recover/recover-range-pats.stderr
@@ -159,7 +159,7 @@ LL |     if let ....3 = 0 {}
    |            ^^^ help: use `..=` instead
 
 error: range-to patterns with `...` are not allowed
-  --> $DIR/recover-range-pats.rs:149:17
+  --> $DIR/recover-range-pats.rs:153:17
    |
 LL |             let ...$e;
    |                 ^^^ help: use `..=` instead
@@ -170,7 +170,7 @@ LL |     mac!(0);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/recover-range-pats.rs:153:19
+  --> $DIR/recover-range-pats.rs:160:19
    |
 LL |             let $e...;
    |                   ^^^ help: use `..` instead
@@ -182,7 +182,7 @@ LL |     mac!(0);
    = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
-  --> $DIR/recover-range-pats.rs:154:19
+  --> $DIR/recover-range-pats.rs:162:19
    |
 LL |             let $e..=;
    |                   ^^^ help: use `..` instead
@@ -271,7 +271,7 @@ LL |     if let X... .0 = 0 {}
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
 
 error: `...` range patterns are deprecated
-  --> $DIR/recover-range-pats.rs:137:20
+  --> $DIR/recover-range-pats.rs:138:20
    |
 LL |             let $e1...$e2;
    |                    ^^^ help: use `..=` for an inclusive range
@@ -478,7 +478,169 @@ LL |     if let ....3 = 0 {}
    |               |
    |               expected integer, found floating-point number
 
-error: aborting due to 60 previous errors
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:136:17
+   |
+LL |             let $e1..$e2;
+   |                 ^^^^^^^^ patterns `i32::MIN..=-1_i32` and `1_i32..=i32::MAX` not covered
+...
+LL |     mac2!(0, 1);
+   |     ----------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |             if let $e1..$e2; { todo!() }
+   |             ++               +++++++++++
 
-Some errors have detailed explanations: E0029, E0308, E0586.
-For more information about an error, try `rustc --explain E0029`.
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:138:17
+   |
+LL |             let $e1...$e2;
+   |                 ^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `2_i32..=i32::MAX` not covered
+...
+LL |     mac2!(0, 1);
+   |     ----------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |             if let $e1...$e2; { todo!() }
+   |             ++                +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:142:17
+   |
+LL |             let $e1..=$e2;
+   |                 ^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `2_i32..=i32::MAX` not covered
+...
+LL |     mac2!(0, 1);
+   |     ----------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |             if let $e1..=$e2; { todo!() }
+   |             ++                +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:151:17
+   |
+LL |             let ..$e;
+   |                 ^^^^ pattern `0_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ..$e; { todo!() }
+   |             ++           +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:153:17
+   |
+LL |             let ...$e;
+   |                 ^^^^^ pattern `1_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ...$e; { todo!() }
+   |             ++            +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:156:17
+   |
+LL |             let ..=$e;
+   |                 ^^^^^ pattern `1_i32..=i32::MAX` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let ..=$e; { todo!() }
+   |             ++            +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:158:17
+   |
+LL |             let $e..;
+   |                 ^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e..; { todo!() }
+   |             ++           +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:160:17
+   |
+LL |             let $e...;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e...; { todo!() }
+   |             ++            +++++++++++
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/recover-range-pats.rs:162:17
+   |
+LL |             let $e..=;
+   |                 ^^^^^ pattern `i32::MIN..=-1_i32` not covered
+...
+LL |     mac!(0);
+   |     ------- in this macro invocation
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+   = note: the matched value is of type `i32`
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you might want to use `if let` to ignore the variant that isn't matched
+   |
+LL |             if let $e..=; { todo!() }
+   |             ++            +++++++++++
+
+error: aborting due to 69 previous errors
+
+Some errors have detailed explanations: E0005, E0029, E0308, E0586.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -34,10 +34,12 @@ extern "C" fn f3_3(..., x: isize) {}
 
 const unsafe extern "C" fn f4_1(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
+//~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_2(x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
 //~| ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
+//~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 
 const extern "C" fn f4_3(..., x: isize, ...) {}
 //~^ ERROR functions cannot be both `const` and C-variadic
@@ -48,7 +50,7 @@ extern "C" {
     fn e_f1(...);
     //~^ ERROR C-variadic function must be declared with at least one named argument
     fn e_f2(..., x: isize);
-//~^ ERROR `...` must be the last argument of a C-variadic function
+    //~^ ERROR `...` must be the last argument of a C-variadic function
 }
 
 struct X;
@@ -68,6 +70,7 @@ impl X {
     const fn i_f5(x: isize, ...) {}
     //~^ ERROR only foreign or `unsafe extern "C"` functions may be C-variadic
     //~| ERROR functions cannot be both `const` and C-variadic
+    //~| ERROR destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
 }
 
 trait T {

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -83,25 +83,25 @@ LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
    | ^^^^^ `const` because of this             ^^^ C-variadic because of this
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:38:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:1
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    | ^^^^^ `const` because of this      ^^^ C-variadic because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:38:36
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
    |                                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:42:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:42:1
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:1
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | ^^^^^                    ^^^            ^^^ C-variadic because of this
@@ -110,67 +110,67 @@ LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    | `const` because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:42:26
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:26
    |
 LL | const extern "C" fn f4_3(..., x: isize, ...) {}
    |                          ^^^            ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:48:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
    |
 LL |     fn e_f1(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:52:13
    |
 LL |     fn e_f2(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:57:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:23
    |
 LL |     fn i_f1(x: isize, ...) {}
    |                       ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:59:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:65:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:65:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^            ^^^
 
 error: functions cannot be both `const` and C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:5
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:5
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |     ^^^^^                   ^^^ C-variadic because of this
@@ -178,70 +178,95 @@ LL |     const fn i_f5(x: isize, ...) {}
    |     `const` because of this
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:29
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
    |                             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:74:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:77:23
    |
 LL |     fn t_f1(x: isize, ...) {}
    |                       ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:76:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:79:23
    |
 LL |     fn t_f2(x: isize, ...);
    |                       ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:78:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:78:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:81:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:84:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:90:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C"` functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:87:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:90:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
-error: aborting due to 40 previous errors
+error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:43
+   |
+LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
+   |                                           ^^^   - value is dropped here
+   |                                           |
+   |                                           the destructor for this type cannot be evaluated in constant functions
 
+error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:39:36
+   |
+LL | const extern "C" fn f4_2(x: isize, ...) {}
+   |                                    ^^^   - value is dropped here
+   |                                    |
+   |                                    the destructor for this type cannot be evaluated in constant functions
+
+error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:29
+   |
+LL |     const fn i_f5(x: isize, ...) {}
+   |                             ^^^   - value is dropped here
+   |                             |
+   |                             the destructor for this type cannot be evaluated in constant functions
+
+error: aborting due to 43 previous errors
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.rs
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.rs
@@ -10,7 +10,7 @@ fn main() {
     match Ok(0) {
         Ok(a @ b @ a)
         //~^ ERROR identifier `a` is bound more than once in the same pattern
-        | Err(a @ b @ a)
+        | Err(a @ b @ a) //~ ERROR cannot assign twice to immutable variable `a`
         //~^ ERROR identifier `a` is bound more than once in the same pattern
         => {}
     }
@@ -20,7 +20,7 @@ fn main() {
     //~| ERROR identifier `a` is bound more than once in the same pattern
     let ref a @ ref a = ();
     //~^ ERROR identifier `a` is bound more than once in the same pattern
-    let ref mut a @ ref mut a = ();
+    let ref mut a @ ref mut a = (); //~ ERROR cannot borrow value as mutable more than once at a time
     //~^ ERROR identifier `a` is bound more than once in the same pattern
 
     let a @ (Ok(a) | Err(a)) = Ok(());

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
@@ -58,7 +58,27 @@ error[E0416]: identifier `a` is bound more than once in the same pattern
 LL |     let a @ (Ok(a) | Err(a)) = Ok(());
    |                          ^ used in a pattern more than once
 
-error: aborting due to 10 previous errors
+error: cannot borrow value as mutable more than once at a time
+  --> $DIR/pat-at-same-name-both.rs:23:9
+   |
+LL |     let ref mut a @ ref mut a = ();
+   |         ^^^^^^^^^   --------- value is mutably borrowed by `a` here
+   |         |
+   |         value is mutably borrowed by `a` here
 
-Some errors have detailed explanations: E0415, E0416.
-For more information about an error, try `rustc --explain E0415`.
+error[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/pat-at-same-name-both.rs:13:15
+   |
+LL |         Ok(a @ b @ a)
+   |                    -
+   |                    |
+   |                    first assignment to `a`
+   |                    help: consider making this binding mutable: `mut a`
+LL |
+LL |         | Err(a @ b @ a)
+   |               ^ cannot assign twice to immutable variable
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0384, E0415, E0416.
+For more information about an error, try `rustc --explain E0384`.

--- a/tests/ui/pattern/pattern-binding-disambiguation.rs
+++ b/tests/ui/pattern/pattern-binding-disambiguation.rs
@@ -26,7 +26,7 @@ fn main() {
     match doesnt_matter {
         BracedStruct => {} // OK, `BracedStruct` is a fresh binding
     }
-    match UnitVariant {
+    match UnitVariant { //~ ERROR: `E::TupleVariant` and `E::BracedVariant {  }` not covered
         UnitVariant => {} // OK, `UnitVariant` is a unit variant pattern
     }
     match doesnt_matter {
@@ -48,7 +48,7 @@ fn main() {
     let UnitStruct = UnitStruct; // OK, `UnitStruct` is a unit struct pattern
     let TupleStruct = doesnt_matter; //~ ERROR let bindings cannot shadow tuple structs
     let BracedStruct = doesnt_matter; // OK, `BracedStruct` is a fresh binding
-    let UnitVariant = UnitVariant; // OK, `UnitVariant` is a unit variant pattern
+    let UnitVariant = UnitVariant; //~ ERROR: refutable pattern in local binding
     let TupleVariant = doesnt_matter; //~ ERROR let bindings cannot shadow tuple variants
     let BracedVariant = doesnt_matter; // OK, `BracedVariant` is a fresh binding
     let CONST = CONST; // OK, `CONST` is a const pattern

--- a/tests/ui/pattern/pattern-binding-disambiguation.stderr
+++ b/tests/ui/pattern/pattern-binding-disambiguation.stderr
@@ -58,6 +58,53 @@ LL | static STATIC: () = ();
 LL |     let STATIC = doesnt_matter;
    |         ^^^^^^ cannot be named the same as a static
 
-error: aborting due to 6 previous errors
+error[E0004]: non-exhaustive patterns: `E::TupleVariant` and `E::BracedVariant {  }` not covered
+  --> $DIR/pattern-binding-disambiguation.rs:29:11
+   |
+LL |     match UnitVariant {
+   |           ^^^^^^^^^^^ patterns `E::TupleVariant` and `E::BracedVariant {  }` not covered
+   |
+note: `E` defined here
+  --> $DIR/pattern-binding-disambiguation.rs:5:6
+   |
+LL | enum E {
+   |      ^
+LL |     UnitVariant,
+LL |     TupleVariant(),
+   |     ------------ not covered
+LL |     BracedVariant{},
+   |     ------------- not covered
+   = note: the matched value is of type `E`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+   |
+LL |         UnitVariant => {}, E::TupleVariant | E::BracedVariant {  } => todo!() // OK, `UnitVariant` is a unit variant pattern
+   |                          ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-For more information about this error, try `rustc --explain E0530`.
+error[E0005]: refutable pattern in local binding
+  --> $DIR/pattern-binding-disambiguation.rs:51:9
+   |
+LL |     let UnitVariant = UnitVariant;
+   |         ^^^^^^^^^^^ patterns `E::TupleVariant` and `E::BracedVariant {  }` not covered
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
+note: `E` defined here
+  --> $DIR/pattern-binding-disambiguation.rs:5:6
+   |
+LL | enum E {
+   |      ^
+LL |     UnitVariant,
+LL |     TupleVariant(),
+   |     ------------ not covered
+LL |     BracedVariant{},
+   |     ------------- not covered
+   = note: the matched value is of type `E`
+help: you might want to use `if let` to ignore the variants that aren't matched
+   |
+LL |     if let UnitVariant = UnitVariant { todo!() };
+   |     ++                               +++++++++++
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0004, E0005, E0530.
+For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.rs
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.rs
@@ -5,13 +5,13 @@ fn a<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) where 'b: 'a {
 
 fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y;
+    *x = *y; //~ ERROR: lifetime may not live long enough
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y);
+    a(x, y); //~ ERROR: lifetime may not live long enough
 }
 
 fn d() {

--- a/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-lifetime-bounds-on-fns-where-clause.stderr
@@ -9,6 +9,35 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
                  found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:8:5
+   |
+LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     // Illegal now because there is no `'b:'a` declaration.
+LL |     *x = *y;
+   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:14:5
+   |
+LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |     a(x, y);
+   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of a mutable reference to `&isize`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.rs
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.rs
@@ -6,14 +6,14 @@ fn a<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) where 
 
 fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y;
+    *x = *y; //~ ERROR: lifetime may not live long enough
     *z = *y;
 }
 
 fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y, z);
+    a(x, y, z); //~ ERROR: lifetime may not live long enough
 }
 
 fn d() {

--- a/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
+++ b/tests/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.stderr
@@ -9,6 +9,35 @@ LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
    = note: expected fn pointer `for<'a, 'b, 'c, 'd, 'e, 'f> fn(&'a mut &'b _, &'c mut &'d _, &'e mut &'f _)`
                  found fn item `for<'a, 'b, 'c> fn(&'a mut &_, &'b mut &_, &'c mut &_) {a::<'_, '_, '_>}`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:9:5
+   |
+LL | fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     // Illegal now because there is no `'b:'a` declaration.
+LL |     *x = *y;
+   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:16:5
+   |
+LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |     a(x, y, z);
+   |     ^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of a mutable reference to `&isize`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.rs
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.rs
@@ -5,13 +5,13 @@ fn a<'a, 'b:'a>(x: &mut &'a isize, y: &mut &'b isize) {
 
 fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
-    *x = *y;
+    *x = *y; //~ ERROR: lifetime may not live long enough
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Here we try to call `foo` but do not know that `'a` and `'b` are
     // related as required.
-    a(x, y);
+    a(x, y); //~ ERROR: lifetime may not live long enough
 }
 
 fn d() {

--- a/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
+++ b/tests/ui/regions/regions-lifetime-bounds-on-fns.stderr
@@ -9,6 +9,35 @@ LL |     let _: fn(&mut &isize, &mut &isize) = a;
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a mut &'b _, &'c mut &'d _)`
                  found fn item `for<'a, 'b> fn(&'a mut &_, &'b mut &_) {a::<'_, '_>}`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:8:5
+   |
+LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+LL |     // Illegal now because there is no `'b:'a` declaration.
+LL |     *x = *y;
+   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:14:5
+   |
+LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
+   |      -- -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |     a(x, y);
+   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of a mutable reference to `&isize`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.rs
@@ -3,8 +3,9 @@ fn main() {}
 fn attr_in_guard() {
     match None::<u32> {
         Some(!) //~ ERROR `!` patterns are experimental
+        //~^ ERROR: mismatched types
             if #[deny(unused_mut)] //~ ERROR attributes on expressions are experimental
             false //~ ERROR a guard on a never pattern will never be run
     }
-    match false {}
+    match false {} //~ ERROR: `bool` is non-empty
 }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:6:16
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:7:16
    |
 LL |             if #[deny(unused_mut)]
    |                ^^^^^^^^^^^^^^^^^^^
@@ -19,11 +19,34 @@ LL |         Some(!)
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: a guard on a never pattern will never be run
-  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:7:13
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:8:13
    |
 LL |             false
    |             ^^^^^ help: remove this guard
 
-error: aborting due to 3 previous errors
+error: mismatched types
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14
+   |
+LL |         Some(!)
+   |              ^ a never pattern must be used on an uninhabited type
+   |
+   = note: the matched value is of type `u32`
 
-For more information about this error, try `rustc --explain E0658`.
+error[E0004]: non-exhaustive patterns: type `bool` is non-empty
+  --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:10:11
+   |
+LL |     match false {}
+   |           ^^^^^
+   |
+   = note: the matched value is of type `bool`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown
+   |
+LL ~     match false {
+LL +         _ => todo!(),
+LL ~     }
+   |
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0004, E0658.
+For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.rs
@@ -1,6 +1,7 @@
 #![feature(never_patterns)]
 #![allow(incomplete_features)]
 
+#[derive(Copy, Clone)]
 enum Void {}
 
 fn main() {

--- a/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/bindings.stderr
@@ -1,47 +1,47 @@
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:16:15
+  --> $DIR/bindings.rs:17:15
    |
 LL |         Err(&(_a, _b, !)),
    |               ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:16:19
+  --> $DIR/bindings.rs:17:19
    |
 LL |         Err(&(_a, _b, !)),
    |                   ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:21:25
+  --> $DIR/bindings.rs:22:25
    |
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
    |                         ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:21:29
+  --> $DIR/bindings.rs:22:29
    |
 LL |         Ok(_ok) | Err(&(_a, _b, !)) => {}
    |                             ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:34:10
+  --> $DIR/bindings.rs:35:10
    |
 LL |     let (_a, (! | !)) = (true, void);
    |          ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:38:9
+  --> $DIR/bindings.rs:39:9
    |
 LL |     let _a @ ! = void;
    |         ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:41:10
+  --> $DIR/bindings.rs:42:10
    |
 LL |     let (_a @ (), !) = ((), void);
    |          ^^ help: use a wildcard `_` instead
 
 error: never patterns cannot contain variable bindings
-  --> $DIR/bindings.rs:44:14
+  --> $DIR/bindings.rs:45:14
    |
 LL |             (_b @ (_, !))) = (true, void);
    |              ^^ help: use a wildcard `_` instead

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.rs
@@ -15,18 +15,18 @@ fn no_arms_or_guards(x: Void) {
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
-    match None::<Void> {
+    match None::<Void> { //~ ERROR: `Some(_)` not covered
         Some(!) if true,
         //~^ ERROR guard on a never pattern
         None => {}
     }
-    match None::<Void> {
+    match None::<Void> { //~ ERROR: `Some(_)` not covered
         Some(!) if true => {}
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
     match None::<Void> {
-        Some(never!()) => {},
+        Some(never!()) => {}
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -25,11 +25,48 @@ LL |         Some(!) if true => {}
 error: a never pattern is always unreachable
   --> $DIR/check.rs:29:27
    |
-LL |         Some(never!()) => {},
+LL |         Some(never!()) => {}
    |                           ^^
    |                           |
    |                           this will never be executed
    |                           help: remove this expression
 
-error: aborting due to 4 previous errors
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+  --> $DIR/check.rs:18:11
+   |
+LL |     match None::<Void> {
+   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |
+note: `Option<Void>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<Void>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => {},
+LL +         Some(_) => todo!()
+   |
 
+error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+  --> $DIR/check.rs:23:11
+   |
+LL |     match None::<Void> {
+   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |
+note: `Option<Void>` defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Option<Void>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         None => {},
+LL +         Some(_) => todo!()
+   |
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
@@ -7,7 +7,9 @@ use std::arch::asm;
 //~^ ERROR `#[track_caller]` requires Rust ABI
 #[naked]
 extern "C" fn f() {
-    asm!("", options(noreturn));
+    unsafe {
+        asm!("", options(noreturn));
+    }
 }
 
 struct S;
@@ -17,7 +19,9 @@ impl S {
     //~^ ERROR `#[track_caller]` requires Rust ABI
     #[naked]
     extern "C" fn g() {
-        asm!("", options(noreturn));
+        unsafe {
+            asm!("", options(noreturn));
+        }
     }
 }
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.stderr
@@ -5,7 +5,7 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error[E0736]: cannot use `#[track_caller]` with `#[naked]`
-  --> $DIR/error-with-naked.rs:16:5
+  --> $DIR/error-with-naked.rs:18:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error[E0737]: `#[track_caller]` requires Rust ABI
-  --> $DIR/error-with-naked.rs:16:5
+  --> $DIR/error-with-naked.rs:18:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -12,7 +12,7 @@ fn call(f: impl Fn()) {
     f()
 }
 
-fn call_mut(f: impl FnMut()) {
+fn call_mut(mut f: impl FnMut()) {
     f()
 }
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -27,10 +27,10 @@ LL |     call_mut(foo);
    = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
-  --> $DIR/fn-traits.rs:15:21
+  --> $DIR/fn-traits.rs:15:25
    |
-LL | fn call_mut(f: impl FnMut()) {
-   |                     ^^^^^^^ required by this bound in `call_mut`
+LL | fn call_mut(mut f: impl FnMut()) {
+   |                         ^^^^^^^ required by this bound in `call_mut`
 
 error[E0277]: expected a `FnOnce()` closure, found `fn() {foo}`
   --> $DIR/fn-traits.rs:26:15
@@ -80,10 +80,10 @@ LL |     call_mut(foo_unsafe);
    = note: wrap the `unsafe fn() {foo_unsafe}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
-  --> $DIR/fn-traits.rs:15:21
+  --> $DIR/fn-traits.rs:15:25
    |
-LL | fn call_mut(f: impl FnMut()) {
-   |                     ^^^^^^^ required by this bound in `call_mut`
+LL | fn call_mut(mut f: impl FnMut()) {
+   |                         ^^^^^^^ required by this bound in `call_mut`
 
 error[E0277]: expected a `FnOnce()` closure, found `unsafe fn() {foo_unsafe}`
   --> $DIR/fn-traits.rs:32:15

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method-fail.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method-fail.stderr
@@ -4,5 +4,19 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
    |                                       ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closure-trait-method-fail.rs:15:5
+   |
+LL |     x(())
+   |     ^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const std::ops::FnOnce<((),)>>(x: T) -> i32 {
+   |                                                         ++++++++++++++++++++++++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closure-trait-method.stderr
@@ -4,5 +4,19 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
    |                                       ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closure-trait-method.rs:15:5
+   |
+LL |     x(())
+   |     ^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const std::ops::FnOnce<((),)>>(x: T) -> i32 {
+   |                                                         ++++++++++++++++++++++++++++++++
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
@@ -22,5 +22,45 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn answer<F: ~const Fn() -> u8>(f: &F) -> u8 {
    |                           ^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:12:5
+   |
+LL |     f() * 7
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |         F: ~const FnOnce() -> u8 + ~const std::ops::Fn<()>,
+   |                                  +++++++++++++++++++++++++
 
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:24:5
+   |
+LL |     f() + f()
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
+   |                                      +++++++++++++++++++++++++
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:24:11
+   |
+LL |     f() + f()
+   |           ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
+   |                                      +++++++++++++++++++++++++
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.rs
@@ -30,8 +30,7 @@ fn non_const_context() {
 #[unstable(feature = "none", issue = "none")]
 const fn const_context() {
     Unstable::func();
-    // ^ This is okay regardless of whether the `unstable` feature is enabled, as this function is
-    // not const-stable.
+    //[stable]~^ ERROR not yet stable as a const fn
     Foo::func();
     //[unstable]~^ ERROR not yet stable as a const fn
     // ^ fails, because the `foo` feature is not active
@@ -42,8 +41,7 @@ const fn const_context() {
 pub const fn const_context_not_const_stable() {
     //[stable]~^ ERROR function has missing const stability attribute
     Unstable::func();
-    // ^ This is okay regardless of whether the `unstable` feature is enabled, as this function is
-    // not const-stable.
+    //[stable]~^ ERROR not yet stable as a const fn
     Foo::func();
     //[unstable]~^ ERROR not yet stable as a const fn
     // ^ fails, because the `foo` feature is not active
@@ -53,7 +51,7 @@ pub const fn const_context_not_const_stable() {
 #[rustc_const_stable(feature = "cheese", since = "1.0.0")]
 const fn stable_const_context() {
     Unstable::func();
-    //[unstable]~^ ERROR not yet stable as a const fn
+    //~^ ERROR not yet stable as a const fn
     Foo::func();
     //[unstable]~^ ERROR not yet stable as a const fn
     const_context_not_const_stable()

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.stable.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.stable.stderr
@@ -10,16 +10,40 @@ LL | | }
    = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
 
 error: function has missing const stability attribute
-  --> $DIR/staged-api.rs:42:1
+  --> $DIR/staged-api.rs:41:1
    |
 LL | / pub const fn const_context_not_const_stable() {
 LL | |
 LL | |     Unstable::func();
-LL | |     // ^ This is okay regardless of whether the `unstable` feature is enabled, as this function is
+LL | |
 ...  |
 LL | |     // ^ fails, because the `foo` feature is not active
 LL | | }
    | |_^
 
-error: aborting due to 2 previous errors
+error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
+  --> $DIR/staged-api.rs:32:5
+   |
+LL |     Unstable::func();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(unstable)]` to the crate attributes to enable
+
+error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
+  --> $DIR/staged-api.rs:43:5
+   |
+LL |     Unstable::func();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(unstable)]` to the crate attributes to enable
+
+error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
+  --> $DIR/staged-api.rs:53:5
+   |
+LL |     Unstable::func();
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: const-stable functions can only call other const-stable functions
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.unstable.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/staged-api.unstable.stderr
@@ -1,5 +1,5 @@
 error: `<Foo as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:35:5
+  --> $DIR/staged-api.rs:34:5
    |
 LL |     Foo::func();
    |     ^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     Foo::func();
    = help: add `#![feature(foo)]` to the crate attributes to enable
 
 error: `<Foo as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:47:5
+  --> $DIR/staged-api.rs:45:5
    |
 LL |     Foo::func();
    |     ^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     Foo::func();
    = help: add `#![feature(foo)]` to the crate attributes to enable
 
 error: `<staged_api::Unstable as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:55:5
+  --> $DIR/staged-api.rs:53:5
    |
 LL |     Unstable::func();
    |     ^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     Unstable::func();
    = help: const-stable functions can only call other const-stable functions
 
 error: `<Foo as staged_api::MyTrait>::func` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:57:5
+  --> $DIR/staged-api.rs:55:5
    |
 LL |     Foo::func();
    |     ^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     Foo::func();
    = help: const-stable functions can only call other const-stable functions
 
 error: `const_context_not_const_stable` is not yet stable as a const fn
-  --> $DIR/staged-api.rs:59:5
+  --> $DIR/staged-api.rs:57:5
    |
 LL |     const_context_not_const_stable()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/std-impl-gate.gated.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/std-impl-gate.gated.stderr
@@ -4,6 +4,16 @@ error[E0635]: unknown feature `const_default_impls`
 LL | #![cfg_attr(gated, feature(const_trait_impl, const_default_impls))]
    |                                              ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const fn `<Vec<usize> as Default>::default` in constant functions
+  --> $DIR/std-impl-gate.rs:13:5
+   |
+LL |     Default::default()
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0635`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0635.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/span/issue-23827.rs
+++ b/tests/ui/span/issue-23827.rs
@@ -2,6 +2,7 @@
 
 #![feature(fn_traits, unboxed_closures)]
 
+#[derive(Copy, Clone)]
 pub struct Prototype {
     pub target: u32
 }

--- a/tests/ui/span/issue-23827.stderr
+++ b/tests/ui/span/issue-23827.stderr
@@ -1,5 +1,5 @@
 error[E0046]: not all trait items implemented, missing: `Output`
-  --> $DIR/issue-23827.rs:26:1
+  --> $DIR/issue-23827.rs:27:1
    |
 LL | impl<C: Component> FnOnce<(C,)> for Prototype {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Output` in implementation

--- a/tests/ui/span/issue-39698.rs
+++ b/tests/ui/span/issue-39698.rs
@@ -12,5 +12,6 @@ fn main() {
         //~| ERROR is not bound in all patterns
         //~| ERROR is not bound in all patterns
         //~| ERROR is not bound in all patterns
+        //~| ERROR `a` is possibly-uninitialized
     }
 }

--- a/tests/ui/span/issue-39698.stderr
+++ b/tests/ui/span/issue-39698.stderr
@@ -38,6 +38,19 @@ LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}
    |                  |          variable not in all patterns
    |                  variable not in all patterns
 
-error: aborting due to 4 previous errors
+error[E0381]: used binding `a` is possibly-uninitialized
+  --> $DIR/issue-39698.rs:10:79
+   |
+LL |         T::T1(a, d) | T::T2(d, b) | T::T3(c) | T::T4(a) => { println!("{:?}", a); }
+   |               -                                      -                        ^ `a` used here but it is possibly-uninitialized
+   |               |                                      |
+   |               |                                      binding initialized here in some conditions
+   |               binding initialized here in some conditions
+   |               binding declared here but left uninitialized
+   |
+   = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0408`.
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0381, E0408.
+For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/specialization/const_trait_impl.stderr
+++ b/tests/ui/specialization/const_trait_impl.stderr
@@ -16,5 +16,33 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | impl<T: ~const Default + ~const Sub> const A for T {
    |                ^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0015]: cannot call non-const fn `<() as A>::a` in constants
+  --> $DIR/const_trait_impl.rs:52:23
+   |
+LL | const _: () = assert!(<()>::a() == 42);
+   |                       ^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
 
+error[E0015]: cannot call non-const fn `<u8 as A>::a` in constants
+  --> $DIR/const_trait_impl.rs:53:23
+   |
+LL | const _: () = assert!(<u8>::a() == 3);
+   |                       ^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `<u16 as A>::a` in constants
+  --> $DIR/const_trait_impl.rs:54:23
+   |
+LL | const _: () = assert!(<u16>::a() == 2);
+   |                       ^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.rs
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.rs
@@ -14,3 +14,4 @@ pub const fn foobar() -> u32 {
 }
 
 const VAR: u32 = foobar();
+//~^ ERROR: `foobar` is not yet stable as a const fn

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-missing.stderr
@@ -4,5 +4,13 @@ error: feature `const_bar` implying `const_foobar` does not exist
 LL | #[rustc_const_unstable(feature = "const_foobar", issue = "1", implied_by = "const_bar")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: `foobar` is not yet stable as a const fn
+  --> $DIR/const-stability-attribute-implies-missing.rs:16:18
+   |
+LL | const VAR: u32 = foobar();
+   |                  ^^^^^^^^
+   |
+   = help: add `#![feature(const_foobar)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/static/static-drop-scope.rs
+++ b/tests/ui/static/static-drop-scope.rs
@@ -6,11 +6,9 @@ impl Drop for WithDtor {
 
 static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
 //~^ ERROR destructor of
-//~| ERROR temporary value dropped while borrowed
 
 const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
 //~^ ERROR destructor of
-//~| ERROR temporary value dropped while borrowed
 
 static EARLY_DROP_S: i32 = (WithDtor, 0).1;
 //~^ ERROR destructor of

--- a/tests/ui/static/static-drop-scope.stderr
+++ b/tests/ui/static/static-drop-scope.stderr
@@ -6,36 +6,16 @@ LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
    |                                                            |
    |                                                            the destructor for this type cannot be evaluated in statics
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/static-drop-scope.rs:7:60
-   |
-LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                      ------^^^^^^^^-
-   |                                                      |     |       |
-   |                                                      |     |       temporary value is freed at the end of this statement
-   |                                                      |     creates a temporary value which is freed while still in use
-   |                                                      using this value as a static requires that borrow lasts for `'static`
-
 error[E0493]: destructor of `WithDtor` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:11:59
+  --> $DIR/static-drop-scope.rs:10:59
    |
 LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
    |                                                           ^^^^^^^^- value is dropped here
    |                                                           |
    |                                                           the destructor for this type cannot be evaluated in constants
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/static-drop-scope.rs:11:59
-   |
-LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                     ------^^^^^^^^-
-   |                                                     |     |       |
-   |                                                     |     |       temporary value is freed at the end of this statement
-   |                                                     |     creates a temporary value which is freed while still in use
-   |                                                     using this value as a constant requires that borrow lasts for `'static`
-
 error[E0493]: destructor of `(WithDtor, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:15:28
+  --> $DIR/static-drop-scope.rs:13:28
    |
 LL | static EARLY_DROP_S: i32 = (WithDtor, 0).1;
    |                            ^^^^^^^^^^^^^ - value is dropped here
@@ -43,7 +23,7 @@ LL | static EARLY_DROP_S: i32 = (WithDtor, 0).1;
    |                            the destructor for this type cannot be evaluated in statics
 
 error[E0493]: destructor of `(WithDtor, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:18:27
+  --> $DIR/static-drop-scope.rs:16:27
    |
 LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
    |                           ^^^^^^^^^^^^^ - value is dropped here
@@ -51,7 +31,7 @@ LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
    |                           the destructor for this type cannot be evaluated in constants
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:21:24
+  --> $DIR/static-drop-scope.rs:19:24
    |
 LL | const fn const_drop<T>(_: T) {}
    |                        ^      - value is dropped here
@@ -59,7 +39,7 @@ LL | const fn const_drop<T>(_: T) {}
    |                        the destructor for this type cannot be evaluated in constant functions
 
 error[E0493]: destructor of `(T, ())` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:25:5
+  --> $DIR/static-drop-scope.rs:23:5
    |
 LL |     (x, ()).1
    |     ^^^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -68,7 +48,7 @@ LL | }
    | - value is dropped here
 
 error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:29:34
+  --> $DIR/static-drop-scope.rs:27:34
    |
 LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
    |                                  ^^^^^^^^^^^^^^^^^^^ - value is dropped here
@@ -76,14 +56,13 @@ LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
    |                                  the destructor for this type cannot be evaluated in constants
 
 error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:34:43
+  --> $DIR/static-drop-scope.rs:32:43
    |
 LL | const EARLY_DROP_C_OPTION_CONSTANT: i32 = (HELPER, 0).1;
    |                                           ^^^^^^^^^^^ - value is dropped here
    |                                           |
    |                                           the destructor for this type cannot be evaluated in constants
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0493, E0716.
-For more information about an error, try `rustc --explain E0493`.
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/structs-enums/enum-rec/issue-17431-6.rs
+++ b/tests/ui/structs-enums/enum-rec/issue-17431-6.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 enum Foo { X(Mutex<Option<Foo>>) }
 //~^ ERROR recursive type `Foo` has infinite size
+//~| ERROR cycle detected
 
 impl Foo { fn bar(self) {} }
 

--- a/tests/ui/structs-enums/enum-rec/issue-17431-6.stderr
+++ b/tests/ui/structs-enums/enum-rec/issue-17431-6.stderr
@@ -9,6 +9,17 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
 LL | enum Foo { X(Mutex<Option<Box<Foo>>>) }
    |                           ++++   +
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing when `Foo` needs drop
+  --> $DIR/issue-17431-6.rs:3:1
+   |
+LL | enum Foo { X(Mutex<Option<Foo>>) }
+   | ^^^^^^^^
+   |
+   = note: ...which immediately requires computing when `Foo` needs drop again
+   = note: cycle used when computing whether `Foo` needs drop
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-For more information about this error, try `rustc --explain E0072`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0072, E0391.
+For more information about an error, try `rustc --explain E0072`.

--- a/tests/ui/suggestions/derive-trait-for-method-call.rs
+++ b/tests/ui/suggestions/derive-trait-for-method-call.rs
@@ -19,7 +19,7 @@ struct CloneStruct {
 struct Foo<X, Y> (X, Y);
 impl<X: Clone + Default + , Y: Clone + Default> Foo<X, Y> {
     fn test(&self) -> (X, Y) {
-        (self.0, self.1)
+        (self.0.clone(), self.1.clone())
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs
@@ -64,6 +64,8 @@ mod bay {
 
     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
         val.use_self()
+        //~^ ERROR: cannot return value referencing function parameter `val`
+        //~| ERROR: borrowed data escapes outside of function
     }
 }
 
@@ -86,6 +88,7 @@ mod bax {
 
     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
         val.use_self()
+        //~^ ERROR: cannot return value referencing function parameter `val`
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.stderr
@@ -17,7 +17,7 @@ LL |         val.use_self()
    |         `val` is borrowed here
 
 error[E0515]: cannot return value referencing function parameter `val`
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:109:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:112:9
    |
 LL |         val.use_self()
    |         ---^^^^^^^^^^^
@@ -25,6 +25,50 @@ LL |         val.use_self()
    |         returns a value referencing data owned by the current function
    |         `val` is borrowed here
 
-error: aborting due to 3 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:66:9
+   |
+LL |     fn use_it<'a>(val: Box<dyn ObjectTrait<Assoc = i32> + 'a>) -> &'a () {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:60:30
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait<Assoc = i32>> {
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+LL |         fn use_self(&self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+help: consider relaxing the implicit `'static` requirement
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait<Assoc = i32> + '_> {
+   |                                                       ++++
 
-For more information about this error, try `rustc --explain E0515`.
+error[E0515]: cannot return value referencing function parameter `val`
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:66:9
+   |
+LL |         val.use_self()
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
+
+error[E0515]: cannot return value referencing function parameter `val`
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound-needing-more-suggestions.rs:90:9
+   |
+LL |         val.use_self()
+   |         ---^^^^^^^^^^^
+   |         |
+   |         returns a value referencing data owned by the current function
+   |         `val` is borrowed here
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0515, E0521.
+For more information about an error, try `rustc --explain E0515`.

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.rs
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.rs
@@ -36,6 +36,7 @@ mod bar {
 
     fn use_it<'a>(val: &'a dyn ObjectTrait) -> &'a () {
         val.use_self()
+        //~^ ERROR: borrowed data escapes
     }
 }
 
@@ -53,6 +54,7 @@ mod baz {
 
     fn use_it<'a>(val: &'a Box<dyn ObjectTrait + 'a>) -> &'a () {
         val.use_self()
+        //~^ ERROR: borrowed data escapes
     }
 }
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -24,7 +24,7 @@ LL |     impl<T> MyTrait<T> for dyn ObjectTrait<T> + '_ {
    |                                               ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:70:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:72:9
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |               --  --- `val` is a reference that is only valid in the function body
@@ -37,7 +37,7 @@ LL |         val.use_self()
    |         argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:65:14
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:67:14
    |
 LL |     impl dyn ObjectTrait {
    |              ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
@@ -49,7 +49,7 @@ LL |     impl dyn ObjectTrait + '_ {
    |                          ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:90:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:92:9
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> {
    |               --  --- `val` is a reference that is only valid in the function body
@@ -62,7 +62,7 @@ LL |         val.use_self()
    |         argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:87:26
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:89:26
    |
 LL |         fn use_self(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
@@ -75,7 +75,7 @@ LL |     impl MyTrait for dyn ObjectTrait + '_ {}
    |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:110:9
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:112:9
    |
 LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
    |               --  --- `val` is a reference that is only valid in the function body
@@ -88,7 +88,7 @@ LL |         MyTrait::use_self(val)
    |         argument requires that `'a` must outlive `'static`
    |
 note: the used `impl` has a `'static` requirement
-  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:106:26
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:108:26
    |
 LL |         fn use_self(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
@@ -100,6 +100,56 @@ help: consider relaxing the implicit `'static` requirement
 LL |     impl MyTrait for dyn ObjectTrait + '_ {}
    |                                      ++++
 
-error: aborting due to 4 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:38:9
+   |
+LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> &'a () {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:32:26
+   |
+LL |     impl MyTrait for dyn ObjectTrait {
+   |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+LL |         fn use_self(&self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+help: consider relaxing the implicit `'static` requirement
+   |
+LL |     impl MyTrait for dyn ObjectTrait + '_ {
+   |                                      ++++
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:56:9
+   |
+LL |     fn use_it<'a>(val: &'a Box<dyn ObjectTrait + 'a>) -> &'a () {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:50:30
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait> {
+   |                              ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+LL |         fn use_self(&self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+help: consider relaxing the implicit `'static` requirement
+   |
+LL |     impl MyTrait for Box<dyn ObjectTrait + '_> {
+   |                                          ++++
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.rs
@@ -8,6 +8,7 @@ fn f(_: impl Iterator<Item = &'_ ()>) {}
 // But that lifetime does not participate in resolution.
 fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
 //~^ ERROR missing lifetime specifier
+//~| ERROR lifetime may not live long enough
 
 // This is understood as `fn foo<'_1>(_: impl Iterator<Item = &'_1 ()>) {}`.
 async fn h(_: impl Iterator<Item = &'_ ()>) {}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -20,7 +20,7 @@ LL + fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime.rs:16:60
+  --> $DIR/impl-trait-missing-lifetime.rs:17:60
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                            ^^ expected named lifetime parameter
@@ -41,13 +41,19 @@ LL + async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime.rs:16:69
+  --> $DIR/impl-trait-missing-lifetime.rs:17:69
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    | -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
    | |
    | return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime.rs:9:63
+   |
+LL | fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |      ----- has type `x`                                       ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/issue-102892.rs
+++ b/tests/ui/suggestions/issue-102892.rs
@@ -9,6 +9,7 @@ struct B;
 
 fn process_without_annot(arc: &Arc<(A, B)>) {
     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+    //~^ ERROR: cannot move out of an `Arc`
 }
 
 fn process_with_annot(arc: &Arc<(A, B)>) {

--- a/tests/ui/suggestions/issue-102892.stderr
+++ b/tests/ui/suggestions/issue-102892.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-102892.rs:15:26
+  --> $DIR/issue-102892.rs:16:26
    |
 LL |     let (a, b): (A, B) = &**arc; // suggests putting `&**arc` here too
    |                 ------   ^^^^^^ expected `(A, B)`, found `&(A, B)`
@@ -19,7 +19,7 @@ LL |     let (a, b): &(A, B) = &**arc; // suggests putting `&**arc` here too
    |                 +
 
 error[E0308]: mismatched types
-  --> $DIR/issue-102892.rs:20:32
+  --> $DIR/issue-102892.rs:21:32
    |
 LL |     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                                ^^^^^^^^^^^^^^ expected `(A, B)`, found `&mut (A, B)`
@@ -37,7 +37,7 @@ LL |     let (a, b): (&mut (A, B), A) = (&mut *mutation, &(**arc).0); // suggest
    |                  ++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-102892.rs:20:48
+  --> $DIR/issue-102892.rs:21:48
    |
 LL |     let (a, b): ((A, B), A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                                                ^^^^^^^^^^ expected `A`, found `&A`
@@ -52,6 +52,23 @@ help: alternatively, consider changing the type annotation
 LL |     let (a, b): ((A, B), &A) = (&mut *mutation, &(**arc).0); // suggests putting `&**arc` here too
    |                          +
 
-error: aborting due to 3 previous errors
+error[E0507]: cannot move out of an `Arc`
+  --> $DIR/issue-102892.rs:11:18
+   |
+LL |     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+   |          -  -    ^^^^^
+   |          |  |
+   |          |  ...and here
+   |          data moved here
+   |
+   = note: move occurs because these variables have types that don't implement the `Copy` trait
+help: consider removing the dereference here
+   |
+LL -     let (a, b) = **arc; // suggests putting `&**arc` here; with that, fixed!
+LL +     let (a, b) = *arc; // suggests putting `&**arc` here; with that, fixed!
+   |
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0507.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/suggestions/issue-86667.rs
+++ b/tests/ui/suggestions/issue-86667.rs
@@ -4,14 +4,15 @@
 // compile-flags: --edition 2018
 
 async fn a(s1: &str, s2: &str) -> &str {
-//~^ ERROR: missing lifetime specifier [E0106]
+    //~^ ERROR: missing lifetime specifier [E0106]
     s1
-//~^ ERROR: lifetime may not live long enough
+    //~^ ERROR: lifetime may not live long enough
 }
 
 fn b(s1: &str, s2: &str) -> &str {
-//~^ ERROR: missing lifetime specifier [E0106]
+    //~^ ERROR: missing lifetime specifier [E0106]
     s1
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/suggestions/issue-86667.stderr
+++ b/tests/ui/suggestions/issue-86667.stderr
@@ -31,6 +31,15 @@ LL |
 LL |     s1
    |     ^^ returning this value requires that `'1` must outlive `'static`
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/issue-86667.rs:14:5
+   |
+LL | fn b(s1: &str, s2: &str) -> &str {
+   |          - let's call the lifetime of this reference `'1`
+LL |
+LL |     s1
+   |     ^^ returning this value requires that `'1` must outlive `'static`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -18,21 +18,31 @@ pub union Qux<'t, 'k, I> {
 trait Tar<'t, 'k, I> {}
 
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
       //~^ ERROR missing lifetime specifiers
       //~| ERROR missing lifetime specifiers
 }
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
       //~^ ERROR missing lifetime specifiers
       //~| ERROR missing lifetime specifiers
 }
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR missing lifetime specifiers
     //~| ERROR missing lifetime specifiers
 }
 thread_local! {
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
+    //~| ERROR lifetime may not live long enough
     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR missing lifetime specifiers
     //~| ERROR missing lifetime specifiers

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:21:44
+  --> $DIR/missing-lifetime-specifier.rs:23:44
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ expected 2 lifetime parameters
@@ -11,9 +11,11 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
    |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:21:44
+  --> $DIR/missing-lifetime-specifier.rs:23:44
    |
 LL | / thread_local! {
+LL | |
+LL | |
 LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    | |                                            ^^^ expected 2 lifetime parameters
 LL | |
@@ -24,7 +26,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:26:44
+  --> $DIR/missing-lifetime-specifier.rs:31:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    |                                            ^^^^ expected 2 lifetime parameters
@@ -38,9 +40,12 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>
    |                                             +++++++    ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:26:44
+  --> $DIR/missing-lifetime-specifier.rs:31:44
    |
 LL | / thread_local! {
+LL | |
+LL | |
+LL | |
 LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    | |                                            ^^^^ expected 2 lifetime parameters
    | |                                            |
@@ -53,7 +58,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:31:47
+  --> $DIR/missing-lifetime-specifier.rs:38:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    |                                               ^ expected 2 lifetime parameters
@@ -65,9 +70,11 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:31:47
+  --> $DIR/missing-lifetime-specifier.rs:38:47
    |
 LL | / thread_local! {
+LL | |
+LL | |
 LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    | |                                               ^ expected 2 lifetime parameters
 LL | |
@@ -78,7 +85,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:36:44
+  --> $DIR/missing-lifetime-specifier.rs:46:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^   ^ expected 2 lifetime parameters
@@ -92,9 +99,12 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i
    |                                             +++++++     +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:36:44
+  --> $DIR/missing-lifetime-specifier.rs:46:44
    |
 LL | / thread_local! {
+LL | |
+LL | |
+LL | |
 LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    | |                                            ^   ^ expected 2 lifetime parameters
    | |                                            |
@@ -107,7 +117,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:46:44
+  --> $DIR/missing-lifetime-specifier.rs:56:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -119,7 +129,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:46:44
+  --> $DIR/missing-lifetime-specifier.rs:56:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -133,7 +143,7 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:42:44
+  --> $DIR/missing-lifetime-specifier.rs:52:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ ------- supplied 1 lifetime argument
@@ -151,7 +161,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:46:45
+  --> $DIR/missing-lifetime-specifier.rs:56:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -168,7 +178,199 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        +++++++++
 
-error: aborting due to 12 previous errors
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:20:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Foo<'1, '_>>>>>>>`
+   |   returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:20:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Foo<'_, '2>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:27:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
+   | |                                            - let's call the lifetime of this reference `'1`
+LL | |
+LL | |
+LL | | }
+   | |_^ returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
+   |                                                 ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:27:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Bar<'2, '_>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
+   |                                                 ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:27:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Bar<'_, '3>>>>>>>`
+   |   returning this value requires that `'3` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar + '_>>>> = RefCell::new(HashMap::new());
+   |                                                 ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:35:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Qux<'1, '_, i32>>>>>>>`
+   |   returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:35:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
+LL | |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<Qux<'_, '2, i32>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:42:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
+   | |                                            - let's call the lifetime of this reference `'1`
+LL | |
+LL | |
+LL | | }
+   | |_^ returning this value requires that `'1` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
+   |                                                      ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:42:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'2, '_, i32>>>>>>>`
+   |   returning this value requires that `'2` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
+   |                                                      ++++
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lifetime-specifier.rs:42:1
+   |
+LL | / thread_local! {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | | ^
+   | | |
+   | |_has type `Option<&mut Option<RefCell<HashMap<i32, Vec<Vec<&dyn Tar<'_, '3, i32>>>>>>>`
+   |   returning this value requires that `'3` must outlive `'static`
+   |
+   = note: this error originates in the macro `$crate::thread::local_impl::thread_local_inner` which comes from the expansion of the macro `thread_local` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: to declare that the trait object captures data from argument `init`, you can add an explicit `'_` lifetime bound
+   |
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32> + '_>>>> = RefCell::new(HashMap::new());
+   |                                                      ++++
+
+error: aborting due to 22 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lt-for-hrtb.rs
+++ b/tests/ui/suggestions/missing-lt-for-hrtb.rs
@@ -8,6 +8,8 @@ fn main() {
     let x = S(&|x| {
         println!("hi");
         x
+        //~^ ERROR lifetime may not live long enough
+        //~| ERROR lifetime may not live long enough
     });
     x.0(&X(&()));
 }

--- a/tests/ui/suggestions/missing-lt-for-hrtb.stderr
+++ b/tests/ui/suggestions/missing-lt-for-hrtb.stderr
@@ -31,6 +31,28 @@ help: consider using one of the available lifetimes here
 LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &'lifetime X<'lifetime>);
    |                                         +++++++++  +++++++++++
 
-error: aborting due to 2 previous errors
+error: lifetime may not live long enough
+  --> $DIR/missing-lt-for-hrtb.rs:10:9
+   |
+LL |     let x = S(&|x| {
+   |                 -- return type of closure is &'2 X<'_>
+   |                 |
+   |                 has type `&'1 X<'_>`
+LL |         println!("hi");
+LL |         x
+   |         ^ returning this value requires that `'1` must outlive `'2`
+
+error: lifetime may not live long enough
+  --> $DIR/missing-lt-for-hrtb.rs:10:9
+   |
+LL |     let x = S(&|x| {
+   |                 -- return type of closure is &X<'4>
+   |                 |
+   |                 has type `&X<'3>`
+LL |         println!("hi");
+LL |         x
+   |         ^ returning this value requires that `'3` must outlive `'4`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/traits/method-on-unbounded-type-param.rs
+++ b/tests/ui/traits/method-on-unbounded-type-param.rs
@@ -1,0 +1,15 @@
+fn f<T>(a: T, b: T) -> std::cmp::Ordering {
+    a.cmp(&b) //~ ERROR E0599
+}
+fn g<T>(a: T, b: T) -> std::cmp::Ordering {
+    (&a).cmp(&b) //~ ERROR E0599
+}
+fn h<T>(a: &T, b: T) -> std::cmp::Ordering {
+    a.cmp(&b) //~ ERROR E0599
+}
+trait T {}
+impl<X: std::cmp::Ord> T for X {}
+fn main() {
+    let x: Box<dyn T> = Box::new(0);
+    x.cmp(&x); //~ ERROR E0599
+}

--- a/tests/ui/traits/method-on-unbounded-type-param.stderr
+++ b/tests/ui/traits/method-on-unbounded-type-param.stderr
@@ -1,0 +1,83 @@
+error[E0599]: `T` is not an iterator
+  --> $DIR/method-on-unbounded-type-param.rs:2:7
+   |
+LL | fn f<T>(a: T, b: T) -> std::cmp::Ordering {
+   |      - method `cmp` not found for this type parameter
+LL |     a.cmp(&b)
+   |       ^^^ `T` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `T: Iterator`
+           which is required by `&mut T: Iterator`
+help: consider restricting the type parameter to satisfy the trait bound
+   |
+LL | fn f<T>(a: T, b: T) -> std::cmp::Ordering where T: Iterator {
+   |                                           +++++++++++++++++
+
+error[E0599]: the method `cmp` exists for reference `&T`, but its trait bounds were not satisfied
+  --> $DIR/method-on-unbounded-type-param.rs:5:10
+   |
+LL |     (&a).cmp(&b)
+   |          ^^^ method cannot be called on `&T` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `T: Ord`
+           which is required by `&T: Ord`
+           `&T: Iterator`
+           which is required by `&mut &T: Iterator`
+           `T: Iterator`
+           which is required by `&mut T: Iterator`
+help: consider restricting the type parameters to satisfy the trait bounds
+   |
+LL | fn g<T>(a: T, b: T) -> std::cmp::Ordering where T: Iterator, T: Ord {
+   |                                           +++++++++++++++++++++++++
+
+error[E0599]: the method `cmp` exists for reference `&T`, but its trait bounds were not satisfied
+  --> $DIR/method-on-unbounded-type-param.rs:8:7
+   |
+LL |     a.cmp(&b)
+   |       ^^^ method cannot be called on `&T` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `T: Ord`
+           which is required by `&T: Ord`
+           `&T: Iterator`
+           which is required by `&mut &T: Iterator`
+           `T: Iterator`
+           which is required by `&mut T: Iterator`
+help: consider restricting the type parameters to satisfy the trait bounds
+   |
+LL | fn h<T>(a: &T, b: T) -> std::cmp::Ordering where T: Iterator, T: Ord {
+   |                                            +++++++++++++++++++++++++
+
+error[E0599]: the method `cmp` exists for struct `Box<dyn T>`, but its trait bounds were not satisfied
+  --> $DIR/method-on-unbounded-type-param.rs:14:7
+   |
+LL |   trait T {}
+   |   -------
+   |   |
+   |   doesn't satisfy `dyn T: Iterator`
+   |   doesn't satisfy `dyn T: Ord`
+...
+LL |       x.cmp(&x);
+   |         ^^^ method cannot be called on `Box<dyn T>` due to unsatisfied trait bounds
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+  ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+   = note: doesn't satisfy `Box<dyn T>: Iterator`
+   |
+   = note: doesn't satisfy `Box<dyn T>: Ord`
+   |
+   = note: the following trait bounds were not satisfied:
+           `dyn T: Iterator`
+           which is required by `Box<dyn T>: Iterator`
+           `dyn T: Ord`
+           which is required by `Box<dyn T>: Ord`
+           `Box<dyn T>: Iterator`
+           which is required by `&mut Box<dyn T>: Iterator`
+           `dyn T: Iterator`
+           which is required by `&mut dyn T: Iterator`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/traits/method-on-unbounded-type-param.stderr
+++ b/tests/ui/traits/method-on-unbounded-type-param.stderr
@@ -27,10 +27,13 @@ LL |     (&a).cmp(&b)
            which is required by `&mut &T: Iterator`
            `T: Iterator`
            which is required by `&mut T: Iterator`
-help: consider restricting the type parameters to satisfy the trait bounds
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following traits define an item `cmp`, perhaps you need to restrict type parameter `T` with one of them:
    |
-LL | fn g<T>(a: T, b: T) -> std::cmp::Ordering where T: Iterator, T: Ord {
-   |                                           +++++++++++++++++++++++++
+LL | fn g<T: Ord>(a: T, b: T) -> std::cmp::Ordering {
+   |       +++++
+LL | fn g<T: Iterator>(a: T, b: T) -> std::cmp::Ordering {
+   |       ++++++++++
 
 error[E0599]: the method `cmp` exists for reference `&T`, but its trait bounds were not satisfied
   --> $DIR/method-on-unbounded-type-param.rs:8:7
@@ -45,10 +48,13 @@ LL |     a.cmp(&b)
            which is required by `&mut &T: Iterator`
            `T: Iterator`
            which is required by `&mut T: Iterator`
-help: consider restricting the type parameters to satisfy the trait bounds
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following traits define an item `cmp`, perhaps you need to restrict type parameter `T` with one of them:
    |
-LL | fn h<T>(a: &T, b: T) -> std::cmp::Ordering where T: Iterator, T: Ord {
-   |                                            +++++++++++++++++++++++++
+LL | fn h<T: Ord>(a: &T, b: T) -> std::cmp::Ordering {
+   |       +++++
+LL | fn h<T: Iterator>(a: &T, b: T) -> std::cmp::Ordering {
+   |       ++++++++++
 
 error[E0599]: the method `cmp` exists for struct `Box<dyn T>`, but its trait bounds were not satisfied
   --> $DIR/method-on-unbounded-type-param.rs:14:7
@@ -68,6 +74,10 @@ LL |     x.cmp(&x);
            which is required by `&mut Box<dyn T>: Iterator`
            `dyn T: Iterator`
            which is required by `&mut dyn T: Iterator`
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `cmp`, perhaps you need to implement one of them:
+           candidate #1: `Ord`
+           candidate #2: `Iterator`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/method-on-unbounded-type-param.stderr
+++ b/tests/ui/traits/method-on-unbounded-type-param.stderr
@@ -1,18 +1,18 @@
-error[E0599]: `T` is not an iterator
+error[E0599]: no method named `cmp` found for type parameter `T` in the current scope
   --> $DIR/method-on-unbounded-type-param.rs:2:7
    |
 LL | fn f<T>(a: T, b: T) -> std::cmp::Ordering {
    |      - method `cmp` not found for this type parameter
 LL |     a.cmp(&b)
-   |       ^^^ `T` is not an iterator
+   |       ^^^ method cannot be called on `T` due to unsatisfied trait bounds
    |
-   = note: the following trait bounds were not satisfied:
-           `T: Iterator`
-           which is required by `&mut T: Iterator`
-help: consider restricting the type parameter to satisfy the trait bound
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following traits define an item `cmp`, perhaps you need to restrict type parameter `T` with one of them:
    |
-LL | fn f<T>(a: T, b: T) -> std::cmp::Ordering where T: Iterator {
-   |                                           +++++++++++++++++
+LL | fn f<T: Ord>(a: T, b: T) -> std::cmp::Ordering {
+   |       +++++
+LL | fn f<T: Iterator>(a: T, b: T) -> std::cmp::Ordering {
+   |       ++++++++++
 
 error[E0599]: the method `cmp` exists for reference `&T`, but its trait bounds were not satisfied
   --> $DIR/method-on-unbounded-type-param.rs:5:10

--- a/tests/ui/traits/method-on-unbounded-type-param.stderr
+++ b/tests/ui/traits/method-on-unbounded-type-param.stderr
@@ -53,20 +53,11 @@ LL | fn h<T>(a: &T, b: T) -> std::cmp::Ordering where T: Iterator, T: Ord {
 error[E0599]: the method `cmp` exists for struct `Box<dyn T>`, but its trait bounds were not satisfied
   --> $DIR/method-on-unbounded-type-param.rs:14:7
    |
-LL |   trait T {}
-   |   -------
-   |   |
-   |   doesn't satisfy `dyn T: Iterator`
-   |   doesn't satisfy `dyn T: Ord`
+LL | trait T {}
+   | ------- doesn't satisfy `dyn T: Iterator` or `dyn T: Ord`
 ...
-LL |       x.cmp(&x);
-   |         ^^^ method cannot be called on `Box<dyn T>` due to unsatisfied trait bounds
-  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
-  ::: $SRC_DIR/alloc/src/boxed.rs:LL:COL
-   |
-   = note: doesn't satisfy `Box<dyn T>: Iterator`
-   |
-   = note: doesn't satisfy `Box<dyn T>: Ord`
+LL |     x.cmp(&x);
+   |       ^^^ method cannot be called on `Box<dyn T>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `dyn T: Iterator`

--- a/tests/ui/traits/self-without-lifetime-constraint.rs
+++ b/tests/ui/traits/self-without-lifetime-constraint.rs
@@ -15,6 +15,7 @@ impl<'a> ValueRef<'a> {
         match *self {
             ValueRef::Text(t) => {
                 std::str::from_utf8(t).map_err(|_| FromSqlError::InvalidType).map(|x| (x, &x))
+                //~^ ERROR: cannot return value referencing function parameter `x`
             }
             _ => Err(FromSqlError::InvalidType),
         }

--- a/tests/ui/traits/self-without-lifetime-constraint.stderr
+++ b/tests/ui/traits/self-without-lifetime-constraint.stderr
@@ -1,5 +1,5 @@
 error: `impl` item signature doesn't match `trait` item signature
-  --> $DIR/self-without-lifetime-constraint.rs:45:5
+  --> $DIR/self-without-lifetime-constraint.rs:46:5
    |
 LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self, &Self>;
    |     -------------------------------------------------------------------- expected `fn(ValueRef<'1>) -> Result<(&'2 str, &'1 &'2 str), FromSqlError>`
@@ -10,10 +10,20 @@ LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<&str, &&str> {
    = note: expected signature `fn(ValueRef<'1>) -> Result<(&'2 str, &'1 &'2 str), FromSqlError>`
               found signature `fn(ValueRef<'1>) -> Result<(&'1 str, &'1 &'1 str), FromSqlError>`
 help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
-  --> $DIR/self-without-lifetime-constraint.rs:41:60
+  --> $DIR/self-without-lifetime-constraint.rs:42:60
    |
 LL |     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self, &Self>;
    |                                                            ^^^^ consider borrowing this type parameter in the trait
 
-error: aborting due to 1 previous error
+error[E0515]: cannot return value referencing function parameter `x`
+  --> $DIR/self-without-lifetime-constraint.rs:17:87
+   |
+LL |                 std::str::from_utf8(t).map_err(|_| FromSqlError::InvalidType).map(|x| (x, &x))
+   |                                                                                       ^^^^--^
+   |                                                                                       |   |
+   |                                                                                       |   `x` is borrowed here
+   |                                                                                       returns a value referencing data owned by the current function
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0515`.

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.rs
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.rs
@@ -6,6 +6,7 @@ mod test_type_param_static {
     fn defining<A: 'static>(s: A) -> Ty<A> { s }
     fn assert_static<A: 'static>() {}
     fn test<A>() where Ty<A>: 'static { assert_static::<A>() }
+    //~^ ERROR: the parameter type `A` may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check4_static.stderr
@@ -12,6 +12,20 @@ help: consider adding an explicit lifetime bound
 LL |     type Ty<A: 'static> = impl Sized + 'static;
    |              +++++++++
 
-error: aborting due to 1 previous error
+error[E0310]: the parameter type `A` may not live long enough
+  --> $DIR/implied_lifetime_wf_check4_static.rs:8:41
+   |
+LL |     fn test<A>() where Ty<A>: 'static { assert_static::<A>() }
+   |                                         ^^^^^^^^^^^^^^^^^^
+   |                                         |
+   |                                         the parameter type `A` must be valid for the static lifetime...
+   |                                         ...so that the type `A` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL |     fn test<A: 'static>() where Ty<A>: 'static { assert_static::<A>() }
+   |              +++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -7,6 +7,7 @@ type Pointer<T> = impl std::ops::Deref<Target = T>;
 fn test() -> Pointer<_> {
     //~^ ERROR: the placeholder `_` is not allowed within types
     Box::new(1)
+    //~^ ERROR: expected generic type parameter, found `i32`
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Pointer<_> {
    |              help: replace with the correct return type: `Pointer<i32>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/issue-77179.rs:17:25
+  --> $DIR/issue-77179.rs:18:25
    |
 LL |     fn bar() -> Pointer<_>;
    |                         ^
@@ -16,6 +16,16 @@ LL |     fn bar() -> Pointer<_>;
    |                         not allowed in type signatures
    |                         help: use type parameters instead: `T`
 
-error: aborting due to 2 previous errors
+error[E0792]: expected generic type parameter, found `i32`
+  --> $DIR/issue-77179.rs:9:5
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |              - this generic parameter must be used with a generic type parameter
+...
+LL |     Box::new(1)
+   |     ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0121`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0121, E0792.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
+++ b/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
@@ -14,5 +14,7 @@ mod foo {
 }
 
 fn main() {
-    let _: foo::Foo = std::mem::transmute(0u8);
+    unsafe {
+        let _: foo::Foo = std::mem::transmute(0u8);
+    }
 }

--- a/tests/ui/typeof/issue-100183.stderr
+++ b/tests/ui/typeof/issue-100183.stderr
@@ -6,8 +6,8 @@ LL |     y: (typeof("hey"),),
    |
 help: consider replacing `typeof(...)` with an actual type
    |
-LL |     y: (&'static str,),
-   |         ~~~~~~~~~~~~
+LL |     y: (&str,),
+   |         ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.rs
@@ -33,6 +33,7 @@ fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
     //~^ ERROR trait takes 1 lifetime argument but 0 lifetime arguments were supplied
     // Here, the omitted lifetimes are expanded to distinct things.
     same_type(x, y)
+    //~^ ERROR borrowed data escapes outside of function
 }
 
 fn main() { }

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-region.stderr
@@ -34,6 +34,22 @@ note: trait defined here, with 1 lifetime parameter: `'a`
 LL | trait Foo<'a,T> {
    |       ^^^ --
 
-error: aborting due to 3 previous errors
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/unboxed-closure-sugar-region.rs:35:5
+   |
+LL | fn test2(x: &dyn Foo<(isize,),Output=()>, y: &dyn Foo(isize)) {
+   |          -                                - `y` declared here, outside of the function body
+   |          |
+   |          `x` is a reference that is only valid in the function body
+   |          has type `&dyn Foo<'1, (isize,), Output = ()>`
+...
+LL |     same_type(x, y)
+   |     ^^^^^^^^^^^^^^^
+   |     |
+   |     `x` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0521.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.rs
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.rs
@@ -14,6 +14,7 @@ fn meh() -> Box<dyn for<'_> Meh<'_>> //~ ERROR cannot be used here
 }
 
 fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y } //~ ERROR missing lifetime specifier
+//~^ ERROR lifetime may not live long enough
 
 fn main() {
     let x = 5;

--- a/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/tests/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -45,7 +45,15 @@ help: consider introducing a named lifetime parameter
 LL | fn foo2<'a>(_: &'a u8, y: &'a u8) -> &'a u8 { y }
    |        ++++     ~~         ~~         ~~
 
-error: aborting due to 5 previous errors
+error: lifetime may not live long enough
+  --> $DIR/underscore-lifetime-binders.rs:16:43
+   |
+LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
+   |                       -                   ^ returning this value requires that `'1` must outlive `'static`
+   |                       |
+   |                       let's call the lifetime of this reference `'1`
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0106, E0637.
 For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Successful merges:

 - #120507 (Account for non-overlapping unmet trait bounds in suggestion)
 - #120518 (riscv only supports split_debuginfo=off for now)
 - #120521 (Make `NonZero` constructors generic.)
 - #120527 (Switch OwnedStore handle count to AtomicU32)
 - #120550 (Continue to borrowck even if there were previous errors)
 - #120587 (miri: normalize struct tail in ABI compat check)
 - #120590 (Remove unused args from functions)
 - #120607 (fix #120603 by adding a check in default_read_buf)

Failed merges:

 - #120575 (Simplify codegen diagnostic handling)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=120507,120518,120521,120527,120550,120587,120590,120607)
<!-- homu-ignore:end -->