### PR TITLE
Startup objects disappearing from sysroot

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -173,6 +173,8 @@ impl Step for Std {
         {
             builder.info("WARNING: Using a potentially old libstd. This may not behave well.");
 
+            builder.ensure(StartupObjects { compiler, target });
+
             self.copy_extra_objects(builder, &compiler, target);
 
             builder.ensure(StdLink::from_std(self, compiler));


### PR DESCRIPTION
When launching tests with --keep-stage option, startup objects such as rsbegin.o an rsend.o may disappear from the corresponding stageN compiler.

Fix issue #120784