### PR TITLE
Provide more suggestions on invalid equality where bounds

### DIFF
--- a/tests/ui/generic-associated-types/equality-bound.rs
+++ b/tests/ui/generic-associated-types/equality-bound.rs
@@ -12,4 +12,60 @@ fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
     panic!()
 }
 
+use std::iter::FromIterator;
+
+struct X {}
+
+impl FromIterator<bool> for X {
+    fn from_iter<T>(_: T) -> Self
+    where
+        T: IntoIterator,
+        IntoIterator::Item = A,
+        //~^ ERROR equality constraints are not yet supported in `where` clauses
+        //~| ERROR cannot find type `A` in this scope
+    {
+        todo!()
+    }
+}
+
+struct Y {}
+
+impl FromIterator<bool> for Y {
+    fn from_iter<T>(_: T) -> Self
+    where
+        T: IntoIterator,
+        T::Item = A,
+        //~^ ERROR equality constraints are not yet supported in `where` clauses
+        //~| ERROR cannot find type `A` in this scope
+    {
+        todo!()
+    }
+}
+
+struct Z {}
+
+impl FromIterator<bool> for Z {
+    fn from_iter<T: IntoIterator>(_: T) -> Self
+    where
+        IntoIterator::Item = A,
+        //~^ ERROR equality constraints are not yet supported in `where` clauses
+        //~| ERROR cannot find type `A` in this scope
+    {
+        todo!()
+    }
+}
+
+struct K {}
+
+impl FromIterator<bool> for K {
+    fn from_iter<T: IntoIterator>(_: T) -> Self
+    where
+        T::Item = A,
+        //~^ ERROR equality constraints are not yet supported in `where` clauses
+        //~| ERROR cannot find type `A` in this scope
+    {
+        todo!()
+    }
+}
+
 fn main() {}

--- a/tests/ui/generic-associated-types/equality-bound.rs
+++ b/tests/ui/generic-associated-types/equality-bound.rs
@@ -17,10 +17,7 @@ use std::iter::FromIterator;
 struct X {}
 
 impl FromIterator<bool> for X {
-    fn from_iter<T>(_: T) -> Self
-    where
-        T: IntoIterator,
-        IntoIterator::Item = A,
+    fn from_iter<T>(_: T) -> Self where T: IntoIterator, IntoIterator::Item = A,
         //~^ ERROR equality constraints are not yet supported in `where` clauses
         //~| ERROR cannot find type `A` in this scope
     {
@@ -31,10 +28,7 @@ impl FromIterator<bool> for X {
 struct Y {}
 
 impl FromIterator<bool> for Y {
-    fn from_iter<T>(_: T) -> Self
-    where
-        T: IntoIterator,
-        T::Item = A,
+    fn from_iter<T>(_: T) -> Self where T: IntoIterator, T::Item = A,
         //~^ ERROR equality constraints are not yet supported in `where` clauses
         //~| ERROR cannot find type `A` in this scope
     {
@@ -45,9 +39,7 @@ impl FromIterator<bool> for Y {
 struct Z {}
 
 impl FromIterator<bool> for Z {
-    fn from_iter<T: IntoIterator>(_: T) -> Self
-    where
-        IntoIterator::Item = A,
+    fn from_iter<T: IntoIterator>(_: T) -> Self where IntoIterator::Item = A,
         //~^ ERROR equality constraints are not yet supported in `where` clauses
         //~| ERROR cannot find type `A` in this scope
     {
@@ -58,9 +50,7 @@ impl FromIterator<bool> for Z {
 struct K {}
 
 impl FromIterator<bool> for K {
-    fn from_iter<T: IntoIterator>(_: T) -> Self
-    where
-        T::Item = A,
+    fn from_iter<T: IntoIterator>(_: T) -> Self where T::Item = A,
         //~^ ERROR equality constraints are not yet supported in `where` clauses
         //~| ERROR cannot find type `A` in this scope
     {
@@ -68,4 +58,25 @@ impl FromIterator<bool> for K {
     }
 }
 
+struct L {}
+
+impl FromIterator<bool> for L {
+    fn from_iter<T>(_: T) -> Self where IntoIterator::Item = A, T: IntoIterator,
+        //~^ ERROR equality constraints are not yet supported in `where` clauses
+        //~| ERROR cannot find type `A` in this scope
+    {
+        todo!()
+    }
+}
+
+struct M {}
+
+impl FromIterator<bool> for M {
+    fn from_iter<T>(_: T) -> Self where T::Item = A, T: IntoIterator,
+        //~^ ERROR equality constraints are not yet supported in `where` clauses
+        //~| ERROR cannot find type `A` in this scope
+    {
+        todo!()
+    }
+}
 fn main() {}

--- a/tests/ui/generic-associated-types/equality-bound.stderr
+++ b/tests/ui/generic-associated-types/equality-bound.stderr
@@ -8,7 +8,7 @@ LL | fn sum<I: Iterator<Item = ()>>(i: I) -> i32 where I::Item = i32 {
 help: if `Iterator::Item` is an associated type you're trying to set, use the associated type binding syntax
    |
 LL - fn sum<I: Iterator<Item = ()>>(i: I) -> i32 where I::Item = i32 {
-LL + fn sum<I: Iterator<Item = (), Item = i32>>(i: I) -> i32 where  {
+LL + fn sum<I: Iterator<Item = (), Item = i32>>(i: I) -> i32  {
    |
 
 error: equality constraints are not yet supported in `where` clauses
@@ -21,7 +21,7 @@ LL | fn sum2<I: Iterator>(i: I) -> i32 where I::Item = i32 {
 help: if `Iterator::Item` is an associated type you're trying to set, use the associated type binding syntax
    |
 LL - fn sum2<I: Iterator>(i: I) -> i32 where I::Item = i32 {
-LL + fn sum2<I: Iterator<Item = i32>>(i: I) -> i32 where  {
+LL + fn sum2<I: Iterator<Item = i32>>(i: I) -> i32  {
    |
 
 error: equality constraints are not yet supported in `where` clauses
@@ -33,94 +33,136 @@ LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/equality-bound.rs:23:9
+  --> $DIR/equality-bound.rs:20:58
    |
-LL |         IntoIterator::Item = A,
-   |         ^^^^^^^^^^^^^^^^^^^^^^ not supported
+LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, IntoIterator::Item = A,
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
    |
-LL ~         T: IntoIterator<Item = A>,
-LL ~         ,
+LL -     fn from_iter<T>(_: T) -> Self where T: IntoIterator, IntoIterator::Item = A,
+LL +     fn from_iter<T>(_: T) -> Self where T: IntoIterator<Item = A>,
    |
 
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/equality-bound.rs:37:9
+  --> $DIR/equality-bound.rs:31:58
    |
-LL |         T::Item = A,
-   |         ^^^^^^^^^^^ not supported
+LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, T::Item = A,
+   |                                                          ^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
    |
-LL ~         T: IntoIterator<Item = A>,
-LL ~         ,
+LL -     fn from_iter<T>(_: T) -> Self where T: IntoIterator, T::Item = A,
+LL +     fn from_iter<T>(_: T) -> Self where T: IntoIterator<Item = A>,
    |
 
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/equality-bound.rs:50:9
+  --> $DIR/equality-bound.rs:42:55
    |
-LL |         IntoIterator::Item = A,
-   |         ^^^^^^^^^^^^^^^^^^^^^^ not supported
+LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where IntoIterator::Item = A,
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
    |
-LL ~     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self
-LL |     where
-LL ~         ,
+LL -     fn from_iter<T: IntoIterator>(_: T) -> Self where IntoIterator::Item = A,
+LL +     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self 
    |
 
 error: equality constraints are not yet supported in `where` clauses
-  --> $DIR/equality-bound.rs:63:9
+  --> $DIR/equality-bound.rs:53:55
    |
-LL |         T::Item = A,
-   |         ^^^^^^^^^^^ not supported
+LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where T::Item = A,
+   |                                                       ^^^^^^^^^^^ not supported
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
    |
-LL ~     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self
-LL |     where
-LL ~         ,
+LL -     fn from_iter<T: IntoIterator>(_: T) -> Self where T::Item = A,
+LL +     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self 
+   |
+
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-bound.rs:64:41
+   |
+LL |     fn from_iter<T>(_: T) -> Self where IntoIterator::Item = A, T: IntoIterator,
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL -     fn from_iter<T>(_: T) -> Self where IntoIterator::Item = A, T: IntoIterator,
+LL +     fn from_iter<T>(_: T) -> Self where T: IntoIterator<Item = A>,
+   |
+
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-bound.rs:75:41
+   |
+LL |     fn from_iter<T>(_: T) -> Self where T::Item = A, T: IntoIterator,
+   |                                         ^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL -     fn from_iter<T>(_: T) -> Self where T::Item = A, T: IntoIterator,
+LL +     fn from_iter<T>(_: T) -> Self where T: IntoIterator<Item = A>,
    |
 
 error[E0412]: cannot find type `A` in this scope
-  --> $DIR/equality-bound.rs:23:30
+  --> $DIR/equality-bound.rs:20:79
    |
-LL |         IntoIterator::Item = A,
-   |                              ^ help: a struct with a similar name exists: `K`
+LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, IntoIterator::Item = A,
+   |                                                                               ^ help: a struct with a similar name exists: `K`
 ...
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 
 error[E0412]: cannot find type `A` in this scope
-  --> $DIR/equality-bound.rs:37:19
+  --> $DIR/equality-bound.rs:31:68
    |
-LL |         T::Item = A,
-   |                   ^ help: a struct with a similar name exists: `K`
+LL |     fn from_iter<T>(_: T) -> Self where T: IntoIterator, T::Item = A,
+   |                                                                    ^ help: a struct with a similar name exists: `K`
 ...
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 
 error[E0412]: cannot find type `A` in this scope
-  --> $DIR/equality-bound.rs:50:30
+  --> $DIR/equality-bound.rs:42:76
    |
-LL |         IntoIterator::Item = A,
-   |                              ^ help: a struct with a similar name exists: `K`
+LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where IntoIterator::Item = A,
+   |                                                                            ^ help: a struct with a similar name exists: `K`
 ...
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 
 error[E0412]: cannot find type `A` in this scope
-  --> $DIR/equality-bound.rs:63:19
+  --> $DIR/equality-bound.rs:53:65
    |
 LL | struct K {}
    | -------- similarly named struct `K` defined here
 ...
-LL |         T::Item = A,
-   |                   ^ help: a struct with a similar name exists: `K`
+LL |     fn from_iter<T: IntoIterator>(_: T) -> Self where T::Item = A,
+   |                                                                 ^ help: a struct with a similar name exists: `K`
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/equality-bound.rs:64:62
+   |
+LL | struct K {}
+   | -------- similarly named struct `K` defined here
+...
+LL |     fn from_iter<T>(_: T) -> Self where IntoIterator::Item = A, T: IntoIterator,
+   |                                                              ^ help: a struct with a similar name exists: `K`
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/equality-bound.rs:75:51
+   |
+LL | struct K {}
+   | -------- similarly named struct `K` defined here
+...
+LL |     fn from_iter<T>(_: T) -> Self where T::Item = A, T: IntoIterator,
+   |                                                   ^ help: a struct with a similar name exists: `K`
 
 error[E0433]: failed to resolve: use of undeclared type `I`
   --> $DIR/equality-bound.rs:9:41
@@ -131,7 +173,7 @@ LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
    |                                         use of undeclared type `I`
    |                                         help: a type parameter with a similar name exists: `J`
 
-error: aborting due to 12 previous errors
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0412, E0433.
 For more information about an error, try `rustc --explain E0412`.

--- a/tests/ui/generic-associated-types/equality-bound.stderr
+++ b/tests/ui/generic-associated-types/equality-bound.stderr
@@ -32,6 +32,96 @@ LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
    |
    = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-bound.rs:23:9
+   |
+LL |         IntoIterator::Item = A,
+   |         ^^^^^^^^^^^^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL ~         T: IntoIterator<Item = A>,
+LL ~         ,
+   |
+
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-bound.rs:37:9
+   |
+LL |         T::Item = A,
+   |         ^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL ~         T: IntoIterator<Item = A>,
+LL ~         ,
+   |
+
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-bound.rs:50:9
+   |
+LL |         IntoIterator::Item = A,
+   |         ^^^^^^^^^^^^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL ~     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self
+LL |     where
+LL ~         ,
+   |
+
+error: equality constraints are not yet supported in `where` clauses
+  --> $DIR/equality-bound.rs:63:9
+   |
+LL |         T::Item = A,
+   |         ^^^^^^^^^^^ not supported
+   |
+   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
+help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
+   |
+LL ~     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self
+LL |     where
+LL ~         ,
+   |
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/equality-bound.rs:23:30
+   |
+LL |         IntoIterator::Item = A,
+   |                              ^ help: a struct with a similar name exists: `K`
+...
+LL | struct K {}
+   | -------- similarly named struct `K` defined here
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/equality-bound.rs:37:19
+   |
+LL |         T::Item = A,
+   |                   ^ help: a struct with a similar name exists: `K`
+...
+LL | struct K {}
+   | -------- similarly named struct `K` defined here
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/equality-bound.rs:50:30
+   |
+LL |         IntoIterator::Item = A,
+   |                              ^ help: a struct with a similar name exists: `K`
+...
+LL | struct K {}
+   | -------- similarly named struct `K` defined here
+
+error[E0412]: cannot find type `A` in this scope
+  --> $DIR/equality-bound.rs:63:19
+   |
+LL | struct K {}
+   | -------- similarly named struct `K` defined here
+...
+LL |         T::Item = A,
+   |                   ^ help: a struct with a similar name exists: `K`
+
 error[E0433]: failed to resolve: use of undeclared type `I`
   --> $DIR/equality-bound.rs:9:41
    |
@@ -41,6 +131,7 @@ LL | fn sum3<J: Iterator>(i: J) -> i32 where I::Item = i32 {
    |                                         use of undeclared type `I`
    |                                         help: a type parameter with a similar name exists: `J`
 
-error: aborting due to 4 previous errors
+error: aborting due to 12 previous errors
 
-For more information about this error, try `rustc --explain E0433`.
+Some errors have detailed explanations: E0412, E0433.
+For more information about an error, try `rustc --explain E0412`.


### PR DESCRIPTION
```
error: equality constraints are not yet supported in `where` clauses
  --> $DIR/equality-bound.rs:50:9
   |
LL |         IntoIterator::Item = A
   |         ^^^^^^^^^^^^^^^^^^^^^^ not supported
   |
   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
   |
LL ~     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self
LL ~
   |

error: equality constraints are not yet supported in `where` clauses
  --> $DIR/equality-bound.rs:63:9
   |
LL |         T::Item = A
   |         ^^^^^^^^^^^ not supported
   |
   = note: see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
help: if `IntoIterator::Item` is an associated type you're trying to set, use the associated type binding syntax
   |
LL ~     fn from_iter<T: IntoIterator<Item = A>>(_: T) -> Self
LL ~
   |
```

Fix #68982.