### PR TITLE
Build DebugInfo for async closures

### DIFF
--- a/tests/codegen/async-closure-debug.rs
+++ b/tests/codegen/async-closure-debug.rs
@@ -1,0 +1,21 @@
+// Just make sure that async closures don't ICE.
+//
+// compile-flags: -C debuginfo=2 --edition=2018
+// ignore-msvc
+
+// CHECK-DAG:  [[GEN_FN:!.*]] = !DINamespace(name: "async_closure_test"
+// CHECK-DAG:  [[CLOSURE:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "{closure_env#0}", scope: [[GEN_FN]]
+// CHECK-DAG:  [[UPVAR:!.*]] = !DIDerivedType(tag: DW_TAG_member, name: "upvar", scope: [[CLOSURE]]
+
+#![feature(async_closure)]
+
+fn async_closure_test(upvar: &str) -> impl async Fn() + '_ {
+    async move || {
+        let hello = String::from("hello");
+        println!("{hello}, {upvar}");
+    }
+}
+
+fn main() {
+    let _async_closure = async_closure_test("world");
+}

--- a/tests/ui/async-await/async-closures/async-fn-mut-for-async-fn.rs
+++ b/tests/ui/async-await/async-closures/async-fn-mut-for-async-fn.rs
@@ -2,9 +2,6 @@
 // edition:2021
 // run-pass
 
-// FIXME(async_closures): When `fn_sig_for_fn_abi` is fixed, remove this.
-// ignore-pass (test emits codegen-time warnings)
-
 #![feature(async_closure)]
 
 extern crate block_on;

--- a/tests/ui/async-await/async-closures/async-fn-once-for-async-fn.rs
+++ b/tests/ui/async-await/async-closures/async-fn-once-for-async-fn.rs
@@ -2,9 +2,6 @@
 // edition:2021
 // run-pass
 
-// FIXME(async_closures): When `fn_sig_for_fn_abi` is fixed, remove this.
-// ignore-pass (test emits codegen-time warnings)
-
 #![feature(async_closure)]
 
 extern crate block_on;


### PR DESCRIPTION
The test is pretty bare, because I don't really know how to write debuginfo tests. I'd like to land this first, and then flesh it out correctly one it's no longer ICEing on master (which breaks people's ability to test using async closures).

r? oli-obk cc @rust-lang/wg-debugging (if any of y'all want to help me write a more fleshed out async closures test)