### PR TITLE
check_consts: fix duplicate errors, make importance consistent

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -619,9 +619,11 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 if base_ty.is_unsafe_ptr() {
                     if place_ref.projection.is_empty() {
                         let decl = &self.body.local_decls[place_ref.local];
-                        if let LocalInfo::StaticRef { def_id, .. } = *decl.local_info() {
-                            let span = decl.source_info.span;
-                            self.check_static(def_id, span);
+                        // If this is a static, then this is not really dereferencing a pointer,
+                        // just directly accessing a static. That is not subject to any feature
+                        // gates (except for the one about whether statics can even be used, but
+                        // that is checked already by `visit_operand`).
+                        if let LocalInfo::StaticRef { .. } = *decl.local_info() {
                             return;
                         }
                     }

--- a/tests/ui/consts/issue-17718-const-bad-values.rs
+++ b/tests/ui/consts/issue-17718-const-bad-values.rs
@@ -4,7 +4,6 @@ const C1: &'static mut [usize] = &mut [];
 static mut S: usize = 3;
 const C2: &'static mut usize = unsafe { &mut S };
 //~^ ERROR: referencing statics in constants
-//~| ERROR: referencing statics in constants
 //~| WARN mutable reference of mutable static is discouraged [static_mut_ref]
 
 fn main() {}

--- a/tests/ui/consts/issue-17718-const-bad-values.stderr
+++ b/tests/ui/consts/issue-17718-const-bad-values.stderr
@@ -31,20 +31,7 @@ LL | const C2: &'static mut usize = unsafe { &mut S };
    = note: `static` and `const` variables can refer to other `const` variables. A `const` variable, however, cannot refer to a `static` variable.
    = help: to fix this, the value can be extracted to a `const` and then used.
 
-error[E0658]: referencing statics in constants is unstable
-  --> $DIR/issue-17718-const-bad-values.rs:5:46
-   |
-LL | const C2: &'static mut usize = unsafe { &mut S };
-   |                                              ^
-   |
-   = note: see issue #119618 <https://github.com/rust-lang/rust/issues/119618> for more information
-   = help: add `#![feature(const_refs_to_static)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: `static` and `const` variables can refer to other `const` variables. A `const` variable, however, cannot refer to a `static` variable.
-   = help: to fix this, the value can be extracted to a `const` and then used.
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0658, E0764.
 For more information about an error, try `rustc --explain E0658`.

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.32bit.stderr
@@ -50,11 +50,6 @@ help: skipping check for `const_refs_to_static` feature
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static.rs:18:32
-   |
-LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   |                                ^^^^^^^
-help: skipping check for `const_refs_to_static` feature
   --> $DIR/const_refers_to_static.rs:24:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.64bit.stderr
@@ -50,11 +50,6 @@ help: skipping check for `const_refs_to_static` feature
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static.rs:18:32
-   |
-LL | const READ_MUT: u32 = unsafe { MUTABLE };
-   |                                ^^^^^^^
-help: skipping check for `const_refs_to_static` feature
   --> $DIR/const_refers_to_static.rs:24:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
@@ -84,21 +84,6 @@ help: skipping check for `const_refs_to_static` feature
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:18:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO[0] }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:18:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO[0] }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
   --> $DIR/const_refers_to_static_cross_crate.rs:18:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
@@ -108,26 +93,6 @@ help: skipping check for `const_refs_to_static` feature
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
   --> $DIR/const_refers_to_static_cross_crate.rs:28:15
    |

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
@@ -84,21 +84,6 @@ help: skipping check for `const_refs_to_static` feature
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:18:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO[0] }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:18:15
-   |
-LL |     unsafe { &static_cross_crate::ZERO[0] }
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
   --> $DIR/const_refers_to_static_cross_crate.rs:18:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
@@ -108,26 +93,6 @@ help: skipping check for `const_refs_to_static` feature
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:28:15
-   |
-LL |         match static_cross_crate::OPT_ZERO {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
   --> $DIR/const_refers_to_static_cross_crate.rs:28:15
    |

--- a/tests/ui/consts/miri_unleashed/mutable_references_err.32bit.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references_err.32bit.stderr
@@ -114,11 +114,6 @@ help: skipping check for `const_refs_to_static` feature
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    |                                        ^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:32:40
-   |
-LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
-   |                                        ^^^
 help: skipping check that does not even have a feature gate
   --> $DIR/mutable_references_err.rs:32:35
    |
@@ -144,16 +139,6 @@ help: skipping check for `const_refs_to_static` feature
    |
 LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
    |                                            ^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:47:44
-   |
-LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
-   |                                            ^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:51:45
-   |
-LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
-   |                                             ^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
   --> $DIR/mutable_references_err.rs:51:45
    |

--- a/tests/ui/consts/miri_unleashed/mutable_references_err.64bit.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references_err.64bit.stderr
@@ -114,11 +114,6 @@ help: skipping check for `const_refs_to_static` feature
    |
 LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
    |                                        ^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:32:40
-   |
-LL | const SUBTLE: &mut i32 = unsafe { &mut FOO };
-   |                                        ^^^
 help: skipping check that does not even have a feature gate
   --> $DIR/mutable_references_err.rs:32:35
    |
@@ -144,16 +139,6 @@ help: skipping check for `const_refs_to_static` feature
    |
 LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
    |                                            ^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:47:44
-   |
-LL | const POINTS_TO_MUTABLE1: &i32 = unsafe { &MUTABLE };
-   |                                            ^^^^^^^
-help: skipping check for `const_refs_to_static` feature
-  --> $DIR/mutable_references_err.rs:51:45
-   |
-LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
-   |                                             ^^^^^^^^^^^
 help: skipping check for `const_refs_to_static` feature
   --> $DIR/mutable_references_err.rs:51:45
    |

--- a/tests/ui/feature-gates/feature-gate-const-refs-to-static.rs
+++ b/tests/ui/feature-gates/feature-gate-const-refs-to-static.rs
@@ -6,7 +6,6 @@ const C1_READ: () = {
     assert!(*C1 == 0);
 };
 const C2: *const i32 = unsafe { std::ptr::addr_of!(S_MUT) }; //~ERROR:  referencing statics in constants is unstable
-//~^ERROR:  referencing statics in constants is unstable
 
 fn main() {
 }

--- a/tests/ui/feature-gates/feature-gate-const-refs-to-static.stderr
+++ b/tests/ui/feature-gates/feature-gate-const-refs-to-static.stderr
@@ -22,19 +22,6 @@ LL | const C2: *const i32 = unsafe { std::ptr::addr_of!(S_MUT) };
    = note: `static` and `const` variables can refer to other `const` variables. A `const` variable, however, cannot refer to a `static` variable.
    = help: to fix this, the value can be extracted to a `const` and then used.
 
-error[E0658]: referencing statics in constants is unstable
-  --> $DIR/feature-gate-const-refs-to-static.rs:8:52
-   |
-LL | const C2: *const i32 = unsafe { std::ptr::addr_of!(S_MUT) };
-   |                                                    ^^^^^
-   |
-   = note: see issue #119618 <https://github.com/rust-lang/rust/issues/119618> for more information
-   = help: add `#![feature(const_refs_to_static)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: `static` and `const` variables can refer to other `const` variables. A `const` variable, however, cannot refer to a `static` variable.
-   = help: to fix this, the value can be extracted to a `const` and then used.
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/thread-local/thread-local-static.rs
+++ b/tests/ui/thread-local/thread-local-static.rs
@@ -12,7 +12,6 @@ const fn g(x: &mut [u32; 8]) {
     //~^^ ERROR thread-local statics cannot be accessed
     //~| ERROR mutable references are not allowed
     //~| ERROR use of mutable static is unsafe
-    //~| referencing statics
 }
 
 fn main() {}

--- a/tests/ui/thread-local/thread-local-static.stderr
+++ b/tests/ui/thread-local/thread-local-static.stderr
@@ -37,18 +37,6 @@ error[E0625]: thread-local statics cannot be accessed at compile-time
 LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    |                            ^^^^^^^^^^^^
 
-error[E0658]: referencing statics in constant functions is unstable
-  --> $DIR/thread-local-static.rs:10:28
-   |
-LL |     std::mem::swap(x, &mut STATIC_VAR_2)
-   |                            ^^^^^^^^^^^^
-   |
-   = note: see issue #119618 <https://github.com/rust-lang/rust/issues/119618> for more information
-   = help: add `#![feature(const_refs_to_static)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = note: `static` and `const` variables can refer to other `const` variables. A `const` variable, however, cannot refer to a `static` variable.
-   = help: to fix this, the value can be extracted to a `const` and then used.
-
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/thread-local-static.rs:10:23
    |
@@ -59,7 +47,7 @@ LL |     std::mem::swap(x, &mut STATIC_VAR_2)
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 5 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0133, E0625, E0658.
 For more information about an error, try `rustc --explain E0133`.


### PR DESCRIPTION
This is stuff I noticed while working on https://github.com/rust-lang/rust/pull/120932, but it's orthogonal to that PR.

r? @oli-obk 