### PR TITLE
add another test for promoteds-in-static

### DIFF
--- a/tests/ui/consts/static-promoted-to-mutable-static.rs
+++ b/tests/ui/consts/static-promoted-to-mutable-static.rs
@@ -1,0 +1,33 @@
+// check-pass
+#![allow(non_camel_case_types, non_upper_case_globals, static_mut_ref)]
+
+pub struct wl_interface {
+    pub version: i32
+}
+
+pub struct Interface {
+    pub other_interfaces: &'static [&'static Interface],
+    pub c_ptr: Option<&'static wl_interface>,
+}
+
+pub static mut wl_callback_interface: wl_interface = wl_interface {
+    version: 0,
+};
+
+pub static WL_CALLBACK_INTERFACE: Interface = Interface {
+    other_interfaces: &[],
+    c_ptr: Some(unsafe { &wl_callback_interface }),
+};
+
+// This static contains a promoted that points to a static that points to a mutable static.
+pub static WL_SURFACE_INTERFACE: Interface = Interface {
+    other_interfaces: &[&WL_CALLBACK_INTERFACE],
+    c_ptr: None,
+};
+
+// And another variant of the same thing, this time with interior mutability.
+use std::sync::OnceLock;
+static LAZY_INIT: OnceLock<u32> = OnceLock::new();
+static LAZY_INIT_REF: &[&OnceLock<u32>] = &[&LAZY_INIT];
+
+fn main() {}


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/119614 led to validation of promoteds recursing into statics. These statics can point to `static mut` and interior mutable `static` and do other things we don't allow in `const`, but promoteds are validated as `const`, so we get strange errors (saying "in `const`" when there is no const) and surprising validation failures.

https://github.com/rust-lang/rust/pull/120960 fixes that; this here adds another test.

r? @oli-obk 
Fixes https://github.com/rust-lang/rust/issues/120968