### PR TITLE
Add documentation on `str::starts_with`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1157,14 +1157,13 @@ impl str {
     ///
     /// Returns `false` if it does not.
     ///
-    /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
-    /// function or closure that determines if a character matches.
+    /// The [pattern] can be a `&str`, in which case this function will return true if
+    /// the `&str` is a prefix of this string slice.
     ///
-    /// Note that there is a footgun to this method when using a slice of [`char`]s.
-    /// Some users may expect that a slice of chars will behave similarly to a `&str` with this method.
-    /// That is not currently the case. When you pass a slice of [`char`]s to this method, it will return true
-    /// if any of the [`char`]s in the slice is the first [`char`] of this string slice. It does not work for
-    /// sequentially comparing a slice of [`char`]s to a string slice. See the second example below.
+    /// The [pattern] can also be a [`char`], a slice of [`char`]s, or a
+    /// function or closure that determines if a character matches.
+    /// These will only be checked against the first character of this string slice.
+    /// Look at the second example below regarding behavior for slices of [`char`]s.
     ///
     /// [`char`]: prim@char
     /// [pattern]: self::pattern

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1160,6 +1160,12 @@ impl str {
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
     ///
+    /// Note that there is a footgun to this method when using a slice of [`char`]s.
+    /// Some users may expect that a slice of chars will behave similarly to a `&str` with this method. 
+    /// That is not currently the case. When you pass a slice of [`char`]s to this method, it will return true
+    /// if any of the [`char`]s in the slice is the first [`char`] of this string slice. It does not work for
+    /// sequentially comparing a slice of [`char`]s to a string slice. See the second example below.
+    ///
     /// [`char`]: prim@char
     /// [pattern]: self::pattern
     ///
@@ -1170,6 +1176,14 @@ impl str {
     ///
     /// assert!(bananas.starts_with("bana"));
     /// assert!(!bananas.starts_with("nana"));
+    /// ```
+    /// 
+    /// ```
+    /// let bananas = "bananas";
+    /// 
+    /// // Note that both of these assert successfully. 
+    /// assert!(bananas.starts_with(&['b', 'a', 'n', 'a']));
+    /// assert!(bananas.starts_with(&['a', 'b', 'c', 'd']));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn starts_with<'a, P: Pattern<'a>>(&'a self, pat: P) -> bool {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1161,7 +1161,7 @@ impl str {
     /// function or closure that determines if a character matches.
     ///
     /// Note that there is a footgun to this method when using a slice of [`char`]s.
-    /// Some users may expect that a slice of chars will behave similarly to a `&str` with this method. 
+    /// Some users may expect that a slice of chars will behave similarly to a `&str` with this method.
     /// That is not currently the case. When you pass a slice of [`char`]s to this method, it will return true
     /// if any of the [`char`]s in the slice is the first [`char`] of this string slice. It does not work for
     /// sequentially comparing a slice of [`char`]s to a string slice. See the second example below.
@@ -1177,11 +1177,11 @@ impl str {
     /// assert!(bananas.starts_with("bana"));
     /// assert!(!bananas.starts_with("nana"));
     /// ```
-    /// 
+    ///
     /// ```
     /// let bananas = "bananas";
-    /// 
-    /// // Note that both of these assert successfully. 
+    ///
+    /// // Note that both of these assert successfully.
     /// assert!(bananas.starts_with(&['b', 'a', 'n', 'a']));
     /// assert!(bananas.starts_with(&['a', 'b', 'c', 'd']));
     /// ```


### PR DESCRIPTION
Add documentation about a current footgun of `str::starts_with`