### PR TITLE
Avoid ICE in drop recursion check in case of invalid drop impls

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1312,6 +1312,7 @@ impl<'tcx> PolyFnSig<'tcx> {
         self.map_bound_ref_unchecked(|fn_sig| fn_sig.inputs())
     }
     #[inline]
+    #[track_caller]
     pub fn input(&self, index: usize) -> ty::Binder<'tcx, Ty<'tcx>> {
         self.map_bound_ref(|fn_sig| fn_sig.inputs()[index])
     }

--- a/tests/ui/drop/recursion-check-on-erroneous-impl.rs
+++ b/tests/ui/drop/recursion-check-on-erroneous-impl.rs
@@ -1,0 +1,11 @@
+// can't use build-fail, because this also fails check-fail, but
+// the ICE from #120787 only reproduces on build-fail.
+// compile-flags: --emit=mir
+
+struct PrintOnDrop<'a>(&'a str);
+
+impl Drop for PrintOnDrop<'_> {
+    fn drop() {} //~ ERROR method `drop` has a `&mut self` declaration in the trait
+}
+
+fn main() {}

--- a/tests/ui/drop/recursion-check-on-erroneous-impl.stderr
+++ b/tests/ui/drop/recursion-check-on-erroneous-impl.stderr
@@ -1,0 +1,11 @@
+error[E0186]: method `drop` has a `&mut self` declaration in the trait, but not in the impl
+  --> $DIR/recursion-check-on-erroneous-impl.rs:8:5
+   |
+LL |     fn drop() {}
+   |     ^^^^^^^^^ expected `&mut self` in impl
+   |
+   = note: `drop` from trait: `fn(&mut Self)`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0186`.


### PR DESCRIPTION
fixes #120787