### PR TITLE
match lowering: eagerly simplify match pairs

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1168,7 +1168,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // be a switch or pattern comparison.
         let mut split_or_candidate = false;
         for candidate in &mut *candidates {
-            self.simplify_candidate(candidate);
+            self.simplify_match_pairs(
+                &mut candidate.match_pairs,
+                &mut candidate.bindings,
+                &mut candidate.ascriptions,
+            );
             if let [MatchPair { pattern: Pat { kind: PatKind::Or { pats }, .. }, place, .. }] =
                 &*candidate.match_pairs
             {
@@ -1181,7 +1185,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // }
                 //
                 // only generates a single switch.
-                candidate.subcandidates = self.create_or_subcandidates(candidate, place, pats);
+                candidate.subcandidates =
+                    self.create_or_subcandidates(place, pats, candidate.has_guard);
                 candidate.match_pairs.pop();
                 split_or_candidate = true;
             }

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -22,8 +22,6 @@ use rustc_middle::ty::{self, CanonicalUserTypeAnnotation, Ty};
 use rustc_span::symbol::Symbol;
 use rustc_span::{BytePos, Pos, Span};
 use rustc_target::abi::VariantIdx;
-use smallvec::{smallvec, SmallVec};
-
 // helper functions, broken out by category:
 mod simplify;
 mod test;
@@ -949,7 +947,7 @@ struct Candidate<'pat, 'tcx> {
     has_guard: bool,
 
     /// All of these must be satisfied...
-    match_pairs: SmallVec<[MatchPair<'pat, 'tcx>; 1]>,
+    match_pairs: Vec<MatchPair<'pat, 'tcx>>,
 
     /// ...these bindings established...
     bindings: Vec<Binding<'tcx>>,
@@ -979,7 +977,7 @@ impl<'tcx, 'pat> Candidate<'pat, 'tcx> {
         Candidate {
             span: pattern.span,
             has_guard,
-            match_pairs: smallvec![MatchPair::new(place, pattern, cx)],
+            match_pairs: vec![MatchPair::new(place, pattern, cx)],
             bindings: Vec::new(),
             ascriptions: Vec::new(),
             subcandidates: Vec::new(),

--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -95,9 +95,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         debug!(simplified = ?match_pairs, "simplify_match_pairs");
     }
 
-    /// Given `candidate` that has a single or-pattern for its match-pairs,
-    /// creates a fresh candidate for each of its input subpatterns passed via
-    /// `pats`.
+    /// Create a new candidate for each pattern in `pats`, and recursively simplify tje
+    /// single-or-pattern case.
     pub(super) fn create_or_subcandidates<'pat>(
         &mut self,
         place: &PlaceBuilder<'tcx>,
@@ -119,11 +118,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .collect()
     }
 
-    /// Tries to simplify `match_pair`, returning `Ok(())` if
-    /// successful. If successful, new match pairs and bindings will
-    /// have been pushed into the candidate. If no simplification is
-    /// possible, `Err` is returned and no changes are made to
-    /// candidate.
+    /// Tries to simplify `match_pair`, returning `Ok(())` if successful. If successful, new match
+    /// pairs and bindings will have been pushed into the respective `Vec`s. If no simplification is
+    /// possible, `Err` is returned.
     fn simplify_match_pair<'pat>(
         &mut self,
         mut match_pair: MatchPair<'pat, 'tcx>,

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -116,6 +116,6 @@ impl<'pat, 'tcx> MatchPair<'pat, 'tcx> {
         if may_need_cast {
             place = place.project(ProjectionElem::OpaqueCast(pattern.ty));
         }
-        MatchPair { place, pattern }
+        MatchPair { place, pattern, subpairs: Vec::new() }
     }
 }

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -6,7 +6,6 @@ use rustc_middle::mir::*;
 use rustc_middle::thir::*;
 use rustc_middle::ty;
 use rustc_middle::ty::TypeVisitableExt;
-use smallvec::SmallVec;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub(crate) fn field_match_pairs<'pat>(
@@ -26,7 +25,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     pub(crate) fn prefix_slice_suffix<'pat>(
         &mut self,
-        match_pairs: &mut SmallVec<[MatchPair<'pat, 'tcx>; 1]>,
+        match_pairs: &mut Vec<MatchPair<'pat, 'tcx>>,
         place: &PlaceBuilder<'tcx>,
         prefix: &'pat [Box<Pat<'tcx>>],
         opt_slice: &'pat Option<Box<Pat<'tcx>>>,

--- a/tests/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/exponential_or.match_tuple.SimplifyCfg-initial.after.mir
@@ -19,7 +19,8 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
 
     bb0: {
         PlaceMention(_1);
-        switchInt((_1.0: u32)) -> [1: bb2, 4: bb2, otherwise: bb1];
+        _2 = discriminant((_1.2: std::option::Option<i32>));
+        switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
     }
 
     bb1: {
@@ -28,12 +29,11 @@ fn match_tuple(_1: (u32, bool, Option<i32>, u32)) -> u32 {
     }
 
     bb2: {
-        _2 = discriminant((_1.2: std::option::Option<i32>));
-        switchInt(move _2) -> [0: bb4, 1: bb3, otherwise: bb1];
+        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1: bb3, 8: bb3, otherwise: bb1];
     }
 
     bb3: {
-        switchInt((((_1.2: std::option::Option<i32>) as Some).0: i32)) -> [1: bb4, 8: bb4, otherwise: bb1];
+        switchInt((_1.0: u32)) -> [1: bb4, 4: bb4, otherwise: bb1];
     }
 
     bb4: {


### PR DESCRIPTION
This removes one important complication from match lowering. Before this, match pair simplification (which includes collecting bindings and type ascriptions) was intertwined with the whole match lowering algorithm.

I'm avoiding this by storing in each `MatchPair` the sub-`MatchPair`s that correspond to its subfields. This makes it possible to simplify everything (except or-patterns) in `Candidate::new()`.

This should open up further simplifications. It will also give us proper control over the order of bindings.

r? @matthewjasper 