### PR TITLE
Properly deal with weak alias types as self types of impls

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -307,7 +307,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             tcx,
             &mut predicates,
             trait_ref,
-            &mut cgp::parameters_for_impl(self_ty, trait_ref),
+            &mut cgp::parameters_for_impl(tcx, self_ty, trait_ref),
         );
     }
 

--- a/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
+++ b/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
@@ -1,4 +1,5 @@
 use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_middle::ty::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitor};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Span;
@@ -27,12 +28,13 @@ impl From<ty::ParamConst> for Parameter {
 
 /// Returns the set of parameters constrained by the impl header.
 pub fn parameters_for_impl<'tcx>(
+    tcx: TyCtxt<'tcx>,
     impl_self_ty: Ty<'tcx>,
     impl_trait_ref: Option<ty::TraitRef<'tcx>>,
 ) -> FxHashSet<Parameter> {
     let vec = match impl_trait_ref {
-        Some(tr) => parameters_for(&tr, false),
-        None => parameters_for(&impl_self_ty, false),
+        Some(tr) => parameters_for(tcx, &tr, false),
+        None => parameters_for(tcx, &impl_self_ty, false),
     };
     vec.into_iter().collect()
 }
@@ -43,25 +45,46 @@ pub fn parameters_for_impl<'tcx>(
 /// of parameters whose values are needed in order to constrain `ty` - these
 /// differ, with the latter being a superset, in the presence of projections.
 pub fn parameters_for<'tcx>(
+    tcx: TyCtxt<'tcx>,
     t: &impl TypeVisitable<TyCtxt<'tcx>>,
     include_nonconstraining: bool,
 ) -> Vec<Parameter> {
-    let mut collector = ParameterCollector { parameters: vec![], include_nonconstraining };
+    let mut collector =
+        ParameterCollector { tcx, parameters: vec![], include_nonconstraining, depth: 0 };
     t.visit_with(&mut collector);
     collector.parameters
 }
 
-struct ParameterCollector {
+struct ParameterCollector<'tcx> {
+    tcx: TyCtxt<'tcx>,
     parameters: Vec<Parameter>,
     include_nonconstraining: bool,
+    depth: usize,
 }
 
-impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ParameterCollector {
+impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ParameterCollector<'tcx> {
     fn visit_ty(&mut self, t: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
         match *t.kind() {
-            ty::Alias(..) if !self.include_nonconstraining => {
-                // projections are not injective
+            ty::Alias(ty::Projection | ty::Inherent | ty::Opaque, _)
+                if !self.include_nonconstraining =>
+            {
+                // Projections are not injective in general.
                 return ControlFlow::Continue(());
+            }
+            ty::Alias(ty::Weak, alias) if !self.include_nonconstraining => {
+                if !self.tcx.recursion_limit().value_within_limit(self.depth) {
+                    // Other constituent types may still constrain some generic params, consider
+                    // `<T> (Overflow, T)` for example. Therefore we want to continue instead of
+                    // breaking. Only affects diagnostics.
+                    return ControlFlow::Continue(());
+                }
+                self.depth += 1;
+                return ensure_sufficient_stack(|| {
+                    self.tcx
+                        .type_of(alias.def_id)
+                        .instantiate(self.tcx, alias.args)
+                        .visit_with(self)
+                });
             }
             ty::Param(data) => {
                 self.parameters.push(Parameter::from(data));
@@ -82,7 +105,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ParameterCollector {
     fn visit_const(&mut self, c: ty::Const<'tcx>) -> ControlFlow<Self::BreakTy> {
         match c.kind() {
             ty::ConstKind::Unevaluated(..) if !self.include_nonconstraining => {
-                // Constant expressions are not injective
+                // Constant expressions are not injective in general.
                 return c.ty().visit_with(self);
             }
             ty::ConstKind::Param(data) => {
@@ -201,12 +224,12 @@ pub fn setup_constraining_predicates<'tcx>(
                 //     `<<T as Bar>::Baz as Iterator>::Output = <U as Iterator>::Output`
                 // Then the projection only applies if `T` is known, but it still
                 // does not determine `U`.
-                let inputs = parameters_for(&projection.projection_ty, true);
+                let inputs = parameters_for(tcx, &projection.projection_ty, true);
                 let relies_only_on_inputs = inputs.iter().all(|p| input_parameters.contains(p));
                 if !relies_only_on_inputs {
                     continue;
                 }
-                input_parameters.extend(parameters_for(&projection.term, false));
+                input_parameters.extend(parameters_for(tcx, &projection.term, false));
             } else {
                 continue;
             }

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -94,7 +94,7 @@ fn enforce_impl_params_are_constrained(
     let impl_predicates = tcx.predicates_of(impl_def_id);
     let impl_trait_ref = tcx.impl_trait_ref(impl_def_id).map(ty::EarlyBinder::instantiate_identity);
 
-    let mut input_parameters = cgp::parameters_for_impl(impl_self_ty, impl_trait_ref);
+    let mut input_parameters = cgp::parameters_for_impl(tcx, impl_self_ty, impl_trait_ref);
     cgp::identify_constrained_generic_params(
         tcx,
         impl_predicates,
@@ -111,7 +111,7 @@ fn enforce_impl_params_are_constrained(
             match item.kind {
                 ty::AssocKind::Type => {
                     if item.defaultness(tcx).has_value() {
-                        cgp::parameters_for(&tcx.type_of(def_id).instantiate_identity(), true)
+                        cgp::parameters_for(tcx, &tcx.type_of(def_id).instantiate_identity(), true)
                     } else {
                         vec![]
                     }

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -266,15 +266,15 @@ fn unconstrained_parent_impl_args<'tcx>(
                 continue;
             }
 
-            unconstrained_parameters.extend(cgp::parameters_for(&projection_ty, true));
+            unconstrained_parameters.extend(cgp::parameters_for(tcx, &projection_ty, true));
 
-            for param in cgp::parameters_for(&projected_ty, false) {
+            for param in cgp::parameters_for(tcx, &projected_ty, false) {
                 if !unconstrained_parameters.contains(&param) {
                     constrained_params.insert(param.0);
                 }
             }
 
-            unconstrained_parameters.extend(cgp::parameters_for(&projected_ty, true));
+            unconstrained_parameters.extend(cgp::parameters_for(tcx, &projected_ty, true));
         }
     }
 
@@ -312,7 +312,7 @@ fn check_duplicate_params<'tcx>(
     parent_args: &Vec<GenericArg<'tcx>>,
     span: Span,
 ) -> Result<(), ErrorGuaranteed> {
-    let mut base_params = cgp::parameters_for(parent_args, true);
+    let mut base_params = cgp::parameters_for(tcx, parent_args, true);
     base_params.sort_by_key(|param| param.0);
     if let (_, [duplicate, ..]) = base_params.partition_dedup() {
         let param = impl1_args[duplicate.0 as usize];

--- a/tests/ui/lazy-type-alias/constrained-params.rs
+++ b/tests/ui/lazy-type-alias/constrained-params.rs
@@ -1,0 +1,27 @@
+//@ check-pass
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Injective<T> = Local<T>;
+struct Local<T>(T);
+
+impl<T> Injective<T> {
+    fn take(_: T) {}
+}
+
+trait Trait {
+    type Out;
+    fn produce() -> Self::Out;
+}
+
+impl<T: Default> Trait for Injective<T> {
+    type Out = T;
+    fn produce() -> Self::Out { T::default() }
+}
+
+fn main() {
+    Injective::take(0);
+    let _: String = Injective::produce();
+    let _: bool = Local::produce();
+}

--- a/tests/ui/lazy-type-alias/inherent-impls-conflicting.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-conflicting.rs
@@ -1,0 +1,10 @@
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Alias = Local;
+struct Local;
+
+impl Alias { fn method() {} } //~ ERROR duplicate definitions with name `method`
+impl Local { fn method() {} }
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/inherent-impls-conflicting.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-conflicting.stderr
@@ -1,0 +1,11 @@
+error[E0592]: duplicate definitions with name `method`
+  --> $DIR/inherent-impls-conflicting.rs:7:14
+   |
+LL | impl Alias { fn method() {} }
+   |              ^^^^^^^^^^^ duplicate definitions for `method`
+LL | impl Local { fn method() {} }
+   |              ----------- other definition for `method`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0592`.

--- a/tests/ui/lazy-type-alias/inherent-impls-not-nominal.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-not-nominal.rs
@@ -1,0 +1,12 @@
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Alias = <() as Trait>::Out;
+
+trait Trait { type Out; }
+impl Trait for () { type Out = Local; }
+struct Local;
+
+impl Alias {} //~ ERROR no nominal type found for inherent implementation
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/inherent-impls-not-nominal.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-not-nominal.stderr
@@ -1,0 +1,11 @@
+error[E0118]: no nominal type found for inherent implementation
+  --> $DIR/inherent-impls-not-nominal.rs:10:1
+   |
+LL | impl Alias {}
+   | ^^^^^^^^^^ impl requires a nominal type
+   |
+   = note: either implement a trait on it or create a newtype to wrap it instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0118`.

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.classic.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.classic.stderr
@@ -1,0 +1,43 @@
+error[E0275]: overflow evaluating the requirement `Loop`
+  --> $DIR/inherent-impls-overflow.rs:7:13
+   |
+LL | type Loop = Loop;
+   |             ^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow evaluating the requirement `Loop`
+  --> $DIR/inherent-impls-overflow.rs:9:1
+   |
+LL | impl Loop {}
+   | ^^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow evaluating the requirement `Poly0<((((((...,),),),),),)>`
+  --> $DIR/inherent-impls-overflow.rs:11:17
+   |
+LL | type Poly0<T> = Poly1<(T,)>;
+   |                 ^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow evaluating the requirement `Poly1<((((((...,),),),),),)>`
+  --> $DIR/inherent-impls-overflow.rs:14:17
+   |
+LL | type Poly1<T> = Poly0<(T,)>;
+   |                 ^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error[E0275]: overflow evaluating the requirement `Poly1<((((((...,),),),),),)>`
+  --> $DIR/inherent-impls-overflow.rs:18:1
+   |
+LL | impl Poly0<()> {}
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.next.stderr
@@ -1,0 +1,38 @@
+error[E0275]: overflow evaluating the requirement `Loop == _`
+  --> $DIR/inherent-impls-overflow.rs:9:6
+   |
+LL | impl Loop {}
+   |      ^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/inherent-impls-overflow.rs:11:12
+   |
+LL | type Poly0<T> = Poly1<(T,)>;
+   |            ^ unused type parameter
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/inherent-impls-overflow.rs:14:12
+   |
+LL | type Poly1<T> = Poly0<(T,)>;
+   |            ^ unused type parameter
+   |
+   = help: consider removing `T` or referring to it in the body of the type alias
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0275]: overflow evaluating the requirement `Poly0<()> == _`
+  --> $DIR/inherent-impls-overflow.rs:18:6
+   |
+LL | impl Poly0<()> {}
+   |      ^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`inherent_impls_overflow`)
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0275, E0392.
+For more information about an error, try `rustc --explain E0275`.

--- a/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls-overflow.rs
@@ -1,0 +1,20 @@
+//@ revisions: classic next
+//@[next] compile-flags: -Znext-solver
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Loop = Loop; //[classic]~ ERROR overflow evaluating the requirement
+
+impl Loop {} //~ ERROR overflow evaluating the requirement
+
+type Poly0<T> = Poly1<(T,)>;
+//[classic]~^ ERROR overflow evaluating the requirement
+//[next]~^^ ERROR type parameter `T` is never used
+type Poly1<T> = Poly0<(T,)>;
+//[classic]~^ ERROR overflow evaluating the requirement
+//[next]~^^ ERROR type parameter `T` is never used
+
+impl Poly0<()> {} //~ ERROR overflow evaluating the requirement
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/inherent-impls.rs
+++ b/tests/ui/lazy-type-alias/inherent-impls.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Alias = Local;
+struct Local;
+
+impl Alias {
+    fn method(self) {}
+}
+
+fn main() {
+    let _ = Local.method();
+    let _ = Local::method;
+    let _ = Alias {}.method();
+    let _ = Alias::method;
+}

--- a/tests/ui/lazy-type-alias/unconstrained-param-due-to-overflow.rs
+++ b/tests/ui/lazy-type-alias/unconstrained-param-due-to-overflow.rs
@@ -1,0 +1,8 @@
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+impl<T> Loop<T> {} //~ ERROR the type parameter `T` is not constrained
+
+type Loop<T> = Loop<T>;
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/unconstrained-param-due-to-overflow.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-param-due-to-overflow.stderr
@@ -1,0 +1,9 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-param-due-to-overflow.rs:4:6
+   |
+LL | impl<T> Loop<T> {}
+   |      ^ unconstrained type parameter
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/lazy-type-alias/unconstrained-params.rs
+++ b/tests/ui/lazy-type-alias/unconstrained-params.rs
@@ -1,0 +1,12 @@
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+impl<T> NotInjective<T> {} //~ ERROR the type parameter `T` is not constrained
+
+type NotInjective<T: ?Sized> = Local<<T as Discard>::Out>;
+struct Local<T>(T);
+
+trait Discard { type Out; }
+impl<T: ?Sized> Discard for T { type Out = (); }
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/unconstrained-params.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-params.stderr
@@ -1,0 +1,9 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-params.rs:4:6
+   |
+LL | impl<T> NotInjective<T> {}
+   |      ^ unconstrained type parameter
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0207`.


### PR DESCRIPTION
Fixes #114216.
Fixes #116100.

Not super happy about the two ad hoc “normalization” implementations for weak alias types:

1. In `inherent_impls`: The “peeling”, normalization to [“WHNF”][whnf]: Semantically that's exactly what we want (neither proper normalization nor shallow normalization would be correct here). Basically a weak alias type is “nominal” (well...^^) if the WHNF is nominal. [#97974](https://github.com/rust-lang/rust/pull/97974) followed the same approach.
2. In `constrained_generic_params`: Generic parameters are constrained by a weak alias type if the corresp. “normalized” type constrains them (where we only normalize *weak* alias types not arbitrary ones). Weak alias types are injective if the corresp. “normalized” type is injective.

Both have ad hoc overflow detection mechanisms.

**Coherence** is handled in #117164.

r? @oli-obk or types

[whnf]: https://en.wikipedia.org/wiki/Lambda_calculus_definition#Weak_head_normal_form