### PR TITLE
Loosen an assertion to account for stashed errors.

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1283,7 +1283,8 @@ fn check_type_alias_type_params_are_used<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalD
     let ty = tcx.type_of(def_id).instantiate_identity();
     if ty.references_error() {
         // If there is already another error, do not emit an error for not using a type parameter.
-        assert!(tcx.dcx().has_errors().is_some());
+        // Without the `stashed_err_count` part this can fail (#120856).
+        assert!(tcx.dcx().has_errors().is_some() || tcx.dcx().stashed_err_count() > 0);
         return;
     }
 

--- a/tests/ui/typeck/issue-120856.rs
+++ b/tests/ui/typeck/issue-120856.rs
@@ -1,0 +1,5 @@
+pub type Archived<T> = <m::Alias as n::Trait>::Archived;
+//~^ ERROR failed to resolve: use of undeclared crate or module `m`
+//~| ERROR failed to resolve: use of undeclared crate or module `n`
+
+fn main() {}

--- a/tests/ui/typeck/issue-120856.stderr
+++ b/tests/ui/typeck/issue-120856.stderr
@@ -1,0 +1,21 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `n`
+  --> $DIR/issue-120856.rs:1:37
+   |
+LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
+   |                                     ^
+   |                                     |
+   |                                     use of undeclared crate or module `n`
+   |                                     help: a trait with a similar name exists: `Fn`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `m`
+  --> $DIR/issue-120856.rs:1:25
+   |
+LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
+   |                         ^
+   |                         |
+   |                         use of undeclared crate or module `m`
+   |                         help: a type parameter with a similar name exists: `T`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
The meaning of this assertion changed in #120828 when the meaning of `has_errors` changed to exclude stashed errors. Evidently the new meaning is too restrictive.

Fixes #120856.

r? @oli-obk 