### PR TITLE
Update E0716.md for clarity

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0716.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0716.md
@@ -30,9 +30,8 @@ let q = p;
 
 Whenever a temporary is created, it is automatically dropped (freed) according
 to fixed rules. Ordinarily, the temporary is dropped at the end of the enclosing
-statement -- in this case, after the outer `let` that assigns to `p`. This is
-illustrated in the example above by showing that `tmp` would be freed as we exit
-the block.
+statement -- in this case, after the `let p`. This is illustrated in the example
+above by showing that `tmp` would be freed as we exit the block.
 
 To fix this problem, you need to create a local variable to store the value in
 rather than relying on a temporary. For example, you might change the original

--- a/compiler/rustc_error_codes/src/error_codes/E0716.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0716.md
@@ -30,8 +30,9 @@ let q = p;
 
 Whenever a temporary is created, it is automatically dropped (freed) according
 to fixed rules. Ordinarily, the temporary is dropped at the end of the enclosing
-statement -- in this case, after the `let`. This is illustrated in the example
-above by showing that `tmp` would be freed as we exit the block.
+statement -- in this case, after the outer `let` that assigns to `p`. This is
+illustrated in the example above by showing that `tmp` would be freed as we exit
+the block.
 
 To fix this problem, you need to create a local variable to store the value in
 rather than relying on a temporary. For example, you might change the original


### PR DESCRIPTION
When reading through this, I got slightly hung up thinking the `let` it was referring to was the `let tmp` on line 25, which was confusing considering the comment states that the temporary is freed at the end of the block. I think adding this clarification could potentially help some beginners like myself without being overly verbose.