### PR TITLE
Run const_prop_lint in check builds, too

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -734,6 +734,8 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
             // Run unsafety check because it's responsible for stealing and
             // deallocating THIR.
             tcx.ensure().check_unsafety(def_id);
+            tcx.ensure().const_prop_lint(def_id);
+            tcx.ensure().const_prop_lint_promoteds(def_id);
             tcx.ensure().mir_borrowck(def_id)
         });
     });

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -76,6 +76,10 @@ impl<'tcx> PlaceTy<'tcx> {
         if self.variant_index.is_some() && !matches!(elem, ProjectionElem::Field(..)) {
             bug!("cannot use non field projection on downcasted place")
         }
+        if self.ty.references_error() {
+            // Cannot do anything useful with error types
+            return PlaceTy::from_ty(self.ty);
+        }
         let answer = match *elem {
             ProjectionElem::Deref => {
                 let ty = self

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -243,6 +243,7 @@ trivial! {
     Option<usize>,
     Option<rustc_span::Symbol>,
     Result<(), rustc_errors::ErrorGuaranteed>,
+    Result<(), traits::util::HasImpossiblePredicates>,
     Result<(), rustc_middle::traits::query::NoSolution>,
     Result<rustc_middle::traits::EvaluationResult, rustc_middle::traits::OverflowError>,
     rustc_ast::expand::allocator::AllocatorKind,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -40,6 +40,7 @@ use crate::traits::query::{
     OutlivesBound,
 };
 use crate::traits::specialization_graph;
+use crate::traits::util::HasImpossiblePredicates;
 use crate::traits::{
     CodegenObligationError, EvaluationResult, ImplSource, ObjectSafetyViolation, ObligationCause,
     OverflowError, WellFormedLoc,
@@ -1013,6 +1014,18 @@ rustc_queries! {
     query mir_borrowck(key: LocalDefId) -> &'tcx mir::BorrowCheckResult<'tcx> {
         desc { |tcx| "borrow-checking `{}`", tcx.def_path_str(key) }
         cache_on_disk_if(tcx) { tcx.is_typeck_child(key.to_def_id()) }
+    }
+
+    /// Run the const prop lints on the `mir_promoted` of an item.
+    query const_prop_lint(key: LocalDefId) -> Result<(), HasImpossiblePredicates> {
+        desc { |tcx| "running const prop lints for `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { true }
+    }
+
+    /// Run the const prop lints on the promoted consts of an item.
+    query const_prop_lint_promoteds(key: LocalDefId) -> Result<(), HasImpossiblePredicates> {
+        desc { |tcx| "running const prop lints for promoteds of `{}`", tcx.def_path_str(key) }
+        cache_on_disk_if { true }
     }
 
     /// Gets a complete map from all types to their inherent impls.

--- a/compiler/rustc_middle/src/traits/util.rs
+++ b/compiler/rustc_middle/src/traits/util.rs
@@ -60,3 +60,9 @@ impl<'tcx> Iterator for Elaborator<'tcx> {
         }
     }
 }
+
+/// Used as an error type to signal that an item may have an invalid body, because its
+/// where bounds are trivially not satisfyable.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(HashStable, Encodable, Decodable)]
+pub struct HasImpossiblePredicates;

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -659,10 +659,17 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Get the type of the pointer to the static that we use in MIR.
     pub fn static_ptr_ty(self, def_id: DefId) -> Ty<'tcx> {
         // Make sure that any constants in the static's type are evaluated.
-        let static_ty = self.normalize_erasing_regions(
+        let mut static_ty = self.normalize_erasing_regions(
             ty::ParamEnv::empty(),
             self.type_of(def_id).instantiate_identity(),
         );
+        if !static_ty.is_sized(self, ty::ParamEnv::reveal_all()) {
+            static_ty = Ty::new_error_with_message(
+                self,
+                self.def_span(def_id),
+                "unsized statics are forbidden and error in wfcheck",
+            );
+        }
 
         // Make sure that accesses to unsafe statics end up using raw pointers.
         // For thread-locals, this needs to be kept in sync with `Rvalue::ty`.

--- a/src/doc/rustc/src/lints/levels.md
+++ b/src/doc/rustc/src/lints/levels.md
@@ -71,7 +71,7 @@ level is capped via cap-lints.
 A 'deny' lint produces an error if you violate it. For example, this code
 runs into the `exceeding_bitshifts` lint.
 
-```rust,no_run
+```rust,compile_fail
 fn main() {
     100u8 << 10;
 }
@@ -246,7 +246,7 @@ pub fn foo() {}
 This is the maximum level for all lints. So for example, if we take our
 code sample from the "deny" lint level above:
 
-```rust,no_run
+```rust,compile_fail
 fn main() {
     100u8 << 10;
 }

--- a/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.rs
+++ b/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.rs
@@ -35,9 +35,8 @@ fn main() {
     x[const { idx() }]; // Ok, should not produce stderr.
     x[const { idx4() }]; // Ok, let rustc's `unconditional_panic` lint handle `usize` indexing on arrays.
     const { &ARR[idx()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-    const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-    //
-    //~^^ ERROR: failed
+    // FIXME errors in rustc and subsequently blocks all lints in this file. Can reenable once solved on the rustc side
+    //const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
 
     let y = &x;
     y[0]; // Ok, referencing shouldn't affect this lint. See the issue 6021

--- a/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.stderr
+++ b/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.stderr
@@ -1,15 +1,3 @@
-error[E0080]: evaluation of `main::{constant#3}` failed
-  --> $DIR/test.rs:38:14
-   |
-LL |     const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-   |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
-
-note: erroneous constant encountered
-  --> $DIR/test.rs:38:5
-   |
-LL |     const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
 error: indexing may panic
   --> $DIR/test.rs:29:5
    |
@@ -21,7 +9,7 @@ LL |     x[index];
    = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
 
 error: indexing may panic
-  --> $DIR/test.rs:47:5
+  --> $DIR/test.rs:46:5
    |
 LL |     v[0];
    |     ^^^^
@@ -29,7 +17,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:48:5
+  --> $DIR/test.rs:47:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -37,7 +25,7 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:49:5
+  --> $DIR/test.rs:48:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
@@ -45,7 +33,7 @@ LL |     v[1 << 3];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:55:5
+  --> $DIR/test.rs:54:5
    |
 LL |     v[N];
    |     ^^^^
@@ -53,7 +41,7 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:56:5
+  --> $DIR/test.rs:55:5
    |
 LL |     v[M];
    |     ^^^^
@@ -66,6 +54,6 @@ error[E0080]: evaluation of constant value failed
 LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/tools/clippy/tests/ui/indexing_slicing_index.rs
+++ b/src/tools/clippy/tests/ui/indexing_slicing_index.rs
@@ -45,8 +45,8 @@ fn main() {
     const { &ARR[idx()] };
     //~^ ERROR: indexing may panic
     // This should be linted, since `suppress-restriction-lint-in-const` default is false.
-    const { &ARR[idx4()] };
-    //~^ ERROR: indexing may panic
+    // FIXME can't include here for now, as the error on it causes all lints to get silenced
+    //const { &ARR[idx4()] };
 
     let y = &x;
     // Ok, referencing shouldn't affect this lint. See the issue 6021

--- a/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
+++ b/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
@@ -18,18 +18,6 @@ LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = note: the suggestion might not be applicable in constant blocks
 
-error[E0080]: evaluation of `main::{constant#3}` failed
-  --> $DIR/indexing_slicing_index.rs:48:14
-   |
-LL |     const { &ARR[idx4()] };
-   |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
-
-note: erroneous constant encountered
-  --> $DIR/indexing_slicing_index.rs:48:5
-   |
-LL |     const { &ARR[idx4()] };
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
 error: indexing may panic
   --> $DIR/indexing_slicing_index.rs:29:5
    |
@@ -58,15 +46,6 @@ error: indexing may panic
    |
 LL |     const { &ARR[idx()] };
    |              ^^^^^^^^^^
-   |
-   = help: consider using `.get(n)` or `.get_mut(n)` instead
-   = note: the suggestion might not be applicable in constant blocks
-
-error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:48:14
-   |
-LL |     const { &ARR[idx4()] };
-   |              ^^^^^^^^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
    = note: the suggestion might not be applicable in constant blocks
@@ -135,6 +114,6 @@ error[E0080]: evaluation of constant value failed
 LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
    |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
-error: aborting due to 17 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -62,7 +62,7 @@ fn statics() {
 
     static RC: &E = &E::V2(4);
 
-    // CHECK: [[t:_.*]] = const {alloc2: &&E};
+    // CHECK: [[t:_.*]] = const {alloc4: &&E};
     // CHECK: [[e2]] = (*[[t]]);
     let e2 = RC;
 

--- a/tests/mir-opt/instsimplify/combine_transmutes.integer_transmutes.InstSimplify.diff
+++ b/tests/mir-opt/instsimplify/combine_transmutes.integer_transmutes.InstSimplify.diff
@@ -5,19 +5,15 @@
       let mut _0: ();
       let mut _1: u32;
       let mut _2: i64;
-      let mut _3: i64;
-      let mut _4: u32;
-      let mut _5: usize;
+      let mut _3: usize;
   
       bb0: {
 -         _1 = const 1_i32 as u32 (Transmute);
+-         _2 = const 1_u64 as i64 (Transmute);
+-         _3 = const 1_isize as usize (Transmute);
 +         _1 = const 1_i32 as u32 (IntToInt);
-          _2 = const 1_i32 as i64 (Transmute);
--         _3 = const 1_u64 as i64 (Transmute);
-+         _3 = const 1_u64 as i64 (IntToInt);
-          _4 = const 1_u64 as u32 (Transmute);
--         _5 = const 1_isize as usize (Transmute);
-+         _5 = const 1_isize as usize (IntToInt);
++         _2 = const 1_u64 as i64 (IntToInt);
++         _3 = const 1_isize as usize (IntToInt);
           return;
       }
   }

--- a/tests/mir-opt/instsimplify/combine_transmutes.rs
+++ b/tests/mir-opt/instsimplify/combine_transmutes.rs
@@ -25,19 +25,15 @@ pub unsafe fn integer_transmutes() {
     // CHECK-LABEL: fn integer_transmutes(
     // CHECK-NOT: _i32 as u32 (Transmute);
     // CHECK: _i32 as u32 (IntToInt);
-    // CHECK: _i32 as i64 (Transmute);
     // CHECK-NOT: _u64 as i64 (Transmute);
     // CHECK: _u64 as i64 (IntToInt);
-    // CHECK: _u64 as u32 (Transmute);
     // CHECK-NOT: _isize as usize (Transmute);
     // CHECK: _isize as usize (IntToInt);
 
     mir! {
         {
             let A = CastTransmute::<i32, u32>(1); // Can be a cast
-            let B = CastTransmute::<i32, i64>(1); // UB
             let C = CastTransmute::<u64, i64>(1); // Can be a cast
-            let D = CastTransmute::<u64, u32>(1); // UB
             let E = CastTransmute::<isize, usize>(1); // Can be a cast
             Return()
         }

--- a/tests/ui/array-slice-vec/array_const_index-0.stderr
+++ b/tests/ui/array-slice-vec/array_const_index-0.stderr
@@ -4,6 +4,20 @@ error[E0080]: evaluation of constant value failed
 LL | const B: i32 = (&A)[1];
    |                ^^^^^^^ index out of bounds: the length is 0 but the index is 1
 
+note: erroneous constant encountered
+  --> $DIR/array_const_index-0.rs:7:13
+   |
+LL |     let _ = B;
+   |             ^
+
+note: erroneous constant encountered
+  --> $DIR/array_const_index-0.rs:7:13
+   |
+LL |     let _ = B;
+   |             ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/array-slice-vec/array_const_index-1.stderr
+++ b/tests/ui/array-slice-vec/array_const_index-1.stderr
@@ -4,6 +4,20 @@ error[E0080]: evaluation of constant value failed
 LL | const B: i32 = A[1];
    |                ^^^^ index out of bounds: the length is 0 but the index is 1
 
+note: erroneous constant encountered
+  --> $DIR/array_const_index-1.rs:7:13
+   |
+LL |     let _ = B;
+   |             ^
+
+note: erroneous constant encountered
+  --> $DIR/array_const_index-1.rs:7:13
+   |
+LL |     let _ = B;
+   |             ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/associated-consts/defaults-cyclic-fail.rs
+++ b/tests/ui/associated-consts/defaults-cyclic-fail.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 // Cyclic assoc. const defaults don't error unless *used*
 trait Tr {
     const A: u8 = Self::B;

--- a/tests/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/tests/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -1,27 +1,27 @@
 error[E0391]: cycle detected when simplifying constant for the type system `Tr::A`
-  --> $DIR/defaults-cyclic-fail.rs:5:5
+  --> $DIR/defaults-cyclic-fail.rs:3:5
    |
 LL |     const A: u8 = Self::B;
    |     ^^^^^^^^^^^
    |
 note: ...which requires const-evaluating + checking `Tr::A`...
-  --> $DIR/defaults-cyclic-fail.rs:5:19
+  --> $DIR/defaults-cyclic-fail.rs:3:19
    |
 LL |     const A: u8 = Self::B;
    |                   ^^^^^^^
 note: ...which requires simplifying constant for the type system `Tr::B`...
-  --> $DIR/defaults-cyclic-fail.rs:8:5
+  --> $DIR/defaults-cyclic-fail.rs:6:5
    |
 LL |     const B: u8 = Self::A;
    |     ^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `Tr::B`...
-  --> $DIR/defaults-cyclic-fail.rs:8:19
+  --> $DIR/defaults-cyclic-fail.rs:6:19
    |
 LL |     const B: u8 = Self::A;
    |                   ^^^^^^^
    = note: ...which again requires simplifying constant for the type system `Tr::A`, completing the cycle
-note: cycle used when optimizing promoted MIR for `main`
-  --> $DIR/defaults-cyclic-fail.rs:16:16
+note: cycle used when running const prop lints for promoteds of `main`
+  --> $DIR/defaults-cyclic-fail.rs:14:16
    |
 LL |     assert_eq!(<() as Tr>::A, 0);
    |                ^^^^^^^^^^^^^

--- a/tests/ui/associated-consts/defaults-not-assumed-fail.rs
+++ b/tests/ui/associated-consts/defaults-not-assumed-fail.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 trait Tr {
     const A: u8 = 255;
 

--- a/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `<() as Tr>::B` failed
-  --> $DIR/defaults-not-assumed-fail.rs:8:19
+  --> $DIR/defaults-not-assumed-fail.rs:6:19
    |
 LL |     const B: u8 = Self::A + 1;
    |                   ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:16
+  --> $DIR/defaults-not-assumed-fail.rs:31:16
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |                ^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:16
+  --> $DIR/defaults-not-assumed-fail.rs:31:16
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |                ^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:5
+  --> $DIR/defaults-not-assumed-fail.rs:31:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:5
+  --> $DIR/defaults-not-assumed-fail.rs:31:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`
+error[E0391]: cycle detected when running const prop lints for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:22
    |
 LL |     const BAR: u32 = IMPL_REF_BAR;
@@ -29,7 +29,12 @@ note: ...which requires caching mir of `<impl at $DIR/issue-24949-assoc-const-st
    |
 LL |     const BAR: u32 = IMPL_REF_BAR;
    |     ^^^^^^^^^^^^^^
-   = note: ...which again requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`, completing the cycle
+note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |     ^^^^^^^^^^^^^^
+   = note: ...which again requires running const prop lints for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when elaborating drops for `FooDefault::BAR`
+error[E0391]: cycle detected when running const prop lints for `FooDefault::BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:22
    |
 LL |     const BAR: u32 = DEFAULT_REF_BAR;
@@ -29,7 +29,12 @@ note: ...which requires caching mir of `FooDefault::BAR` for CTFE...
    |
 LL |     const BAR: u32 = DEFAULT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-   = note: ...which again requires elaborating drops for `FooDefault::BAR`, completing the cycle
+note: ...which requires elaborating drops for `FooDefault::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^
+   = note: ...which again requires running const prop lints for `FooDefault::BAR`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -1,4 +1,4 @@
-error[E0391]: cycle detected when elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`
+error[E0391]: cycle detected when running const prop lints for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:22
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
@@ -29,7 +29,12 @@ note: ...which requires caching mir of `<impl at $DIR/issue-24949-assoc-const-st
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-   = note: ...which again requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`, completing the cycle
+note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |     ^^^^^^^^^^^^^^
+   = note: ...which again requires running const prop lints for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 

--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.rs
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.rs
@@ -1,8 +1,5 @@
 //@ edition: 2021
 
-// Test doesn't fail until monomorphization time, unfortunately.
-//@ build-fail
-
 fn main() {
     let _ = async {
         A.first().await.second().await;

--- a/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/async-await/in-trait/indirect-recursion-issue-112047.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in an async fn requires boxing
-  --> $DIR/indirect-recursion-issue-112047.rs:34:5
+  --> $DIR/indirect-recursion-issue-112047.rs:31:5
    |
 LL |     async fn second(self) {
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Trait<Alias<_>>` for type `Alias<_>`
-  --> $DIR/opaques.rs:30:1
+  --> $DIR/opaques.rs:34:1
    |
 LL | impl<T> Trait<T> for T {
    | ---------------------- first implementation here
@@ -8,7 +8,7 @@ LL | impl<T> Trait<T> for defining_scope::Alias<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Alias<_>`
 
 error[E0282]: type annotations needed
-  --> $DIR/opaques.rs:13:20
+  --> $DIR/opaques.rs:17:20
    |
 LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
    |                    ^ cannot infer type for struct `Container<Alias<T>, T>`

--- a/tests/ui/coherence/occurs-check/opaques.old.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.old.stderr
@@ -1,0 +1,8 @@
+error: internal compiler error: unexpected ambiguity: Canonical { value: ParamEnvAnd { param_env: ParamEnv { caller_bounds: [Binder { value: TraitPredicate(<T as std::marker::Sized>, polarity:Positive), bound_vars: [] }], reveal: All }, value: AliasTy { args: [T/#0, T/#0], def_id: DefId(0:15 ~ opaques[e7ab]::Trait::Assoc) } }, max_universe: U0, variables: [] } Canonical { value: QueryResponse { var_values: CanonicalVarValues { var_values: [] }, region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, certainty: Ambiguous, opaque_types: [], value: NormalizationResult { normalized_ty: ^0 } }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
+   |
+   = error: internal compiler error: unexpected ambiguity: Canonical { value: ParamEnvAnd { param_env: ParamEnv { caller_bounds: [], reveal: All }, value: AliasTy { args: [(), ()], def_id: DefId(0:15 ~ opaques[e7ab]::Trait::Assoc) } }, max_universe: U0, variables: [] } Canonical { value: QueryResponse { var_values: CanonicalVarValues { var_values: [] }, region_constraints: QueryRegionConstraints { outlives: [], member_constraints: [] }, certainty: Ambiguous, opaque_types: [], value: NormalizationResult { normalized_ty: ^0 } }, max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }
+   |
+   = query stack during panic:
+end of query stack
+error: aborting due to 2 previous errors
+

--- a/tests/ui/coherence/occurs-check/opaques.rs
+++ b/tests/ui/coherence/occurs-check/opaques.rs
@@ -4,7 +4,11 @@
 // A regression test for #105787
 
 //@[old] known-bug: #105787
-//@[old] check-pass
+//@[old] failure-status: 101
+//@ normalize-stderr-test "note: .*\n\n" -> ""
+//@ normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+//@ normalize-stderr-test "(error: internal compiler error: [^:]+):\d+:\d+: " -> "$1:LL:CC: "
+//@ rustc-env:RUST_BACKTRACE=0
 #![feature(type_alias_impl_trait)]
 mod defining_scope {
     use super::*;

--- a/tests/ui/const_prop/const-prop-ice.rs
+++ b/tests/ui/const_prop/const-prop-ice.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 fn main() {
     [0; 3][3u64 as usize]; //~ ERROR this operation will panic at runtime
 }

--- a/tests/ui/const_prop/const-prop-ice.stderr
+++ b/tests/ui/const_prop/const-prop-ice.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/const-prop-ice.rs:4:5
+  --> $DIR/const-prop-ice.rs:2:5
    |
 LL |     [0; 3][3u64 as usize];
    |     ^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 3

--- a/tests/ui/const_prop/const-prop-ice2.rs
+++ b/tests/ui/const_prop/const-prop-ice2.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 fn main() {
     enum Enum { One=1 }
     let xs=[0;1 as usize];

--- a/tests/ui/const_prop/const-prop-ice2.stderr
+++ b/tests/ui/const_prop/const-prop-ice2.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/const-prop-ice2.rs:6:20
+  --> $DIR/const-prop-ice2.rs:4:20
    |
 LL |     println!("{}", xs[Enum::One as usize]);
    |                    ^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1

--- a/tests/ui/consts/const-array-oob.rs
+++ b/tests/ui/consts/const-array-oob.rs
@@ -1,5 +1,6 @@
 const FOO: [usize; 3] = [1, 2, 3];
-const BAR: usize = FOO[5]; // no error, because the error below occurs before regular const eval
+const BAR: usize = FOO[5];
+//~^ ERROR: evaluation of constant value failed
 
 const BLUB: [u32; FOO[4]] = [5, 6];
 //~^ ERROR evaluation of constant value failed [E0080]

--- a/tests/ui/consts/const-array-oob.stderr
+++ b/tests/ui/consts/const-array-oob.stderr
@@ -1,9 +1,29 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-array-oob.rs:4:19
+  --> $DIR/const-array-oob.rs:5:19
    |
 LL | const BLUB: [u32; FOO[4]] = [5, 6];
    |                   ^^^^^^ index out of bounds: the length is 3 but the index is 4
 
-error: aborting due to 1 previous error
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-array-oob.rs:2:20
+   |
+LL | const BAR: usize = FOO[5];
+   |                    ^^^^^^ index out of bounds: the length is 3 but the index is 5
+
+note: erroneous constant encountered
+  --> $DIR/const-array-oob.rs:10:13
+   |
+LL |     let _ = BAR;
+   |             ^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-array-oob.rs:10:13
+   |
+LL |     let _ = BAR;
+   |             ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-err-early.rs
+++ b/tests/ui/consts/const-err-early.rs
@@ -10,5 +10,5 @@ fn main() {
     let _c = C;
     let _d = D;
     let _e = E;
-    let _e = [6u8][1];
+    let _e = [6u8][1]; //~ ERROR: will panic at runtime
 }

--- a/tests/ui/consts/const-err-early.stderr
+++ b/tests/ui/consts/const-err-early.stderr
@@ -4,11 +4,39 @@ error[E0080]: evaluation of constant value failed
 LL | pub const A: i8 = -i8::MIN;
    |                   ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:8:14
+   |
+LL |     let _a = A;
+   |              ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:8:14
+   |
+LL |     let _a = A;
+   |              ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-err-early.rs:2:19
    |
 LL | pub const B: u8 = 200u8 + 200u8;
    |                   ^^^^^^^^^^^^^ attempt to compute `200_u8 + 200_u8`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:9:14
+   |
+LL |     let _b = B;
+   |              ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:9:14
+   |
+LL |     let _b = B;
+   |              ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-err-early.rs:3:19
@@ -16,11 +44,39 @@ error[E0080]: evaluation of constant value failed
 LL | pub const C: u8 = 200u8 * 4;
    |                   ^^^^^^^^^ attempt to compute `200_u8 * 4_u8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:10:14
+   |
+LL |     let _c = C;
+   |              ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:10:14
+   |
+LL |     let _c = C;
+   |              ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-err-early.rs:4:19
    |
 LL | pub const D: u8 = 42u8 - (42u8 + 1);
    |                   ^^^^^^^^^^^^^^^^^ attempt to compute `42_u8 - 43_u8`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:11:14
+   |
+LL |     let _d = D;
+   |              ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:11:14
+   |
+LL |     let _d = D;
+   |              ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-err-early.rs:5:19
@@ -28,6 +84,28 @@ error[E0080]: evaluation of constant value failed
 LL | pub const E: u8 = [5u8][1];
    |                   ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
-error: aborting due to 5 previous errors
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:12:14
+   |
+LL |     let _e = E;
+   |              ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-early.rs:12:14
+   |
+LL |     let _e = E;
+   |              ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: this operation will panic at runtime
+  --> $DIR/const-err-early.rs:13:14
+   |
+LL |     let _e = [6u8][1];
+   |              ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
+   |
+   = note: `#[deny(unconditional_panic)]` on by default
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-err-enum-discriminant.stderr
+++ b/tests/ui/consts/const-err-enum-discriminant.stderr
@@ -4,6 +4,85 @@ error[E0080]: evaluation of constant value failed
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
    |                     ^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:16
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |                ^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:5
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const-err-enum-discriminant.rs:14:5
+   |
+LL |     assert_ne!(Bar::Boo as isize, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-err-late.rs
+++ b/tests/ui/consts/const-err-late.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C overflow-checks=on
 
 #![allow(arithmetic_overflow, unconditional_panic)]

--- a/tests/ui/consts/const-err-late.stderr
+++ b/tests/ui/consts/const-err-late.stderr
@@ -1,29 +1,29 @@
 error[E0080]: evaluation of `S::<i32>::FOO` failed
-  --> $DIR/const-err-late.rs:13:21
+  --> $DIR/const-err-late.rs:12:21
    |
 LL |     const FOO: u8 = [5u8][1];
    |                     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:16
+  --> $DIR/const-err-late.rs:18:16
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                ^^^^^^^^^^^^^
 
 error[E0080]: evaluation of `S::<u32>::FOO` failed
-  --> $DIR/const-err-late.rs:13:21
+  --> $DIR/const-err-late.rs:12:21
    |
 LL |     const FOO: u8 = [5u8][1];
    |                     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:31
+  --> $DIR/const-err-late.rs:18:31
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                               ^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:16
+  --> $DIR/const-err-late.rs:18:16
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                ^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:31
+  --> $DIR/const-err-late.rs:18:31
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                               ^^^^^^^^^^^^^

--- a/tests/ui/consts/const-err-multi.stderr
+++ b/tests/ui/consts/const-err-multi.stderr
@@ -5,10 +5,22 @@ LL | pub const A: i8 = -i8::MIN;
    |                   ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
 
 note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:14
+   |
+LL |     let _ = (A, B, C, D);
+   |              ^
+
+note: erroneous constant encountered
   --> $DIR/const-err-multi.rs:3:19
    |
 LL | pub const B: i8 = A;
    |                   ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:17
+   |
+LL |     let _ = (A, B, C, D);
+   |                 ^
 
 note: erroneous constant encountered
   --> $DIR/const-err-multi.rs:5:19
@@ -17,10 +29,54 @@ LL | pub const C: u8 = A as u8;
    |                   ^
 
 note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:20
+   |
+LL |     let _ = (A, B, C, D);
+   |                    ^
+
+note: erroneous constant encountered
   --> $DIR/const-err-multi.rs:7:24
    |
 LL | pub const D: i8 = 50 - A;
    |                        ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:23
+   |
+LL |     let _ = (A, B, C, D);
+   |                       ^
+
+note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:14
+   |
+LL |     let _ = (A, B, C, D);
+   |              ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:17
+   |
+LL |     let _ = (A, B, C, D);
+   |                 ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:20
+   |
+LL |     let _ = (A, B, C, D);
+   |                    ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-err-multi.rs:11:23
+   |
+LL |     let _ = (A, B, C, D);
+   |                       ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/tests/ui/consts/const-eval/conditional_array_execution.stderr
@@ -4,6 +4,37 @@ error[E0080]: evaluation of constant value failed
 LL | const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
    |                   ^^^^^ attempt to compute `5_u32 - 6_u32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/conditional_array_execution.rs:7:20
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+
+note: erroneous constant encountered
+  --> $DIR/conditional_array_execution.rs:7:20
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/conditional_array_execution.rs:7:20
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/conditional_array_execution.rs:7:20
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -4,11 +4,23 @@ error[E0080]: evaluation of constant value failed
 LL |      i8::MIN - 1,
    |      ^^^^^^^^^^^ attempt to compute `i8::MIN - 1_i8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:57:9
+   |
+LL |     foo(VALS_I8);
+   |         ^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:18:6
    |
 LL |      i16::MIN - 1,
    |      ^^^^^^^^^^^^ attempt to compute `i16::MIN - 1_i16`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:58:9
+   |
+LL |     foo(VALS_I16);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:24:6
@@ -16,11 +28,23 @@ error[E0080]: evaluation of constant value failed
 LL |      i32::MIN - 1,
    |      ^^^^^^^^^^^^ attempt to compute `i32::MIN - 1_i32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:59:9
+   |
+LL |     foo(VALS_I32);
+   |         ^^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:30:6
    |
 LL |      i64::MIN - 1,
    |      ^^^^^^^^^^^^ attempt to compute `i64::MIN - 1_i64`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:60:9
+   |
+LL |     foo(VALS_I64);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:36:6
@@ -28,11 +52,23 @@ error[E0080]: evaluation of constant value failed
 LL |      u8::MIN - 1,
    |      ^^^^^^^^^^^ attempt to compute `0_u8 - 1_u8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:62:9
+   |
+LL |     foo(VALS_U8);
+   |         ^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:41:6
    |
 LL |      u16::MIN - 1,
    |      ^^^^^^^^^^^^ attempt to compute `0_u16 - 1_u16`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:63:9
+   |
+LL |     foo(VALS_U16);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:46:6
@@ -40,11 +76,23 @@ error[E0080]: evaluation of constant value failed
 LL |      u32::MIN - 1,
    |      ^^^^^^^^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:64:9
+   |
+LL |     foo(VALS_U32);
+   |         ^^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2.rs:52:6
    |
 LL |      u64::MIN - 1,
    |      ^^^^^^^^^^^^ attempt to compute `0_u64 - 1_u64`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2.rs:65:9
+   |
+LL |     foo(VALS_U64);
+   |         ^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -4,11 +4,23 @@ error[E0080]: evaluation of constant value failed
 LL |      i8::MAX + 1,
    |      ^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:57:9
+   |
+LL |     foo(VALS_I8);
+   |         ^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:18:6
    |
 LL |      i16::MAX + 1,
    |      ^^^^^^^^^^^^ attempt to compute `i16::MAX + 1_i16`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:58:9
+   |
+LL |     foo(VALS_I16);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:24:6
@@ -16,11 +28,23 @@ error[E0080]: evaluation of constant value failed
 LL |      i32::MAX + 1,
    |      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:59:9
+   |
+LL |     foo(VALS_I32);
+   |         ^^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:30:6
    |
 LL |      i64::MAX + 1,
    |      ^^^^^^^^^^^^ attempt to compute `i64::MAX + 1_i64`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:60:9
+   |
+LL |     foo(VALS_I64);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:36:6
@@ -28,11 +52,23 @@ error[E0080]: evaluation of constant value failed
 LL |      u8::MAX + 1,
    |      ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:62:9
+   |
+LL |     foo(VALS_U8);
+   |         ^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:41:6
    |
 LL |      u16::MAX + 1,
    |      ^^^^^^^^^^^^ attempt to compute `u16::MAX + 1_u16`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:63:9
+   |
+LL |     foo(VALS_U16);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:46:6
@@ -40,11 +76,23 @@ error[E0080]: evaluation of constant value failed
 LL |      u32::MAX + 1,
    |      ^^^^^^^^^^^^ attempt to compute `u32::MAX + 1_u32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:64:9
+   |
+LL |     foo(VALS_U32);
+   |         ^^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2b.rs:52:6
    |
 LL |      u64::MAX + 1,
    |      ^^^^^^^^^^^^ attempt to compute `u64::MAX + 1_u64`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2b.rs:65:9
+   |
+LL |     foo(VALS_U64);
+   |         ^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -4,11 +4,23 @@ error[E0080]: evaluation of constant value failed
 LL |      i8::MIN * 2,
    |      ^^^^^^^^^^^ attempt to compute `i8::MIN * 2_i8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:57:9
+   |
+LL |     foo(VALS_I8);
+   |         ^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:18:6
    |
 LL |      i16::MIN * 2,
    |      ^^^^^^^^^^^^ attempt to compute `i16::MIN * 2_i16`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:58:9
+   |
+LL |     foo(VALS_I16);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:24:6
@@ -16,11 +28,23 @@ error[E0080]: evaluation of constant value failed
 LL |      i32::MIN * 2,
    |      ^^^^^^^^^^^^ attempt to compute `i32::MIN * 2_i32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:59:9
+   |
+LL |     foo(VALS_I32);
+   |         ^^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:30:6
    |
 LL |      i64::MIN * 2,
    |      ^^^^^^^^^^^^ attempt to compute `i64::MIN * 2_i64`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:60:9
+   |
+LL |     foo(VALS_I64);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:36:6
@@ -28,11 +52,23 @@ error[E0080]: evaluation of constant value failed
 LL |      u8::MAX * 2,
    |      ^^^^^^^^^^^ attempt to compute `u8::MAX * 2_u8`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:62:9
+   |
+LL |     foo(VALS_U8);
+   |         ^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:41:6
    |
 LL |      u16::MAX * 2,
    |      ^^^^^^^^^^^^ attempt to compute `u16::MAX * 2_u16`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:63:9
+   |
+LL |     foo(VALS_U16);
+   |         ^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:46:6
@@ -40,11 +76,23 @@ error[E0080]: evaluation of constant value failed
 LL |      u32::MAX * 2,
    |      ^^^^^^^^^^^^ attempt to compute `u32::MAX * 2_u32`, which would overflow
 
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:64:9
+   |
+LL |     foo(VALS_U32);
+   |         ^^^^^^^^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-eval-overflow2c.rs:52:6
    |
 LL |      u64::MAX * 2,
    |      ^^^^^^^^^^^^ attempt to compute `u64::MAX * 2_u64`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/const-eval-overflow2c.rs:65:9
+   |
+LL |     foo(VALS_U64);
+   |         ^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -7,6 +7,10 @@ LL | const X: i32 = 1 / 0;
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `X`
 #1 [eval_to_const_value_raw] simplifying constant for the type system `X`
-#2 [lint_mod] linting top-level module
-#3 [analysis] running analysis passes on this crate
+#2 [const_prop_lint_promoteds] running const prop lints for promoteds of `main`
+#3 [promoted_mir] optimizing promoted MIR for `main`
+#4 [eval_to_allocation_raw] const-evaluating + checking `main::promoted[1]`
+#5 [eval_to_const_value_raw] simplifying constant for the type system `main::promoted[1]`
+#6 [const_prop_lint] running const prop lints for `main`
+#7 [analysis] running analysis passes on this crate
 end of query stack

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -9,11 +9,17 @@ note: inside `bar`
    |
 LL |     x(y)
    |     ^^^^
-note: inside `Y`
-  --> $DIR/const_fn_ptr_fail2.rs:14:18
+note: inside `Z`
+  --> $DIR/const_fn_ptr_fail2.rs:15:18
    |
-LL | const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^
+LL | const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
+   |                  ^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:19:16
+   |
+LL |     assert_eq!(Z, 4);
+   |                ^
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_fn_ptr_fail2.rs:9:5
@@ -26,11 +32,67 @@ note: inside `bar`
    |
 LL |     x(y)
    |     ^^^^
-note: inside `Z`
-  --> $DIR/const_fn_ptr_fail2.rs:15:18
+note: inside `Y`
+  --> $DIR/const_fn_ptr_fail2.rs:14:18
    |
-LL | const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^^^^^^
+LL | const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
+   |                  ^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:18:16
+   |
+LL |     assert_eq!(Y, 4);
+   |                ^
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:18:16
+   |
+LL |     assert_eq!(Y, 4);
+   |                ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:18:5
+   |
+LL |     assert_eq!(Y, 4);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:18:5
+   |
+LL |     assert_eq!(Y, 4);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:19:16
+   |
+LL |     assert_eq!(Z, 4);
+   |                ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:19:5
+   |
+LL |     assert_eq!(Z, 4);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const_fn_ptr_fail2.rs:19:5
+   |
+LL |     assert_eq!(Z, 4);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/const-eval/index_out_of_bounds_propagated.rs
+++ b/tests/ui/consts/const-eval/index_out_of_bounds_propagated.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 fn main() {
     let array = [std::env::args().len()];
     array[1]; //~ ERROR operation will panic

--- a/tests/ui/consts/const-eval/index_out_of_bounds_propagated.stderr
+++ b/tests/ui/consts/const-eval/index_out_of_bounds_propagated.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/index_out_of_bounds_propagated.rs:5:5
+  --> $DIR/index_out_of_bounds_propagated.rs:3:5
    |
 LL |     array[1];
    |     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1

--- a/tests/ui/consts/const-eval/issue-104390.stderr
+++ b/tests/ui/consts/const-eval/issue-104390.stderr
@@ -61,5 +61,89 @@ LL | fn f6() -> impl Sized { &'_ 2E }
    |                          annotated with lifetime here
    |                          help: remove the lifetime annotation
 
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:1:25
+   |
+LL | fn f1() -> impl Sized { & 2E }
+   |                         ^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:1:25
+   |
+LL | fn f1() -> impl Sized { & 2E }
+   |                         ^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:2:25
+   |
+LL | fn f2() -> impl Sized { && 2E }
+   |                         ^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:2:25
+   |
+LL | fn f2() -> impl Sized { && 2E }
+   |                         ^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:3:25
+   |
+LL | fn f3() -> impl Sized { &'a 2E }
+   |                         ^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:3:25
+   |
+LL | fn f3() -> impl Sized { &'a 2E }
+   |                         ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:5:25
+   |
+LL | fn f4() -> impl Sized { &'static 2E }
+   |                         ^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:5:25
+   |
+LL | fn f4() -> impl Sized { &'static 2E }
+   |                         ^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:7:26
+   |
+LL | fn f5() -> impl Sized { *& 2E }
+   |                          ^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:7:26
+   |
+LL | fn f5() -> impl Sized { *& 2E }
+   |                          ^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:8:25
+   |
+LL | fn f6() -> impl Sized { &'_ 2E }
+   |                         ^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-104390.rs:8:25
+   |
+LL | fn f6() -> impl Sized { &'_ 2E }
+   |                         ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 9 previous errors
 

--- a/tests/ui/consts/const-eval/issue-43197.stderr
+++ b/tests/ui/consts/const-eval/issue-43197.stderr
@@ -1,14 +1,76 @@
 error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-43197.rs:8:24
+   |
+LL |     const Y: u32 = foo(0 - 1);
+   |                        ^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:26
+   |
+LL |     println!("{} {}", X, Y);
+   |                          ^
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/issue-43197.rs:6:20
    |
 LL |     const X: u32 = 0 - 1;
    |                    ^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-43197.rs:8:24
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:23
    |
-LL |     const Y: u32 = foo(0 - 1);
-   |                        ^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
+LL |     println!("{} {}", X, Y);
+   |                       ^
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:23
+   |
+LL |     println!("{} {}", X, Y);
+   |                       ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:23
+   |
+LL |     println!("{} {}", X, Y);
+   |                       ^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:23
+   |
+LL |     println!("{} {}", X, Y);
+   |                       ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:26
+   |
+LL |     println!("{} {}", X, Y);
+   |                          ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:26
+   |
+LL |     println!("{} {}", X, Y);
+   |                          ^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/issue-43197.rs:10:26
+   |
+LL |     println!("{} {}", X, Y);
+   |                          ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/issue-44578.rs
+++ b/tests/ui/consts/const-eval/issue-44578.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 trait Foo {
     const AMT: usize;
 }

--- a/tests/ui/consts/const-eval/issue-44578.stderr
+++ b/tests/ui/consts/const-eval/issue-44578.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `<Bar<u16, u8> as Foo>::AMT` failed
-  --> $DIR/issue-44578.rs:13:24
+  --> $DIR/issue-44578.rs:11:24
    |
 LL |     const AMT: usize = [A::AMT][(A::AMT > B::AMT) as usize];
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:23:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:23:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:23:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:23:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/issue-49296.stderr
+++ b/tests/ui/consts/const-eval/issue-49296.stderr
@@ -4,6 +4,37 @@ error[E0080]: evaluation of constant value failed
 LL | const X: u64 = *wat(42);
    |                ^^^^^^^^ memory access failed: ALLOC0 has been freed, so this pointer is dangling
 
+note: erroneous constant encountered
+  --> $DIR/issue-49296.rs:13:20
+   |
+LL |     println!("{}", X);
+   |                    ^
+
+note: erroneous constant encountered
+  --> $DIR/issue-49296.rs:13:20
+   |
+LL |     println!("{}", X);
+   |                    ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-49296.rs:13:20
+   |
+LL |     println!("{}", X);
+   |                    ^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/issue-49296.rs:13:20
+   |
+LL |     println!("{}", X);
+   |                    ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-eval/issue-50814.rs
+++ b/tests/ui/consts/const-eval/issue-50814.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 trait Unsigned {
     const MAX: u8;
 }
@@ -14,7 +12,6 @@ struct Sum<A, B>(A, B);
 impl<A: Unsigned, B: Unsigned> Unsigned for Sum<A, B> {
     const MAX: u8 = A::MAX + B::MAX;
     //~^ ERROR evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
-    //~| ERROR evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
 }
 
 fn foo<T>(_: T) -> &'static u8 {

--- a/tests/ui/consts/const-eval/issue-50814.stderr
+++ b/tests/ui/consts/const-eval/issue-50814.stderr
@@ -1,37 +1,15 @@
 error[E0080]: evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
-  --> $DIR/issue-50814.rs:15:21
+  --> $DIR/issue-50814.rs:13:21
    |
 LL |     const MAX: u8 = A::MAX + B::MAX;
    |                     ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + u8::MAX`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814.rs:21:6
+  --> $DIR/issue-50814.rs:18:6
    |
 LL |     &Sum::<U8, U8>::MAX
    |      ^^^^^^^^^^^^^^^^^^
 
-error[E0080]: evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
-  --> $DIR/issue-50814.rs:15:21
-   |
-LL |     const MAX: u8 = A::MAX + B::MAX;
-   |                     ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + u8::MAX`, which would overflow
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-note: erroneous constant encountered
-  --> $DIR/issue-50814.rs:21:6
-   |
-LL |     &Sum::<U8, U8>::MAX
-   |      ^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-note: the above error was encountered while instantiating `fn foo::<i32>`
-  --> $DIR/issue-50814.rs:26:5
-   |
-LL |     foo(0);
-   |     ^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 // Regression test for #66975
 #![feature(never_type)]
 

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -1,19 +1,19 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/panic-assoc-never-type.rs:9:21
+  --> $DIR/panic-assoc-never-type.rs:7:21
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:9:21
+   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:7:21
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $DIR/panic-assoc-never-type.rs:14:13
+  --> $DIR/panic-assoc-never-type.rs:12:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/panic-assoc-never-type.rs:14:13
+  --> $DIR/panic-assoc-never-type.rs:12:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/panic-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-never-type.stderr
@@ -6,6 +6,20 @@ LL | const VOID: ! = panic!();
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+note: erroneous constant encountered
+  --> $DIR/panic-never-type.rs:8:13
+   |
+LL |     let _ = VOID;
+   |             ^^^^
+
+note: erroneous constant encountered
+  --> $DIR/panic-never-type.rs:8:13
+   |
+LL |     let _ = VOID;
+   |             ^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-eval/stable-metric/ctfe-fn-call.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-fn-call.stderr
@@ -13,5 +13,36 @@ LL | const X: u32 = call_foo();
    | ^^^^^^^^^^^^
    = note: `#[deny(long_running_const_eval)]` on by default
 
+note: erroneous constant encountered
+  --> $DIR/ctfe-fn-call.rs:35:16
+   |
+LL |     println!("{X}");
+   |                ^
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-fn-call.rs:35:16
+   |
+LL |     println!("{X}");
+   |                ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-fn-call.rs:35:15
+   |
+LL |     println!("{X}");
+   |               ^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-fn-call.rs:35:15
+   |
+LL |     println!("{X}");
+   |               ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/stable-metric/ctfe-labelled-loop.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-labelled-loop.stderr
@@ -19,5 +19,36 @@ LL | const X: u32 = labelled_loop(19);
    | ^^^^^^^^^^^^
    = note: `#[deny(long_running_const_eval)]` on by default
 
+note: erroneous constant encountered
+  --> $DIR/ctfe-labelled-loop.rs:19:16
+   |
+LL |     println!("{X}");
+   |                ^
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-labelled-loop.rs:19:16
+   |
+LL |     println!("{X}");
+   |                ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-labelled-loop.rs:19:15
+   |
+LL |     println!("{X}");
+   |               ^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-labelled-loop.rs:19:15
+   |
+LL |     println!("{X}");
+   |               ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/stable-metric/ctfe-recursion.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-recursion.stderr
@@ -13,5 +13,36 @@ LL | const X: u32 = recurse(19);
    | ^^^^^^^^^^^^
    = note: `#[deny(long_running_const_eval)]` on by default
 
+note: erroneous constant encountered
+  --> $DIR/ctfe-recursion.rs:16:16
+   |
+LL |     println!("{X}");
+   |                ^
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-recursion.rs:16:16
+   |
+LL |     println!("{X}");
+   |                ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-recursion.rs:16:15
+   |
+LL |     println!("{X}");
+   |               ^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/ctfe-recursion.rs:16:15
+   |
+LL |     println!("{X}");
+   |               ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,7 +1,6 @@
 const fn foo() -> ! {
     unsafe { std::mem::transmute(()) }
     //~^ ERROR evaluation of constant value failed
-    //~| WARN the type `!` does not permit zero-initialization [invalid_value]
 }
 
 // Type defined in a submodule, so that it is not "visibly"
@@ -18,7 +17,6 @@ const FOO: [empty::Empty; 3] = [foo(); 3];
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
 //~^ ERROR evaluation of constant value failed
-//~| WARN the type `empty::Empty` does not permit zero-initialization
 
 fn main() {
     FOO;

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,12 +1,3 @@
-warning: the type `!` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:2:14
-   |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
-   |
-   = note: the `!` type has no valid value
-   = note: `#[warn(invalid_value)]` on by default
-
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:2:14
    |
@@ -19,34 +10,45 @@ note: inside `foo`
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^
 note: inside `FOO`
-  --> $DIR/validate_uninhabited_zsts.rs:17:33
+  --> $DIR/validate_uninhabited_zsts.rs:16:33
    |
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
    |                                 ^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/validate_uninhabited_zsts.rs:22:5
+   |
+LL |     FOO;
+   |     ^^^
+
+note: erroneous constant encountered
+  --> $DIR/validate_uninhabited_zsts.rs:22:5
+   |
+LL |     FOO;
+   |     ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:19:42
+  --> $DIR/validate_uninhabited_zsts.rs:18:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered a value of uninhabited type `Void`
 
-warning: the type `empty::Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:19:42
+note: erroneous constant encountered
+  --> $DIR/validate_uninhabited_zsts.rs:23:5
    |
-LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
-   |
-note: in this struct field
-  --> $DIR/validate_uninhabited_zsts.rs:14:22
-   |
-LL |     pub struct Empty(Void);
-   |                      ^^^^
-note: enums with no inhabited variants have no valid value
-  --> $DIR/validate_uninhabited_zsts.rs:11:5
-   |
-LL |     enum Void {}
-   |     ^^^^^^^^^
+LL |     BAR;
+   |     ^^^
 
-error: aborting due to 2 previous errors; 2 warnings emitted
+note: erroneous constant encountered
+  --> $DIR/validate_uninhabited_zsts.rs:23:5
+   |
+LL |     BAR;
+   |     ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-float-bits-reject-conv.stderr
+++ b/tests/ui/consts/const-float-bits-reject-conv.stderr
@@ -14,22 +14,6 @@ LL |     const MASKED_NAN1: u32 = f32::NAN.to_bits() ^ 0x002A_AAAA;
    |                              ^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/f32.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'const-eval error: cannot use f32::to_bits on a NaN', $SRC_DIR/core/src/num/f32.rs:LL:COL
-   |
-note: inside `core::f32::<impl f32>::to_bits::ct_f32_to_u32`
-  --> $SRC_DIR/core/src/num/f32.rs:LL:COL
-note: inside `core::f32::<impl f32>::to_bits`
-  --> $SRC_DIR/core/src/num/f32.rs:LL:COL
-note: inside `f32::MASKED_NAN2`
-  --> $DIR/const-float-bits-reject-conv.rs:30:30
-   |
-LL |     const MASKED_NAN2: u32 = f32::NAN.to_bits() ^ 0x0055_5555;
-   |                              ^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 note: erroneous constant encountered
   --> $DIR/const-float-bits-reject-conv.rs:35:34
    |
@@ -49,10 +33,38 @@ LL |     const_assert!(f32::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
    |                                  ^^^^^^^^^^^
 
 note: erroneous constant encountered
+  --> $DIR/const-float-bits-reject-conv.rs:42:58
+   |
+LL |     const_assert!(f32::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
+   |                                                          ^^^^^^^^^^^
+
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/num/f32.rs:LL:COL
+   |
+   = note: the evaluated program panicked at 'const-eval error: cannot use f32::to_bits on a NaN', $SRC_DIR/core/src/num/f32.rs:LL:COL
+   |
+note: inside `core::f32::<impl f32>::to_bits::ct_f32_to_u32`
+  --> $SRC_DIR/core/src/num/f32.rs:LL:COL
+note: inside `core::f32::<impl f32>::to_bits`
+  --> $SRC_DIR/core/src/num/f32.rs:LL:COL
+note: inside `f32::MASKED_NAN2`
+  --> $DIR/const-float-bits-reject-conv.rs:30:30
+   |
+LL |     const MASKED_NAN2: u32 = f32::NAN.to_bits() ^ 0x0055_5555;
+   |                              ^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
   --> $DIR/const-float-bits-reject-conv.rs:43:34
    |
 LL |     const_assert!(f32::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
    |                                  ^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-float-bits-reject-conv.rs:43:58
+   |
+LL |     const_assert!(f32::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
+   |                                                          ^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/num/f64.rs:LL:COL
@@ -67,22 +79,6 @@ note: inside `f64::MASKED_NAN1`
   --> $DIR/const-float-bits-reject-conv.rs:50:30
    |
 LL |     const MASKED_NAN1: u64 = f64::NAN.to_bits() ^ 0x000A_AAAA_AAAA_AAAA;
-   |                              ^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/f64.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'const-eval error: cannot use f64::to_bits on a NaN', $SRC_DIR/core/src/num/f64.rs:LL:COL
-   |
-note: inside `core::f64::<impl f64>::to_bits::ct_f64_to_u64`
-  --> $SRC_DIR/core/src/num/f64.rs:LL:COL
-note: inside `core::f64::<impl f64>::to_bits`
-  --> $SRC_DIR/core/src/num/f64.rs:LL:COL
-note: inside `f64::MASKED_NAN2`
-  --> $DIR/const-float-bits-reject-conv.rs:52:30
-   |
-LL |     const MASKED_NAN2: u64 = f64::NAN.to_bits() ^ 0x0005_5555_5555_5555;
    |                              ^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -105,10 +101,38 @@ LL |     const_assert!(f64::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
    |                                  ^^^^^^^^^^^
 
 note: erroneous constant encountered
+  --> $DIR/const-float-bits-reject-conv.rs:61:58
+   |
+LL |     const_assert!(f64::from_bits(MASKED_NAN1).to_bits(), MASKED_NAN1);
+   |                                                          ^^^^^^^^^^^
+
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/num/f64.rs:LL:COL
+   |
+   = note: the evaluated program panicked at 'const-eval error: cannot use f64::to_bits on a NaN', $SRC_DIR/core/src/num/f64.rs:LL:COL
+   |
+note: inside `core::f64::<impl f64>::to_bits::ct_f64_to_u64`
+  --> $SRC_DIR/core/src/num/f64.rs:LL:COL
+note: inside `core::f64::<impl f64>::to_bits`
+  --> $SRC_DIR/core/src/num/f64.rs:LL:COL
+note: inside `f64::MASKED_NAN2`
+  --> $DIR/const-float-bits-reject-conv.rs:52:30
+   |
+LL |     const MASKED_NAN2: u64 = f64::NAN.to_bits() ^ 0x0005_5555_5555_5555;
+   |                              ^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
   --> $DIR/const-float-bits-reject-conv.rs:62:34
    |
 LL |     const_assert!(f64::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
    |                                  ^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-float-bits-reject-conv.rs:62:58
+   |
+LL |     const_assert!(f64::from_bits(MASKED_NAN2).to_bits(), MASKED_NAN2);
+   |                                                          ^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
@@ -8,6 +8,7 @@ const A: *const i32 = &4;
 // but we do not want to allow this to compile,
 // as that would be an enormous footgun in oli-obk's opinion.
 const B: *mut i32 = &mut 4; //~ ERROR mutable references are not allowed
+//~^ ERROR mutable pointer in final value of constant
 
 // Ok, no actual mutable allocation exists
 const B2: Option<&mut i32> = None;

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -5,7 +5,7 @@ LL | const B: *mut i32 = &mut 4;
    |                     ^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:16:40
+  --> $DIR/mut_ref_in_final.rs:17:40
    |
 LL | const B3: Option<&mut i32> = Some(&mut 42);
    |                              ----------^^-
@@ -15,7 +15,7 @@ LL | const B3: Option<&mut i32> = Some(&mut 42);
    |                              using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:19:42
+  --> $DIR/mut_ref_in_final.rs:20:42
    |
 LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              ------------^^-
@@ -25,7 +25,7 @@ LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:34:65
+  --> $DIR/mut_ref_in_final.rs:35:65
    |
 LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                  -------------------------------^^--
@@ -35,7 +35,7 @@ LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                  using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:37:67
+  --> $DIR/mut_ref_in_final.rs:38:67
    |
 LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                    -------------------------------^^--
@@ -45,7 +45,7 @@ LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                    using this value as a static requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:40:71
+  --> $DIR/mut_ref_in_final.rs:41:71
    |
 LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                        -------------------------------^^--
@@ -55,30 +55,50 @@ LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                        using this value as a static requires that borrow lasts for `'static`
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/mut_ref_in_final.rs:53:53
+  --> $DIR/mut_ref_in_final.rs:54:53
    |
 LL | static RAW_MUT_CAST_S: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                     ^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/mut_ref_in_final.rs:55:54
+  --> $DIR/mut_ref_in_final.rs:56:54
    |
 LL | static RAW_MUT_COERCE_S: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                      ^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/mut_ref_in_final.rs:57:52
+  --> $DIR/mut_ref_in_final.rs:58:52
    |
 LL | const RAW_MUT_CAST_C: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                    ^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/mut_ref_in_final.rs:59:53
+  --> $DIR/mut_ref_in_final.rs:60:53
    |
 LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                     ^^^^^^
 
-error: aborting due to 10 previous errors
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mut_ref_in_final.rs:10:1
+   |
+LL | const B: *mut i32 = &mut 4;
+   | ^^^^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/mut_ref_in_final.rs:65:15
+   |
+LL |     unsafe { *B = 4 } // Bad news
+   |               ^
+
+note: erroneous constant encountered
+  --> $DIR/mut_ref_in_final.rs:65:15
+   |
+LL |     unsafe { *B = 4 } // Bad news
+   |               ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0716, E0764.
 For more information about an error, try `rustc --explain E0716`.

--- a/tests/ui/consts/const-slice-oob.stderr
+++ b/tests/ui/consts/const-slice-oob.stderr
@@ -4,6 +4,20 @@ error[E0080]: evaluation of constant value failed
 LL | const BAR: u32 = FOO[5];
    |                  ^^^^^^ index out of bounds: the length is 3 but the index is 5
 
+note: erroneous constant encountered
+  --> $DIR/const-slice-oob.rs:7:13
+   |
+LL |     let _ = BAR;
+   |             ^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-slice-oob.rs:7:13
+   |
+LL |     let _ = BAR;
+   |             ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-unsized.rs
+++ b/tests/ui/consts/const-unsized.rs
@@ -20,4 +20,5 @@ fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
     //~^ ERROR: cannot move a value of type `str`
     //~| ERROR: cannot move a value of type `dyn Debug + Sync`
+    //~| ERROR: evaluation of constant value failed
 }

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -78,7 +78,30 @@ error[E0161]: cannot move a value of type `dyn Debug + Sync`
 LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
    |                                      ^^^^^^^ the size of `dyn Debug + Sync` cannot be statically determined
 
-error: aborting due to 10 previous errors
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-unsized.rs:20:48
+   |
+LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
+   |                                                ^^^^^^^^^ unsized locals are not supported
 
-Some errors have detailed explanations: E0161, E0277.
-For more information about an error, try `rustc --explain E0161`.
+note: erroneous constant encountered
+  --> $DIR/const-unsized.rs:20:47
+   |
+LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
+   |                                               ^^^^^^^^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const-unsized.rs:20:47
+   |
+LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
+   |                                               ^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0080, E0161, E0277.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-unwrap.stderr
+++ b/tests/ui/consts/const-unwrap.stderr
@@ -4,6 +4,37 @@ error[E0080]: evaluation of constant value failed
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:7:38
 
+note: erroneous constant encountered
+  --> $DIR/const-unwrap.rs:12:20
+   |
+LL |     println!("{}", BAR);
+   |                    ^^^
+
+note: erroneous constant encountered
+  --> $DIR/const-unwrap.rs:12:20
+   |
+LL |     println!("{}", BAR);
+   |                    ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-unwrap.rs:12:20
+   |
+LL |     println!("{}", BAR);
+   |                    ^^^
+   |
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const-unwrap.rs:12:20
+   |
+LL |     println!("{}", BAR);
+   |                    ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -16,6 +16,37 @@ note: inside `BAR`
 LL | const BAR: bool = unsafe { foo(false) };
    |                            ^^^^^^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/const_unsafe_unreachable_ub.rs:13:16
+   |
+LL |     assert_eq!(BAR, true);
+   |                ^^^
+
+note: erroneous constant encountered
+  --> $DIR/const_unsafe_unreachable_ub.rs:13:16
+   |
+LL |     assert_eq!(BAR, true);
+   |                ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const_unsafe_unreachable_ub.rs:13:5
+   |
+LL |     assert_eq!(BAR, true);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const_unsafe_unreachable_ub.rs:13:5
+   |
+LL |     assert_eq!(BAR, true);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/dangling_raw_ptr.stderr
+++ b/tests/ui/consts/dangling_raw_ptr.stderr
@@ -4,5 +4,19 @@ error: encountered dangling pointer in final value of constant
 LL | const FOO: *const u32 = {
    | ^^^^^^^^^^^^^^^^^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/dangling_raw_ptr.rs:7:13
+   |
+LL |     let x = FOO;
+   |             ^^^
+
+note: erroneous constant encountered
+  --> $DIR/dangling_raw_ptr.rs:7:13
+   |
+LL |     let x = FOO;
+   |             ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/interior-mut-const-via-union.64bit.stderr
+++ b/tests/ui/consts/interior-mut-const-via-union.64bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/interior-mut-const-via-union.rs:35:1
+  --> $DIR/interior-mut-const-via-union.rs:34:1
    |
 LL | fn main() {
    | ^^^^^^^^^ constructing invalid value at .<deref>.y.<enum-variant(B)>.0: encountered `UnsafeCell` in read-only memory
@@ -10,13 +10,13 @@ LL | fn main() {
            }
 
 note: erroneous constant encountered
-  --> $DIR/interior-mut-const-via-union.rs:37:25
+  --> $DIR/interior-mut-const-via-union.rs:36:25
    |
 LL |     let _: &'static _ = &C;
    |                         ^^
 
 note: erroneous constant encountered
-  --> $DIR/interior-mut-const-via-union.rs:37:25
+  --> $DIR/interior-mut-const-via-union.rs:36:25
    |
 LL |     let _: &'static _ = &C;
    |                         ^^

--- a/tests/ui/consts/interior-mut-const-via-union.rs
+++ b/tests/ui/consts/interior-mut-const-via-union.rs
@@ -1,7 +1,6 @@
 // Check that constants with interior mutability inside unions are rejected
 // during validation.
 //
-//@ build-fail
 //@ stderr-per-bitwidth
 #![feature(const_mut_refs)]
 

--- a/tests/ui/consts/issue-54348.rs
+++ b/tests/ui/consts/issue-54348.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 fn main() {
     [1][0u64 as usize];
     [1][1.5 as usize]; //~ ERROR operation will panic

--- a/tests/ui/consts/issue-54348.stderr
+++ b/tests/ui/consts/issue-54348.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/issue-54348.rs:5:5
+  --> $DIR/issue-54348.rs:3:5
    |
 LL |     [1][1.5 as usize];
    |     ^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
@@ -7,7 +7,7 @@ LL |     [1][1.5 as usize];
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-54348.rs:6:5
+  --> $DIR/issue-54348.rs:4:5
    |
 LL |     [1][1u64 as usize];
    |     ^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1

--- a/tests/ui/consts/large_const_alloc.rs
+++ b/tests/ui/consts/large_const_alloc.rs
@@ -9,7 +9,8 @@ const FOO: () = {
 
 static FOO2: () = {
     let x = [0_u8; (1 << 47) - 1];
-    //~^ ERROR could not evaluate static initializer
+    //^ if this errors again, remove `large_static_alloc.rs`
+    // error hidden by previous error.
 };
 
 fn main() {

--- a/tests/ui/consts/large_const_alloc.stderr
+++ b/tests/ui/consts/large_const_alloc.stderr
@@ -4,12 +4,20 @@ error[E0080]: evaluation of constant value failed
 LL |     let x = [0_u8; (1 << 47) - 1];
    |             ^^^^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler
 
-error[E0080]: could not evaluate static initializer
-  --> $DIR/large_const_alloc.rs:11:13
+note: erroneous constant encountered
+  --> $DIR/large_const_alloc.rs:17:5
    |
-LL |     let x = [0_u8; (1 << 47) - 1];
-   |             ^^^^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler
+LL |     FOO;
+   |     ^^^
 
-error: aborting due to 2 previous errors
+note: erroneous constant encountered
+  --> $DIR/large_const_alloc.rs:17:5
+   |
+LL |     FOO;
+   |     ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/large_static_alloc.rs
+++ b/tests/ui/consts/large_static_alloc.rs
@@ -1,0 +1,11 @@
+// only-64bit
+// on 32bit and 16bit platforms it is plausible that the maximum allocation size will succeed
+
+static FOO2: () = {
+    let x = [0_u8; (1 << 47) - 1];
+    //~^ ERROR could not evaluate static initializer
+};
+
+fn main() {
+    FOO2;
+}

--- a/tests/ui/consts/large_static_alloc.stderr
+++ b/tests/ui/consts/large_static_alloc.stderr
@@ -1,0 +1,9 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/large_static_alloc.rs:5:13
+   |
+LL |     let x = [0_u8; (1 << 47) - 1];
+   |             ^^^^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/miri_unleashed/assoc_const.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
 
 // a test demonstrating why we do need to run static const qualification on associated constants

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -8,19 +8,19 @@ note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
 note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 note: inside `<String as Bar<Vec<u32>, String>>::F`
-  --> $DIR/assoc_const.rs:12:31
+  --> $DIR/assoc_const.rs:11:31
    |
 LL |     const F: u32 = (U::X, 42).1;
    |                               ^
 
 note: erroneous constant encountered
-  --> $DIR/assoc_const.rs:29:13
+  --> $DIR/assoc_const.rs:28:13
    |
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/assoc_const.rs:29:13
+  --> $DIR/assoc_const.rs:28:13
    |
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL |     let y = <String as Bar<Vec<u32>, String>>::F;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/assoc_const.rs:12:20
+  --> $DIR/assoc_const.rs:11:20
    |
 LL |     const F: u32 = (U::X, 42).1;
    |                    ^^^^^^^^^^

--- a/tests/ui/consts/miri_unleashed/assoc_const_2.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const_2.rs
@@ -1,4 +1,4 @@
-//@ build-fail
+//@ check-fail
 
 // a test demonstrating that const qualification cannot prevent monomorphization time errors
 

--- a/tests/ui/consts/miri_unleashed/mutable_pointer_in_const.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_pointer_in_const.64bit.stderr
@@ -1,0 +1,22 @@
+error: encountered mutable pointer in final value of constant
+  --> $DIR/mutable_pointer_in_const.rs:16:1
+   |
+LL | const MUH: Meh = Meh {
+   | ^^^^^^^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/mutable_pointer_in_const.rs:23:10
+   |
+LL |         *MUH.x.get() = 99;
+   |          ^^^
+
+warning: skipping const checks
+   |
+help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_pointer_in_const.rs:18:8
+   |
+LL |     x: &UnsafeCell::new(42),
+   |        ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/consts/miri_unleashed/mutable_pointer_in_const.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_pointer_in_const.rs
@@ -1,0 +1,25 @@
+//@ stderr-per-bitwidth
+//@ compile-flags: -Zunleash-the-miri-inside-of-you
+#![allow(invalid_reference_casting, static_mut_refs)]
+
+use std::cell::UnsafeCell;
+
+// this test ensures that our mutability story is sound
+
+struct Meh {
+    x: &'static UnsafeCell<i32>,
+}
+unsafe impl Sync for Meh {}
+
+// the following will never be ok! no interior mut behind consts, because
+// all allocs interned here will be marked immutable.
+const MUH: Meh = Meh {
+    //~^ ERROR: mutable pointer in final value
+    x: &UnsafeCell::new(42),
+};
+
+fn main() {
+    unsafe {
+        *MUH.x.get() = 99;
+    }
+}

--- a/tests/ui/consts/miri_unleashed/mutable_references_err.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references_err.64bit.stderr
@@ -1,17 +1,11 @@
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:17:1
-   |
-LL | const MUH: Meh = Meh {
-   | ^^^^^^^^^^^^^^
-
-error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:28:1
+  --> $DIR/mutable_references_err.rs:16:1
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references_err.rs:33:1
+  --> $DIR/mutable_references_err.rs:21:1
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference in a `const` or `static`
@@ -22,13 +16,13 @@ LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
            }
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:36:1
+  --> $DIR/mutable_references_err.rs:24:1
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references_err.rs:41:1
+  --> $DIR/mutable_references_err.rs:29:1
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -39,7 +33,7 @@ LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const 
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references_err.rs:48:1
+  --> $DIR/mutable_references_err.rs:36:1
    |
 LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -50,49 +44,49 @@ LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
            }
 
 note: erroneous constant encountered
-  --> $DIR/mutable_references_err.rs:50:34
+  --> $DIR/mutable_references_err.rs:38:34
    |
 LL | const READS_FROM_MUTABLE: i32 = *POINTS_TO_MUTABLE1;
    |                                  ^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/mutable_references_err.rs:52:43
+  --> $DIR/mutable_references_err.rs:40:43
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
    |                                           ^^^^^^^^^^^^^ constant accesses mutable global memory
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:56:1
+  --> $DIR/mutable_references_err.rs:44:1
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:58:1
+  --> $DIR/mutable_references_err.rs:46:1
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:60:1
+  --> $DIR/mutable_references_err.rs:48:1
    |
 LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:72:1
+  --> $DIR/mutable_references_err.rs:60:1
    |
 LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:74:1
+  --> $DIR/mutable_references_err.rs:62:1
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references_err.rs:76:1
+  --> $DIR/mutable_references_err.rs:64:1
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,81 +94,76 @@ LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:19:8
-   |
-LL |     x: &UnsafeCell::new(42),
-   |        ^^^^^^^^^^^^^^^^^^^^
-help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:28:27
+  --> $DIR/mutable_references_err.rs:16:27
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:33:40
+  --> $DIR/mutable_references_err.rs:21:40
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    |                                        ^^^
 help: skipping check for `const_mut_refs` feature
-  --> $DIR/mutable_references_err.rs:33:35
+  --> $DIR/mutable_references_err.rs:21:35
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    |                                   ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:36:25
+  --> $DIR/mutable_references_err.rs:24:25
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    |                         ^^^^^^^
 help: skipping check for `const_mut_refs` feature
-  --> $DIR/mutable_references_err.rs:41:49
+  --> $DIR/mutable_references_err.rs:29:49
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_mut_refs` feature
-  --> $DIR/mutable_references_err.rs:41:49
+  --> $DIR/mutable_references_err.rs:29:49
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:48:44
+  --> $DIR/mutable_references_err.rs:36:44
    |
 LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
    |                                            ^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:52:45
+  --> $DIR/mutable_references_err.rs:40:45
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
    |                                             ^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:56:45
+  --> $DIR/mutable_references_err.rs:44:45
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    |                                             ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:58:46
+  --> $DIR/mutable_references_err.rs:46:46
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    |                                              ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:60:47
+  --> $DIR/mutable_references_err.rs:48:47
    |
 LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                               ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:72:51
+  --> $DIR/mutable_references_err.rs:60:51
    |
 LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                   ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:74:49
+  --> $DIR/mutable_references_err.rs:62:49
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    |                                                 ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references_err.rs:76:51
+  --> $DIR/mutable_references_err.rs:64:51
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                   ^^^^^^
 
-error: aborting due to 13 previous errors; 1 warning emitted
+error: aborting due to 12 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/miri_unleashed/mutable_references_err.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references_err.rs
@@ -7,18 +7,6 @@ use std::sync::atomic::*;
 
 // this test ensures that our mutability story is sound
 
-struct Meh {
-    x: &'static UnsafeCell<i32>,
-}
-unsafe impl Sync for Meh {}
-
-// the following will never be ok! no interior mut behind consts, because
-// all allocs interned here will be marked immutable.
-const MUH: Meh = Meh {
-    //~^ ERROR encountered mutable pointer in final value of constant
-    x: &UnsafeCell::new(42),
-};
-
 struct Synced {
     x: UnsafeCell<i32>,
 }
@@ -76,8 +64,4 @@ const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
 const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
 //~^ ERROR mutable pointer in final value
 
-fn main() {
-    unsafe {
-        *MUH.x.get() = 99;
-    }
-}
+fn main() {}

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -23,6 +23,20 @@ note: inside `X`
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
+note: erroneous constant encountered
+  --> $DIR/missing_span_in_backtrace.rs:26:5
+   |
+26 |     X
+   |     ^
+
+note: erroneous constant encountered
+  --> $DIR/missing_span_in_backtrace.rs:26:5
+   |
+26 |     X
+   |     ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/try-operator.stderr
+++ b/tests/ui/consts/try-operator.stderr
@@ -4,28 +4,6 @@ error[E0635]: unknown feature `const_convert`
 LL | #![feature(const_convert)]
    |            ^^^^^^^^^^^^^
 
-error[E0015]: `?` cannot determine the branch of `Result<(), ()>` in constant functions
-  --> $DIR/try-operator.rs:10:9
-   |
-LL |         Err(())?;
-   |         ^^^^^^^^
-   |
-note: impl defined here, but it is not `const`
-  --> $SRC_DIR/core/src/result.rs:LL:COL
-   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = help: add `#![feature(effects)]` to the crate attributes to enable
-
-error[E0015]: `?` cannot convert from residual of `Result<bool, ()>` in constant functions
-  --> $DIR/try-operator.rs:10:9
-   |
-LL |         Err(())?;
-   |         ^^^^^^^^
-   |
-note: impl defined here, but it is not `const`
-  --> $SRC_DIR/core/src/result.rs:LL:COL
-   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = help: add `#![feature(effects)]` to the crate attributes to enable
-
 error[E0015]: `?` cannot determine the branch of `Option<()>` in constant functions
   --> $DIR/try-operator.rs:18:9
    |
@@ -45,6 +23,28 @@ LL |         None?;
    |
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/option.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: `?` cannot determine the branch of `Result<(), ()>` in constant functions
+  --> $DIR/try-operator.rs:10:9
+   |
+LL |         Err(())?;
+   |         ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: `?` cannot convert from residual of `Result<bool, ()>` in constant functions
+  --> $DIR/try-operator.rs:10:9
+   |
+LL |         Err(())?;
+   |         ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/result.rs:LL:COL
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = help: add `#![feature(effects)]` to the crate attributes to enable
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 pub const unsafe fn fake_type<T>() -> T {
     hint_unreachable() //~ ERROR evaluation of `<i32 as Const>::CONSTANT` failed
 }

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -1,658 +1,658 @@
 error[E0080]: evaluation of `<i32 as Const>::CONSTANT` failed
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:6:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<i32>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:2:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `<i32 as Const>::CONSTANT`
-  --> $DIR/uninhabited-const-issue-61744.rs:12:36
+  --> $DIR/uninhabited-const-issue-61744.rs:10:36
    |
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
    |                                    ^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/uninhabited-const-issue-61744.rs:18:10
+  --> $DIR/uninhabited-const-issue-61744.rs:16:10
    |
 LL |     dbg!(i32::CONSTANT);
    |          ^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/uninhabited-const-issue-61744.rs:18:10
+  --> $DIR/uninhabited-const-issue-61744.rs:16:10
    |
 LL |     dbg!(i32::CONSTANT);
    |          ^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.current.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:10:5
+  --> $DIR/recursive-coroutine-indirect.rs:9:5
    |
 LL |     move || {
    |     ^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.next.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in a coroutine requires boxing
-  --> $DIR/recursive-coroutine-indirect.rs:10:5
+  --> $DIR/recursive-coroutine-indirect.rs:9:5
    |
 LL |     move || {
    |     ^^^^^^^

--- a/tests/ui/impl-trait/recursive-coroutine-indirect.rs
+++ b/tests/ui/impl-trait/recursive-coroutine-indirect.rs
@@ -1,7 +1,6 @@
 //@ revisions: current next
 //@[next] compile-flags: -Znext-solver
 
-//@[next] build-fail
 // Deeply normalizing writeback results of opaques makes this into a post-mono error :(
 
 #![feature(coroutines)]

--- a/tests/ui/impl-trait/recursive-impl-trait-type-indirect.rs
+++ b/tests/ui/impl-trait/recursive-impl-trait-type-indirect.rs
@@ -1,3 +1,6 @@
+//~ ERROR overflow
+//~^ ERROR overflow
+//~| ERROR overflow
 // Test that impl trait does not allow creating recursive types that are
 // otherwise forbidden.
 #![feature(coroutines)]

--- a/tests/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
+++ b/tests/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
@@ -1,5 +1,5 @@
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:6:22
+  --> $DIR/recursive-impl-trait-type-indirect.rs:9:22
    |
 LL | fn option(i: i32) -> impl Sized {
    |                      ^^^^^^^^^^ recursive opaque type
@@ -10,7 +10,7 @@ LL |     if i < 0 { None } else { Some((option(i - 1), i)) }
    |                returning here with type `Option<(impl Sized, i32)>`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:11:15
+  --> $DIR/recursive-impl-trait-type-indirect.rs:14:15
    |
 LL | fn tuple() -> impl Sized {
    |               ^^^^^^^^^^ recursive opaque type
@@ -19,7 +19,7 @@ LL |     (tuple(),)
    |     ---------- returning here with type `(impl Sized,)`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:16:15
+  --> $DIR/recursive-impl-trait-type-indirect.rs:19:15
    |
 LL | fn array() -> impl Sized {
    |               ^^^^^^^^^^ recursive opaque type
@@ -28,7 +28,7 @@ LL |     [array()]
    |     --------- returning here with type `[impl Sized; 1]`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:21:13
+  --> $DIR/recursive-impl-trait-type-indirect.rs:24:13
    |
 LL | fn ptr() -> impl Sized {
    |             ^^^^^^^^^^ recursive opaque type
@@ -37,7 +37,7 @@ LL |     &ptr() as *const _
    |     ------------------ returning here with type `*const impl Sized`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:26:16
+  --> $DIR/recursive-impl-trait-type-indirect.rs:29:16
    |
 LL | fn fn_ptr() -> impl Sized {
    |                ^^^^^^^^^^ recursive opaque type
@@ -46,7 +46,7 @@ LL |     fn_ptr as fn() -> _
    |     ------------------- returning here with type `fn() -> impl Sized`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:31:25
+  --> $DIR/recursive-impl-trait-type-indirect.rs:34:25
    |
 LL |   fn closure_capture() -> impl Sized {
    |                           ^^^^^^^^^^ recursive opaque type
@@ -55,10 +55,10 @@ LL | /     move || {
 LL | |         x;
    | |         - closure captures itself here
 LL | |     }
-   | |_____- returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:34:5: 34:12}`
+   | |_____- returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:37:5: 37:12}`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:39:29
+  --> $DIR/recursive-impl-trait-type-indirect.rs:42:29
    |
 LL |   fn closure_ref_capture() -> impl Sized {
    |                               ^^^^^^^^^^ recursive opaque type
@@ -67,28 +67,28 @@ LL | /     move || {
 LL | |         &x;
    | |          - closure captures itself here
 LL | |     }
-   | |_____- returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:42:5: 42:12}`
+   | |_____- returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:45:5: 45:12}`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:47:21
+  --> $DIR/recursive-impl-trait-type-indirect.rs:50:21
    |
 LL | fn closure_sig() -> impl Sized {
    |                     ^^^^^^^^^^ recursive opaque type
 LL |
 LL |     || closure_sig()
-   |     ---------------- returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:49:5: 49:7}`
+   |     ---------------- returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:52:5: 52:7}`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:52:23
+  --> $DIR/recursive-impl-trait-type-indirect.rs:55:23
    |
 LL | fn coroutine_sig() -> impl Sized {
    |                       ^^^^^^^^^^ recursive opaque type
 LL |
 LL |     || coroutine_sig()
-   |     ------------------ returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:54:5: 54:7}`
+   |     ------------------ returning here with type `{closure@$DIR/recursive-impl-trait-type-indirect.rs:57:5: 57:7}`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:57:27
+  --> $DIR/recursive-impl-trait-type-indirect.rs:60:27
    |
 LL |   fn coroutine_capture() -> impl Sized {
    |                             ^^^^^^^^^^ recursive opaque type
@@ -98,10 +98,10 @@ LL | |         yield;
 LL | |         x;
    | |         - coroutine captures itself here
 LL | |     }
-   | |_____- returning here with type `{coroutine@$DIR/recursive-impl-trait-type-indirect.rs:60:5: 60:12}`
+   | |_____- returning here with type `{coroutine@$DIR/recursive-impl-trait-type-indirect.rs:63:5: 63:12}`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:66:35
+  --> $DIR/recursive-impl-trait-type-indirect.rs:69:35
    |
 LL | fn substs_change<T: 'static>() -> impl Sized {
    |                                   ^^^^^^^^^^ recursive opaque type
@@ -110,7 +110,7 @@ LL |     (substs_change::<&T>(),)
    |     ------------------------ returning here with type `(impl Sized,)`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:76:26
+  --> $DIR/recursive-impl-trait-type-indirect.rs:79:26
    |
 LL | fn mutual_recursion() -> impl Sync {
    |                          ^^^^^^^^^ recursive opaque type
@@ -122,7 +122,7 @@ LL | fn mutual_recursion_b() -> impl Sized {
    |                            ---------- returning this opaque type `impl Sized`
 
 error[E0720]: cannot resolve opaque type
-  --> $DIR/recursive-impl-trait-type-indirect.rs:81:28
+  --> $DIR/recursive-impl-trait-type-indirect.rs:84:28
    |
 LL | fn mutual_recursion() -> impl Sync {
    |                          --------- returning this opaque type `impl Sync`
@@ -133,6 +133,21 @@ LL |
 LL |     mutual_recursion()
    |     ------------------ returning here with type `impl Sync`
 
-error: aborting due to 13 previous errors
+error[E0275]: overflow evaluating the requirement `impl Sized`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_impl_trait_type_indirect`)
 
-For more information about this error, try `rustc --explain E0720`.
+error[E0275]: overflow evaluating the requirement `impl Sized`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_impl_trait_type_indirect`)
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0275]: overflow evaluating the requirement `impl Sized`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`recursive_impl_trait_type_indirect`)
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 16 previous errors
+
+Some errors have detailed explanations: E0275, E0720.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/issues/issue-3779.rs
+++ b/tests/ui/issues/issue-3779.rs
@@ -1,5 +1,6 @@
 struct S {
     //~^ ERROR E0072
+    //~| ERROR cycle
     element: Option<S>
 }
 

--- a/tests/ui/issues/issue-3779.stderr
+++ b/tests/ui/issues/issue-3779.stderr
@@ -3,7 +3,7 @@ error[E0072]: recursive type `S` has infinite size
    |
 LL | struct S {
    | ^^^^^^^^
-LL |
+...
 LL |     element: Option<S>
    |                     - recursive without indirection
    |
@@ -12,6 +12,18 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
 LL |     element: Option<Box<S>>
    |                     ++++ +
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing layout of `S`
+   |
+   = note: ...which requires computing layout of `core::option::Option<S>`...
+   = note: ...which again requires computing layout of `S`, completing the cycle
+note: cycle used when running const prop lints for `main`
+  --> $DIR/issue-3779.rs:7:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-For more information about this error, try `rustc --explain E0072`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0072, E0391.
+For more information about an error, try `rustc --explain E0072`.

--- a/tests/ui/limits/issue-55878.rs
+++ b/tests/ui/limits/issue-55878.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ normalize-stderr-64bit "18446744073709551615" -> "SIZE"
 //@ normalize-stderr-32bit "4294967295" -> "SIZE"
 

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -6,13 +6,13 @@ error[E0080]: evaluation of constant value failed
 note: inside `std::mem::size_of::<[u8; usize::MAX]>`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 note: inside `main`
-  --> $DIR/issue-55878.rs:7:26
+  --> $DIR/issue-55878.rs:6:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-55878.rs:7:26
+  --> $DIR/issue-55878.rs:6:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $DIR/issue-55878.rs:7:26
+  --> $DIR/issue-55878.rs:6:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/lint/issue-117949.noopt.stderr
+++ b/tests/ui/lint/issue-117949.noopt.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:16:24
+  --> $DIR/issue-117949.rs:14:24
    |
 LL |     format_args!("{}", 5 * i32::MAX);
    |                        ^^^^^^^^^^^^ attempt to compute `5_i32 * i32::MAX`, which would overflow
@@ -7,31 +7,31 @@ LL |     format_args!("{}", 5 * i32::MAX);
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:15:24
+  --> $DIR/issue-117949.rs:13:24
    |
 LL |     format_args!("{}", -5 - i32::MAX);
    |                        ^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:14:24
+  --> $DIR/issue-117949.rs:12:24
    |
 LL |     format_args!("{}", 1 + i32::MAX);
    |                        ^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:13:24
+  --> $DIR/issue-117949.rs:11:24
    |
 LL |     format_args!("{}", 1 >> 32);
    |                        ^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:12:24
+  --> $DIR/issue-117949.rs:10:24
    |
 LL |     format_args!("{}", 1 << 32);
    |                        ^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:17:24
+  --> $DIR/issue-117949.rs:15:24
    |
 LL |     format_args!("{}", 1 / 0);
    |                        ^^^^^ attempt to divide `1_i32` by zero
@@ -39,13 +39,13 @@ LL |     format_args!("{}", 1 / 0);
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:18:24
+  --> $DIR/issue-117949.rs:16:24
    |
 LL |     format_args!("{}", 1 % 0);
    |                        ^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:19:24
+  --> $DIR/issue-117949.rs:17:24
    |
 LL |     format_args!("{}", [1, 2, 3][4]);
    |                        ^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/lint/issue-117949.opt.stderr
+++ b/tests/ui/lint/issue-117949.opt.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:16:24
+  --> $DIR/issue-117949.rs:14:24
    |
 LL |     format_args!("{}", 5 * i32::MAX);
    |                        ^^^^^^^^^^^^ attempt to compute `5_i32 * i32::MAX`, which would overflow
@@ -7,31 +7,31 @@ LL |     format_args!("{}", 5 * i32::MAX);
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:15:24
+  --> $DIR/issue-117949.rs:13:24
    |
 LL |     format_args!("{}", -5 - i32::MAX);
    |                        ^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:14:24
+  --> $DIR/issue-117949.rs:12:24
    |
 LL |     format_args!("{}", 1 + i32::MAX);
    |                        ^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:13:24
+  --> $DIR/issue-117949.rs:11:24
    |
 LL |     format_args!("{}", 1 >> 32);
    |                        ^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:12:24
+  --> $DIR/issue-117949.rs:10:24
    |
 LL |     format_args!("{}", 1 << 32);
    |                        ^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:17:24
+  --> $DIR/issue-117949.rs:15:24
    |
 LL |     format_args!("{}", 1 / 0);
    |                        ^^^^^ attempt to divide `1_i32` by zero
@@ -39,13 +39,13 @@ LL |     format_args!("{}", 1 / 0);
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:18:24
+  --> $DIR/issue-117949.rs:16:24
    |
 LL |     format_args!("{}", 1 % 0);
    |                        ^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:19:24
+  --> $DIR/issue-117949.rs:17:24
    |
 LL |     format_args!("{}", [1, 2, 3][4]);
    |                        ^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/lint/issue-117949.opt_with_overflow_checks.stderr
+++ b/tests/ui/lint/issue-117949.opt_with_overflow_checks.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:16:24
+  --> $DIR/issue-117949.rs:14:24
    |
 LL |     format_args!("{}", 5 * i32::MAX);
    |                        ^^^^^^^^^^^^ attempt to compute `5_i32 * i32::MAX`, which would overflow
@@ -7,31 +7,31 @@ LL |     format_args!("{}", 5 * i32::MAX);
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:15:24
+  --> $DIR/issue-117949.rs:13:24
    |
 LL |     format_args!("{}", -5 - i32::MAX);
    |                        ^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:14:24
+  --> $DIR/issue-117949.rs:12:24
    |
 LL |     format_args!("{}", 1 + i32::MAX);
    |                        ^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:13:24
+  --> $DIR/issue-117949.rs:11:24
    |
 LL |     format_args!("{}", 1 >> 32);
    |                        ^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-117949.rs:12:24
+  --> $DIR/issue-117949.rs:10:24
    |
 LL |     format_args!("{}", 1 << 32);
    |                        ^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:17:24
+  --> $DIR/issue-117949.rs:15:24
    |
 LL |     format_args!("{}", 1 / 0);
    |                        ^^^^^ attempt to divide `1_i32` by zero
@@ -39,13 +39,13 @@ LL |     format_args!("{}", 1 / 0);
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:18:24
+  --> $DIR/issue-117949.rs:16:24
    |
 LL |     format_args!("{}", 1 % 0);
    |                        ^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-117949.rs:19:24
+  --> $DIR/issue-117949.rs:17:24
    |
 LL |     format_args!("{}", [1, 2, 3][4]);
    |                        ^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/lint/issue-117949.rs
+++ b/tests/ui/lint/issue-117949.rs
@@ -4,9 +4,7 @@
 //@ [noopt]compile-flags: -C opt-level=0 -Z deduplicate-diagnostics=yes
 //@ [opt]compile-flags: -O
 //@ [opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O -Z deduplicate-diagnostics=yes
-//@ build-fail
 //@ ignore-pass (test tests codegen-time behaviour)
-
 
 fn main() {
     format_args!("{}", 1 << 32); //~ ERROR: arithmetic operation will overflow

--- a/tests/ui/lint/lint-overflowing-ops.noopt.stderr
+++ b/tests/ui/lint/lint-overflowing-ops.noopt.stderr
@@ -1,731 +1,731 @@
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:26:14
+  --> $DIR/lint-overflowing-ops.rs:25:14
    |
 LL |     let _n = 1u8 << 8;
    |              ^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/lint-overflowing-ops.rs:17:9
+  --> $DIR/lint-overflowing-ops.rs:16:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:212:15
+  --> $DIR/lint-overflowing-ops.rs:211:15
    |
 LL |     let _n = &(usize::MAX * 5);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `usize::MAX * 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:209:15
+  --> $DIR/lint-overflowing-ops.rs:208:15
    |
 LL |     let _n = &(isize::MAX * 5);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `isize::MAX * 5_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:206:15
+  --> $DIR/lint-overflowing-ops.rs:205:15
    |
 LL |     let _n = &(i128::MAX * 5);
    |               ^^^^^^^^^^^^^^^ attempt to compute `i128::MAX * 5_i128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:203:15
+  --> $DIR/lint-overflowing-ops.rs:202:15
    |
 LL |     let _n = &(i64::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i64::MAX * 5_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:200:15
+  --> $DIR/lint-overflowing-ops.rs:199:15
    |
 LL |     let _n = &(i32::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i32::MAX * 5_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:197:15
+  --> $DIR/lint-overflowing-ops.rs:196:15
    |
 LL |     let _n = &(i16::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i16::MAX * 5_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:194:15
+  --> $DIR/lint-overflowing-ops.rs:193:15
    |
 LL |     let _n = &(i8::MAX * i8::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX * i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:191:15
+  --> $DIR/lint-overflowing-ops.rs:190:15
    |
 LL |     let _n = &(u128::MAX * 5);
    |               ^^^^^^^^^^^^^^^ attempt to compute `u128::MAX * 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:188:15
+  --> $DIR/lint-overflowing-ops.rs:187:15
    |
 LL |     let _n = &(u64::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u64::MAX * 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:185:15
+  --> $DIR/lint-overflowing-ops.rs:184:15
    |
 LL |     let _n = &(u32::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u32::MAX * 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:182:15
+  --> $DIR/lint-overflowing-ops.rs:181:15
    |
 LL |     let _n = &(u16::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u16::MAX * 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:179:15
+  --> $DIR/lint-overflowing-ops.rs:178:15
    |
 LL |     let _n = &(u8::MAX * 5);
    |               ^^^^^^^^^^^^^ attempt to compute `u8::MAX * 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:174:15
+  --> $DIR/lint-overflowing-ops.rs:173:15
    |
 LL |     let _n = &(1usize - 5);
    |               ^^^^^^^^^^^^ attempt to compute `1_usize - 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:171:15
+  --> $DIR/lint-overflowing-ops.rs:170:15
    |
 LL |     let _n = &(-5isize - isize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_isize - isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:168:15
+  --> $DIR/lint-overflowing-ops.rs:167:15
    |
 LL |     let _n = &(-5i128 - i128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i128 - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:165:15
+  --> $DIR/lint-overflowing-ops.rs:164:15
    |
 LL |     let _n = &(-5i64 - i64::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i64 - i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:162:15
+  --> $DIR/lint-overflowing-ops.rs:161:15
    |
 LL |     let _n = &(-5i32 - i32::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:159:15
+  --> $DIR/lint-overflowing-ops.rs:158:15
    |
 LL |     let _n = &(-5i16 - i16::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i16 - i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:156:15
+  --> $DIR/lint-overflowing-ops.rs:155:15
    |
 LL |     let _n = &(-5i8 - i8::MAX);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `-5_i8 - i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:153:15
+  --> $DIR/lint-overflowing-ops.rs:152:15
    |
 LL |     let _n = &(1u128 - 5);
    |               ^^^^^^^^^^^ attempt to compute `1_u128 - 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:150:15
+  --> $DIR/lint-overflowing-ops.rs:149:15
    |
 LL |     let _n = &(1u64 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u64 - 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:147:15
+  --> $DIR/lint-overflowing-ops.rs:146:15
    |
 LL |     let _n = &(1u32 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u32 - 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:144:15
+  --> $DIR/lint-overflowing-ops.rs:143:15
    |
 LL |     let _n = &(1u16 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u16 - 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:141:15
+  --> $DIR/lint-overflowing-ops.rs:140:15
    |
 LL |     let _n = &(1u8 - 5);
    |               ^^^^^^^^^ attempt to compute `1_u8 - 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:136:15
+  --> $DIR/lint-overflowing-ops.rs:135:15
    |
 LL |     let _n = &(1usize + usize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize + usize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:133:15
+  --> $DIR/lint-overflowing-ops.rs:132:15
    |
 LL |     let _n = &(1isize + isize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_isize + isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:130:15
+  --> $DIR/lint-overflowing-ops.rs:129:15
    |
 LL |     let _n = &(1i128 + i128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_i128 + i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:127:15
+  --> $DIR/lint-overflowing-ops.rs:126:15
    |
 LL |     let _n = &(1i64 + i64::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i64 + i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:124:15
+  --> $DIR/lint-overflowing-ops.rs:123:15
    |
 LL |     let _n = &(1i32 + i32::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:121:15
+  --> $DIR/lint-overflowing-ops.rs:120:15
    |
 LL |     let _n = &(1i16 + i16::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i16 + i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:118:15
+  --> $DIR/lint-overflowing-ops.rs:117:15
    |
 LL |     let _n = &(1i8 + i8::MAX);
    |               ^^^^^^^^^^^^^^^ attempt to compute `1_i8 + i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:115:15
+  --> $DIR/lint-overflowing-ops.rs:114:15
    |
 LL |     let _n = &(1u128 + u128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_u128 + u128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:112:15
+  --> $DIR/lint-overflowing-ops.rs:111:15
    |
 LL |     let _n = &(1u64 + u64::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u64 + u64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:109:15
+  --> $DIR/lint-overflowing-ops.rs:108:15
    |
 LL |     let _n = &(1u32 + u32::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u32 + u32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:106:15
+  --> $DIR/lint-overflowing-ops.rs:105:15
    |
 LL |     let _n = &(1u16 + u16::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u16 + u16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:103:15
+  --> $DIR/lint-overflowing-ops.rs:102:15
    |
 LL |     let _n = &(1u8 + u8::MAX);
    |               ^^^^^^^^^^^^^^^ attempt to compute `1_u8 + u8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:98:15
+  --> $DIR/lint-overflowing-ops.rs:97:15
    |
 LL |     let _n = &(1_usize >> BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:95:15
+  --> $DIR/lint-overflowing-ops.rs:94:15
    |
 LL |     let _n = &(1_isize >> BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:92:15
+  --> $DIR/lint-overflowing-ops.rs:91:15
    |
 LL |     let _n = &(1i128 >> 128);
    |               ^^^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:89:15
+  --> $DIR/lint-overflowing-ops.rs:88:15
    |
 LL |     let _n = &(1i64 >> 64);
    |               ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:86:15
+  --> $DIR/lint-overflowing-ops.rs:85:15
    |
 LL |     let _n = &(1i32 >> 32);
    |               ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:83:15
+  --> $DIR/lint-overflowing-ops.rs:82:15
    |
 LL |     let _n = &(1i16 >> 16);
    |               ^^^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:80:15
+  --> $DIR/lint-overflowing-ops.rs:79:15
    |
 LL |     let _n = &(1i8 >> 8);
    |               ^^^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:77:15
+  --> $DIR/lint-overflowing-ops.rs:76:15
    |
 LL |     let _n = &(1u128 >> 128);
    |               ^^^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:74:15
+  --> $DIR/lint-overflowing-ops.rs:73:15
    |
 LL |     let _n = &(1u64 >> 64);
    |               ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:71:15
+  --> $DIR/lint-overflowing-ops.rs:70:15
    |
 LL |     let _n = &(1u32 >> 32);
    |               ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:68:15
+  --> $DIR/lint-overflowing-ops.rs:67:15
    |
 LL |     let _n = &(1u16 >> 16);
    |               ^^^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:65:15
+  --> $DIR/lint-overflowing-ops.rs:64:15
    |
 LL |     let _n = &(1u8 >> 8);
    |               ^^^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:60:15
+  --> $DIR/lint-overflowing-ops.rs:59:15
    |
 LL |     let _n = &(1_usize << BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:57:15
+  --> $DIR/lint-overflowing-ops.rs:56:15
    |
 LL |     let _n = &(1_isize << BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:54:15
+  --> $DIR/lint-overflowing-ops.rs:53:15
    |
 LL |     let _n = &(1i128 << 128);
    |               ^^^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:51:15
+  --> $DIR/lint-overflowing-ops.rs:50:15
    |
 LL |     let _n = &(1i64 << 64);
    |               ^^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:48:15
+  --> $DIR/lint-overflowing-ops.rs:47:15
    |
 LL |     let _n = &(1i32 << 32);
    |               ^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:45:15
+  --> $DIR/lint-overflowing-ops.rs:44:15
    |
 LL |     let _n = &(1i16 << 16);
    |               ^^^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:42:15
+  --> $DIR/lint-overflowing-ops.rs:41:15
    |
 LL |     let _n = &(1i8 << 8);
    |               ^^^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:39:15
+  --> $DIR/lint-overflowing-ops.rs:38:15
    |
 LL |     let _n = &(1u128 << 128);
    |               ^^^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:36:15
+  --> $DIR/lint-overflowing-ops.rs:35:15
    |
 LL |     let _n = &(1u64 << 64);
    |               ^^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:33:15
+  --> $DIR/lint-overflowing-ops.rs:32:15
    |
 LL |     let _n = &(1u32 << 32);
    |               ^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:30:15
+  --> $DIR/lint-overflowing-ops.rs:29:15
    |
 LL |     let _n = &(1u16 << 16);
    |               ^^^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:27:15
+  --> $DIR/lint-overflowing-ops.rs:26:15
    |
 LL |     let _n = &(1u8 << 8);
    |               ^^^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:29:14
+  --> $DIR/lint-overflowing-ops.rs:28:14
    |
 LL |     let _n = 1u16 << 16;
    |              ^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:32:14
+  --> $DIR/lint-overflowing-ops.rs:31:14
    |
 LL |     let _n = 1u32 << 32;
    |              ^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:35:14
+  --> $DIR/lint-overflowing-ops.rs:34:14
    |
 LL |     let _n = 1u64 << 64;
    |              ^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:38:14
+  --> $DIR/lint-overflowing-ops.rs:37:14
    |
 LL |     let _n = 1u128 << 128;
    |              ^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:41:14
+  --> $DIR/lint-overflowing-ops.rs:40:14
    |
 LL |     let _n = 1i8 << 8;
    |              ^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:44:14
+  --> $DIR/lint-overflowing-ops.rs:43:14
    |
 LL |     let _n = 1i16 << 16;
    |              ^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:47:14
+  --> $DIR/lint-overflowing-ops.rs:46:14
    |
 LL |     let _n = 1i32 << 32;
    |              ^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:50:14
+  --> $DIR/lint-overflowing-ops.rs:49:14
    |
 LL |     let _n = 1i64 << 64;
    |              ^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:53:14
+  --> $DIR/lint-overflowing-ops.rs:52:14
    |
 LL |     let _n = 1i128 << 128;
    |              ^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:56:14
+  --> $DIR/lint-overflowing-ops.rs:55:14
    |
 LL |     let _n = 1_isize << BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:59:14
+  --> $DIR/lint-overflowing-ops.rs:58:14
    |
 LL |     let _n = 1_usize << BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:64:14
+  --> $DIR/lint-overflowing-ops.rs:63:14
    |
 LL |     let _n = 1u8 >> 8;
    |              ^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:67:14
+  --> $DIR/lint-overflowing-ops.rs:66:14
    |
 LL |     let _n = 1u16 >> 16;
    |              ^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:70:14
+  --> $DIR/lint-overflowing-ops.rs:69:14
    |
 LL |     let _n = 1u32 >> 32;
    |              ^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:73:14
+  --> $DIR/lint-overflowing-ops.rs:72:14
    |
 LL |     let _n = 1u64 >> 64;
    |              ^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:76:14
+  --> $DIR/lint-overflowing-ops.rs:75:14
    |
 LL |     let _n = 1u128 >> 128;
    |              ^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:79:14
+  --> $DIR/lint-overflowing-ops.rs:78:14
    |
 LL |     let _n = 1i8 >> 8;
    |              ^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:82:14
+  --> $DIR/lint-overflowing-ops.rs:81:14
    |
 LL |     let _n = 1i16 >> 16;
    |              ^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:85:14
+  --> $DIR/lint-overflowing-ops.rs:84:14
    |
 LL |     let _n = 1i32 >> 32;
    |              ^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:88:14
+  --> $DIR/lint-overflowing-ops.rs:87:14
    |
 LL |     let _n = 1i64 >> 64;
    |              ^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:91:14
+  --> $DIR/lint-overflowing-ops.rs:90:14
    |
 LL |     let _n = 1i128 >> 128;
    |              ^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:94:14
+  --> $DIR/lint-overflowing-ops.rs:93:14
    |
 LL |     let _n = 1_isize >> BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:97:14
+  --> $DIR/lint-overflowing-ops.rs:96:14
    |
 LL |     let _n = 1_usize >> BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:102:14
+  --> $DIR/lint-overflowing-ops.rs:101:14
    |
 LL |     let _n = 1u8 + u8::MAX;
    |              ^^^^^^^^^^^^^ attempt to compute `1_u8 + u8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:105:14
+  --> $DIR/lint-overflowing-ops.rs:104:14
    |
 LL |     let _n = 1u16 + u16::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u16 + u16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:108:14
+  --> $DIR/lint-overflowing-ops.rs:107:14
    |
 LL |     let _n = 1u32 + u32::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u32 + u32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:111:14
+  --> $DIR/lint-overflowing-ops.rs:110:14
    |
 LL |     let _n = 1u64 + u64::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u64 + u64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:114:14
+  --> $DIR/lint-overflowing-ops.rs:113:14
    |
 LL |     let _n = 1u128 + u128::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `1_u128 + u128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:117:14
+  --> $DIR/lint-overflowing-ops.rs:116:14
    |
 LL |     let _n = 1i8 + i8::MAX;
    |              ^^^^^^^^^^^^^ attempt to compute `1_i8 + i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:120:14
+  --> $DIR/lint-overflowing-ops.rs:119:14
    |
 LL |     let _n = 1i16 + i16::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i16 + i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:123:14
+  --> $DIR/lint-overflowing-ops.rs:122:14
    |
 LL |     let _n = 1i32 + i32::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:126:14
+  --> $DIR/lint-overflowing-ops.rs:125:14
    |
 LL |     let _n = 1i64 + i64::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i64 + i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:129:14
+  --> $DIR/lint-overflowing-ops.rs:128:14
    |
 LL |     let _n = 1i128 + i128::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `1_i128 + i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:132:14
+  --> $DIR/lint-overflowing-ops.rs:131:14
    |
 LL |     let _n = 1isize + isize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_isize + isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:135:14
+  --> $DIR/lint-overflowing-ops.rs:134:14
    |
 LL |     let _n = 1usize + usize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize + usize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:140:14
+  --> $DIR/lint-overflowing-ops.rs:139:14
    |
 LL |     let _n = 1u8 - 5;
    |              ^^^^^^^ attempt to compute `1_u8 - 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:143:14
+  --> $DIR/lint-overflowing-ops.rs:142:14
    |
 LL |     let _n = 1u16 - 5;
    |              ^^^^^^^^ attempt to compute `1_u16 - 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:146:14
+  --> $DIR/lint-overflowing-ops.rs:145:14
    |
 LL |     let _n = 1u32 - 5;
    |              ^^^^^^^^ attempt to compute `1_u32 - 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:149:14
+  --> $DIR/lint-overflowing-ops.rs:148:14
    |
 LL |     let _n = 1u64 - 5 ;
    |              ^^^^^^^^ attempt to compute `1_u64 - 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:152:14
+  --> $DIR/lint-overflowing-ops.rs:151:14
    |
 LL |     let _n = 1u128 - 5 ;
    |              ^^^^^^^^^ attempt to compute `1_u128 - 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:155:14
+  --> $DIR/lint-overflowing-ops.rs:154:14
    |
 LL |     let _n = -5i8 - i8::MAX;
    |              ^^^^^^^^^^^^^^ attempt to compute `-5_i8 - i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:158:14
+  --> $DIR/lint-overflowing-ops.rs:157:14
    |
 LL |     let _n = -5i16 - i16::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i16 - i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:161:14
+  --> $DIR/lint-overflowing-ops.rs:160:14
    |
 LL |     let _n = -5i32 - i32::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:164:14
+  --> $DIR/lint-overflowing-ops.rs:163:14
    |
 LL |     let _n = -5i64 - i64::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i64 - i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:167:14
+  --> $DIR/lint-overflowing-ops.rs:166:14
    |
 LL |     let _n = -5i128 - i128::MAX;
    |              ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i128 - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:170:14
+  --> $DIR/lint-overflowing-ops.rs:169:14
    |
 LL |     let _n = -5isize - isize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_isize - isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:173:14
+  --> $DIR/lint-overflowing-ops.rs:172:14
    |
 LL |     let _n = 1usize - 5;
    |              ^^^^^^^^^^ attempt to compute `1_usize - 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:178:14
+  --> $DIR/lint-overflowing-ops.rs:177:14
    |
 LL |     let _n = u8::MAX * 5;
    |              ^^^^^^^^^^^ attempt to compute `u8::MAX * 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:181:14
+  --> $DIR/lint-overflowing-ops.rs:180:14
    |
 LL |     let _n = u16::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u16::MAX * 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:184:14
+  --> $DIR/lint-overflowing-ops.rs:183:14
    |
 LL |     let _n = u32::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u32::MAX * 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:187:14
+  --> $DIR/lint-overflowing-ops.rs:186:14
    |
 LL |     let _n = u64::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u64::MAX * 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:190:14
+  --> $DIR/lint-overflowing-ops.rs:189:14
    |
 LL |     let _n = u128::MAX * 5;
    |              ^^^^^^^^^^^^^ attempt to compute `u128::MAX * 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:193:14
+  --> $DIR/lint-overflowing-ops.rs:192:14
    |
 LL |     let _n = i8::MAX * i8::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX * i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:196:14
+  --> $DIR/lint-overflowing-ops.rs:195:14
    |
 LL |     let _n = i16::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i16::MAX * 5_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:199:14
+  --> $DIR/lint-overflowing-ops.rs:198:14
    |
 LL |     let _n = i32::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i32::MAX * 5_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:202:14
+  --> $DIR/lint-overflowing-ops.rs:201:14
    |
 LL |     let _n = i64::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i64::MAX * 5_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:205:14
+  --> $DIR/lint-overflowing-ops.rs:204:14
    |
 LL |     let _n = i128::MAX * 5;
    |              ^^^^^^^^^^^^^ attempt to compute `i128::MAX * 5_i128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:208:14
+  --> $DIR/lint-overflowing-ops.rs:207:14
    |
 LL |     let _n = isize::MAX * 5;
    |              ^^^^^^^^^^^^^^ attempt to compute `isize::MAX * 5_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:211:14
+  --> $DIR/lint-overflowing-ops.rs:210:14
    |
 LL |     let _n = usize::MAX * 5;
    |              ^^^^^^^^^^^^^^ attempt to compute `usize::MAX * 5_usize`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:216:14
+  --> $DIR/lint-overflowing-ops.rs:215:14
    |
 LL |     let _n = 1u8 / 0;
    |              ^^^^^^^ attempt to divide `1_u8` by zero
@@ -733,295 +733,295 @@ LL |     let _n = 1u8 / 0;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:217:15
+  --> $DIR/lint-overflowing-ops.rs:216:15
    |
 LL |     let _n = &(1u8 / 0);
    |               ^^^^^^^^^ attempt to divide `1_u8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:219:14
+  --> $DIR/lint-overflowing-ops.rs:218:14
    |
 LL |     let _n = 1u16 / 0;
    |              ^^^^^^^^ attempt to divide `1_u16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:220:15
+  --> $DIR/lint-overflowing-ops.rs:219:15
    |
 LL |     let _n = &(1u16 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:222:14
+  --> $DIR/lint-overflowing-ops.rs:221:14
    |
 LL |     let _n = 1u32 / 0;
    |              ^^^^^^^^ attempt to divide `1_u32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:223:15
+  --> $DIR/lint-overflowing-ops.rs:222:15
    |
 LL |     let _n = &(1u32 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:225:14
+  --> $DIR/lint-overflowing-ops.rs:224:14
    |
 LL |     let _n = 1u64 / 0;
    |              ^^^^^^^^ attempt to divide `1_u64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:226:15
+  --> $DIR/lint-overflowing-ops.rs:225:15
    |
 LL |     let _n = &(1u64 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:228:14
+  --> $DIR/lint-overflowing-ops.rs:227:14
    |
 LL |     let _n = 1u128 / 0;
    |              ^^^^^^^^^ attempt to divide `1_u128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:229:15
+  --> $DIR/lint-overflowing-ops.rs:228:15
    |
 LL |     let _n = &(1u128 / 0);
    |               ^^^^^^^^^^^ attempt to divide `1_u128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:231:14
+  --> $DIR/lint-overflowing-ops.rs:230:14
    |
 LL |     let _n = 1i8 / 0;
    |              ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:232:15
+  --> $DIR/lint-overflowing-ops.rs:231:15
    |
 LL |     let _n = &(1i8 / 0);
    |               ^^^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:234:14
+  --> $DIR/lint-overflowing-ops.rs:233:14
    |
 LL |     let _n = 1i16 / 0;
    |              ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:235:15
+  --> $DIR/lint-overflowing-ops.rs:234:15
    |
 LL |     let _n = &(1i16 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:237:14
+  --> $DIR/lint-overflowing-ops.rs:236:14
    |
 LL |     let _n = 1i32 / 0;
    |              ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:238:15
+  --> $DIR/lint-overflowing-ops.rs:237:15
    |
 LL |     let _n = &(1i32 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:240:14
+  --> $DIR/lint-overflowing-ops.rs:239:14
    |
 LL |     let _n = 1i64 / 0;
    |              ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:241:15
+  --> $DIR/lint-overflowing-ops.rs:240:15
    |
 LL |     let _n = &(1i64 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:243:14
+  --> $DIR/lint-overflowing-ops.rs:242:14
    |
 LL |     let _n = 1i128 / 0;
    |              ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:244:15
+  --> $DIR/lint-overflowing-ops.rs:243:15
    |
 LL |     let _n = &(1i128 / 0);
    |               ^^^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:246:14
+  --> $DIR/lint-overflowing-ops.rs:245:14
    |
 LL |     let _n = 1isize / 0;
    |              ^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:247:15
+  --> $DIR/lint-overflowing-ops.rs:246:15
    |
 LL |     let _n = &(1isize / 0);
    |               ^^^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:249:14
+  --> $DIR/lint-overflowing-ops.rs:248:14
    |
 LL |     let _n = 1usize / 0;
    |              ^^^^^^^^^^ attempt to divide `1_usize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:250:15
+  --> $DIR/lint-overflowing-ops.rs:249:15
    |
 LL |     let _n = &(1usize / 0);
    |               ^^^^^^^^^^^^ attempt to divide `1_usize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:254:14
+  --> $DIR/lint-overflowing-ops.rs:253:14
    |
 LL |     let _n = 1u8 % 0;
    |              ^^^^^^^ attempt to calculate the remainder of `1_u8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:255:15
+  --> $DIR/lint-overflowing-ops.rs:254:15
    |
 LL |     let _n = &(1u8 % 0);
    |               ^^^^^^^^^ attempt to calculate the remainder of `1_u8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:257:14
+  --> $DIR/lint-overflowing-ops.rs:256:14
    |
 LL |     let _n = 1u16 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:258:15
+  --> $DIR/lint-overflowing-ops.rs:257:15
    |
 LL |     let _n = &(1u16 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:260:14
+  --> $DIR/lint-overflowing-ops.rs:259:14
    |
 LL |     let _n = 1u32 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:261:15
+  --> $DIR/lint-overflowing-ops.rs:260:15
    |
 LL |     let _n = &(1u32 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:263:14
+  --> $DIR/lint-overflowing-ops.rs:262:14
    |
 LL |     let _n = 1u64 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:264:15
+  --> $DIR/lint-overflowing-ops.rs:263:15
    |
 LL |     let _n = &(1u64 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:266:14
+  --> $DIR/lint-overflowing-ops.rs:265:14
    |
 LL |     let _n = 1u128 % 0;
    |              ^^^^^^^^^ attempt to calculate the remainder of `1_u128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:267:15
+  --> $DIR/lint-overflowing-ops.rs:266:15
    |
 LL |     let _n = &(1u128 % 0);
    |               ^^^^^^^^^^^ attempt to calculate the remainder of `1_u128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:269:14
+  --> $DIR/lint-overflowing-ops.rs:268:14
    |
 LL |     let _n = 1i8 % 0;
    |              ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:270:15
+  --> $DIR/lint-overflowing-ops.rs:269:15
    |
 LL |     let _n = &(1i8 % 0);
    |               ^^^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:272:14
+  --> $DIR/lint-overflowing-ops.rs:271:14
    |
 LL |     let _n = 1i16 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:273:15
+  --> $DIR/lint-overflowing-ops.rs:272:15
    |
 LL |     let _n = &(1i16 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:275:14
+  --> $DIR/lint-overflowing-ops.rs:274:14
    |
 LL |     let _n = 1i32 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:276:15
+  --> $DIR/lint-overflowing-ops.rs:275:15
    |
 LL |     let _n = &(1i32 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:278:14
+  --> $DIR/lint-overflowing-ops.rs:277:14
    |
 LL |     let _n = 1i64 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:279:15
+  --> $DIR/lint-overflowing-ops.rs:278:15
    |
 LL |     let _n = &(1i64 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:281:14
+  --> $DIR/lint-overflowing-ops.rs:280:14
    |
 LL |     let _n = 1i128 % 0;
    |              ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:282:15
+  --> $DIR/lint-overflowing-ops.rs:281:15
    |
 LL |     let _n = &(1i128 % 0);
    |               ^^^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:284:14
+  --> $DIR/lint-overflowing-ops.rs:283:14
    |
 LL |     let _n = 1isize % 0;
    |              ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:285:15
+  --> $DIR/lint-overflowing-ops.rs:284:15
    |
 LL |     let _n = &(1isize % 0);
    |               ^^^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:287:14
+  --> $DIR/lint-overflowing-ops.rs:286:14
    |
 LL |     let _n = 1usize % 0;
    |              ^^^^^^^^^^ attempt to calculate the remainder of `1_usize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:288:15
+  --> $DIR/lint-overflowing-ops.rs:287:15
    |
 LL |     let _n = &(1usize % 0);
    |               ^^^^^^^^^^^^ attempt to calculate the remainder of `1_usize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:292:14
+  --> $DIR/lint-overflowing-ops.rs:291:14
    |
 LL |     let _n = [1, 2, 3][4];
    |              ^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:293:15
+  --> $DIR/lint-overflowing-ops.rs:292:15
    |
 LL |     let _n = &([1, 2, 3][4]);
    |               ^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/lint/lint-overflowing-ops.opt.stderr
+++ b/tests/ui/lint/lint-overflowing-ops.opt.stderr
@@ -1,731 +1,731 @@
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:26:14
+  --> $DIR/lint-overflowing-ops.rs:25:14
    |
 LL |     let _n = 1u8 << 8;
    |              ^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/lint-overflowing-ops.rs:17:9
+  --> $DIR/lint-overflowing-ops.rs:16:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:212:15
+  --> $DIR/lint-overflowing-ops.rs:211:15
    |
 LL |     let _n = &(usize::MAX * 5);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `usize::MAX * 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:209:15
+  --> $DIR/lint-overflowing-ops.rs:208:15
    |
 LL |     let _n = &(isize::MAX * 5);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `isize::MAX * 5_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:206:15
+  --> $DIR/lint-overflowing-ops.rs:205:15
    |
 LL |     let _n = &(i128::MAX * 5);
    |               ^^^^^^^^^^^^^^^ attempt to compute `i128::MAX * 5_i128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:203:15
+  --> $DIR/lint-overflowing-ops.rs:202:15
    |
 LL |     let _n = &(i64::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i64::MAX * 5_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:200:15
+  --> $DIR/lint-overflowing-ops.rs:199:15
    |
 LL |     let _n = &(i32::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i32::MAX * 5_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:197:15
+  --> $DIR/lint-overflowing-ops.rs:196:15
    |
 LL |     let _n = &(i16::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i16::MAX * 5_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:194:15
+  --> $DIR/lint-overflowing-ops.rs:193:15
    |
 LL |     let _n = &(i8::MAX * i8::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX * i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:191:15
+  --> $DIR/lint-overflowing-ops.rs:190:15
    |
 LL |     let _n = &(u128::MAX * 5);
    |               ^^^^^^^^^^^^^^^ attempt to compute `u128::MAX * 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:188:15
+  --> $DIR/lint-overflowing-ops.rs:187:15
    |
 LL |     let _n = &(u64::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u64::MAX * 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:185:15
+  --> $DIR/lint-overflowing-ops.rs:184:15
    |
 LL |     let _n = &(u32::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u32::MAX * 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:182:15
+  --> $DIR/lint-overflowing-ops.rs:181:15
    |
 LL |     let _n = &(u16::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u16::MAX * 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:179:15
+  --> $DIR/lint-overflowing-ops.rs:178:15
    |
 LL |     let _n = &(u8::MAX * 5);
    |               ^^^^^^^^^^^^^ attempt to compute `u8::MAX * 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:174:15
+  --> $DIR/lint-overflowing-ops.rs:173:15
    |
 LL |     let _n = &(1usize - 5);
    |               ^^^^^^^^^^^^ attempt to compute `1_usize - 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:171:15
+  --> $DIR/lint-overflowing-ops.rs:170:15
    |
 LL |     let _n = &(-5isize - isize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_isize - isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:168:15
+  --> $DIR/lint-overflowing-ops.rs:167:15
    |
 LL |     let _n = &(-5i128 - i128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i128 - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:165:15
+  --> $DIR/lint-overflowing-ops.rs:164:15
    |
 LL |     let _n = &(-5i64 - i64::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i64 - i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:162:15
+  --> $DIR/lint-overflowing-ops.rs:161:15
    |
 LL |     let _n = &(-5i32 - i32::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:159:15
+  --> $DIR/lint-overflowing-ops.rs:158:15
    |
 LL |     let _n = &(-5i16 - i16::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i16 - i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:156:15
+  --> $DIR/lint-overflowing-ops.rs:155:15
    |
 LL |     let _n = &(-5i8 - i8::MAX);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `-5_i8 - i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:153:15
+  --> $DIR/lint-overflowing-ops.rs:152:15
    |
 LL |     let _n = &(1u128 - 5);
    |               ^^^^^^^^^^^ attempt to compute `1_u128 - 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:150:15
+  --> $DIR/lint-overflowing-ops.rs:149:15
    |
 LL |     let _n = &(1u64 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u64 - 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:147:15
+  --> $DIR/lint-overflowing-ops.rs:146:15
    |
 LL |     let _n = &(1u32 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u32 - 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:144:15
+  --> $DIR/lint-overflowing-ops.rs:143:15
    |
 LL |     let _n = &(1u16 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u16 - 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:141:15
+  --> $DIR/lint-overflowing-ops.rs:140:15
    |
 LL |     let _n = &(1u8 - 5);
    |               ^^^^^^^^^ attempt to compute `1_u8 - 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:136:15
+  --> $DIR/lint-overflowing-ops.rs:135:15
    |
 LL |     let _n = &(1usize + usize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize + usize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:133:15
+  --> $DIR/lint-overflowing-ops.rs:132:15
    |
 LL |     let _n = &(1isize + isize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_isize + isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:130:15
+  --> $DIR/lint-overflowing-ops.rs:129:15
    |
 LL |     let _n = &(1i128 + i128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_i128 + i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:127:15
+  --> $DIR/lint-overflowing-ops.rs:126:15
    |
 LL |     let _n = &(1i64 + i64::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i64 + i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:124:15
+  --> $DIR/lint-overflowing-ops.rs:123:15
    |
 LL |     let _n = &(1i32 + i32::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:121:15
+  --> $DIR/lint-overflowing-ops.rs:120:15
    |
 LL |     let _n = &(1i16 + i16::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i16 + i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:118:15
+  --> $DIR/lint-overflowing-ops.rs:117:15
    |
 LL |     let _n = &(1i8 + i8::MAX);
    |               ^^^^^^^^^^^^^^^ attempt to compute `1_i8 + i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:115:15
+  --> $DIR/lint-overflowing-ops.rs:114:15
    |
 LL |     let _n = &(1u128 + u128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_u128 + u128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:112:15
+  --> $DIR/lint-overflowing-ops.rs:111:15
    |
 LL |     let _n = &(1u64 + u64::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u64 + u64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:109:15
+  --> $DIR/lint-overflowing-ops.rs:108:15
    |
 LL |     let _n = &(1u32 + u32::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u32 + u32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:106:15
+  --> $DIR/lint-overflowing-ops.rs:105:15
    |
 LL |     let _n = &(1u16 + u16::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u16 + u16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:103:15
+  --> $DIR/lint-overflowing-ops.rs:102:15
    |
 LL |     let _n = &(1u8 + u8::MAX);
    |               ^^^^^^^^^^^^^^^ attempt to compute `1_u8 + u8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:98:15
+  --> $DIR/lint-overflowing-ops.rs:97:15
    |
 LL |     let _n = &(1_usize >> BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:95:15
+  --> $DIR/lint-overflowing-ops.rs:94:15
    |
 LL |     let _n = &(1_isize >> BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:92:15
+  --> $DIR/lint-overflowing-ops.rs:91:15
    |
 LL |     let _n = &(1i128 >> 128);
    |               ^^^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:89:15
+  --> $DIR/lint-overflowing-ops.rs:88:15
    |
 LL |     let _n = &(1i64 >> 64);
    |               ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:86:15
+  --> $DIR/lint-overflowing-ops.rs:85:15
    |
 LL |     let _n = &(1i32 >> 32);
    |               ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:83:15
+  --> $DIR/lint-overflowing-ops.rs:82:15
    |
 LL |     let _n = &(1i16 >> 16);
    |               ^^^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:80:15
+  --> $DIR/lint-overflowing-ops.rs:79:15
    |
 LL |     let _n = &(1i8 >> 8);
    |               ^^^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:77:15
+  --> $DIR/lint-overflowing-ops.rs:76:15
    |
 LL |     let _n = &(1u128 >> 128);
    |               ^^^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:74:15
+  --> $DIR/lint-overflowing-ops.rs:73:15
    |
 LL |     let _n = &(1u64 >> 64);
    |               ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:71:15
+  --> $DIR/lint-overflowing-ops.rs:70:15
    |
 LL |     let _n = &(1u32 >> 32);
    |               ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:68:15
+  --> $DIR/lint-overflowing-ops.rs:67:15
    |
 LL |     let _n = &(1u16 >> 16);
    |               ^^^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:65:15
+  --> $DIR/lint-overflowing-ops.rs:64:15
    |
 LL |     let _n = &(1u8 >> 8);
    |               ^^^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:60:15
+  --> $DIR/lint-overflowing-ops.rs:59:15
    |
 LL |     let _n = &(1_usize << BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:57:15
+  --> $DIR/lint-overflowing-ops.rs:56:15
    |
 LL |     let _n = &(1_isize << BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:54:15
+  --> $DIR/lint-overflowing-ops.rs:53:15
    |
 LL |     let _n = &(1i128 << 128);
    |               ^^^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:51:15
+  --> $DIR/lint-overflowing-ops.rs:50:15
    |
 LL |     let _n = &(1i64 << 64);
    |               ^^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:48:15
+  --> $DIR/lint-overflowing-ops.rs:47:15
    |
 LL |     let _n = &(1i32 << 32);
    |               ^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:45:15
+  --> $DIR/lint-overflowing-ops.rs:44:15
    |
 LL |     let _n = &(1i16 << 16);
    |               ^^^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:42:15
+  --> $DIR/lint-overflowing-ops.rs:41:15
    |
 LL |     let _n = &(1i8 << 8);
    |               ^^^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:39:15
+  --> $DIR/lint-overflowing-ops.rs:38:15
    |
 LL |     let _n = &(1u128 << 128);
    |               ^^^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:36:15
+  --> $DIR/lint-overflowing-ops.rs:35:15
    |
 LL |     let _n = &(1u64 << 64);
    |               ^^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:33:15
+  --> $DIR/lint-overflowing-ops.rs:32:15
    |
 LL |     let _n = &(1u32 << 32);
    |               ^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:30:15
+  --> $DIR/lint-overflowing-ops.rs:29:15
    |
 LL |     let _n = &(1u16 << 16);
    |               ^^^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:27:15
+  --> $DIR/lint-overflowing-ops.rs:26:15
    |
 LL |     let _n = &(1u8 << 8);
    |               ^^^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:29:14
+  --> $DIR/lint-overflowing-ops.rs:28:14
    |
 LL |     let _n = 1u16 << 16;
    |              ^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:32:14
+  --> $DIR/lint-overflowing-ops.rs:31:14
    |
 LL |     let _n = 1u32 << 32;
    |              ^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:35:14
+  --> $DIR/lint-overflowing-ops.rs:34:14
    |
 LL |     let _n = 1u64 << 64;
    |              ^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:38:14
+  --> $DIR/lint-overflowing-ops.rs:37:14
    |
 LL |     let _n = 1u128 << 128;
    |              ^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:41:14
+  --> $DIR/lint-overflowing-ops.rs:40:14
    |
 LL |     let _n = 1i8 << 8;
    |              ^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:44:14
+  --> $DIR/lint-overflowing-ops.rs:43:14
    |
 LL |     let _n = 1i16 << 16;
    |              ^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:47:14
+  --> $DIR/lint-overflowing-ops.rs:46:14
    |
 LL |     let _n = 1i32 << 32;
    |              ^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:50:14
+  --> $DIR/lint-overflowing-ops.rs:49:14
    |
 LL |     let _n = 1i64 << 64;
    |              ^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:53:14
+  --> $DIR/lint-overflowing-ops.rs:52:14
    |
 LL |     let _n = 1i128 << 128;
    |              ^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:56:14
+  --> $DIR/lint-overflowing-ops.rs:55:14
    |
 LL |     let _n = 1_isize << BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:59:14
+  --> $DIR/lint-overflowing-ops.rs:58:14
    |
 LL |     let _n = 1_usize << BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:64:14
+  --> $DIR/lint-overflowing-ops.rs:63:14
    |
 LL |     let _n = 1u8 >> 8;
    |              ^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:67:14
+  --> $DIR/lint-overflowing-ops.rs:66:14
    |
 LL |     let _n = 1u16 >> 16;
    |              ^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:70:14
+  --> $DIR/lint-overflowing-ops.rs:69:14
    |
 LL |     let _n = 1u32 >> 32;
    |              ^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:73:14
+  --> $DIR/lint-overflowing-ops.rs:72:14
    |
 LL |     let _n = 1u64 >> 64;
    |              ^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:76:14
+  --> $DIR/lint-overflowing-ops.rs:75:14
    |
 LL |     let _n = 1u128 >> 128;
    |              ^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:79:14
+  --> $DIR/lint-overflowing-ops.rs:78:14
    |
 LL |     let _n = 1i8 >> 8;
    |              ^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:82:14
+  --> $DIR/lint-overflowing-ops.rs:81:14
    |
 LL |     let _n = 1i16 >> 16;
    |              ^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:85:14
+  --> $DIR/lint-overflowing-ops.rs:84:14
    |
 LL |     let _n = 1i32 >> 32;
    |              ^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:88:14
+  --> $DIR/lint-overflowing-ops.rs:87:14
    |
 LL |     let _n = 1i64 >> 64;
    |              ^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:91:14
+  --> $DIR/lint-overflowing-ops.rs:90:14
    |
 LL |     let _n = 1i128 >> 128;
    |              ^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:94:14
+  --> $DIR/lint-overflowing-ops.rs:93:14
    |
 LL |     let _n = 1_isize >> BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:97:14
+  --> $DIR/lint-overflowing-ops.rs:96:14
    |
 LL |     let _n = 1_usize >> BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:102:14
+  --> $DIR/lint-overflowing-ops.rs:101:14
    |
 LL |     let _n = 1u8 + u8::MAX;
    |              ^^^^^^^^^^^^^ attempt to compute `1_u8 + u8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:105:14
+  --> $DIR/lint-overflowing-ops.rs:104:14
    |
 LL |     let _n = 1u16 + u16::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u16 + u16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:108:14
+  --> $DIR/lint-overflowing-ops.rs:107:14
    |
 LL |     let _n = 1u32 + u32::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u32 + u32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:111:14
+  --> $DIR/lint-overflowing-ops.rs:110:14
    |
 LL |     let _n = 1u64 + u64::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u64 + u64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:114:14
+  --> $DIR/lint-overflowing-ops.rs:113:14
    |
 LL |     let _n = 1u128 + u128::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `1_u128 + u128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:117:14
+  --> $DIR/lint-overflowing-ops.rs:116:14
    |
 LL |     let _n = 1i8 + i8::MAX;
    |              ^^^^^^^^^^^^^ attempt to compute `1_i8 + i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:120:14
+  --> $DIR/lint-overflowing-ops.rs:119:14
    |
 LL |     let _n = 1i16 + i16::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i16 + i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:123:14
+  --> $DIR/lint-overflowing-ops.rs:122:14
    |
 LL |     let _n = 1i32 + i32::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:126:14
+  --> $DIR/lint-overflowing-ops.rs:125:14
    |
 LL |     let _n = 1i64 + i64::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i64 + i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:129:14
+  --> $DIR/lint-overflowing-ops.rs:128:14
    |
 LL |     let _n = 1i128 + i128::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `1_i128 + i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:132:14
+  --> $DIR/lint-overflowing-ops.rs:131:14
    |
 LL |     let _n = 1isize + isize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_isize + isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:135:14
+  --> $DIR/lint-overflowing-ops.rs:134:14
    |
 LL |     let _n = 1usize + usize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize + usize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:140:14
+  --> $DIR/lint-overflowing-ops.rs:139:14
    |
 LL |     let _n = 1u8 - 5;
    |              ^^^^^^^ attempt to compute `1_u8 - 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:143:14
+  --> $DIR/lint-overflowing-ops.rs:142:14
    |
 LL |     let _n = 1u16 - 5;
    |              ^^^^^^^^ attempt to compute `1_u16 - 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:146:14
+  --> $DIR/lint-overflowing-ops.rs:145:14
    |
 LL |     let _n = 1u32 - 5;
    |              ^^^^^^^^ attempt to compute `1_u32 - 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:149:14
+  --> $DIR/lint-overflowing-ops.rs:148:14
    |
 LL |     let _n = 1u64 - 5 ;
    |              ^^^^^^^^ attempt to compute `1_u64 - 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:152:14
+  --> $DIR/lint-overflowing-ops.rs:151:14
    |
 LL |     let _n = 1u128 - 5 ;
    |              ^^^^^^^^^ attempt to compute `1_u128 - 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:155:14
+  --> $DIR/lint-overflowing-ops.rs:154:14
    |
 LL |     let _n = -5i8 - i8::MAX;
    |              ^^^^^^^^^^^^^^ attempt to compute `-5_i8 - i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:158:14
+  --> $DIR/lint-overflowing-ops.rs:157:14
    |
 LL |     let _n = -5i16 - i16::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i16 - i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:161:14
+  --> $DIR/lint-overflowing-ops.rs:160:14
    |
 LL |     let _n = -5i32 - i32::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:164:14
+  --> $DIR/lint-overflowing-ops.rs:163:14
    |
 LL |     let _n = -5i64 - i64::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i64 - i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:167:14
+  --> $DIR/lint-overflowing-ops.rs:166:14
    |
 LL |     let _n = -5i128 - i128::MAX;
    |              ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i128 - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:170:14
+  --> $DIR/lint-overflowing-ops.rs:169:14
    |
 LL |     let _n = -5isize - isize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_isize - isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:173:14
+  --> $DIR/lint-overflowing-ops.rs:172:14
    |
 LL |     let _n = 1usize - 5;
    |              ^^^^^^^^^^ attempt to compute `1_usize - 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:178:14
+  --> $DIR/lint-overflowing-ops.rs:177:14
    |
 LL |     let _n = u8::MAX * 5;
    |              ^^^^^^^^^^^ attempt to compute `u8::MAX * 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:181:14
+  --> $DIR/lint-overflowing-ops.rs:180:14
    |
 LL |     let _n = u16::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u16::MAX * 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:184:14
+  --> $DIR/lint-overflowing-ops.rs:183:14
    |
 LL |     let _n = u32::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u32::MAX * 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:187:14
+  --> $DIR/lint-overflowing-ops.rs:186:14
    |
 LL |     let _n = u64::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u64::MAX * 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:190:14
+  --> $DIR/lint-overflowing-ops.rs:189:14
    |
 LL |     let _n = u128::MAX * 5;
    |              ^^^^^^^^^^^^^ attempt to compute `u128::MAX * 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:193:14
+  --> $DIR/lint-overflowing-ops.rs:192:14
    |
 LL |     let _n = i8::MAX * i8::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX * i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:196:14
+  --> $DIR/lint-overflowing-ops.rs:195:14
    |
 LL |     let _n = i16::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i16::MAX * 5_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:199:14
+  --> $DIR/lint-overflowing-ops.rs:198:14
    |
 LL |     let _n = i32::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i32::MAX * 5_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:202:14
+  --> $DIR/lint-overflowing-ops.rs:201:14
    |
 LL |     let _n = i64::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i64::MAX * 5_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:205:14
+  --> $DIR/lint-overflowing-ops.rs:204:14
    |
 LL |     let _n = i128::MAX * 5;
    |              ^^^^^^^^^^^^^ attempt to compute `i128::MAX * 5_i128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:208:14
+  --> $DIR/lint-overflowing-ops.rs:207:14
    |
 LL |     let _n = isize::MAX * 5;
    |              ^^^^^^^^^^^^^^ attempt to compute `isize::MAX * 5_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:211:14
+  --> $DIR/lint-overflowing-ops.rs:210:14
    |
 LL |     let _n = usize::MAX * 5;
    |              ^^^^^^^^^^^^^^ attempt to compute `usize::MAX * 5_usize`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:216:14
+  --> $DIR/lint-overflowing-ops.rs:215:14
    |
 LL |     let _n = 1u8 / 0;
    |              ^^^^^^^ attempt to divide `1_u8` by zero
@@ -733,295 +733,295 @@ LL |     let _n = 1u8 / 0;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:217:15
+  --> $DIR/lint-overflowing-ops.rs:216:15
    |
 LL |     let _n = &(1u8 / 0);
    |               ^^^^^^^^^ attempt to divide `1_u8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:219:14
+  --> $DIR/lint-overflowing-ops.rs:218:14
    |
 LL |     let _n = 1u16 / 0;
    |              ^^^^^^^^ attempt to divide `1_u16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:220:15
+  --> $DIR/lint-overflowing-ops.rs:219:15
    |
 LL |     let _n = &(1u16 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:222:14
+  --> $DIR/lint-overflowing-ops.rs:221:14
    |
 LL |     let _n = 1u32 / 0;
    |              ^^^^^^^^ attempt to divide `1_u32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:223:15
+  --> $DIR/lint-overflowing-ops.rs:222:15
    |
 LL |     let _n = &(1u32 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:225:14
+  --> $DIR/lint-overflowing-ops.rs:224:14
    |
 LL |     let _n = 1u64 / 0;
    |              ^^^^^^^^ attempt to divide `1_u64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:226:15
+  --> $DIR/lint-overflowing-ops.rs:225:15
    |
 LL |     let _n = &(1u64 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:228:14
+  --> $DIR/lint-overflowing-ops.rs:227:14
    |
 LL |     let _n = 1u128 / 0;
    |              ^^^^^^^^^ attempt to divide `1_u128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:229:15
+  --> $DIR/lint-overflowing-ops.rs:228:15
    |
 LL |     let _n = &(1u128 / 0);
    |               ^^^^^^^^^^^ attempt to divide `1_u128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:231:14
+  --> $DIR/lint-overflowing-ops.rs:230:14
    |
 LL |     let _n = 1i8 / 0;
    |              ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:232:15
+  --> $DIR/lint-overflowing-ops.rs:231:15
    |
 LL |     let _n = &(1i8 / 0);
    |               ^^^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:234:14
+  --> $DIR/lint-overflowing-ops.rs:233:14
    |
 LL |     let _n = 1i16 / 0;
    |              ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:235:15
+  --> $DIR/lint-overflowing-ops.rs:234:15
    |
 LL |     let _n = &(1i16 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:237:14
+  --> $DIR/lint-overflowing-ops.rs:236:14
    |
 LL |     let _n = 1i32 / 0;
    |              ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:238:15
+  --> $DIR/lint-overflowing-ops.rs:237:15
    |
 LL |     let _n = &(1i32 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:240:14
+  --> $DIR/lint-overflowing-ops.rs:239:14
    |
 LL |     let _n = 1i64 / 0;
    |              ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:241:15
+  --> $DIR/lint-overflowing-ops.rs:240:15
    |
 LL |     let _n = &(1i64 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:243:14
+  --> $DIR/lint-overflowing-ops.rs:242:14
    |
 LL |     let _n = 1i128 / 0;
    |              ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:244:15
+  --> $DIR/lint-overflowing-ops.rs:243:15
    |
 LL |     let _n = &(1i128 / 0);
    |               ^^^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:246:14
+  --> $DIR/lint-overflowing-ops.rs:245:14
    |
 LL |     let _n = 1isize / 0;
    |              ^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:247:15
+  --> $DIR/lint-overflowing-ops.rs:246:15
    |
 LL |     let _n = &(1isize / 0);
    |               ^^^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:249:14
+  --> $DIR/lint-overflowing-ops.rs:248:14
    |
 LL |     let _n = 1usize / 0;
    |              ^^^^^^^^^^ attempt to divide `1_usize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:250:15
+  --> $DIR/lint-overflowing-ops.rs:249:15
    |
 LL |     let _n = &(1usize / 0);
    |               ^^^^^^^^^^^^ attempt to divide `1_usize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:254:14
+  --> $DIR/lint-overflowing-ops.rs:253:14
    |
 LL |     let _n = 1u8 % 0;
    |              ^^^^^^^ attempt to calculate the remainder of `1_u8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:255:15
+  --> $DIR/lint-overflowing-ops.rs:254:15
    |
 LL |     let _n = &(1u8 % 0);
    |               ^^^^^^^^^ attempt to calculate the remainder of `1_u8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:257:14
+  --> $DIR/lint-overflowing-ops.rs:256:14
    |
 LL |     let _n = 1u16 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:258:15
+  --> $DIR/lint-overflowing-ops.rs:257:15
    |
 LL |     let _n = &(1u16 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:260:14
+  --> $DIR/lint-overflowing-ops.rs:259:14
    |
 LL |     let _n = 1u32 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:261:15
+  --> $DIR/lint-overflowing-ops.rs:260:15
    |
 LL |     let _n = &(1u32 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:263:14
+  --> $DIR/lint-overflowing-ops.rs:262:14
    |
 LL |     let _n = 1u64 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:264:15
+  --> $DIR/lint-overflowing-ops.rs:263:15
    |
 LL |     let _n = &(1u64 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:266:14
+  --> $DIR/lint-overflowing-ops.rs:265:14
    |
 LL |     let _n = 1u128 % 0;
    |              ^^^^^^^^^ attempt to calculate the remainder of `1_u128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:267:15
+  --> $DIR/lint-overflowing-ops.rs:266:15
    |
 LL |     let _n = &(1u128 % 0);
    |               ^^^^^^^^^^^ attempt to calculate the remainder of `1_u128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:269:14
+  --> $DIR/lint-overflowing-ops.rs:268:14
    |
 LL |     let _n = 1i8 % 0;
    |              ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:270:15
+  --> $DIR/lint-overflowing-ops.rs:269:15
    |
 LL |     let _n = &(1i8 % 0);
    |               ^^^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:272:14
+  --> $DIR/lint-overflowing-ops.rs:271:14
    |
 LL |     let _n = 1i16 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:273:15
+  --> $DIR/lint-overflowing-ops.rs:272:15
    |
 LL |     let _n = &(1i16 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:275:14
+  --> $DIR/lint-overflowing-ops.rs:274:14
    |
 LL |     let _n = 1i32 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:276:15
+  --> $DIR/lint-overflowing-ops.rs:275:15
    |
 LL |     let _n = &(1i32 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:278:14
+  --> $DIR/lint-overflowing-ops.rs:277:14
    |
 LL |     let _n = 1i64 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:279:15
+  --> $DIR/lint-overflowing-ops.rs:278:15
    |
 LL |     let _n = &(1i64 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:281:14
+  --> $DIR/lint-overflowing-ops.rs:280:14
    |
 LL |     let _n = 1i128 % 0;
    |              ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:282:15
+  --> $DIR/lint-overflowing-ops.rs:281:15
    |
 LL |     let _n = &(1i128 % 0);
    |               ^^^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:284:14
+  --> $DIR/lint-overflowing-ops.rs:283:14
    |
 LL |     let _n = 1isize % 0;
    |              ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:285:15
+  --> $DIR/lint-overflowing-ops.rs:284:15
    |
 LL |     let _n = &(1isize % 0);
    |               ^^^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:287:14
+  --> $DIR/lint-overflowing-ops.rs:286:14
    |
 LL |     let _n = 1usize % 0;
    |              ^^^^^^^^^^ attempt to calculate the remainder of `1_usize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:288:15
+  --> $DIR/lint-overflowing-ops.rs:287:15
    |
 LL |     let _n = &(1usize % 0);
    |               ^^^^^^^^^^^^ attempt to calculate the remainder of `1_usize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:292:14
+  --> $DIR/lint-overflowing-ops.rs:291:14
    |
 LL |     let _n = [1, 2, 3][4];
    |              ^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:293:15
+  --> $DIR/lint-overflowing-ops.rs:292:15
    |
 LL |     let _n = &([1, 2, 3][4]);
    |               ^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/lint/lint-overflowing-ops.opt_with_overflow_checks.stderr
+++ b/tests/ui/lint/lint-overflowing-ops.opt_with_overflow_checks.stderr
@@ -1,731 +1,731 @@
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:26:14
+  --> $DIR/lint-overflowing-ops.rs:25:14
    |
 LL |     let _n = 1u8 << 8;
    |              ^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/lint-overflowing-ops.rs:17:9
+  --> $DIR/lint-overflowing-ops.rs:16:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:212:15
+  --> $DIR/lint-overflowing-ops.rs:211:15
    |
 LL |     let _n = &(usize::MAX * 5);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `usize::MAX * 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:209:15
+  --> $DIR/lint-overflowing-ops.rs:208:15
    |
 LL |     let _n = &(isize::MAX * 5);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `isize::MAX * 5_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:206:15
+  --> $DIR/lint-overflowing-ops.rs:205:15
    |
 LL |     let _n = &(i128::MAX * 5);
    |               ^^^^^^^^^^^^^^^ attempt to compute `i128::MAX * 5_i128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:203:15
+  --> $DIR/lint-overflowing-ops.rs:202:15
    |
 LL |     let _n = &(i64::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i64::MAX * 5_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:200:15
+  --> $DIR/lint-overflowing-ops.rs:199:15
    |
 LL |     let _n = &(i32::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i32::MAX * 5_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:197:15
+  --> $DIR/lint-overflowing-ops.rs:196:15
    |
 LL |     let _n = &(i16::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `i16::MAX * 5_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:194:15
+  --> $DIR/lint-overflowing-ops.rs:193:15
    |
 LL |     let _n = &(i8::MAX * i8::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX * i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:191:15
+  --> $DIR/lint-overflowing-ops.rs:190:15
    |
 LL |     let _n = &(u128::MAX * 5);
    |               ^^^^^^^^^^^^^^^ attempt to compute `u128::MAX * 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:188:15
+  --> $DIR/lint-overflowing-ops.rs:187:15
    |
 LL |     let _n = &(u64::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u64::MAX * 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:185:15
+  --> $DIR/lint-overflowing-ops.rs:184:15
    |
 LL |     let _n = &(u32::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u32::MAX * 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:182:15
+  --> $DIR/lint-overflowing-ops.rs:181:15
    |
 LL |     let _n = &(u16::MAX * 5);
    |               ^^^^^^^^^^^^^^ attempt to compute `u16::MAX * 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:179:15
+  --> $DIR/lint-overflowing-ops.rs:178:15
    |
 LL |     let _n = &(u8::MAX * 5);
    |               ^^^^^^^^^^^^^ attempt to compute `u8::MAX * 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:174:15
+  --> $DIR/lint-overflowing-ops.rs:173:15
    |
 LL |     let _n = &(1usize - 5);
    |               ^^^^^^^^^^^^ attempt to compute `1_usize - 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:171:15
+  --> $DIR/lint-overflowing-ops.rs:170:15
    |
 LL |     let _n = &(-5isize - isize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_isize - isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:168:15
+  --> $DIR/lint-overflowing-ops.rs:167:15
    |
 LL |     let _n = &(-5i128 - i128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i128 - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:165:15
+  --> $DIR/lint-overflowing-ops.rs:164:15
    |
 LL |     let _n = &(-5i64 - i64::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i64 - i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:162:15
+  --> $DIR/lint-overflowing-ops.rs:161:15
    |
 LL |     let _n = &(-5i32 - i32::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:159:15
+  --> $DIR/lint-overflowing-ops.rs:158:15
    |
 LL |     let _n = &(-5i16 - i16::MAX);
    |               ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i16 - i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:156:15
+  --> $DIR/lint-overflowing-ops.rs:155:15
    |
 LL |     let _n = &(-5i8 - i8::MAX);
    |               ^^^^^^^^^^^^^^^^ attempt to compute `-5_i8 - i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:153:15
+  --> $DIR/lint-overflowing-ops.rs:152:15
    |
 LL |     let _n = &(1u128 - 5);
    |               ^^^^^^^^^^^ attempt to compute `1_u128 - 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:150:15
+  --> $DIR/lint-overflowing-ops.rs:149:15
    |
 LL |     let _n = &(1u64 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u64 - 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:147:15
+  --> $DIR/lint-overflowing-ops.rs:146:15
    |
 LL |     let _n = &(1u32 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u32 - 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:144:15
+  --> $DIR/lint-overflowing-ops.rs:143:15
    |
 LL |     let _n = &(1u16 - 5);
    |               ^^^^^^^^^^ attempt to compute `1_u16 - 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:141:15
+  --> $DIR/lint-overflowing-ops.rs:140:15
    |
 LL |     let _n = &(1u8 - 5);
    |               ^^^^^^^^^ attempt to compute `1_u8 - 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:136:15
+  --> $DIR/lint-overflowing-ops.rs:135:15
    |
 LL |     let _n = &(1usize + usize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize + usize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:133:15
+  --> $DIR/lint-overflowing-ops.rs:132:15
    |
 LL |     let _n = &(1isize + isize::MAX);
    |               ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_isize + isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:130:15
+  --> $DIR/lint-overflowing-ops.rs:129:15
    |
 LL |     let _n = &(1i128 + i128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_i128 + i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:127:15
+  --> $DIR/lint-overflowing-ops.rs:126:15
    |
 LL |     let _n = &(1i64 + i64::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i64 + i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:124:15
+  --> $DIR/lint-overflowing-ops.rs:123:15
    |
 LL |     let _n = &(1i32 + i32::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:121:15
+  --> $DIR/lint-overflowing-ops.rs:120:15
    |
 LL |     let _n = &(1i16 + i16::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_i16 + i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:118:15
+  --> $DIR/lint-overflowing-ops.rs:117:15
    |
 LL |     let _n = &(1i8 + i8::MAX);
    |               ^^^^^^^^^^^^^^^ attempt to compute `1_i8 + i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:115:15
+  --> $DIR/lint-overflowing-ops.rs:114:15
    |
 LL |     let _n = &(1u128 + u128::MAX);
    |               ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_u128 + u128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:112:15
+  --> $DIR/lint-overflowing-ops.rs:111:15
    |
 LL |     let _n = &(1u64 + u64::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u64 + u64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:109:15
+  --> $DIR/lint-overflowing-ops.rs:108:15
    |
 LL |     let _n = &(1u32 + u32::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u32 + u32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:106:15
+  --> $DIR/lint-overflowing-ops.rs:105:15
    |
 LL |     let _n = &(1u16 + u16::MAX);
    |               ^^^^^^^^^^^^^^^^^ attempt to compute `1_u16 + u16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:103:15
+  --> $DIR/lint-overflowing-ops.rs:102:15
    |
 LL |     let _n = &(1u8 + u8::MAX);
    |               ^^^^^^^^^^^^^^^ attempt to compute `1_u8 + u8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:98:15
+  --> $DIR/lint-overflowing-ops.rs:97:15
    |
 LL |     let _n = &(1_usize >> BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:95:15
+  --> $DIR/lint-overflowing-ops.rs:94:15
    |
 LL |     let _n = &(1_isize >> BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:92:15
+  --> $DIR/lint-overflowing-ops.rs:91:15
    |
 LL |     let _n = &(1i128 >> 128);
    |               ^^^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:89:15
+  --> $DIR/lint-overflowing-ops.rs:88:15
    |
 LL |     let _n = &(1i64 >> 64);
    |               ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:86:15
+  --> $DIR/lint-overflowing-ops.rs:85:15
    |
 LL |     let _n = &(1i32 >> 32);
    |               ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:83:15
+  --> $DIR/lint-overflowing-ops.rs:82:15
    |
 LL |     let _n = &(1i16 >> 16);
    |               ^^^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:80:15
+  --> $DIR/lint-overflowing-ops.rs:79:15
    |
 LL |     let _n = &(1i8 >> 8);
    |               ^^^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:77:15
+  --> $DIR/lint-overflowing-ops.rs:76:15
    |
 LL |     let _n = &(1u128 >> 128);
    |               ^^^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:74:15
+  --> $DIR/lint-overflowing-ops.rs:73:15
    |
 LL |     let _n = &(1u64 >> 64);
    |               ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:71:15
+  --> $DIR/lint-overflowing-ops.rs:70:15
    |
 LL |     let _n = &(1u32 >> 32);
    |               ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:68:15
+  --> $DIR/lint-overflowing-ops.rs:67:15
    |
 LL |     let _n = &(1u16 >> 16);
    |               ^^^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:65:15
+  --> $DIR/lint-overflowing-ops.rs:64:15
    |
 LL |     let _n = &(1u8 >> 8);
    |               ^^^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:60:15
+  --> $DIR/lint-overflowing-ops.rs:59:15
    |
 LL |     let _n = &(1_usize << BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:57:15
+  --> $DIR/lint-overflowing-ops.rs:56:15
    |
 LL |     let _n = &(1_isize << BITS);
    |               ^^^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:54:15
+  --> $DIR/lint-overflowing-ops.rs:53:15
    |
 LL |     let _n = &(1i128 << 128);
    |               ^^^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:51:15
+  --> $DIR/lint-overflowing-ops.rs:50:15
    |
 LL |     let _n = &(1i64 << 64);
    |               ^^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:48:15
+  --> $DIR/lint-overflowing-ops.rs:47:15
    |
 LL |     let _n = &(1i32 << 32);
    |               ^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:45:15
+  --> $DIR/lint-overflowing-ops.rs:44:15
    |
 LL |     let _n = &(1i16 << 16);
    |               ^^^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:42:15
+  --> $DIR/lint-overflowing-ops.rs:41:15
    |
 LL |     let _n = &(1i8 << 8);
    |               ^^^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:39:15
+  --> $DIR/lint-overflowing-ops.rs:38:15
    |
 LL |     let _n = &(1u128 << 128);
    |               ^^^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:36:15
+  --> $DIR/lint-overflowing-ops.rs:35:15
    |
 LL |     let _n = &(1u64 << 64);
    |               ^^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:33:15
+  --> $DIR/lint-overflowing-ops.rs:32:15
    |
 LL |     let _n = &(1u32 << 32);
    |               ^^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:30:15
+  --> $DIR/lint-overflowing-ops.rs:29:15
    |
 LL |     let _n = &(1u16 << 16);
    |               ^^^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:27:15
+  --> $DIR/lint-overflowing-ops.rs:26:15
    |
 LL |     let _n = &(1u8 << 8);
    |               ^^^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:29:14
+  --> $DIR/lint-overflowing-ops.rs:28:14
    |
 LL |     let _n = 1u16 << 16;
    |              ^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:32:14
+  --> $DIR/lint-overflowing-ops.rs:31:14
    |
 LL |     let _n = 1u32 << 32;
    |              ^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:35:14
+  --> $DIR/lint-overflowing-ops.rs:34:14
    |
 LL |     let _n = 1u64 << 64;
    |              ^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:38:14
+  --> $DIR/lint-overflowing-ops.rs:37:14
    |
 LL |     let _n = 1u128 << 128;
    |              ^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:41:14
+  --> $DIR/lint-overflowing-ops.rs:40:14
    |
 LL |     let _n = 1i8 << 8;
    |              ^^^^^^^^ attempt to shift left by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:44:14
+  --> $DIR/lint-overflowing-ops.rs:43:14
    |
 LL |     let _n = 1i16 << 16;
    |              ^^^^^^^^^^ attempt to shift left by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:47:14
+  --> $DIR/lint-overflowing-ops.rs:46:14
    |
 LL |     let _n = 1i32 << 32;
    |              ^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:50:14
+  --> $DIR/lint-overflowing-ops.rs:49:14
    |
 LL |     let _n = 1i64 << 64;
    |              ^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:53:14
+  --> $DIR/lint-overflowing-ops.rs:52:14
    |
 LL |     let _n = 1i128 << 128;
    |              ^^^^^^^^^^^^ attempt to shift left by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:56:14
+  --> $DIR/lint-overflowing-ops.rs:55:14
    |
 LL |     let _n = 1_isize << BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:59:14
+  --> $DIR/lint-overflowing-ops.rs:58:14
    |
 LL |     let _n = 1_usize << BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift left by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:64:14
+  --> $DIR/lint-overflowing-ops.rs:63:14
    |
 LL |     let _n = 1u8 >> 8;
    |              ^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:67:14
+  --> $DIR/lint-overflowing-ops.rs:66:14
    |
 LL |     let _n = 1u16 >> 16;
    |              ^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:70:14
+  --> $DIR/lint-overflowing-ops.rs:69:14
    |
 LL |     let _n = 1u32 >> 32;
    |              ^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:73:14
+  --> $DIR/lint-overflowing-ops.rs:72:14
    |
 LL |     let _n = 1u64 >> 64;
    |              ^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:76:14
+  --> $DIR/lint-overflowing-ops.rs:75:14
    |
 LL |     let _n = 1u128 >> 128;
    |              ^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:79:14
+  --> $DIR/lint-overflowing-ops.rs:78:14
    |
 LL |     let _n = 1i8 >> 8;
    |              ^^^^^^^^ attempt to shift right by `8_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:82:14
+  --> $DIR/lint-overflowing-ops.rs:81:14
    |
 LL |     let _n = 1i16 >> 16;
    |              ^^^^^^^^^^ attempt to shift right by `16_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:85:14
+  --> $DIR/lint-overflowing-ops.rs:84:14
    |
 LL |     let _n = 1i32 >> 32;
    |              ^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:88:14
+  --> $DIR/lint-overflowing-ops.rs:87:14
    |
 LL |     let _n = 1i64 >> 64;
    |              ^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:91:14
+  --> $DIR/lint-overflowing-ops.rs:90:14
    |
 LL |     let _n = 1i128 >> 128;
    |              ^^^^^^^^^^^^ attempt to shift right by `128_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:94:14
+  --> $DIR/lint-overflowing-ops.rs:93:14
    |
 LL |     let _n = 1_isize >> BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:97:14
+  --> $DIR/lint-overflowing-ops.rs:96:14
    |
 LL |     let _n = 1_usize >> BITS;
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `%BITS%`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:102:14
+  --> $DIR/lint-overflowing-ops.rs:101:14
    |
 LL |     let _n = 1u8 + u8::MAX;
    |              ^^^^^^^^^^^^^ attempt to compute `1_u8 + u8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:105:14
+  --> $DIR/lint-overflowing-ops.rs:104:14
    |
 LL |     let _n = 1u16 + u16::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u16 + u16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:108:14
+  --> $DIR/lint-overflowing-ops.rs:107:14
    |
 LL |     let _n = 1u32 + u32::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u32 + u32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:111:14
+  --> $DIR/lint-overflowing-ops.rs:110:14
    |
 LL |     let _n = 1u64 + u64::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_u64 + u64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:114:14
+  --> $DIR/lint-overflowing-ops.rs:113:14
    |
 LL |     let _n = 1u128 + u128::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `1_u128 + u128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:117:14
+  --> $DIR/lint-overflowing-ops.rs:116:14
    |
 LL |     let _n = 1i8 + i8::MAX;
    |              ^^^^^^^^^^^^^ attempt to compute `1_i8 + i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:120:14
+  --> $DIR/lint-overflowing-ops.rs:119:14
    |
 LL |     let _n = 1i16 + i16::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i16 + i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:123:14
+  --> $DIR/lint-overflowing-ops.rs:122:14
    |
 LL |     let _n = 1i32 + i32::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i32 + i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:126:14
+  --> $DIR/lint-overflowing-ops.rs:125:14
    |
 LL |     let _n = 1i64 + i64::MAX;
    |              ^^^^^^^^^^^^^^^ attempt to compute `1_i64 + i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:129:14
+  --> $DIR/lint-overflowing-ops.rs:128:14
    |
 LL |     let _n = 1i128 + i128::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `1_i128 + i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:132:14
+  --> $DIR/lint-overflowing-ops.rs:131:14
    |
 LL |     let _n = 1isize + isize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_isize + isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:135:14
+  --> $DIR/lint-overflowing-ops.rs:134:14
    |
 LL |     let _n = 1usize + usize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize + usize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:140:14
+  --> $DIR/lint-overflowing-ops.rs:139:14
    |
 LL |     let _n = 1u8 - 5;
    |              ^^^^^^^ attempt to compute `1_u8 - 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:143:14
+  --> $DIR/lint-overflowing-ops.rs:142:14
    |
 LL |     let _n = 1u16 - 5;
    |              ^^^^^^^^ attempt to compute `1_u16 - 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:146:14
+  --> $DIR/lint-overflowing-ops.rs:145:14
    |
 LL |     let _n = 1u32 - 5;
    |              ^^^^^^^^ attempt to compute `1_u32 - 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:149:14
+  --> $DIR/lint-overflowing-ops.rs:148:14
    |
 LL |     let _n = 1u64 - 5 ;
    |              ^^^^^^^^ attempt to compute `1_u64 - 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:152:14
+  --> $DIR/lint-overflowing-ops.rs:151:14
    |
 LL |     let _n = 1u128 - 5 ;
    |              ^^^^^^^^^ attempt to compute `1_u128 - 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:155:14
+  --> $DIR/lint-overflowing-ops.rs:154:14
    |
 LL |     let _n = -5i8 - i8::MAX;
    |              ^^^^^^^^^^^^^^ attempt to compute `-5_i8 - i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:158:14
+  --> $DIR/lint-overflowing-ops.rs:157:14
    |
 LL |     let _n = -5i16 - i16::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i16 - i16::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:161:14
+  --> $DIR/lint-overflowing-ops.rs:160:14
    |
 LL |     let _n = -5i32 - i32::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i32 - i32::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:164:14
+  --> $DIR/lint-overflowing-ops.rs:163:14
    |
 LL |     let _n = -5i64 - i64::MAX;
    |              ^^^^^^^^^^^^^^^^ attempt to compute `-5_i64 - i64::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:167:14
+  --> $DIR/lint-overflowing-ops.rs:166:14
    |
 LL |     let _n = -5i128 - i128::MAX;
    |              ^^^^^^^^^^^^^^^^^^ attempt to compute `-5_i128 - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:170:14
+  --> $DIR/lint-overflowing-ops.rs:169:14
    |
 LL |     let _n = -5isize - isize::MAX;
    |              ^^^^^^^^^^^^^^^^^^^^ attempt to compute `-5_isize - isize::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:173:14
+  --> $DIR/lint-overflowing-ops.rs:172:14
    |
 LL |     let _n = 1usize - 5;
    |              ^^^^^^^^^^ attempt to compute `1_usize - 5_usize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:178:14
+  --> $DIR/lint-overflowing-ops.rs:177:14
    |
 LL |     let _n = u8::MAX * 5;
    |              ^^^^^^^^^^^ attempt to compute `u8::MAX * 5_u8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:181:14
+  --> $DIR/lint-overflowing-ops.rs:180:14
    |
 LL |     let _n = u16::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u16::MAX * 5_u16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:184:14
+  --> $DIR/lint-overflowing-ops.rs:183:14
    |
 LL |     let _n = u32::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u32::MAX * 5_u32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:187:14
+  --> $DIR/lint-overflowing-ops.rs:186:14
    |
 LL |     let _n = u64::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `u64::MAX * 5_u64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:190:14
+  --> $DIR/lint-overflowing-ops.rs:189:14
    |
 LL |     let _n = u128::MAX * 5;
    |              ^^^^^^^^^^^^^ attempt to compute `u128::MAX * 5_u128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:193:14
+  --> $DIR/lint-overflowing-ops.rs:192:14
    |
 LL |     let _n = i8::MAX * i8::MAX;
    |              ^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX * i8::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:196:14
+  --> $DIR/lint-overflowing-ops.rs:195:14
    |
 LL |     let _n = i16::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i16::MAX * 5_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:199:14
+  --> $DIR/lint-overflowing-ops.rs:198:14
    |
 LL |     let _n = i32::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i32::MAX * 5_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:202:14
+  --> $DIR/lint-overflowing-ops.rs:201:14
    |
 LL |     let _n = i64::MAX * 5;
    |              ^^^^^^^^^^^^ attempt to compute `i64::MAX * 5_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:205:14
+  --> $DIR/lint-overflowing-ops.rs:204:14
    |
 LL |     let _n = i128::MAX * 5;
    |              ^^^^^^^^^^^^^ attempt to compute `i128::MAX * 5_i128`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:208:14
+  --> $DIR/lint-overflowing-ops.rs:207:14
    |
 LL |     let _n = isize::MAX * 5;
    |              ^^^^^^^^^^^^^^ attempt to compute `isize::MAX * 5_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/lint-overflowing-ops.rs:211:14
+  --> $DIR/lint-overflowing-ops.rs:210:14
    |
 LL |     let _n = usize::MAX * 5;
    |              ^^^^^^^^^^^^^^ attempt to compute `usize::MAX * 5_usize`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:216:14
+  --> $DIR/lint-overflowing-ops.rs:215:14
    |
 LL |     let _n = 1u8 / 0;
    |              ^^^^^^^ attempt to divide `1_u8` by zero
@@ -733,295 +733,295 @@ LL |     let _n = 1u8 / 0;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:217:15
+  --> $DIR/lint-overflowing-ops.rs:216:15
    |
 LL |     let _n = &(1u8 / 0);
    |               ^^^^^^^^^ attempt to divide `1_u8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:219:14
+  --> $DIR/lint-overflowing-ops.rs:218:14
    |
 LL |     let _n = 1u16 / 0;
    |              ^^^^^^^^ attempt to divide `1_u16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:220:15
+  --> $DIR/lint-overflowing-ops.rs:219:15
    |
 LL |     let _n = &(1u16 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:222:14
+  --> $DIR/lint-overflowing-ops.rs:221:14
    |
 LL |     let _n = 1u32 / 0;
    |              ^^^^^^^^ attempt to divide `1_u32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:223:15
+  --> $DIR/lint-overflowing-ops.rs:222:15
    |
 LL |     let _n = &(1u32 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:225:14
+  --> $DIR/lint-overflowing-ops.rs:224:14
    |
 LL |     let _n = 1u64 / 0;
    |              ^^^^^^^^ attempt to divide `1_u64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:226:15
+  --> $DIR/lint-overflowing-ops.rs:225:15
    |
 LL |     let _n = &(1u64 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_u64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:228:14
+  --> $DIR/lint-overflowing-ops.rs:227:14
    |
 LL |     let _n = 1u128 / 0;
    |              ^^^^^^^^^ attempt to divide `1_u128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:229:15
+  --> $DIR/lint-overflowing-ops.rs:228:15
    |
 LL |     let _n = &(1u128 / 0);
    |               ^^^^^^^^^^^ attempt to divide `1_u128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:231:14
+  --> $DIR/lint-overflowing-ops.rs:230:14
    |
 LL |     let _n = 1i8 / 0;
    |              ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:232:15
+  --> $DIR/lint-overflowing-ops.rs:231:15
    |
 LL |     let _n = &(1i8 / 0);
    |               ^^^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:234:14
+  --> $DIR/lint-overflowing-ops.rs:233:14
    |
 LL |     let _n = 1i16 / 0;
    |              ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:235:15
+  --> $DIR/lint-overflowing-ops.rs:234:15
    |
 LL |     let _n = &(1i16 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:237:14
+  --> $DIR/lint-overflowing-ops.rs:236:14
    |
 LL |     let _n = 1i32 / 0;
    |              ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:238:15
+  --> $DIR/lint-overflowing-ops.rs:237:15
    |
 LL |     let _n = &(1i32 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:240:14
+  --> $DIR/lint-overflowing-ops.rs:239:14
    |
 LL |     let _n = 1i64 / 0;
    |              ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:241:15
+  --> $DIR/lint-overflowing-ops.rs:240:15
    |
 LL |     let _n = &(1i64 / 0);
    |               ^^^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:243:14
+  --> $DIR/lint-overflowing-ops.rs:242:14
    |
 LL |     let _n = 1i128 / 0;
    |              ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:244:15
+  --> $DIR/lint-overflowing-ops.rs:243:15
    |
 LL |     let _n = &(1i128 / 0);
    |               ^^^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:246:14
+  --> $DIR/lint-overflowing-ops.rs:245:14
    |
 LL |     let _n = 1isize / 0;
    |              ^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:247:15
+  --> $DIR/lint-overflowing-ops.rs:246:15
    |
 LL |     let _n = &(1isize / 0);
    |               ^^^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:249:14
+  --> $DIR/lint-overflowing-ops.rs:248:14
    |
 LL |     let _n = 1usize / 0;
    |              ^^^^^^^^^^ attempt to divide `1_usize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:250:15
+  --> $DIR/lint-overflowing-ops.rs:249:15
    |
 LL |     let _n = &(1usize / 0);
    |               ^^^^^^^^^^^^ attempt to divide `1_usize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:254:14
+  --> $DIR/lint-overflowing-ops.rs:253:14
    |
 LL |     let _n = 1u8 % 0;
    |              ^^^^^^^ attempt to calculate the remainder of `1_u8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:255:15
+  --> $DIR/lint-overflowing-ops.rs:254:15
    |
 LL |     let _n = &(1u8 % 0);
    |               ^^^^^^^^^ attempt to calculate the remainder of `1_u8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:257:14
+  --> $DIR/lint-overflowing-ops.rs:256:14
    |
 LL |     let _n = 1u16 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:258:15
+  --> $DIR/lint-overflowing-ops.rs:257:15
    |
 LL |     let _n = &(1u16 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:260:14
+  --> $DIR/lint-overflowing-ops.rs:259:14
    |
 LL |     let _n = 1u32 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:261:15
+  --> $DIR/lint-overflowing-ops.rs:260:15
    |
 LL |     let _n = &(1u32 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:263:14
+  --> $DIR/lint-overflowing-ops.rs:262:14
    |
 LL |     let _n = 1u64 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_u64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:264:15
+  --> $DIR/lint-overflowing-ops.rs:263:15
    |
 LL |     let _n = &(1u64 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_u64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:266:14
+  --> $DIR/lint-overflowing-ops.rs:265:14
    |
 LL |     let _n = 1u128 % 0;
    |              ^^^^^^^^^ attempt to calculate the remainder of `1_u128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:267:15
+  --> $DIR/lint-overflowing-ops.rs:266:15
    |
 LL |     let _n = &(1u128 % 0);
    |               ^^^^^^^^^^^ attempt to calculate the remainder of `1_u128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:269:14
+  --> $DIR/lint-overflowing-ops.rs:268:14
    |
 LL |     let _n = 1i8 % 0;
    |              ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:270:15
+  --> $DIR/lint-overflowing-ops.rs:269:15
    |
 LL |     let _n = &(1i8 % 0);
    |               ^^^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:272:14
+  --> $DIR/lint-overflowing-ops.rs:271:14
    |
 LL |     let _n = 1i16 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:273:15
+  --> $DIR/lint-overflowing-ops.rs:272:15
    |
 LL |     let _n = &(1i16 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:275:14
+  --> $DIR/lint-overflowing-ops.rs:274:14
    |
 LL |     let _n = 1i32 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:276:15
+  --> $DIR/lint-overflowing-ops.rs:275:15
    |
 LL |     let _n = &(1i32 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:278:14
+  --> $DIR/lint-overflowing-ops.rs:277:14
    |
 LL |     let _n = 1i64 % 0;
    |              ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:279:15
+  --> $DIR/lint-overflowing-ops.rs:278:15
    |
 LL |     let _n = &(1i64 % 0);
    |               ^^^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:281:14
+  --> $DIR/lint-overflowing-ops.rs:280:14
    |
 LL |     let _n = 1i128 % 0;
    |              ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:282:15
+  --> $DIR/lint-overflowing-ops.rs:281:15
    |
 LL |     let _n = &(1i128 % 0);
    |               ^^^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:284:14
+  --> $DIR/lint-overflowing-ops.rs:283:14
    |
 LL |     let _n = 1isize % 0;
    |              ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:285:15
+  --> $DIR/lint-overflowing-ops.rs:284:15
    |
 LL |     let _n = &(1isize % 0);
    |               ^^^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:287:14
+  --> $DIR/lint-overflowing-ops.rs:286:14
    |
 LL |     let _n = 1usize % 0;
    |              ^^^^^^^^^^ attempt to calculate the remainder of `1_usize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:288:15
+  --> $DIR/lint-overflowing-ops.rs:287:15
    |
 LL |     let _n = &(1usize % 0);
    |               ^^^^^^^^^^^^ attempt to calculate the remainder of `1_usize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:292:14
+  --> $DIR/lint-overflowing-ops.rs:291:14
    |
 LL |     let _n = [1, 2, 3][4];
    |              ^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4
 
 error: this operation will panic at runtime
-  --> $DIR/lint-overflowing-ops.rs:293:15
+  --> $DIR/lint-overflowing-ops.rs:292:15
    |
 LL |     let _n = &([1, 2, 3][4]);
    |               ^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/lint/lint-overflowing-ops.rs
+++ b/tests/ui/lint/lint-overflowing-ops.rs
@@ -9,7 +9,6 @@
 //@ [noopt]compile-flags: -C opt-level=0 -Z deduplicate-diagnostics=yes
 //@ [opt]compile-flags: -O
 //@ [opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O -Z deduplicate-diagnostics=yes
-//@ build-fail
 //@ ignore-pass (test tests codegen-time behaviour)
 //@ normalize-stderr-test "shift left by `(64|32)_usize`, which" -> "shift left by `%BITS%`, which"
 //@ normalize-stderr-test "shift right by `(64|32)_usize`, which" -> "shift right by `%BITS%`, which"

--- a/tests/ui/lint/lint-type-overflow2.rs
+++ b/tests/ui/lint/lint-type-overflow2.rs
@@ -4,6 +4,7 @@
 
 fn main() {
     let x2: i8 = --128; //~ ERROR literal out of range for `i8`
+    //~^ ERROR arithmetic operation will overflow
 
     let x = -3.40282357e+38_f32; //~ ERROR literal out of range for `f32`
     let x =  3.40282357e+38_f32; //~ ERROR literal out of range for `f32`

--- a/tests/ui/lint/lint-type-overflow2.stderr
+++ b/tests/ui/lint/lint-type-overflow2.stderr
@@ -1,3 +1,11 @@
+error: this arithmetic operation will overflow
+  --> $DIR/lint-type-overflow2.rs:6:18
+   |
+LL |     let x2: i8 = --128;
+   |                  ^^^^^ attempt to negate `i8::MIN`, which would overflow
+   |
+   = note: `#[deny(arithmetic_overflow)]` on by default
+
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow2.rs:6:20
    |
@@ -13,7 +21,7 @@ LL | #![deny(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: literal out of range for `f32`
-  --> $DIR/lint-type-overflow2.rs:8:14
+  --> $DIR/lint-type-overflow2.rs:9:14
    |
 LL |     let x = -3.40282357e+38_f32;
    |              ^^^^^^^^^^^^^^^^^^
@@ -21,7 +29,7 @@ LL |     let x = -3.40282357e+38_f32;
    = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `f32::INFINITY`
 
 error: literal out of range for `f32`
-  --> $DIR/lint-type-overflow2.rs:9:14
+  --> $DIR/lint-type-overflow2.rs:10:14
    |
 LL |     let x =  3.40282357e+38_f32;
    |              ^^^^^^^^^^^^^^^^^^
@@ -29,7 +37,7 @@ LL |     let x =  3.40282357e+38_f32;
    = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `f32::INFINITY`
 
 error: literal out of range for `f64`
-  --> $DIR/lint-type-overflow2.rs:10:14
+  --> $DIR/lint-type-overflow2.rs:11:14
    |
 LL |     let x = -1.7976931348623159e+308_f64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,12 +45,12 @@ LL |     let x = -1.7976931348623159e+308_f64;
    = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `f64::INFINITY`
 
 error: literal out of range for `f64`
-  --> $DIR/lint-type-overflow2.rs:11:14
+  --> $DIR/lint-type-overflow2.rs:12:14
    |
 LL |     let x =  1.7976931348623159e+308_f64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `f64::INFINITY`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/unconditional_panic_98444.rs
+++ b/tests/ui/lint/unconditional_panic_98444.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 fn main() {
     let xs: [i32; 5] = [1, 2, 3, 4, 5];
     let _ = &xs;

--- a/tests/ui/lint/unconditional_panic_98444.stderr
+++ b/tests/ui/lint/unconditional_panic_98444.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/unconditional_panic_98444.rs:6:13
+  --> $DIR/unconditional_panic_98444.rs:4:13
    |
 LL |     let _ = xs[7];
    |             ^^^^^ index out of bounds: the length is 5 but the index is 7

--- a/tests/ui/mir/mir_detects_invalid_ops.rs
+++ b/tests/ui/mir/mir_detects_invalid_ops.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 fn main() {
     divide_by_zero();
     mod_by_zero();

--- a/tests/ui/mir/mir_detects_invalid_ops.stderr
+++ b/tests/ui/mir/mir_detects_invalid_ops.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/mir_detects_invalid_ops.rs:11:14
+  --> $DIR/mir_detects_invalid_ops.rs:9:14
    |
 LL |     let _z = 1 / y;
    |              ^^^^^ attempt to divide `1_i32` by zero
@@ -7,7 +7,7 @@ LL |     let _z = 1 / y;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/mir_detects_invalid_ops.rs:16:14
+  --> $DIR/mir_detects_invalid_ops.rs:14:14
    |
 LL |     let _z = 1 % y;
    |              ^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero

--- a/tests/ui/numbers-arithmetic/issue-8460-const.noopt.stderr
+++ b/tests/ui/numbers-arithmetic/issue-8460-const.noopt.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:11:36
+  --> $DIR/issue-8460-const.rs:9:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
@@ -7,139 +7,139 @@ LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:13:36
+  --> $DIR/issue-8460-const.rs:11:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:15:36
+  --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:17:36
+  --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:19:36
+  --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:21:36
+  --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:23:36
+  --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:25:36
+  --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:27:36
+  --> $DIR/issue-8460-const.rs:25:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:29:36
+  --> $DIR/issue-8460-const.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:31:36
+  --> $DIR/issue-8460-const.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:33:36
+  --> $DIR/issue-8460-const.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:35:36
+  --> $DIR/issue-8460-const.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN % -1_isize`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:37:36
+  --> $DIR/issue-8460-const.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN % -1_i8`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:39:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN % -1_i16`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:41:36
+  --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN % -1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:43:36
+  --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN % -1_i64`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:45:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN % -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:47:36
+  --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:49:36
+  --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:51:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:53:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:55:36
+  --> $DIR/issue-8460-const.rs:53:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:57:36
+  --> $DIR/issue-8460-const.rs:55:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero

--- a/tests/ui/numbers-arithmetic/issue-8460-const.opt.stderr
+++ b/tests/ui/numbers-arithmetic/issue-8460-const.opt.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:11:36
+  --> $DIR/issue-8460-const.rs:9:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
@@ -7,139 +7,139 @@ LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:13:36
+  --> $DIR/issue-8460-const.rs:11:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:15:36
+  --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:17:36
+  --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:19:36
+  --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:21:36
+  --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:23:36
+  --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:25:36
+  --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:27:36
+  --> $DIR/issue-8460-const.rs:25:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:29:36
+  --> $DIR/issue-8460-const.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:31:36
+  --> $DIR/issue-8460-const.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:33:36
+  --> $DIR/issue-8460-const.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:35:36
+  --> $DIR/issue-8460-const.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN % -1_isize`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:37:36
+  --> $DIR/issue-8460-const.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN % -1_i8`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:39:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN % -1_i16`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:41:36
+  --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN % -1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:43:36
+  --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN % -1_i64`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:45:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN % -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:47:36
+  --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:49:36
+  --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:51:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:53:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:55:36
+  --> $DIR/issue-8460-const.rs:53:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:57:36
+  --> $DIR/issue-8460-const.rs:55:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero

--- a/tests/ui/numbers-arithmetic/issue-8460-const.opt_with_overflow_checks.stderr
+++ b/tests/ui/numbers-arithmetic/issue-8460-const.opt_with_overflow_checks.stderr
@@ -1,5 +1,5 @@
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:11:36
+  --> $DIR/issue-8460-const.rs:9:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
@@ -7,139 +7,139 @@ LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:13:36
+  --> $DIR/issue-8460-const.rs:11:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:15:36
+  --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:17:36
+  --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:19:36
+  --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:21:36
+  --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:23:36
+  --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:25:36
+  --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:27:36
+  --> $DIR/issue-8460-const.rs:25:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:29:36
+  --> $DIR/issue-8460-const.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:31:36
+  --> $DIR/issue-8460-const.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:33:36
+  --> $DIR/issue-8460-const.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:35:36
+  --> $DIR/issue-8460-const.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN % -1_isize`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:37:36
+  --> $DIR/issue-8460-const.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN % -1_i8`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:39:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN % -1_i16`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:41:36
+  --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN % -1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:43:36
+  --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN % -1_i64`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:45:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN % -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:47:36
+  --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:49:36
+  --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:51:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:53:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:55:36
+  --> $DIR/issue-8460-const.rs:53:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:57:36
+  --> $DIR/issue-8460-const.rs:55:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero

--- a/tests/ui/numbers-arithmetic/issue-8460-const.rs
+++ b/tests/ui/numbers-arithmetic/issue-8460-const.rs
@@ -3,8 +3,6 @@
 //@[opt]compile-flags: -O
 //@[opt_with_overflow_checks]compile-flags: -C overflow-checks=on -O
 
-//@ build-fail
-
 use std::thread;
 
 fn main() {

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-1.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-1.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-1.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-1.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-lsh-1.rs:7:14
+  --> $DIR/overflowing-lsh-1.rs:6:14
    |
 LL |     let _x = 1_i32 << 32;
    |              ^^^^^^^^^^^ attempt to shift left by `32_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-lsh-1.rs:4:9
+  --> $DIR/overflowing-lsh-1.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-2.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-2.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-2.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-2.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-lsh-2.rs:7:14
+  --> $DIR/overflowing-lsh-2.rs:6:14
    |
 LL |     let _x = 1 << -1;
    |              ^^^^^^^ attempt to shift left by `-1_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-lsh-2.rs:4:9
+  --> $DIR/overflowing-lsh-2.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-3.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-3.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-3.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-3.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-lsh-3.rs:7:14
+  --> $DIR/overflowing-lsh-3.rs:6:14
    |
 LL |     let _x = 1_u64 << 64;
    |              ^^^^^^^^^^^ attempt to shift left by `64_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-lsh-3.rs:4:9
+  --> $DIR/overflowing-lsh-3.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-4.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-4.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 // This function is checking that our automatic truncation does not

--- a/tests/ui/numbers-arithmetic/overflowing-lsh-4.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-lsh-4.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-lsh-4.rs:11:13
+  --> $DIR/overflowing-lsh-4.rs:10:13
    |
 LL |     let x = 1_i8 << 17;
    |             ^^^^^^^^^^ attempt to shift left by `17_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-lsh-4.rs:7:9
+  --> $DIR/overflowing-lsh-4.rs:6:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-1.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-1.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-1.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-1.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-rsh-1.rs:7:14
+  --> $DIR/overflowing-rsh-1.rs:6:14
    |
 LL |     let _x = -1_i32 >> 32;
    |              ^^^^^^^^^^^^ attempt to shift right by `32_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-rsh-1.rs:4:9
+  --> $DIR/overflowing-rsh-1.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-2.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-2.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-2.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-2.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-rsh-2.rs:7:14
+  --> $DIR/overflowing-rsh-2.rs:6:14
    |
 LL |     let _x = -1_i32 >> -1;
    |              ^^^^^^^^^^^^ attempt to shift right by `-1_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-rsh-2.rs:4:9
+  --> $DIR/overflowing-rsh-2.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-3.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-3.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-3.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-3.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-rsh-3.rs:7:14
+  --> $DIR/overflowing-rsh-3.rs:6:14
    |
 LL |     let _x = -1_i64 >> 64;
    |              ^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-rsh-3.rs:4:9
+  --> $DIR/overflowing-rsh-3.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-4.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-4.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 // This function is checking that our (type-based) automatic

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-4.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-4.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-rsh-4.rs:11:13
+  --> $DIR/overflowing-rsh-4.rs:10:13
    |
 LL |     let x = 2_i8 >> 17;
    |             ^^^^^^^^^^ attempt to shift right by `17_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-rsh-4.rs:7:9
+  --> $DIR/overflowing-rsh-4.rs:6:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-5.rs
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-5.rs
@@ -1,4 +1,3 @@
-//@ build-fail
 //@ compile-flags: -C debug-assertions
 
 #![deny(arithmetic_overflow)]

--- a/tests/ui/numbers-arithmetic/overflowing-rsh-5.stderr
+++ b/tests/ui/numbers-arithmetic/overflowing-rsh-5.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/overflowing-rsh-5.rs:7:14
+  --> $DIR/overflowing-rsh-5.rs:6:14
    |
 LL |     let _n = 1i64 >> [64][0];
    |              ^^^^^^^^^^^^^^^ attempt to shift right by `64_i32`, which would overflow
    |
 note: the lint level is defined here
-  --> $DIR/overflowing-rsh-5.rs:4:9
+  --> $DIR/overflowing-rsh-5.rs:3:9
    |
 LL | #![deny(arithmetic_overflow)]
    |         ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/query-system/query_depth.rs
+++ b/tests/ui/query-system/query_depth.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 #![recursion_limit = "64"]
 type Byte = Option<Option<Option<Option< Option<Option<Option<Option<
     Option<Option<Option<Option< Option<Option<Option<Option<
@@ -26,6 +24,6 @@ type Byte = Option<Option<Option<Option< Option<Option<Option<Option<
 >>>> >>>>;
 
 fn main() {
-//~^ ERROR: queries overflow the depth limit!
+    //~^ ERROR: queries overflow the depth limit!
     println!("{}", std::mem::size_of::<Byte>());
 }

--- a/tests/ui/query-system/query_depth.stderr
+++ b/tests/ui/query-system/query_depth.stderr
@@ -1,5 +1,5 @@
 error: queries overflow the depth limit!
-  --> $DIR/query_depth.rs:28:1
+  --> $DIR/query_depth.rs:26:1
    |
 LL | fn main() {
    | ^^^^^^^^^

--- a/tests/ui/recursion/issue-26548-recursion-via-normalize.rs
+++ b/tests/ui/recursion/issue-26548-recursion-via-normalize.rs
@@ -1,9 +1,8 @@
-//~ ERROR cycle detected when computing layout of `core::option::Option<S>`
+//~ ERROR cycle detected when computing layout of `S`
 //~| NOTE see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
-//~| NOTE ...which requires computing layout of `S`...
+//~| NOTE ...which requires computing layout of `core::option::Option<S>`...
 //~| NOTE ...which requires computing layout of `core::option::Option<<S as Mirror>::It>`...
-//~| NOTE ...which again requires computing layout of `core::option::Option<S>`, completing the cycle
-//~| NOTE cycle used when computing layout of `core::option::Option<<S as Mirror>::It>`
+//~| NOTE ...which again requires computing layout of `S`, completing the cycle
 
 trait Mirror {
     type It: ?Sized;
@@ -14,5 +13,6 @@ impl<T: ?Sized> Mirror for T {
 struct S(Option<<S as Mirror>::It>);
 
 fn main() {
+    //~^ NOTE cycle used when running const prop lints for `main`
     let _s = S(None);
 }

--- a/tests/ui/recursion/issue-26548-recursion-via-normalize.stderr
+++ b/tests/ui/recursion/issue-26548-recursion-via-normalize.stderr
@@ -1,9 +1,13 @@
-error[E0391]: cycle detected when computing layout of `core::option::Option<S>`
+error[E0391]: cycle detected when computing layout of `S`
    |
-   = note: ...which requires computing layout of `S`...
    = note: ...which requires computing layout of `core::option::Option<<S as Mirror>::It>`...
-   = note: ...which again requires computing layout of `core::option::Option<S>`, completing the cycle
-   = note: cycle used when computing layout of `core::option::Option<<S as Mirror>::It>`
+   = note: ...which requires computing layout of `core::option::Option<S>`...
+   = note: ...which again requires computing layout of `S`, completing the cycle
+note: cycle used when running const prop lints for `main`
+  --> $DIR/issue-26548-recursion-via-normalize.rs:15:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
@@ -1,15 +1,65 @@
-error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/const-drop.rs:19:32
-   |
-LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                                ^ the destructor for this type cannot be evaluated in constant functions
-
 error[E0493]: destructor of `S<'_>` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:24:13
    |
 LL |     let _ = S(&mut c);
    |             ^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 2 previous errors
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<S<'_> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<S<'_>> - shim(Some(S<'_>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `b`
+  --> $DIR/const-drop.rs:24:22
+   |
+LL |     let _ = S(&mut c);
+   |                      ^
+note: inside `C`
+  --> $DIR/const-drop.rs:30:15
+   |
+LL | const C: u8 = b();
+   |               ^^^
 
-For more information about this error, try `rustc --explain E0493`.
+note: erroneous constant encountered
+  --> $DIR/const-drop.rs:115:16
+   |
+LL |     assert_eq!(C, 2);
+   |                ^
+
+note: erroneous constant encountered
+  --> $DIR/const-drop.rs:115:16
+   |
+LL |     assert_eq!(C, 2);
+   |                ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/const-drop.rs:115:5
+   |
+LL |     assert_eq!(C, 2);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: erroneous constant encountered
+  --> $DIR/const-drop.rs:115:5
+   |
+LL |     assert_eq!(C, 2);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/const-drop.rs:19:32
+   |
+LL | const fn a<T: ~const Destruct>(_: T) {}
+   |                                ^ the destructor for this type cannot be evaluated in constant functions
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0080, E0493.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/simd/type-generic-monomorphisation-empty.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-empty.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 #![feature(repr_simd, platform_intrinsics)]
 
 //@ error-pattern:monomorphising SIMD type `Simd<0>` of zero length

--- a/tests/ui/simd/type-generic-monomorphisation-non-primitive.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-non-primitive.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 #![feature(repr_simd)]
 
 struct E;

--- a/tests/ui/simd/type-generic-monomorphisation-oversized.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-oversized.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 #![feature(repr_simd, platform_intrinsics)]
 
 //@ error-pattern:monomorphising SIMD type `Simd<65536>` of length greater than 32768

--- a/tests/ui/simd/type-generic-monomorphisation-wide-ptr.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-wide-ptr.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 #![feature(repr_simd)]
 
 //@ error-pattern:monomorphising SIMD type `S<[*mut [u8]; 4]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`

--- a/tests/ui/simd/type-generic-monomorphisation.rs
+++ b/tests/ui/simd/type-generic-monomorphisation.rs
@@ -1,7 +1,4 @@
-//@ build-fail
-
 #![feature(repr_simd, platform_intrinsics)]
-
 
 //@ error-pattern:monomorphising SIMD type `Simd2<X>` with a non-primitive-scalar (integer/float/pointer) element type `X`
 

--- a/tests/ui/simd/type-wide-ptr.rs
+++ b/tests/ui/simd/type-wide-ptr.rs
@@ -1,5 +1,3 @@
-//@ build-fail
-
 #![feature(repr_simd)]
 
 //@ error-pattern:monomorphising SIMD type `S` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`

--- a/tests/ui/sized/recursive-type-binding.rs
+++ b/tests/ui/sized/recursive-type-binding.rs
@@ -1,5 +1,4 @@
-//@ build-fail
-//~^ ERROR cycle detected when computing layout of `Foo<()>`
+//~ ERROR cycle detected when computing layout of `Foo<()>`
 
 trait A { type Assoc: ?Sized; }
 

--- a/tests/ui/sized/recursive-type-binding.stderr
+++ b/tests/ui/sized/recursive-type-binding.stderr
@@ -2,8 +2,8 @@ error[E0391]: cycle detected when computing layout of `Foo<()>`
    |
    = note: ...which requires computing layout of `<() as A>::Assoc`...
    = note: ...which again requires computing layout of `Foo<()>`, completing the cycle
-note: cycle used when elaborating drops for `main`
-  --> $DIR/recursive-type-binding.rs:11:1
+note: cycle used when running const prop lints for `main`
+  --> $DIR/recursive-type-binding.rs:10:1
    |
 LL | fn main() {
    | ^^^^^^^^^

--- a/tests/ui/sized/recursive-type-coercion-from-never.rs
+++ b/tests/ui/sized/recursive-type-coercion-from-never.rs
@@ -1,5 +1,4 @@
-//@ build-fail
-//~^ ERROR cycle detected when computing layout of `Foo<()>`
+//~ ERROR cycle detected when computing layout of `Foo<()>`
 
 // Regression test for a stack overflow: https://github.com/rust-lang/rust/issues/113197
 

--- a/tests/ui/sized/recursive-type-coercion-from-never.stderr
+++ b/tests/ui/sized/recursive-type-coercion-from-never.stderr
@@ -2,8 +2,8 @@ error[E0391]: cycle detected when computing layout of `Foo<()>`
    |
    = note: ...which requires computing layout of `<() as A>::Assoc`...
    = note: ...which again requires computing layout of `Foo<()>`, completing the cycle
-note: cycle used when elaborating drops for `main`
-  --> $DIR/recursive-type-coercion-from-never.rs:14:1
+note: cycle used when running const prop lints for `main`
+  --> $DIR/recursive-type-coercion-from-never.rs:13:1
    |
 LL | fn main() {
    | ^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.rs
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.rs
@@ -1,5 +1,4 @@
 //@ edition: 2021
-//@ build-fail
 
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
+++ b/tests/ui/type-alias-impl-trait/indirect-recursion-issue-112047.stderr
@@ -1,5 +1,5 @@
 error[E0733]: recursion in an async block requires boxing
-  --> $DIR/indirect-recursion-issue-112047.rs:22:9
+  --> $DIR/indirect-recursion-issue-112047.rs:21:9
    |
 LL |         async move { recur(self).await; }
    |         ^^^^^^^^^^^^^-----------------^^^
@@ -7,7 +7,7 @@ LL |         async move { recur(self).await; }
    |                      recursive call here
    |
 note: which leads to this async fn
-  --> $DIR/indirect-recursion-issue-112047.rs:14:1
+  --> $DIR/indirect-recursion-issue-112047.rs:13:1
    |
 LL | async fn recur(t: impl Recur) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/issue-53092.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092.stderr
@@ -14,6 +14,12 @@ help: consider restricting type parameter `U`
 LL | type Bug<T, U: std::convert::From<T>> = impl Fn(T) -> U + Copy;
    |              +++++++++++++++++++++++
 
+note: erroneous constant encountered
+  --> $DIR/issue-53092.rs:18:5
+   |
+LL |     CONST_BUG(0);
+   |     ^^^^^^^^^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs
+++ b/tests/ui/type-alias-impl-trait/mututally-recursive-overflow.rs
@@ -1,6 +1,5 @@
 //@ edition: 2021
-//@ build-fail
-//~^^ ERROR overflow evaluating the requirement `<() as B>::Assoc == _`
+//~^ ERROR overflow evaluating the requirement `<() as B>::Assoc == _`
 
 #![feature(rustc_attrs)]
 #![feature(impl_trait_in_assoc_type)]

--- a/tests/ui/unsafe/unsafe-borrow.rs
+++ b/tests/ui/unsafe/unsafe-borrow.rs
@@ -1,5 +1,5 @@
 #![feature(rustc_attrs)]
-#![allow(unused,dead_code)]
+#![allow(unused, dead_code)]
 
 fn tuple_struct() {
     #[rustc_layout_scalar_valid_range_start(1)]
@@ -18,16 +18,6 @@ fn slice() {
     let mut foo = unsafe { NonZero(&mut nums[..]) };
     let a = &mut foo.0[2];
     // ^ not unsafe because there is an implicit dereference here
-}
-
-fn array() {
-    #[rustc_layout_scalar_valid_range_start(1)]
-    struct NonZero<T>([T; 4]);
-
-    let nums = [1, 2, 3, 4];
-    let mut foo = unsafe { NonZero(nums) };
-    let a = &mut foo.0[2];
-    //~^ ERROR: mutation of layout constrained field is unsafe
 }
 
 fn block() {

--- a/tests/ui/unsafe/unsafe-borrow.stderr
+++ b/tests/ui/unsafe/unsafe-borrow.stderr
@@ -7,21 +7,13 @@ LL |     let a = &mut foo.0.0;
    = note: mutating layout constrained fields cannot statically be checked for valid values
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:29:13
-   |
-LL |     let a = &mut foo.0[2];
-   |             ^^^^^^^^^^^^^ mutation of layout constrained field
-   |
-   = note: mutating layout constrained fields cannot statically be checked for valid values
-
-error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-borrow.rs:48:18
+  --> $DIR/unsafe-borrow.rs:38:18
    |
 LL |         NonZero((a,)) => *a = 0,
    |                  ^ mutation of layout constrained field
    |
    = note: mutating layout constrained fields cannot statically be checked for valid values
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
implements https://github.com/rust-lang/rust/pull/108730#issuecomment-1875557745

addresses a large part of #49292

Turns the const_prop_lint pass into a query that is run alongside borrowck.