### PR TITLE
Dejargonize `subst`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -691,7 +691,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         // If the type is opaque/param/closure, and it is Fn or FnMut, let's suggest (mutably)
         // borrowing the type, since `&mut F: FnMut` iff `F: FnMut` and similarly for `Fn`.
-        // These types seem reasonably opaque enough that they could be substituted with their
+        // These types seem reasonably opaque enough that they could be instantiated with their
         // borrowed variants in a function body when we see a move error.
         let borrow_level = match *ty.kind() {
             ty::Param(_) => tcx

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -696,9 +696,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         trace!("eval_place_to_op: got {:?}", op);
         // Sanity-check the type we ended up with.
         if cfg!(debug_assertions) {
-            let normalized_place_ty = self.subst_from_current_frame_and_normalize_erasing_regions(
-                mir_place.ty(&self.frame().body.local_decls, *self.tcx).ty,
-            )?;
+            let normalized_place_ty = self
+                .instantiate_from_current_frame_and_normalize_erasing_regions(
+                    mir_place.ty(&self.frame().body.local_decls, *self.tcx).ty,
+                )?;
             if !mir_assign_valid_types(
                 *self.tcx,
                 self.param_env,
@@ -731,8 +732,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             &Copy(place) | &Move(place) => self.eval_place_to_op(place, layout)?,
 
             Constant(constant) => {
-                let c =
-                    self.subst_from_current_frame_and_normalize_erasing_regions(constant.const_)?;
+                let c = self.instantiate_from_current_frame_and_normalize_erasing_regions(
+                    constant.const_,
+                )?;
 
                 // This can still fail:
                 // * During ConstProp, with `TooGeneric` or since the `required_consts` were not all

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -542,9 +542,10 @@ where
         trace!("{:?}", self.dump_place(&place));
         // Sanity-check the type we ended up with.
         if cfg!(debug_assertions) {
-            let normalized_place_ty = self.subst_from_current_frame_and_normalize_erasing_regions(
-                mir_place.ty(&self.frame().body.local_decls, *self.tcx).ty,
-            )?;
+            let normalized_place_ty = self
+                .instantiate_from_current_frame_and_normalize_erasing_regions(
+                    mir_place.ty(&self.frame().body.local_decls, *self.tcx).ty,
+                )?;
             if !mir_assign_valid_types(
                 *self.tcx,
                 self.param_env,

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -235,7 +235,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             NullaryOp(ref null_op, ty) => {
-                let ty = self.subst_from_current_frame_and_normalize_erasing_regions(ty)?;
+                let ty = self.instantiate_from_current_frame_and_normalize_erasing_regions(ty)?;
                 let layout = self.layout_of(ty)?;
                 if let mir::NullOp::SizeOf | mir::NullOp::AlignOf = null_op
                     && layout.is_unsized()
@@ -276,7 +276,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Cast(cast_kind, ref operand, cast_ty) => {
                 let src = self.eval_operand(operand, None)?;
                 let cast_ty =
-                    self.subst_from_current_frame_and_normalize_erasing_regions(cast_ty)?;
+                    self.instantiate_from_current_frame_and_normalize_erasing_regions(cast_ty)?;
                 self.cast(&src, cast_kind, cast_ty, &dest)?;
             }
 

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -173,7 +173,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Drop { place, target, unwind, replace: _ } => {
                 let frame = self.frame();
                 let ty = place.ty(&frame.body.local_decls, *self.tcx).ty;
-                let ty = self.subst_from_frame_and_normalize_erasing_regions(frame, ty)?;
+                let ty = self.instantiate_from_frame_and_normalize_erasing_regions(frame, ty)?;
                 let instance = Instance::resolve_drop_in_place(*self.tcx, ty);
                 if let ty::InstanceDef::DropGlue(_, None) = instance.def {
                     // This is the branch we enter if and only if the dropped type has no drop glue
@@ -672,8 +672,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         // Construct the destination place for this argument. At this point all
                         // locals are still dead, so we cannot construct a `PlaceTy`.
                         let dest = mir::Place::from(local);
-                        // `layout_of_local` does more than just the substitution we need to get the
-                        // type, but the result gets cached so this avoids calling the substitution
+                        // `layout_of_local` does more than just the instantiation we need to get the
+                        // type, but the result gets cached so this avoids calling the instantiation
                         // query *again* the next time this local is accessed.
                         let ty = self.layout_of_local(self.frame(), local, None)?.ty;
                         if Some(local) == body.spread_arg {

--- a/compiler/rustc_const_eval/src/interpret/util.rs
+++ b/compiler/rustc_const_eval/src/interpret/util.rs
@@ -19,11 +19,11 @@ where
     }
 
     struct FoundParam;
-    struct UsedParamsNeedSubstVisitor<'tcx> {
+    struct UsedParamsNeedInstantiationVisitor<'tcx> {
         tcx: TyCtxt<'tcx>,
     }
 
-    impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for UsedParamsNeedSubstVisitor<'tcx> {
+    impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for UsedParamsNeedInstantiationVisitor<'tcx> {
         type BreakTy = FoundParam;
 
         fn visit_ty(&mut self, ty: Ty<'tcx>) -> ControlFlow<Self::BreakTy> {
@@ -38,17 +38,17 @@ where
                 | ty::FnDef(def_id, args) => {
                     let instance = ty::InstanceDef::Item(def_id);
                     let unused_params = self.tcx.unused_generic_params(instance);
-                    for (index, subst) in args.into_iter().enumerate() {
+                    for (index, arg) in args.into_iter().enumerate() {
                         let index = index
                             .try_into()
                             .expect("more generic parameters than can fit into a `u32`");
                         // Only recurse when generic parameters in fns, closures and coroutines
                         // are used and have to be instantiated.
                         //
-                        // Just in case there are closures or coroutines within this subst,
+                        // Just in case there are closures or coroutines within this arg,
                         // recurse.
-                        if unused_params.is_used(index) && subst.has_param() {
-                            return subst.visit_with(self);
+                        if unused_params.is_used(index) && arg.has_param() {
+                            return arg.visit_with(self);
                         }
                     }
                     ControlFlow::Continue(())
@@ -65,7 +65,7 @@ where
         }
     }
 
-    let mut vis = UsedParamsNeedSubstVisitor { tcx };
+    let mut vis = UsedParamsNeedInstantiationVisitor { tcx };
     if matches!(ty.visit_with(&mut vis), ControlFlow::Break(FoundParam)) {
         throw_inval!(TooGeneric);
     } else {

--- a/compiler/rustc_error_codes/src/error_codes/E0139.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0139.md
@@ -22,9 +22,9 @@ fn foo<T>(x: Vec<T>) {
 In this specific case there's a good chance that the transmute is harmless (but
 this is not guaranteed by Rust). However, when alignment and enum optimizations
 come into the picture, it's quite likely that the sizes may or may not match
-with different type parameter substitutions. It's not possible to check this for
-_all_ possible types, so `transmute()` simply only accepts types without any
-unsubstituted type parameters.
+with different type parameter instantiations. It's not possible to check this
+for _all_ possible types, so `transmute()` simply only accepts types without any
+uninstantiated type parameters.
 
 If you need this, there's a good chance you're doing something wrong. Keep in
 mind that Rust doesn't guarantee much about the layout of different structs
@@ -32,7 +32,7 @@ mind that Rust doesn't guarantee much about the layout of different structs
 there is a solution that avoids the transmute entirely, try it instead.
 
 If it's possible, hand-monomorphize the code by writing the function for each
-possible type substitution. It's possible to use traits to do this cleanly,
+possible type instantiation. It's possible to use traits to do this cleanly,
 for example:
 
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0230.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0230.md
@@ -15,9 +15,9 @@ There will be an error about `bool` not implementing `Index<u8>`, followed by a
 note saying "the type `bool` cannot be indexed by `u8`".
 
 As you can see, you can specify type parameters in curly braces for
-substitution with the actual types (using the regular format string syntax) in
-a given situation. Furthermore, `{Self}` will substitute to the type (in this
-case, `bool`) that we tried to use.
+instantiation with the actual types (using the regular format string syntax) in
+a given situation. Furthermore, `{Self}` will be instantiated to the type (in
+this case, `bool`) that we tried to use.
 
 This error appears when the curly braces contain an identifier which doesn't
 match with any of the type parameters or the string `Self`. This might happen

--- a/compiler/rustc_error_codes/src/error_codes/E0231.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0231.md
@@ -15,9 +15,9 @@ there will be an error about `bool` not implementing `Index<u8>`, followed by a
 note saying "the type `bool` cannot be indexed by `u8`".
 
 As you can see, you can specify type parameters in curly braces for
-substitution with the actual types (using the regular format string syntax) in
-a given situation. Furthermore, `{Self}` will substitute to the type (in this
-case, `bool`) that we tried to use.
+instantiation with the actual types (using the regular format string syntax) in
+a given situation. Furthermore, `{Self}` will be instantiated to the type (in
+this case, `bool`) that we tried to use.
 
 This error appears when the curly braces do not contain an identifier. Please
 add one of the same name as a type parameter. If you intended to use literal

--- a/compiler/rustc_error_codes/src/error_codes/E0393.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0393.md
@@ -12,12 +12,12 @@ fn together_we_will_rule_the_galaxy(son: &A) {}
 ```
 
 A trait object is defined over a single, fully-defined trait. With a regular
-default parameter, this parameter can just be substituted in. However, if the
+default parameter, this parameter can just be instantiated in. However, if the
 default parameter is `Self`, the trait changes for each concrete type; i.e.
 `i32` will be expected to implement `A<i32>`, `bool` will be expected to
 implement `A<bool>`, etc... These types will not share an implementation of a
 fully-defined trait; instead they share implementations of a trait with
-different parameters substituted in for each implementation. This is
+different parameters instantiated in for each implementation. This is
 irreconcilable with what we need to make a trait object work, and is thus
 disallowed. Making the trait concrete by explicitly specifying the value of the
 defaulted parameter will fix this issue. Fixed example:

--- a/compiler/rustc_error_codes/src/error_codes/E0794.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0794.md
@@ -14,7 +14,7 @@ let _ = foo::<'static>;
 
 The type of a concrete instance of a generic function is universally quantified
 over late-bound lifetime parameters. This is because we want the function to
-work for any lifetime substituted for the late-bound lifetime parameter, no
+work for any lifetime instantiated for the late-bound lifetime parameter, no
 matter where the function is called. Consequently, it doesn't make sense to
 specify arguments for late-bound lifetime parameters, since they are not
 resolved until the function's call site(s).
@@ -56,7 +56,7 @@ let bar_fn3 = bar::<Bar>; // OK
 
 In the definition of `bar`, the lifetime parameter `'a` is late-bound, while
 `'b` is early-bound. This is reflected in the type annotation for `bar_fn`,
-where `'a` is universally quantified and `'b` is substituted by a specific
+where `'a` is universally quantified and `'b` is instantiated with a specific
 lifetime. It is not allowed to explicitly specify early-bound lifetime
 arguments when late-bound lifetime parameters are present (as for `bar_fn2`,
 see [issue #42868](https://github.com/rust-lang/rust/issues/42868)), although

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2536,7 +2536,7 @@ pub struct OpaqueTy<'hir> {
     /// lifetimes that are captured from the function signature they originate from.
     ///
     /// This is done by generating a new early-bound lifetime parameter local to the
-    /// opaque which is substituted in the function signature with the late-bound
+    /// opaque which is instantiated in the function signature with the late-bound
     /// lifetime.
     ///
     /// This mapping associated a captured lifetime (first parameter) with the new

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -131,6 +131,8 @@ hir_analysis_function_not_have_default_implementation = function doesn't have a 
 hir_analysis_functions_names_duplicated = functions names are duplicated
     .note = all `#[rustc_must_implement_one_of]` arguments must be unique
 
+hir_analysis_generic_args_on_overridden_impl = could not resolve generic parameters on overridden impl
+
 hir_analysis_impl_not_marked_default = `{$ident}` specializes an item from a parent `impl`, but that item is not marked `default`
     .label = cannot specialize default item `{$ident}`
     .ok_label = parent `impl` is here
@@ -364,8 +366,6 @@ hir_analysis_static_mut_ref_lint = {$shared}reference of mutable static is disco
     .why_note = mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
 
 hir_analysis_static_specialize = cannot specialize on `'static` lifetime
-
-hir_analysis_substs_on_overridden_impl = could not resolve substs on overridden impl
 
 hir_analysis_tait_forward_compat = item constrains opaque type that is not in its signature
     .note = this item must mention the opaque type in its signature in order to be able to register hidden types

--- a/compiler/rustc_hir_analysis/src/astconv/generics.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/generics.rs
@@ -1,6 +1,6 @@
 use super::IsMethodCall;
 use crate::astconv::{
-    errors::prohibit_assoc_ty_binding, CreateSubstsForGenericArgsCtxt, ExplicitLateBound,
+    errors::prohibit_assoc_ty_binding, CreateInstantiationsForGenericArgsCtxt, ExplicitLateBound,
     GenericArgCountMismatch, GenericArgCountResult, GenericArgPosition,
 };
 use crate::structured_errors::{GenericArgsInfo, StructuredDiagnostic, WrongNumberOfGenericArgs};
@@ -177,9 +177,9 @@ pub fn create_args_for_parent_generic_args<'tcx: 'a, 'a>(
     has_self: bool,
     self_ty: Option<Ty<'tcx>>,
     arg_count: &GenericArgCountResult,
-    ctx: &mut impl CreateSubstsForGenericArgsCtxt<'a, 'tcx>,
+    ctx: &mut impl CreateInstantiationsForGenericArgsCtxt<'a, 'tcx>,
 ) -> GenericArgsRef<'tcx> {
-    // Collect the segments of the path; we need to substitute arguments
+    // Collect the segments of the path; we need to instantiate arguments
     // for parameters throughout the entire path (wherever there are
     // generic parameters).
     let mut parent_defs = tcx.generics_of(def_id);
@@ -191,7 +191,7 @@ pub fn create_args_for_parent_generic_args<'tcx: 'a, 'a>(
     }
 
     // We manually build up the generic arguments, rather than using convenience
-    // methods in `subst.rs`, so that we can iterate over the arguments and
+    // methods in `rustc_middle/src/ty/generic_args.rs`, so that we can iterate over the arguments and
     // parameters in lock-step linearly, instead of trying to match each pair.
     let mut args: SmallVec<[ty::GenericArg<'tcx>; 8]> = SmallVec::with_capacity(count);
     // Iterate over each segment of the path.

--- a/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/object_safety.rs
@@ -175,7 +175,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     }
                     ty::PredicateKind::Clause(ty::ClauseKind::Projection(pred)) => {
                         let pred = bound_predicate.rebind(pred);
-                        // A `Self` within the original bound will be substituted with a
+                        // A `Self` within the original bound will be instantiated with a
                         // `trait_object_dummy_self`, so check for that.
                         let references_self = match pred.skip_binder().term.unpack() {
                             ty::TermKind::Ty(ty) => ty.walk().any(|arg| arg == dummy_self.into()),

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1030,7 +1030,7 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
             match t.kind() {
                 ty::Tuple(list) => list.iter().try_for_each(|t| check_non_exhaustive(tcx, t)),
                 ty::Array(ty, _) => check_non_exhaustive(tcx, *ty),
-                ty::Adt(def, subst) => {
+                ty::Adt(def, args) => {
                     if !def.did().is_local() {
                         let non_exhaustive = def.is_variant_list_non_exhaustive()
                             || def
@@ -1042,13 +1042,13 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
                             return ControlFlow::Break((
                                 def.descr(),
                                 def.did(),
-                                subst,
+                                args,
                                 non_exhaustive,
                             ));
                         }
                     }
                     def.all_fields()
-                        .map(|field| field.ty(tcx, subst))
+                        .map(|field| field.ty(tcx, args))
                         .try_for_each(|t| check_non_exhaustive(tcx, t))
                 }
                 _ => ControlFlow::Continue(()),

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -125,9 +125,9 @@ fn check_method_is_structurally_compatible<'tcx>(
 /// <'b> fn(t: &'i0 U0, m: &'b N0) -> Foo
 /// ```
 ///
-/// We now want to extract and substitute the type of the *trait*
+/// We now want to extract and instantiate the type of the *trait*
 /// method and compare it. To do so, we must create a compound
-/// substitution by combining `trait_to_impl_args` and
+/// instantiation by combining `trait_to_impl_args` and
 /// `impl_to_placeholder_args`, and also adding a mapping for the method
 /// type parameters. We extend the mapping to also include
 /// the method parameters.
@@ -146,11 +146,11 @@ fn check_method_is_structurally_compatible<'tcx>(
 /// vs `'b`). However, the normal subtyping rules on fn types handle
 /// this kind of equivalency just fine.
 ///
-/// We now use these substitutions to ensure that all declared bounds are
-/// satisfied by the implementation's method.
+/// We now use these generic parameters to ensure that all declared bounds
+/// are satisfied by the implementation's method.
 ///
 /// We do this by creating a parameter environment which contains a
-/// substitution corresponding to `impl_to_placeholder_args`. We then build
+/// generic parameter corresponding to `impl_to_placeholder_args`. We then build
 /// `trait_to_placeholder_args` and use it to convert the predicates contained
 /// in the `trait_m` generics to the placeholder form.
 ///
@@ -454,7 +454,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
     let impl_trait_ref =
         tcx.impl_trait_ref(impl_m.impl_container(tcx).unwrap()).unwrap().instantiate_identity();
     // First, check a few of the same things as `compare_impl_method`,
-    // just so we don't ICE during substitution later.
+    // just so we don't ICE during instantiation later.
     check_method_is_structurally_compatible(tcx, impl_m, trait_m, impl_trait_ref, true)?;
 
     let trait_to_impl_args = impl_trait_ref.args;
@@ -543,7 +543,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
     // }
     // ```
     // .. to compile. However, since we use both the normalized and unnormalized
-    // inputs and outputs from the substituted trait signature, we will end up
+    // inputs and outputs from the instantiated trait signature, we will end up
     // seeing the hidden type of an RPIT in the signature itself. Naively, this
     // means that we will use the hidden type to imply the hidden type's own
     // well-formedness.
@@ -699,7 +699,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
                 // NOTE(compiler-errors): RPITITs, like all other RPITs, have early-bound
                 // region args that are synthesized during AST lowering. These are args
                 // that are appended to the parent args (trait and trait method). However,
-                // we're trying to infer the unsubstituted type value of the RPITIT inside
+                // we're trying to infer the uninstantiated type value of the RPITIT inside
                 // the *impl*, so we can later use the impl's method args to normalize
                 // an RPITIT to a concrete type (`confirm_impl_trait_in_trait_candidate`).
                 //
@@ -711,7 +711,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
                 // guarantee that the indices from the trait args and impl args line up.
                 // So to fix this, we subtract the number of trait args and add the number of
                 // impl args to *renumber* these early-bound regions to their corresponding
-                // indices in the impl's substitutions list.
+                // indices in the impl's generic parameters list.
                 //
                 // Also, we only need to account for a difference in trait and impl args,
                 // since we previously enforce that the trait method and impl method have the

--- a/compiler/rustc_hir_analysis/src/check/dropck.rs
+++ b/compiler/rustc_hir_analysis/src/check/dropck.rs
@@ -124,14 +124,14 @@ fn ensure_drop_predicates_are_implied_by_item_defn<'tcx>(
     let infcx = tcx.infer_ctxt().build();
     let ocx = ObligationCtxt::new(&infcx);
 
-    // Take the param-env of the adt and substitute the args that show up in
+    // Take the param-env of the adt and instantiate the args that show up in
     // the implementation's self type. This gives us the assumptions that the
     // self ty of the implementation is allowed to know just from it being a
     // well-formed adt, since that's all we're allowed to assume while proving
     // the Drop implementation is not specialized.
     //
     // We don't need to normalize this param-env or anything, since we're only
-    // substituting it with free params, so no additional param-env normalization
+    // instantiating it with free params, so no additional param-env normalization
     // can occur on top of what has been done in the param_env query itself.
     let param_env =
         ty::EarlyBinder::bind(tcx.param_env(adt_def_id)).instantiate(tcx, adt_to_impl_args);

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -56,7 +56,7 @@ type variable is an instance of a type parameter. That is,
 given a generic function `fn foo<T>(t: T)`, while checking the
 function `foo`, the type `ty_param(0)` refers to the type `T`, which
 is treated in abstract. However, when `foo()` is called, `T` will be
-substituted for a fresh type variable `N`. This variable will
+instantiated with a fresh type variable `N`. This variable will
 eventually be resolved to some concrete type (which might itself be
 a type parameter).
 

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -396,7 +396,7 @@ pub fn coerce_unsized_info<'tcx>(
             //
             // To check if this impl is legal, we would walk down
             // the fields of `Foo` and consider their types with
-            // both substitutes. We are looking to find that
+            // both generic parameters. We are looking to find that
             // exactly one (non-phantom) field has changed its
             // type, which we will expect to be the pointer that
             // is becoming fat (we could probably generalize this

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -71,7 +71,7 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
                     // end up with that const looking like: `ty::ConstKind::Unevaluated(def_id, args: [N#0])`.
                     //
                     // This causes ICEs (#86580) when building the args for Foo in `fn foo() -> Foo { .. }` as
-                    // we substitute the defaults with the partially built args when we build the args. Subst'ing
+                    // we instantiate the defaults with the partially built args when we build the args. Instantiating
                     // the `N#0` on the unevaluated const indexes into the empty args we're in the process of building.
                     //
                     // We fix this by having this function return the parent's generics ourselves and truncating the

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1786,7 +1786,8 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                 let bound_predicate = pred.kind();
                 match bound_predicate.skip_binder() {
                     ty::ClauseKind::Trait(data) => {
-                        // The order here needs to match what we would get from `subst_supertrait`
+                        // The order here needs to match what we would get from
+                        // `rustc_middle::ty::predicate::Clause::instantiate_supertrait`
                         let pred_bound_vars = bound_predicate.bound_vars();
                         let mut all_bound_vars = bound_vars.clone();
                         all_bound_vars.extend(pred_bound_vars.iter());

--- a/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
+++ b/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
@@ -119,7 +119,7 @@ pub fn identify_constrained_generic_params<'tcx>(
 ///   * `<U as Iterator>::Item = T` -- a desugared ProjectionPredicate
 ///
 /// When we, for example, try to go over the trait-reference
-/// `IntoIter<u32> as Trait`, we substitute the impl parameters with fresh
+/// `IntoIter<u32> as Trait`, we instantiate the impl parameters with fresh
 /// variables and match them with the impl trait-ref, so we know that
 /// `$U = IntoIter<u32>`.
 ///

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -372,8 +372,8 @@ pub struct ManualImplementation {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_substs_on_overridden_impl)]
-pub struct SubstsOnOverriddenImpl {
+#[diag(hir_analysis_generic_args_on_overridden_impl)]
+pub struct GenericArgsOnOverriddenImpl {
     #[primary_span]
     pub span: Span,
 }

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -34,8 +34,8 @@
 //! impl<T, I: Iterator<Item=T>> SpecExtend<T> for I { /* default impl */ }
 //! ```
 //!
-//! We get that the subst for `impl2` are `[T, std::vec::IntoIter<T>]`. `T` is
-//! constrained to be `<I as Iterator>::Item`, so we check only
+//! We get that the generic pamameters for `impl2` are `[T, std::vec::IntoIter<T>]`.
+//! `T` is constrained to be `<I as Iterator>::Item`, so we check only
 //! `std::vec::IntoIter<T>` for repeated parameters, which it doesn't have. The
 //! predicates of `impl1` are only `T: Sized`, which is also a predicate of
 //! `impl2`. So this specialization is sound.
@@ -65,7 +65,7 @@
 //! cause use after frees with purely safe code in the same way as specializing
 //! on traits with methods can.
 
-use crate::errors::SubstsOnOverriddenImpl;
+use crate::errors::GenericArgsOnOverriddenImpl;
 use crate::{constrained_generic_params as cgp, errors};
 
 use rustc_data_structures::fx::FxHashSet;
@@ -179,8 +179,8 @@ fn check_constness(
 }
 
 /// Given a specializing impl `impl1`, and the base impl `impl2`, returns two
-/// substitutions `(S1, S2)` that equate their trait references. The returned
-/// types are expressed in terms of the generics of `impl1`.
+/// generic parameters `(S1, S2)` that equate their trait references.
+/// The returned types are expressed in terms of the generics of `impl1`.
 ///
 /// Example
 ///
@@ -228,13 +228,13 @@ fn get_impl_args(
     let _ = ocx.resolve_regions_and_report_errors(impl1_def_id, &outlives_env);
     let Ok(impl2_args) = infcx.fully_resolve(impl2_args) else {
         let span = tcx.def_span(impl1_def_id);
-        let guar = tcx.dcx().emit_err(SubstsOnOverriddenImpl { span });
+        let guar = tcx.dcx().emit_err(GenericArgsOnOverriddenImpl { span });
         return Err(guar);
     };
     Ok((impl1_args, impl2_args))
 }
 
-/// Returns a list of all of the unconstrained subst of the given impl.
+/// Returns a list of all of the unconstrained generic parameters of the given impl.
 ///
 /// For example given the impl:
 ///

--- a/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_hir_analysis/src/outlives/implicit_infer.rs
@@ -229,7 +229,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
 /// Here, we should fetch the explicit predicates, which
 /// will give us `U: 'static` and `U: Outer`. The latter we
 /// can ignore, but we will want to process `U: 'static`,
-/// applying the substitution as above.
+/// applying the instantiation as above.
 fn check_explicit_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
@@ -316,7 +316,7 @@ fn check_explicit_predicates<'tcx>(
 /// Here, when processing the type of field `outer`, we would request the
 /// set of implicit predicates computed for `Inner` thus far. This will
 /// initially come back empty, but in next round we will get `U: 'b`.
-/// We then apply the substitution `['b => 'a, U => T]` and thus get the
+/// We then apply the instantiation `['b => 'a, U => T]` and thus get the
 /// requirement that `T: 'a` holds for `Outer`.
 fn check_inferred_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -334,7 +334,7 @@ fn check_inferred_predicates<'tcx>(
 
     for (&predicate, &span) in predicates.as_ref().skip_binder() {
         // `predicate` is `U: 'b` in the example above.
-        // So apply the substitution to get `T: 'a`.
+        // So apply the instantiation to get `T: 'a`.
         let ty::OutlivesPredicate(arg, region) =
             predicates.rebind(predicate).instantiate(tcx, args);
         insert_outlives_predicate(tcx, arg, region, span, required_predicates);

--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -172,16 +172,16 @@ fn variance_of_opaque(tcx: TyCtxt<'_>, item_def_id: LocalDefId) -> &[ty::Varianc
                 trait_ref: ty::TraitRef { def_id: _, args, .. },
                 polarity: _,
             }) => {
-                for subst in &args[1..] {
-                    subst.visit_with(&mut collector);
+                for arg in &args[1..] {
+                    arg.visit_with(&mut collector);
                 }
             }
             ty::ClauseKind::Projection(ty::ProjectionPredicate {
                 projection_ty: ty::AliasTy { args, .. },
                 term,
             }) => {
-                for subst in &args[1..] {
-                    subst.visit_with(&mut collector);
+                for arg in &args[1..] {
+                    arg.visit_with(&mut collector);
                 }
                 term.visit_with(&mut collector);
             }

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -123,7 +123,7 @@ pub(super) fn check_fn<'a, 'tcx>(
     if let ty::Dynamic(..) = declared_ret_ty.kind() {
         // We have special-cased the case where the function is declared
         // `-> dyn Foo` and we don't actually relate it to the
-        // `fcx.ret_coercion`, so just substitute a type variable.
+        // `fcx.ret_coercion`, so just instantiate a type variable.
         actual_return_ty =
             fcx.next_ty_var(TypeVariableOrigin { kind: TypeVariableOriginKind::DynReturnFn, span });
         debug!("actual_return_ty replaced with {:?}", actual_return_ty);

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -752,7 +752,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         let mut obligations: Vec<_> = predicates
             .iter()
             .map(|predicate| {
-                // For each existential predicate (e.g., `?Self: Clone`) substitute
+                // For each existential predicate (e.g., `?Self: Clone`) instantiate
                 // the type of the expression (e.g., `usize` in our example above)
                 // and then require that the resulting predicate (e.g., `usize: Clone`)
                 // holds (it does).

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1801,7 +1801,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // consistency. But they should be merged as much as possible.
             let fru_tys = if self.tcx.features().type_changing_struct_update {
                 if adt.is_struct() {
-                    // Make some fresh substitutions for our ADT type.
+                    // Make some fresh generic parameters for our ADT type.
                     let fresh_args = self.fresh_args_for_item(base_expr.span, adt.did());
                     // We do subtyping on the FRU fields first, so we can
                     // learn exactly what types we expect the base expr

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -15,7 +15,7 @@ use rustc_hir_analysis::astconv::generics::{
     check_generic_arg_count_for_call, create_args_for_parent_generic_args,
 };
 use rustc_hir_analysis::astconv::{
-    AstConv, CreateSubstsForGenericArgsCtxt, ExplicitLateBound, GenericArgCountMismatch,
+    AstConv, CreateInstantiationsForGenericArgsCtxt, ExplicitLateBound, GenericArgCountMismatch,
     GenericArgCountResult, IsMethodCall, PathSeg,
 };
 use rustc_infer::infer::canonical::{Canonical, OriginalQueryValues, QueryResponse};
@@ -179,8 +179,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Given the args that we just converted from the HIR, try to
-    /// canonicalize them and store them as user-given substitutions
-    /// (i.e., substitutions that must be respected by the NLL check).
+    /// canonicalize them and store them as user-given parameters
+    /// (i.e., parameters that must be respected by the NLL check).
     ///
     /// This should be invoked **before any unifications have
     /// occurred**, so that annotations like `Vec<_>` are preserved
@@ -733,7 +733,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     return Err(TypeError::Mismatch);
                 }
 
-                // Record all the argument types, with the substitutions
+                // Record all the argument types, with the args
                 // produced from the above subtyping unification.
                 Ok(Some(formal_args.iter().map(|&ty| self.resolve_vars_if_possible(ty)).collect()))
             })
@@ -1163,7 +1163,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Now we have to compare the types that the user *actually*
         // provided against the types that were *expected*. If the user
-        // did not provide any types, then we want to substitute inference
+        // did not provide any types, then we want to instantiate inference
         // variables. If the user provided some types, we may still need
         // to add defaults. If the user provided *too many* types, that's
         // a problem.
@@ -1253,14 +1253,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             },
         };
 
-        struct CreateCtorSubstsContext<'a, 'tcx> {
+        struct CreateCtorInstantiationsContext<'a, 'tcx> {
             fcx: &'a FnCtxt<'a, 'tcx>,
             span: Span,
             path_segs: &'a [PathSeg],
             infer_args_for_err: &'a FxHashSet<usize>,
             segments: &'tcx [hir::PathSegment<'tcx>],
         }
-        impl<'tcx, 'a> CreateSubstsForGenericArgsCtxt<'a, 'tcx> for CreateCtorSubstsContext<'a, 'tcx> {
+        impl<'tcx, 'a> CreateInstantiationsForGenericArgsCtxt<'a, 'tcx>
+            for CreateCtorInstantiationsContext<'a, 'tcx>
+        {
             fn args_for_def_id(
                 &mut self,
                 def_id: DefId,
@@ -1384,7 +1386,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 has_self,
                 self_ty.map(|s| s.raw),
                 &arg_count,
-                &mut CreateCtorSubstsContext {
+                &mut CreateCtorInstantiationsContext {
                     fcx: self,
                     span,
                     path_segs: &path_segs,
@@ -1402,18 +1404,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         self.add_required_obligations_for_hir(span, def_id, args, hir_id);
 
-        // Substitute the values for the type parameters into the type of
+        // Instantiate the values for the type parameters into the type of
         // the referenced item.
         let ty = tcx.type_of(def_id);
         assert!(!args.has_escaping_bound_vars());
         assert!(!ty.skip_binder().has_escaping_bound_vars());
-        let ty_substituted = self.normalize(span, ty.instantiate(tcx, args));
+        let ty_instantiated = self.normalize(span, ty.instantiate(tcx, args));
 
         if let Some(UserSelfTy { impl_def_id, self_ty }) = user_self_ty {
             // In the case of `Foo<T>::method` and `<Foo<T>>::method`, if `method`
             // is inherent, there is no `Self` parameter; instead, the impl needs
             // type parameters, which we can infer by unifying the provided `Self`
-            // with the substituted impl type.
+            // with the instantiated impl type.
             // This also occurs for an enum variant on a type alias.
             let impl_ty = self.normalize(span, tcx.type_of(impl_def_id).instantiate(tcx, args));
             let self_ty = self.normalize(span, self_ty);
@@ -1434,13 +1436,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        debug!("instantiate_value_path: type of {:?} is {:?}", hir_id, ty_substituted);
+        debug!("instantiate_value_path: type of {:?} is {:?}", hir_id, ty_instantiated);
         self.write_args(hir_id, args);
 
-        (ty_substituted, res)
+        (ty_instantiated, res)
     }
 
-    /// Add all the obligations that are required, substituting and normalized appropriately.
+    /// Add all the obligations that are required, instantiated and normalized appropriately.
     pub(crate) fn add_required_obligations_for_hir(
         &self,
         span: Span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/adjust_fulfillment_errors.rs
@@ -21,7 +21,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         };
 
-        let Some(unsubstituted_pred) = self
+        let Some(uninstantiated_pred) = self
             .tcx
             .predicates_of(def_id)
             .instantiate_identity(self.tcx)
@@ -34,7 +34,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let generics = self.tcx.generics_of(def_id);
         let (predicate_args, predicate_self_type_to_point_at) =
-            match unsubstituted_pred.kind().skip_binder() {
+            match uninstantiated_pred.kind().skip_binder() {
                 ty::ClauseKind::Trait(pred) => {
                     (pred.trait_ref.args.to_vec(), Some(pred.self_ty().into()))
                 }
@@ -343,10 +343,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     && let TypeVariableOriginKind::TypeParameterDefinition(_, def_id) = origin.kind
                     && let generics = self.0.tcx.generics_of(self.1)
                     && let Some(index) = generics.param_def_id_to_index(self.0.tcx, def_id)
-                    && let Some(subst) =
+                    && let Some(arg) =
                         ty::GenericArgs::identity_for_item(self.0.tcx, self.1).get(index as usize)
                 {
-                    ControlFlow::Break(*subst)
+                    ControlFlow::Break(*arg)
                 } else {
                     ty.super_visit_with(self)
                 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2133,17 +2133,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr_ty: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
-        let (adt, substs, unwrap) = match expected.kind() {
+        let (adt, args, unwrap) = match expected.kind() {
             // In case Option<NonZero*> is wanted, but * is provided, suggest calling new
-            ty::Adt(adt, substs) if tcx.is_diagnostic_item(sym::Option, adt.did()) => {
-                let nonzero_type = substs.type_at(0); // Unwrap option type.
-                let ty::Adt(adt, substs) = nonzero_type.kind() else {
+            ty::Adt(adt, args) if tcx.is_diagnostic_item(sym::Option, adt.did()) => {
+                let nonzero_type = args.type_at(0); // Unwrap option type.
+                let ty::Adt(adt, args) = nonzero_type.kind() else {
                     return false;
                 };
-                (adt, substs, "")
+                (adt, args, "")
             }
             // In case `NonZero<*>` is wanted but `*` is provided, also add `.unwrap()` to satisfy types.
-            ty::Adt(adt, substs) => (adt, substs, ".unwrap()"),
+            ty::Adt(adt, args) => (adt, args, ".unwrap()"),
             _ => return false,
         };
 
@@ -2165,7 +2165,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ("NonZeroI128", tcx.types.i128),
         ];
 
-        let int_type = substs.type_at(0);
+        let int_type = args.type_at(0);
 
         let Some(nonzero_alias) = coercable_types.iter().find_map(|(nonzero_alias, t)| {
             if *t == int_type && self.can_coerce(expr_ty, *t) { Some(nonzero_alias) } else { None }

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -38,7 +38,7 @@ pub struct MethodCallee<'tcx> {
     pub args: GenericArgsRef<'tcx>,
 
     /// Instantiated method signature, i.e., it has been
-    /// substituted, normalized, and has had late-bound
+    /// instantiated, normalized, and has had late-bound
     /// lifetimes replaced with inference variables.
     pub sig: ty::FnSig<'tcx>,
 }
@@ -395,7 +395,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         debug!("lookup_in_trait_adjusted: method_item={:?}", method_item);
         let mut obligations = vec![];
 
-        // Instantiate late-bound regions and substitute the trait
+        // Instantiate late-bound regions and instantiate the trait
         // parameters into the method type to get the actual method type.
         //
         // N.B., instantiate late-bound regions before normalizing the

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -111,7 +111,7 @@ pub(crate) struct Candidate<'tcx> {
     // The way this is handled is through `xform_self_ty`. It contains
     // the receiver type of this candidate, but `xform_self_ty`,
     // `xform_ret_ty` and `kind` (which contains the predicates) have the
-    // generic parameters of this candidate substituted with the *same set*
+    // generic parameters of this candidate instantiated with the *same set*
     // of inference variables, which acts as some weird sort of "query".
     //
     // When we check out a candidate, we require `xform_self_ty` to be
@@ -799,7 +799,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         // the `Self` type. An [`ObjectSafetyViolation::SupertraitSelf`] error
         // will be reported by `object_safety.rs` if the method refers to the
         // `Self` type anywhere other than the receiver. Here, we use a
-        // substitution that replaces `Self` with the object type itself. Hence,
+        // instantiation that replaces `Self` with the object type itself. Hence,
         // a `&self` method will wind up with an argument type like `&dyn Trait`.
         let trait_ref = principal.with_self_ty(self.tcx, self_ty);
         self.elaborate_bounds(iter::once(trait_ref), |this, new_trait_ref, item| {
@@ -1857,8 +1857,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         assert!(!args.has_escaping_bound_vars());
 
         // It is possible for type parameters or early-bound lifetimes
-        // to appear in the signature of `self`. The substitutions we
-        // are given do not include type/lifetime parameters for the
+        // to appear in the signature of `self`. The generic parameters
+        // we are given do not include type/lifetime parameters for the
         // method yet. So create fresh variables here for those too,
         // if there are any.
         let generics = self.tcx.generics_of(method);
@@ -1889,7 +1889,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         self.instantiate_bound_regions_with_erased(xform_fn_sig)
     }
 
-    /// Gets the type of an impl and generate substitutions with inference vars.
+    /// Gets the type of an impl and generate generic parameters with inference vars.
     fn impl_ty_and_args(
         &self,
         impl_def_id: DefId,
@@ -1913,7 +1913,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     ///    late-bound regions with 'static. Otherwise, if we were going to replace late-bound
     ///    regions with actual region variables as is proper, we'd have to ensure that the same
     ///    region got replaced with the same variable, which requires a bit more coordination
-    ///    and/or tracking the substitution and
+    ///    and/or tracking the instantiations and
     ///    so forth.
     fn instantiate_bound_regions_with_erased<T>(&self, value: ty::Binder<'tcx, T>) -> T
     where

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -357,7 +357,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PlaceOp::Deref => None,
             PlaceOp::Index => {
                 // We would need to recover the `T` used when we resolve `<_ as Index<T>>::index`
-                // in try_index_step. This is the subst at index 1.
+                // in try_index_step. This is the arg at index 1.
                 //
                 // Note: we should *not* use `expr_ty` of index_expr here because autoderef
                 // during coercions can cause type of index_expr to differ from `T` (#72002).

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -1,6 +1,6 @@
 // Type resolution: the phase that finds all the types in the AST with
 // unresolved type variables and replaces "ty_var" types with their
-// substitutions.
+// generic parameters.
 
 use crate::FnCtxt;
 use rustc_data_structures::unord::ExtendUnord;
@@ -616,7 +616,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         self.write_ty_to_typeck_results(hir_id, n_ty);
         debug!(?n_ty);
 
-        // Resolve any substitutions
+        // Resolve any generic parameters
         if let Some(args) = self.fcx.typeck_results.borrow().node_args_opt(hir_id) {
             let args = self.resolve(args, &span);
             debug!("write_args_to_tcx({:?}, {:?})", hir_id, args);

--- a/compiler/rustc_infer/src/infer/canonical/instantiate.rs
+++ b/compiler/rustc_infer/src/infer/canonical/instantiate.rs
@@ -1,4 +1,4 @@
-//! This module contains code to substitute new values into a
+//! This module contains code to instantiate new values into a
 //! `Canonical<'tcx, T>`.
 //!
 //! For an overview of what canonicalization is and how it fits into
@@ -16,17 +16,17 @@ use rustc_middle::ty::{self, TyCtxt};
 pub trait CanonicalExt<'tcx, V> {
     /// Instantiate the wrapped value, replacing each canonical value
     /// with the value given in `var_values`.
-    fn substitute(&self, tcx: TyCtxt<'tcx>, var_values: &CanonicalVarValues<'tcx>) -> V
+    fn instantiate(&self, tcx: TyCtxt<'tcx>, var_values: &CanonicalVarValues<'tcx>) -> V
     where
         V: TypeFoldable<TyCtxt<'tcx>>;
 
-    /// Allows one to apply a substitute to some subset of
+    /// Allows one to apply a instantiation to some subset of
     /// `self.value`. Invoke `projection_fn` with `self.value` to get
     /// a value V that is expressed in terms of the same canonical
     /// variables bound in `self` (usually this extracts from subset
-    /// of `self`). Apply the substitution `var_values` to this value
+    /// of `self`). Apply the instantiation `var_values` to this value
     /// V, replacing each of the canonical variables.
-    fn substitute_projected<T>(
+    fn instantiate_projected<T>(
         &self,
         tcx: TyCtxt<'tcx>,
         var_values: &CanonicalVarValues<'tcx>,
@@ -37,14 +37,14 @@ pub trait CanonicalExt<'tcx, V> {
 }
 
 impl<'tcx, V> CanonicalExt<'tcx, V> for Canonical<'tcx, V> {
-    fn substitute(&self, tcx: TyCtxt<'tcx>, var_values: &CanonicalVarValues<'tcx>) -> V
+    fn instantiate(&self, tcx: TyCtxt<'tcx>, var_values: &CanonicalVarValues<'tcx>) -> V
     where
         V: TypeFoldable<TyCtxt<'tcx>>,
     {
-        self.substitute_projected(tcx, var_values, |value| value.clone())
+        self.instantiate_projected(tcx, var_values, |value| value.clone())
     }
 
-    fn substitute_projected<T>(
+    fn instantiate_projected<T>(
         &self,
         tcx: TyCtxt<'tcx>,
         var_values: &CanonicalVarValues<'tcx>,
@@ -55,14 +55,14 @@ impl<'tcx, V> CanonicalExt<'tcx, V> for Canonical<'tcx, V> {
     {
         assert_eq!(self.variables.len(), var_values.len());
         let value = projection_fn(&self.value);
-        substitute_value(tcx, var_values, value)
+        instantiate_value(tcx, var_values, value)
     }
 }
 
-/// Substitute the values from `var_values` into `value`. `var_values`
+/// Instantiate the values from `var_values` into `value`. `var_values`
 /// must be values for the set of canonical variables that appear in
 /// `value`.
-pub(super) fn substitute_value<'tcx, T>(
+pub(super) fn instantiate_value<'tcx, T>(
     tcx: TyCtxt<'tcx>,
     var_values: &CanonicalVarValues<'tcx>,
     value: T,

--- a/compiler/rustc_infer/src/infer/canonical/mod.rs
+++ b/compiler/rustc_infer/src/infer/canonical/mod.rs
@@ -30,24 +30,24 @@ use rustc_middle::ty::GenericArg;
 use rustc_middle::ty::{self, List, Ty, TyCtxt};
 use rustc_span::Span;
 
+pub use instantiate::CanonicalExt;
 pub use rustc_middle::infer::canonical::*;
-pub use substitute::CanonicalExt;
 
 mod canonicalizer;
+mod instantiate;
 pub mod query_response;
-mod substitute;
 
 impl<'tcx> InferCtxt<'tcx> {
-    /// Creates a substitution S for the canonical value with fresh
+    /// Creates an instantiation S for the canonical value with fresh
     /// inference variables and applies it to the canonical value.
-    /// Returns both the instantiated result *and* the substitution S.
+    /// Returns both the instantiated result *and* the instantiation S.
     ///
     /// This can be invoked as part of constructing an
     /// inference context at the start of a query (see
     /// `InferCtxtBuilder::build_with_canonical`). It basically
     /// brings the canonical value "into scope" within your new infcx.
     ///
-    /// At the end of processing, the substitution S (once
+    /// At the end of processing, the instantiation S (once
     /// canonicalized) then represents the values that you computed
     /// for each of the canonical inputs to your query.
     pub fn instantiate_canonical_with_fresh_inference_vars<T>(
@@ -73,14 +73,14 @@ impl<'tcx> InferCtxt<'tcx> {
 
         let canonical_inference_vars =
             self.instantiate_canonical_vars(span, canonical.variables, |ui| universes[ui]);
-        let result = canonical.substitute(self.tcx, &canonical_inference_vars);
+        let result = canonical.instantiate(self.tcx, &canonical_inference_vars);
         (result, canonical_inference_vars)
     }
 
     /// Given the "infos" about the canonical variables from some
     /// canonical, creates fresh variables with the same
     /// characteristics (see `instantiate_canonical_var` for
-    /// details). You can then use `substitute` to instantiate the
+    /// details). You can then use `instantiate` to instantiate the
     /// canonical variable with these inference variables.
     fn instantiate_canonical_vars(
         &self,

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -7,7 +7,7 @@
 //!
 //! [c]: https://rust-lang.github.io/chalk/book/canonical_queries/canonicalization.html
 
-use crate::infer::canonical::substitute::{substitute_value, CanonicalExt};
+use crate::infer::canonical::instantiate::{instantiate_value, CanonicalExt};
 use crate::infer::canonical::{
     Canonical, CanonicalQueryResponse, CanonicalVarValues, Certainty, OriginalQueryValues,
     QueryOutlivesConstraint, QueryRegionConstraints, QueryResponse,
@@ -189,18 +189,18 @@ impl<'tcx> InferCtxt<'tcx> {
     where
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
     {
-        let InferOk { value: result_subst, mut obligations } =
-            self.query_response_substitution(cause, param_env, original_values, query_response)?;
+        let InferOk { value: result_args, mut obligations } =
+            self.query_response_instantiation(cause, param_env, original_values, query_response)?;
 
         obligations.extend(self.query_outlives_constraints_into_obligations(
             cause,
             param_env,
             &query_response.value.region_constraints.outlives,
-            &result_subst,
+            &result_args,
         ));
 
         let user_result: R =
-            query_response.substitute_projected(self.tcx, &result_subst, |q_r| q_r.value.clone());
+            query_response.instantiate_projected(self.tcx, &result_args, |q_r| q_r.value.clone());
 
         Ok(InferOk { value: user_result, obligations })
     }
@@ -225,11 +225,11 @@ impl<'tcx> InferCtxt<'tcx> {
     /// basic operations as `instantiate_query_response_and_region_obligations` but
     /// it returns its result differently:
     ///
-    /// - It creates a substitution `S` that maps from the original
+    /// - It creates an instantiation `S` that maps from the original
     ///   query variables to the values computed in the query
     ///   result. If any errors arise, they are propagated back as an
     ///   `Err` result.
-    /// - In the case of a successful substitution, we will append
+    /// - In the case of a successful instantiation, we will append
     ///   `QueryOutlivesConstraint` values onto the
     ///   `output_query_region_constraints` vector for the solver to
     ///   use (if an error arises, some values may also be pushed, but
@@ -239,7 +239,7 @@ impl<'tcx> InferCtxt<'tcx> {
     ///   that must be processed. In this case, those subobligations
     ///   are propagated back in the return value.
     /// - Finally, the query result (of type `R`) is propagated back,
-    ///   after applying the substitution `S`.
+    ///   after applying the instantiation `S`.
     pub fn instantiate_nll_query_response_and_region_obligations<R>(
         &self,
         cause: &ObligationCause<'tcx>,
@@ -251,8 +251,13 @@ impl<'tcx> InferCtxt<'tcx> {
     where
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
     {
-        let InferOk { value: result_subst, mut obligations } = self
-            .query_response_substitution_guess(cause, param_env, original_values, query_response)?;
+        let InferOk { value: result_args, mut obligations } = self
+            .query_response_instantiation_guess(
+                cause,
+                param_env,
+                original_values,
+                query_response,
+            )?;
 
         // Compute `QueryOutlivesConstraint` values that unify each of
         // the original values `v_o` that was canonicalized into a
@@ -262,7 +267,7 @@ impl<'tcx> InferCtxt<'tcx> {
 
         for (index, original_value) in original_values.var_values.iter().enumerate() {
             // ...with the value `v_r` of that variable from the query.
-            let result_value = query_response.substitute_projected(self.tcx, &result_subst, |v| {
+            let result_value = query_response.instantiate_projected(self.tcx, &result_args, |v| {
                 v.var_values[BoundVar::new(index)]
             });
             match (original_value.unpack(), result_value.unpack()) {
@@ -321,7 +326,7 @@ impl<'tcx> InferCtxt<'tcx> {
         // ...also include the other query region constraints from the query.
         output_query_region_constraints.outlives.extend(
             query_response.value.region_constraints.outlives.iter().filter_map(|&r_c| {
-                let r_c = substitute_value(self.tcx, &result_subst, r_c);
+                let r_c = instantiate_value(self.tcx, &result_args, r_c);
 
                 // Screen out `'a: 'a` cases.
                 let ty::OutlivesPredicate(k1, r2) = r_c.0;
@@ -336,26 +341,26 @@ impl<'tcx> InferCtxt<'tcx> {
                 .region_constraints
                 .member_constraints
                 .iter()
-                .map(|p_c| substitute_value(self.tcx, &result_subst, p_c.clone())),
+                .map(|p_c| instantiate_value(self.tcx, &result_args, p_c.clone())),
         );
 
         let user_result: R =
-            query_response.substitute_projected(self.tcx, &result_subst, |q_r| q_r.value.clone());
+            query_response.instantiate_projected(self.tcx, &result_args, |q_r| q_r.value.clone());
 
         Ok(InferOk { value: user_result, obligations })
     }
 
     /// Given the original values and the (canonicalized) result from
-    /// computing a query, returns a substitution that can be applied
+    /// computing a query, returns an instantiation that can be applied
     /// to the query result to convert the result back into the
     /// original namespace.
     ///
-    /// The substitution also comes accompanied with subobligations
+    /// The instantiation also comes accompanied with subobligations
     /// that arose from unification; these might occur if (for
     /// example) we are doing lazy normalization and the value
     /// assigned to a type variable is unified with an unnormalized
     /// projection.
-    fn query_response_substitution<R>(
+    fn query_response_instantiation<R>(
         &self,
         cause: &ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
@@ -366,11 +371,11 @@ impl<'tcx> InferCtxt<'tcx> {
         R: Debug + TypeFoldable<TyCtxt<'tcx>>,
     {
         debug!(
-            "query_response_substitution(original_values={:#?}, query_response={:#?})",
+            "query_response_instantiation(original_values={:#?}, query_response={:#?})",
             original_values, query_response,
         );
 
-        let mut value = self.query_response_substitution_guess(
+        let mut value = self.query_response_instantiation_guess(
             cause,
             param_env,
             original_values,
@@ -378,7 +383,7 @@ impl<'tcx> InferCtxt<'tcx> {
         )?;
 
         value.obligations.extend(
-            self.unify_query_response_substitution_guess(
+            self.unify_query_response_instantiation_guess(
                 cause,
                 param_env,
                 original_values,
@@ -392,7 +397,7 @@ impl<'tcx> InferCtxt<'tcx> {
     }
 
     /// Given the original values and the (canonicalized) result from
-    /// computing a query, returns a **guess** at a substitution that
+    /// computing a query, returns a **guess** at an instantiation that
     /// can be applied to the query result to convert the result back
     /// into the original namespace. This is called a **guess**
     /// because it uses a quick heuristic to find the values for each
@@ -401,7 +406,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// variable instead. Therefore, the result of this method must be
     /// properly unified
     #[instrument(level = "debug", skip(self, cause, param_env))]
-    fn query_response_substitution_guess<R>(
+    fn query_response_instantiation_guess<R>(
         &self,
         cause: &ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
@@ -450,7 +455,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     if let ty::Bound(debruijn, b) = *result_value.kind() {
                         // ...in which case we would set `canonical_vars[0]` to `Some(?U)`.
 
-                        // We only allow a `ty::INNERMOST` index in substitutions.
+                        // We only allow a `ty::INNERMOST` index in generic parameters.
                         assert_eq!(debruijn, ty::INNERMOST);
                         opt_values[b.var] = Some(*original_value);
                     }
@@ -460,7 +465,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     if let ty::ReBound(debruijn, br) = *result_value {
                         // ... in which case we would set `canonical_vars[0]` to `Some('static)`.
 
-                        // We only allow a `ty::INNERMOST` index in substitutions.
+                        // We only allow a `ty::INNERMOST` index in generic parameters.
                         assert_eq!(debruijn, ty::INNERMOST);
                         opt_values[br.var] = Some(*original_value);
                     }
@@ -469,7 +474,7 @@ impl<'tcx> InferCtxt<'tcx> {
                     if let ty::ConstKind::Bound(debruijn, b) = result_value.kind() {
                         // ...in which case we would set `canonical_vars[0]` to `Some(const X)`.
 
-                        // We only allow a `ty::INNERMOST` index in substitutions.
+                        // We only allow a `ty::INNERMOST` index in generic parameters.
                         assert_eq!(debruijn, ty::INNERMOST);
                         opt_values[b] = Some(*original_value);
                     }
@@ -477,10 +482,10 @@ impl<'tcx> InferCtxt<'tcx> {
             }
         }
 
-        // Create a result substitution: if we found a value for a
+        // Create result arguments: if we found a value for a
         // given variable in the loop above, use that. Otherwise, use
         // a fresh inference variable.
-        let result_subst = CanonicalVarValues {
+        let result_args = CanonicalVarValues {
             var_values: self.tcx.mk_args_from_iter(
                 query_response.variables.iter().enumerate().map(|(index, info)| {
                     if info.universe() != ty::UniverseIndex::ROOT {
@@ -511,8 +516,8 @@ impl<'tcx> InferCtxt<'tcx> {
 
         // Carry all newly resolved opaque types to the caller's scope
         for &(a, b) in &query_response.value.opaque_types {
-            let a = substitute_value(self.tcx, &result_subst, a);
-            let b = substitute_value(self.tcx, &result_subst, b);
+            let a = instantiate_value(self.tcx, &result_args, a);
+            let b = instantiate_value(self.tcx, &result_args, b);
             debug!(?a, ?b, "constrain opaque type");
             // We use equate here instead of, for example, just registering the
             // opaque type's hidden value directly, because we may be instantiating
@@ -532,7 +537,7 @@ impl<'tcx> InferCtxt<'tcx> {
             );
         }
 
-        Ok(InferOk { value: result_subst, obligations })
+        Ok(InferOk { value: result_args, obligations })
     }
 
     /// Given a "guess" at the values for the canonical variables in
@@ -540,13 +545,13 @@ impl<'tcx> InferCtxt<'tcx> {
     /// query result. Often, but not always, this is a no-op, because
     /// we already found the mapping in the "guessing" step.
     ///
-    /// See also: `query_response_substitution_guess`
-    fn unify_query_response_substitution_guess<R>(
+    /// See also: [`Self::query_response_instantiation_guess`]
+    fn unify_query_response_instantiation_guess<R>(
         &self,
         cause: &ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         original_values: &OriginalQueryValues<'tcx>,
-        result_subst: &CanonicalVarValues<'tcx>,
+        result_args: &CanonicalVarValues<'tcx>,
         query_response: &Canonical<'tcx, QueryResponse<'tcx, R>>,
     ) -> InferResult<'tcx, ()>
     where
@@ -554,15 +559,15 @@ impl<'tcx> InferCtxt<'tcx> {
     {
         // A closure that yields the result value for the given
         // canonical variable; this is taken from
-        // `query_response.var_values` after applying the substitution
-        // `result_subst`.
-        let substituted_query_response = |index: BoundVar| -> GenericArg<'tcx> {
-            query_response.substitute_projected(self.tcx, result_subst, |v| v.var_values[index])
+        // `query_response.var_values` after applying the instantiation
+        // by `result_args`.
+        let instantiated_query_response = |index: BoundVar| -> GenericArg<'tcx> {
+            query_response.instantiate_projected(self.tcx, result_args, |v| v.var_values[index])
         };
 
         // Unify the original value for each variable with the value
-        // taken from `query_response` (after applying `result_subst`).
-        self.unify_canonical_vars(cause, param_env, original_values, substituted_query_response)
+        // taken from `query_response` (after applying `result_args`).
+        self.unify_canonical_vars(cause, param_env, original_values, instantiated_query_response)
     }
 
     /// Converts the region constraints resulting from a query into an
@@ -571,11 +576,11 @@ impl<'tcx> InferCtxt<'tcx> {
         &'a self,
         cause: &'a ObligationCause<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
-        unsubstituted_region_constraints: &'a [QueryOutlivesConstraint<'tcx>],
-        result_subst: &'a CanonicalVarValues<'tcx>,
+        uninstantiated_region_constraints: &'a [QueryOutlivesConstraint<'tcx>],
+        result_args: &'a CanonicalVarValues<'tcx>,
     ) -> impl Iterator<Item = PredicateObligation<'tcx>> + 'a + Captures<'tcx> {
-        unsubstituted_region_constraints.iter().map(move |&constraint| {
-            let predicate = substitute_value(self.tcx, result_subst, constraint);
+        uninstantiated_region_constraints.iter().map(move |&constraint| {
+            let predicate = instantiate_value(self.tcx, result_args, constraint);
             self.query_outlives_constraint_to_obligation(predicate, cause.clone(), param_env)
         })
     }

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -219,7 +219,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// ```
     ///
     /// As indicating in the comments above, each of those references
-    /// is (in the compiler) basically a substitution (`args`)
+    /// is (in the compiler) basically generic paramters (`args`)
     /// applied to the type of a suitable `def_id` (which identifies
     /// `Foo1` or `Foo2`).
     ///

--- a/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
+++ b/compiler/rustc_infer/src/infer/outlives/test_type_match.rs
@@ -25,7 +25,7 @@ use crate::infer::region_constraints::VerifyIfEq;
 /// * `None` if `some_type` cannot be made equal to `test_ty`,
 ///   no matter the values of the variables in `exists`.
 /// * `Some(r)` with a suitable bound (typically the value of `bound_region`, modulo
-///   any bound existential variables, which will be substituted) for the
+///   any bound existential variables, which will be instantiated) for the
 ///   type under test.
 ///
 /// NB: This function uses a simplistic, syntactic version of type equality.
@@ -59,7 +59,7 @@ pub fn extract_verify_if_eq<'tcx>(
         }
     } else {
         // The region does not contain any bound variables, so we don't need
-        // to do any substitution.
+        // to do any instantiation.
         //
         // Example:
         //

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -277,7 +277,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
     /// ```
     ///
     /// If we were given the `DefId` of `Foo::Bar`, we would return
-    /// `'a`. You could then apply the substitutions from the
+    /// `'a`. You could then apply the instantiations from the
     /// projection to convert this into your namespace. This also
     /// works if the user writes `where <Self as Foo<'a>>::Bar: 'a` on
     /// the trait. In fact, it works by searching for just such a

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -183,14 +183,14 @@ where
     fn relate_item_args(
         &mut self,
         item_def_id: DefId,
-        a_subst: ty::GenericArgsRef<'tcx>,
-        b_subst: ty::GenericArgsRef<'tcx>,
+        a_arg: ty::GenericArgsRef<'tcx>,
+        b_arg: ty::GenericArgsRef<'tcx>,
     ) -> RelateResult<'tcx, ty::GenericArgsRef<'tcx>> {
         if self.ambient_variance == ty::Variance::Invariant {
             // Avoid fetching the variance if we are in an invariant
             // context; no need, and it can induce dependency cycles
             // (e.g., #41849).
-            relate::relate_args_invariantly(self, a_subst, b_subst)
+            relate::relate_args_invariantly(self, a_arg, b_arg)
         } else {
             let tcx = self.tcx();
             let opt_variances = tcx.variances_of(item_def_id);
@@ -198,8 +198,8 @@ where
                 self,
                 item_def_id,
                 opt_variances,
-                a_subst,
-                b_subst,
+                a_arg,
+                b_arg,
                 false,
             )
         }

--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -118,7 +118,7 @@ pub enum TypeVariableOriginKind {
     AdjustmentType,
 
     /// In type check, when we are type checking a function that
-    /// returns `-> dyn Foo`, we substitute a type variable for the
+    /// returns `-> dyn Foo`, we instantiate a type variable with the
     /// return type for diagnostic purposes.
     DynReturnFn,
     LatticeVariable,

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -285,7 +285,8 @@ impl<'tcx, O: Elaboratable<'tcx>> Elaborator<'tcx, O> {
                 let obligations =
                     predicates.predicates.iter().enumerate().map(|(index, &(clause, span))| {
                         elaboratable.child_with_derived_cause(
-                            clause.subst_supertrait(tcx, &bound_clause.rebind(data.trait_ref)),
+                            clause
+                                .instantiate_supertrait(tcx, &bound_clause.rebind(data.trait_ref)),
                             span,
                             bound_clause.rebind(data),
                             index,

--- a/compiler/rustc_middle/src/infer/canonical.rs
+++ b/compiler/rustc_middle/src/infer/canonical.rs
@@ -53,7 +53,7 @@ impl<'tcx> ty::TypeFoldable<TyCtxt<'tcx>> for CanonicalVarInfos<'tcx> {
 
 /// A set of values corresponding to the canonical variables from some
 /// `Canonical`. You can give these values to
-/// `canonical_value.substitute` to substitute them into the canonical
+/// `canonical_value.instantiate` to instantiate them into the canonical
 /// value at the right places.
 ///
 /// When you canonicalize a value `V`, you get back one of these

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -11,13 +11,13 @@ use rustc_session::lint;
 use rustc_span::{Span, DUMMY_SP};
 
 impl<'tcx> TyCtxt<'tcx> {
-    /// Evaluates a constant without providing any substitutions. This is useful to evaluate consts
+    /// Evaluates a constant without providing any generic parameters. This is useful to evaluate consts
     /// that can't take any generic arguments like statics, const items or enum discriminants. If a
     /// generic parameter is used within the constant `ErrorHandled::ToGeneric` will be returned.
     #[instrument(skip(self), level = "debug")]
     pub fn const_eval_poly(self, def_id: DefId) -> EvalToConstValueResult<'tcx> {
-        // In some situations def_id will have substitutions within scope, but they aren't allowed
-        // to be used. So we can't use `Instance::mono`, instead we feed unresolved substitutions
+        // In some situations def_id will have generic parameters within scope, but they aren't allowed
+        // to be used. So we can't use `Instance::mono`, instead we feed unresolved generic parameters
         // into `const_eval` which will return `ErrorHandled::ToGeneric` if any of them are
         // encountered.
         let args = GenericArgs::identity_for_item(self, def_id);
@@ -29,10 +29,10 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Resolves and evaluates a constant.
     ///
     /// The constant can be located on a trait like `<A as B>::C`, in which case the given
-    /// substitutions and environment are used to resolve the constant. Alternatively if the
-    /// constant has generic parameters in scope the substitutions are used to evaluate the value of
+    /// generic parameters and environment are used to resolve the constant. Alternatively if the
+    /// constant has generic parameters in scope the generic parameters are used to evaluate the value of
     /// the constant. For example in `fn foo<T>() { let _ = [0; bar::<T>()]; }` the repeat count
-    /// constant `bar::<T>()` requires a substitution for `T`, if the substitution for `T` is still
+    /// constant `bar::<T>()` requires a instantiation for `T`, if the instantiation for `T` is still
     /// too generic for the constant to be evaluated then `Err(ErrorHandled::TooGeneric)` is
     /// returned.
     #[instrument(level = "debug", skip(self))]
@@ -214,13 +214,13 @@ impl<'tcx> TyCtxtAt<'tcx> {
 }
 
 impl<'tcx> TyCtxtEnsure<'tcx> {
-    /// Evaluates a constant without providing any substitutions. This is useful to evaluate consts
+    /// Evaluates a constant without providing any generic parameters. This is useful to evaluate consts
     /// that can't take any generic arguments like statics, const items or enum discriminants. If a
     /// generic parameter is used within the constant `ErrorHandled::ToGeneric` will be returned.
     #[instrument(skip(self), level = "debug")]
     pub fn const_eval_poly(self, def_id: DefId) {
-        // In some situations def_id will have substitutions within scope, but they aren't allowed
-        // to be used. So we can't use `Instance::mono`, instead we feed unresolved substitutions
+        // In some situations def_id will have generic parameters within scope, but they aren't allowed
+        // to be used. So we can't use `Instance::mono`, instead we feed unresolved generic parameters
         // into `const_eval` which will return `ErrorHandled::ToGeneric` if any of them are
         // encountered.
         let args = GenericArgs::identity_for_item(self.tcx, def_id);

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -186,7 +186,7 @@ impl<'tcx> MonoItem<'tcx> {
             MonoItem::GlobalAsm(..) => return true,
         };
 
-        !tcx.subst_and_check_impossible_predicates((def_id, &args))
+        !tcx.instantiate_and_check_impossible_predicates((def_id, &args))
     }
 
     pub fn local_span(&self, tcx: TyCtxt<'tcx>) -> Option<Span> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2078,9 +2078,9 @@ rustc_queries! {
         desc { "normalizing `{:?}`", goal.value.value.value }
     }
 
-    query subst_and_check_impossible_predicates(key: (DefId, GenericArgsRef<'tcx>)) -> bool {
+    query instantiate_and_check_impossible_predicates(key: (DefId, GenericArgsRef<'tcx>)) -> bool {
         desc { |tcx|
-            "checking impossible substituted predicates: `{}`",
+            "checking impossible instantiated predicates: `{}`",
             tcx.def_path_str(key.0)
         }
     }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -721,7 +721,7 @@ impl<'tcx, N> ImplSource<'tcx, N> {
 }
 
 /// Identifies a particular impl in the source, along with a set of
-/// substitutions from the impl's type/lifetime parameters. The
+/// generic parameters from the impl's type/lifetime parameters. The
 /// `nested` vector corresponds to the nested obligations attached to
 /// the impl's type parameters.
 ///

--- a/compiler/rustc_middle/src/traits/select.rs
+++ b/compiler/rustc_middle/src/traits/select.rs
@@ -49,7 +49,8 @@ pub type EvaluationCache<'tcx> = Cache<
 /// parameters don't unify with regular types, but they *can* unify
 /// with variables from blanket impls, and (unless we know its bounds
 /// will always be satisfied) picking the blanket impl will be wrong
-/// for at least *some* substitutions. To make this concrete, if we have
+/// for at least *some* generic parameters. To make this concrete, if
+/// we have
 ///
 /// ```rust, ignore
 /// trait AsDebug { type Out: fmt::Debug; fn debug(self) -> Self::Out; }

--- a/compiler/rustc_middle/src/traits/util.rs
+++ b/compiler/rustc_middle/src/traits/util.rs
@@ -37,7 +37,7 @@ impl<'tcx> Elaborator<'tcx> {
         let super_predicates =
             self.tcx.super_predicates_of(trait_ref.def_id()).predicates.iter().filter_map(
                 |&(pred, _)| {
-                    let clause = pred.subst_supertrait(self.tcx, &trait_ref);
+                    let clause = pred.instantiate_supertrait(self.tcx, &trait_ref);
                     self.visited.insert(clause).then_some(clause)
                 },
             );

--- a/compiler/rustc_middle/src/ty/_match.rs
+++ b/compiler/rustc_middle/src/ty/_match.rs
@@ -3,7 +3,7 @@ use crate::ty::relate::{self, Relate, RelateResult, TypeRelation};
 use crate::ty::{self, InferConst, Ty, TyCtxt};
 
 /// A type "A" *matches* "B" if the fresh types in B could be
-/// substituted with values so as to make it equal to A. Matching is
+/// instantiated with values so as to make it equal to A. Matching is
 /// intended to be used only on freshened types, and it basically
 /// indicates if the non-freshened versions of A and B could have been
 /// unified.

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -235,7 +235,7 @@ impl<'tcx> Const<'tcx> {
         // FIXME(const_generics): We currently have to special case parameters because `min_const_generics`
         // does not provide the parents generics to anonymous constants. We still allow generic const
         // parameters by themselves however, e.g. `N`. These constants would cause an ICE if we were to
-        // ever try to substitute the generic parameters in their bodies.
+        // ever try to instantiate the generic parameters in their bodies.
         match expr.kind {
             hir::ExprKind::Path(hir::QPath::Resolved(
                 _,

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -418,10 +418,10 @@ impl<'tcx> TyCtxt<'tcx> {
 // Shifter
 //
 // Shifts the De Bruijn indices on all escaping bound vars by a
-// fixed amount. Useful in substitution or when otherwise introducing
+// fixed amount. Useful in instantiation or when otherwise introducing
 // a binding level that is not intended to capture the existing bound
 // vars. See comment on `shift_vars_through_binders` method in
-// `subst.rs` for more details.
+// `rustc_middle/src/ty/generic_args.rs` for more details.
 
 struct Shifter<'tcx> {
     tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_middle/src/ty/generic_args.rs
+++ b/compiler/rustc_middle/src/ty/generic_args.rs
@@ -803,13 +803,13 @@ impl<'tcx, T: TypeFoldable<TyCtxt<'tcx>>> ty::EarlyBinder<T> {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-// The actual substitution engine itself is a type folder.
+// The actual instantiation engine itself is a type folder.
 
 struct ArgFolder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     args: &'a [GenericArg<'tcx>],
 
-    /// Number of region binders we have passed through while doing the substitution
+    /// Number of region binders we have passed through while doing the instantiation
     binders_passed: u32,
 }
 
@@ -834,7 +834,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for ArgFolder<'a, 'tcx> {
         #[inline(never)]
         fn region_param_out_of_range(data: ty::EarlyParamRegion, args: &[GenericArg<'_>]) -> ! {
             bug!(
-                "Region parameter out of range when substituting in region {} (index={}, args = {:?})",
+                "Region parameter out of range when instantiating in region {} (index={}, args = {:?})",
                 data.name,
                 data.index,
                 args,
@@ -845,7 +845,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for ArgFolder<'a, 'tcx> {
         #[inline(never)]
         fn region_param_invalid(data: ty::EarlyParamRegion, other: GenericArgKind<'_>) -> ! {
             bug!(
-                "Unexpected parameter {:?} when substituting in region {} (index={})",
+                "Unexpected parameter {:?} when instantiating in region {} (index={})",
                 other,
                 data.name,
                 data.index
@@ -854,7 +854,7 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for ArgFolder<'a, 'tcx> {
 
         // Note: This routine only handles regions that are bound on
         // type declarations and other outer declarations, not those
-        // bound in *fn types*. Region substitution of the bound
+        // bound in *fn types*. Region instantiation of the bound
         // regions that appear in a function signature is done using
         // the specialized routine `ty::replace_late_regions()`.
         match *r {
@@ -913,7 +913,7 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
     #[inline(never)]
     fn type_param_expected(&self, p: ty::ParamTy, ty: Ty<'tcx>, kind: GenericArgKind<'tcx>) -> ! {
         bug!(
-            "expected type for `{:?}` ({:?}/{}) but found {:?} when substituting, args={:?}",
+            "expected type for `{:?}` ({:?}/{}) but found {:?} when instantiating, args={:?}",
             p,
             ty,
             p.index,
@@ -926,7 +926,7 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
     #[inline(never)]
     fn type_param_out_of_range(&self, p: ty::ParamTy, ty: Ty<'tcx>) -> ! {
         bug!(
-            "type parameter `{:?}` ({:?}/{}) out of range when substituting, args={:?}",
+            "type parameter `{:?}` ({:?}/{}) out of range when instantiating, args={:?}",
             p,
             ty,
             p.index,
@@ -955,7 +955,7 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
         kind: GenericArgKind<'tcx>,
     ) -> ! {
         bug!(
-            "expected const for `{:?}` ({:?}/{}) but found {:?} when substituting args={:?}",
+            "expected const for `{:?}` ({:?}/{}) but found {:?} when instantiating args={:?}",
             p,
             ct,
             p.index,
@@ -968,7 +968,7 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
     #[inline(never)]
     fn const_param_out_of_range(&self, p: ty::ParamConst, ct: ty::Const<'tcx>) -> ! {
         bug!(
-            "const parameter `{:?}` ({:?}/{}) out of range when substituting args={:?}",
+            "const parameter `{:?}` ({:?}/{}) out of range when instantiating args={:?}",
             p,
             ct,
             p.index,
@@ -976,8 +976,8 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
         )
     }
 
-    /// It is sometimes necessary to adjust the De Bruijn indices during substitution. This occurs
-    /// when we are substituting a type with escaping bound vars into a context where we have
+    /// It is sometimes necessary to adjust the De Bruijn indices during instantiation. This occurs
+    /// when we are instantating a type with escaping bound vars into a context where we have
     /// passed through binders. That's quite a mouthful. Let's see an example:
     ///
     /// ```
@@ -997,7 +997,7 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
     /// inner one. Therefore, that appearance will have a DebruijnIndex of 2, because we must skip
     /// over the inner binder (remember that we count De Bruijn indices from 1). However, in the
     /// definition of `MetaFunc`, the binder is not visible, so the type `&'a i32` will have a
-    /// De Bruijn index of 1. It's only during the substitution that we can see we must increase the
+    /// De Bruijn index of 1. It's only during the instantiation that we can see we must increase the
     /// depth by 1 to account for the binder that we passed through.
     ///
     /// As a second example, consider this twist:
@@ -1015,7 +1015,7 @@ impl<'a, 'tcx> ArgFolder<'a, 'tcx> {
     /// //   DebruijnIndex of 1 |
     /// //               DebruijnIndex of 2
     /// ```
-    /// As indicated in the diagram, here the same type `&'a i32` is substituted once, but in the
+    /// As indicated in the diagram, here the same type `&'a i32` is instantiated once, but in the
     /// first case we do not increase the De Bruijn index and in the second case we do. The reason
     /// is that only in the second case have we passed through a fn binder.
     fn shift_vars_through_binders<T: TypeFoldable<TyCtxt<'tcx>>>(&self, val: T) -> T {

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -125,7 +125,7 @@ pub struct GenericParamCount {
 /// Information about the formal type/lifetime parameters associated
 /// with an item or method. Analogous to `hir::Generics`.
 ///
-/// The ordering of parameters is the same as in `Subst` (excluding child generics):
+/// The ordering of parameters is the same as in [`ty::GenericArg`] (excluding child generics):
 /// `Self` (optionally), `Lifetime` params..., `Type` params...
 #[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable)]
 pub struct Generics {
@@ -140,7 +140,7 @@ pub struct Generics {
     pub has_self: bool,
     pub has_late_bound_regions: Option<Span>,
 
-    // The index of the host effect when substituted. (i.e. might be index to parent args)
+    // The index of the host effect when instantiated. (i.e. might be index to parent args)
     pub host_effect_index: Option<usize>,
 }
 

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -19,7 +19,7 @@ use std::fmt;
 ///
 /// Monomorphization happens on-the-fly and no monomorphized MIR is ever created. Instead, this type
 /// simply couples a potentially generic `InstanceDef` with some args, and codegen and const eval
-/// will do all required substitution as they run.
+/// will do all required instantiations as they run.
 ///
 /// Note: the `Lift` impl is currently not used by rustc, but is used by
 /// rustc_codegen_cranelift when the `jit` feature is enabled.
@@ -138,7 +138,7 @@ pub enum InstanceDef<'tcx> {
 }
 
 impl<'tcx> Instance<'tcx> {
-    /// Returns the `Ty` corresponding to this `Instance`, with generic substitutions applied and
+    /// Returns the `Ty` corresponding to this `Instance`, with generic instantiations applied and
     /// lifetimes erased, allowing a `ParamEnv` to be specified for use during normalization.
     pub fn ty(&self, tcx: TyCtxt<'tcx>, param_env: ty::ParamEnv<'tcx>) -> Ty<'tcx> {
         let ty = tcx.type_of(self.def.def_id());
@@ -298,11 +298,11 @@ impl<'tcx> InstanceDef<'tcx> {
     }
 
     /// Returns `true` when the MIR body associated with this instance should be monomorphized
-    /// by its users (e.g. codegen or miri) by substituting the `args` from `Instance` (see
+    /// by its users (e.g. codegen or miri) by instantiating the `args` from `Instance` (see
     /// `Instance::args_for_mir_body`).
     ///
     /// Otherwise, returns `false` only for some kinds of shims where the construction of the MIR
-    /// body should perform necessary substitutions.
+    /// body should perform necessary instantiations.
     pub fn has_polymorphic_mir_body(&self) -> bool {
         match *self {
             InstanceDef::CloneShim(..)
@@ -672,13 +672,13 @@ impl<'tcx> Instance<'tcx> {
 
     /// Depending on the kind of `InstanceDef`, the MIR body associated with an
     /// instance is expressed in terms of the generic parameters of `self.def_id()`, and in other
-    /// cases the MIR body is expressed in terms of the types found in the substitution array.
-    /// In the former case, we want to substitute those generic types and replace them with the
+    /// cases the MIR body is expressed in terms of the types found in the generic parameter array.
+    /// In the former case, we want to instantiate those generic types and replace them with the
     /// values from the args when monomorphizing the function body. But in the latter case, we
-    /// don't want to do that substitution, since it has already been done effectively.
+    /// don't want to do that instantiation, since it has already been done effectively.
     ///
     /// This function returns `Some(args)` in the former case and `None` otherwise -- i.e., if
-    /// this function returns `None`, then the MIR body does not require substitution during
+    /// this function returns `None`, then the MIR body does not require instantiation during
     /// codegen.
     fn args_for_mir_body(&self) -> Option<GenericArgsRef<'tcx>> {
         self.def.has_polymorphic_mir_body().then_some(self.args)

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -728,7 +728,7 @@ impl From<ty::ConstVid> for TermVid {
 /// the `GenericPredicates` are expressed in terms of the bound type
 /// parameters of the impl/trait/whatever, an `InstantiatedPredicates` instance
 /// represented a set of bounds for some particular instantiation,
-/// meaning that the generic parameters have been substituted with
+/// meaning that the generic parameters have been instantiated with
 /// their values.
 ///
 /// Example:
@@ -1654,7 +1654,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    /// Returns the possibly-auto-generated MIR of a `(DefId, Subst)` pair.
+    /// Returns the possibly-auto-generated MIR of a [`ty::InstanceDef`].
     #[instrument(skip(self), level = "debug")]
     pub fn instance_mir(self, instance: ty::InstanceDef<'tcx>) -> &'tcx Body<'tcx> {
         match instance {

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -135,7 +135,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     /// Monomorphizes a type from the AST by first applying the
-    /// in-scope substitutions and then normalizing any associated
+    /// in-scope instantiations and then normalizing any associated
     /// types.
     /// Panics if normalization fails. In case normalization might fail
     /// use `try_instantiate_and_normalize_erasing_regions` instead.
@@ -149,12 +149,12 @@ impl<'tcx> TyCtxt<'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        let substituted = value.instantiate(self, param_args);
-        self.normalize_erasing_regions(param_env, substituted)
+        let instantiated = value.instantiate(self, param_args);
+        self.normalize_erasing_regions(param_env, instantiated)
     }
 
     /// Monomorphizes a type from the AST by first applying the
-    /// in-scope substitutions and then trying to normalize any associated
+    /// in-scope instantiations and then trying to normalize any associated
     /// types. Contrary to `instantiate_and_normalize_erasing_regions` this does
     /// not assume that normalization succeeds.
     #[instrument(level = "debug", skip(self))]
@@ -167,8 +167,8 @@ impl<'tcx> TyCtxt<'tcx> {
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
-        let substituted = value.instantiate(self, param_args);
-        self.try_normalize_erasing_regions(param_env, substituted)
+        let instantiated = value.instantiate(self, param_args);
+        self.try_normalize_erasing_regions(param_env, instantiated)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -164,9 +164,9 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
             }
 
             ty::Param(param) => {
-                // Look it up in the substitution list.
+                // Look it up in the generic parameters list.
                 match self.map.get(&ty.into()).map(|k| k.unpack()) {
-                    // Found it in the substitution list; replace with the parameter from the
+                    // Found it in the generic parameters list; replace with the parameter from the
                     // opaque type.
                     Some(GenericArgKind::Type(t1)) => t1,
                     Some(u) => panic!("type mapped to unexpected kind: {u:?}"),
@@ -199,9 +199,9 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
         // Find a const parameter
         match ct.kind() {
             ty::ConstKind::Param(..) => {
-                // Look it up in the substitution list.
+                // Look it up in the generic parameters list.
                 match self.map.get(&ct.into()).map(|k| k.unpack()) {
-                    // Found it in the substitution list, replace with the parameter from the
+                    // Found it in the generic parameters list, replace with the parameter from the
                     // opaque type.
                     Some(GenericArgKind::Const(c1)) => c1,
                     Some(u) => panic!("const mapped to unexpected kind: {u:?}"),

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -208,7 +208,7 @@ impl<'tcx> ClosureArgs<'tcx> {
         }
     }
 
-    /// Returns the substitutions of the closure's parent.
+    /// Returns the generic parameters of the closure's parent.
     pub fn parent_args(self) -> &'tcx [GenericArg<'tcx>] {
         self.split().parent_args
     }
@@ -615,7 +615,7 @@ impl<'tcx> CoroutineArgs<'tcx> {
         }
     }
 
-    /// Returns the substitutions of the coroutine's parent.
+    /// Returns the generic parameters of the coroutine's parent.
     pub fn parent_args(self) -> &'tcx [GenericArg<'tcx>] {
         self.split().parent_args
     }
@@ -819,7 +819,7 @@ impl<'tcx> UpvarArgs<'tcx> {
 ///   inherited from the item that defined the inline const,
 /// - R represents the type of the constant.
 ///
-/// When the inline const is instantiated, `R` is substituted as the actual inferred
+/// When the inline const is instantiated, `R` is instantiated as the actual inferred
 /// type of the constant. The reason that `R` is represented as an extra type parameter
 /// is the same reason that [`ClosureArgs`] have `CS` and `U` as type parameters:
 /// inline const can reference lifetimes that are internal to the creating function.
@@ -858,7 +858,7 @@ impl<'tcx> InlineConstArgs<'tcx> {
         }
     }
 
-    /// Returns the substitutions of the inline const's parent.
+    /// Returns the generic parameters of the inline const's parent.
     pub fn parent_args(self) -> &'tcx [GenericArg<'tcx>] {
         self.split().parent_args
     }
@@ -1105,13 +1105,13 @@ where
 pub struct AliasTy<'tcx> {
     /// The parameters of the associated or opaque item.
     ///
-    /// For a projection, these are the substitutions for the trait and the
-    /// GAT substitutions, if there are any.
+    /// For a projection, these are the generic parameters for the trait and the
+    /// GAT parameters, if there are any.
     ///
-    /// For an inherent projection, they consist of the self type and the GAT substitutions,
+    /// For an inherent projection, they consist of the self type and the GAT parameters,
     /// if there are any.
     ///
-    /// For RPIT the substitutions are for the generics of the function,
+    /// For RPIT the generic parameters are for the generics of the function,
     /// while for TAIT it is used for the generic parameters of the alias.
     pub args: GenericArgsRef<'tcx>,
 
@@ -1235,15 +1235,15 @@ impl<'tcx> AliasTy<'tcx> {
 
 /// The following methods work only with inherent associated type projections.
 impl<'tcx> AliasTy<'tcx> {
-    /// Transform the substitutions to have the given `impl` args as the base and the GAT args on top of that.
+    /// Transform the generic parameters to have the given `impl` args as the base and the GAT args on top of that.
     ///
     /// Does the following transformation:
     ///
     /// ```text
     /// [Self, P_0...P_m] -> [I_0...I_n, P_0...P_m]
     ///
-    ///     I_i impl subst
-    ///     P_j GAT subst
+    ///     I_i impl args
+    ///     P_j GAT args
     /// ```
     pub fn rebase_inherent_args_onto_impl(
         self,
@@ -1690,7 +1690,7 @@ impl<'tcx> Ty<'tcx> {
         debug_assert_eq!(
             closure_args.len(),
             tcx.generics_of(tcx.typeck_root_def_id(def_id)).count() + 3,
-            "closure constructed with incorrect substitutions"
+            "closure constructed with incorrect generic parameters"
         );
         Ty::new(tcx, Closure(def_id, closure_args))
     }
@@ -1704,7 +1704,7 @@ impl<'tcx> Ty<'tcx> {
         debug_assert_eq!(
             closure_args.len(),
             tcx.generics_of(tcx.typeck_root_def_id(def_id)).count() + 5,
-            "closure constructed with incorrect substitutions"
+            "closure constructed with incorrect generic parameters"
         );
         Ty::new(tcx, CoroutineClosure(def_id, closure_args))
     }
@@ -1718,7 +1718,7 @@ impl<'tcx> Ty<'tcx> {
         debug_assert_eq!(
             coroutine_args.len(),
             tcx.generics_of(tcx.typeck_root_def_id(def_id)).count() + 6,
-            "coroutine constructed with incorrect number of substitutions"
+            "coroutine constructed with incorrect number of generic parameters"
         );
         Ty::new(tcx, Coroutine(def_id, coroutine_args))
     }
@@ -2530,7 +2530,7 @@ impl<'tcx> Ty<'tcx> {
     }
 
     /// Returns `true` when the outermost type cannot be further normalized,
-    /// resolved, or substituted. This includes all primitive types, but also
+    /// resolved, or instantiated. This includes all primitive types, but also
     /// things like ADTs and trait objects, sice even if their arguments or
     /// nested types may be further simplified, the outermost [`TyKind`] or
     /// type constructor remains the same.

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -49,19 +49,19 @@ pub struct TypeckResults<'tcx> {
     /// typeck::check::fn_ctxt for details.
     node_types: ItemLocalMap<Ty<'tcx>>,
 
-    /// Stores the type parameters which were substituted to obtain the type
+    /// Stores the type parameters which were instantiated to obtain the type
     /// of this node. This only applies to nodes that refer to entities
     /// parameterized by type parameters, such as generic fns, types, or
     /// other items.
     node_args: ItemLocalMap<GenericArgsRef<'tcx>>,
 
     /// This will either store the canonicalized types provided by the user
-    /// or the substitutions that the user explicitly gave (if any) attached
+    /// or the generic parameters that the user explicitly gave (if any) attached
     /// to `id`. These will not include any inferred values. The canonical form
     /// is used to capture things like `_` or other unspecified values.
     ///
     /// For example, if the user wrote `foo.collect::<Vec<_>>()`, then the
-    /// canonical substitutions would include only `for<X> { Vec<X> }`.
+    /// canonical generic parameters would include only `for<X> { Vec<X> }`.
     ///
     /// See also `AscribeUserType` statement in MIR.
     user_provided_types: ItemLocalMap<CanonicalUserType<'tcx>>,
@@ -329,7 +329,7 @@ impl<'tcx> TypeckResults<'tcx> {
     }
 
     /// Returns the type of a pattern as a monotype. Like [`expr_ty`], this function
-    /// doesn't provide type parameter substitutions.
+    /// doesn't provide type parameter args.
     ///
     /// [`expr_ty`]: TypeckResults::expr_ty
     pub fn pat_ty(&self, pat: &hir::Pat<'_>) -> Ty<'tcx> {
@@ -341,9 +341,9 @@ impl<'tcx> TypeckResults<'tcx> {
     /// NB (1): This is the PRE-ADJUSTMENT TYPE for the expression. That is, in
     /// some cases, we insert `Adjustment` annotations such as auto-deref or
     /// auto-ref. The type returned by this function does not consider such
-    /// adjustments. See `expr_ty_adjusted()` instead.
+    /// adjustments. See [`Self::expr_ty_adjusted`] instead.
     ///
-    /// NB (2): This type doesn't provide type parameter substitutions; e.g., if you
+    /// NB (2): This type doesn't provide type parameter args; e.g., if you
     /// ask for the type of `id` in `id(3)`, it will return `fn(&isize) -> isize`
     /// instead of `fn(ty) -> T with T = isize`.
     pub fn expr_ty(&self, expr: &hir::Expr<'_>) -> Ty<'tcx> {
@@ -608,7 +608,7 @@ pub enum UserType<'tcx> {
     Ty(Ty<'tcx>),
 
     /// The canonical type is the result of `type_of(def_id)` with the
-    /// given substitutions applied.
+    /// given generic parameters applied.
     TypeOf(DefId, UserArgs<'tcx>),
 }
 
@@ -617,7 +617,7 @@ pub trait IsIdentity {
 }
 
 impl<'tcx> IsIdentity for CanonicalUserType<'tcx> {
-    /// Returns `true` if this represents a substitution of the form `[?0, ?1, ?2]`,
+    /// Returns `true` if this represents the generic parameters of the form `[?0, ?1, ?2]`,
     /// i.e., each thing is mapped to a canonical variable with the same index.
     fn is_identity(&self) -> bool {
         match self.value {
@@ -631,7 +631,7 @@ impl<'tcx> IsIdentity for CanonicalUserType<'tcx> {
                     match kind.unpack() {
                         GenericArgKind::Type(ty) => match ty.kind() {
                             ty::Bound(debruijn, b) => {
-                                // We only allow a `ty::INNERMOST` index in substitutions.
+                                // We only allow a `ty::INNERMOST` index in generic parameters.
                                 assert_eq!(*debruijn, ty::INNERMOST);
                                 cvar == b.var
                             }
@@ -640,7 +640,7 @@ impl<'tcx> IsIdentity for CanonicalUserType<'tcx> {
 
                         GenericArgKind::Lifetime(r) => match *r {
                             ty::ReBound(debruijn, br) => {
-                                // We only allow a `ty::INNERMOST` index in substitutions.
+                                // We only allow a `ty::INNERMOST` index in generic parameters.
                                 assert_eq!(debruijn, ty::INNERMOST);
                                 cvar == br.var
                             }
@@ -649,7 +649,7 @@ impl<'tcx> IsIdentity for CanonicalUserType<'tcx> {
 
                         GenericArgKind::Const(ct) => match ct.kind() {
                             ty::ConstKind::Bound(debruijn, b) => {
-                                // We only allow a `ty::INNERMOST` index in substitutions.
+                                // We only allow a `ty::INNERMOST` index in generic parameters.
                                 assert_eq!(debruijn, ty::INNERMOST);
                                 cvar == b
                             }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -801,7 +801,7 @@ impl<'tcx> Cx<'tcx> {
         let user_provided_type = match res {
             // A reference to something callable -- e.g., a fn, method, or
             // a tuple-struct or tuple-variant. This has the type of a
-            // `Fn` but with the user-given substitutions.
+            // `Fn` but with the user-given generic parameters.
             Res::Def(DefKind::Fn, _)
             | Res::Def(DefKind::AssocFn, _)
             | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _)
@@ -812,7 +812,7 @@ impl<'tcx> Cx<'tcx> {
 
             // A unit struct/variant which is used as a value (e.g.,
             // `None`). This has the type of the enum/struct that defines
-            // this variant -- but with the substitutions given by the
+            // this variant -- but with the generic parameters given by the
             // user.
             Res::Def(DefKind::Ctor(_, CtorKind::Const), _) => {
                 self.user_args_applied_to_ty_of_hir_id(hir_id).map(Box::new)

--- a/compiler/rustc_mir_build/src/thir/util.rs
+++ b/compiler/rustc_mir_build/src/thir/util.rs
@@ -7,7 +7,7 @@ pub(crate) trait UserAnnotatedTyHelpers<'tcx> {
     fn typeck_results(&self) -> &ty::TypeckResults<'tcx>;
 
     /// Looks up the type associated with this hir-id and applies the
-    /// user-given substitutions; the hir-id must map to a suitable
+    /// user-given generic parameters; the hir-id must map to a suitable
     /// type.
     fn user_args_applied_to_ty_of_hir_id(
         &self,

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -36,10 +36,10 @@ fn may_contain_reference<'tcx>(ty: Ty<'tcx>, depth: u32, tcx: TyCtxt<'tcx>) -> b
         ty::Tuple(tys) => {
             depth == 0 || tys.iter().any(|ty| may_contain_reference(ty, depth - 1, tcx))
         }
-        ty::Adt(adt, subst) => {
+        ty::Adt(adt, args) => {
             depth == 0
                 || adt.variants().iter().any(|v| {
-                    v.fields.iter().any(|f| may_contain_reference(f.ty(tcx, subst), depth - 1, tcx))
+                    v.fields.iter().any(|f| may_contain_reference(f.ty(tcx, args), depth - 1, tcx))
                 })
         }
         // Conservative fallback

--- a/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
+++ b/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
@@ -205,8 +205,8 @@ pub fn deduced_param_attrs<'tcx>(
             |(arg_index, local_decl)| DeducedParamAttrs {
                 read_only: !deduce_read_only.mutable_args.contains(arg_index)
                     // We must normalize here to reveal opaques and normalize
-                    // their substs, otherwise we'll see exponential blow-up in
-                    // compile times: #113372
+                    // their generic parameters, otherwise we'll see exponential
+                    // blow-up in compile times: #113372
                     && tcx
                         .normalize_erasing_regions(param_env, local_decl.ty)
                         .is_freeze(tcx, param_env),

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -63,7 +63,7 @@ impl<'tcx> Visitor<'tcx> for FunctionItemRefChecker<'_, 'tcx> {
 
 impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
     /// Emits a lint for function reference arguments bound by `fmt::Pointer` in calls to the
-    /// function defined by `def_id` with the substitutions `args_ref`.
+    /// function defined by `def_id` with the generic parameters `args_ref`.
     fn check_bound_args(
         &self,
         def_id: DefId,
@@ -83,11 +83,11 @@ impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
                     for inner_ty in arg_def.walk().filter_map(|arg| arg.as_type()) {
                         // If the inner type matches the type bound by `Pointer`
                         if inner_ty == bound_ty {
-                            // Do a substitution using the parameters from the callsite
-                            let subst_ty =
+                            // Do an instantiation using the parameters from the callsite
+                            let instantiated_ty =
                                 EarlyBinder::bind(inner_ty).instantiate(self.tcx, args_ref);
                             if let Some((fn_id, fn_args)) =
-                                FunctionItemRefChecker::is_fn_ref(subst_ty)
+                                FunctionItemRefChecker::is_fn_ref(instantiated_ty)
                             {
                                 let mut span = self.nth_arg_span(args, arg_num);
                                 if span.from_expansion() {

--- a/compiler/rustc_mir_transform/src/inline/cycle.rs
+++ b/compiler/rustc_mir_transform/src/inline/cycle.rs
@@ -80,7 +80,7 @@ pub(crate) fn mir_callgraph_reachable<'tcx>(
                 }
                 // These have no own callable MIR.
                 InstanceDef::Intrinsic(_) | InstanceDef::Virtual(..) => continue,
-                // These have MIR and if that MIR is inlined, substituted and then inlining is run
+                // These have MIR and if that MIR is inlined, instantiated and then inlining is run
                 // again, a function item can end up getting inlined. Thus we'll be able to cause
                 // a cycle that way
                 InstanceDef::VTableShim(_)
@@ -95,7 +95,7 @@ pub(crate) fn mir_callgraph_reachable<'tcx>(
                 // This shim does not call any other functions, thus there can be no recursion.
                 InstanceDef::FnPtrAddrShim(..) => continue,
                 InstanceDef::DropGlue(..) => {
-                    // FIXME: A not fully substituted drop shim can cause ICEs if one attempts to
+                    // FIXME: A not fully instantiated drop shim can cause ICEs if one attempts to
                     // have its MIR built. Likely oli-obk just screwed up the `ParamEnv`s, so this
                     // needs some more analysis.
                     if callee.has_param() {

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -211,7 +211,7 @@ impl<'tcx> InstSimplifyContext<'tcx, '_> {
         // Only bother looking more if it's easy to know what we're calling
         let Some((fn_def_id, fn_args)) = func.const_fn_def() else { return };
 
-        // Clone needs one subst, so we can cheaply rule out other stuff
+        // Clone needs one arg, so we can cheaply rule out other stuff
         if fn_args.len() != 1 {
             return;
         }

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -436,7 +436,7 @@ fn mir_drops_elaborated_and_const_checked(tcx: TyCtxt<'_>, def: LocalDefId) -> &
     //
     // We manually filter the predicates, skipping anything that's not
     // "global". We are in a potentially generic context
-    // (e.g. we are evaluating a function without substituting generic
+    // (e.g. we are evaluating a function without instantiating generic
     // parameters, so this filtering serves two purposes:
     //
     // 1. We skip evaluating any predicates that we would
@@ -576,10 +576,10 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &inline::Inline,
             // Code from other crates may have storage markers, so this needs to happen after inlining.
             &remove_storage_markers::RemoveStorageMarkers,
-            // Inlining and substitution may introduce ZST and useless drops.
+            // Inlining and instantiation may introduce ZST and useless drops.
             &remove_zsts::RemoveZsts,
             &remove_unneeded_drops::RemoveUnneededDrops,
-            // Type substitution may create uninhabited enums.
+            // Type instantiation may create uninhabited enums.
             &uninhabited_enum_branching::UninhabitedEnumBranching,
             &unreachable_prop::UnreachablePropagation,
             &o1(simplify::SimplifyCfg::AfterUninhabitedEnumBranching),
@@ -673,7 +673,7 @@ fn inner_optimized_mir(tcx: TyCtxt<'_>, did: LocalDefId) -> Body<'_> {
 }
 
 /// Fetch all the promoteds of an item and prepare their MIR bodies to be ready for
-/// constant evaluation once all substitutions become known.
+/// constant evaluation once all generic parameters become known.
 fn promoted_mir(tcx: TyCtxt<'_>, def: LocalDefId) -> &IndexVec<Promoted, Body<'_>> {
     if tcx.is_constructor(def.to_def_id()) {
         return tcx.arena.alloc(IndexVec::new());

--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -44,7 +44,7 @@ use crate::ssa::{SsaLocals, StorageLiveLocals};
 ///
 /// # Liveness
 ///
-/// When performing a substitution, we must take care not to introduce uses of dangling locals.
+/// When performing an instantiation, we must take care not to introduce uses of dangling locals.
 /// To ensure this, we walk the body with the `MaybeStorageDead` dataflow analysis:
 /// - if we want to replace `*x` by reborrow `*y` and `y` may be dead, we allow replacement and
 ///   mark storage statements on `y` for removal;
@@ -55,7 +55,7 @@ use crate::ssa::{SsaLocals, StorageLiveLocals};
 ///
 /// For `&mut` borrows, we also need to preserve the uniqueness property:
 /// we must avoid creating a state where we interleave uses of `*_1` and `_2`.
-/// To do it, we only perform full substitution of mutable borrows:
+/// To do it, we only perform full instantiation of mutable borrows:
 /// we replace either all or none of the occurrences of `*_1`.
 ///
 /// Some care has to be taken when `_1` is copied in other locals.
@@ -63,10 +63,10 @@ use crate::ssa::{SsaLocals, StorageLiveLocals};
 ///   _3 = *_1;
 ///   _4 = _1
 ///   _5 = *_4
-/// In such cases, fully substituting `_1` means fully substituting all of the copies.
+/// In such cases, fully instantiating `_1` means fully instantiating all of the copies.
 ///
 /// For immutable borrows, we do not need to preserve such uniqueness property,
-/// so we perform all the possible substitutions without removing the `_1 = &_2` statement.
+/// so we perform all the possible instantiations without removing the `_1 = &_2` statement.
 pub struct ReferencePropagation;
 
 impl<'tcx> MirPass<'tcx> for ReferencePropagation {

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -477,7 +477,7 @@ struct CloneShimBuilder<'tcx> {
 
 impl<'tcx> CloneShimBuilder<'tcx> {
     fn new(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -> Self {
-        // we must subst the self_ty because it's
+        // we must instantiate the self_ty because it's
         // otherwise going to be TySelf and we can't index
         // or access fields of a Place of type TySelf.
         let sig = tcx.fn_sig(def_id).instantiate(tcx, &[self_ty.into()]);
@@ -716,8 +716,8 @@ fn build_call_shim<'tcx>(
     call_kind: CallKind<'tcx>,
 ) -> Body<'tcx> {
     // `FnPtrShim` contains the fn pointer type that a call shim is being built for - this is used
-    // to substitute into the signature of the shim. It is not necessary for users of this
-    // MIR body to perform further substitutions (see `InstanceDef::has_polymorphic_mir_body`).
+    // to instantiate into the signature of the shim. It is not necessary for users of this
+    // MIR body to perform further instantiations (see `InstanceDef::has_polymorphic_mir_body`).
     let (sig_args, untuple_args) = if let ty::InstanceDef::FnPtrShim(_, ty) = instance {
         let sig = tcx.instantiate_bound_regions_with_erased(ty.fn_sig(tcx));
 

--- a/compiler/rustc_mir_transform/src/ssa.rs
+++ b/compiler/rustc_mir_transform/src/ssa.rs
@@ -170,7 +170,7 @@ impl SsaLocals {
     ///   _c => _a
     ///   _d => _a // transitively through _c
     ///
-    /// Exception: we do not see through the return place, as it cannot be substituted.
+    /// Exception: we do not see through the return place, as it cannot be instantiated.
     pub fn copy_classes(&self) -> &IndexSlice<Local, Local> {
         &self.copy_classes
     }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -62,7 +62,7 @@
 //! syntactic items in the source code. We find them by walking the HIR of the
 //! crate, and whenever we hit upon a public function, method, or static item,
 //! we create a mono item consisting of the items DefId and, since we only
-//! consider non-generic items, an empty type-substitution set. (In eager
+//! consider non-generic items, an empty type-parameters set. (In eager
 //! collection mode, during incremental compilation, all non-generic functions
 //! are considered as roots, as well as when the `-Clink-dead-code` option is
 //! specified. Functions marked `#[no_mangle]` and functions called by inlinable
@@ -1383,11 +1383,11 @@ fn create_mono_items_for_default_impls<'tcx>(
     // items, we never actually check that the predicates of this impl are satisfied
     // in a empty reveal-all param env (i.e. with no assumptions).
     //
-    // Even though this impl has no type or const substitutions, because we don't
+    // Even though this impl has no type or const generic parameters, because we don't
     // consider higher-ranked predicates such as `for<'a> &'a mut [u8]: Copy` to
     // be trivially false. We must now check that the impl has no impossible-to-satisfy
     // predicates.
-    if tcx.subst_and_check_impossible_predicates((item.owner_id.to_def_id(), impl_args)) {
+    if tcx.instantiate_and_check_impossible_predicates((item.owner_id.to_def_id(), impl_args)) {
         return;
     }
 
@@ -1404,7 +1404,7 @@ fn create_mono_items_for_default_impls<'tcx>(
         }
 
         // As mentioned above, the method is legal to eagerly instantiate if it
-        // only has lifetime substitutions. This is validated by
+        // only has lifetime generic parameters. This is validated by
         let args = trait_ref.args.extend_to(tcx, method.def_id, only_region_params);
         let instance = ty::Instance::expect_resolve(tcx, param_env, method.def_id, args);
 

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -90,7 +90,7 @@ fn should_polymorphize<'tcx>(
     def_id: DefId,
     instance: ty::InstanceDef<'tcx>,
 ) -> bool {
-    // If an instance's MIR body is not polymorphic then the modified substitutions that are
+    // If an instance's MIR body is not polymorphic then the modified generic parameters that are
     // derived from polymorphization's result won't make any difference.
     if !instance.has_polymorphic_mir_body() {
         return false;

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -263,11 +263,11 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
         for &(variant, field) in indices {
             match current_ty.kind() {
-                ty::Adt(def, subst) => {
+                ty::Adt(def, args) => {
                     let field = &def.variant(variant).fields[field];
 
                     self.insert_def_id(field.did);
-                    let field_ty = field.ty(self.tcx, subst);
+                    let field_ty = field.ty(self.tcx, args);
 
                     current_ty = self.tcx.normalize_erasing_regions(param_env, field_ty);
                 }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -173,7 +173,7 @@ impl<'p, 'tcx: 'p> RustcMatchCheckCtxt<'p, 'tcx> {
 
         variant.fields.iter().enumerate().filter_map(move |(i, field)| {
             let ty = field.ty(cx.tcx, args);
-            // `field.ty()` doesn't normalize after substituting.
+            // `field.ty()` doesn't normalize after instantiating.
             let ty = cx.tcx.normalize_erasing_regions(cx.param_env, ty);
             let is_visible = adt.is_enum() || field.vis.is_accessible_from(cx.module, cx.tcx);
             let is_uninhabited = (cx.tcx.features().exhaustive_patterns

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -133,7 +133,7 @@ where
         if V::SHALLOW {
             ControlFlow::Continue(())
         } else {
-            assoc_args.iter().try_for_each(|subst| subst.visit_with(self))
+            assoc_args.iter().try_for_each(|arg| arg.visit_with(self))
         }
     }
 
@@ -209,7 +209,7 @@ where
                     // Visitors searching for minimal visibility/reachability want to
                     // conservatively approximate associated types like `Type::Alias`
                     // as visible/reachable even if `Type` is private.
-                    // Ideally, associated types should be substituted in the same way as
+                    // Ideally, associated types should be instantiated in the same way as
                     // free type aliases, but this isn't done yet.
                     return ControlFlow::Continue(());
                 }
@@ -230,7 +230,7 @@ where
                 } else if kind == ty::Projection {
                     self.visit_projection_ty(data)
                 } else {
-                    data.args.iter().try_for_each(|subst| subst.visit_with(self))
+                    data.args.iter().try_for_each(|arg| arg.visit_with(self))
                 };
             }
             ty::Dynamic(predicates, ..) => {

--- a/compiler/rustc_smir/src/rustc_smir/context.rs
+++ b/compiler/rustc_smir/src/rustc_smir/context.rs
@@ -369,7 +369,7 @@ impl<'tcx> Context for TablesWrapper<'tcx> {
     fn instance_ty(&self, def: InstanceDef) -> stable_mir::ty::Ty {
         let mut tables = self.0.borrow_mut();
         let instance = tables.instances[def];
-        assert!(!instance.has_non_region_param(), "{instance:?} needs further substitution");
+        assert!(!instance.has_non_region_param(), "{instance:?} needs further instantiation");
         instance.ty(tables.tcx, ParamEnv::reveal_all()).stable(&mut *tables)
     }
 

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -99,7 +99,7 @@ fn get_symbol_hash<'tcx>(
     instance: Instance<'tcx>,
 
     // type of the item, without any generic
-    // parameters substituted; this is
+    // parameters instantiated; this is
     // included in the hash as a kind of
     // safeguard.
     item_type: Ty<'tcx>,

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -251,8 +251,8 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
             None => "M",
         });
 
-        // Encode impl generic params if the substitutions contain parameters (implying
-        // polymorphization is enabled) and this isn't an inherent impl.
+        // Encode impl generic params if the generic parameters contain non-region parameters
+        // (implying polymorphization is enabled) and this isn't an inherent impl.
         if impl_trait_ref.is_some() && args.iter().any(|a| a.has_non_region_param()) {
             self.path_generic_args(
                 |this| {

--- a/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_trait_selection/src/solve/assembly/structural_traits.rs
@@ -576,7 +576,7 @@ pub(in crate::solve) fn predicates_for_object_candidate<'tcx>(
             assert_eq!(
                 old_ty,
                 None,
-                "{} has two substitutions: {} and {}",
+                "{} has two generic parameters: {} and {}",
                 proj.projection_ty,
                 proj.term,
                 old_ty.unwrap()

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/select.rs
@@ -312,8 +312,8 @@ fn rematch_unsize<'tcx>(
             let a_tail_ty = tail_field_ty.instantiate(tcx, a_args);
             let b_tail_ty = tail_field_ty.instantiate(tcx, b_args);
 
-            // Substitute just the unsizing params from B into A. The type after
-            // this substitution must be equal to B. This is so we don't unsize
+            // Instantiate just the unsizing params from B into A. The type after
+            // this instantiation must be equal to B. This is so we don't unsize
             // unrelated type parameters.
             let new_a_args = tcx.mk_args_from_iter(
                 a_args
@@ -349,7 +349,7 @@ fn rematch_unsize<'tcx>(
             let (a_last_ty, a_rest_tys) = a_tys.split_last().unwrap();
             let b_last_ty = b_tys.last().unwrap();
 
-            // Substitute just the tail field of B., and require that they're equal.
+            // Instantiate just the tail field of B., and require that they're equal.
             let unsized_a_ty =
                 Ty::new_tup_from_iter(tcx, a_rest_tys.iter().chain([b_last_ty]).copied());
             nested.extend(

--- a/compiler/rustc_trait_selection/src/solve/trait_goals.rs
+++ b/compiler/rustc_trait_selection/src/solve/trait_goals.rs
@@ -877,8 +877,8 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         let a_tail_ty = tail_field_ty.instantiate(tcx, a_args);
         let b_tail_ty = tail_field_ty.instantiate(tcx, b_args);
 
-        // Substitute just the unsizing params from B into A. The type after
-        // this substitution must be equal to B. This is so we don't unsize
+        // Instantiate just the unsizing params from B into A. The type after
+        // this instantiation must be equal to B. This is so we don't unsize
         // unrelated type parameters.
         let new_a_args = tcx.mk_args_from_iter(
             a_args
@@ -927,7 +927,7 @@ impl<'tcx> EvalCtxt<'_, 'tcx> {
         let (&a_last_ty, a_rest_tys) = a_tys.split_last().unwrap();
         let &b_last_ty = b_tys.last().unwrap();
 
-        // Substitute just the tail field of B., and require that they're equal.
+        // Instantiate just the tail field of B., and require that they're equal.
         let unsized_a_ty =
             Ty::new_tup_from_iter(tcx, a_rest_tys.iter().copied().chain([b_last_ty]));
         self.eq(goal.param_env, unsized_a_ty, b_ty)?;

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/infer_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/infer_ctxt_ext.rs
@@ -242,7 +242,7 @@ impl<'tcx> InferCtxtExt<'tcx> for InferCtxt<'tcx> {
                 self.tcx.lang_items().fn_once_trait(),
             ] {
                 let Some(trait_def_id) = trait_def_id else { continue };
-                // Make a fresh inference variable so we can determine what the substitutions
+                // Make a fresh inference variable so we can determine what the generic parameters
                 // of the trait are.
                 let var = self.next_ty_var(TypeVariableOrigin {
                     span: DUMMY_SP,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -814,7 +814,7 @@ impl<'tcx> OnUnimplementedFormatString {
                             tcx.dcx(),
                             self.span,
                             E0231,
-                            "only named substitution parameters are allowed"
+                            "only named generic parameters are allowed"
                         )
                         .emit();
                         result = Err(reported);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -635,7 +635,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 | hir::Node::ImplItem(hir::ImplItem { generics, .. })
                     if param_ty =>
                 {
-                    // We skip the 0'th subst (self) because we do not want
+                    // We skip the 0'th arg (self) because we do not want
                     // to consider the predicate as not suggestible if the
                     // self type is an arg position `impl Trait` -- instead,
                     // we handle that by adding ` + Bound` below.
@@ -2343,7 +2343,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         err: &mut DiagnosticBuilder<'tcx>,
     ) {
         // First, look for an `ExprBindingObligation`, which means we can get
-        // the unsubstituted predicate list of the called function. And check
+        // the uninstantiated predicate list of the called function. And check
         // that the predicate that we failed to satisfy is a `Fn`-like trait.
         if let ObligationCauseCode::ExprBindingObligation(def_id, _, _, idx) = cause
             && let predicates = self.tcx.predicates_of(def_id).instantiate_identity(self.tcx)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -2426,16 +2426,16 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 // known, since we don't dispatch based on region
                 // relationships.
 
-                // Pick the first substitution that still contains inference variables as the one
+                // Pick the first generic parameter that still contains inference variables as the one
                 // we're going to emit an error for. If there are none (see above), fall back to
                 // a more general error.
-                let subst = data.trait_ref.args.iter().find(|s| s.has_non_region_infer());
+                let arg = data.trait_ref.args.iter().find(|s| s.has_non_region_infer());
 
-                let mut err = if let Some(subst) = subst {
+                let mut err = if let Some(arg) = arg {
                     self.emit_inference_failure_err(
                         obligation.cause.body_id,
                         span,
-                        subst,
+                        arg,
                         ErrorCode::E0283,
                         true,
                     )
@@ -2473,9 +2473,9 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 }
                 if ambiguities.len() > 1 && ambiguities.len() < 10 && has_non_region_infer {
                     if let Some(e) = self.tainted_by_errors()
-                        && subst.is_none()
+                        && arg.is_none()
                     {
-                        // If `subst.is_none()`, then this is probably two param-env
+                        // If `arg.is_none()`, then this is probably two param-env
                         // candidates or impl candidates that are equal modulo lifetimes.
                         // Therefore, if we've already emitted an error, just skip this
                         // one, since it's not particularly actionable.
@@ -2509,7 +2509,7 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     self.suggest_fully_qualified_path(&mut err, def_id, span, trait_ref.def_id());
                 }
 
-                if let Some(ty::GenericArgKind::Type(_)) = subst.map(|subst| subst.unpack())
+                if let Some(ty::GenericArgKind::Type(_)) = arg.map(|arg| arg.unpack())
                     && let Some(body_id) =
                         self.tcx.hir().maybe_body_owned_by(obligation.cause.body_id)
                 {
@@ -2687,23 +2687,23 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                     // other `Foo` impls are incoherent.
                     return guar;
                 }
-                let subst = data
+                let arg = data
                     .projection_ty
                     .args
                     .iter()
                     .chain(Some(data.term.into_arg()))
                     .find(|g| g.has_non_region_infer());
-                if let Some(subst) = subst {
+                if let Some(arg) = arg {
                     self.emit_inference_failure_err(
                         obligation.cause.body_id,
                         span,
-                        subst,
+                        arg,
                         ErrorCode::E0284,
                         true,
                     )
                     .with_note(format!("cannot satisfy `{predicate}`"))
                 } else {
-                    // If we can't find a substitution, just print a generic error
+                    // If we can't find a generic parameter, just print a generic error
                     struct_span_code_err!(
                         self.dcx(),
                         span,
@@ -2722,18 +2722,18 @@ impl<'tcx> InferCtxtPrivExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                 if let Some(e) = self.tainted_by_errors() {
                     return e;
                 }
-                let subst = data.walk().find(|g| g.is_non_region_infer());
-                if let Some(subst) = subst {
+                let arg = data.walk().find(|g| g.is_non_region_infer());
+                if let Some(arg) = arg {
                     let err = self.emit_inference_failure_err(
                         obligation.cause.body_id,
                         span,
-                        subst,
+                        arg,
                         ErrorCode::E0284,
                         true,
                     );
                     err
                 } else {
-                    // If we can't find a substitution, just print a generic error
+                    // If we can't find a generic parameter, just print a generic error
                     struct_span_code_err!(
                         self.dcx(),
                         span,

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -443,11 +443,11 @@ pub fn impossible_predicates<'tcx>(tcx: TyCtxt<'tcx>, predicates: Vec<ty::Clause
     result
 }
 
-fn subst_and_check_impossible_predicates<'tcx>(
+fn instantiate_and_check_impossible_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: (DefId, GenericArgsRef<'tcx>),
 ) -> bool {
-    debug!("subst_and_check_impossible_predicates(key={:?})", key);
+    debug!("instantiate_and_check_impossible_predicates(key={:?})", key);
 
     let mut predicates = tcx.predicates_of(key.0).instantiate(tcx, key.1).predicates;
 
@@ -461,7 +461,7 @@ fn subst_and_check_impossible_predicates<'tcx>(
     predicates.retain(|predicate| !predicate.has_param());
     let result = impossible_predicates(tcx, predicates);
 
-    debug!("subst_and_check_impossible_predicates(key={:?}) = {:?}", key, result);
+    debug!("instantiate_and_check_impossible_predicates(key={:?}) = {:?}", key, result);
     result
 }
 
@@ -548,7 +548,7 @@ pub fn provide(providers: &mut Providers) {
     *providers = Providers {
         specialization_graph_of: specialize::specialization_graph_provider,
         specializes: specialize::specializes,
-        subst_and_check_impossible_predicates,
+        instantiate_and_check_impossible_predicates,
         check_tys_might_be_eq: misc::check_tys_might_be_eq,
         is_impossible_associated_item,
         ..*providers

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -263,7 +263,7 @@ fn predicates_reference_self(
     predicates
         .predicates
         .iter()
-        .map(|&(predicate, sp)| (predicate.subst_supertrait(tcx, &trait_ref), sp))
+        .map(|&(predicate, sp)| (predicate.instantiate_supertrait(tcx, &trait_ref), sp))
         .filter_map(|predicate| predicate_references_self(tcx, predicate))
         .collect()
 }
@@ -607,7 +607,7 @@ fn virtual_call_violations_for_method<'tcx>(
     errors
 }
 
-/// Performs a type substitution to produce the version of `receiver_ty` when `Self = self_ty`.
+/// Performs a type instantiation to produce the version of `receiver_ty` when `Self = self_ty`.
 /// For example, for `receiver_ty = Rc<Self>` and `self_ty = Foo`, returns `Rc<Foo>`.
 fn receiver_for_self_ty<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -682,7 +682,7 @@ fn object_ty_for_trait<'tcx>(
 ///   ```
 ///
 ///   where `Foo[X => Y]` means "the same type as `Foo`, but with `X` replaced with `Y`"
-///   (substitution notation).
+///   (instantiation notation).
 ///
 /// Some examples of receiver types and their required obligation:
 /// - `&'a mut self` requires `&'a mut Self: DispatchFromDyn<&'a mut dyn Trait>`,

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -266,7 +266,7 @@ pub(super) fn poly_project_and_unify_type<'cx, 'tcx>(
                 // universe just created. Otherwise, we can end up with something like `for<'a> I: 'a`,
                 // which isn't quite what we want. Ideally, we want either an implied
                 // `for<'a where I: 'a> I: 'a` or we want to "lazily" check these hold when we
-                // substitute concrete regions. There is design work to be done here; until then,
+                // instantiate concrete regions. There is design work to be done here; until then,
                 // however, this allows experimenting potential GAT features without running into
                 // well-formedness issues.
                 let new_obligations = obligations
@@ -1115,7 +1115,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for PlaceholderReplacer<'_, 'tcx> {
 /// as Trait>::Item`. The result is always a type (and possibly
 /// additional obligations). If ambiguity arises, which implies that
 /// there are unresolved type variables in the projection, we will
-/// substitute a fresh type variable `$X` and generate a new
+/// instantiate it with a fresh type variable `$X` and generate a new
 /// obligation `<T as Trait>::Item == $X` for later.
 pub fn normalize_projection_type<'a, 'b, 'tcx>(
     selcx: &'a mut SelectionContext<'b, 'tcx>,
@@ -1400,7 +1400,7 @@ pub fn normalize_inherent_projection<'a, 'b, 'tcx>(
             cause.span,
             cause.body_id,
             // FIXME(inherent_associated_types): Since we can't pass along the self type to the
-            // cause code, inherent projections will be printed with identity substitutions in
+            // cause code, inherent projections will be printed with identity instantiation in
             // diagnostics which is not ideal.
             // Consider creating separate cause codes for this specific situation.
             if span.is_dummy() {

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/ascribe_user_type.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/ascribe_user_type.rs
@@ -116,7 +116,7 @@ fn relate_mir_and_user_args<'tcx>(
         ocx.register_obligation(Obligation::new(tcx, cause, param_env, instantiated_predicate));
     }
 
-    // Now prove the well-formedness of `def_id` with `substs`.
+    // Now prove the well-formedness of `def_id` with `args`.
     // Note for some items, proving the WF of `ty` is not sufficient because the
     // well-formedness of an item may depend on the WF of gneneric args not present in the
     // item's type. Currently this is true for associated consts, e.g.:

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -170,7 +170,7 @@ pub fn compute_implied_outlives_bounds_compat_inner<'tcx>(
         }
 
         // Compute the obligations for `arg` to be well-formed. If `arg` is
-        // an unresolved inference variable, just substituted an empty set
+        // an unresolved inference variable, just instantiated an empty set
         // -- because the return type here is going to be things we *add*
         // to the environment, it's always ok for this set to be smaller
         // than the ultimate set. (Note: normally there won't be

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -557,7 +557,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             obligation.predicate.def_id(),
             obligation.predicate.skip_binder().trait_ref.self_ty(),
             |impl_def_id| {
-                // Before we create the substitutions and everything, first
+                // Before we create the generic parameters and everything, first
                 // consider a "quick reject". This avoids creating more types
                 // and so forth that we need to.
                 let impl_trait_ref = self.tcx().impl_trait_ref(impl_def_id).unwrap();

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -444,7 +444,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     ) -> ImplSourceUserDefinedData<'tcx, PredicateObligation<'tcx>> {
         debug!(?obligation, ?impl_def_id, "confirm_impl_candidate");
 
-        // First, create the substitutions by matching the impl again,
+        // First, create the generic parameters by matching the impl again,
         // this time not in a probe.
         let args = self.rematch_impl(impl_def_id, obligation);
         debug!(?args, "impl args");
@@ -585,7 +585,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // higher-ranked things.
             // Prevent, e.g., `dyn Iterator<Item = str>`.
             for bound in self.tcx().item_bounds(assoc_type).transpose_iter() {
-                let subst_bound = if defs.count() == 0 {
+                let arg_bound = if defs.count() == 0 {
                     bound.instantiate(tcx, trait_predicate.trait_ref.args)
                 } else {
                     let mut args = smallvec::SmallVec::with_capacity(defs.count());
@@ -649,7 +649,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     obligation.param_env,
                     obligation.cause.clone(),
                     obligation.recursion_depth + 1,
-                    subst_bound,
+                    arg_bound,
                     &mut nested,
                 );
                 nested.push(obligation.with(tcx, normalized_bound));

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1684,7 +1684,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
     /// Return `Yes` if the obligation's predicate type applies to the env_predicate, and
     /// `No` if it does not. Return `Ambiguous` in the case that the projection type is a GAT,
-    /// and applying this env_predicate constrains any of the obligation's GAT substitutions.
+    /// and applying this env_predicate constrains any of the obligation's GAT parameters.
     ///
     /// This behavior is a somewhat of a hack to prevent over-constraining inference variables
     /// in cases like #91762.
@@ -2673,7 +2673,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
     }
 
     /// Returns the obligations that are implied by instantiating an
-    /// impl or trait. The obligations are substituted and fully
+    /// impl or trait. The obligations are instantiated and fully
     /// normalized. This is used when confirming an impl or default
     /// impl.
     #[instrument(level = "debug", skip(self, cause, param_env))]
@@ -2698,7 +2698,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         //    U: Iterator, U: Sized,
         //    V: Iterator, V: Sized,
         //    <U as Iterator>::Item: Copy
-        // When we substitute, say, `V => IntoIter<u32>, U => $0`, the last
+        // When we instantiate, say, `V => IntoIter<u32>, U => $0`, the last
         // obligation will normalize to `<$0 as Iterator>::Item = $1` and
         // `$1: Copy`, so we must ensure the obligations are emitted in
         // that order.

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -128,7 +128,7 @@ impl<'tcx> TraitAliasExpander<'tcx> {
         debug!(?predicates);
 
         let items = predicates.predicates.iter().rev().filter_map(|(pred, span)| {
-            pred.subst_supertrait(tcx, &trait_ref)
+            pred.instantiate_supertrait(tcx, &trait_ref)
                 .as_trait_clause()
                 .map(|trait_ref| item.clone_and_push(trait_ref.map_bound(|t| t.trait_ref), *span))
         });

--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -124,7 +124,7 @@ fn prepare_vtable_segments_inner<'tcx, T>(
                 .predicates
                 .into_iter()
                 .filter_map(move |(pred, _)| {
-                    pred.subst_supertrait(tcx, &inner_most_trait_ref).as_trait_clause()
+                    pred.instantiate_supertrait(tcx, &inner_most_trait_ref).as_trait_clause()
                 });
 
             // Find an unvisited supertrait

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -380,7 +380,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                 .filter(|(_, arg)| !arg.has_escaping_bound_vars())
                 .map(|(i, arg)| {
                     let mut cause = traits::ObligationCause::misc(self.span, self.body_id);
-                    // The first subst is the self ty - use the correct span for it.
+                    // The first arg is the self ty - use the correct span for it.
                     if i == 0 {
                         if let Some(hir::ItemKind::Impl(hir::Impl { self_ty, .. })) =
                             item.map(|i| &i.kind)

--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -42,7 +42,7 @@ fn normalize_projection_ty<'tcx>(
             );
             ocx.register_obligations(obligations);
             // #112047: With projections and opaques, we are able to create opaques that
-            // are recursive (given some substitution of the opaque's type variables).
+            // are recursive (given some generic parameters of the opaque's type variables).
             // In that case, we may only realize a cycle error when calling
             // `normalize_erasing_regions` in mono.
             if !ocx.infcx.next_trait_solver() {

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -50,7 +50,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             // `tests/ui/polymorphization/normalized_sig_types.rs`), and codegen not keeping
             // track of a polymorphization `ParamEnv` to allow normalizing later.
             //
-            // We normalize the `fn_sig` again after substituting at a later point.
+            // We normalize the `fn_sig` again after instantiating at a later point.
             let mut sig = match *ty.kind() {
                 ty::FnDef(def_id, args) => tcx
                     .fn_sig(def_id)
@@ -163,7 +163,7 @@ fn fn_sig_for_fn_abi<'tcx>(
             // a separate def-id for these bodies.
             if let InstanceDef::CoroutineKindShim { target_kind, .. } = instance.def {
                 // Grab the parent coroutine-closure. It has the same args for the purposes
-                // of substitution, so this will be okay to do.
+                // of instantiation, so this will be okay to do.
                 let ty::CoroutineClosure(_, coroutine_closure_args) = *tcx
                     .instantiate_and_normalize_erasing_regions(
                         args,

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -741,7 +741,7 @@ fn coroutine_layout<'tcx>(
 ) -> Result<Layout<'tcx>, &'tcx LayoutError<'tcx>> {
     use SavedLocalEligibility::*;
     let tcx = cx.tcx;
-    let subst_field = |ty: Ty<'tcx>| EarlyBinder::bind(ty).instantiate(tcx, args);
+    let instantiate_field = |ty: Ty<'tcx>| EarlyBinder::bind(ty).instantiate(tcx, args);
 
     let Some(info) = tcx.coroutine_layout(def_id) else {
         return Err(error(cx, LayoutError::Unknown(ty)));
@@ -763,7 +763,7 @@ fn coroutine_layout<'tcx>(
     let tag_layout = cx.tcx.mk_layout(LayoutS::scalar(cx, tag));
 
     let promoted_layouts = ineligible_locals.iter().map(|local| {
-        let field_ty = subst_field(info.field_tys[local].ty);
+        let field_ty = instantiate_field(info.field_tys[local].ty);
         let uninit_ty = Ty::new_maybe_uninit(tcx, field_ty);
         Ok(cx.spanned_layout_of(uninit_ty, info.field_tys[local].source_info.span)?.layout)
     });
@@ -838,7 +838,7 @@ fn coroutine_layout<'tcx>(
                     Ineligible(_) => false,
                 })
                 .map(|local| {
-                    let field_ty = subst_field(info.field_tys[*local].ty);
+                    let field_ty = instantiate_field(info.field_tys[*local].ty);
                     Ty::new_maybe_uninit(tcx, field_ty)
                 });
 

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -155,7 +155,7 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
 
                 // Collect opaque types nested within the associated type bounds of this opaque type.
                 // We use identity args here, because we already know that the opaque type uses
-                // only generic parameters, and thus substituting would not give us more information.
+                // only generic parameters, and thus instantiating would not give us more information.
                 for (pred, span) in self
                     .tcx
                     .explicit_item_bounds(alias_ty.def_id)
@@ -211,7 +211,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
                 // in the same impl block.
                 if let Some(parent_trait_ref) = self.parent_trait_ref() {
                     // If the trait ref of the associated item and the impl differs,
-                    // then we can't use the impl's identity substitutions below, so
+                    // then we can't use the impl's identity args below, so
                     // just skip.
                     if alias_ty.trait_ref(self.tcx) == parent_trait_ref {
                         let parent = self.parent().expect("we should have a parent here");
@@ -258,11 +258,11 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
                     for field in variant.fields.iter() {
                         // Don't use the `ty::Adt` args, we either
                         // * found the opaque in the args
-                        // * will find the opaque in the unsubstituted fields
-                        // The only other situation that can occur is that after substituting,
+                        // * will find the opaque in the uninstantiated fields
+                        // The only other situation that can occur is that after instantiating,
                         // some projection resolves to an opaque that we would have otherwise
-                        // not found. While we could substitute and walk those, that would mean we
-                        // would have to walk all substitutions of an Adt, which can quickly
+                        // not found. While we could instantiate and walk those, that would mean we
+                        // would have to walk all generic parameters of an Adt, which can quickly
                         // degenerate into looking at an exponential number of types.
                         let ty = self.tcx.type_of(field.did).instantiate_identity();
                         self.visit_spanned(self.tcx.def_span(field.did), ty);
@@ -306,7 +306,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for ImplTraitInAssocTypeCollector<'tcx> {
                     .parent_trait_ref()
                     .expect("impl trait in assoc type collector used on non-assoc item");
                 // If the trait ref of the associated item and the impl differs,
-                // then we can't use the impl's identity substitutions below, so
+                // then we can't use the impl's identity args below, so
                 // just skip.
                 if alias_ty.trait_ref(self.0.tcx) == parent_trait_ref {
                     let parent = self.0.parent().expect("we should have a parent here");

--- a/compiler/rustc_ty_utils/src/representability.rs
+++ b/compiler/rustc_ty_utils/src/representability.rs
@@ -73,8 +73,8 @@ fn representability_adt_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Representab
     // At this point, we know that the item of the ADT type is representable;
     // but the type parameters may cause a cycle with an upstream type
     let params_in_repr = tcx.params_in_repr(adt.did());
-    for (i, subst) in args.iter().enumerate() {
-        if let ty::GenericArgKind::Type(ty) = subst.unpack() {
+    for (i, arg) in args.iter().enumerate() {
+        if let ty::GenericArgKind::Type(ty) = arg.unpack() {
             if params_in_repr.contains(i as u32) {
                 rtry!(representability_ty(tcx, ty));
             }
@@ -103,8 +103,8 @@ fn params_in_repr_ty<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, params_in_repr: &mut
     match *ty.kind() {
         ty::Adt(adt, args) => {
             let inner_params_in_repr = tcx.params_in_repr(adt.did());
-            for (i, subst) in args.iter().enumerate() {
-                if let ty::GenericArgKind::Type(ty) = subst.unpack() {
+            for (i, arg) in args.iter().enumerate() {
+                if let ty::GenericArgKind::Type(ty) = arg.unpack() {
                     if inner_params_in_repr.contains(i as u32) {
                         params_in_repr_ty(tcx, ty, params_in_repr);
                     }

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -5,7 +5,7 @@ bitflags! {
     /// over the type itself.
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct TypeFlags: u32 {
-        // Does this have parameters? Used to determine whether substitution is
+        // Does this have parameters? Used to determine whether instantiation is
         // required.
         /// Does this have `Param`?
         const HAS_TY_PARAM                = 1 << 0;

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -64,17 +64,17 @@ use self::RegionKind::*;
 ///
 /// ## Bound Regions
 ///
-/// These are regions that are stored behind a binder and must be substituted
+/// These are regions that are stored behind a binder and must be instantiated
 /// with some concrete region before being used. There are two kind of
 /// bound regions: early-bound, which are bound in an item's `Generics`,
-/// and are substituted by an `GenericArgs`, and late-bound, which are part of
-/// higher-ranked types (e.g., `for<'a> fn(&'a ())`), and are substituted by
+/// and are instantiated by an `GenericArgs`, and late-bound, which are part of
+/// higher-ranked types (e.g., `for<'a> fn(&'a ())`), and are instantiated by
 /// the likes of `liberate_late_bound_regions`. The distinction exists
 /// because higher-ranked lifetimes aren't supported in all places. See [1][2].
 ///
 /// Unlike `Param`s, bound regions are not supposed to exist "in the wild"
 /// outside their binder, e.g., in types passed to type inference, and
-/// should first be substituted (by placeholder regions, free regions,
+/// should first be instantiated (by placeholder regions, free regions,
 /// or region variables).
 ///
 /// ## Placeholder and Free Regions
@@ -101,7 +101,7 @@ use self::RegionKind::*;
 /// `RePlaceholder` is designed for this purpose. In these contexts,
 /// there's also the risk that some inference variable laying around will
 /// get unified with your placeholder region: if you want to check whether
-/// `for<'a> Foo<'_>: 'a`, and you substitute your bound region `'a`
+/// `for<'a> Foo<'_>: 'a`, and you instantiate your bound region `'a`
 /// with a placeholder region `'%a`, the variable `'_` would just be
 /// instantiated to the placeholder region `'%a`, which is wrong because
 /// the inference variable is supposed to satisfy the relation

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -143,7 +143,7 @@ pub enum TyKind<I: Interner> {
     /// For example, the type `List<i32>` would be represented using the `AdtDef`
     /// for `struct List<T>` and the args `[i32]`.
     ///
-    /// Note that generic parameters in fields only get lazily substituted
+    /// Note that generic parameters in fields only get lazily instantiated
     /// by using something like `adt_def.all_fields().map(|field| field.ty(tcx, args))`.
     Adt(I::AdtDef, I::GenericArgs),
 
@@ -197,14 +197,14 @@ pub enum TyKind<I: Interner> {
 
     /// The anonymous type of a closure. Used to represent the type of `|a| a`.
     ///
-    /// Closure args contain both the - potentially substituted - generic parameters
+    /// Closure args contain both the - potentially instantiated - generic parameters
     /// of its parent and some synthetic parameters. See the documentation for
     /// `ClosureArgs` for more details.
     Closure(I::DefId, I::GenericArgs),
 
     /// The anonymous type of a closure. Used to represent the type of `async |a| a`.
     ///
-    /// Coroutine-closure args contain both the - potentially substituted - generic
+    /// Coroutine-closure args contain both the - potentially instantiated - generic
     /// parameters of its parent and some synthetic parameters. See the documentation
     /// for `CoroutineClosureArgs` for more details.
     CoroutineClosure(I::DefId, I::GenericArgs),

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -124,7 +124,7 @@ pub trait Context {
     /// Get the body of an Instance which is already monomorphized.
     fn instance_body(&self, instance: InstanceDef) -> Option<Body>;
 
-    /// Get the instance type with generic substitutions applied and lifetimes erased.
+    /// Get the instance type with generic instantiations applied and lifetimes erased.
     fn instance_ty(&self, instance: InstanceDef) -> Ty;
 
     /// Get the instantiation types.

--- a/compiler/stable_mir/src/mir/mono.rs
+++ b/compiler/stable_mir/src/mir/mono.rs
@@ -57,7 +57,7 @@ impl Instance {
         with(|cx| cx.is_foreign_item(self.def.def_id()))
     }
 
-    /// Get the instance type with generic substitutions applied and lifetimes erased.
+    /// Get the instance type with generic instantiations applied and lifetimes erased.
     pub fn ty(&self) -> Ty {
         with(|context| context.instance_ty(self.def))
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1796,7 +1796,7 @@ fn maybe_expand_private_type_alias<'tcx>(
                     } else {
                         Lifetime::elided()
                     };
-                    args.insert(param.def_id.to_def_id(), SubstParam::Lifetime(cleaned));
+                    args.insert(param.def_id.to_def_id(), InstantiationParam::Lifetime(cleaned));
                 }
                 indices.lifetimes += 1;
             }
@@ -1813,9 +1813,15 @@ fn maybe_expand_private_type_alias<'tcx>(
                     _ => None,
                 });
                 if let Some(ty) = type_ {
-                    args.insert(param.def_id.to_def_id(), SubstParam::Type(clean_ty(ty, cx)));
+                    args.insert(
+                        param.def_id.to_def_id(),
+                        InstantiationParam::Type(clean_ty(ty, cx)),
+                    );
                 } else if let Some(default) = *default {
-                    args.insert(param.def_id.to_def_id(), SubstParam::Type(clean_ty(default, cx)));
+                    args.insert(
+                        param.def_id.to_def_id(),
+                        InstantiationParam::Type(clean_ty(default, cx)),
+                    );
                 }
                 indices.types += 1;
             }
@@ -1832,7 +1838,7 @@ fn maybe_expand_private_type_alias<'tcx>(
                     _ => None,
                 });
                 if let Some(_) = const_ {
-                    args.insert(param.def_id.to_def_id(), SubstParam::Constant);
+                    args.insert(param.def_id.to_def_id(), InstantiationParam::Constant);
                 }
                 // FIXME(const_generics_defaults)
                 indices.consts += 1;

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2542,14 +2542,14 @@ pub(crate) enum TypeBindingKind {
 /// ```
 ///
 /// `public_fn`'s docs will show it as returning `Vec<i32>`, since `PrivAlias` is private.
-/// [`SubstParam`] is used to record that `T` should be mapped to `i32`.
-pub(crate) enum SubstParam {
+/// [`InstantiationParam`] is used to record that `T` should be mapped to `i32`.
+pub(crate) enum InstantiationParam {
     Type(Type),
     Lifetime(Lifetime),
     Constant,
 }
 
-impl SubstParam {
+impl InstantiationParam {
     pub(crate) fn as_ty(&self) -> Option<&Type> {
         if let Self::Type(ty) = self { Some(ty) } else { None }
     }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -44,10 +44,10 @@ pub(crate) struct DocContext<'tcx> {
     /// Used while populating `external_traits` to ensure we don't process the same trait twice at
     /// the same time.
     pub(crate) active_extern_traits: DefIdSet,
-    // The current set of parameter substitutions,
+    // The current set of parameter instantiations,
     // for expanding type aliases at the HIR level:
-    /// Table `DefId` of type, lifetime, or const parameter -> substituted type, lifetime, or const
-    pub(crate) args: DefIdMap<clean::SubstParam>,
+    /// Table `DefId` of type, lifetime, or const parameter -> instantiated type, lifetime, or const
+    pub(crate) args: DefIdMap<clean::InstantiationParam>,
     pub(crate) current_type_aliases: DefIdMap<usize>,
     /// Table synthetic type parameter for `impl Trait` in argument position -> bounds
     pub(crate) impl_trait_bounds: FxHashMap<ImplTraitParam, Vec<clean::GenericBound>>,
@@ -84,10 +84,10 @@ impl<'tcx> DocContext<'tcx> {
     }
 
     /// Call the closure with the given parameters set as
-    /// the substitutions for a type alias' RHS.
+    /// the generic parameters for a type alias' RHS.
     pub(crate) fn enter_alias<F, R>(
         &mut self,
-        args: DefIdMap<clean::SubstParam>,
+        args: DefIdMap<clean::InstantiationParam>,
         def_id: DefId,
         f: F,
     ) -> R

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -25,7 +25,7 @@ trait BadAnnotation2<A,B>
 {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
-//~^ only named substitution parameters are allowed
+//~^ only named generic parameters are allowed
 trait BadAnnotation3<A,B>
 {}
 

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -17,7 +17,7 @@ error[E0230]: there is no parameter `C` on trait `BadAnnotation2`
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0231]: only named substitution parameters are allowed
+error[E0231]: only named generic parameters are allowed
   --> $DIR/bad-annotation.rs:27:1
    |
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]


### PR DESCRIPTION
In favor of #110793, replace almost every occurence of `subst` and `substitution` from rustc codes, but they still remains in subtrees under `src/tools/` like clippy and test codes (I'd like to replace them after this)