### PR TITLE
Add parallel rustc ui tests

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 const ISSUES_ENTRY_LIMIT: usize = 1819;
-const ROOT_ENTRY_LIMIT: usize = 870;
+const ROOT_ENTRY_LIMIT: usize = 871;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.rs
+++ b/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Z threads=16
+// build-fail
+
+#![crate_type="rlib"]
+#![allow(warnings)]
+
+#[export_name="fail"]
+pub fn a() {
+}
+
+#[export_name="fail"]
+pub fn b() {
+//~^ Error symbol `fail` is already defined
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.stderr
+++ b/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.stderr
@@ -1,0 +1,8 @@
+error: symbol `fail` is already defined
+  --> $DIR/cache-after-waiting-issue-111528.rs:12:1
+   |
+LL | pub fn b() {
+   | ^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205-2.rs
+++ b/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205-2.rs
@@ -1,0 +1,7 @@
+// compile-flags:-C extra-filename=-1 -Z threads=16
+// no-prefer-dynamic
+// build-pass
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize { 10 }

--- a/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205.rs
+++ b/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205.rs
@@ -1,0 +1,22 @@
+// compile-flags: -Z threads=16
+// build-pass
+
+pub static GLOBAL: isize = 3;
+
+static GLOBAL0: isize = 4;
+
+pub static GLOBAL2: &'static isize = &GLOBAL0;
+
+pub fn verify_same(a: &'static isize) {
+    let a = a as *const isize as usize;
+    let b = &GLOBAL as *const isize as usize;
+    assert_eq!(a, b);
+}
+
+pub fn verify_same2(a: &'static isize) {
+    let a = a as *const isize as usize;
+    let b = GLOBAL2 as *const isize as usize;
+    assert_eq!(a, b);
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/hello_world.rs
+++ b/tests/ui/parallel-rustc/hello_world.rs
@@ -1,0 +1,6 @@
+// compile-flags: -Z threads=8
+// run-pass
+
+fn main() {
+    println!("Hello world!");
+}

--- a/tests/ui/parallel-rustc/read-stolen-value-issue-111520.rs
+++ b/tests/ui/parallel-rustc/read-stolen-value-issue-111520.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Z threads=16
+// run-pass
+
+#[repr(transparent)]
+struct Sched {
+    i: i32,
+}
+impl Sched {
+    extern "C" fn get(self) -> i32 { self.i }
+}
+
+fn main() {
+    let s = Sched { i: 4 };
+    let f = || -> i32 {
+        s.get()
+    };
+    println!("f: {}", f());
+}


### PR DESCRIPTION
Updates #118698

Add some ui tests for parallel rustc front end

This is a relatively large feature so I think it's worth creating a new entity in tests/ui folder, so we need to modify the limit in tidy.