### PR TITLE
Add release note for new ambiguous_wide_pointer_comparisons lint

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@ Language
 - [Document Rust ABI compatibility between various types](https://github.com/rust-lang/rust/pull/115476/)
 - [Also: guarantee that char and u32 are ABI-compatible](https://github.com/rust-lang/rust/pull/118032/)
 - [Warn against ambiguous wide pointer comparisons](https://github.com/rust-lang/rust/pull/117758/)
+- [Add lint `ambiguous_wide_pointer_comparisons` that supersedes `clippy::vtable_address_comparisons`](https://github.com/rust-lang/rust/pull/117758)
 
 <a id="1.76.0-Compiler"></a>
 


### PR DESCRIPTION
I found out about this new lint in Rust because I had code allowing the Clippy lint. Clippy alerted me to the lint name change, and I went searching for the new lint's name in the release notes and was surprised there wasn't an item for it.