### PR TITLE
Encode `coroutine_for_closure` for foreign crates

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -250,6 +250,7 @@ provide! { tcx, def_id, other, cdata,
     asyncness => { table_direct }
     fn_arg_names => { table }
     coroutine_kind => { table_direct }
+    coroutine_for_closure => { table }
     trait_def => { table }
     deduced_param_attrs => { table }
     is_type_alias_impl_trait => {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1447,6 +1447,13 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             {
                 self.tables.coroutine_kind.set(def_id.index, Some(coroutine_kind))
             }
+            if def_kind == DefKind::Closure
+                && tcx.type_of(def_id).skip_binder().is_coroutine_closure()
+            {
+                self.tables
+                    .coroutine_for_closure
+                    .set_some(def_id.index, self.tcx.coroutine_for_closure(def_id).into());
+            }
             if let DefKind::Enum | DefKind::Struct | DefKind::Union = def_kind {
                 self.encode_info_for_adt(local_id);
             }

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -443,6 +443,7 @@ define_tables! {
     asyncness: Table<DefIndex, ty::Asyncness>,
     fn_arg_names: Table<DefIndex, LazyArray<Ident>>,
     coroutine_kind: Table<DefIndex, hir::CoroutineKind>,
+    coroutine_for_closure: Table<DefIndex, RawDefId>,
     trait_def: Table<DefIndex, LazyValue<ty::TraitDef>>,
     trait_item_def_id: Table<DefIndex, RawDefId>,
     expn_that_defined: Table<DefIndex, LazyValue<ExpnId>>,

--- a/tests/ui/async-await/async-closures/auxiliary/foreign.rs
+++ b/tests/ui/async-await/async-closures/auxiliary/foreign.rs
@@ -1,0 +1,7 @@
+// edition:2021
+
+#![feature(async_closure)]
+
+pub fn closure() -> impl async Fn() {
+    async || { /* Don't really need to do anything here. */ }
+}

--- a/tests/ui/async-await/async-closures/foreign.rs
+++ b/tests/ui/async-await/async-closures/foreign.rs
@@ -1,0 +1,19 @@
+// aux-build:block-on.rs
+// aux-build:foreign.rs
+// edition:2021
+// build-pass
+
+#![feature(async_closure)]
+
+use std::future::Future;
+
+extern crate block_on;
+extern crate foreign;
+
+struct NoCopy;
+
+fn main() {
+    block_on::block_on(async {
+        foreign::closure()().await;
+    });
+}


### PR DESCRIPTION
Async closures (and "coroutine closures" in general) need to have their child coroutine encoded. This PR does that.

r? oli-obk