### PR TITLE
Remove unnecessary `#![feature(min_specialization)]`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(hash_raw_entry)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
-#![feature(min_specialization)]
 #![feature(impl_trait_in_assoc_type)]
 
 #[macro_use]

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -35,7 +35,6 @@
 #![feature(iter_order_by)]
 #![feature(let_chains)]
 #![feature(trait_upcasting)]
-#![feature(min_specialization)]
 #![feature(rustc_attrs)]
 #![allow(internal_features)]
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(min_specialization)]
-
 #[macro_use]
 extern crate rustc_macros;
 

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(internal_features)]
 #![feature(let_chains)]
 #![feature(map_try_insert)]
-#![feature(min_specialization)]
 #![feature(try_blocks)]
 
 #[macro_use]


### PR DESCRIPTION
As of #119963 and #120676, we can now rely on `newtype_index!` having `#[allow_internal_unstable(min_specialization)]`, so there are a few compiler crates that no longer need to include min-spec in their own crate features.

---

Some of the expansions of `newtype_index!` still appear to require min-spec in the crate features. I think this is because `#[orderable]` causes the expansion to include an implementation of `TrustedStep`, which is flagged with `#[rustc_specialization_trait]`, and for whatever reason that isn't permitted by allow-internal-unstable. So this PR only touches the crates where that isn't the case.