### PR TITLE
Remove b-naber from the compiler review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -658,7 +658,6 @@ compiler-team = [
 ]
 compiler-team-contributors = [
     "@TaKO8Ki",
-    "@b-naber",
     "@nnethercote",
     "@fmease",
 ]


### PR DESCRIPTION
They have been inactive for over two months and occasionally S-waiting-on-review PRs didn't get reviewed for a while. I've stolen a few of them.

I've discussed this with @b-naber in private and they agreed to leave the review rotation for now.
Thank you very much for all the helpful PR reviews you did in the past! <3

r? compiler