### PR TITLE
ast_lowering: Fix regression in `use ::{}` imports.

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -569,7 +569,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     });
                 }
 
-                let path = if trees.is_empty() && !prefix.segments.is_empty() {
+                // Condition should match `build_reduced_graph_for_use_tree`.
+                let path = if trees.is_empty()
+                    && !(prefix.segments.is_empty()
+                        || prefix.segments.len() == 1
+                            && prefix.segments[0].ident.name == kw::PathRoot)
+                {
                     // For empty lists we need to lower the prefix so it is checked for things
                     // like stability later.
                     let res = self.lower_import_res(id, span);

--- a/tests/ui/imports/empty-import-prefix-pass-2015.rs
+++ b/tests/ui/imports/empty-import-prefix-pass-2015.rs
@@ -1,0 +1,10 @@
+// check-pass
+// edition:2015
+
+use {};
+use {{}};
+
+use ::{};
+use {::{}};
+
+fn main() {}

--- a/tests/ui/imports/empty-import-prefix-pass.rs
+++ b/tests/ui/imports/empty-import-prefix-pass.rs
@@ -1,0 +1,10 @@
+// check-pass
+// edition:2018
+
+use {};
+use {{}};
+
+use ::{};
+use {::{}};
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/120789