### PR TITLE
Continue compilation after check_mod_type_wf errors

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -187,8 +187,10 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
     }
 
     tcx.sess.time("wf_checking", || {
-        tcx.hir().try_par_for_each_module(|module| tcx.ensure().check_mod_type_wf(module))
-    })?;
+        tcx.hir().par_for_each_module(|module| {
+            let _ = tcx.ensure().check_mod_type_wf(module);
+        })
+    });
 
     if tcx.features().rustc_attrs {
         collect::test_opaque_hidden_types(tcx)?;

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -518,12 +518,9 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                         .report_mismatched_types(&cause, method_self_ty, self_ty, terr)
                         .emit();
                 } else {
-                    span_bug!(
-                        self.span,
-                        "{} was a subtype of {} but now is not?",
-                        self_ty,
-                        method_self_ty
-                    );
+                    error!("{self_ty} was a subtype of {method_self_ty} but now is not?");
+                    // This must already have errored elsewhere.
+                    self.dcx().has_errors().unwrap();
                 }
             }
         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -3112,10 +3112,11 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             obligation.param_env,
             trait_ref.args.const_at(3),
         ) else {
-            span_bug!(
+            self.dcx().span_delayed_bug(
                 span,
-                "Unable to construct rustc_transmute::Assume where it was previously possible"
+                "Unable to construct rustc_transmute::Assume where it was previously possible",
             );
+            return GetSafeTransmuteErrorAndReason::Silent;
         };
 
         match rustc_transmute::TransmuteTypeEnv::new(self.infcx).is_transmutable(

--- a/tests/ui/abi/issues/issue-22565-rust-call.rs
+++ b/tests/ui/abi/issues/issue-22565-rust-call.rs
@@ -25,7 +25,11 @@ impl Tr for Foo {
 
 fn main() {
     b(10);
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
     Foo::bar();
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
     <Foo as Tr>::a();
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
     <Foo as Tr>::b();
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
 }

--- a/tests/ui/abi/issues/issue-22565-rust-call.stderr
+++ b/tests/ui/abi/issues/issue-22565-rust-call.stderr
@@ -28,6 +28,30 @@ error: functions with the "rust-call" ABI must take a single non-self tuple argu
 LL |     extern "rust-call" fn b() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error[E0277]: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/issue-22565-rust-call.rs:27:7
+   |
+LL |     b(10);
+   |       ^^ the trait `Tuple` is not implemented for `i32`
+
+error: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/issue-22565-rust-call.rs:29:5
+   |
+LL |     Foo::bar();
+   |     ^^^^^^^^^^
+
+error: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/issue-22565-rust-call.rs:31:5
+   |
+LL |     <Foo as Tr>::a();
+   |     ^^^^^^^^^^^^^^^^
+
+error: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/issue-22565-rust-call.rs:33:5
+   |
+LL |     <Foo as Tr>::b();
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -7,6 +7,7 @@ trait Trait {
 impl dyn Trait {
     //~^ ERROR the trait `Trait` cannot be made into an object [E0038]
     const fn n() -> usize { Self::N }
+    //~^ ERROR the trait `Trait` cannot be made into an object [E0038]
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -13,6 +13,21 @@ LL |     const N: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `N` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/associated-const-in-trait.rs:9:29
+   |
+LL |     const fn n() -> usize { Self::N }
+   |                             ^^^^ `Trait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
+LL |     const N: usize;
+   |           ^ ...because it contains this associated `const`
+   = help: consider moving `N` to another trait
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/associated-consts/issue-105330.rs
+++ b/tests/ui/associated-consts/issue-105330.rs
@@ -10,10 +10,15 @@ impl TraitWAssocConst for impl Demo { //~ ERROR E0404
 
 fn foo<A: TraitWAssocConst<A=32>>() { //~ ERROR E0658
     foo::<Demo>()();
+    //~^ ERROR is not satisfied
+    //~| ERROR type mismatch
+    //~| ERROR expected function, found `()`
 }
 
 fn main<A: TraitWAssocConst<A=32>>() {
     //~^ ERROR E0658
     //~| ERROR E0131
     foo::<Demo>();
+    //~^ ERROR type mismatch
+    //~| ERROR is not satisfied
 }

--- a/tests/ui/associated-consts/issue-105330.stderr
+++ b/tests/ui/associated-consts/issue-105330.stderr
@@ -26,7 +26,7 @@ LL | fn foo<A: TraitWAssocConst<A=32>>() {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: associated const equality is incomplete
-  --> $DIR/issue-105330.rs:15:29
+  --> $DIR/issue-105330.rs:18:29
    |
 LL | fn main<A: TraitWAssocConst<A=32>>() {
    |                             ^^^^
@@ -44,12 +44,76 @@ LL | impl TraitWAssocConst for impl Demo {
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0131]: `main` function is not allowed to have generic parameters
-  --> $DIR/issue-105330.rs:15:8
+  --> $DIR/issue-105330.rs:18:8
    |
 LL | fn main<A: TraitWAssocConst<A=32>>() {
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `main` cannot have generic parameters
 
-error: aborting due to 6 previous errors
+error[E0277]: the trait bound `Demo: TraitWAssocConst` is not satisfied
+  --> $DIR/issue-105330.rs:12:11
+   |
+LL |     foo::<Demo>()();
+   |           ^^^^ the trait `TraitWAssocConst` is not implemented for `Demo`
+   |
+   = help: the trait `TraitWAssocConst` is implemented for `{type error}`
+note: required by a bound in `foo`
+  --> $DIR/issue-105330.rs:11:11
+   |
+LL | fn foo<A: TraitWAssocConst<A=32>>() {
+   |           ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
 
-Some errors have detailed explanations: E0131, E0404, E0562, E0658.
+error[E0271]: type mismatch resolving `<Demo as TraitWAssocConst>::A == 32`
+  --> $DIR/issue-105330.rs:12:11
+   |
+LL |     foo::<Demo>()();
+   |           ^^^^ expected `32`, found `<Demo as TraitWAssocConst>::A`
+   |
+   = note: expected constant `32`
+              found constant `<Demo as TraitWAssocConst>::A`
+note: required by a bound in `foo`
+  --> $DIR/issue-105330.rs:11:28
+   |
+LL | fn foo<A: TraitWAssocConst<A=32>>() {
+   |                            ^^^^ required by this bound in `foo`
+
+error[E0618]: expected function, found `()`
+  --> $DIR/issue-105330.rs:12:5
+   |
+LL | fn foo<A: TraitWAssocConst<A=32>>() {
+   | ----------------------------------- `foo::<Demo>` defined here returns `()`
+LL |     foo::<Demo>()();
+   |     ^^^^^^^^^^^^^--
+   |     |
+   |     call expression requires function
+
+error[E0277]: the trait bound `Demo: TraitWAssocConst` is not satisfied
+  --> $DIR/issue-105330.rs:21:11
+   |
+LL |     foo::<Demo>();
+   |           ^^^^ the trait `TraitWAssocConst` is not implemented for `Demo`
+   |
+   = help: the trait `TraitWAssocConst` is implemented for `{type error}`
+note: required by a bound in `foo`
+  --> $DIR/issue-105330.rs:11:11
+   |
+LL | fn foo<A: TraitWAssocConst<A=32>>() {
+   |           ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error[E0271]: type mismatch resolving `<Demo as TraitWAssocConst>::A == 32`
+  --> $DIR/issue-105330.rs:21:11
+   |
+LL |     foo::<Demo>();
+   |           ^^^^ expected `32`, found `<Demo as TraitWAssocConst>::A`
+   |
+   = note: expected constant `32`
+              found constant `<Demo as TraitWAssocConst>::A`
+note: required by a bound in `foo`
+  --> $DIR/issue-105330.rs:11:28
+   |
+LL | fn foo<A: TraitWAssocConst<A=32>>() {
+   |                            ^^^^ required by this bound in `foo`
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0131, E0271, E0277, E0404, E0562, E0618, E0658.
 For more information about an error, try `rustc --explain E0131`.

--- a/tests/ui/associated-inherent-types/issue-109299.rs
+++ b/tests/ui/associated-inherent-types/issue-109299.rs
@@ -8,5 +8,6 @@ impl Lexer<'d> { //~ ERROR use of undeclared lifetime name `'d`
 }
 
 fn test(_: Lexer::Cursor) {}
+//~^ ERROR: lifetime may not live long enough
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109299.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299.stderr
@@ -6,6 +6,15 @@ LL | impl Lexer<'d> {
    |     |
    |     help: consider introducing lifetime `'d` here: `<'d>`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/issue-109299.rs:10:1
+   |
+LL | fn test(_: Lexer::Cursor) {}
+   | ^^^^^^^^-^^^^^^^^^^^^^^^^
+   | |       |
+   | |       has type `Lexer<'1>::Cursor`
+   | requires that `'1` must outlive `'static`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0261`.

--- a/tests/ui/associated-inherent-types/issue-109789.rs
+++ b/tests/ui/associated-inherent-types/issue-109789.rs
@@ -18,5 +18,7 @@ impl Other for u32 {}
 fn bar(_: Foo<for<'a> fn(&'a ())>::Assoc) {}
 //~^ ERROR mismatched types
 //~| ERROR mismatched types
+//~| ERROR higher-ranked subtype error
+//~| ERROR higher-ranked subtype error
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/issue-109789.stderr
+++ b/tests/ui/associated-inherent-types/issue-109789.stderr
@@ -17,6 +17,20 @@ LL | fn bar(_: Foo<for<'a> fn(&'a ())>::Assoc) {}
               found struct `Foo<for<'a> fn(&'a ())>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error: higher-ranked subtype error
+  --> $DIR/issue-109789.rs:18:1
+   |
+LL | fn bar(_: Foo<for<'a> fn(&'a ())>::Assoc) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: higher-ranked subtype error
+  --> $DIR/issue-109789.rs:18:1
+   |
+LL | fn bar(_: Foo<for<'a> fn(&'a ())>::Assoc) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/associated-inherent-types/regionck-2.rs
+++ b/tests/ui/associated-inherent-types/regionck-2.rs
@@ -10,5 +10,6 @@ impl Lexer<'static> {
 }
 
 fn test(_: Lexer::Cursor) {} //~ ERROR mismatched types
+//~^ ERROR: lifetime may not live long enough
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/regionck-2.stderr
+++ b/tests/ui/associated-inherent-types/regionck-2.stderr
@@ -13,6 +13,15 @@ LL | fn test(_: Lexer::Cursor) {}
    |            ^^^^^
    = note: ...does not necessarily outlive the static lifetime
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/regionck-2.rs:12:1
+   |
+LL | fn test(_: Lexer::Cursor) {}
+   | ^^^^^^^^-^^^^^^^^^^^^^^^^
+   | |       |
+   | |       has type `Lexer<'1>::Cursor`
+   | requires that `'1` must outlive `'static`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.fixed
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.fixed
@@ -8,9 +8,9 @@ trait Get {
 }
 
 trait Other {
-    fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
+    fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized, Self: Get, Self: Get {}
     //~^ ERROR the trait bound `Self: Get` is not satisfied
+    //~| ERROR the trait bound `Self: Get` is not satisfied
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.rs
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.rs
@@ -8,9 +8,9 @@ trait Get {
 }
 
 trait Other {
-    fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
+    fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized {}
     //~^ ERROR the trait bound `Self: Get` is not satisfied
+    //~| ERROR the trait bound `Self: Get` is not satisfied
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.stderr
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.stderr
@@ -1,14 +1,25 @@
 error[E0277]: the trait bound `Self: Get` is not satisfied
-  --> $DIR/associated-types-for-unimpl-trait.rs:11:40
+  --> $DIR/associated-types-for-unimpl-trait.rs:11:41
    |
-LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
-   |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
+LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized {}
+   |                                         ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
 help: consider further restricting `Self`
    |
-LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
-   |                                                              +++++++++++++++
+LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized, Self: Get {}
+   |                                                                                +++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `Self: Get` is not satisfied
+  --> $DIR/associated-types-for-unimpl-trait.rs:11:81
+   |
+LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized {}
+   |                                                                                 ^^ the trait `Get` is not implemented for `Self`
+   |
+help: consider further restricting `Self`
+   |
+LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized, Self: Get {}
+   |                                                                                +++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-types-no-suitable-bound.rs
+++ b/tests/ui/associated-types/associated-types-no-suitable-bound.rs
@@ -10,7 +10,7 @@ struct Struct {
 impl Struct {
     fn uhoh<T>(foo: <T as Get>::Value) {}
     //~^ ERROR the trait bound `T: Get` is not satisfied
+    //~| ERROR the trait bound `T: Get` is not satisfied
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/associated-types/associated-types-no-suitable-bound.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-bound.stderr
@@ -9,6 +9,17 @@ help: consider restricting type parameter `T`
 LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}
    |              +++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `T: Get` is not satisfied
+  --> $DIR/associated-types-no-suitable-bound.rs:11:40
+   |
+LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
+   |                                        ^^ the trait `Get` is not implemented for `T`
+   |
+help: consider restricting type parameter `T`
+   |
+LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}
+   |              +++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait-2.rs
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait-2.rs
@@ -16,6 +16,7 @@ trait Get {
 trait Other {
     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
     //~^ ERROR the trait bound `Self: Get` is not satisfied
+    //~| ERROR the trait bound `Self: Get` is not satisfied
 }
 
 fn main() { }

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait-2.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait-2.stderr
@@ -9,6 +9,17 @@ help: consider further restricting `Self`
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
    |                                                              +++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `Self: Get` is not satisfied
+  --> $DIR/associated-types-no-suitable-supertrait-2.rs:17:62
+   |
+LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
+   |                                                              ^^ the trait `Get` is not implemented for `Self`
+   |
+help: consider further restricting `Self`
+   |
+LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
+   |                                                              +++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait.rs
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait.rs
@@ -16,11 +16,13 @@ trait Get {
 trait Other {
     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
     //~^ ERROR the trait bound `Self: Get` is not satisfied
+    //~| ERROR the trait bound `Self: Get` is not satisfied
 }
 
 impl<T:Get> Other for T {
     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
     //~^ ERROR the trait bound `(T, U): Get` is not satisfied
+    //~| ERROR the trait bound `(T, U): Get` is not satisfied
     //~| ERROR the trait bound `(T, U): Get` is not satisfied
 }
 

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `(T, U): Get` is not satisfied
-  --> $DIR/associated-types-no-suitable-supertrait.rs:22:5
+  --> $DIR/associated-types-no-suitable-supertrait.rs:23:5
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `(T, U)`
@@ -11,7 +11,7 @@ LL | trait Get {
    | ^^^^^^^^^
 
 error[E0277]: the trait bound `(T, U): Get` is not satisfied
-  --> $DIR/associated-types-no-suitable-supertrait.rs:22:40
+  --> $DIR/associated-types-no-suitable-supertrait.rs:23:40
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
    |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `(T, U)`
@@ -33,6 +33,29 @@ help: consider further restricting `Self`
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
    |                                                              +++++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `Self: Get` is not satisfied
+  --> $DIR/associated-types-no-suitable-supertrait.rs:17:62
+   |
+LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
+   |                                                              ^^ the trait `Get` is not implemented for `Self`
+   |
+help: consider further restricting `Self`
+   |
+LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
+   |                                                              +++++++++++++++
+
+error[E0277]: the trait bound `(T, U): Get` is not satisfied
+  --> $DIR/associated-types-no-suitable-supertrait.rs:23:64
+   |
+LL |     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
+   |                                                                ^^ the trait `Get` is not implemented for `(T, U)`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/associated-types-no-suitable-supertrait.rs:12:1
+   |
+LL | trait Get {
+   | ^^^^^^^^^
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-1.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-1.rs
@@ -15,4 +15,5 @@ impl X<'_> for i32 {
 
 fn main() {
     1i32.f("abc");
+    //~^ ERROR the trait bound `str: Clone`
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-1.stderr
@@ -14,6 +14,22 @@ LL | where
 LL |     for<'b> <Self as X<'b>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-1.rs:17:10
+   |
+LL |     1i32.f("abc");
+   |          ^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `X::f`
+  --> $DIR/hr-associated-type-bound-1.rs:3:33
+   |
+LL |     for<'b> <Self as X<'b>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X::f`
+...
+LL |     fn f(&self, x: &Self::U) {
+   |        - required by a bound in this associated function
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-object.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-object.rs
@@ -7,6 +7,9 @@ where
 fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) {
     //~^ ERROR the trait bound `for<'b> <T as X<'b>>::U: Clone` is not satisfied
     <<T as X<'_>>::U>::clone(x);
+    //~^ ERROR the trait bound `for<'b> <T as X<'b>>::U: Clone` is not satisfied
+    //~| ERROR the trait bound `for<'b> <T as X<'b>>::U: Clone` is not satisfied
+    //~| ERROR the trait bound `<T as X<'_>>::U: Clone` is not satisfied
 }
 
 pub fn main() {

--- a/tests/ui/associated-types/hr-associated-type-bound-object.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-object.stderr
@@ -17,6 +17,55 @@ help: consider further restricting the associated type
 LL | fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) where for<'b> <T as X<'b>>::U: Clone {
    |                                                  ++++++++++++++++++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `for<'b> <T as X<'b>>::U: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-object.rs:9:7
+   |
+LL |     <<T as X<'_>>::U>::clone(x);
+   |       ^ the trait `for<'b> Clone` is not implemented for `<T as X<'b>>::U`
+   |
+note: required by a bound in `X::U`
+  --> $DIR/hr-associated-type-bound-object.rs:3:33
+   |
+LL |     for<'b> <Self as X<'b>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X::U`
+LL | {
+LL |     type U: ?Sized;
+   |          - required by a bound in this associated type
+help: consider further restricting the associated type
+   |
+LL | fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) where for<'b> <T as X<'b>>::U: Clone {
+   |                                                  ++++++++++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `<T as X<'_>>::U: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-object.rs:9:6
+   |
+LL |     <<T as X<'_>>::U>::clone(x);
+   |      ^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<T as X<'_>>::U`
+   |
+help: consider further restricting the associated type
+   |
+LL | fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) where <T as X<'_>>::U: Clone {
+   |                                                  ++++++++++++++++++++++++++++
+
+error[E0277]: the trait bound `for<'b> <T as X<'b>>::U: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-object.rs:9:5
+   |
+LL |     <<T as X<'_>>::U>::clone(x);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'b> Clone` is not implemented for `<T as X<'b>>::U`
+   |
+note: required by a bound in `X`
+  --> $DIR/hr-associated-type-bound-object.rs:3:33
+   |
+LL | trait X<'a>
+   |       - required by a bound in this trait
+LL | where
+LL |     for<'b> <Self as X<'b>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X`
+help: consider further restricting the associated type
+   |
+LL | fn f<'a, T: X<'a> + ?Sized>(x: &<T as X<'a>>::U) where for<'b> <T as X<'b>>::U: Clone {
+   |                                                  ++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-param-1.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-1.rs
@@ -17,4 +17,5 @@ impl<'a> Y<'a, u8> for u8 {
 
 fn main() {
     1u8.g("abc");
+    //~^ ERROR the trait bound `str: Clone` is not satisfied
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-1.stderr
@@ -14,6 +14,22 @@ LL | trait Y<'a, T: ?Sized>
 LL |     for<'b> <Self as Y<'b, T>>::V: Clone,
    |                                    ^^^^^ required by this bound in `Y`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-1.rs:19:9
+   |
+LL |     1u8.g("abc");
+   |         ^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `Y::g`
+  --> $DIR/hr-associated-type-bound-param-1.rs:4:36
+   |
+LL |     for<'b> <Self as Y<'b, T>>::V: Clone,
+   |                                    ^^^^^ required by this bound in `Y::g`
+...
+LL |     fn g(&self, x: &Self::V) {
+   |        - required by a bound in this associated function
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.rs
@@ -8,6 +8,8 @@ where
     type W: ?Sized;
     fn h(&self, x: &T::W) {
         <T::W>::clone(x);
+        //~^ the trait bound `str: Clone` is not satisfied
+        //~| the trait bound `str: Clone` is not satisfied
     }
 }
 
@@ -18,4 +20,5 @@ impl<'a> Z<'a, u16> for u16 {
 
 fn main() {
     1u16.h("abc");
+    //~^ ERROR Clone` is not satisfied
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.stderr
@@ -15,7 +15,7 @@ LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
 
 error[E0277]: the trait bound `str: Clone` is not satisfied
-  --> $DIR/hr-associated-type-bound-param-2.rs:15:14
+  --> $DIR/hr-associated-type-bound-param-2.rs:17:14
    |
 LL |     type W = str;
    |              ^^^ the trait `Clone` is not implemented for `str`, which is required by `for<'b> <u16 as Z<'b, u16>>::W: Clone`
@@ -47,6 +47,54 @@ LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
    |                                   ^^^^^ required by this bound in `Z`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-2.rs:10:10
+   |
+LL |         <T::W>::clone(x);
+   |          ^^^^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `Z::W`
+  --> $DIR/hr-associated-type-bound-param-2.rs:6:35
+   |
+LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
+   |                                   ^^^^^ required by this bound in `Z::W`
+LL | {
+LL |     type W: ?Sized;
+   |          - required by a bound in this associated type
+
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-2.rs:10:9
+   |
+LL |         <T::W>::clone(x);
+   |         ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `Z`
+  --> $DIR/hr-associated-type-bound-param-2.rs:6:35
+   |
+LL | trait Z<'a, T: ?Sized>
+   |       - required by a bound in this trait
+...
+LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
+   |                                   ^^^^^ required by this bound in `Z`
+
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-2.rs:22:10
+   |
+LL |     1u16.h("abc");
+   |          ^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `Z::h`
+  --> $DIR/hr-associated-type-bound-param-2.rs:6:35
+   |
+LL |     for<'b> <T as Z<'b, u16>>::W: Clone,
+   |                                   ^^^^^ required by this bound in `Z::h`
+...
+LL |     fn h(&self, x: &T::W) {
+   |        - required by a bound in this associated function
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-param-3.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-3.rs
@@ -16,4 +16,5 @@ impl<S, T> X<'_, (T,)> for (S,) {
 
 pub fn main() {
     <(i32,) as X<(i32,)>>::f("abc");
+    //~^ ERROR the trait bound `str: Clone` is not satisfied
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-3.stderr
@@ -14,6 +14,22 @@ LL | trait X<'a, T>
 LL |     for<'b> <T as X<'b, T>>::U: Clone,
    |                                 ^^^^^ required by this bound in `X`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-3.rs:18:5
+   |
+LL |     <(i32,) as X<(i32,)>>::f("abc");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `X::f`
+  --> $DIR/hr-associated-type-bound-param-3.rs:4:33
+   |
+LL |     for<'b> <T as X<'b, T>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X::f`
+...
+LL |     fn f(x: &<T as X<'_, T>>::U) {
+   |        - required by a bound in this associated function
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-param-4.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-4.rs
@@ -16,4 +16,5 @@ impl<S, T> X<'_, T> for (S,) {
 
 pub fn main() {
     <(i32,) as X<i32>>::f("abc");
+    //~^ ERROR the trait bound `str: Clone` is not satisfied
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-4.stderr
@@ -14,6 +14,22 @@ LL | trait X<'a, T>
 LL |     for<'b> <(T,) as X<'b, T>>::U: Clone,
    |                                    ^^^^^ required by this bound in `X`
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-4.rs:18:5
+   |
+LL |     <(i32,) as X<i32>>::f("abc");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `X::f`
+  --> $DIR/hr-associated-type-bound-param-4.rs:4:36
+   |
+LL |     for<'b> <(T,) as X<'b, T>>::U: Clone,
+   |                                    ^^^^^ required by this bound in `X::f`
+...
+LL |     fn f(x: &<(T,) as X<'_, T>>::U) {
+   |        - required by a bound in this associated function
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-param-5.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-5.rs
@@ -34,4 +34,5 @@ impl<S, T> X<'_, Box<T>> for S {
 
 pub fn main() {
     <i32 as X<Box<i32>>>::f("abc");
+    //~^ ERROR the trait bound `str: Clone` is not satisfied
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-5.stderr
@@ -30,6 +30,22 @@ LL | trait X<'a, T: Cycle + for<'b> X<'b, T>>
 LL |     for<'b> <T::Next as X<'b, T::Next>>::U: Clone,
    |                                             ^^^^^ required by this bound in `X`
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `str: Clone` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-5.rs:36:5
+   |
+LL |     <i32 as X<Box<i32>>>::f("abc");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |
+   = help: the trait `Clone` is implemented for `String`
+note: required by a bound in `X::f`
+  --> $DIR/hr-associated-type-bound-param-5.rs:15:33
+   |
+LL |     for<'b> <T as X<'b, T>>::U: Clone,
+   |                                 ^^^^^ required by this bound in `X::f`
+...
+LL |     fn f(x: &<T as X<'_, T>>::U) {
+   |        - required by a bound in this associated function
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-bound-param-6.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-6.rs
@@ -16,4 +16,6 @@ impl<S, T> X<'_, T> for (S,) {
 
 pub fn main() {
     <(i32,) as X<i32>>::f("abc");
+    //~^ ERROR the trait bound `for<'b> i32: X<'b, i32>` is not satisfied
+    //~| ERROR the trait bound `i32: X<'_, i32>` is not satisfied
 }

--- a/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
@@ -9,6 +9,22 @@ help: consider restricting type parameter `T`
 LL | impl<S, T: for<'b> X<'b, T>> X<'_, T> for (S,) {
    |          ++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `for<'b> i32: X<'b, i32>` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-6.rs:18:5
+   |
+LL |     <(i32,) as X<i32>>::f("abc");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'b> X<'b, i32>` is not implemented for `i32`
+   |
+   = help: the trait `X<'_, T>` is implemented for `(S,)`
+
+error[E0277]: the trait bound `i32: X<'_, i32>` is not satisfied
+  --> $DIR/hr-associated-type-bound-param-6.rs:18:27
+   |
+LL |     <(i32,) as X<i32>>::f("abc");
+   |                           ^^^^^ the trait `X<'_, i32>` is not implemented for `i32`
+   |
+   = help: the trait `X<'_, T>` is implemented for `(S,)`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/hr-associated-type-projection-1.rs
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.rs
@@ -17,4 +17,5 @@ impl<T: Copy + std::ops::Deref> UnsafeCopy<'_, T> for T {
 
 pub fn main() {
     <&'static str>::bug(&"");
+    //~^ type mismatch resolving `<&str as Deref>::Target == &str`
 }

--- a/tests/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -21,6 +21,21 @@ help: consider further restricting this bound
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<'_, T> for T {
    |                               ++++++++++++
 
-error: aborting due to 1 previous error
+error[E0271]: type mismatch resolving `<&str as Deref>::Target == &str`
+  --> $DIR/hr-associated-type-projection-1.rs:19:6
+   |
+LL |     <&'static str>::bug(&"");
+   |      ^^^^^^^^^^^^ expected `&str`, found `str`
+   |
+note: required by a bound in `UnsafeCopy::bug`
+  --> $DIR/hr-associated-type-projection-1.rs:3:64
+   |
+LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
+   |                                                                ^^^^^^^^^^ required by this bound in `UnsafeCopy::bug`
+...
+LL |     fn bug(item: &Self::Item) -> () {
+   |        --- required by a bound in this associated function
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/associated-types/issue-20005.rs
+++ b/tests/ui/associated-types/issue-20005.rs
@@ -6,9 +6,9 @@ trait From<Src> {
 
 trait To {
     fn to<Dst>(
-        self
+        self //~ ERROR the size for values of type
     ) -> <Dst as From<Self>>::Result where Dst: From<Self> { //~ ERROR the size for values of type
-        From::from(self)
+        From::from(self) //~ ERROR the size for values of type
     }
 }
 

--- a/tests/ui/associated-types/issue-20005.stderr
+++ b/tests/ui/associated-types/issue-20005.stderr
@@ -18,6 +18,42 @@ help: consider relaxing the implicit `Sized` restriction
 LL | trait From<Src: ?Sized> {
    |               ++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-20005.rs:9:9
+   |
+LL |         self
+   |         ^^^^ doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider further restricting `Self`
+   |
+LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {
+   |                                                           +++++++++++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |         &self
+   |         +
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-20005.rs:11:9
+   |
+LL |         From::from(self)
+   |         ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by an implicit `Sized` bound in `From`
+  --> $DIR/issue-20005.rs:1:12
+   |
+LL | trait From<Src> {
+   |            ^^^ required by the implicit `Sized` requirement on this type parameter in `From`
+help: consider further restricting `Self`
+   |
+LL |     ) -> <Dst as From<Self>>::Result where Dst: From<Self>, Self: Sized {
+   |                                                           +++++++++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait From<Src: ?Sized> {
+   |               ++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/issue-38821.rs
+++ b/tests/ui/associated-types/issue-38821.rs
@@ -35,6 +35,8 @@ pub trait Column: Expression {}
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+//~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 pub enum ColumnInsertValue<Col, Expr> where
 //~^ ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
 //~| ERROR the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -18,7 +18,7 @@ LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Co
    |                                                                       +++++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:1
+  --> $DIR/issue-38821.rs:40:1
    |
 LL | pub enum ColumnInsertValue<Col, Expr> where
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
@@ -36,7 +36,7 @@ LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Co
    |                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:38:1
+  --> $DIR/issue-38821.rs:40:1
    |
 LL | / pub enum ColumnInsertValue<Col, Expr> where
 LL | |
@@ -283,6 +283,38 @@ LL | impl<T: NotNull> IntoNullable for T {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 16 previous errors
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:10
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 18 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/issue-59324.rs
+++ b/tests/ui/associated-types/issue-59324.rs
@@ -22,5 +22,7 @@ pub trait ThriftService<Bug: NotFoo>:
 
 fn with_factory<H>(factory: dyn ThriftService<()>) {}
 //~^ ERROR the trait bound `(): Foo` is not satisfied
+//~| ERROR the trait bound `(): Foo` is not satisfied
+//~| ERROR cannot be known at compilation time
 
 fn main() {}

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -66,6 +66,35 @@ help: consider further restricting this bound
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
 
-error: aborting due to 5 previous errors
+error[E0277]: the trait bound `(): Foo` is not satisfied
+  --> $DIR/issue-59324.rs:23:52
+   |
+LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
+   |                                                    ^^ the trait `Foo` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/issue-59324.rs:3:1
+   |
+LL | pub trait Foo: NotFoo {
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
+  --> $DIR/issue-59324.rs:23:20
+   |
+LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
+   |                    ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn ThriftService<(), AssocType = _> + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn with_factory<H>(factory: impl ThriftService<()>) {}
+   |                             ~~~~
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn with_factory<H>(factory: &dyn ThriftService<()>) {}
+   |                             +
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/auto-traits/issue-83857-ub.rs
+++ b/tests/ui/auto-traits/issue-83857-ub.rs
@@ -21,7 +21,9 @@ impl WithAssoc for Foo<u32, ()> {
 
 fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
     //~^ ERROR `Foo<T, U>` cannot be sent between threads safely
+    //~| ERROR `Foo<T, U>` cannot be sent between threads safely
     f(foo(v));
+    //~^ ERROR `Foo<T, U>` cannot be sent between threads safely
 }
 
 fn foo<T: Send>(x: T) -> <T as WithAssoc>::Output {

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -17,6 +17,50 @@ help: consider introducing a `where` clause, but there might be an alternative b
 LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) where Foo<T, U>: Send {
    |                                                                                +++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: `Foo<T, U>` cannot be sent between threads safely
+  --> $DIR/issue-83857-ub.rs:22:80
+   |
+LL |   fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
+   |  ________________________________________________________________________________^
+LL | |
+LL | |
+LL | |     f(foo(v));
+LL | |
+LL | | }
+   | |_^ `Foo<T, U>` cannot be sent between threads safely
+   |
+   = help: the trait `Send` is not implemented for `Foo<T, U>`, which is required by `Foo<T, U>: WithAssoc`
+note: required for `Foo<T, U>` to implement `WithAssoc`
+  --> $DIR/issue-83857-ub.rs:15:15
+   |
+LL | impl<T: Send> WithAssoc for T {
+   |         ----  ^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) where Foo<T, U>: Send {
+   |                                                                                +++++++++++++++++++++
+
+error[E0277]: `Foo<T, U>` cannot be sent between threads safely
+  --> $DIR/issue-83857-ub.rs:25:11
+   |
+LL |     f(foo(v));
+   |       --- ^ `Foo<T, U>` cannot be sent between threads safely
+   |       |
+   |       required by a bound introduced by this call
+   |
+   = help: the trait `Send` is not implemented for `Foo<T, U>`
+note: required by a bound in `foo`
+  --> $DIR/issue-83857-ub.rs:29:11
+   |
+LL | fn foo<T: Send>(x: T) -> <T as WithAssoc>::Output {
+   |           ^^^^ required by this bound in `foo`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) where Foo<T, U>: Send {
+   |                                                                                +++++++++++++++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/builtin-superkinds/builtin-superkinds-self-type.rs
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-self-type.rs
@@ -14,4 +14,5 @@ fn main() {
     let (tx, rx) = channel();
     1193182.foo(tx);
     assert_eq!(rx.recv(), 1193182);
+    //~^ ERROR: mismatched types
 }

--- a/tests/ui/builtin-superkinds/builtin-superkinds-self-type.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-self-type.stderr
@@ -17,6 +17,20 @@ help: consider adding an explicit lifetime bound
 LL | impl <T: Sync + 'static> Foo for T { }
    |               +++++++++
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/builtin-superkinds-self-type.rs:16:27
+   |
+LL |     assert_eq!(rx.recv(), 1193182);
+   |                           ^^^^^^^ expected `Result<{integer}, RecvError>`, found integer
+   |
+   = note: expected enum `Result<{integer}, RecvError>`
+              found type `{integer}`
+help: try wrapping the expression in `Ok`
+   |
+LL |     assert_eq!(rx.recv(), Ok(1193182));
+   |                           +++       +
 
-For more information about this error, try `rustc --explain E0310`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0310.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.rs
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.rs
@@ -5,6 +5,7 @@ struct X<F> where F: FnOnce() + 'static + Send {
 fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
     //~^ ERROR `F` cannot be sent between threads safely
     return X { field: blk };
+    //~^ ERROR `F` cannot be sent between threads safely
 }
 
 fn main() {

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -14,6 +14,22 @@ help: consider further restricting this bound
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: `F` cannot be sent between threads safely
+  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:7:23
+   |
+LL |     return X { field: blk };
+   |                       ^^^ `F` cannot be sent between threads safely
+   |
+note: required by a bound in `X`
+  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:43
+   |
+LL | struct X<F> where F: FnOnce() + 'static + Send {
+   |                                           ^^^^ required by this bound in `X`
+help: consider further restricting this bound
+   |
+LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
+   |                                                       +++++++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.rs
+++ b/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.rs
@@ -23,6 +23,7 @@ impl MyTrait<MyType> for MyType {
 //~^ ERROR E0119
     fn get(&self) -> usize { (*self).clone() }
     //~^ ERROR incompatible type
+    //~| ERROR mismatched types
 }
 
 fn main() { }

--- a/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.stderr
+++ b/tests/ui/coherence/coherence-blanket-conflicts-with-specific-multidispatch.stderr
@@ -24,7 +24,15 @@ LL |     fn get(&self) -> T;
    = note: expected signature `fn(&MyType) -> MyType`
               found signature `fn(&MyType) -> usize`
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/coherence-blanket-conflicts-with-specific-multidispatch.rs:24:30
+   |
+LL |     fn get(&self) -> usize { (*self).clone() }
+   |                      -----   ^^^^^^^^^^^^^^^ expected `usize`, found `MyType`
+   |                      |
+   |                      expected `usize` because of return type
 
-Some errors have detailed explanations: E0053, E0119.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0053, E0119, E0308.
 For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/coherence/coherence-tuple-conflict.rs
+++ b/tests/ui/coherence/coherence-tuple-conflict.rs
@@ -15,6 +15,7 @@ impl<T> MyTrait for (T,T) {
 impl<A,B> MyTrait for (A,B) {
 //~^ ERROR E0119
     fn get(&self) -> usize { self.dummy }
+    //~^ ERROR: no field `dummy`
 }
 
 fn main() { }

--- a/tests/ui/coherence/coherence-tuple-conflict.stderr
+++ b/tests/ui/coherence/coherence-tuple-conflict.stderr
@@ -7,6 +7,13 @@ LL | impl<T> MyTrait for (T,T) {
 LL | impl<A,B> MyTrait for (A,B) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(_, _)`
 
-error: aborting due to 1 previous error
+error[E0609]: no field `dummy` on type `&(A, B)`
+  --> $DIR/coherence-tuple-conflict.rs:17:35
+   |
+LL |     fn get(&self) -> usize { self.dummy }
+   |                                   ^^^^^ unknown field
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0609.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/occurs-check/associated-type.next.stderr
+++ b/tests/ui/coherence/occurs-check/associated-type.next.stderr
@@ -20,6 +20,13 @@ LL | |     for<'a> *const T: ToUnit<'a>,
    |
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
 
-error: aborting due to 1 previous error
+error[E0284]: type annotations needed: cannot satisfy `<for<'a> fn(&'a (), ()) as Overlap<for<'a> fn(&'a (), ())>>::Assoc == usize`
+  --> $DIR/associated-type.rs:44:59
+   |
+LL |     foo::<for<'a> fn(&'a (), ()), for<'a> fn(&'a (), ())>(3usize);
+   |                                                           ^^^^^^ cannot satisfy `<for<'a> fn(&'a (), ()) as Overlap<for<'a> fn(&'a (), ())>>::Assoc == usize`
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0284.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/coherence/occurs-check/associated-type.rs
+++ b/tests/ui/coherence/occurs-check/associated-type.rs
@@ -42,4 +42,5 @@ fn foo<T: Overlap<U>, U>(x: T::Assoc) -> T::Assoc {
 
 fn main() {
     foo::<for<'a> fn(&'a (), ()), for<'a> fn(&'a (), ())>(3usize);
+    //[next]~^ ERROR: cannot satisfy
 }

--- a/tests/ui/const-generics/const-argument-if-length.full.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.full.stderr
@@ -1,5 +1,5 @@
 error: unconstrained generic constant
-  --> $DIR/const-argument-if-length.rs:17:10
+  --> $DIR/const-argument-if-length.rs:18:10
    |
 LL |     pad: [u8; is_zst::<T>()],
    |          ^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     pad: [u8; is_zst::<T>()],
    = help: try adding a `where` bound using this expression: `where [(); is_zst::<T>()]:`
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/const-argument-if-length.rs:15:12
+  --> $DIR/const-argument-if-length.rs:16:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
    |                        - this type parameter needs to be `Sized`
@@ -30,6 +30,22 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     value: Box<T>,
    |            ++++ +
 
-error: aborting due to 2 previous errors
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/const-argument-if-length.rs:7:28
+   |
+LL | pub const fn is_zst<T: ?Sized>() -> usize {
+   |                     - this type parameter needs to be `Sized`
+LL |     if std::mem::size_of::<T>() == 0 {
+   |                            ^ doesn't have a size known at compile-time
+   |
+note: required by an implicit `Sized` bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - pub const fn is_zst<T: ?Sized>() -> usize {
+LL + pub const fn is_zst<T>() -> usize {
+   |
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/const-argument-if-length.min.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/const-argument-if-length.rs:17:24
+  --> $DIR/const-argument-if-length.rs:18:24
    |
 LL |     pad: [u8; is_zst::<T>()],
    |                        ^ cannot perform const operation using `T`
@@ -8,7 +8,7 @@ LL |     pad: [u8; is_zst::<T>()],
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/const-argument-if-length.rs:15:12
+  --> $DIR/const-argument-if-length.rs:16:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
    |                        - this type parameter needs to be `Sized`
@@ -31,6 +31,22 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     value: Box<T>,
    |            ++++ +
 
-error: aborting due to 2 previous errors
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/const-argument-if-length.rs:7:28
+   |
+LL | pub const fn is_zst<T: ?Sized>() -> usize {
+   |                     - this type parameter needs to be `Sized`
+LL |     if std::mem::size_of::<T>() == 0 {
+   |                            ^ doesn't have a size known at compile-time
+   |
+note: required by an implicit `Sized` bound in `std::mem::size_of`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - pub const fn is_zst<T: ?Sized>() -> usize {
+LL + pub const fn is_zst<T>() -> usize {
+   |
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/const-argument-if-length.rs
+++ b/tests/ui/const-generics/const-argument-if-length.rs
@@ -5,6 +5,7 @@
 
 pub const fn is_zst<T: ?Sized>() -> usize {
     if std::mem::size_of::<T>() == 0 {
+        //~^ ERROR the size for values of type `T` cannot be known at compilation time
         1
     } else {
         0

--- a/tests/ui/const-generics/fn-const-param-infer.full.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.full.stderr
@@ -4,6 +4,27 @@ error[E0741]: using function pointers as const generic parameters is forbidden
 LL | struct Checked<const F: fn(usize) -> bool>;
    |                         ^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/fn-const-param-infer.rs:23:24
+   |
+LL |     let _ = Checked::<{generic_arg::<u32>}>;
+   |                        ^^^^^^^^^^^^^^^^^^ expected fn pointer, found fn item
+   |
+   = note: expected fn pointer `fn(usize) -> _`
+                 found fn item `fn(u32) -> _ {generic_arg::<u32>}`
 
-For more information about this error, try `rustc --explain E0741`.
+error[E0282]: type annotations needed
+  --> $DIR/fn-const-param-infer.rs:25:23
+   |
+LL |     let _ = Checked::<generic>;
+   |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
+   |
+help: consider specifying the generic argument
+   |
+LL |     let _ = Checked::<generic::<T>>;
+   |                              +++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0308, E0741.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.min.stderr
@@ -6,5 +6,27 @@ LL | struct Checked<const F: fn(usize) -> bool>;
    |
    = note: the only supported types are integers, `bool` and `char`
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/fn-const-param-infer.rs:23:24
+   |
+LL |     let _ = Checked::<{generic_arg::<u32>}>;
+   |                        ^^^^^^^^^^^^^^^^^^ expected fn pointer, found fn item
+   |
+   = note: expected fn pointer `fn(usize) -> _`
+                 found fn item `fn(u32) -> _ {generic_arg::<u32>}`
 
+error[E0282]: type annotations needed
+  --> $DIR/fn-const-param-infer.rs:25:23
+   |
+LL |     let _ = Checked::<generic>;
+   |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
+   |
+help: consider specifying the generic argument
+   |
+LL |     let _ = Checked::<generic::<T>>;
+   |                              +++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0308.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/const-generics/fn-const-param-infer.rs
+++ b/tests/ui/const-generics/fn-const-param-infer.rs
@@ -20,9 +20,9 @@ fn main() {
 
     let _ = Checked::<generic_arg>;
     let _ = Checked::<{generic_arg::<usize>}>;
-    let _ = Checked::<{generic_arg::<u32>}>;
+    let _ = Checked::<{generic_arg::<u32>}>; //~ ERROR: mismatched types
 
-    let _ = Checked::<generic>;
+    let _ = Checked::<generic>; //~ ERROR: type annotations needed
     let _ = Checked::<{generic::<u16>}>;
     let _: Checked<{generic::<u16>}> = Checked::<{generic::<u16>}>;
     let _: Checked<{generic::<u32>}> = Checked::<{generic::<u16>}>;

--- a/tests/ui/const-generics/generic_const_exprs/no_where_clause.rs
+++ b/tests/ui/const-generics/generic_const_exprs/no_where_clause.rs
@@ -16,6 +16,7 @@ impl<const N: usize> Example<N> {
     Self {
       a: [0.; N],
       b: [0.; complex_maths(N)],
+      //~^ ERROR: unconstrained generic constant
     }
   }
 }

--- a/tests/ui/const-generics/generic_const_exprs/no_where_clause.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/no_where_clause.stderr
@@ -6,5 +6,13 @@ LL |   b: [f32; complex_maths(N)],
    |
    = help: try adding a `where` bound using this expression: `where [(); complex_maths(N)]:`
 
-error: aborting due to 1 previous error
+error: unconstrained generic constant
+  --> $DIR/no_where_clause.rs:18:15
+   |
+LL |       b: [0.; complex_maths(N)],
+   |               ^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); complex_maths(N)]:`
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/object-safety-err-ret.rs
+++ b/tests/ui/const-generics/generic_const_exprs/object-safety-err-ret.rs
@@ -15,7 +15,7 @@ impl Foo for () {
 }
 
 fn use_dyn(v: &dyn Foo) { //~ERROR the trait `Foo` cannot be made into an object
-    v.test();
+    v.test(); //~ERROR the trait `Foo` cannot be made into an object
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/object-safety-err-ret.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/object-safety-err-ret.stderr
@@ -16,6 +16,24 @@ LL |     fn test(&self) -> [u8; bar::<Self>()];
    = help: consider moving `test` to another trait
    = help: only type `()` implements the trait, consider using it directly instead
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-safety-err-ret.rs:18:5
+   |
+LL |     v.test();
+   |     ^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-err-ret.rs:8:8
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     fn test(&self) -> [u8; bar::<Self>()];
+   |        ^^^^           ^^^^^^^^^^^^^^^^^^^ ...because method `test` references the `Self` type in its return type
+   |        |
+   |        ...because method `test` references the `Self` type in its `where` clause
+   = help: consider moving `test` to another trait
+   = help: only type `()` implements the trait, consider using it directly instead
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/generic_const_exprs/unify-op-with-fn-call.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unify-op-with-fn-call.stderr
@@ -34,6 +34,47 @@ LL + #[derive(ConstParamTy)]
 LL | struct Foo(u8);
    |
 
-error: aborting due to 3 previous errors
+error: unconstrained generic constant
+  --> $DIR/unify-op-with-fn-call.rs:30:12
+   |
+LL |     bar2::<{ std::ops::Add::add(N, N) }>();
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { std::ops::Add::add(N, N) }]:`
 
-For more information about this error, try `rustc --explain E0741`.
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/unify-op-with-fn-call.rs:20:39
+   |
+LL | fn foo<const N: Foo>(a: Evaluatable<{ N + N }>) {
+   |                                       ^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $DIR/unify-op-with-fn-call.rs:10:1
+   |
+LL | impl const std::ops::Add for Foo {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `<Foo as Add>::add` in constants
+  --> $DIR/unify-op-with-fn-call.rs:21:13
+   |
+LL |     bar::<{ std::ops::Add::add(N, N) }>();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `<usize as Add>::add` in constants
+  --> $DIR/unify-op-with-fn-call.rs:30:14
+   |
+LL |     bar2::<{ std::ops::Add::add(N, N) }>();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0015, E0741.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -15,6 +15,16 @@ LL | fn foo<const N: usize, const A: [u8; N]>() {}
    = note: the only supported types are integers, `bool` and `char`
    = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
-error: aborting due to 2 previous errors
+error[E0747]: type provided when a constant was expected
+  --> $DIR/issue-62878.rs:10:11
+   |
+LL |     foo::<_, { [1] }>();
+   |           ^
+   |
+   = help: const arguments cannot yet be inferred with `_`
+   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0770`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0747, E0770.
+For more information about an error, try `rustc --explain E0747`.

--- a/tests/ui/const-generics/issues/issue-62878.rs
+++ b/tests/ui/const-generics/issues/issue-62878.rs
@@ -8,4 +8,5 @@ fn foo<const N: usize, const A: [u8; N]>() {}
 
 fn main() {
     foo::<_, { [1] }>();
+    //[min]~^ ERROR: type provided when a constant was expected
 }

--- a/tests/ui/const-generics/issues/issue-72352.full.stderr
+++ b/tests/ui/const-generics/issues/issue-72352.full.stderr
@@ -1,7 +1,7 @@
 error[E0741]: using function pointers as const generic parameters is forbidden
-  --> $DIR/issue-72352.rs:7:42
+  --> $DIR/issue-72352.rs:8:42
    |
-LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {
+LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const c_char) -> usize {
    |                                          ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/issues/issue-72352.min.stderr
+++ b/tests/ui/const-generics/issues/issue-72352.min.stderr
@@ -1,7 +1,7 @@
 error: using function pointers as const generic parameters is forbidden
-  --> $DIR/issue-72352.rs:7:42
+  --> $DIR/issue-72352.rs:8:42
    |
-LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {
+LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const c_char) -> usize {
    |                                          ^^^^^^^^^^^^^^^^^^
    |
    = note: the only supported types are integers, `bool` and `char`

--- a/tests/ui/const-generics/issues/issue-72352.rs
+++ b/tests/ui/const-generics/issues/issue-72352.rs
@@ -1,10 +1,11 @@
 // revisions: full min
+
 #![cfg_attr(full, feature(adt_const_params))]
 #![cfg_attr(full, allow(incomplete_features))]
 
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr, CString};
 
-unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {
+unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const c_char) -> usize {
     //~^ ERROR: using function pointers as const generic parameters is forbidden
     F(CStr::from_ptr(ptr))
 }
@@ -16,7 +17,5 @@ fn safely_do_the_thing(s: &CStr) -> usize {
 fn main() {
     let baguette = CString::new("baguette").unwrap();
     let ptr = baguette.as_ptr();
-    println!("{}", unsafe {
-        unsafely_do_the_thing::<safely_do_the_thing>(ptr)
-    });
+    println!("{}", unsafe { unsafely_do_the_thing::<safely_do_the_thing>(ptr) });
 }

--- a/tests/ui/const-generics/raw-ptr-const-param.full.stderr
+++ b/tests/ui/const-generics/raw-ptr-const-param.full.stderr
@@ -4,6 +4,18 @@ error[E0741]: using raw pointers as const generic parameters is forbidden
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/raw-ptr-const-param.rs:9:40
+   |
+LL |     let _: Const<{ 15 as *const _ }> = Const::<{ 10 as *const _ }>;
+   |            -------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{0xf as *const u32}`, found `{0xa as *const u32}`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Const<{0xf as *const u32}>`
+              found struct `Const<{0xa as *const u32}>`
 
-For more information about this error, try `rustc --explain E0741`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0741.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/raw-ptr-const-param.min.stderr
+++ b/tests/ui/const-generics/raw-ptr-const-param.min.stderr
@@ -6,5 +6,17 @@ LL | struct Const<const P: *const u32>;
    |
    = note: the only supported types are integers, `bool` and `char`
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/raw-ptr-const-param.rs:9:40
+   |
+LL |     let _: Const<{ 15 as *const _ }> = Const::<{ 10 as *const _ }>;
+   |            -------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `{0xf as *const u32}`, found `{0xa as *const u32}`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Const<{0xf as *const u32}>`
+              found struct `Const<{0xa as *const u32}>`
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/raw-ptr-const-param.rs
+++ b/tests/ui/const-generics/raw-ptr-const-param.rs
@@ -7,5 +7,6 @@ struct Const<const P: *const u32>; //~ ERROR: using raw pointers as const generi
 
 fn main() {
     let _: Const<{ 15 as *const _ }> = Const::<{ 10 as *const _ }>;
+    //~^ ERROR: mismatched types
     let _: Const<{ 10 as *const _ }> = Const::<{ 10 as *const _ }>;
 }

--- a/tests/ui/const-generics/slice-const-param-mismatch.min.stderr
+++ b/tests/ui/const-generics/slice-const-param-mismatch.min.stderr
@@ -16,5 +16,39 @@ LL | struct ConstBytes<const T: &'static [u8]>;
    = note: the only supported types are integers, `bool` and `char`
    = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/slice-const-param-mismatch.rs:14:35
+   |
+LL |     let _: ConstString<"Hello"> = ConstString::<"World">;
+   |            --------------------   ^^^^^^^^^^^^^^^^^^^^^^ expected `"Hello"`, found `"World"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `ConstString<"Hello">`
+              found struct `ConstString<"World">`
 
+error[E0308]: mismatched types
+  --> $DIR/slice-const-param-mismatch.rs:16:33
+   |
+LL |     let _: ConstString<"ℇ㇈↦"> = ConstString::<"ℇ㇈↥">;
+   |            -------------------   ^^^^^^^^^^^^^^^^^^^^^ expected `"ℇ㇈↦"`, found `"ℇ㇈↥"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `ConstString<"ℇ㇈↦">`
+              found struct `ConstString<"ℇ㇈↥">`
+
+error[E0308]: mismatched types
+  --> $DIR/slice-const-param-mismatch.rs:18:33
+   |
+LL |     let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">;
+   |            ------------------   ^^^^^^^^^^^^^^^^^^^^ expected `b"AAA"`, found `b"BBB"`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `ConstBytes<b"AAA">`
+              found struct `ConstBytes<b"BBB">`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/slice-const-param-mismatch.rs
+++ b/tests/ui/const-generics/slice-const-param-mismatch.rs
@@ -11,9 +11,9 @@ struct ConstBytes<const T: &'static [u8]>;
 
 pub fn main() {
     let _: ConstString<"Hello"> = ConstString::<"Hello">;
-    let _: ConstString<"Hello"> = ConstString::<"World">; //[full]~ ERROR mismatched types
+    let _: ConstString<"Hello"> = ConstString::<"World">; //~ ERROR mismatched types
     let _: ConstString<"ℇ㇈↦"> = ConstString::<"ℇ㇈↦">;
-    let _: ConstString<"ℇ㇈↦"> = ConstString::<"ℇ㇈↥">; //[full]~ ERROR mismatched types
+    let _: ConstString<"ℇ㇈↦"> = ConstString::<"ℇ㇈↥">; //~ ERROR mismatched types
     let _: ConstBytes<b"AAA"> = ConstBytes::<{&[0x41, 0x41, 0x41]}>;
-    let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">; //[full]~ ERROR mismatched types
+    let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">; //~ ERROR mismatched types
 }

--- a/tests/ui/consts/const-unsized.rs
+++ b/tests/ui/consts/const-unsized.rs
@@ -18,4 +18,6 @@ static STATIC_BAR: str = *"bar";
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
+    //~^ ERROR: cannot move a value of type `str`
+    //~| ERROR: cannot move a value of type `dyn Debug + Sync`
 }

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -66,6 +66,19 @@ LL | static STATIC_BAR: str = *"bar";
    = help: the trait `Sized` is not implemented for `str`
    = note: constant expressions must have a statically known size
 
-error: aborting due to 8 previous errors
+error[E0161]: cannot move a value of type `str`
+  --> $DIR/const-unsized.rs:20:48
+   |
+LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
+   |                                                ^^^^^^^^^ the size of `str` cannot be statically determined
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0161]: cannot move a value of type `dyn Debug + Sync`
+  --> $DIR/const-unsized.rs:20:38
+   |
+LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);
+   |                                      ^^^^^^^ the size of `dyn Debug + Sync` cannot be statically determined
+
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0161, E0277.
+For more information about an error, try `rustc --explain E0161`.

--- a/tests/ui/cross/cross-fn-cache-hole.rs
+++ b/tests/ui/cross/cross-fn-cache-hole.rs
@@ -28,4 +28,5 @@ fn require<A,B>()
 
 fn main() {
     require::<i32, u32>();
+    //~^ ERROR `i32: Bar<u32>` is not satisfied
 }

--- a/tests/ui/cross/cross-fn-cache-hole.stderr
+++ b/tests/ui/cross/cross-fn-cache-hole.stderr
@@ -12,6 +12,25 @@ LL | trait Bar<X> { }
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `i32: Bar<u32>` is not satisfied
+  --> $DIR/cross-fn-cache-hole.rs:30:15
+   |
+LL |     require::<i32, u32>();
+   |               ^^^ the trait `Bar<u32>` is not implemented for `i32`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/cross-fn-cache-hole.rs:11:1
+   |
+LL | trait Bar<X> { }
+   | ^^^^^^^^^^^^
+note: required by a bound in `require`
+  --> $DIR/cross-fn-cache-hole.rs:25:14
+   |
+LL | fn require<A,B>()
+   |    ------- required by a bound in this function
+LL |     where A: Bar<B>
+   |              ^^^^^^ required by this bound in `require`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/error-codes/E0038.rs
+++ b/tests/ui/error-codes/E0038.rs
@@ -5,6 +5,8 @@ trait Trait {
 fn call_foo(x: Box<dyn Trait>) {
     //~^ ERROR E0038
     let y = x.foo();
+    //~^ ERROR E0038
+    //~| ERROR E0277
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -13,6 +13,32 @@ LL |     fn foo(&self) -> Self;
    |                      ^^^^ ...because method `foo` references the `Self` type in its return type
    = help: consider moving `foo` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/E0038.rs:7:13
+   |
+LL |     let y = x.foo();
+   |             ^^^^^^^ `Trait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/E0038.rs:2:22
+   |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
+LL |     fn foo(&self) -> Self;
+   |                      ^^^^ ...because method `foo` references the `Self` type in its return type
+   = help: consider moving `foo` to another trait
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
+  --> $DIR/E0038.rs:7:9
+   |
+LL |     let y = x.foo();
+   |         ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+   = note: all local variables must have a statically known size
+   = help: unsized locals are gated as an unstable feature
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/error-codes/E0059.rs
+++ b/tests/ui/error-codes/E0059.rs
@@ -1,6 +1,8 @@
 #![feature(unboxed_closures)]
 
 fn foo<F: Fn<i32>>(f: F) -> F::Output { f(3) } //~ ERROR E0059
+//~^ ERROR `i32` is not a tuple
+//~| ERROR cannot use call notation
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0059.stderr
+++ b/tests/ui/error-codes/E0059.stderr
@@ -7,6 +7,19 @@ LL | fn foo<F: Fn<i32>>(f: F) -> F::Output { f(3) }
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-error: aborting due to 1 previous error
+error[E0277]: `i32` is not a tuple
+  --> $DIR/E0059.rs:3:41
+   |
+LL | fn foo<F: Fn<i32>>(f: F) -> F::Output { f(3) }
+   |                                         ^^^^ the trait `Tuple` is not implemented for `i32`
 
-For more information about this error, try `rustc --explain E0059`.
+error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+  --> $DIR/E0059.rs:3:41
+   |
+LL | fn foo<F: Fn<i32>>(f: F) -> F::Output { f(3) }
+   |                                         ^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0059, E0277.
+For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/error-codes/E0229.rs
+++ b/tests/ui/error-codes/E0229.rs
@@ -15,6 +15,7 @@ fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
 //~| ERROR associated type bindings are not allowed here [E0229]
 //~| ERROR associated type bindings are not allowed here [E0229]
 //~| ERROR the trait bound `I: Foo` is not satisfied
+//~| ERROR the trait bound `I: Foo` is not satisfied
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -31,7 +31,18 @@ help: consider restricting type parameter `I`
 LL | fn baz<I: Foo>(x: &<I as Foo<A=Bar>>::A) {}
    |         +++++
 
-error: aborting due to 4 previous errors
+error[E0277]: the trait bound `I: Foo` is not satisfied
+  --> $DIR/E0229.rs:13:37
+   |
+LL | fn baz<I>(x: &<I as Foo<A=Bar>>::A) {}
+   |                                     ^^ the trait `Foo` is not implemented for `I`
+   |
+help: consider restricting type parameter `I`
+   |
+LL | fn baz<I: Foo>(x: &<I as Foo<A=Bar>>::A) {}
+   |         +++++
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0229, E0277.
 For more information about an error, try `rustc --explain E0229`.

--- a/tests/ui/extern/issue-36122-accessing-externed-dst.rs
+++ b/tests/ui/extern/issue-36122-accessing-externed-dst.rs
@@ -3,4 +3,5 @@ fn main() {
         static symbol: [usize]; //~ ERROR: the size for values of type
     }
     println!("{}", symbol[0]);
+    //~^ ERROR: extern static is unsafe
 }

--- a/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
+++ b/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
@@ -6,6 +6,15 @@ LL |         static symbol: [usize];
    |
    = help: the trait `Sized` is not implemented for `[usize]`
 
-error: aborting due to 1 previous error
+error[E0133]: use of extern static is unsafe and requires unsafe function or block
+  --> $DIR/issue-36122-accessing-externed-dst.rs:5:20
+   |
+LL |     println!("{}", symbol[0]);
+   |                    ^^^^^^ use of extern static
+   |
+   = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0133, E0277.
+For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/fn/implied-bounds-unnorm-associated-type-5.rs
+++ b/tests/ui/fn/implied-bounds-unnorm-associated-type-5.rs
@@ -18,6 +18,6 @@ where
 fn main() {
     let x = String::from("Hello World!");
     let y = f(&x, ());
-    drop(x);
+    drop(x); //~ ERROR cannot move out of `x`
     println!("{}", y);
 }

--- a/tests/ui/fn/implied-bounds-unnorm-associated-type-5.stderr
+++ b/tests/ui/fn/implied-bounds-unnorm-associated-type-5.stderr
@@ -16,6 +16,19 @@ help: consider adding an explicit lifetime bound
 LL | impl<'a, T: 'a> Trait<'a> for T {
    |           ++++
 
-error: aborting due to 1 previous error
+error[E0505]: cannot move out of `x` because it is borrowed
+  --> $DIR/implied-bounds-unnorm-associated-type-5.rs:21:10
+   |
+LL |     let x = String::from("Hello World!");
+   |         - binding `x` declared here
+LL |     let y = f(&x, ());
+   |               -- borrow of `x` occurs here
+LL |     drop(x);
+   |          ^ move out of `x` occurs here
+LL |     println!("{}", y);
+   |                    - borrow later used here
 
-For more information about this error, try `rustc --explain E0309`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0309, E0505.
+For more information about an error, try `rustc --explain E0309`.

--- a/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
@@ -16,6 +16,43 @@ LL |     type A<'a> where Self: 'a;
              Fooer<T>
              Fooy
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/gat-in-trait-path.rs:32:5
+   |
+LL |   f(Box::new(foo));
+   |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-in-trait-path.rs:10:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type A<'a> where Self: 'a;
+   |          ^ ...because it contains the generic associated type `A`
+   = help: consider moving `A` to another trait
+   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
+             Fooer<T>
+             Fooy
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/gat-in-trait-path.rs:32:5
+   |
+LL |   f(Box::new(foo));
+   |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-in-trait-path.rs:10:10
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     type A<'a> where Self: 'a;
+   |          ^ ...because it contains the generic associated type `A`
+   = help: consider moving `A` to another trait
+   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
+             Fooer<T>
+             Fooy
+   = note: required for the cast from `Box<Fooer<{integer}>>` to `Box<(dyn Foo<A = &'a ()> + 'static)>`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/gat-in-trait-path.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.rs
@@ -30,4 +30,6 @@ fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
 fn main() {
   let foo = Fooer(5);
   f(Box::new(foo));
+  //[base]~^ the trait `Foo` cannot be made into an object
+  //[base]~| the trait `Foo` cannot be made into an object
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
@@ -9,6 +9,7 @@ impl<T> X for T { //~ ERROR: not all trait items implemented
     //~^ ERROR missing generics for associated type
     //~^^ ERROR missing generics for associated type
     //~| ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+    //~| ERROR may not live long enough
     t
   }
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -51,7 +51,16 @@ LL |   type Y<'a>;
 LL | impl<T> X for T {
    | ^^^^^^^^^^^^^^^ missing `Y` in implementation
 
-error: aborting due to 4 previous errors
+error: lifetime may not live long enough
+  --> $DIR/gat-trait-path-missing-lifetime.rs:8:3
+   |
+LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
+   |   ^^^^^^^--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   |      |
+   |   |      lifetime `'a` defined here
+   |   requires that `'a` must outlive `'static`
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0046, E0049, E0107.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/generic-associated-types/trait-objects.base.stderr
+++ b/tests/ui/generic-associated-types/trait-objects.base.stderr
@@ -13,6 +13,36 @@ LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `StreamingIterator` cannot be made into an object
+  --> $DIR/trait-objects.rs:15:7
+   |
+LL |     x.size_hint().0
+   |       ^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/trait-objects.rs:7:10
+   |
+LL | trait StreamingIterator {
+   |       ----------------- this trait cannot be made into an object...
+LL |     type Item<'a> where Self: 'a;
+   |          ^^^^ ...because it contains the generic associated type `Item`
+   = help: consider moving `Item` to another trait
+
+error[E0038]: the trait `StreamingIterator` cannot be made into an object
+  --> $DIR/trait-objects.rs:15:5
+   |
+LL |     x.size_hint().0
+   |     ^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/trait-objects.rs:7:10
+   |
+LL | trait StreamingIterator {
+   |       ----------------- this trait cannot be made into an object...
+LL |     type Item<'a> where Self: 'a;
+   |          ^^^^ ...because it contains the generic associated type `Item`
+   = help: consider moving `Item` to another trait
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/generic-associated-types/trait-objects.rs
+++ b/tests/ui/generic-associated-types/trait-objects.rs
@@ -14,6 +14,8 @@ fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize 
     //[base]~^ the trait `StreamingIterator` cannot be made into an object
     x.size_hint().0
     //[extended]~^ borrowed data escapes
+    //[base]~^^ the trait `StreamingIterator` cannot be made into an object
+    //[base]~| the trait `StreamingIterator` cannot be made into an object
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.rs
@@ -19,6 +19,7 @@ impl NotObjectSafe for B {
 }
 
 fn car() -> dyn NotObjectSafe { //~ ERROR the trait `NotObjectSafe` cannot be made into an object
+//~^ ERROR return type cannot have an unboxed trait object
     if true {
         return A;
     }
@@ -27,9 +28,9 @@ fn car() -> dyn NotObjectSafe { //~ ERROR the trait `NotObjectSafe` cannot be ma
 
 fn cat() -> Box<dyn NotObjectSafe> { //~ ERROR the trait `NotObjectSafe` cannot be made into an
     if true {
-        return Box::new(A);
+        return Box::new(A); //~ ERROR cannot be made into an object
     }
-    Box::new(B)
+    Box::new(B) //~ ERROR cannot be made into an object
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -24,7 +24,7 @@ LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
 error[E0038]: the trait `NotObjectSafe` cannot be made into an object
-  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:28:17
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:29:17
    |
 LL | fn cat() -> Box<dyn NotObjectSafe> {
    |                 ^^^^^^^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
@@ -48,6 +48,79 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:21:13
+   |
+LL | fn car() -> dyn NotObjectSafe {
+   |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: return an `impl Trait` instead of a `dyn Trait`, if all returned values are the same type
+   |
+LL | fn car() -> impl NotObjectSafe {
+   |             ~~~~
+help: box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn car() -> Box<dyn NotObjectSafe> {
+LL |
+LL |     if true {
+LL ~         return Box::new(A);
+LL |     }
+LL ~     Box::new(B)
+   |
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0038]: the trait `NotObjectSafe` cannot be made into an object
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:31:16
+   |
+LL |         return Box::new(A);
+   |                ^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
+   |
+LL | trait NotObjectSafe {
+   |       ------------- this trait cannot be made into an object...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `NotObjectSafe` for this new enum and using it instead:
+             A
+             B
+   = note: required for the cast from `Box<A>` to `Box<(dyn NotObjectSafe + 'static)>`
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
+error[E0038]: the trait `NotObjectSafe` cannot be made into an object
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:33:5
+   |
+LL |     Box::new(B)
+   |     ^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
+   |
+LL | trait NotObjectSafe {
+   |       ------------- this trait cannot be made into an object...
+LL |     fn foo() -> Self;
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `NotObjectSafe` for this new enum and using it instead:
+             A
+             B
+   = note: required for the cast from `Box<B>` to `Box<(dyn NotObjectSafe + 'static)>`
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) -> Self;
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() -> Self where Self: Sized;
+   |                      +++++++++++++++++
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0038, E0746.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
+++ b/tests/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
@@ -29,16 +29,19 @@ impl<'long: 'short, 'short, T> Convert<'long, 'short> for T {
 fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out T {
     //~^ ERROR lifetime mismatch
     sadness.cast()
+    //~^ ERROR may not live long enough
 }
 
 fn badboi2<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) {
     //~^ ERROR lifetime mismatch
     let _: &'out T = sadness.cast();
+    //~^ ERROR may not live long enough
 }
 
 fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: &'in_ T) {
     //~^ ERROR lifetime mismatch
     let _: &'out T = sadness.cast();
+    //~^ ERROR may not live long enough
 }
 
 fn bad<'short, T>(value: &'short T) -> &'static T {

--- a/tests/ui/implied-bounds/hrlt-implied-trait-bounds-guard.stderr
+++ b/tests/ui/implied-bounds/hrlt-implied-trait-bounds-guard.stderr
@@ -8,7 +8,7 @@ LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out 
    |                             ...but data from `x` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/hrlt-implied-trait-bounds-guard.rs:34:30
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:35:30
    |
 LL | fn badboi2<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) {
    |                              ^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | fn badboi2<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) {
    |                              ...but data with one lifetime flows into the other here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/hrlt-implied-trait-bounds-guard.rs:39:30
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:41:30
    |
 LL | fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: &'in_ T) {
    |                              ^^^^^^^^^^^^^^^^^-------^^-------^^
@@ -25,6 +25,45 @@ LL | fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: 
    |                              |                these two types are declared with different lifetimes...
    |                              ...but data from `a` flows into `a` here
 
-error: aborting due to 3 previous errors
+error: lifetime may not live long enough
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:31:5
+   |
+LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out T {
+   |           ----  ---- lifetime `'out` defined here
+   |           |
+   |           lifetime `'in_` defined here
+LL |
+LL |     sadness.cast()
+   |     ^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'out` but it is returning data with lifetime `'in_`
+   |
+   = help: consider adding the following bound: `'in_: 'out`
+
+error: lifetime may not live long enough
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:37:12
+   |
+LL | fn badboi2<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) {
+   |            ----  ---- lifetime `'out` defined here
+   |            |
+   |            lifetime `'in_` defined here
+LL |
+LL |     let _: &'out T = sadness.cast();
+   |            ^^^^^^^ type annotation requires that `'in_` must outlive `'out`
+   |
+   = help: consider adding the following bound: `'in_: 'out`
+
+error: lifetime may not live long enough
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:43:12
+   |
+LL | fn badboi3<'in_, 'out, T>(a: Foo<'in_, 'out, (&'in_ T, &'out T)>, sadness: &'in_ T) {
+   |            ----  ---- lifetime `'out` defined here
+   |            |
+   |            lifetime `'in_` defined here
+LL |
+LL |     let _: &'out T = sadness.cast();
+   |            ^^^^^^^ type annotation requires that `'in_` must outlive `'out`
+   |
+   = help: consider adding the following bound: `'in_: 'out`
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0623`.

--- a/tests/ui/inference/issue-107090.rs
+++ b/tests/ui/inference/issue-107090.rs
@@ -19,7 +19,7 @@ impl<'long: 'short, 'short, T> Convert<'long, 'b> for Foo<'short, 'out, T> {
 
 fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 'out, T>) -> &'out T {
     //~^ ERROR use of undeclared lifetime name
-    sadness.cast()
+    sadness.cast() //~ ERROR: mismatched types
 }
 
 fn main() {}

--- a/tests/ui/inference/issue-107090.stderr
+++ b/tests/ui/inference/issue-107090.stderr
@@ -66,6 +66,19 @@ LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 
    |           |
    |           help: consider introducing lifetime `'short` here: `'short,`
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-107090.rs:22:5
+   |
+LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ Foo<'short, 'out, T>) -> &'out T {
+   |                       - expected this type parameter                                    ------- expected `&'out T` because of return type
+LL |
+LL |     sadness.cast()
+   |     ^^^^^^^^^^^^^^ expected `&T`, found `&Foo<'_, '_, T>`
+   |
+   = note: expected reference `&'out T`
+              found reference `&Foo<'_, '_, T>`
 
-For more information about this error, try `rustc --explain E0261`.
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0261, E0308.
+For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/issues/issue-18611.rs
+++ b/tests/ui/issues/issue-18611.rs
@@ -1,5 +1,6 @@
 fn add_state(op: <isize as HasState>::State) {
 //~^ ERROR `isize: HasState` is not satisfied
+//~| ERROR `isize: HasState` is not satisfied
 }
 
 trait HasState {

--- a/tests/ui/issues/issue-18611.stderr
+++ b/tests/ui/issues/issue-18611.stderr
@@ -5,11 +5,27 @@ LL | fn add_state(op: <isize as HasState>::State) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasState` is not implemented for `isize`
    |
 help: this trait has no implementations, consider adding one
-  --> $DIR/issue-18611.rs:5:1
+  --> $DIR/issue-18611.rs:6:1
    |
 LL | trait HasState {
    | ^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `isize: HasState` is not satisfied
+  --> $DIR/issue-18611.rs:1:46
+   |
+LL |   fn add_state(op: <isize as HasState>::State) {
+   |  ______________________________________________^
+LL | |
+LL | |
+LL | | }
+   | |_^ the trait `HasState` is not implemented for `isize`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/issue-18611.rs:6:1
+   |
+LL | trait HasState {
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-18959.rs
+++ b/tests/ui/issues/issue-18959.rs
@@ -11,10 +11,14 @@ impl Foo for Thing {
 fn foo(b: &dyn Bar) {
     //~^ ERROR E0038
     b.foo(&0)
+    //~^ ERROR E0038
 }
 
 fn main() {
     let mut thing = Thing;
     let test: &dyn Bar = &mut thing;
+    //~^ ERROR E0038
+    //~| ERROR E0038
     foo(test);
+    //~^ ERROR E0038
 }

--- a/tests/ui/issues/issue-18959.stderr
+++ b/tests/ui/issues/issue-18959.stderr
@@ -13,6 +13,67 @@ LL | pub trait Bar: Foo { }
    |           --- this trait cannot be made into an object...
    = help: consider moving `foo` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/issue-18959.rs:13:5
+   |
+LL |     b.foo(&0)
+   |     ^^^^^^^^^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-18959.rs:1:20
+   |
+LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+   |                    ^^^ ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait cannot be made into an object...
+   = help: consider moving `foo` to another trait
+
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/issue-18959.rs:19:15
+   |
+LL |     let test: &dyn Bar = &mut thing;
+   |               ^^^^^^^^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-18959.rs:1:20
+   |
+LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+   |                    ^^^ ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait cannot be made into an object...
+   = help: consider moving `foo` to another trait
+
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/issue-18959.rs:19:26
+   |
+LL |     let test: &dyn Bar = &mut thing;
+   |                          ^^^^^^^^^^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-18959.rs:1:20
+   |
+LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+   |                    ^^^ ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait cannot be made into an object...
+   = help: consider moving `foo` to another trait
+   = note: required for the cast from `&mut Thing` to `&dyn Bar`
+
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/issue-18959.rs:22:9
+   |
+LL |     foo(test);
+   |         ^^^^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-18959.rs:1:20
+   |
+LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
+   |                    ^^^ ...because method `foo` has generic type parameters
+LL | pub trait Bar: Foo { }
+   |           --- this trait cannot be made into an object...
+   = help: consider moving `foo` to another trait
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/issues/issue-20831-debruijn.rs
+++ b/tests/ui/issues/issue-20831-debruijn.rs
@@ -28,6 +28,8 @@ impl<'a> Publisher<'a> for MyStruct<'a> {
     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
         // Not obvious, but there is an implicit lifetime here -------^
         //~^^ ERROR cannot infer
+        //~| ERROR may not live long enough
+        //~| ERROR may not live long enough
         //
         // The fact that `Publisher` is using an implicit lifetime is
         // what was causing the debruijn accounting to be off, so

--- a/tests/ui/issues/issue-20831-debruijn.stderr
+++ b/tests/ui/issues/issue-20831-debruijn.stderr
@@ -22,6 +22,30 @@ LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher
    = note: expected `<MyStruct<'a> as Publisher<'_>>`
               found `<MyStruct<'_> as Publisher<'_>>`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/issue-20831-debruijn.rs:28:5
+   |
+LL | impl<'a> Publisher<'a> for MyStruct<'a> {
+   |      -- lifetime `'a` defined here
+LL |     type Output = u64;
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |                       |
+   |     |                       has type `Box<dyn Subscriber<Input = <MyStruct<'_> as Publisher<'1>>::Output>>`
+   |     requires that `'a` must outlive `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-20831-debruijn.rs:28:5
+   |
+LL | impl<'a> Publisher<'a> for MyStruct<'a> {
+   |      -- lifetime `'a` defined here
+LL |     type Output = u64;
+LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |                       |
+   |     |                       has type `Box<dyn Subscriber<Input = <MyStruct<'_> as Publisher<'1>>::Output>>`
+   |     requires that `'1` must outlive `'a`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0495`.

--- a/tests/ui/issues/issue-21974.rs
+++ b/tests/ui/issues/issue-21974.rs
@@ -11,7 +11,7 @@ fn foo<'a,'b,T>(x: &'a T, y: &'b T)
     where &'a T : Foo, //~ ERROR type annotations needed
           &'b T : Foo
 {
-    x.foo();
+    x.foo(); //~ ERROR type annotations needed
     y.foo();
 }
 

--- a/tests/ui/issues/issue-21974.stderr
+++ b/tests/ui/issues/issue-21974.stderr
@@ -12,6 +12,20 @@ LL |     where &'a T : Foo,
 LL |           &'b T : Foo
    |                   ^^^
 
-error: aborting due to 1 previous error
+error[E0283]: type annotations needed: cannot satisfy `&T: Foo`
+  --> $DIR/issue-21974.rs:14:7
+   |
+LL |     x.foo();
+   |       ^^^
+   |
+note: multiple `impl`s or `where` clauses satisfying `&T: Foo` found
+  --> $DIR/issue-21974.rs:11:19
+   |
+LL |     where &'a T : Foo,
+   |                   ^^^
+LL |           &'b T : Foo
+   |                   ^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/issues/issue-22874.rs
+++ b/tests/ui/issues/issue-22874.rs
@@ -5,6 +5,7 @@ struct Table {
 
 fn f(table: &Table) -> &[String] {
     &table.rows[0]
+    //~^ ERROR the size for values of type
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-22874.stderr
+++ b/tests/ui/issues/issue-22874.stderr
@@ -7,6 +7,15 @@ LL |     rows: [[String]],
    = help: the trait `Sized` is not implemented for `[String]`
    = note: slice and array elements must have `Sized` type
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `[String]` cannot be known at compilation time
+  --> $DIR/issue-22874.rs:7:6
+   |
+LL |     &table.rows[0]
+   |      ^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[String]`, which is required by `[_]: Index<_>`
+   = note: required for `[[String]]` to implement `Index<_>`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-27340.rs
+++ b/tests/ui/issues/issue-27340.rs
@@ -2,5 +2,6 @@ struct Foo;
 #[derive(Copy, Clone)]
 //~^ ERROR the trait `Copy` cannot be implemented for this type
 struct Bar(Foo);
+//~^ ERROR `Foo: Clone` is not satisfied
 
 fn main() {}

--- a/tests/ui/issues/issue-27340.stderr
+++ b/tests/ui/issues/issue-27340.stderr
@@ -9,6 +9,25 @@ LL | struct Bar(Foo);
    |
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `Foo: Clone` is not satisfied
+  --> $DIR/issue-27340.rs:4:12
+   |
+LL | #[derive(Copy, Clone)]
+   |                ----- in this derive macro expansion
+LL |
+LL | struct Bar(Foo);
+   |            ^^^ the trait `Clone` is not implemented for `Foo`
+   |
+note: required by a bound in `AssertParamIsClone`
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Foo` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct Foo;
+   |
 
-For more information about this error, try `rustc --explain E0204`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0204, E0277.
+For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/issues/issue-35570.rs
+++ b/tests/ui/issues/issue-35570.rs
@@ -7,6 +7,7 @@ trait Trait2<'a> {
 
 fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
     //~^ ERROR the trait bound `for<'a> (): Trait2<'a>` is not satisfied
+    //~| ERROR the trait bound `for<'a> (): Trait2<'a>` is not satisfied
     let _e: (usize, usize) = unsafe{mem::transmute(param)};
 }
 

--- a/tests/ui/issues/issue-35570.stderr
+++ b/tests/ui/issues/issue-35570.stderr
@@ -10,6 +10,23 @@ help: this trait has no implementations, consider adding one
 LL | trait Trait2<'a> {
    | ^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `for<'a> (): Trait2<'a>` is not satisfied
+  --> $DIR/issue-35570.rs:8:66
+   |
+LL |   fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
+   |  __________________________________________________________________^
+LL | |
+LL | |
+LL | |     let _e: (usize, usize) = unsafe{mem::transmute(param)};
+LL | | }
+   | |_^ the trait `for<'a> Trait2<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/issue-35570.rs:4:1
+   |
+LL | trait Trait2<'a> {
+   | ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-54410.rs
+++ b/tests/ui/issues/issue-54410.rs
@@ -5,4 +5,5 @@ extern "C" {
 
 fn main() {
     println!("{:p}", unsafe { &symbol });
+    //~^ WARN: shared reference of mutable static is discouraged
 }

--- a/tests/ui/issues/issue-54410.stderr
+++ b/tests/ui/issues/issue-54410.stderr
@@ -6,6 +6,21 @@ LL |     pub static mut symbol: [i8];
    |
    = help: the trait `Sized` is not implemented for `[i8]`
 
-error: aborting due to 1 previous error
+warning: shared reference of mutable static is discouraged
+  --> $DIR/issue-54410.rs:7:31
+   |
+LL |     println!("{:p}", unsafe { &symbol });
+   |                               ^^^^^^^ shared reference of mutable static
+   |
+   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
+   = note: reference of mutable static is a hard error from 2024 edition
+   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
+   = note: `#[warn(static_mut_ref)]` on by default
+help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer
+   |
+LL |     println!("{:p}", unsafe { addr_of!(symbol) });
+   |                               ~~~~~~~~~~~~~~~~
+
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-7364.rs
+++ b/tests/ui/issues/issue-7364.rs
@@ -3,5 +3,6 @@ use std::cell::RefCell;
 // Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
 //~^ ERROR `RefCell<isize>` cannot be shared between threads safely [E0277]
+//~| ERROR cannot call non-const fn
 
 fn main() { }

--- a/tests/ui/issues/issue-7364.stderr
+++ b/tests/ui/issues/issue-7364.stderr
@@ -11,6 +11,16 @@ note: required because it appears within the type `Box<RefCell<isize>>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    = note: shared static variables must have a type that implements `Sync`
 
-error: aborting due to 1 previous error
+error[E0015]: cannot call non-const fn `Box::<RefCell<isize>>::new` in statics
+  --> $DIR/issue-7364.rs:4:37
+   |
+LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/layout/cannot-transmute-unnormalizable-type.rs
+++ b/tests/ui/layout/cannot-transmute-unnormalizable-type.rs
@@ -16,8 +16,7 @@ struct Other {
 
 fn main() {
     unsafe {
-        // FIXME(oli-obk): make this report a transmute error again.
         std::mem::transmute::<Option<()>, Option<&Other>>(None);
-        //^ ERROR cannot transmute between types of different sizes, or dependently-sized types
+        //~^ ERROR cannot transmute between types of different sizes, or dependently-sized types
     }
 }

--- a/tests/ui/layout/cannot-transmute-unnormalizable-type.stderr
+++ b/tests/ui/layout/cannot-transmute-unnormalizable-type.stderr
@@ -4,6 +4,16 @@ error[E0412]: cannot find type `Missing` in this scope
 LL |     Missing: Trait,
    |     ^^^^^^^ not found in this scope
 
-error: aborting due to 1 previous error
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/cannot-transmute-unnormalizable-type.rs:19:9
+   |
+LL |         std::mem::transmute::<Option<()>, Option<&Other>>(None);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `Option<()>` (8 bits)
+   = note: target type: `Option<&Other>` (unable to determine layout for `Other` because `<() as Trait>::RefTarget` cannot be normalized)
 
-For more information about this error, try `rustc --explain E0412`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0412, E0512.
+For more information about an error, try `rustc --explain E0412`.

--- a/tests/ui/lifetimes/issue-95023.rs
+++ b/tests/ui/lifetimes/issue-95023.rs
@@ -9,5 +9,6 @@ impl Fn(&isize) for Error {
     //~^ ERROR associated function in `impl` without body
     //~^^ ERROR method `foo` is not a member of trait `Fn` [E0407]
     //~^^^ ERROR associated type `B` not found for `Self` [E0220]
+    //~| ERROR associated type `B` not found for `Self` [E0220]
 }
 fn main() {}

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -56,7 +56,15 @@ LL | impl Fn(&isize) for Error {
    |
    = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
 
-error: aborting due to 7 previous errors
+error[E0220]: associated type `B` not found for `Self`
+  --> $DIR/issue-95023.rs:8:44
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |                                            ^ help: `Self` has the following associated type: `Output`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0046, E0183, E0220, E0229, E0277, E0407.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/nll/normalization-bounds-error.rs
+++ b/tests/ui/nll/normalization-bounds-error.rs
@@ -10,6 +10,7 @@ impl<'a, 'd: 'a> Visitor<'d> for &'a () {
 }
 
 fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
-//~^ ERROR
+//~^ ERROR lifetime may not live long enough
+//~| ERROR cannot infer
 
 fn main() {}

--- a/tests/ui/nll/normalization-bounds-error.stderr
+++ b/tests/ui/nll/normalization-bounds-error.stderr
@@ -22,6 +22,18 @@ LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
    = note: expected `Visitor<'d>`
               found `Visitor<'_>`
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/normalization-bounds-error.rs:12:1
+   |
+LL | fn visit_seq<'d, 'a: 'd>() -> <&'a () as Visitor<'d>>::Value {}
+   | ^^^^^^^^^^^^^--^^--^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |            |   |
+   | |            |   lifetime `'a` defined here
+   | |            lifetime `'d` defined here
+   | requires that `'d` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'d: 'a`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0495`.

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
@@ -7,6 +7,35 @@ LL | fn id<F>(f: Copy) -> usize {
    = note: the trait cannot be made into an object because it requires `Self: Sized`
    = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
-error: aborting due to 1 previous error
+error[E0618]: expected function, found `(dyn Copy + 'static)`
+  --> $DIR/avoid-ice-on-warning-2.rs:11:5
+   |
+LL | fn id<F>(f: Copy) -> usize {
+   |          - `f` has type `(dyn Copy + 'static)`
+...
+LL |     f()
+   |     ^--
+   |     |
+   |     call expression requires function
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
+  --> $DIR/avoid-ice-on-warning-2.rs:4:10
+   |
+LL | fn id<F>(f: Copy) -> usize {
+   |          ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn id<F>(f: impl Copy) -> usize {
+   |             ++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn id<F>(f: &dyn Copy) -> usize {
+   |             ++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0038, E0277, E0618.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
@@ -35,6 +35,35 @@ LL | fn id<F>(f: Copy) -> usize {
    = note: the trait cannot be made into an object because it requires `Self: Sized`
    = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
-error: aborting due to 1 previous error; 2 warnings emitted
+error[E0618]: expected function, found `(dyn Copy + 'static)`
+  --> $DIR/avoid-ice-on-warning-2.rs:11:5
+   |
+LL | fn id<F>(f: Copy) -> usize {
+   |          - `f` has type `(dyn Copy + 'static)`
+...
+LL |     f()
+   |     ^--
+   |     |
+   |     call expression requires function
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
+  --> $DIR/avoid-ice-on-warning-2.rs:4:10
+   |
+LL | fn id<F>(f: Copy) -> usize {
+   |          ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: you can use `impl Trait` as the argument type
+   |
+LL | fn id<F>(f: impl Copy) -> usize {
+   |             ++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn id<F>(f: &dyn Copy) -> usize {
+   |             ++++
+
+error: aborting due to 3 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0038, E0277, E0618.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.rs
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.rs
@@ -3,10 +3,12 @@
 //[new] edition:2021
 fn id<F>(f: Copy) -> usize {
 //~^ ERROR the trait `Copy` cannot be made into an object
+//~| ERROR: the size for values of type `(dyn Copy + 'static)`
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     f()
+    //~^ ERROR: expected function, found `(dyn Copy + 'static)`
 }
 fn main() {}

--- a/tests/ui/object-safety/issue-102762.rs
+++ b/tests/ui/object-safety/issue-102762.rs
@@ -22,5 +22,7 @@ fn fetcher() -> Box<dyn Fetcher> {
 
 pub fn foo() {
     let fetcher = fetcher();
+    //~^ ERROR the trait `Fetcher` cannot be made into an object
     let _ = fetcher.get();
+    //~^ ERROR the trait `Fetcher` cannot be made into an object
 }

--- a/tests/ui/object-safety/issue-102762.stderr
+++ b/tests/ui/object-safety/issue-102762.stderr
@@ -15,6 +15,40 @@ LL | pub trait Fetcher: Send + Sync {
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Fetcher` cannot be made into an object
+  --> $DIR/issue-102762.rs:24:19
+   |
+LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+   |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
+...
+LL |     let fetcher = fetcher();
+   |                   ^^^^^^^^^ `Fetcher` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-102762.rs:10:22
+   |
+LL | pub trait Fetcher: Send + Sync {
+   |           ------- this trait cannot be made into an object...
+LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+   |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
+
+error[E0038]: the trait `Fetcher` cannot be made into an object
+  --> $DIR/issue-102762.rs:26:13
+   |
+LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+   |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
+...
+LL |     let _ = fetcher.get();
+   |             ^^^^^^^^^^^^^ `Fetcher` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-102762.rs:10:22
+   |
+LL | pub trait Fetcher: Send + Sync {
+   |           ------- this trait cannot be made into an object...
+LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
+   |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-associated-consts.curr.stderr
+++ b/tests/ui/object-safety/object-safety-associated-consts.curr.stderr
@@ -13,6 +13,22 @@ LL |     const X: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `X` to another trait
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-associated-consts.rs:14:5
+   |
+LL |     t
+   |     ^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-associated-consts.rs:9:11
+   |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
+LL |     const X: usize;
+   |           ^ ...because it contains this associated `const`
+   = help: consider moving `X` to another trait
+   = note: required for the cast from `&T` to `&dyn Bar`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-associated-consts.rs
+++ b/tests/ui/object-safety/object-safety-associated-consts.rs
@@ -12,7 +12,7 @@ trait Bar {
 fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
     //[curr]~^ ERROR E0038
     t
-    //[object_safe_for_dispatch]~^ ERROR E0038
+    //~^ ERROR E0038
 }
 
 fn main() {

--- a/tests/ui/object-safety/object-safety-generics.curr.stderr
+++ b/tests/ui/object-safety/object-safety-generics.curr.stderr
@@ -14,7 +14,7 @@ LL |     fn bar<T>(&self, t: T);
    = help: consider moving `bar` to another trait
 
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-generics.rs:24:40
+  --> $DIR/object-safety-generics.rs:25:40
    |
 LL | fn make_bar_explicit<T:Bar>(t: &T) -> &dyn Bar {
    |                                        ^^^^^^^ `Bar` cannot be made into an object
@@ -28,6 +28,53 @@ LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-generics.rs:20:5
+   |
+LL |     t
+   |     ^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-generics.rs:10:8
+   |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
+LL |     fn bar<T>(&self, t: T);
+   |        ^^^ ...because method `bar` has generic type parameters
+   = help: consider moving `bar` to another trait
+   = note: required for the cast from `&T` to `&dyn Bar`
+
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-generics.rs:27:10
+   |
+LL |     t as &dyn Bar
+   |          ^^^^^^^^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-generics.rs:10:8
+   |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
+LL |     fn bar<T>(&self, t: T);
+   |        ^^^ ...because method `bar` has generic type parameters
+   = help: consider moving `bar` to another trait
+
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-generics.rs:27:5
+   |
+LL |     t as &dyn Bar
+   |     ^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-generics.rs:10:8
+   |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
+LL |     fn bar<T>(&self, t: T);
+   |        ^^^ ...because method `bar` has generic type parameters
+   = help: consider moving `bar` to another trait
+   = note: required for the cast from `&T` to `&dyn Bar`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-generics.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-generics.object_safe_for_dispatch.stderr
@@ -15,7 +15,7 @@ LL |     fn bar<T>(&self, t: T);
    = note: required for the cast from `&T` to `&dyn Bar`
 
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-generics.rs:26:5
+  --> $DIR/object-safety-generics.rs:27:5
    |
 LL |     t as &dyn Bar
    |     ^ `Bar` cannot be made into an object

--- a/tests/ui/object-safety/object-safety-generics.rs
+++ b/tests/ui/object-safety/object-safety-generics.rs
@@ -19,12 +19,15 @@ fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
     //[curr]~^ ERROR E0038
     t
     //[object_safe_for_dispatch]~^ ERROR E0038
+    //[curr]~^^ ERROR E0038
 }
 
 fn make_bar_explicit<T:Bar>(t: &T) -> &dyn Bar {
     //[curr]~^ ERROR E0038
     t as &dyn Bar
     //[object_safe_for_dispatch]~^ ERROR E0038
+    //[curr]~^^ ERROR E0038
+    //[curr]~| ERROR E0038
 }
 
 fn make_quux<T:Quux>(t: &T) -> &dyn Quux {

--- a/tests/ui/object-safety/object-safety-issue-22040.rs
+++ b/tests/ui/object-safety/object-safety-issue-22040.rs
@@ -36,7 +36,9 @@ impl <'x> Expr for SExpr<'x> {
 
 fn main() {
     let a: Box<dyn Expr> = Box::new(SExpr::new());
+    //~^ ERROR: `Expr` cannot be made into an object
     let b: Box<dyn Expr> = Box::new(SExpr::new());
+    //~^ ERROR: `Expr` cannot be made into an object
 
     // assert_eq!(a , b);
 }

--- a/tests/ui/object-safety/object-safety-issue-22040.stderr
+++ b/tests/ui/object-safety/object-safety-issue-22040.stderr
@@ -13,6 +13,36 @@ LL | trait Expr: Debug + PartialEq {
    |       this trait cannot be made into an object...
    = help: only type `SExpr<'x>` implements the trait, consider using it directly instead
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Expr` cannot be made into an object
+  --> $DIR/object-safety-issue-22040.rs:38:16
+   |
+LL |     let a: Box<dyn Expr> = Box::new(SExpr::new());
+   |                ^^^^^^^^ `Expr` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-issue-22040.rs:5:21
+   |
+LL | trait Expr: Debug + PartialEq {
+   |       ----          ^^^^^^^^^ ...because it uses `Self` as a type parameter
+   |       |
+   |       this trait cannot be made into an object...
+   = help: only type `SExpr<'x>` implements the trait, consider using it directly instead
+
+error[E0038]: the trait `Expr` cannot be made into an object
+  --> $DIR/object-safety-issue-22040.rs:40:16
+   |
+LL |     let b: Box<dyn Expr> = Box::new(SExpr::new());
+   |                ^^^^^^^^ `Expr` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-issue-22040.rs:5:21
+   |
+LL | trait Expr: Debug + PartialEq {
+   |       ----          ^^^^^^^^^ ...because it uses `Self` as a type parameter
+   |       |
+   |       this trait cannot be made into an object...
+   = help: only type `SExpr<'x>` implements the trait, consider using it directly instead
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-mentions-Self.curr.stderr
+++ b/tests/ui/object-safety/object-safety-mentions-Self.curr.stderr
@@ -28,6 +28,38 @@ LL |     fn baz(&self) -> Self;
    |                      ^^^^ ...because method `baz` references the `Self` type in its return type
    = help: consider moving `baz` to another trait
 
-error: aborting due to 2 previous errors
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-mentions-Self.rs:24:5
+   |
+LL |     t
+   |     ^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-mentions-Self.rs:11:22
+   |
+LL | trait Bar {
+   |       --- this trait cannot be made into an object...
+LL |     fn bar(&self, x: &Self);
+   |                      ^^^^^ ...because method `bar` references the `Self` type in this parameter
+   = help: consider moving `bar` to another trait
+   = note: required for the cast from `&T` to `&dyn Bar`
+
+error[E0038]: the trait `Baz` cannot be made into an object
+  --> $DIR/object-safety-mentions-Self.rs:30:5
+   |
+LL |     t
+   |     ^ `Baz` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-mentions-Self.rs:15:22
+   |
+LL | trait Baz {
+   |       --- this trait cannot be made into an object...
+LL |     fn baz(&self) -> Self;
+   |                      ^^^^ ...because method `baz` references the `Self` type in its return type
+   = help: consider moving `baz` to another trait
+   = note: required for the cast from `&T` to `&dyn Baz`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-mentions-Self.rs
+++ b/tests/ui/object-safety/object-safety-mentions-Self.rs
@@ -22,13 +22,13 @@ trait Quux {
 fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
     //[curr]~^ ERROR E0038
     t
-    //[object_safe_for_dispatch]~^ ERROR E0038
+    //~^ ERROR E0038
 }
 
 fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
     //[curr]~^ ERROR E0038
     t
-    //[object_safe_for_dispatch]~^ ERROR E0038
+    //~^ ERROR E0038
 }
 
 fn make_quux<T:Quux>(t: &T) -> &dyn Quux {

--- a/tests/ui/object-safety/object-safety-no-static.curr.stderr
+++ b/tests/ui/object-safety/object-safety-no-static.curr.stderr
@@ -21,6 +21,53 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-safety-no-static.rs:22:12
+   |
+LL |     let b: Box<dyn Foo> = Box::new(Bar);
+   |            ^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-no-static.rs:9:8
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     fn foo() {}
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: only type `Bar` implements the trait, consider using it directly instead
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) {}
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized {}
+   |              +++++++++++++++++
+
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-safety-no-static.rs:22:27
+   |
+LL |     let b: Box<dyn Foo> = Box::new(Bar);
+   |                           ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-no-static.rs:9:8
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     fn foo() {}
+   |        ^^^ ...because associated function `foo` has no `self` parameter
+   = help: only type `Bar` implements the trait, consider using it directly instead
+   = note: required for the cast from `Box<Bar>` to `Box<dyn Foo>`
+help: consider turning `foo` into a method by giving it a `&self` argument
+   |
+LL |     fn foo(&self) {}
+   |            +++++
+help: alternatively, consider constraining `foo` so it does not apply to trait objects
+   |
+LL |     fn foo() where Self: Sized {}
+   |              +++++++++++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-no-static.rs
+++ b/tests/ui/object-safety/object-safety-no-static.rs
@@ -20,5 +20,6 @@ impl Foo for Bar {}
 
 fn main() {
     let b: Box<dyn Foo> = Box::new(Bar);
-    //[object_safe_for_dispatch]~^ ERROR E0038
+    //~^ ERROR E0038
+    //[curr]~| ERROR E0038
 }

--- a/tests/ui/object-safety/object-safety-sized-2.curr.stderr
+++ b/tests/ui/object-safety/object-safety-sized-2.curr.stderr
@@ -12,6 +12,21 @@ LL | trait Bar
 LL |     where Self : Sized
    |                  ^^^^^ ...because it requires `Self: Sized`
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-sized-2.rs:16:5
+   |
+LL |     t
+   |     ^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-sized-2.rs:9:18
+   |
+LL | trait Bar
+   |       --- this trait cannot be made into an object...
+LL |     where Self : Sized
+   |                  ^^^^^ ...because it requires `Self: Sized`
+   = note: required for the cast from `&T` to `&dyn Bar`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-sized-2.rs
+++ b/tests/ui/object-safety/object-safety-sized-2.rs
@@ -14,7 +14,7 @@ trait Bar
 fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
     //[curr]~^ ERROR E0038
     t
-    //[object_safe_for_dispatch]~^ ERROR E0038
+    //~^ ERROR E0038
 }
 
 fn main() {

--- a/tests/ui/object-safety/object-safety-sized.curr.stderr
+++ b/tests/ui/object-safety/object-safety-sized.curr.stderr
@@ -1,17 +1,32 @@
 error[E0038]: the trait `Bar` cannot be made into an object
-  --> $DIR/object-safety-sized.rs:12:31
+  --> $DIR/object-safety-sized.rs:12:32
    |
-LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                               ^^^^^^^ `Bar` cannot be made into an object
+LL | fn make_bar<T: Bar>(t: &T) -> &dyn Bar {
+   |                                ^^^^^^^ `Bar` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/object-safety-sized.rs:8:13
+  --> $DIR/object-safety-sized.rs:8:12
    |
-LL | trait Bar : Sized {
-   |       ---   ^^^^^ ...because it requires `Self: Sized`
+LL | trait Bar: Sized {
+   |       ---  ^^^^^ ...because it requires `Self: Sized`
    |       |
    |       this trait cannot be made into an object...
 
-error: aborting due to 1 previous error
+error[E0038]: the trait `Bar` cannot be made into an object
+  --> $DIR/object-safety-sized.rs:14:5
+   |
+LL |     t
+   |     ^ `Bar` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-sized.rs:8:12
+   |
+LL | trait Bar: Sized {
+   |       ---  ^^^^^ ...because it requires `Self: Sized`
+   |       |
+   |       this trait cannot be made into an object...
+   = note: required for the cast from `&T` to `&dyn Bar`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
@@ -5,10 +5,10 @@ LL |     t
    |     ^ `Bar` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/object-safety-sized.rs:8:13
+  --> $DIR/object-safety-sized.rs:8:12
    |
-LL | trait Bar : Sized {
-   |       ---   ^^^^^ ...because it requires `Self: Sized`
+LL | trait Bar: Sized {
+   |       ---  ^^^^^ ...because it requires `Self: Sized`
    |       |
    |       this trait cannot be made into an object...
    = note: required for the cast from `&T` to `&dyn Bar`

--- a/tests/ui/object-safety/object-safety-sized.rs
+++ b/tests/ui/object-safety/object-safety-sized.rs
@@ -5,15 +5,14 @@
 
 #![cfg_attr(object_safe_for_dispatch, feature(object_safe_for_dispatch))]
 
-trait Bar : Sized {
+trait Bar: Sized {
     fn bar<T>(&self, t: T);
 }
 
-fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
+fn make_bar<T: Bar>(t: &T) -> &dyn Bar {
     //[curr]~^ ERROR E0038
     t
-    //[object_safe_for_dispatch]~^ ERROR E0038
+    //~^ ERROR E0038
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/overloaded/overloaded-calls-nontuple.rs
+++ b/tests/ui/overloaded/overloaded-calls-nontuple.rs
@@ -20,11 +20,12 @@ impl FnOnce<isize> for S {
     type Output = isize;
     extern "rust-call" fn call_once(mut self, z: isize) -> isize {
         //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
-        self.call_mut(z)
+        self.call_mut(z) //~ ERROR `isize` is not a tuple
     }
 }
 
 fn main() {
     let mut s = S { x: 1, y: 2 };
-    drop(s(3))
+    drop(s(3)) //~ ERROR `isize` is not a tuple
+    //~^ ERROR cannot use call notation
 }

--- a/tests/ui/overloaded/overloaded-calls-nontuple.stderr
+++ b/tests/ui/overloaded/overloaded-calls-nontuple.stderr
@@ -28,7 +28,30 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_once(mut self, z: isize) -> isize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `isize`
 
-error: aborting due to 4 previous errors
+error[E0277]: `isize` is not a tuple
+  --> $DIR/overloaded-calls-nontuple.rs:23:23
+   |
+LL |         self.call_mut(z)
+   |              -------- ^ the trait `Tuple` is not implemented for `isize`
+   |              |
+   |              required by a bound introduced by this call
+   |
+note: required by a bound in `call_mut`
+  --> $SRC_DIR/core/src/ops/function.rs:LL:COL
+
+error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+  --> $DIR/overloaded-calls-nontuple.rs:29:10
+   |
+LL |     drop(s(3))
+   |          ^^^^
+
+error[E0277]: `isize` is not a tuple
+  --> $DIR/overloaded-calls-nontuple.rs:29:10
+   |
+LL |     drop(s(3))
+   |          ^^^^ the trait `Tuple` is not implemented for `isize`
+
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0059, E0277.
 For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/parser/variadic-ffi-nested-syntactic-fail.rs
+++ b/tests/ui/parser/variadic-ffi-nested-syntactic-fail.rs
@@ -5,9 +5,6 @@ fn f2<'a>(x: u8, y: Vec<&'a ...>) {}
 //~^ ERROR C-variadic type `...` may not be nested inside another type
 
 fn main() {
-    // While this is an error, wf-checks happen before typeck, and if any wf-checks
-    // encountered errors, we do not continue to typeck, even if the items are
-    // unrelated.
-    // FIXME(oli-obk): make this report a type mismatch again.
     let _recovery_witness: () = 0;
+    //~^ ERROR: mismatched types
 }

--- a/tests/ui/parser/variadic-ffi-nested-syntactic-fail.stderr
+++ b/tests/ui/parser/variadic-ffi-nested-syntactic-fail.stderr
@@ -10,6 +10,15 @@ error[E0743]: C-variadic type `...` may not be nested inside another type
 LL | fn f2<'a>(x: u8, y: Vec<&'a ...>) {}
    |                             ^^^
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/variadic-ffi-nested-syntactic-fail.rs:8:33
+   |
+LL |     let _recovery_witness: () = 0;
+   |                            --   ^ expected `()`, found integer
+   |                            |
+   |                            expected due to this
 
-For more information about this error, try `rustc --explain E0743`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0743.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/proc-macro/bad-projection.rs
+++ b/tests/ui/proc-macro/bad-projection.rs
@@ -14,4 +14,5 @@ trait Project {
 pub fn uwu() -> <() as Project>::Assoc {}
 //~^ ERROR the trait bound `(): Project` is not satisfied
 //~| ERROR the trait bound `(): Project` is not satisfied
+//~| ERROR the trait bound `(): Project` is not satisfied
 //~| ERROR function is expected to take 1 argument, but it takes 0 arguments

--- a/tests/ui/proc-macro/bad-projection.stderr
+++ b/tests/ui/proc-macro/bad-projection.stderr
@@ -35,7 +35,19 @@ help: this trait has no implementations, consider adding one
 LL | trait Project {
    | ^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `(): Project` is not satisfied
+  --> $DIR/bad-projection.rs:14:40
+   |
+LL | pub fn uwu() -> <() as Project>::Assoc {}
+   |                                        ^^ the trait `Project` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/bad-projection.rs:9:1
+   |
+LL | trait Project {
+   | ^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0593.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
@@ -14,7 +14,9 @@ struct PriorityQueueEntry<T> {
 //~^ ERROR can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
 //~| ERROR the trait bound `PriorityQueue<T>: Eq` is not satisfied
 //~| ERROR can't compare `T` with `T`
+//~| ERROR `BinaryHeap<PriorityQueueEntry<T>>` is not an iterator
+//~| ERROR no field `height` on type `&PriorityQueue<T>`
 
 struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
-
+//~^ ERROR can't compare `BinaryHeap<PriorityQueueEntry<T>>` with `_`
 fn main() {}

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -34,6 +34,38 @@ note: required by a bound in `Ord`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: this error originates in the derive macro `AddImpl` which comes from the expansion of the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error[E0277]: can't compare `BinaryHeap<PriorityQueueEntry<T>>` with `_`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:20:25
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |          ---------- in this derive macro expansion
+...
+LL | struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `BinaryHeap<PriorityQueueEntry<T>> < _` and `BinaryHeap<PriorityQueueEntry<T>> > _`
+   |
+   = help: the trait `PartialOrd<_>` is not implemented for `BinaryHeap<PriorityQueueEntry<T>>`
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0277`.
+error[E0599]: `BinaryHeap<PriorityQueueEntry<T>>` is not an iterator
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |                      ^^^^^^^ `BinaryHeap<PriorityQueueEntry<T>>` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `BinaryHeap<PriorityQueueEntry<T>>: Iterator`
+           which is required by `&mut BinaryHeap<PriorityQueueEntry<T>>: Iterator`
+   = note: this error originates in the derive macro `AddImpl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `height` on type `&PriorityQueue<T>`
+  --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
+   |
+LL | #[derive(PartialOrd, AddImpl)]
+   |                      ^^^^^^^ unknown field
+   |
+   = note: this error originates in the derive macro `AddImpl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0599, E0609.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/regions/regions-free-region-ordering-callee-4.rs
+++ b/tests/ui/regions/regions-free-region-ordering-callee-4.rs
@@ -6,6 +6,7 @@ fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'
     //~^ ERROR reference has a longer lifetime than the data it references
     // Do not infer ordering from closure argument types.
     let z: Option<&'a &'b usize> = None;
+    //~^ ERROR may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/regions/regions-free-region-ordering-callee-4.stderr
+++ b/tests/ui/regions/regions-free-region-ordering-callee-4.stderr
@@ -15,6 +15,19 @@ note: but the referenced data is only valid for the lifetime `'b` as defined her
 LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
    |                  ^^
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/regions-free-region-ordering-callee-4.rs:8:12
+   |
+LL | fn ordering4<'a, 'b, F>(a: &'a usize, b: &'b usize, x: F) where F: FnOnce(&'a &'b usize) {
+   |              --  -- lifetime `'b` defined here
+   |              |
+   |              lifetime `'a` defined here
+...
+LL |     let z: Option<&'a &'b usize> = None;
+   |            ^^^^^^^^^^^^^^^^^^^^^ requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0491`.

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.rs
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.rs
@@ -21,6 +21,7 @@ trait Trait2<'a, 'b> {
 fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
     //~^ ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 {
+    //~^ ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 }
 
 fn main() { }

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
@@ -9,6 +9,19 @@ help: consider restricting type parameter `T`
 LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                    ++++++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
+  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:23:1
+   |
+LL | / {
+LL | |
+LL | | }
+   | |_^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
+   |                    ++++++++++++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/resolve/issue-3907-2.rs
+++ b/tests/ui/resolve/issue-3907-2.rs
@@ -10,5 +10,6 @@ struct S {
 
 fn bar(_x: Foo) {}
 //~^ ERROR E0038
+//~| ERROR E0277
 
 fn main() {}

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -10,6 +10,20 @@ note: for a trait to be "object safe" it needs to allow building a vtable to all
 LL |     fn bar();
    |        ^^^ the trait cannot be made into an object because associated function `bar` has no `self` parameter
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `(dyn issue_3907::Foo + 'static)` cannot be known at compilation time
+  --> $DIR/issue-3907-2.rs:11:8
+   |
+LL | fn bar(_x: Foo) {}
+   |        ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn issue_3907::Foo + 'static)`
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL | fn bar(_x: &Foo) {}
+   |            +
 
-For more information about this error, try `rustc --explain E0038`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specializing-constness-2.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specializing-constness-2.stderr
@@ -7,6 +7,16 @@ LL | impl<T: Default> A for T {
 LL | impl<T: Default + ~const Sup> const A for T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/specializing-constness-2.rs:27:5
+   |
+LL |     <T as A>::a();
+   |     ^^^^^^^^^^^^^ expected `host`, found `true`
+   |
+   = note: expected constant `host`
+              found constant `true`
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0308.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.default.stderr
@@ -9,6 +9,7 @@ LL |     fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
+ERROR rustc_hir_typeck::method::confirm Foo was a subtype of &Foo but now is not?
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/simd/array-trait.rs
+++ b/tests/ui/simd/array-trait.rs
@@ -23,6 +23,7 @@ impl Simd for i32x4 {
 pub struct T<S: Simd>([S::Lane; S::SIZE]);
 //~^ ERROR unconstrained generic constant
 //~| ERROR SIMD vector element type should be a primitive scalar
+//~| ERROR unconstrained generic constant
 
 extern "platform-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
@@ -37,6 +38,7 @@ pub fn main() {
         }
         for i in 0_i32..4 {
             assert_eq!(i, simd_extract(t, i as u32));
+            //~^ ERROR: use of moved value: `t`
         }
     }
 }

--- a/tests/ui/simd/array-trait.stderr
+++ b/tests/ui/simd/array-trait.stderr
@@ -12,6 +12,29 @@ error[E0077]: SIMD vector element type should be a primitive scalar (integer/flo
 LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: unconstrained generic constant
+  --> $DIR/array-trait.rs:23:23
+   |
+LL | #[derive(Copy, Clone)]
+   |                ----- in this derive macro expansion
+LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
+   |                       ^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); S::SIZE]:`
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0077`.
+error[E0382]: use of moved value: `t`
+  --> $DIR/array-trait.rs:40:40
+   |
+LL |     let mut t = T::<i32x4>([0; 4]);
+   |         ----- move occurs because `t` has type `T<i32x4>`, which does not implement the `Copy` trait
+...
+LL |         for i in 0_i32..4 {
+   |         ----------------- inside of this loop
+LL |             assert_eq!(i, simd_extract(t, i as u32));
+   |                                        ^ value moved here, in previous iteration of loop
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0077, E0382.
+For more information about an error, try `rustc --explain E0077`.

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
@@ -6,6 +6,7 @@
 struct S<const L: usize>;
 
 impl<const N: i32> Copy for S<N> {}
+//~^ ERROR: mismatched types
 impl<const M: usize> Copy for S<M> {}
 //~^ ERROR: conflicting implementations of trait `Copy` for type `S<_>`
 

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
@@ -1,11 +1,19 @@
 error[E0119]: conflicting implementations of trait `Copy` for type `S<_>`
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:9:1
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:10:1
    |
 LL | impl<const N: i32> Copy for S<N> {}
    | -------------------------------- first implementation here
+LL |
 LL | impl<const M: usize> Copy for S<M> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S<_>`
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:8:31
+   |
+LL | impl<const N: i32> Copy for S<N> {}
+   |                               ^ expected `usize`, found `i32`
 
-For more information about this error, try `rustc --explain E0119`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0119, E0308.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/specialization/min_specialization/issue-79224.rs
+++ b/tests/ui/specialization/min_specialization/issue-79224.rs
@@ -20,6 +20,7 @@ impl<B: ?Sized> Display for Cow<'_, B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         //~^ ERROR: the trait bound `B: Clone` is not satisfied [E0277]
         //~| ERROR: the trait bound `B: Clone` is not satisfied [E0277]
+        //~| ERROR: the trait bound `B: Clone` is not satisfied [E0277]
         write!(f, "foo")
     }
 }

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -34,6 +34,24 @@ help: consider further restricting this bound
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `B: Clone` is not satisfied
+  --> $DIR/issue-79224.rs:20:62
+   |
+LL |       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+   |  ______________________________________________________________^
+LL | |
+LL | |
+LL | |
+LL | |         write!(f, "foo")
+LL | |     }
+   | |_____^ the trait `Clone` is not implemented for `B`, which is required by `B: ToOwned`
+   |
+   = note: required for `B` to implement `ToOwned`
+help: consider further restricting this bound
+   |
+LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
+   |                +++++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/fn-trait-notation.fixed
+++ b/tests/ui/suggestions/fn-trait-notation.fixed
@@ -7,12 +7,14 @@ where
     H: Fn(i32) -> i32, //~ ERROR E0658
 {
     f(3);
+    //~^ ERROR: cannot use call notation
+    //~| ERROR: `i32` is not a tuple
     g(3, 4);
     h(3)
 }
 
 fn main() {
-    e0658(
+    e0658( //~ ERROR: mismatched types
         |a| a,
         |a, b| (b, a),
         |a| a,

--- a/tests/ui/suggestions/fn-trait-notation.rs
+++ b/tests/ui/suggestions/fn-trait-notation.rs
@@ -7,12 +7,14 @@ where
     H: Fn<(i32,), Output = i32>, //~ ERROR E0658
 {
     f(3);
+    //~^ ERROR: cannot use call notation
+    //~| ERROR: `i32` is not a tuple
     g(3, 4);
     h(3)
 }
 
 fn main() {
-    e0658(
+    e0658( //~ ERROR: mismatched types
         |a| a,
         |a, b| (b, a),
         |a| a,

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -37,7 +37,40 @@ LL |     F: Fn<i32, Output = i32>,
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-error: aborting due to 4 previous errors
+error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+  --> $DIR/fn-trait-notation.rs:9:5
+   |
+LL |     f(3);
+   |     ^^^^
 
-Some errors have detailed explanations: E0059, E0658.
+error[E0277]: `i32` is not a tuple
+  --> $DIR/fn-trait-notation.rs:9:5
+   |
+LL |     f(3);
+   |     ^^^^ the trait `Tuple` is not implemented for `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-trait-notation.rs:17:5
+   |
+LL | /     e0658(
+LL | |         |a| a,
+LL | |         |a, b| (b, a),
+LL | |         |a| a,
+LL | |     );
+   | |_____^ types differ
+   |
+   = note: expected trait `Fn<i32>`
+              found trait `Fn(_)`
+note: required by a bound in `e0658`
+  --> $DIR/fn-trait-notation.rs:4:8
+   |
+LL | fn e0658<F, G, H>(f: F, g: G, h: H) -> i32
+   |    ----- required by a bound in this function
+LL | where
+LL |     F: Fn<i32, Output = i32>,
+   |        ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `e0658`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0059, E0277, E0308, E0658.
 For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.fixed
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.fixed
@@ -2,15 +2,17 @@
 use std::fmt::Debug;
 
 #[derive(Debug, Copy, Clone)]
-pub struct Vector2<T: Debug + Copy + Clone>{
+pub struct Vector2<T: Debug + Copy + Clone> {
     pub x: T,
-    pub y: T
+    pub y: T,
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct AABB<K: Debug + std::marker::Copy>{
+pub struct AABB<K: Debug + std::marker::Copy + std::marker::Copy + std::marker::Copy + std::marker::Copy> {
     pub loc: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
-    pub size: Vector2<K>
+    //~^ ERROR the trait bound `K: Copy` is not satisfied
+    //~| ERROR the trait bound `K: Copy` is not satisfied
+    pub size: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.rs
@@ -2,15 +2,17 @@
 use std::fmt::Debug;
 
 #[derive(Debug, Copy, Clone)]
-pub struct Vector2<T: Debug + Copy + Clone>{
+pub struct Vector2<T: Debug + Copy + Clone> {
     pub x: T,
-    pub y: T
+    pub y: T,
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct AABB<K: Debug>{
+pub struct AABB<K: Debug> {
     pub loc: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
-    pub size: Vector2<K>
+    //~^ ERROR the trait bound `K: Copy` is not satisfied
+    //~| ERROR the trait bound `K: Copy` is not satisfied
+    pub size: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -7,13 +7,80 @@ LL |     pub loc: Vector2<K>,
 note: required by a bound in `Vector2`
   --> $DIR/missing-bound-in-derive-copy-impl-2.rs:5:31
    |
-LL | pub struct Vector2<T: Debug + Copy + Clone>{
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
 help: consider further restricting this bound
    |
-LL | pub struct AABB<K: Debug + std::marker::Copy>{
+LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:12:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ----- in this derive macro expansion
+LL | pub struct AABB<K: Debug> {
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `K`, which is required by `Vector2<K>: Debug`
+   |
+note: required for `Vector2<K>` to implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:4:10
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
+   |                               ---- unsatisfied trait bound introduced in this `derive` macro
+   = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Debug + std::marker::Copy> {
+   |                          +++++++++++++++++++
+
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:12:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+LL | pub struct AABB<K: Debug> {
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `K`, which is required by `Vector2<K>: Clone`
+   |
+note: required for `Vector2<K>` to implement `Clone`
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:4:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
+   |                               ---- unsatisfied trait bound introduced in this `derive` macro
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Debug + std::marker::Copy> {
+   |                          +++++++++++++++++++
+
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:15:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+...
+LL |     pub size: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `K`, which is required by `Vector2<K>: Clone`
+   |
+note: required for `Vector2<K>` to implement `Clone`
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:4:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
+   |                               ---- unsatisfied trait bound introduced in this `derive` macro
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Debug + std::marker::Copy> {
+   |                          +++++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
@@ -8,9 +8,10 @@ pub struct Vector2<T: Debug + Copy + Clone>{
 }
 
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
-pub struct AABB<K: Copy + Debug + std::fmt::Debug>{
+pub struct AABB<K: Copy + Debug + std::fmt::Debug + std::fmt::Debug + std::fmt::Debug>{
     pub loc: Vector2<K>, //~ ERROR `K` doesn't implement `Debug`
-    pub size: Vector2<K>
+    //~^ ERROR `K` doesn't implement `Debug`
+    pub size: Vector2<K> //~ ERROR `K` doesn't implement `Debug`
 }
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
@@ -10,7 +10,8 @@ pub struct Vector2<T: Debug + Copy + Clone>{
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
 pub struct AABB<K: Copy>{
     pub loc: Vector2<K>, //~ ERROR `K` doesn't implement `Debug`
-    pub size: Vector2<K>
+    //~^ ERROR `K` doesn't implement `Debug`
+    pub size: Vector2<K> //~ ERROR `K` doesn't implement `Debug`
 }
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -34,7 +34,37 @@ help: consider further restricting this bound
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: `K` doesn't implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:12:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+LL | pub struct AABB<K: Copy>{
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Copy + std::fmt::Debug>{
+   |                         +++++++++++++++++
+
+error[E0277]: `K` doesn't implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:14:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+...
+LL |     pub size: Vector2<K>
+   |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Copy + std::fmt::Debug>{
+   |                         +++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0204, E0277.
 For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.rs
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.rs
@@ -1,17 +1,22 @@
 use std::fmt::Debug;
 
 #[derive(Debug, Copy, Clone)]
-pub struct Vector2<T: Debug + Copy + Clone>{
+pub struct Vector2<T: Debug + Copy + Clone> {
     pub x: T,
-    pub y: T
+    pub y: T,
 }
 
 #[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` cannot be implemented for this type
-pub struct AABB<K>{
+pub struct AABB<K> {
     pub loc: Vector2<K>,
     //~^ ERROR doesn't implement `Debug`
     //~| ERROR `K: Copy` is not satisfied
-    pub size: Vector2<K>
+    //~| ERROR doesn't implement `Debug`
+    //~| ERROR `K: Copy` is not satisfied
+    //~| ERROR `K: Copy` is not satisfied
+    pub size: Vector2<K>,
+    //~^ ERROR doesn't implement `Debug`
+    //~| ERROR `K: Copy` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -3,7 +3,7 @@ error[E0204]: the trait `Copy` cannot be implemented for this type
    |
 LL | #[derive(Debug, Copy, Clone)]
    |                 ^^^^
-LL | pub struct AABB<K>{
+LL | pub struct AABB<K> {
 LL |     pub loc: Vector2<K>,
    |     ------------------- this field does not implement `Copy`
    |
@@ -15,7 +15,7 @@ LL |     pub loc: Vector2<K>,
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K`
    |
-LL | pub struct AABB<K: Debug>{
+LL | pub struct AABB<K: Debug> {
    |                  +++++++
 
 error[E0277]: `K` doesn't implement `Debug`
@@ -27,11 +27,11 @@ LL |     pub loc: Vector2<K>,
 note: required by a bound in `Vector2`
   --> $DIR/missing-bound-in-derive-copy-impl.rs:4:23
    |
-LL | pub struct Vector2<T: Debug + Copy + Clone>{
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                       ^^^^^ required by this bound in `Vector2`
 help: consider restricting type parameter `K`
    |
-LL | pub struct AABB<K: std::fmt::Debug>{
+LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
 
 error[E0277]: the trait bound `K: Copy` is not satisfied
@@ -43,14 +43,111 @@ LL |     pub loc: Vector2<K>,
 note: required by a bound in `Vector2`
   --> $DIR/missing-bound-in-derive-copy-impl.rs:4:31
    |
-LL | pub struct Vector2<T: Debug + Copy + Clone>{
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
 help: consider restricting type parameter `K`
    |
-LL | pub struct AABB<K: std::marker::Copy>{
+LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ----- in this derive macro expansion
+LL | pub struct AABB<K> {
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `K`, which is required by `Vector2<K>: Debug`
+   |
+note: required for `Vector2<K>` to implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:3:10
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |          ^^^^^
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
+   |                               ---- unsatisfied trait bound introduced in this `derive` macro
+   = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::marker::Copy> {
+   |                  +++++++++++++++++++
+
+error[E0277]: `K` doesn't implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+LL | pub struct AABB<K> {
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::fmt::Debug> {
+   |                  +++++++++++++++++
+
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+LL | pub struct AABB<K> {
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `K`, which is required by `Vector2<K>: Clone`
+   |
+note: required for `Vector2<K>` to implement `Clone`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:3:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
+   |                               ---- unsatisfied trait bound introduced in this `derive` macro
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::marker::Copy> {
+   |                  +++++++++++++++++++
+
+error[E0277]: `K` doesn't implement `Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:17:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+...
+LL |     pub size: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::fmt::Debug> {
+   |                  +++++++++++++++++
+
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:17:5
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ----- in this derive macro expansion
+...
+LL |     pub size: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `K`, which is required by `Vector2<K>: Clone`
+   |
+note: required for `Vector2<K>` to implement `Clone`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:3:23
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                       ^^^^^
+LL | pub struct Vector2<T: Debug + Copy + Clone> {
+   |                               ---- unsatisfied trait bound introduced in this `derive` macro
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: std::marker::Copy> {
+   |                  +++++++++++++++++++
+
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0204, E0277.
 For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/suggestions/object-unsafe-trait-references-self.rs
+++ b/tests/ui/suggestions/object-unsafe-trait-references-self.rs
@@ -1,6 +1,9 @@
 trait Trait {
     fn baz(&self, _: Self) {}
+    //~^ ERROR the size for values of type `Self` cannot be known
     fn bat(&self) -> Self {}
+    //~^ ERROR mismatched types
+    //~| ERROR the size for values of type `Self` cannot be known
 }
 
 fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object

--- a/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/object-unsafe-trait-references-self.rs:6:12
+  --> $DIR/object-unsafe-trait-references-self.rs:9:12
    |
 LL | fn bar(x: &dyn Trait) {}
    |            ^^^^^^^^^ `Trait` cannot be made into an object
@@ -11,25 +11,67 @@ LL | trait Trait {
    |       ----- this trait cannot be made into an object...
 LL |     fn baz(&self, _: Self) {}
    |                      ^^^^ ...because method `baz` references the `Self` type in this parameter
+LL |
 LL |     fn bat(&self) -> Self {}
    |                      ^^^^ ...because method `bat` references the `Self` type in its return type
    = help: consider moving `baz` to another trait
    = help: consider moving `bat` to another trait
 
 error[E0038]: the trait `Other` cannot be made into an object
-  --> $DIR/object-unsafe-trait-references-self.rs:10:12
+  --> $DIR/object-unsafe-trait-references-self.rs:13:12
    |
 LL | fn foo(x: &dyn Other) {}
    |            ^^^^^^^^^ `Other` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/object-unsafe-trait-references-self.rs:8:14
+  --> $DIR/object-unsafe-trait-references-self.rs:11:14
    |
 LL | trait Other: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
    |       this trait cannot be made into an object...
 
-error: aborting due to 2 previous errors
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/object-unsafe-trait-references-self.rs:2:19
+   |
+LL |     fn baz(&self, _: Self) {}
+   |                   ^ doesn't have a size known at compile-time
+   |
+   = help: unsized fn params are gated as an unstable feature
+help: consider further restricting `Self`
+   |
+LL |     fn baz(&self, _: Self) where Self: Sized {}
+   |                            +++++++++++++++++
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     fn baz(&self, _: &Self) {}
+   |                      +
 
-For more information about this error, try `rustc --explain E0038`.
+error[E0308]: mismatched types
+  --> $DIR/object-unsafe-trait-references-self.rs:4:27
+   |
+LL | trait Trait {
+   | ----------- expected this type parameter
+...
+LL |     fn bat(&self) -> Self {}
+   |                           ^^ expected type parameter `Self`, found `()`
+   |
+   = note: expected type parameter `Self`
+                   found unit type `()`
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/object-unsafe-trait-references-self.rs:4:22
+   |
+LL |     fn bat(&self) -> Self {}
+   |                      ^^^^ doesn't have a size known at compile-time
+   |
+   = note: the return type of a function must have a statically known size
+help: consider further restricting `Self`
+   |
+LL |     fn bat(&self) -> Self where Self: Sized {}
+   |                           +++++++++++++++++
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0038, E0277, E0308.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/trait-bounds/impl-bound-with-references-error.rs
+++ b/tests/ui/trait-bounds/impl-bound-with-references-error.rs
@@ -13,7 +13,7 @@ where
     //~^ ERROR cannot find type `Cow` in this scope [E0412]
 {
     fn from(text: T) -> Self {
-        LabelText::Plain(text.into())
+        LabelText::Plain(text.into()) //~ ERROR expected function, found `LabelText`
     }
 }
 

--- a/tests/ui/trait-bounds/impl-bound-with-references-error.stderr
+++ b/tests/ui/trait-bounds/impl-bound-with-references-error.stderr
@@ -21,7 +21,18 @@ LL | |     T: Into<Cow<'static, str>>,
    = note: conflicting implementation in crate `core`:
            - impl<T> From<T> for T;
 
-error: aborting due to 2 previous errors
+error[E0618]: expected function, found `LabelText`
+  --> $DIR/impl-bound-with-references-error.rs:16:9
+   |
+LL |     Plain,
+   |     ----- `LabelText::Plain` defined here
+...
+LL |         LabelText::Plain(text.into())
+   |         ^^^^^^^^^^^^^^^^-------------
+   |         |
+   |         call expression requires function
 
-Some errors have detailed explanations: E0119, E0412.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0119, E0412, E0618.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/trait-impl-bound-suggestions.fixed
+++ b/tests/ui/trait-impl-bound-suggestions.fixed
@@ -10,19 +10,21 @@ struct ConstrainedStruct<X: Copy> {
 }
 
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {
+trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy, X: std::marker::Copy {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
+        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 
 // Regression test for #120838
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where X: std::marker::Copy {
+trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy, X: std::marker::Copy {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
+        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 

--- a/tests/ui/trait-impl-bound-suggestions.rs
+++ b/tests/ui/trait-impl-bound-suggestions.rs
@@ -10,19 +10,21 @@ struct ConstrainedStruct<X: Copy> {
 }
 
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGeneric<X=()> {
+trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
+        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 
 // Regression test for #120838
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where {
+trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }
+        //~^ ERROR the trait bound `X: Copy` is not satisfied
     }
 }
 

--- a/tests/ui/trait-impl-bound-suggestions.stderr
+++ b/tests/ui/trait-impl-bound-suggestions.stderr
@@ -11,11 +11,11 @@ LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
 help: consider further restricting type parameter `X`
    |
-LL | trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {
-   |                                              ++++++++++++++++++++++++++
+LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
+   |                                                               ++++++++++++++++++++++
 
 error[E0277]: the trait bound `X: Copy` is not satisfied
-  --> $DIR/trait-impl-bound-suggestions.rs:23:52
+  --> $DIR/trait-impl-bound-suggestions.rs:24:52
    |
 LL |     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
    |                                                    ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `X`
@@ -27,9 +27,41 @@ LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
 help: consider further restricting type parameter `X`
    |
-LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where X: std::marker::Copy {
-   |                                                                  ++++++++++++++++++++
+LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
+   |                                                                             ++++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `X: Copy` is not satisfied
+  --> $DIR/trait-impl-bound-suggestions.rs:16:29
+   |
+LL |         ConstrainedStruct { x }
+   |                             ^ the trait `Copy` is not implemented for `X`
+   |
+note: required by a bound in `ConstrainedStruct`
+  --> $DIR/trait-impl-bound-suggestions.rs:8:29
+   |
+LL | struct ConstrainedStruct<X: Copy> {
+   |                             ^^^^ required by this bound in `ConstrainedStruct`
+help: consider further restricting type parameter `X`
+   |
+LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
+   |                                                               ++++++++++++++++++++++
+
+error[E0277]: the trait bound `X: Copy` is not satisfied
+  --> $DIR/trait-impl-bound-suggestions.rs:26:29
+   |
+LL |         ConstrainedStruct { x }
+   |                             ^ the trait `Copy` is not implemented for `X`
+   |
+note: required by a bound in `ConstrainedStruct`
+  --> $DIR/trait-impl-bound-suggestions.rs:8:29
+   |
+LL | struct ConstrainedStruct<X: Copy> {
+   |                             ^^^^ required by this bound in `ConstrainedStruct`
+help: consider further restricting type parameter `X`
+   |
+LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
+   |                                                                             ++++++++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-106072.rs
+++ b/tests/ui/traits/issue-106072.rs
@@ -1,5 +1,6 @@
 #[derive(Clone)] //~  trait objects must include the `dyn` keyword
 //~^ ERROR: the size for values of type `(dyn Foo + 'static)` cannot be known
+//~| ERROR: return type cannot have an unboxed trait object
 struct Foo;
 trait Foo {} //~ the name `Foo` is defined multiple times
 fn main() {}

--- a/tests/ui/traits/issue-106072.stderr
+++ b/tests/ui/traits/issue-106072.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/issue-106072.rs:4:1
+  --> $DIR/issue-106072.rs:5:1
    |
 LL | struct Foo;
    | ----------- previous definition of the type `Foo` here
@@ -19,6 +19,14 @@ note: required by a bound in `Clone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/issue-106072.rs:1:10
+   |
+LL | #[derive(Clone)]
+   |          ^^^^^ doesn't have a size known at compile-time
+   |
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/issue-106072.rs:1:10
    |
@@ -27,7 +35,7 @@ LL | #[derive(Clone)]
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0428, E0782.
+Some errors have detailed explanations: E0277, E0428, E0746, E0782.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-50480.rs
+++ b/tests/ui/traits/issue-50480.rs
@@ -6,12 +6,15 @@ struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~| ERROR cannot find type `N` in this scope
 //~| ERROR cannot find type `N` in this scope
 //~| ERROR `i32` is not an iterator
+//~| ERROR `i32` is not an iterator
 
 #[derive(Clone, Copy)]
 //~^ ERROR the trait `Copy` cannot be implemented for this type
+//~| ERROR `i32` is not an iterator
 struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
 //~^ ERROR cannot find type `NotDefined` in this scope
 //~| ERROR cannot find type `N` in this scope
+//~| ERROR `i32` is not an iterator
 //~| ERROR `i32` is not an iterator
 
 fn main() {}

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -38,7 +38,7 @@ LL | struct Foo<NotDefined>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, St
    |           ++++++++++++
 
 error[E0412]: cannot find type `N` in this scope
-  --> $DIR/issue-50480.rs:12:18
+  --> $DIR/issue-50480.rs:14:18
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |            -     ^
@@ -55,7 +55,7 @@ LL | struct Bar<T, N>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, Strin
    |             +++
 
 error[E0412]: cannot find type `NotDefined` in this scope
-  --> $DIR/issue-50480.rs:12:21
+  --> $DIR/issue-50480.rs:14:21
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                     ^^^^^^^^^^ not found in this scope
@@ -74,11 +74,11 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` cannot be implemented for this type
-  --> $DIR/issue-50480.rs:10:17
+  --> $DIR/issue-50480.rs:11:17
    |
 LL | #[derive(Clone, Copy)]
    |                 ^^^^
-LL |
+...
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                                          --------  ------ this field does not implement `Copy`
    |                                                          |
@@ -96,7 +96,7 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
 error[E0277]: `i32` is not an iterator
-  --> $DIR/issue-50480.rs:12:33
+  --> $DIR/issue-50480.rs:14:33
    |
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
@@ -104,7 +104,39 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    = help: the trait `Iterator` is not implemented for `i32`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
-error: aborting due to 10 previous errors
+error[E0277]: `i32` is not an iterator
+  --> $DIR/issue-50480.rs:3:28
+   |
+LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |                            ^^^ `i32` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
+
+error[E0277]: `i32` is not an iterator
+  --> $DIR/issue-50480.rs:11:10
+   |
+LL | #[derive(Clone, Copy)]
+   |          ^^^^^ `i32` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `i32` is not an iterator
+  --> $DIR/issue-50480.rs:14:33
+   |
+LL | #[derive(Clone, Copy)]
+   |          ----- in this derive macro expansion
+...
+LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `i32`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0204, E0277, E0412.
 For more information about an error, try `rustc --explain E0204`.

--- a/tests/ui/traits/next-solver/normalize-param-env-2.stderr
+++ b/tests/ui/traits/next-solver/normalize-param-env-2.stderr
@@ -30,6 +30,30 @@ LL |         Self::Assoc: A<T>,
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`normalize_param_env_2`)
 
-error: aborting due to 3 previous errors
+error[E0275]: overflow evaluating the requirement `(): A<T>`
+  --> $DIR/normalize-param-env-2.rs:27:10
+   |
+LL |         <() as A<T>>::f();
+   |          ^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`normalize_param_env_2`)
+
+error[E0275]: overflow evaluating the requirement `<() as A<T>>::Assoc: A<T>`
+  --> $DIR/normalize-param-env-2.rs:27:9
+   |
+LL |         <() as A<T>>::f();
+   |         ^^^^^^^^^^^^^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`normalize_param_env_2`)
+note: required by a bound in `A::f`
+  --> $DIR/normalize-param-env-2.rs:14:22
+   |
+LL |     fn f()
+   |        - required by a bound in this associated function
+LL |     where
+LL |         Self::Assoc: A<T>,
+   |                      ^^^^ required by this bound in `A::f`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/normalize-param-env-4.next.stderr
+++ b/tests/ui/traits/next-solver/normalize-param-env-4.next.stderr
@@ -14,6 +14,19 @@ LL |     <T as Trait>::Assoc: Trait,
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`normalize_param_env_4`)
 
-error: aborting due to 2 previous errors
+error[E0275]: overflow evaluating the requirement `T: Trait`
+  --> $DIR/normalize-param-env-4.rs:31:19
+   |
+LL |     impls_trait::<T>();
+   |                   ^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`normalize_param_env_4`)
+note: required by a bound in `impls_trait`
+  --> $DIR/normalize-param-env-4.rs:14:19
+   |
+LL | fn impls_trait<T: Trait>() {}
+   |                   ^^^^^ required by this bound in `impls_trait`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/specialization-transmute.rs
+++ b/tests/ui/traits/next-solver/specialization-transmute.rs
@@ -15,7 +15,7 @@ impl<T> Default for T {
     // This will be fixed by #111994
     fn intu(&self) -> &Self::Id {
         //~^ ERROR type annotations needed
-        self
+        self //~ ERROR cannot satisfy
     }
 }
 
@@ -25,6 +25,6 @@ fn transmute<T: Default<Id = U>, U: Copy>(t: T) -> U {
 
 use std::num::NonZeroU8;
 fn main() {
-    let s = transmute::<u8, Option<NonZeroU8>>(0); // this call should then error
+    let s = transmute::<u8, Option<NonZeroU8>>(0); //~ ERROR cannot satisfy
     assert_eq!(s, None);
 }

--- a/tests/ui/traits/next-solver/specialization-transmute.stderr
+++ b/tests/ui/traits/next-solver/specialization-transmute.stderr
@@ -16,13 +16,31 @@ error[E0284]: type annotations needed: cannot satisfy `<T as Default>::Id == _`
 LL |     fn intu(&self) -> &Self::Id {
    |                       ^^^^^^^^^ cannot satisfy `<T as Default>::Id == _`
 
+error[E0284]: type annotations needed: cannot satisfy `T <: <T as Default>::Id`
+  --> $DIR/specialization-transmute.rs:18:9
+   |
+LL |         self
+   |         ^^^^ cannot satisfy `T <: <T as Default>::Id`
+
+error[E0284]: type annotations needed: cannot satisfy `<u8 as Default>::Id == Option<NonZero<u8>>`
+  --> $DIR/specialization-transmute.rs:28:13
+   |
+LL |     let s = transmute::<u8, Option<NonZeroU8>>(0);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot satisfy `<u8 as Default>::Id == Option<NonZero<u8>>`
+   |
+note: required by a bound in `transmute`
+  --> $DIR/specialization-transmute.rs:22:25
+   |
+LL | fn transmute<T: Default<Id = U>, U: Copy>(t: T) -> U {
+   |                         ^^^^^^ required by this bound in `transmute`
+
 error[E0282]: type annotations needed
   --> $DIR/specialization-transmute.rs:14:23
    |
 LL |     default type Id = T;
    |                       ^ cannot infer type for associated type `<T as Default>::Id`
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 5 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0282, E0284.
 For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/transmutability/issue-101739-1.rs
+++ b/tests/ui/transmutability/issue-101739-1.rs
@@ -7,6 +7,7 @@ mod assert {
     where
         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME_ALIGNMENT>, //~ ERROR cannot find type `Dst` in this scope
         //~^ the constant `ASSUME_ALIGNMENT` is not of type `Assume`
+        //~| ERROR: mismatched types
     {
     }
 }

--- a/tests/ui/transmutability/issue-101739-1.stderr
+++ b/tests/ui/transmutability/issue-101739-1.stderr
@@ -13,6 +13,13 @@ LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME_ALIGNMENT>,
 note: required by a bound in `BikeshedIntrinsicFrom`
   --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-101739-1.rs:8:50
+   |
+LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME_ALIGNMENT>,
+   |                                                  ^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
 
-For more information about this error, try `rustc --explain E0412`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0412.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -19,7 +19,7 @@ mod assert {
         //~^ ERROR: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
             Src,
             Context,
-            ASSUME_ALIGNMENT,
+            ASSUME_ALIGNMENT, //~ ERROR: mismatched types
             ASSUME_LIFETIMES,
             ASSUME_VALIDITY,
             ASSUME_VISIBILITY,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -25,6 +25,13 @@ LL | |         >,
 note: required by a bound in `BikeshedIntrinsicFrom`
   --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-101739-2.rs:22:13
+   |
+LL |             ASSUME_ALIGNMENT,
+   |             ^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
 
-For more information about this error, try `rustc --explain E0107`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0308.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/type/type-check/issue-40294.rs
+++ b/tests/ui/type/type-check/issue-40294.rs
@@ -6,7 +6,7 @@ fn foo<'a,'b,T>(x: &'a T, y: &'b T)
     where &'a T : Foo, //~ ERROR type annotations needed
           &'b T : Foo
 {
-    x.foo();
+    x.foo(); //~ ERROR type annotations needed
     y.foo();
 }
 

--- a/tests/ui/type/type-check/issue-40294.stderr
+++ b/tests/ui/type/type-check/issue-40294.stderr
@@ -12,6 +12,20 @@ LL |     where &'a T : Foo,
 LL |           &'b T : Foo
    |                   ^^^
 
-error: aborting due to 1 previous error
+error[E0283]: type annotations needed: cannot satisfy `&T: Foo`
+  --> $DIR/issue-40294.rs:9:7
+   |
+LL |     x.foo();
+   |       ^^^
+   |
+note: multiple `impl`s or `where` clauses satisfying `&T: Foo` found
+  --> $DIR/issue-40294.rs:6:19
+   |
+LL |     where &'a T : Foo,
+   |                   ^^^
+LL |           &'b T : Foo
+   |                   ^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -47,7 +47,7 @@ impl Test9 {
 
 fn test11(x: &usize) -> &_ {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
-    &x
+    &x //~ ERROR cannot return reference to function parameter
 }
 
 unsafe fn test12(x: *const usize) -> *const *const _ {
@@ -229,3 +229,5 @@ fn evens_squared(n: usize) -> _ {
 
 const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
 //~^ ERROR the placeholder
+//~| ERROR cannot call non-const
+//~| ERROR cannot call non-const

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -666,7 +666,31 @@ LL |     type F: std::ops::Fn(_);
 LL | impl Qux for Struct {
    | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
-error: aborting due to 72 previous errors
+error[E0515]: cannot return reference to function parameter `x`
+  --> $DIR/typeck_type_placeholder_item.rs:50:5
+   |
+LL |     &x
+   |     ^^ returns a reference to data owned by the current function
 
-Some errors have detailed explanations: E0046, E0121, E0282, E0403.
-For more information about an error, try `rustc --explain E0046`.
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:230:22
+   |
+LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:230:49: 230:52}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:230:45
+   |
+LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+   |                                             ^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error: aborting due to 75 previous errors
+
+Some errors have detailed explanations: E0015, E0046, E0121, E0282, E0403, E0515.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -7,7 +7,7 @@ struct Foo {
 impl Foo {
     fn foo(self: isize, x: isize) -> isize {
         //~^ ERROR invalid `self` parameter type
-        self.f + x
+        self.f + x //~ ERROR: doesn't have fields
     }
 }
 
@@ -53,8 +53,10 @@ fn main() {
         f: 1,
     });
     println!("{}", foo.foo(2));
+    //~^ ERROR: no method named `foo`
     let bar = Box::new(Bar {
         f: 1,
     });
     println!("{} {}", bar.foo(2), bar.bar(2));
+    //~^ ERROR: no method named `bar`
 }

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -118,7 +118,25 @@ note: ...does not necessarily outlive the anonymous lifetime defined here
 LL |     fn dummy3(self: &&Bar<T>) {}
    |                      ^^^^^^^
 
-error: aborting due to 8 previous errors
+error[E0610]: `isize` is a primitive type and therefore doesn't have fields
+  --> $DIR/ufcs-explicit-self-bad.rs:10:14
+   |
+LL |         self.f + x
+   |              ^
 
-Some errors have detailed explanations: E0053, E0307, E0308.
+error[E0599]: no method named `foo` found for struct `Box<Foo>` in the current scope
+  --> $DIR/ufcs-explicit-self-bad.rs:55:24
+   |
+LL |     println!("{}", foo.foo(2));
+   |                        ^^^ method not found in `Box<Foo>`
+
+error[E0599]: no method named `bar` found for struct `Box<Bar<isize>>` in the current scope
+  --> $DIR/ufcs-explicit-self-bad.rs:60:39
+   |
+LL |     println!("{} {}", bar.foo(2), bar.bar(2));
+   |                                       ^^^ method not found in `Box<Bar<isize>>`
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0053, E0307, E0308, E0599, E0610.
 For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/unboxed-closures/non-tupled-arg-mismatch.rs
+++ b/tests/ui/unboxed-closures/non-tupled-arg-mismatch.rs
@@ -4,5 +4,5 @@ fn a<F: Fn<usize>>(f: F) {}
 //~^ ERROR type parameter to bare `Fn` trait must be a tuple
 
 fn main() {
-    a(|_: usize| {});
+    a(|_: usize| {}); //~ ERROR: mismatched types
 }

--- a/tests/ui/unboxed-closures/non-tupled-arg-mismatch.stderr
+++ b/tests/ui/unboxed-closures/non-tupled-arg-mismatch.stderr
@@ -7,6 +7,21 @@ LL | fn a<F: Fn<usize>>(f: F) {}
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/non-tupled-arg-mismatch.rs:7:5
+   |
+LL |     a(|_: usize| {});
+   |     ^^^^^^^^^^^^^^^^ types differ
+   |
+   = note: expected trait `Fn<usize>`
+              found trait `Fn(usize)`
+note: required by a bound in `a`
+  --> $DIR/non-tupled-arg-mismatch.rs:3:9
+   |
+LL | fn a<F: Fn<usize>>(f: F) {}
+   |         ^^^^^^^^^ required by this bound in `a`
 
-For more information about this error, try `rustc --explain E0059`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0059, E0308.
+For more information about an error, try `rustc --explain E0059`.

--- a/tests/ui/wf/wf-in-fn-ret.rs
+++ b/tests/ui/wf/wf-in-fn-ret.rs
@@ -3,12 +3,13 @@
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 
-struct MustBeCopy<T:Copy> {
-    t: T
+struct MustBeCopy<T: Copy> {
+    t: T,
 }
 
 fn bar<T>() -> MustBeCopy<T> //~ ERROR E0277
+//~^ ERROR mismatched types
 {
 }
 
-fn main() { }
+fn main() {}

--- a/tests/ui/wf/wf-in-fn-ret.stderr
+++ b/tests/ui/wf/wf-in-fn-ret.stderr
@@ -5,15 +5,27 @@ LL | fn bar<T>() -> MustBeCopy<T>
    |                ^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `MustBeCopy`
-  --> $DIR/wf-in-fn-ret.rs:6:21
+  --> $DIR/wf-in-fn-ret.rs:6:22
    |
-LL | struct MustBeCopy<T:Copy> {
-   |                     ^^^^ required by this bound in `MustBeCopy`
+LL | struct MustBeCopy<T: Copy> {
+   |                      ^^^^ required by this bound in `MustBeCopy`
 help: consider restricting type parameter `T`
    |
 LL | fn bar<T: std::marker::Copy>() -> MustBeCopy<T>
    |         +++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/wf-in-fn-ret.rs:10:16
+   |
+LL | fn bar<T>() -> MustBeCopy<T>
+   |    ---         ^^^^^^^^^^^^^ expected `MustBeCopy<T>`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected struct `MustBeCopy<T>`
+           found unit type `()`
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
The ICEs fixed here were probably reachable through const eval gymnastics before, but now they are easily reachable without that, too.

The new errors are often bugfixes, where useful errors were missing, because they were reported after the early abort. In other cases sometimes they are just duplication of already emitted errors, which won't be user-visible due to deduplication.

fixes https://github.com/rust-lang/rust/issues/120860