### PR TITLE
Fix suggestion span for `?Sized` when param type has default

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3042,7 +3042,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             this = "the implicit `Sized` requirement on this type parameter";
                         }
                         if let Some(hir::Node::TraitItem(hir::TraitItem {
-                            ident,
+                            generics,
                             kind: hir::TraitItemKind::Type(bounds, None),
                             ..
                         })) = tcx.hir().get_if_local(item_def_id)
@@ -3054,7 +3054,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             let (span, separator) = if let [.., last] = bounds {
                                 (last.span().shrink_to_hi(), " +")
                             } else {
-                                (ident.span.shrink_to_hi(), ":")
+                                (generics.span.shrink_to_hi(), ":")
                             };
                             err.span_suggestion_verbose(
                                 span,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2993,7 +2993,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         {
             (s, " +")
         } else {
-            (span.shrink_to_hi(), ":")
+            (param.name.ident().span.shrink_to_hi(), ":")
         };
         err.span_suggestion_verbose(
             span,

--- a/tests/ui/trait-bounds/suggest-maybe-sized-bound.rs
+++ b/tests/ui/trait-bounds/suggest-maybe-sized-bound.rs
@@ -1,0 +1,20 @@
+// issue: 120878
+fn main() {
+    struct StructA<A, B = A> {
+        _marker: std::marker::PhantomData<fn() -> (A, B)>,
+    }
+
+    struct StructB {
+        a: StructA<isize, [u8]>,
+        //~^ ERROR: the size for values of type `[u8]` cannot be known at compilation time [E0277]
+    }
+
+    trait Trait {
+        type P<X>;
+    }
+
+    impl Trait for () {
+        type P<X> = [u8];
+        //~^ ERROR: the size for values of type `[u8]` cannot be known at compilation time [E0277]
+    }
+}

--- a/tests/ui/trait-bounds/suggest-maybe-sized-bound.stderr
+++ b/tests/ui/trait-bounds/suggest-maybe-sized-bound.stderr
@@ -1,0 +1,37 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/suggest-maybe-sized-bound.rs:8:12
+   |
+LL |         a: StructA<isize, [u8]>,
+   |            ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by an implicit `Sized` bound in `StructA`
+  --> $DIR/suggest-maybe-sized-bound.rs:3:23
+   |
+LL |     struct StructA<A, B = A> {
+   |                       ^^^^^ required by the implicit `Sized` requirement on this type parameter in `StructA`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     struct StructA<A, B: ?Sized = A> {
+   |                        ++++++++
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/suggest-maybe-sized-bound.rs:17:21
+   |
+LL |         type P<X> = [u8];
+   |                     ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+note: required by a bound in `Trait::P`
+  --> $DIR/suggest-maybe-sized-bound.rs:13:9
+   |
+LL |         type P<X>;
+   |         ^^^^^^^^^^ required by this bound in `Trait::P`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |         type P<X>: ?Sized;
+   |                  ++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -36,8 +36,8 @@ LL | pub trait Bar: Foo<Assoc=()> + Sized {
    |                              +++++++
 help: consider relaxing the implicit `Sized` restriction
    |
-LL | pub trait Foo<RHS=Self: ?Sized> {
-   |                       ++++++++
+LL | pub trait Foo<RHS: ?Sized=Self> {
+   |                  ++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/issue-28576.rs:5:16
@@ -56,8 +56,8 @@ LL |     ) where Self: Sized;
    |       +++++++++++++++++
 help: consider relaxing the implicit `Sized` restriction
    |
-LL | pub trait Foo<RHS=Self: ?Sized> {
-   |                       ++++++++
+LL | pub trait Foo<RHS: ?Sized=Self> {
+   |                  ++++++++
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fixes #120878 

Diagnostic suggests adding `: ?Sized` in an incorrect place if a type parameter default is present

r? @fmease