### PR TITLE
Suggest pattern tests when modifying exhaustiveness

### DIFF
--- a/src/tools/suggest-tests/src/dynamic_suggestions.rs
+++ b/src/tools/suggest-tests/src/dynamic_suggestions.rs
@@ -4,20 +4,29 @@ use crate::Suggestion;
 
 type DynamicSuggestion = fn(&Path) -> Vec<Suggestion>;
 
-pub(crate) const DYNAMIC_SUGGESTIONS: &[DynamicSuggestion] = &[|path: &Path| -> Vec<Suggestion> {
-    if path.starts_with("compiler/") || path.starts_with("library/") {
-        let path = path.components().take(2).collect::<Vec<_>>();
+pub(crate) const DYNAMIC_SUGGESTIONS: &[DynamicSuggestion] = &[
+    |path: &Path| -> Vec<Suggestion> {
+        if path.starts_with("compiler/") || path.starts_with("library/") {
+            let path = path.components().take(2).collect::<Vec<_>>();
 
-        vec![Suggestion::with_single_path(
-            "test",
-            None,
-            &format!(
-                "{}/{}",
-                path[0].as_os_str().to_str().unwrap(),
-                path[1].as_os_str().to_str().unwrap()
-            ),
-        )]
-    } else {
-        Vec::new()
-    }
-}];
+            vec![Suggestion::with_single_path(
+                "test",
+                None,
+                &format!(
+                    "{}/{}",
+                    path[0].as_os_str().to_str().unwrap(),
+                    path[1].as_os_str().to_str().unwrap()
+                ),
+            )]
+        } else {
+            Vec::new()
+        }
+    },
+    |path: &Path| -> Vec<Suggestion> {
+        if path.starts_with("compiler/rustc_pattern_analysis") {
+            vec![Suggestion::new("test", None, &["tests/ui", "--test-args", "pattern"])]
+        } else {
+            Vec::new()
+        }
+    },
+];


### PR DESCRIPTION
The vast majority of exhaustiveness tests are in `tests/ui/pattern`, this is what I've been using for years. This PR is me telling `x suggest` about that.

cc @Ezrashaw 