### PR TITLE
large_assignments: Allow moves into functions

### DIFF
--- a/tests/ui/lint/large_assignments/copy_into_box_rc_arc.rs
+++ b/tests/ui/lint/large_assignments/copy_into_box_rc_arc.rs
@@ -2,7 +2,7 @@
 #![feature(large_assignments)]
 #![move_size_limit = "1000"]
 // build-fail
-// only-x86_64
+// only-64bit
 
 // edition:2018
 // compile-flags: -Zmir-opt-level=1

--- a/tests/ui/lint/large_assignments/copy_into_box_rc_arc.rs
+++ b/tests/ui/lint/large_assignments/copy_into_box_rc_arc.rs
@@ -17,6 +17,9 @@ fn main() {
     let _ = Arc::new(data); // OK!
     let _ = Box::new(data); // OK!
     let _ = Rc::new(data); // OK!
+
+    // Looking at --emit llvm-ir, we can see that a memcpy is involved in the
+    // parameter passing. So we want the lint to trigger here.
     let _ = NotBox::new(data); //~ ERROR large_assignments
 }
 
@@ -26,6 +29,8 @@ struct NotBox {
 
 impl NotBox {
     fn new(data: [u8; 9999]) -> Self {
+        // Looking at --emit llvm-ir, we can see that a memcpy is involved.
+        // So we want the lint to trigger here.
         Self { //~ ERROR large_assignments
             data,
         }

--- a/tests/ui/lint/large_assignments/copy_into_box_rc_arc.rs
+++ b/tests/ui/lint/large_assignments/copy_into_box_rc_arc.rs
@@ -1,0 +1,33 @@
+#![deny(large_assignments)]
+#![feature(large_assignments)]
+#![move_size_limit = "1000"]
+// build-fail
+// only-x86_64
+
+// edition:2018
+// compile-flags: -Zmir-opt-level=1
+
+use std::{sync::Arc, rc::Rc};
+
+fn main() {
+    let data = [0; 9999];
+
+    // Looking at --emit mir, we can see that all parameters below are passed by
+    // copy. But it requires at least mir-opt-level=1.
+    let _ = Arc::new(data); // OK!
+    let _ = Box::new(data); // OK!
+    let _ = Rc::new(data); // OK!
+    let _ = NotBox::new(data); //~ ERROR large_assignments
+}
+
+struct NotBox {
+    data: [u8; 9999],
+}
+
+impl NotBox {
+    fn new(data: [u8; 9999]) -> Self {
+        Self { //~ ERROR large_assignments
+            data,
+        }
+    }
+}

--- a/tests/ui/lint/large_assignments/copy_into_box_rc_arc.stderr
+++ b/tests/ui/lint/large_assignments/copy_into_box_rc_arc.stderr
@@ -1,5 +1,5 @@
 error: moving 9999 bytes
-  --> $DIR/copy_into_box_rc_arc.rs:20:25
+  --> $DIR/copy_into_box_rc_arc.rs:23:25
    |
 LL |     let _ = NotBox::new(data);
    |                         ^^^^ value moved from here
@@ -12,7 +12,7 @@ LL | #![deny(large_assignments)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: moving 9999 bytes
-  --> $DIR/copy_into_box_rc_arc.rs:29:9
+  --> $DIR/copy_into_box_rc_arc.rs:34:9
    |
 LL | /         Self {
 LL | |             data,

--- a/tests/ui/lint/large_assignments/copy_into_box_rc_arc.stderr
+++ b/tests/ui/lint/large_assignments/copy_into_box_rc_arc.stderr
@@ -1,0 +1,25 @@
+error: moving 9999 bytes
+  --> $DIR/copy_into_box_rc_arc.rs:20:25
+   |
+LL |     let _ = NotBox::new(data);
+   |                         ^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+note: the lint level is defined here
+  --> $DIR/copy_into_box_rc_arc.rs:1:9
+   |
+LL | #![deny(large_assignments)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: moving 9999 bytes
+  --> $DIR/copy_into_box_rc_arc.rs:29:9
+   |
+LL | /         Self {
+LL | |             data,
+LL | |         }
+   | |_________^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/lint/large_assignments/large_future.rs
+++ b/tests/ui/lint/large_assignments/large_future.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(attribute, feature(large_assignments))]
 #![cfg_attr(attribute, move_size_limit = "1000")]
 // build-fail
-// only-x86_64
+// only-64bit
 // revisions: attribute option
 // [option]compile-flags: -Zmove-size-limit=1000
 

--- a/tests/ui/lint/large_assignments/move_into_box_rc_arc.rs
+++ b/tests/ui/lint/large_assignments/move_into_box_rc_arc.rs
@@ -2,7 +2,7 @@
 #![feature(large_assignments)]
 #![move_size_limit = "1000"]
 // build-fail
-// only-x86_64
+// only-64bit
 
 // edition:2018
 // compile-flags: -Zmir-opt-level=0

--- a/tests/ui/lint/large_assignments/move_into_box_rc_arc.rs
+++ b/tests/ui/lint/large_assignments/move_into_box_rc_arc.rs
@@ -10,6 +10,8 @@
 use std::{sync::Arc, rc::Rc};
 
 fn main() {
+    // Looking at --emit mir, we can see that all parameters below are passed
+    // with by move.
     let _ = Arc::new([0; 9999]); // OK!
     let _ = Box::new([0; 9999]); // OK!
     let _ = Rc::new([0; 9999]); // OK!

--- a/tests/ui/lint/large_assignments/move_into_box_rc_arc.stderr
+++ b/tests/ui/lint/large_assignments/move_into_box_rc_arc.stderr
@@ -1,18 +1,18 @@
 error: moving 9999 bytes
-  --> $DIR/box_rc_arc_allowed.rs:16:25
+  --> $DIR/move_into_box_rc_arc.rs:18:25
    |
 LL |     let _ = NotBox::new([0; 9999]);
    |                         ^^^^^^^^^ value moved from here
    |
    = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
-  --> $DIR/box_rc_arc_allowed.rs:1:9
+  --> $DIR/move_into_box_rc_arc.rs:1:9
    |
 LL | #![deny(large_assignments)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: moving 9999 bytes
-  --> $DIR/box_rc_arc_allowed.rs:26:13
+  --> $DIR/move_into_box_rc_arc.rs:28:13
    |
 LL |             data,
    |             ^^^^ value moved from here

--- a/tests/ui/lint/large_assignments/move_into_fn.rs
+++ b/tests/ui/lint/large_assignments/move_into_fn.rs
@@ -1,0 +1,22 @@
+// build-fail
+
+#![feature(large_assignments)]
+#![move_size_limit = "1000"]
+#![deny(large_assignments)]
+#![allow(unused)]
+
+// Note: This type does not implement Copy.
+struct Data([u8; 9999]);
+
+fn main() {
+    // Looking at llvm-ir output, we can see a memcpy'd into Data, so we want
+    // the lint to trigger here.
+    let data = Data([100; 9999]); //~ ERROR large_assignments
+
+    // Looking at llvm-ir output, we can see that there is no memcpy involved in
+    // this function call. Instead, just a pointer is passed to the function. So
+    // the lint shall not trigger here.
+    take_data(data);
+}
+
+fn take_data(data: Data) {}

--- a/tests/ui/lint/large_assignments/move_into_fn.stderr
+++ b/tests/ui/lint/large_assignments/move_into_fn.stderr
@@ -1,12 +1,12 @@
 error: moving 9999 bytes
-  --> $DIR/move_into_box_rc_arc.rs:35:13
+  --> $DIR/move_into_fn.rs:14:16
    |
-LL |             data,
-   |             ^^^^ value moved from here
+LL |     let data = Data([100; 9999]);
+   |                ^^^^^^^^^^^^^^^^^ value moved from here
    |
    = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 note: the lint level is defined here
-  --> $DIR/move_into_box_rc_arc.rs:1:9
+  --> $DIR/move_into_fn.rs:5:9
    |
 LL | #![deny(large_assignments)]
    |         ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Moves into functions are typically implemented with pointer passing
rather than memcpy's at the llvm-ir level, so allow moves into
functions.

Part of the "Differentiate between Operand::Move and Operand::Copy" step of https://github.com/rust-lang/rust/issues/83518.

r? @oli-obk (who I think is still E-mentor?)