### PR TITLE
Take empty `where` bounds into account when suggesting predicates

### DIFF
--- a/tests/ui/trait-impl-bound-suggestions.fixed
+++ b/tests/ui/trait-impl-bound-suggestions.fixed
@@ -17,4 +17,13 @@ trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {
     }
 }
 
+// Regression test for #120838
+#[allow(dead_code)]
+trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where X: std::marker::Copy {
+    fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
+        //~^ ERROR the trait bound `X: Copy` is not satisfied
+        ConstrainedStruct { x }
+    }
+}
+
 pub fn main() { }

--- a/tests/ui/trait-impl-bound-suggestions.rs
+++ b/tests/ui/trait-impl-bound-suggestions.rs
@@ -17,4 +17,13 @@ trait InsufficientlyConstrainedGeneric<X=()> {
     }
 }
 
+// Regression test for #120838
+#[allow(dead_code)]
+trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where {
+    fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
+        //~^ ERROR the trait bound `X: Copy` is not satisfied
+        ConstrainedStruct { x }
+    }
+}
+
 pub fn main() { }

--- a/tests/ui/trait-impl-bound-suggestions.stderr
+++ b/tests/ui/trait-impl-bound-suggestions.stderr
@@ -14,6 +14,22 @@ help: consider further restricting type parameter `X`
 LL | trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {
    |                                              ++++++++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `X: Copy` is not satisfied
+  --> $DIR/trait-impl-bound-suggestions.rs:23:52
+   |
+LL |     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `X`
+   |
+note: required by a bound in `ConstrainedStruct`
+  --> $DIR/trait-impl-bound-suggestions.rs:8:29
+   |
+LL | struct ConstrainedStruct<X: Copy> {
+   |                             ^^^^ required by this bound in `ConstrainedStruct`
+help: consider further restricting type parameter `X`
+   |
+LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where X: std::marker::Copy {
+   |                                                                  ++++++++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #120838