### PR TITLE
Ignore derived Default implementations during dead code analysis

### DIFF
--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -99,6 +99,7 @@
 /// ```
 #[cfg_attr(not(test), rustc_diagnostic_item = "Default")]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_trivial_field_reads]
 pub trait Default: Sized {
     /// Returns the "default value" for a type.
     ///

--- a/tests/ui/lint/dead-code/issue-98871.rs
+++ b/tests/ui/lint/dead-code/issue-98871.rs
@@ -1,0 +1,6 @@
+#![deny(dead_code)]
+
+#[derive(Default)]
+struct T {} //~ ERROR struct `T` is never constructed
+
+fn main() {}

--- a/tests/ui/lint/dead-code/issue-98871.stderr
+++ b/tests/ui/lint/dead-code/issue-98871.stderr
@@ -1,0 +1,15 @@
+error: struct `T` is never constructed
+  --> $DIR/issue-98871.rs:4:8
+   |
+LL | struct T {}
+   |        ^
+   |
+   = note: `T` has a derived impl for the trait `Default`, but this is intentionally ignored during dead code analysis
+note: the lint level is defined here
+  --> $DIR/issue-98871.rs:1:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #98871