### PR TITLE
fix cycle error when a static and a promoted are mutually recursive

### DIFF
--- a/tests/ui/consts/cycle-static-promoted.rs
+++ b/tests/ui/consts/cycle-static-promoted.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+struct Value {
+    values: &'static [&'static Value],
+}
+
+// This `static` recursively points to itself through a promoted (the slice).
+static VALUE: Value = Value {
+    values: &[&VALUE],
+};
+
+fn main() {}


### PR DESCRIPTION
This also now allows promoteds everywhere to point to 'extern static', because why not? We still check that constants cannot transitively reach 'extern static' through references. (We allow it through raw pointers.)

r? @oli-obk 
Fixes https://github.com/rust-lang/rust/issues/120949