### PR TITLE
assert_unsafe_precondition cleanup

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -237,9 +237,9 @@
 
 use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
-use crate::intrinsics::is_nonoverlapping;
+use crate::intrinsics;
 use crate::marker::{PhantomData, Unsize};
-use crate::mem;
+use crate::mem::{self, size_of};
 use crate::ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn};
 use crate::ptr::{self, NonNull};
 
@@ -435,11 +435,15 @@ impl<T> Cell<T> {
     #[inline]
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn swap(&self, other: &Self) {
+        fn is_nonoverlapping<T>(src: *const T, dst: *const T) -> bool {
+            intrinsics::is_nonoverlapping(src.cast(), dst.cast(), size_of::<T>(), 1)
+        }
+
         if ptr::eq(self, other) {
             // Swapping wouldn't change anything.
             return;
         }
-        if !is_nonoverlapping(self, other, 1) {
+        if !is_nonoverlapping(self, other) {
             // See <https://github.com/rust-lang/rust/issues/80778> for why we need to stop here.
             panic!("`Cell::swap` on overlapping non-identical `Cell`s");
         }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -381,7 +381,7 @@ use crate::cmp::Ordering;
 use crate::fmt;
 use crate::hash;
 use crate::intrinsics::{
-    self, assert_unsafe_precondition, is_aligned_and_not_null, is_nonoverlapping_mono,
+    self, assert_unsafe_precondition, is_aligned_and_not_null, is_nonoverlapping,
 };
 use crate::marker::FnPtr;
 
@@ -976,7 +976,7 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
             ) =>
             is_aligned_and_not_null(x, align)
                 && is_aligned_and_not_null(y, align)
-                && is_nonoverlapping_mono(x, y, size, count)
+                && is_nonoverlapping(x, y, size, count)
         );
     }
 


### PR DESCRIPTION
I moved the polymorphic `is_nonoverlapping` into the `Cell` function that uses it and renamed `intrinsics::is_nonoverlapping_mono` to just `intrinsics::is_nonoverlapping`.

We now also have some docs for `intrinsics::debug_assertions`.

r? RalfJung