### PR TITLE
Gracefully handle non-WF alias in `assemble_alias_bound_candidates_recur`

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/mod.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::fast_reject::{SimplifiedType, TreatParams};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::ty::{fast_reject, TypeFoldable};
 use rustc_middle::ty::{ToPredicate, TypeVisitableExt};
-use rustc_span::ErrorGuaranteed;
+use rustc_span::{ErrorGuaranteed, DUMMY_SP};
 use std::fmt::Debug;
 
 pub(super) mod structural_traits;
@@ -612,7 +612,11 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
 
             ty::Alias(kind @ (ty::Projection | ty::Opaque), alias_ty) => (kind, alias_ty),
             ty::Alias(ty::Inherent | ty::Weak, _) => {
-                unreachable!("Weak and Inherent aliases should have been normalized away already")
+                self.tcx().sess.dcx().span_delayed_bug(
+                    DUMMY_SP,
+                    format!("could not normalize {self_ty}, it is not WF"),
+                );
+                return;
             }
         };
 

--- a/tests/ui/impl-trait/in-trait/alias-bounds-when-not-wf.rs
+++ b/tests/ui/impl-trait/in-trait/alias-bounds-when-not-wf.rs
@@ -1,0 +1,19 @@
+// compile-flags: -Znext-solver
+
+#![feature(lazy_type_alias)]
+//~^ WARN the feature `lazy_type_alias` is incomplete
+
+trait Foo {}
+
+type A<T: Foo> = T;
+
+struct W<T>(T);
+
+// For `W<A<usize>>` to be WF, `A<usize>: Sized` must hold. However, when assembling
+// alias bounds for `A<usize>`, we try to normalize it, but it doesn't hold because
+// `usize: Foo` doesn't hold. Therefore we ICE, because we don't expect to still
+// encounter weak types in `assemble_alias_bound_candidates_recur`.
+fn hello(_: W<A<usize>>) {}
+//~^ ERROR the type `W<A<usize>>` is not well-formed
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/alias-bounds-when-not-wf.stderr
+++ b/tests/ui/impl-trait/in-trait/alias-bounds-when-not-wf.stderr
@@ -1,0 +1,17 @@
+warning: the feature `lazy_type_alias` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/alias-bounds-when-not-wf.rs:3:12
+   |
+LL | #![feature(lazy_type_alias)]
+   |            ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: the type `W<A<usize>>` is not well-formed
+  --> $DIR/alias-bounds-when-not-wf.rs:16:13
+   |
+LL | fn hello(_: W<A<usize>>) {}
+   |             ^^^^^^^^^^^
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
See explanation in test. I think it's fine to delay a bug here -- I don't believe we ever construct a non-wf alias on the good path? If so, then we can just remove the delay.

Fixes #120891

r? lcnr