### PR TITLE
Clean inlined type alias with correct param-env

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1840,7 +1840,9 @@ fn maybe_expand_private_type_alias<'tcx>(
         }
     }
 
-    Some(cx.enter_alias(args, def_id.to_def_id(), |cx| clean_ty(&ty, cx)))
+    Some(cx.enter_alias(args, def_id.to_def_id(), |cx| {
+        cx.with_param_env(def_id.to_def_id(), |cx| clean_ty(&ty, cx))
+    }))
 }
 
 pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> Type {

--- a/tests/rustdoc-ui/normalize-in-inlined-type-alias.rs
+++ b/tests/rustdoc-ui/normalize-in-inlined-type-alias.rs
@@ -1,0 +1,14 @@
+// check-pass
+// compile-flags: -Znormalize-docs
+
+trait Woo<T> {
+    type Assoc;
+}
+
+impl<T> Woo<T> for () {
+    type Assoc = ();
+}
+
+type Alias<P> = <() as Woo<P>>::Assoc;
+
+pub fn hello<S>() -> Alias<S> {}


### PR DESCRIPTION
We were cleaning the `hir::Ty` of a type alias item in the param-env of the item that *references* the type alias, and not the alias's own param-env.

Fixes #120954