### PR TITLE
llvm-wrapper: adapt for LLVM 19 API change

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1801,6 +1801,9 @@ extern "C" LLVMRustResult LLVMRustWriteImportLibrary(
       std::string{},    // ExtName
       std::string{},    // SymbolName
       std::string{},    // AliasTarget
+#if LLVM_VERSION_GE(19, 0)
+      std::string{},    // ExportAs
+#endif
       ordinal,          // Ordinal
       ordinal_present,  // Noname
       false,            // Data


### PR DESCRIPTION
No functional changes intended.

Adapts llvm-wrapper for https://github.com/llvm/llvm-project/commit/8f23464a5d957242c89ca6f33d4379c42519cd81.