### PR TITLE
Remove `suffix` from `MetaItemLit`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1764,8 +1764,6 @@ pub enum StrStyle {
 pub struct MetaItemLit {
     /// The original literal as written in the source code.
     pub symbol: Symbol,
-    /// The original suffix as written in the source code.
-    pub suffix: Option<Symbol>,
     /// The "semantic" representation of the literal lowered from the original tokens.
     /// Strings are unescaped, hexadecimal forms are eliminated, etc.
     pub kind: LitKind,
@@ -1777,8 +1775,6 @@ pub struct MetaItemLit {
 pub struct StrLit {
     /// The original literal as written in source code.
     pub symbol: Symbol,
-    /// The original suffix as written in source code.
-    pub suffix: Option<Symbol>,
     /// The semantic (unescaped) representation of the literal.
     pub symbol_unescaped: Symbol,
     pub style: StrStyle,
@@ -1791,7 +1787,7 @@ impl StrLit {
             StrStyle::Cooked => token::Str,
             StrStyle::Raw(n) => token::StrRaw(n),
         };
-        token::Lit::new(token_kind, self.symbol, self.suffix)
+        token::Lit::new(token_kind, self.symbol, None)
     }
 }
 
@@ -3315,7 +3311,7 @@ mod size_asserts {
     static_assert_size!(Block, 32);
     static_assert_size!(Expr, 72);
     static_assert_size!(ExprKind, 40);
-    static_assert_size!(Fn, 160);
+    static_assert_size!(Fn, 152);
     static_assert_size!(ForeignItem, 96);
     static_assert_size!(ForeignItemKind, 24);
     static_assert_size!(GenericArg, 24);

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1872,28 +1872,24 @@ impl LitKind {
         matches!(self, LitKind::Int(..) | LitKind::Float(..))
     }
 
-    /// Returns `true` if this literal has no suffix.
-    /// Note: this will return true for literals with prefixes such as raw strings and byte strings.
-    pub fn is_unsuffixed(&self) -> bool {
-        !self.is_suffixed()
-    }
-
-    /// Returns `true` if this literal has a suffix.
-    pub fn is_suffixed(&self) -> bool {
+    pub fn suffix(&self) -> Option<Symbol> {
         match *self {
-            // suffixed variants
-            LitKind::Int(_, LitIntType::Signed(..) | LitIntType::Unsigned(..))
-            | LitKind::Float(_, LitFloatType::Suffixed(..)) => true,
-            // unsuffixed variants
+            LitKind::Int(_, kind) => match kind {
+                LitIntType::Signed(ty) => Some(ty.name()),
+                LitIntType::Unsigned(ty) => Some(ty.name()),
+                LitIntType::Unsuffixed => None,
+            },
+            LitKind::Float(_, kind) => match kind {
+                LitFloatType::Suffixed(ty) => Some(ty.name()),
+                LitFloatType::Unsuffixed => None,
+            },
             LitKind::Str(..)
             | LitKind::ByteStr(..)
             | LitKind::CStr(..)
             | LitKind::Byte(..)
             | LitKind::Char(..)
-            | LitKind::Int(_, LitIntType::Unsuffixed)
-            | LitKind::Float(_, LitFloatType::Unsuffixed)
             | LitKind::Bool(..)
-            | LitKind::Err => false,
+            | LitKind::Err => None,
         }
     }
 }

--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -218,7 +218,6 @@ impl MetaItemLit {
     pub fn from_token_lit(token_lit: token::Lit, span: Span) -> Result<MetaItemLit, LitError> {
         Ok(MetaItemLit {
             symbol: token_lit.symbol,
-            suffix: token_lit.suffix,
             kind: LitKind::from_token_lit(token_lit)?,
             span,
         })
@@ -241,7 +240,7 @@ impl MetaItemLit {
             LitKind::Err => token::Err,
         };
 
-        token::Lit::new(kind, self.symbol, self.suffix)
+        token::Lit::new(kind, self.symbol, self.kind.suffix())
     }
 
     /// Converts an arbitrary token into meta item literal.

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -968,12 +968,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 {
                     lit
                 } else {
-                    MetaItemLit {
-                        symbol: kw::Empty,
-                        suffix: None,
-                        kind: LitKind::Err,
-                        span: DUMMY_SP,
-                    }
+                    MetaItemLit { symbol: kw::Empty, kind: LitKind::Err, span: DUMMY_SP }
                 };
                 AttrArgs::Eq(*eq_span, AttrArgsEq::Hir(lit))
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2806,7 +2806,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             },
         ));
         let literal_is_ty_suffixed = |expr: &hir::Expr<'_>| {
-            if let hir::ExprKind::Lit(lit) = &expr.kind { lit.node.is_suffixed() } else { false }
+            if let hir::ExprKind::Lit(lit) = &expr.kind {
+                lit.node.suffix().is_some()
+            } else {
+                false
+            }
         };
         let is_negative_int =
             |expr: &hir::Expr<'_>| matches!(expr.kind, hir::ExprKind::Unary(hir::UnOp::Neg, ..));

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -326,7 +326,7 @@ impl<'a> Parser<'a> {
         let lit = self.parse_meta_item_lit()?;
         debug!("checking if {:?} is unsuffixed", lit);
 
-        if !lit.kind.is_unsuffixed() {
+        if lit.kind.suffix().is_some() {
             self.dcx().emit_err(SuffixedLiteralInAttribute { span: lit.span });
         }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2005,13 +2005,9 @@ impl<'a> Parser<'a> {
     pub fn parse_str_lit(&mut self) -> Result<ast::StrLit, Option<MetaItemLit>> {
         match self.parse_opt_meta_item_lit() {
             Some(lit) => match lit.kind {
-                ast::LitKind::Str(symbol_unescaped, style) => Ok(ast::StrLit {
-                    style,
-                    symbol: lit.symbol,
-                    suffix: lit.suffix,
-                    span: lit.span,
-                    symbol_unescaped,
-                }),
+                ast::LitKind::Str(symbol_unescaped, style) => {
+                    Ok(ast::StrLit { style, symbol: lit.symbol, span: lit.span, symbol_unescaped })
+                }
                 _ => Err(Some(lit)),
             },
             None => Err(None),
@@ -2025,7 +2021,6 @@ impl<'a> Parser<'a> {
     fn mk_meta_item_lit_char(name: Symbol, span: Span) -> MetaItemLit {
         ast::MetaItemLit {
             symbol: name,
-            suffix: None,
             kind: ast::LitKind::Char(name.as_str().chars().next().unwrap_or('_')),
             span,
         }

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -73,7 +73,6 @@ pub fn parse_meta<'a>(sess: &'a ParseSess, attr: &Attribute) -> PResult<'a, Meta
                             report_lit_error(sess, err, token_lit, expr.span);
                             let lit = ast::MetaItemLit {
                                 symbol: token_lit.symbol,
-                                suffix: token_lit.suffix,
                                 kind: ast::LitKind::Err,
                                 span: expr.span,
                             };

--- a/src/librustdoc/clean/cfg/tests.rs
+++ b/src/librustdoc/clean/cfg/tests.rs
@@ -23,7 +23,7 @@ fn dummy_meta_item_word(name: &str) -> MetaItem {
 }
 
 fn dummy_meta_item_name_value(name: &str, symbol: Symbol, kind: LitKind) -> MetaItem {
-    let lit = MetaItemLit { symbol, suffix: None, kind, span: DUMMY_SP };
+    let lit = MetaItemLit { symbol, kind, span: DUMMY_SP };
     MetaItem {
         path: Path::from_ident(Ident::from_str(name)),
         kind: MetaItemKind::NameValue(lit),

--- a/src/tools/clippy/clippy_lints/src/redundant_type_annotations.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_type_annotations.rs
@@ -197,7 +197,7 @@ impl LateLintPass<'_> for RedundantTypeAnnotations {
                         },
                         LitKind::Int(..) | LitKind::Float(..) => {
                             // If the initialization value is a suffixed literal we lint
-                            if init_lit.node.is_suffixed() {
+                            if init_lit.node.suffix().is_some() {
                                 span_lint(cx, REDUNDANT_TYPE_ANNOTATIONS, local.span, "redundant type annotation");
                             }
                         },

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -723,7 +723,7 @@ pub fn eq_ext(l: &Extern, r: &Extern) -> bool {
 }
 
 pub fn eq_str_lit(l: &StrLit, r: &StrLit) -> bool {
-    l.style == r.style && l.symbol == r.symbol && l.suffix == r.suffix
+    l.style == r.style && l.symbol == r.symbol
 }
 
 pub fn eq_poly_ref_trait(l: &PolyTraitRef, r: &PolyTraitRef) -> bool {

--- a/src/tools/rustfmt/tests/source/hex_literal_lower.rs
+++ b/src/tools/rustfmt/tests/source/hex_literal_lower.rs
@@ -2,4 +2,5 @@
 fn main() {
     let h1 = 0xCAFE_5EA7;
     let h2 = 0xCAFE_F00Du32;
+    let h3 = 0xCAFE_F00D_u32;
 }

--- a/src/tools/rustfmt/tests/target/hex_literal_lower.rs
+++ b/src/tools/rustfmt/tests/target/hex_literal_lower.rs
@@ -2,4 +2,5 @@
 fn main() {
     let h1 = 0xcafe_5ea7;
     let h2 = 0xcafe_f00du32;
+    let h3 = 0xcafe_f00d_u32;
 }


### PR DESCRIPTION
...as well as `StrLit` for which I believe it is always `None`. Otherwise, I believe the only functional change is in ast pretty printing where `1_u32` may change to `1u32`.