### PR TITLE
Fix more `ty::Error` ICEs in MIR passes

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -60,6 +60,8 @@ impl<'tcx> MirPass<'tcx> for Validator {
                 ty::Closure(..) => Abi::RustCall,
                 ty::CoroutineClosure(..) => Abi::RustCall,
                 ty::Coroutine(..) => Abi::Rust,
+                // No need to do MIR validation on error bodies
+                ty::Error(_) => return,
                 _ => {
                     span_bug!(body.span, "unexpected body ty: {:?} phase {:?}", body_ty, mir_phase)
                 }

--- a/tests/ui/async-await/async-closures/tainted-body.rs
+++ b/tests/ui/async-await/async-closures/tainted-body.rs
@@ -1,0 +1,13 @@
+// edition:2021
+
+#![feature(async_closure)]
+
+// Don't ICE in ByMove shim builder when MIR body is tainted by writeback errors
+
+fn main() {
+    let _ = async || {
+        used_fn();
+        //~^ ERROR cannot find function `used_fn` in this scope
+        0
+    };
+}

--- a/tests/ui/async-await/async-closures/tainted-body.stderr
+++ b/tests/ui/async-await/async-closures/tainted-body.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `used_fn` in this scope
+  --> $DIR/tainted-body.rs:9:9
+   |
+LL |         used_fn();
+   |         ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/mir/validate/error-body.rs
+++ b/tests/ui/mir/validate/error-body.rs
@@ -1,0 +1,9 @@
+// compile-flags: -Zvalidate-mir
+
+fn _test() {
+    let x = || 45;
+    missing();
+    //~^ ERROR cannot find function `missing` in this scope
+}
+
+fn main() {}

--- a/tests/ui/mir/validate/error-body.stderr
+++ b/tests/ui/mir/validate/error-body.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `missing` in this scope
+  --> $DIR/error-body.rs:5:5
+   |
+LL |     missing();
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes #120791 - Add a check for `ty::Error` in the `ByMove` coroutine pass
Fixes #120816 - Add a check for `ty::Error` in the MIR validator

Also a drive-by fix for a FIXME I had asked oli to add

r? oli-obk