### PR TITLE
Add `or_try_*` variants for HashMap Entry API

### DIFF
--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2665,7 +2665,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// Ensures a value is in the entry by inserting the result of a fallible default function
     /// if empty, and returns a mutable reference to the value in the entry.
     ///
-    /// This methods works identically to [`or_insert_with`] except that the default function
+    /// This method works identically to [`or_insert_with`] except that the default function
     /// should return a `Result` and, in the case of an error, the error is propagated.
     ///
     /// [`or_insert_with`]: Self::or_insert_with
@@ -2726,7 +2726,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// This method allows for generating key-derived values for insertion by providing the default
     /// function a reference to the key that was moved during the `entry(key)` method call.
     ///
-    /// This methods works identically to [`or_insert_with_key`] except that the default function
+    /// This method works identically to [`or_insert_with_key`] except that the default function
     /// should return a `Result` and, in the case of an error, the error is propagated.
     ///
     /// [`or_insert_with_key`]: Self::or_insert_with_key

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2659,9 +2659,42 @@ impl<'a, K, V> Entry<'a, K, V> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        self.or_try_insert_with(|| Result::<_, !>::Ok(default())).unwrap()
+    }
+
+    /// Ensures a value is in the entry by inserting the result of a fallible default function
+    /// if empty, and returns a mutable reference to the value in the entry.
+    ///
+    /// This methods works identically to [`or_insert_with`] except that the default function
+    /// should return a `Result` and, in the case of an error, the error is propagated.
+    ///
+    /// [`or_insert_with`]: Self::or_insert_with
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(try_entry)]
+    /// # fn main() -> Result<(), std::num::ParseIntError> {
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map: HashMap<&str, usize> = HashMap::new();
+    /// let value = "42";
+    ///
+    /// map.entry("poneyland").or_try_insert_with(|| value.parse())?;
+    ///
+    /// assert_eq!(map["poneyland"], 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[unstable(feature = "try_entry", issue = "none")]
+    pub fn or_try_insert_with<F: FnOnce() -> Result<V, E>, E>(
+        self,
+        default: F,
+    ) -> Result<&'a mut V, E> {
         match self {
-            Occupied(entry) => entry.into_mut(),
-            Vacant(entry) => entry.insert(default()),
+            Occupied(entry) => Ok(entry.into_mut()),
+            Vacant(entry) => Ok(entry.insert(default()?)),
         }
     }
 
@@ -2686,11 +2719,44 @@ impl<'a, K, V> Entry<'a, K, V> {
     #[inline]
     #[stable(feature = "or_insert_with_key", since = "1.50.0")]
     pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
+        self.or_try_insert_with_key(|k| Result::<_, !>::Ok(default(k))).unwrap()
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    /// This method allows for generating key-derived values for insertion by providing the default
+    /// function a reference to the key that was moved during the `entry(key)` method call.
+    ///
+    /// This methods works identically to [`or_insert_with_key`] except that the default function
+    /// should return a `Result` and, in the case of an error, the error is propagated.
+    ///
+    /// [`or_insert_with_key`]: Self::or_insert_with_key
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(try_entry)]
+    /// # fn main() -> Result<(), std::num::ParseIntError> {
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map: HashMap<&str, usize> = HashMap::new();
+    ///
+    /// map.entry("42").or_try_insert_with_key(|key| key.parse())?;
+    ///
+    /// assert_eq!(map["42"], 42);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[unstable(feature = "try_entry", issue = "none")]
+    pub fn or_try_insert_with_key<F: FnOnce(&K) -> Result<V, E>, E>(
+        self,
+        default: F,
+    ) -> Result<&'a mut V, E> {
         match self {
-            Occupied(entry) => entry.into_mut(),
+            Occupied(entry) => Ok(entry.into_mut()),
             Vacant(entry) => {
-                let value = default(entry.key());
-                entry.insert(value)
+                let value = default(entry.key())?;
+                Ok(entry.insert(value))
             }
         }
     }


### PR DESCRIPTION
These methods are technically unneeded as you can implement them yourself by matching on `Entry::Occupied` and `Entry::Vacant`, but this makes it more ergonomic to use the `Entry` API in cases where construction of a value can fail.

I realise that the same methods can also be added to `BTreeMap`'s `Entry`, but I thought I'd wait to see if this was accepted first.

ACP: https://github.com/rust-lang/libs-team/issues/336