### PR TITLE
fix `llvm_out` to use the correct LLVM root

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -98,7 +98,7 @@ pub fn prebuilt_llvm_config(
     let out_dir = builder.llvm_out(target);
 
     let mut llvm_config_ret_dir = builder.llvm_out(builder.config.build);
-    if !builder.config.build.is_msvc() || builder.ninja() {
+    if (!builder.config.build.is_msvc() || builder.ninja()) && !builder.config.llvm_from_ci {
         llvm_config_ret_dir.push("build");
     }
     llvm_config_ret_dir.push("bin");

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -525,6 +525,23 @@ mod dist {
     }
 
     #[test]
+    fn llvm_out_behaviour() {
+        let mut config = configure(&["A"], &["B"]);
+        config.llvm_from_ci = true;
+        let build = Build::new(config.clone());
+
+        let target = TargetSelection::from_user("A");
+        assert!(build.llvm_out(target).ends_with("ci-llvm"));
+        let target = TargetSelection::from_user("B");
+        assert!(build.llvm_out(target).ends_with("llvm"));
+
+        config.llvm_from_ci = false;
+        let build = Build::new(config.clone());
+        let target = TargetSelection::from_user("A");
+        assert!(build.llvm_out(target).ends_with("llvm"));
+    }
+
+    #[test]
     fn build_with_empty_host() {
         let config = configure(&[], &["C"]);
         let build = Build::new(config);

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -796,12 +796,16 @@ impl Build {
         self.stage_out(compiler, mode).join(&*target.triple).join(self.cargo_dir())
     }
 
-    /// Root output directory for LLVM compiled for `target`
+    /// Root output directory of LLVM for `target`
     ///
     /// Note that if LLVM is configured externally then the directory returned
     /// will likely be empty.
     fn llvm_out(&self, target: TargetSelection) -> PathBuf {
-        self.out.join(&*target.triple).join("llvm")
+        if self.config.llvm_from_ci && self.config.build == target {
+            self.config.ci_llvm_root()
+        } else {
+            self.out.join(&*target.triple).join("llvm")
+        }
     }
 
     fn lld_out(&self, target: TargetSelection) -> PathBuf {


### PR DESCRIPTION
When `download-ci-llvm` is enabled, `llvm_out` ends up with the
error below due to an incorrect path on cross-compilations. This change fixes that.

```sh
failed to execute command: "/rust/build/x86_64-unknown-linux-gnu/llvm/build/bin/llvm-config" "--version"
ERROR: No such file or directory (os error 2)
```