### PR TITLE
Make async closures test use async bound modifier

### DIFF
--- a/tests/ui/async-await/async-closures/async-fn-mut-for-async-fn.rs
+++ b/tests/ui/async-await/async-closures/async-fn-mut-for-async-fn.rs
@@ -5,17 +5,15 @@
 // FIXME(async_closures): When `fn_sig_for_fn_abi` is fixed, remove this.
 // ignore-pass (test emits codegen-time warnings)
 
-#![feature(async_closure, async_fn_traits)]
+#![feature(async_closure)]
 
 extern crate block_on;
-
-use std::ops::AsyncFnMut;
 
 fn main() {
     block_on::block_on(async {
         let x = async || {};
 
-        async fn needs_async_fn_mut(mut x: impl AsyncFnMut()) {
+        async fn needs_async_fn_mut(mut x: impl async FnMut()) {
             x().await;
         }
         needs_async_fn_mut(x).await;

--- a/tests/ui/async-await/async-closures/async-fn-once-for-async-fn.rs
+++ b/tests/ui/async-await/async-closures/async-fn-once-for-async-fn.rs
@@ -5,17 +5,15 @@
 // FIXME(async_closures): When `fn_sig_for_fn_abi` is fixed, remove this.
 // ignore-pass (test emits codegen-time warnings)
 
-#![feature(async_closure, async_fn_traits)]
+#![feature(async_closure)]
 
 extern crate block_on;
-
-use std::ops::AsyncFnOnce;
 
 fn main() {
     block_on::block_on(async {
         let x = async || {};
 
-        async fn needs_async_fn_once(x: impl AsyncFnOnce()) {
+        async fn needs_async_fn_once(x: impl async FnOnce()) {
             x().await;
         }
         needs_async_fn_once(x).await;

--- a/tests/ui/async-await/async-closures/auxiliary/block-on.rs
+++ b/tests/ui/async-await/async-closures/auxiliary/block-on.rs
@@ -1,6 +1,6 @@
 // edition: 2021
 
-#![feature(async_closure, noop_waker, async_fn_traits)]
+#![feature(async_closure, noop_waker)]
 
 use std::future::Future;
 use std::pin::pin;

--- a/tests/ui/async-await/async-closures/brand.rs
+++ b/tests/ui/async-await/async-closures/brand.rs
@@ -2,19 +2,18 @@
 // edition:2021
 // build-pass
 
-#![feature(async_closure, async_fn_traits)]
+#![feature(async_closure)]
 
 extern crate block_on;
 
 use std::future::Future;
 use std::marker::PhantomData;
-use std::ops::AsyncFn;
 
 struct S;
 struct B<'b>(PhantomData<&'b mut &'b mut ()>);
 
 impl S {
-    async fn q<F: AsyncFn(B<'_>)>(self, f: F) {
+    async fn q<F: async Fn(B<'_>)>(self, f: F) {
         f(B(PhantomData)).await;
     }
 }

--- a/tests/ui/async-await/async-closures/drop.rs
+++ b/tests/ui/async-await/async-closures/drop.rs
@@ -3,12 +3,10 @@
 // run-pass
 // check-run-results
 
-#![feature(async_closure, async_fn_traits)]
+#![feature(async_closure)]
 #![allow(unused)]
 
 extern crate block_on;
-
-use std::ops::AsyncFnOnce;
 
 struct DropMe(i32);
 
@@ -18,7 +16,7 @@ impl Drop for DropMe {
     }
 }
 
-async fn call_once(f: impl AsyncFnOnce()) {
+async fn call_once(f: impl async FnOnce()) {
     println!("before call");
     let fut = Box::pin(f());
     println!("after call");

--- a/tests/ui/async-await/async-closures/mangle.rs
+++ b/tests/ui/async-await/async-closures/mangle.rs
@@ -8,20 +8,19 @@
 // FIXME(async_closures): When `fn_sig_for_fn_abi` is fixed, remove this.
 // ignore-pass (test emits codegen-time warnings)
 
-#![feature(async_closure, noop_waker, async_fn_traits)]
+#![feature(async_closure, noop_waker)]
 
 extern crate block_on;
 
 use std::future::Future;
-use std::ops::{AsyncFnMut, AsyncFnOnce};
 use std::pin::pin;
 use std::task::*;
 
-async fn call_mut(f: &mut impl AsyncFnMut()) {
+async fn call_mut(f: &mut impl async FnMut()) {
     f().await;
 }
 
-async fn call_once(f: impl AsyncFnOnce()) {
+async fn call_once(f: impl async FnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.rs
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.rs
@@ -2,17 +2,15 @@
 
 // FIXME(async_closures): This needs a better error message!
 
-#![feature(async_closure, async_fn_traits)]
-
-use std::ops::AsyncFn;
+#![feature(async_closure)]
 
 fn main() {
-    fn needs_async_fn(_: impl AsyncFn()) {}
+    fn needs_async_fn(_: impl async Fn()) {}
 
     let mut x = 1;
     needs_async_fn(async || {
         //~^ ERROR i16: ops::async_function::internal_implementation_detail::AsyncFnKindHelper<i8>
-        // FIXME: Should say "closure is AsyncFnMut but it needs AsyncFn" or sth.
+        // FIXME: Should say "closure is `async FnMut` but it needs `async Fn`" or sth.
         x += 1;
     });
 }

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
@@ -1,21 +1,21 @@
 error[E0277]: the trait bound `i16: ops::async_function::internal_implementation_detail::AsyncFnKindHelper<i8>` is not satisfied
-  --> $DIR/wrong-fn-kind.rs:13:20
+  --> $DIR/wrong-fn-kind.rs:11:20
    |
 LL |       needs_async_fn(async || {
    |  _____--------------_^
    | |     |
    | |     required by a bound introduced by this call
 LL | |
-LL | |         // FIXME: Should say "closure is AsyncFnMut but it needs AsyncFn" or sth.
+LL | |         // FIXME: Should say "closure is `async FnMut` but it needs `async Fn`" or sth.
 LL | |         x += 1;
 LL | |     });
    | |_____^ the trait `ops::async_function::internal_implementation_detail::AsyncFnKindHelper<i8>` is not implemented for `i16`
    |
 note: required by a bound in `needs_async_fn`
-  --> $DIR/wrong-fn-kind.rs:10:31
+  --> $DIR/wrong-fn-kind.rs:8:31
    |
-LL |     fn needs_async_fn(_: impl AsyncFn()) {}
-   |                               ^^^^^^^^^ required by this bound in `needs_async_fn`
+LL |     fn needs_async_fn(_: impl async Fn()) {}
+   |                               ^^^^^^^^^^ required by this bound in `needs_async_fn`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Cosmetic change, separates the `AsyncFn` definitions from the tests.