### PR TITLE
Adapt `llvm-has-rust-patches` validation to take `llvm-config` into account.

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1810,10 +1810,9 @@ impl Config {
                     target.llvm_config = Some(config.src.join(s));
                 }
                 if let Some(patches) = cfg.llvm_has_rust_patches {
-                    assert_eq!(
-                        config.submodules,
-                        Some(false),
-                        "cannot set `llvm-has-rust-patches` for a managed submodule (set `build.submodules = false` if you want to apply patches)"
+                    assert!(
+                        config.submodules == Some(false) || cfg.llvm_config.is_some(),
+                        "use of `llvm-has-rust-patches` is restricted to cases where either submodules are disabled or llvm-config been provided"
                     );
                     target.llvm_has_rust_patches = Some(patches);
                 }


### PR DESCRIPTION
This adapts an assertion that was added in #119556.

The current assertion does not take the `llvm-config` setting into accounts, which does not match the `llvm-has-rust-patches` documentation, which states:

> This would be used in conjunction with either an llvm-config or build.submodules = false.

(It also breaks my workflow: I build LLVM separately, but do have the rust patches applied).

---

**edit:** Originally this PR just removed the assertion, but it now implements the alternative mentioned here:

An alternative fix would be to take `llvm-config` into account in the assertion, but to me the assertion seems to provide little value, thus the simpler fix of just removing it. 

cc @onur-ozkan, in case I'm missing a reason to keep the assertion.