### PR TITLE
interpret: rename ReadExternStatic → ExternStatic

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -96,6 +96,8 @@ const_eval_error = {$error_kind ->
 const_eval_exact_div_has_remainder =
     exact_div: {$a} cannot be divided by {$b} without remainder
 
+const_eval_extern_static =
+    cannot access extern static ({$did})
 const_eval_fn_ptr_call =
     function pointers need an RFC before allowed to be called in {const_eval_const_context}s
 const_eval_for_loop_into_iter_non_const =
@@ -296,8 +298,6 @@ const_eval_raw_ptr_to_int =
     .note = at compile-time, pointers do not have an integer value
     .note2 = avoiding this restriction via `transmute`, `union`, or raw pointers leads to compile-time undefined behavior
 
-const_eval_read_extern_static =
-    cannot read from extern static ({$did})
 const_eval_read_pointer_as_int =
     unable to turn pointer into integer
 const_eval_realloc_or_alloc_with_offset =

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -801,7 +801,7 @@ impl ReportErrorExt for UnsupportedOpInfo {
             UnsupportedOpInfo::ReadPartialPointer(_) => const_eval_partial_pointer_copy,
             UnsupportedOpInfo::ReadPointerAsInt(_) => const_eval_read_pointer_as_int,
             UnsupportedOpInfo::ThreadLocalStatic(_) => const_eval_thread_local_static,
-            UnsupportedOpInfo::ReadExternStatic(_) => const_eval_read_extern_static,
+            UnsupportedOpInfo::ExternStatic(_) => const_eval_extern_static,
         }
     }
     fn add_args<G: EmissionGuarantee>(self, _: &DiagCtxt, builder: &mut DiagnosticBuilder<'_, G>) {
@@ -820,7 +820,7 @@ impl ReportErrorExt for UnsupportedOpInfo {
             OverwritePartialPointer(ptr) | ReadPartialPointer(ptr) => {
                 builder.arg("ptr", ptr);
             }
-            ThreadLocalStatic(did) | ReadExternStatic(did) => {
+            ThreadLocalStatic(did) | ExternStatic(did) => {
                 builder.arg("did", format!("{did:?}"));
             }
         }

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -557,7 +557,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 if self.tcx.is_foreign_item(def_id) {
                     // This is unreachable in Miri, but can happen in CTFE where we actually *do* support
                     // referencing arbitrary (declared) extern statics.
-                    throw_unsup!(ReadExternStatic(def_id));
+                    throw_unsup!(ExternStatic(def_id));
                 }
 
                 // We don't give a span -- statics don't need that, they cannot be generic or associated.

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -466,7 +466,7 @@ pub enum UnsupportedOpInfo {
     /// Accessing thread local statics
     ThreadLocalStatic(DefId),
     /// Accessing an unsupported extern static.
-    ReadExternStatic(DefId),
+    ExternStatic(DefId),
 }
 
 /// Error information for when the program exhausted the resources granted to it

--- a/tests/ui/consts/miri_unleashed/extern-static.rs
+++ b/tests/ui/consts/miri_unleashed/extern-static.rs
@@ -1,0 +1,24 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+#![feature(thread_local)]
+#![allow(static_mut_ref)]
+
+extern "C" {
+    static mut DATA: u8;
+}
+
+// Make sure we catch accessing extern static.
+static TEST_READ: () = {
+    unsafe { let _val = DATA; }
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE cannot access extern static
+};
+static TEST_WRITE: () = {
+    unsafe { DATA = 0; }
+    //~^ ERROR could not evaluate static initializer
+    //~| NOTE cannot access extern static
+};
+
+// Just creating a reference is fine, as long as we are not reading or writing.
+static TEST_REF: &u8 = unsafe { &DATA };
+
+fn main() {}

--- a/tests/ui/consts/miri_unleashed/extern-static.stderr
+++ b/tests/ui/consts/miri_unleashed/extern-static.stderr
@@ -1,0 +1,15 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/extern-static.rs:11:25
+   |
+LL |     unsafe { let _val = DATA; }
+   |                         ^^^^ cannot access extern static (DefId(0:4 ~ extern_static[c41e]::{extern#0}::DATA))
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/extern-static.rs:16:14
+   |
+LL |     unsafe { DATA = 0; }
+   |              ^^^^^^^^ cannot access extern static (DefId(0:4 ~ extern_static[c41e]::{extern#0}::DATA))
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/miri_unleashed/tls.rs
+++ b/tests/ui/consts/miri_unleashed/tls.rs
@@ -14,6 +14,8 @@ static TEST_BAD: () = {
 };
 
 // Make sure we catch taking a reference to thread-local storage.
+// The actual pointer depends on the thread, so even just taking a reference already does not make
+// sense at compile-time.
 static TEST_BAD_REF: () = {
     unsafe { let _val = &A; }
     //~^ ERROR could not evaluate static initializer

--- a/tests/ui/consts/miri_unleashed/tls.stderr
+++ b/tests/ui/consts/miri_unleashed/tls.stderr
@@ -5,7 +5,7 @@ LL |     unsafe { let _val = A; }
    |                         ^ cannot access thread local static (DefId(0:4 ~ tls[ca29]::A))
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/tls.rs:18:26
+  --> $DIR/tls.rs:20:26
    |
 LL |     unsafe { let _val = &A; }
    |                          ^ cannot access thread local static (DefId(0:4 ~ tls[ca29]::A))
@@ -18,7 +18,7 @@ help: skipping check that does not even have a feature gate
 LL |     unsafe { let _val = A; }
    |                         ^
 help: skipping check that does not even have a feature gate
-  --> $DIR/tls.rs:18:26
+  --> $DIR/tls.rs:20:26
    |
 LL |     unsafe { let _val = &A; }
    |                          ^


### PR DESCRIPTION
This error shows up for reads and writes, so `ReadExternStatic` is misleading.