### PR TITLE
`uncommon_codepoints`: lint against 00B7 MIDDLE DOT in final position

### DIFF
--- a/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.rs
+++ b/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.rs
@@ -11,3 +11,9 @@ fn main() {
     // using the same identifier the second time won't trigger the lint.
     println!("{}", ㇻㇲㇳ);
 }
+
+// 00B7 MIDDLE DOT '·' is linted against only in final position.
+
+const FOO·: () = (); //~ ERROR identifier contains an uncommon Unicode codepoint
+
+const FOL·LY: () = ();

--- a/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.stderr
+++ b/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.stderr
@@ -22,6 +22,12 @@ error: identifier contains uncommon Unicode codepoints: 'ㇻ', 'ㇲ', and 'ㇳ'
 LL |     let ㇻㇲㇳ = "rust";
    |         ^^^^^^
 
+error: identifier contains an uncommon Unicode codepoint: '·'
+  --> $DIR/lint-uncommon-codepoints.rs:17:7
+   |
+LL | const FOO·: () = ();
+   |       ^^^^
+
 warning: constant `µ` should have an upper case name
   --> $DIR/lint-uncommon-codepoints.rs:3:7
    |
@@ -30,5 +36,5 @@ LL | const µ: f64 = 0.000001;
    |
    = note: `#[warn(non_upper_case_globals)]` on by default
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors; 1 warning emitted
 


### PR DESCRIPTION
00B7 MIDDLE DOT '·' is considered by [UTS 39](https://unicode.org/reports/tr39/#Identifier_Status_and_Type) to be "Allowed - Inclusion" due to its presence in [UTR 31 Table 3a - Optional Characters for Medial](https://www.unicode.org/reports/tr31/#Table_Optional_Medial); as such, it is unsuitable for appearing in the final position of identifiers.

@rustbot label T-compiler A-diagnostics A-unicode