### PR TITLE
Don't expect early-bound region to be local when reporting errors in RPITIT well-formedness

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1193,7 +1193,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let (suitable_region_binding_scope, bound_region) = loop {
             let def_id = match region.kind() {
                 ty::ReLateParam(fr) => fr.bound_region.get_id()?.as_local()?,
-                ty::ReEarlyParam(ebr) => ebr.def_id.expect_local(),
+                ty::ReEarlyParam(ebr) => ebr.def_id.as_local()?,
                 _ => return None, // not a free region
             };
             let scope = self.local_parent(def_id);

--- a/tests/ui/async-await/in-trait/auxiliary/bad-region.rs
+++ b/tests/ui/async-await/in-trait/auxiliary/bad-region.rs
@@ -1,0 +1,7 @@
+// edition:2021
+
+#[allow(async_fn_in_trait)]
+
+pub trait BleRadio<'a> {
+    async fn transmit(&mut self);
+}

--- a/tests/ui/async-await/in-trait/bad-region.rs
+++ b/tests/ui/async-await/in-trait/bad-region.rs
@@ -1,0 +1,17 @@
+// aux-build:bad-region.rs
+// edition:2021
+
+#![allow(async_fn_in_trait)]
+
+extern crate bad_region as jewel;
+
+use jewel::BleRadio;
+
+pub struct Radio {}
+
+impl BleRadio for Radio {
+//~^ ERROR implicit elided lifetime not allowed here
+    async fn transmit(&mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/async-await/in-trait/bad-region.stderr
+++ b/tests/ui/async-await/in-trait/bad-region.stderr
@@ -1,0 +1,14 @@
+error[E0726]: implicit elided lifetime not allowed here
+  --> $DIR/bad-region.rs:12:6
+   |
+LL | impl BleRadio for Radio {
+   |      ^^^^^^^^ expected lifetime parameter
+   |
+help: indicate the anonymous lifetime
+   |
+LL | impl BleRadio<'_> for Radio {
+   |              ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0726`.


### PR DESCRIPTION
The implicit lifetime in the example code gets replaced with `ReError`, which fails a `sub_regions` check in the lexical region solver. Error reporting ends up calling `is_suitable_region` on an early bound region in the *trait* definition. This causes an ICE because we `expect_local()`.

This is kind of a bad explanation, but this code just makes diagnostics reporting a bit more gracefully fallible. If the reviewer wants a thorough investigation of exactly where we get this region outlives obligation, I can write one up. Doesn't really seem worth it, though, imo.

Fixes #120638
Fixes #120648