### PR TITLE
match lowering: simplify block creation

### DIFF
--- a/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
@@ -110,7 +110,7 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body@$DIR/async_await.rs:15:18: 18:2}>,
 
     bb0: {
         _39 = discriminant((*(_1.0: &mut {async fn body@$DIR/async_await.rs:15:18: 18:2})));
-        switchInt(move _39) -> [0: bb1, 1: bb29, 3: bb27, 4: bb28, otherwise: bb9];
+        switchInt(move _39) -> [0: bb1, 1: bb29, 3: bb27, 4: bb28, otherwise: bb8];
     }
 
     bb1: {
@@ -165,10 +165,14 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body@$DIR/async_await.rs:15:18: 18:2}>,
         StorageDead(_10);
         PlaceMention(_9);
         _16 = discriminant(_9);
-        switchInt(move _16) -> [0: bb10, 1: bb8, otherwise: bb9];
+        switchInt(move _16) -> [0: bb10, 1: bb9, otherwise: bb8];
     }
 
     bb8: {
+        unreachable;
+    }
+
+    bb9: {
         _8 = const ();
         StorageDead(_14);
         StorageDead(_12);
@@ -184,10 +188,6 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body@$DIR/async_await.rs:15:18: 18:2}>,
         StorageDead(_20);
         discriminant((*(_1.0: &mut {async fn body@$DIR/async_await.rs:15:18: 18:2}))) = 3;
         return;
-    }
-
-    bb9: {
-        unreachable;
     }
 
     bb10: {
@@ -267,7 +267,7 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body@$DIR/async_await.rs:15:18: 18:2}>,
         StorageDead(_26);
         PlaceMention(_25);
         _32 = discriminant(_25);
-        switchInt(move _32) -> [0: bb21, 1: bb20, otherwise: bb9];
+        switchInt(move _32) -> [0: bb21, 1: bb20, otherwise: bb8];
     }
 
     bb20: {

--- a/tests/mir-opt/building/issue_101867.main.built.after.mir
+++ b/tests/mir-opt/building/issue_101867.main.built.after.mir
@@ -27,13 +27,13 @@ fn main() -> () {
         StorageLive(_5);
         PlaceMention(_1);
         _6 = discriminant(_1);
-        switchInt(move _6) -> [1: bb4, otherwise: bb3];
+        switchInt(move _6) -> [1: bb5, otherwise: bb4];
     }
 
     bb1: {
         StorageLive(_3);
         StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb7;
+        _4 = begin_panic::<&str>(const "explicit panic") -> bb8;
     }
 
     bb2: {
@@ -43,14 +43,19 @@ fn main() -> () {
     }
 
     bb3: {
-        goto -> bb6;
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
     }
 
     bb4: {
-        falseEdge -> [real: bb5, imaginary: bb3];
+        goto -> bb7;
     }
 
     bb5: {
+        falseEdge -> [real: bb6, imaginary: bb4];
+    }
+
+    bb6: {
         _5 = ((_1 as Some).0: u8);
         _0 = const ();
         StorageDead(_5);
@@ -58,12 +63,12 @@ fn main() -> () {
         return;
     }
 
-    bb6: {
+    bb7: {
         StorageDead(_5);
         goto -> bb1;
     }
 
-    bb7 (cleanup): {
+    bb8 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/issue_49232.main.built.after.mir
+++ b/tests/mir-opt/building/issue_49232.main.built.after.mir
@@ -17,7 +17,7 @@ fn main() -> () {
     }
 
     bb1: {
-        falseUnwind -> [real: bb2, unwind: bb11];
+        falseUnwind -> [real: bb2, unwind: bb12];
     }
 
     bb2: {
@@ -25,41 +25,46 @@ fn main() -> () {
         StorageLive(_3);
         _3 = const true;
         PlaceMention(_3);
-        switchInt(_3) -> [0: bb3, otherwise: bb4];
+        switchInt(_3) -> [0: bb4, otherwise: bb5];
     }
 
     bb3: {
-        falseEdge -> [real: bb5, imaginary: bb4];
-    }
-
-    bb4: {
-        _0 = const ();
-        goto -> bb10;
-    }
-
-    bb5: {
-        _2 = const 4_i32;
-        goto -> bb8;
-    }
-
-    bb6: {
+        FakeRead(ForMatchedPlace(None), _3);
         unreachable;
     }
 
+    bb4: {
+        falseEdge -> [real: bb6, imaginary: bb5];
+    }
+
+    bb5: {
+        _0 = const ();
+        goto -> bb11;
+    }
+
+    bb6: {
+        _2 = const 4_i32;
+        goto -> bb9;
+    }
+
     bb7: {
-        goto -> bb8;
+        unreachable;
     }
 
     bb8: {
+        goto -> bb9;
+    }
+
+    bb9: {
         FakeRead(ForLet(None), _2);
         StorageDead(_3);
         StorageLive(_5);
         StorageLive(_6);
         _6 = &_2;
-        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb9, unwind: bb11];
+        _5 = std::mem::drop::<&i32>(move _6) -> [return: bb10, unwind: bb12];
     }
 
-    bb9: {
+    bb10: {
         StorageDead(_6);
         StorageDead(_5);
         _1 = const ();
@@ -67,13 +72,13 @@ fn main() -> () {
         goto -> bb1;
     }
 
-    bb10: {
+    bb11: {
         StorageDead(_3);
         StorageDead(_2);
         return;
     }
 
-    bb11 (cleanup): {
+    bb12 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
+++ b/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
@@ -19,168 +19,178 @@ fn test_complex() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = E::f() -> [return: bb1, unwind: bb31];
+        _2 = E::f() -> [return: bb1, unwind: bb33];
     }
 
     bb1: {
         PlaceMention(_2);
         _3 = discriminant(_2);
-        switchInt(move _3) -> [0: bb2, otherwise: bb3];
+        switchInt(move _3) -> [0: bb4, otherwise: bb3];
     }
 
     bb2: {
-        falseEdge -> [real: bb4, imaginary: bb3];
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
     }
 
     bb3: {
-        goto -> bb19;
+        goto -> bb20;
     }
 
     bb4: {
-        StorageLive(_4);
-        _4 = always_true() -> [return: bb5, unwind: bb31];
+        falseEdge -> [real: bb5, imaginary: bb3];
     }
 
     bb5: {
-        switchInt(move _4) -> [0: bb7, otherwise: bb6];
+        StorageLive(_4);
+        _4 = always_true() -> [return: bb6, unwind: bb33];
     }
 
     bb6: {
+        switchInt(move _4) -> [0: bb8, otherwise: bb7];
+    }
+
+    bb7: {
         StorageLive(_5);
         StorageLive(_6);
         StorageLive(_7);
         _7 = Droppy(const 0_u8);
         _6 = (_7.0: u8);
         _5 = Gt(move _6, const 0_u8);
-        switchInt(move _5) -> [0: bb9, otherwise: bb8];
-    }
-
-    bb7: {
-        goto -> bb13;
+        switchInt(move _5) -> [0: bb10, otherwise: bb9];
     }
 
     bb8: {
-        drop(_7) -> [return: bb10, unwind: bb31];
+        goto -> bb14;
     }
 
     bb9: {
-        goto -> bb11;
+        drop(_7) -> [return: bb11, unwind: bb33];
     }
 
     bb10: {
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb16;
+        goto -> bb12;
     }
 
     bb11: {
-        drop(_7) -> [return: bb12, unwind: bb31];
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb17;
     }
 
     bb12: {
-        StorageDead(_7);
-        StorageDead(_6);
-        goto -> bb13;
+        drop(_7) -> [return: bb13, unwind: bb33];
     }
 
     bb13: {
+        StorageDead(_7);
+        StorageDead(_6);
+        goto -> bb14;
+    }
+
+    bb14: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_10);
         _10 = Droppy(const 1_u8);
         _9 = (_10.0: u8);
         _8 = Gt(move _9, const 1_u8);
-        switchInt(move _8) -> [0: bb15, otherwise: bb14];
-    }
-
-    bb14: {
-        drop(_10) -> [return: bb16, unwind: bb31];
+        switchInt(move _8) -> [0: bb16, otherwise: bb15];
     }
 
     bb15: {
-        goto -> bb17;
+        drop(_10) -> [return: bb17, unwind: bb33];
     }
 
     bb16: {
-        StorageDead(_10);
-        StorageDead(_9);
-        _1 = const ();
-        goto -> bb20;
+        goto -> bb18;
     }
 
     bb17: {
-        drop(_10) -> [return: bb18, unwind: bb31];
+        StorageDead(_10);
+        StorageDead(_9);
+        _1 = const ();
+        goto -> bb21;
     }
 
     bb18: {
-        StorageDead(_10);
-        StorageDead(_9);
-        goto -> bb19;
+        drop(_10) -> [return: bb19, unwind: bb33];
     }
 
     bb19: {
-        _1 = const ();
+        StorageDead(_10);
+        StorageDead(_9);
         goto -> bb20;
     }
 
     bb20: {
+        _1 = const ();
+        goto -> bb21;
+    }
+
+    bb21: {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_4);
         StorageDead(_2);
         StorageDead(_1);
         StorageLive(_11);
-        _11 = always_true() -> [return: bb21, unwind: bb31];
-    }
-
-    bb21: {
-        switchInt(move _11) -> [0: bb23, otherwise: bb22];
+        _11 = always_true() -> [return: bb22, unwind: bb33];
     }
 
     bb22: {
-        goto -> bb29;
+        switchInt(move _11) -> [0: bb24, otherwise: bb23];
     }
 
     bb23: {
-        goto -> bb24;
+        goto -> bb31;
     }
 
     bb24: {
-        StorageLive(_12);
-        _12 = E::f() -> [return: bb25, unwind: bb31];
+        goto -> bb25;
     }
 
     bb25: {
-        PlaceMention(_12);
-        _13 = discriminant(_12);
-        switchInt(move _13) -> [1: bb27, otherwise: bb26];
+        StorageLive(_12);
+        _12 = E::f() -> [return: bb26, unwind: bb33];
     }
 
     bb26: {
-        goto -> bb29;
+        PlaceMention(_12);
+        _13 = discriminant(_12);
+        switchInt(move _13) -> [1: bb29, otherwise: bb28];
     }
 
     bb27: {
-        falseEdge -> [real: bb28, imaginary: bb26];
+        FakeRead(ForMatchedPlace(None), _12);
+        unreachable;
     }
 
     bb28: {
-        _0 = const ();
-        goto -> bb30;
+        goto -> bb31;
     }
 
     bb29: {
-        _0 = const ();
-        goto -> bb30;
+        falseEdge -> [real: bb30, imaginary: bb28];
     }
 
     bb30: {
+        _0 = const ();
+        goto -> bb32;
+    }
+
+    bb31: {
+        _0 = const ();
+        goto -> bb32;
+    }
+
+    bb32: {
         StorageDead(_11);
         StorageDead(_12);
         return;
     }
 
-    bb31 (cleanup): {
+    bb33 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match_false_edges.full_tested_match.built.after.mir
+++ b/tests/mir-opt/building/match_false_edges.full_tested_match.built.after.mir
@@ -28,25 +28,25 @@ fn full_tested_match() -> () {
         _2 = Option::<i32>::Some(const 42_i32);
         PlaceMention(_2);
         _3 = discriminant(_2);
-        switchInt(move _3) -> [0: bb1, 1: bb2, otherwise: bb4];
+        switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
     }
 
     bb1: {
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
+    }
+
+    bb2: {
         _1 = (const 3_i32, const 3_i32);
         goto -> bb11;
     }
 
-    bb2: {
-        falseEdge -> [real: bb5, imaginary: bb3];
-    }
-
     bb3: {
-        falseEdge -> [real: bb10, imaginary: bb1];
+        falseEdge -> [real: bb5, imaginary: bb4];
     }
 
     bb4: {
-        FakeRead(ForMatchedPlace(None), _2);
-        unreachable;
+        falseEdge -> [real: bb10, imaginary: bb2];
     }
 
     bb5: {
@@ -54,7 +54,7 @@ fn full_tested_match() -> () {
         _6 = &((_2 as Some).0: i32);
         _4 = &fake _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb6, unwind: bb12];
+        _7 = guard() -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
@@ -83,7 +83,7 @@ fn full_tested_match() -> () {
     bb9: {
         StorageDead(_7);
         StorageDead(_6);
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb10: {
@@ -105,7 +105,12 @@ fn full_tested_match() -> () {
         return;
     }
 
-    bb12 (cleanup): {
+    bb12: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb13 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match_false_edges.full_tested_match2.built.after.mir
+++ b/tests/mir-opt/building/match_false_edges.full_tested_match2.built.after.mir
@@ -28,18 +28,23 @@ fn full_tested_match2() -> () {
         _2 = Option::<i32>::Some(const 42_i32);
         PlaceMention(_2);
         _3 = discriminant(_2);
-        switchInt(move _3) -> [0: bb1, 1: bb2, otherwise: bb4];
+        switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
     }
 
     bb1: {
-        falseEdge -> [real: bb10, imaginary: bb3];
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
     }
 
     bb2: {
-        falseEdge -> [real: bb5, imaginary: bb1];
+        falseEdge -> [real: bb10, imaginary: bb4];
     }
 
     bb3: {
+        falseEdge -> [real: bb5, imaginary: bb2];
+    }
+
+    bb4: {
         StorageLive(_9);
         _9 = ((_2 as Some).0: i32);
         StorageLive(_10);
@@ -50,17 +55,12 @@ fn full_tested_match2() -> () {
         goto -> bb11;
     }
 
-    bb4: {
-        FakeRead(ForMatchedPlace(None), _2);
-        unreachable;
-    }
-
     bb5: {
         StorageLive(_6);
         _6 = &((_2 as Some).0: i32);
         _4 = &fake _2;
         StorageLive(_7);
-        _7 = guard() -> [return: bb6, unwind: bb12];
+        _7 = guard() -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
@@ -89,7 +89,7 @@ fn full_tested_match2() -> () {
     bb9: {
         StorageDead(_7);
         StorageDead(_6);
-        falseEdge -> [real: bb3, imaginary: bb1];
+        falseEdge -> [real: bb4, imaginary: bb2];
     }
 
     bb10: {
@@ -105,7 +105,12 @@ fn full_tested_match2() -> () {
         return;
     }
 
-    bb12 (cleanup): {
+    bb12: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb13 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/match_false_edges.main.built.after.mir
+++ b/tests/mir-opt/building/match_false_edges.main.built.after.mir
@@ -39,55 +39,60 @@ fn main() -> () {
         _2 = Option::<i32>::Some(const 1_i32);
         PlaceMention(_2);
         _4 = discriminant(_2);
-        switchInt(move _4) -> [1: bb2, otherwise: bb1];
+        switchInt(move _4) -> [1: bb7, otherwise: bb2];
     }
 
     bb1: {
-        falseEdge -> [real: bb13, imaginary: bb6];
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
     }
 
     bb2: {
-        falseEdge -> [real: bb8, imaginary: bb1];
+        falseEdge -> [real: bb14, imaginary: bb5];
     }
 
     bb3: {
-        goto -> bb1;
+        _3 = discriminant(_2);
+        switchInt(move _3) -> [1: bb5, otherwise: bb4];
     }
 
     bb4: {
-        _3 = discriminant(_2);
-        switchInt(move _3) -> [1: bb6, otherwise: bb5];
-    }
-
-    bb5: {
         StorageLive(_14);
         _14 = _2;
         _1 = const 4_i32;
         StorageDead(_14);
-        goto -> bb19;
+        goto -> bb20;
+    }
+
+    bb5: {
+        falseEdge -> [real: bb15, imaginary: bb4];
     }
 
     bb6: {
-        falseEdge -> [real: bb14, imaginary: bb5];
+        goto -> bb4;
     }
 
     bb7: {
-        goto -> bb5;
+        falseEdge -> [real: bb9, imaginary: bb2];
     }
 
     bb8: {
+        goto -> bb2;
+    }
+
+    bb9: {
         StorageLive(_7);
         _7 = &((_2 as Some).0: i32);
         _5 = &fake _2;
         StorageLive(_8);
-        _8 = guard() -> [return: bb9, unwind: bb20];
-    }
-
-    bb9: {
-        switchInt(move _8) -> [0: bb11, otherwise: bb10];
+        _8 = guard() -> [return: bb10, unwind: bb22];
     }
 
     bb10: {
+        switchInt(move _8) -> [0: bb12, otherwise: bb11];
+    }
+
+    bb11: {
         StorageDead(_8);
         FakeRead(ForMatchGuard, _5);
         FakeRead(ForGuardBinding, _7);
@@ -96,42 +101,42 @@ fn main() -> () {
         _1 = const 1_i32;
         StorageDead(_6);
         StorageDead(_7);
-        goto -> bb19;
-    }
-
-    bb11: {
-        goto -> bb12;
+        goto -> bb20;
     }
 
     bb12: {
-        StorageDead(_8);
-        StorageDead(_7);
-        falseEdge -> [real: bb3, imaginary: bb1];
+        goto -> bb13;
     }
 
     bb13: {
+        StorageDead(_8);
+        StorageDead(_7);
+        falseEdge -> [real: bb8, imaginary: bb2];
+    }
+
+    bb14: {
         StorageLive(_9);
         _9 = _2;
         _1 = const 2_i32;
         StorageDead(_9);
-        goto -> bb19;
+        goto -> bb20;
     }
 
-    bb14: {
+    bb15: {
         StorageLive(_11);
         _11 = &((_2 as Some).0: i32);
         _5 = &fake _2;
         StorageLive(_12);
         StorageLive(_13);
         _13 = (*_11);
-        _12 = guard2(move _13) -> [return: bb15, unwind: bb20];
-    }
-
-    bb15: {
-        switchInt(move _12) -> [0: bb17, otherwise: bb16];
+        _12 = guard2(move _13) -> [return: bb16, unwind: bb22];
     }
 
     bb16: {
+        switchInt(move _12) -> [0: bb18, otherwise: bb17];
+    }
+
+    bb17: {
         StorageDead(_13);
         StorageDead(_12);
         FakeRead(ForMatchGuard, _5);
@@ -141,21 +146,21 @@ fn main() -> () {
         _1 = const 3_i32;
         StorageDead(_10);
         StorageDead(_11);
-        goto -> bb19;
-    }
-
-    bb17: {
-        goto -> bb18;
+        goto -> bb20;
     }
 
     bb18: {
-        StorageDead(_13);
-        StorageDead(_12);
-        StorageDead(_11);
-        falseEdge -> [real: bb7, imaginary: bb5];
+        goto -> bb19;
     }
 
     bb19: {
+        StorageDead(_13);
+        StorageDead(_12);
+        StorageDead(_11);
+        falseEdge -> [real: bb6, imaginary: bb4];
+    }
+
+    bb20: {
         PlaceMention(_1);
         StorageDead(_2);
         StorageDead(_1);
@@ -163,7 +168,12 @@ fn main() -> () {
         return;
     }
 
-    bb20 (cleanup): {
+    bb21: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb22 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/simple_match.match_bool.built.after.mir
+++ b/tests/mir-opt/building/simple_match.match_bool.built.after.mir
@@ -6,24 +6,29 @@ fn match_bool(_1: bool) -> usize {
 
     bb0: {
         PlaceMention(_1);
-        switchInt(_1) -> [0: bb2, otherwise: bb1];
+        switchInt(_1) -> [0: bb2, otherwise: bb3];
     }
 
     bb1: {
-        falseEdge -> [real: bb3, imaginary: bb2];
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
     }
 
     bb2: {
         _0 = const 20_usize;
-        goto -> bb4;
+        goto -> bb5;
     }
 
     bb3: {
-        _0 = const 10_usize;
-        goto -> bb4;
+        falseEdge -> [real: bb4, imaginary: bb2];
     }
 
     bb4: {
+        _0 = const 10_usize;
+        goto -> bb5;
+    }
+
+    bb5: {
         return;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.built.after.mir
@@ -30,7 +30,7 @@ fn move_out_by_subslice() -> () {
         StorageLive(_2);
         _3 = SizeOf(i32);
         _4 = AlignOf(i32);
-        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12];
+        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb13];
     }
 
     bb1: {
@@ -38,7 +38,7 @@ fn move_out_by_subslice() -> () {
         _6 = ShallowInitBox(move _5, i32);
         (*_6) = const 1_i32;
         _2 = move _6;
-        drop(_6) -> [return: bb2, unwind: bb11];
+        drop(_6) -> [return: bb2, unwind: bb12];
     }
 
     bb2: {
@@ -46,7 +46,7 @@ fn move_out_by_subslice() -> () {
         StorageLive(_7);
         _8 = SizeOf(i32);
         _9 = AlignOf(i32);
-        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11];
+        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb12];
     }
 
     bb3: {
@@ -54,18 +54,18 @@ fn move_out_by_subslice() -> () {
         _11 = ShallowInitBox(move _10, i32);
         (*_11) = const 2_i32;
         _7 = move _11;
-        drop(_11) -> [return: bb4, unwind: bb10];
+        drop(_11) -> [return: bb4, unwind: bb11];
     }
 
     bb4: {
         StorageDead(_11);
         _1 = [move _2, move _7];
-        drop(_7) -> [return: bb5, unwind: bb11];
+        drop(_7) -> [return: bb5, unwind: bb12];
     }
 
     bb5: {
         StorageDead(_7);
-        drop(_2) -> [return: bb6, unwind: bb12];
+        drop(_2) -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
@@ -75,32 +75,37 @@ fn move_out_by_subslice() -> () {
         StorageLive(_12);
         _12 = move _1[0..2];
         _0 = const ();
-        drop(_12) -> [return: bb7, unwind: bb9];
+        drop(_12) -> [return: bb8, unwind: bb10];
     }
 
     bb7: {
-        StorageDead(_12);
-        drop(_1) -> [return: bb8, unwind: bb12];
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
     }
 
     bb8: {
+        StorageDead(_12);
+        drop(_1) -> [return: bb9, unwind: bb13];
+    }
+
+    bb9: {
         StorageDead(_1);
         return;
     }
 
-    bb9 (cleanup): {
-        drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
     bb10 (cleanup): {
-        drop(_7) -> [return: bb11, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {
+        drop(_2) -> [return: bb13, unwind terminate(cleanup)];
+    }
+
+    bb13 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.built.after.mir
@@ -30,7 +30,7 @@ fn move_out_from_end() -> () {
         StorageLive(_2);
         _3 = SizeOf(i32);
         _4 = AlignOf(i32);
-        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb12];
+        _5 = alloc::alloc::exchange_malloc(move _3, move _4) -> [return: bb1, unwind: bb13];
     }
 
     bb1: {
@@ -38,7 +38,7 @@ fn move_out_from_end() -> () {
         _6 = ShallowInitBox(move _5, i32);
         (*_6) = const 1_i32;
         _2 = move _6;
-        drop(_6) -> [return: bb2, unwind: bb11];
+        drop(_6) -> [return: bb2, unwind: bb12];
     }
 
     bb2: {
@@ -46,7 +46,7 @@ fn move_out_from_end() -> () {
         StorageLive(_7);
         _8 = SizeOf(i32);
         _9 = AlignOf(i32);
-        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb11];
+        _10 = alloc::alloc::exchange_malloc(move _8, move _9) -> [return: bb3, unwind: bb12];
     }
 
     bb3: {
@@ -54,18 +54,18 @@ fn move_out_from_end() -> () {
         _11 = ShallowInitBox(move _10, i32);
         (*_11) = const 2_i32;
         _7 = move _11;
-        drop(_11) -> [return: bb4, unwind: bb10];
+        drop(_11) -> [return: bb4, unwind: bb11];
     }
 
     bb4: {
         StorageDead(_11);
         _1 = [move _2, move _7];
-        drop(_7) -> [return: bb5, unwind: bb11];
+        drop(_7) -> [return: bb5, unwind: bb12];
     }
 
     bb5: {
         StorageDead(_7);
-        drop(_2) -> [return: bb6, unwind: bb12];
+        drop(_2) -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
@@ -75,32 +75,37 @@ fn move_out_from_end() -> () {
         StorageLive(_12);
         _12 = move _1[1 of 2];
         _0 = const ();
-        drop(_12) -> [return: bb7, unwind: bb9];
+        drop(_12) -> [return: bb8, unwind: bb10];
     }
 
     bb7: {
-        StorageDead(_12);
-        drop(_1) -> [return: bb8, unwind: bb12];
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
     }
 
     bb8: {
+        StorageDead(_12);
+        drop(_1) -> [return: bb9, unwind: bb13];
+    }
+
+    bb9: {
         StorageDead(_1);
         return;
     }
 
-    bb9 (cleanup): {
-        drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
     bb10 (cleanup): {
-        drop(_7) -> [return: bb11, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb13, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        drop(_2) -> [return: bb12, unwind terminate(cleanup)];
+        drop(_7) -> [return: bb12, unwind terminate(cleanup)];
     }
 
     bb12 (cleanup): {
+        drop(_2) -> [return: bb13, unwind terminate(cleanup)];
+    }
+
+    bb13 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.panic-abort.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.panic-abort.diff
@@ -79,10 +79,14 @@
       bb4: {
           StorageDead(_12);
           _14 = discriminant(_11);
-          switchInt(move _14) -> [0: bb7, 1: bb5, otherwise: bb6];
+          switchInt(move _14) -> [0: bb7, 1: bb6, otherwise: bb5];
       }
   
       bb5: {
+          unreachable;
+      }
+  
+      bb6: {
 -         StorageLive(_16);
           _16 = ((_11 as Some).0: usize);
           StorageLive(_17);
@@ -93,10 +97,6 @@
 -         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _18) -> [success: bb8, unwind unreachable];
 +         _20 = Lt(_16, _19);
 +         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _16) -> [success: bb8, unwind unreachable];
-      }
-  
-      bb6: {
-          unreachable;
       }
   
       bb7: {

--- a/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.panic-unwind.diff
+++ b/tests/mir-opt/copy-prop/issue_107511.main.CopyProp.panic-unwind.diff
@@ -79,10 +79,14 @@
       bb4: {
           StorageDead(_12);
           _14 = discriminant(_11);
-          switchInt(move _14) -> [0: bb7, 1: bb5, otherwise: bb6];
+          switchInt(move _14) -> [0: bb7, 1: bb6, otherwise: bb5];
       }
   
       bb5: {
+          unreachable;
+      }
+  
+      bb6: {
 -         StorageLive(_16);
           _16 = ((_11 as Some).0: usize);
           StorageLive(_17);
@@ -93,10 +97,6 @@
 -         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _18) -> [success: bb8, unwind continue];
 +         _20 = Lt(_16, _19);
 +         assert(move _20, "index out of bounds: the length is {} but the index is {}", move _19, _16) -> [success: bb8, unwind continue];
-      }
-  
-      bb6: {
-          unreachable;
       }
   
       bb7: {

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.32bit.diff
@@ -26,21 +26,21 @@
           _1 = const _;
           StorageLive(_2);
 -         _3 = discriminant(_1);
--         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         _3 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb1, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_5);
           _5 = ((_1 as V2).0: i32);
           _2 = _5;
           StorageDead(_5);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.constant.DataflowConstProp.64bit.diff
@@ -26,21 +26,21 @@
           _1 = const _;
           StorageLive(_2);
 -         _3 = discriminant(_1);
--         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         _3 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb1, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_5);
           _5 = ((_1 as V2).0: i32);
           _2 = _5;
           StorageDead(_5);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.32bit.diff
@@ -49,16 +49,16 @@
           StorageDead(_4);
           StorageLive(_6);
           _7 = discriminant(_3);
-          switchInt(move _7) -> [0: bb4, 1: bb6, otherwise: bb5];
+          switchInt(move _7) -> [0: bb5, 1: bb6, otherwise: bb4];
       }
   
       bb4: {
-          _6 = const 0_u8;
-          goto -> bb7;
+          unreachable;
       }
   
       bb5: {
-          unreachable;
+          _6 = const 0_u8;
+          goto -> bb7;
       }
   
       bb6: {

--- a/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.multiple.DataflowConstProp.64bit.diff
@@ -49,16 +49,16 @@
           StorageDead(_4);
           StorageLive(_6);
           _7 = discriminant(_3);
-          switchInt(move _7) -> [0: bb4, 1: bb6, otherwise: bb5];
+          switchInt(move _7) -> [0: bb5, 1: bb6, otherwise: bb4];
       }
   
       bb4: {
-          _6 = const 0_u8;
-          goto -> bb7;
+          unreachable;
       }
   
       bb5: {
-          unreachable;
+          _6 = const 0_u8;
+          goto -> bb7;
       }
   
       bb6: {

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -20,7 +20,7 @@ fn simple() {
     // CHECK: [[e]] = const E::V1(0_i32);
     let e = E::V1(0);
 
-    // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb1, otherwise: bb2];
+    // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb2, otherwise: bb1];
     // CHECK: [[target_bb]]: {
     // CHECK:     [[x]] = const 0_i32;
     let x = match e { E::V1(x1) => x1, E::V2(x2) => x2 };
@@ -36,7 +36,7 @@ fn constant() {
 
     // CHECK: [[e]] = const _;
     let e = C;
-    // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb1, otherwise: bb2];
+    // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb2, otherwise: bb1];
     // CHECK: [[target_bb]]: {
     // CHECK:     [[x]] = const 0_i32;
     let x = match e { E::V1(x1) => x1, E::V2(x2) => x2 };
@@ -55,7 +55,7 @@ fn statics() {
 
     // CHECK: [[e1]] = const E::V1(0_i32);
     let e1 = C;
-    // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb1, otherwise: bb2];
+    // CHECK: switchInt(const 0_isize) -> [0: [[target_bb:bb.*]], 1: bb2, otherwise: bb1];
     // CHECK: [[target_bb]]: {
     // CHECK:     [[x1]] = const 0_i32;
     let x1 = match e1 { E::V1(x11) => x11, E::V2(x12) => x12 };

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.32bit.diff
@@ -27,21 +27,21 @@
 +         _1 = const E::V1(0_i32);
           StorageLive(_2);
 -         _3 = discriminant(_1);
--         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         _3 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb1, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_5);
           _5 = ((_1 as V2).0: i32);
           _2 = _5;
           StorageDead(_5);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.simple.DataflowConstProp.64bit.diff
@@ -27,21 +27,21 @@
 +         _1 = const E::V1(0_i32);
           StorageLive(_2);
 -         _3 = discriminant(_1);
--         switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+-         switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         _3 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb1, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_5);
           _5 = ((_1 as V2).0: i32);
           _2 = _5;
           StorageDead(_5);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.32bit.diff
@@ -49,21 +49,21 @@
           StorageDead(_2);
           StorageLive(_3);
 -         _4 = discriminant(_1);
--         switchInt(move _4) -> [0: bb3, 1: bb1, otherwise: bb2];
+-         switchInt(move _4) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         _4 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb1, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_6);
           _6 = ((_1 as V2).0: i32);
           _3 = _6;
           StorageDead(_6);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -84,7 +84,7 @@
           StorageDead(_8);
           StorageLive(_9);
           _10 = discriminant((*_7));
-          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb2];
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {

--- a/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
+++ b/tests/mir-opt/dataflow-const-prop/enum.statics.DataflowConstProp.64bit.diff
@@ -49,21 +49,21 @@
           StorageDead(_2);
           StorageLive(_3);
 -         _4 = discriminant(_1);
--         switchInt(move _4) -> [0: bb3, 1: bb1, otherwise: bb2];
+-         switchInt(move _4) -> [0: bb3, 1: bb2, otherwise: bb1];
 +         _4 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb1, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_6);
           _6 = ((_1 as V2).0: i32);
           _3 = _6;
           StorageDead(_6);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -84,7 +84,7 @@
           StorageDead(_8);
           StorageLive(_9);
           _10 = discriminant((*_7));
-          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb2];
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {

--- a/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-abort.diff
+++ b/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-abort.diff
@@ -25,58 +25,66 @@
           _7 = Len((*_2));
           _8 = const 4_usize;
           _9 = Ge(move _7, move _8);
-          switchInt(move _9) -> [0: bb6, otherwise: bb2];
+-         switchInt(move _9) -> [0: bb2, otherwise: bb7];
++         switchInt(move _9) -> [0: bb2, otherwise: bb6];
       }
   
       bb2: {
-          switchInt((*_2)[0 of 4]) -> [47: bb3, otherwise: bb6];
-      }
-  
-      bb3: {
-          switchInt((*_2)[1 of 4]) -> [47: bb4, otherwise: bb6];
-      }
-  
-      bb4: {
-          switchInt((*_2)[2 of 4]) -> [47: bb5, otherwise: bb6];
-      }
-  
-      bb5: {
--         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb6];
-+         switchInt((*_2)[3 of 4]) -> [47: bb10, otherwise: bb6];
-      }
-  
-      bb6: {
           _4 = Len((*_2));
           _5 = const 3_usize;
           _6 = Ge(move _4, move _5);
-          switchInt(move _6) -> [0: bb10, otherwise: bb7];
+-         switchInt(move _6) -> [0: bb3, otherwise: bb4];
++         switchInt(move _6) -> [0: bb10, otherwise: bb3];
       }
   
-      bb7: {
-          switchInt((*_2)[0 of 3]) -> [47: bb8, otherwise: bb10];
+      bb3: {
+-         _0 = const false;
+-         goto -> bb14;
++         switchInt((*_2)[0 of 3]) -> [47: bb4, otherwise: bb10];
       }
   
-      bb8: {
-          switchInt((*_2)[1 of 3]) -> [47: bb9, otherwise: bb10];
+      bb4: {
+-         switchInt((*_2)[0 of 3]) -> [47: bb5, otherwise: bb3];
++         switchInt((*_2)[1 of 3]) -> [47: bb5, otherwise: bb10];
       }
   
-      bb9: {
--         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb13, otherwise: bb10];
+      bb5: {
+-         switchInt((*_2)[1 of 3]) -> [47: bb6, otherwise: bb3];
 +         switchInt((*_2)[2 of 3]) -> [47: bb11, 33: bb11, otherwise: bb10];
       }
   
+      bb6: {
+-         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb13, otherwise: bb3];
++         switchInt((*_2)[0 of 4]) -> [47: bb7, otherwise: bb2];
+      }
+  
+      bb7: {
+-         switchInt((*_2)[0 of 4]) -> [47: bb8, otherwise: bb2];
++         switchInt((*_2)[1 of 4]) -> [47: bb8, otherwise: bb2];
+      }
+  
+      bb8: {
+-         switchInt((*_2)[1 of 4]) -> [47: bb9, otherwise: bb2];
++         switchInt((*_2)[2 of 4]) -> [47: bb9, otherwise: bb2];
+      }
+  
+      bb9: {
+-         switchInt((*_2)[2 of 4]) -> [47: bb10, otherwise: bb2];
++         switchInt((*_2)[3 of 4]) -> [47: bb10, otherwise: bb2];
+      }
+  
       bb10: {
+-         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb2];
+-     }
+- 
+-     bb11: {
           _0 = const false;
 -         goto -> bb14;
 +         goto -> bb12;
       }
   
-      bb11: {
--         _0 = const false;
--         goto -> bb14;
--     }
-- 
 -     bb12: {
++     bb11: {
           _0 = const true;
 -         goto -> bb14;
 +         goto -> bb12;

--- a/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-unwind.diff
+++ b/tests/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.panic-unwind.diff
@@ -25,58 +25,66 @@
           _7 = Len((*_2));
           _8 = const 4_usize;
           _9 = Ge(move _7, move _8);
-          switchInt(move _9) -> [0: bb6, otherwise: bb2];
+-         switchInt(move _9) -> [0: bb2, otherwise: bb7];
++         switchInt(move _9) -> [0: bb2, otherwise: bb6];
       }
   
       bb2: {
-          switchInt((*_2)[0 of 4]) -> [47: bb3, otherwise: bb6];
-      }
-  
-      bb3: {
-          switchInt((*_2)[1 of 4]) -> [47: bb4, otherwise: bb6];
-      }
-  
-      bb4: {
-          switchInt((*_2)[2 of 4]) -> [47: bb5, otherwise: bb6];
-      }
-  
-      bb5: {
--         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb6];
-+         switchInt((*_2)[3 of 4]) -> [47: bb10, otherwise: bb6];
-      }
-  
-      bb6: {
           _4 = Len((*_2));
           _5 = const 3_usize;
           _6 = Ge(move _4, move _5);
-          switchInt(move _6) -> [0: bb10, otherwise: bb7];
+-         switchInt(move _6) -> [0: bb3, otherwise: bb4];
++         switchInt(move _6) -> [0: bb10, otherwise: bb3];
       }
   
-      bb7: {
-          switchInt((*_2)[0 of 3]) -> [47: bb8, otherwise: bb10];
+      bb3: {
+-         _0 = const false;
+-         goto -> bb14;
++         switchInt((*_2)[0 of 3]) -> [47: bb4, otherwise: bb10];
       }
   
-      bb8: {
-          switchInt((*_2)[1 of 3]) -> [47: bb9, otherwise: bb10];
+      bb4: {
+-         switchInt((*_2)[0 of 3]) -> [47: bb5, otherwise: bb3];
++         switchInt((*_2)[1 of 3]) -> [47: bb5, otherwise: bb10];
       }
   
-      bb9: {
--         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb13, otherwise: bb10];
+      bb5: {
+-         switchInt((*_2)[1 of 3]) -> [47: bb6, otherwise: bb3];
 +         switchInt((*_2)[2 of 3]) -> [47: bb11, 33: bb11, otherwise: bb10];
       }
   
+      bb6: {
+-         switchInt((*_2)[2 of 3]) -> [47: bb12, 33: bb13, otherwise: bb3];
++         switchInt((*_2)[0 of 4]) -> [47: bb7, otherwise: bb2];
+      }
+  
+      bb7: {
+-         switchInt((*_2)[0 of 4]) -> [47: bb8, otherwise: bb2];
++         switchInt((*_2)[1 of 4]) -> [47: bb8, otherwise: bb2];
+      }
+  
+      bb8: {
+-         switchInt((*_2)[1 of 4]) -> [47: bb9, otherwise: bb2];
++         switchInt((*_2)[2 of 4]) -> [47: bb9, otherwise: bb2];
+      }
+  
+      bb9: {
+-         switchInt((*_2)[2 of 4]) -> [47: bb10, otherwise: bb2];
++         switchInt((*_2)[3 of 4]) -> [47: bb10, otherwise: bb2];
+      }
+  
       bb10: {
+-         switchInt((*_2)[3 of 4]) -> [47: bb11, otherwise: bb2];
+-     }
+- 
+-     bb11: {
           _0 = const false;
 -         goto -> bb14;
 +         goto -> bb12;
       }
   
-      bb11: {
--         _0 = const false;
--         goto -> bb14;
--     }
-- 
 -     bb12: {
++     bb11: {
           _0 = const true;
 -         goto -> bb14;
 +         goto -> bb12;

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-abort.diff
@@ -55,10 +55,14 @@
           StorageDead(_8);
           PlaceMention(_7);
           _10 = discriminant(_7);
-          switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5];
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb4];
       }
   
       bb4: {
+          unreachable;
+      }
+  
+      bb5: {
           StorageLive(_12);
 -         _12 = (*((_7 as Some).0: &i32));
 +         _15 = deref_copy ((_7 as Some).0: &i32);
@@ -66,10 +70,6 @@
           StorageLive(_13);
           _13 = _12;
           _6 = std::mem::drop::<i32>(move _13) -> [return: bb7, unwind: bb8];
-      }
-  
-      bb5: {
-          unreachable;
       }
   
       bb6: {

--- a/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_complex_case.main.Derefer.panic-unwind.diff
@@ -55,10 +55,14 @@
           StorageDead(_8);
           PlaceMention(_7);
           _10 = discriminant(_7);
-          switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5];
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb4];
       }
   
       bb4: {
+          unreachable;
+      }
+  
+      bb5: {
           StorageLive(_12);
 -         _12 = (*((_7 as Some).0: &i32));
 +         _15 = deref_copy ((_7 as Some).0: &i32);
@@ -66,10 +70,6 @@
           StorageLive(_13);
           _13 = _12;
           _6 = std::mem::drop::<i32>(move _13) -> [return: bb7, unwind continue];
-      }
-  
-      bb5: {
-          unreachable;
       }
   
       bb6: {

--- a/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -30,7 +30,7 @@
           StorageDead(_5);
           StorageDead(_4);
           _8 = discriminant((_3.0: std::option::Option<u32>));
--         switchInt(move _8) -> [0: bb1, 1: bb3, otherwise: bb2];
+-         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb1];
 +         StorageLive(_11);
 +         _11 = discriminant((_3.1: std::option::Option<u32>));
 +         StorageLive(_12);
@@ -40,24 +40,23 @@
       }
   
       bb1: {
--         _6 = discriminant((_3.1: std::option::Option<u32>));
--         switchInt(move _6) -> [0: bb5, otherwise: bb2];
--     }
-- 
--     bb2: {
 +         StorageDead(_12);
           _0 = const 1_u32;
 -         goto -> bb6;
 +         goto -> bb4;
       }
   
+      bb2: {
+-         _6 = discriminant((_3.1: std::option::Option<u32>));
+-         switchInt(move _6) -> [0: bb5, otherwise: bb1];
+-     }
+- 
 -     bb3: {
 -         _7 = discriminant((_3.1: std::option::Option<u32>));
--         switchInt(move _7) -> [1: bb4, otherwise: bb2];
+-         switchInt(move _7) -> [1: bb4, otherwise: bb1];
 -     }
 - 
 -     bb4: {
-+     bb2: {
           StorageLive(_10);
           _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
           StorageLive(_9);

--- a/tests/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -78,16 +78,10 @@
           StorageDead(_5);
           _34 = deref_copy (_4.0: &ViewportPercentageLength);
           _11 = discriminant((*_34));
-          switchInt(move _11) -> [0: bb1, 1: bb3, 2: bb4, 3: bb5, otherwise: bb2];
+          switchInt(move _11) -> [0: bb2, 1: bb3, 2: bb4, 3: bb5, otherwise: bb1];
       }
   
       bb1: {
-          _35 = deref_copy (_4.1: &ViewportPercentageLength);
-          _7 = discriminant((*_35));
-          switchInt(move _7) -> [0: bb6, otherwise: bb2];
-      }
-  
-      bb2: {
           StorageLive(_33);
           _33 = ();
           _0 = Result::<ViewportPercentageLength, ()>::Err(move _33);
@@ -97,22 +91,28 @@
           goto -> bb11;
       }
   
+      bb2: {
+          _35 = deref_copy (_4.1: &ViewportPercentageLength);
+          _7 = discriminant((*_35));
+          switchInt(move _7) -> [0: bb6, otherwise: bb1];
+      }
+  
       bb3: {
           _36 = deref_copy (_4.1: &ViewportPercentageLength);
           _8 = discriminant((*_36));
-          switchInt(move _8) -> [1: bb7, otherwise: bb2];
+          switchInt(move _8) -> [1: bb7, otherwise: bb1];
       }
   
       bb4: {
           _37 = deref_copy (_4.1: &ViewportPercentageLength);
           _9 = discriminant((*_37));
-          switchInt(move _9) -> [2: bb8, otherwise: bb2];
+          switchInt(move _9) -> [2: bb8, otherwise: bb1];
       }
   
       bb5: {
           _38 = deref_copy (_4.1: &ViewportPercentageLength);
           _10 = discriminant((*_38));
-          switchInt(move _10) -> [3: bb9, otherwise: bb2];
+          switchInt(move _10) -> [3: bb9, otherwise: bb1];
       }
   
       bb6: {

--- a/tests/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -36,26 +36,26 @@
           StorageDead(_5);
           StorageDead(_4);
           _8 = discriminant((_3.0: std::option::Option<u32>));
-          switchInt(move _8) -> [0: bb1, 1: bb4, otherwise: bb3];
+          switchInt(move _8) -> [0: bb2, 1: bb4, otherwise: bb1];
       }
   
       bb1: {
-          _6 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _6) -> [0: bb2, 1: bb7, otherwise: bb3];
+          unreachable;
       }
   
       bb2: {
+          _6 = discriminant((_3.1: std::option::Option<u32>));
+          switchInt(move _6) -> [0: bb3, 1: bb7, otherwise: bb1];
+      }
+  
+      bb3: {
           _0 = const 3_u32;
           goto -> bb8;
       }
   
-      bb3: {
-          unreachable;
-      }
-  
       bb4: {
           _7 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _7) -> [0: bb6, 1: bb5, otherwise: bb3];
+          switchInt(move _7) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-abort.diff
@@ -21,18 +21,18 @@
 +         _2 = Option::<T>::Some(_1);
           StorageDead(_3);
 -         _4 = discriminant(_2);
--         switchInt(move _4) -> [0: bb1, 1: bb3, otherwise: bb2];
+-         switchInt(move _4) -> [0: bb2, 1: bb3, otherwise: bb1];
 +         _4 = const 1_isize;
-+         switchInt(const 1_isize) -> [0: bb1, 1: bb3, otherwise: bb2];
++         switchInt(const 1_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
       bb1: {
-          StorageLive(_6);
-          _6 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+          unreachable;
       }
   
       bb2: {
-          unreachable;
+          StorageLive(_6);
+          _6 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.wrap_unwrap.GVN.panic-unwind.diff
@@ -21,18 +21,18 @@
 +         _2 = Option::<T>::Some(_1);
           StorageDead(_3);
 -         _4 = discriminant(_2);
--         switchInt(move _4) -> [0: bb1, 1: bb3, otherwise: bb2];
+-         switchInt(move _4) -> [0: bb2, 1: bb3, otherwise: bb1];
 +         _4 = const 1_isize;
-+         switchInt(const 1_isize) -> [0: bb1, 1: bb3, otherwise: bb2];
++         switchInt(const 1_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
       bb1: {
-          StorageLive(_6);
-          _6 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
+          unreachable;
       }
   
       bb2: {
-          unreachable;
+          StorageLive(_6);
+          _6 = begin_panic::<&str>(const "explicit panic") -> unwind continue;
       }
   
       bb3: {

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -28,18 +28,18 @@
 +         StorageLive(_3);
 +         StorageLive(_5);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb1, 1: bb3, otherwise: bb2];
++         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
       bb1: {
-+         StorageLive(_4);
-+         _4 = cfg!(debug_assertions);
-+         assume(_4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb2, unwind unreachable];
++         unreachable;
 +     }
 + 
 +     bb2: {
-+         unreachable;
++         StorageLive(_4);
++         _4 = cfg!(debug_assertions);
++         assume(_4);
++         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -28,22 +28,22 @@
 +         StorageLive(_3);
 +         StorageLive(_5);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb1, 1: bb3, otherwise: bb2];
++         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
       bb1: {
 -         StorageDead(_2);
 -         return;
-+         StorageLive(_4);
-+         _4 = cfg!(debug_assertions);
-+         assume(_4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb2, unwind unreachable];
++         unreachable;
       }
   
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         unreachable;
++         StorageLive(_4);
++         _4 = cfg!(debug_assertions);
++         assume(_4);
++         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-abort.mir
@@ -47,20 +47,20 @@ fn test() -> Option<Box<u32>> {
         StorageDead(_7);
         PlaceMention(_6);
         _8 = discriminant(_6);
-        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb4];
+        switchInt(move _8) -> [0: bb4, 1: bb5, otherwise: bb3];
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         StorageLive(_12);
         _12 = ((_6 as Continue).0: u32);
         (*_5) = _12;
         StorageDead(_12);
         _1 = move _5;
         drop(_5) -> [return: bb7, unwind: bb11];
-    }
-
-    bb4: {
-        unreachable;
     }
 
     bb5: {

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.before.panic-unwind.mir
@@ -47,20 +47,20 @@ fn test() -> Option<Box<u32>> {
         StorageDead(_7);
         PlaceMention(_6);
         _8 = discriminant(_6);
-        switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb4];
+        switchInt(move _8) -> [0: bb4, 1: bb5, otherwise: bb3];
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         StorageLive(_12);
         _12 = ((_6 as Continue).0: u32);
         (*_5) = _12;
         StorageDead(_12);
         _1 = move _5;
         drop(_5) -> [return: bb7, unwind: bb11];
-    }
-
-    bb4: {
-        unreachable;
     }
 
     bb5: {

--- a/tests/mir-opt/issue_72181.bar.built.after.mir
+++ b/tests/mir-opt/issue_72181.bar.built.after.mir
@@ -14,4 +14,9 @@ fn bar(_1: [(Never, u32); 1]) -> u32 {
         StorageDead(_2);
         return;
     }
+
+    bb1: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
 }

--- a/tests/mir-opt/issue_72181.main.built.after.mir
+++ b/tests/mir-opt/issue_72181.main.built.after.mir
@@ -22,7 +22,7 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);
-        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb3];
+        _1 = std::mem::size_of::<Foo>() -> [return: bb1, unwind: bb5];
     }
 
     bb1: {
@@ -42,10 +42,15 @@ fn main() -> () {
         _6 = const 0_usize;
         _7 = Len(_2);
         _8 = Lt(_6, _7);
-        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb2, unwind: bb3];
+        assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> [success: bb3, unwind: bb5];
     }
 
     bb2: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb3: {
         _5 = (_2[_6].0: u64);
         PlaceMention(_5);
         StorageDead(_6);
@@ -55,7 +60,12 @@ fn main() -> () {
         return;
     }
 
-    bb3 (cleanup): {
+    bb4: {
+        FakeRead(ForMatchedPlace(None), _5);
+        unreachable;
+    }
+
+    bb5 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_72181_1.f.built.after.mir
+++ b/tests/mir-opt/issue_72181_1.f.built.after.mir
@@ -6,11 +6,15 @@ fn f(_1: Void) -> ! {
 
     bb0: {
         PlaceMention(_1);
+        goto -> bb1;
+    }
+
+    bb1: {
         FakeRead(ForMatchedPlace(None), _1);
         unreachable;
     }
 
-    bb1: {
+    bb2: {
         return;
     }
 }

--- a/tests/mir-opt/issue_91633.bar.built.after.mir
+++ b/tests/mir-opt/issue_91633.bar.built.after.mir
@@ -12,7 +12,7 @@ fn bar(_1: Box<[T]>) -> () {
         StorageLive(_2);
         StorageLive(_3);
         _3 = &(*_1);
-        _2 = <[T] as Index<usize>>::index(move _3, const 0_usize) -> [return: bb1, unwind: bb3];
+        _2 = <[T] as Index<usize>>::index(move _3, const 0_usize) -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
@@ -20,18 +20,23 @@ fn bar(_1: Box<[T]>) -> () {
         PlaceMention((*_2));
         StorageDead(_2);
         _0 = const ();
-        drop(_1) -> [return: bb2, unwind: bb4];
+        drop(_1) -> [return: bb3, unwind: bb5];
     }
 
     bb2: {
+        FakeRead(ForMatchedPlace(None), (*_2));
+        unreachable;
+    }
+
+    bb3: {
         return;
     }
 
-    bb3 (cleanup): {
-        drop(_1) -> [return: bb4, unwind terminate(cleanup)];
+    bb4 (cleanup): {
+        drop(_1) -> [return: bb5, unwind terminate(cleanup)];
     }
 
-    bb4 (cleanup): {
+    bb5 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_91633.hey.built.after.mir
+++ b/tests/mir-opt/issue_91633.hey.built.after.mir
@@ -14,7 +14,7 @@ fn hey(_1: &[T]) -> () {
         StorageLive(_3);
         StorageLive(_4);
         _4 = &(*_1);
-        _3 = <[T] as Index<usize>>::index(move _4, const 0_usize) -> [return: bb1, unwind: bb2];
+        _3 = <[T] as Index<usize>>::index(move _4, const 0_usize) -> [return: bb1, unwind: bb3];
     }
 
     bb1: {
@@ -27,7 +27,12 @@ fn hey(_1: &[T]) -> () {
         return;
     }
 
-    bb2 (cleanup): {
+    bb2: {
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
+    }
+
+    bb3 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_99325.main.built.after.32bit.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.32bit.mir
@@ -67,7 +67,7 @@ fn main() -> () {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb21];
+        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb23];
     }
 
     bb1: {
@@ -91,24 +91,29 @@ fn main() -> () {
         _11 = &(*_8);
         StorageLive(_12);
         _12 = &(*_9);
-        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb2, unwind: bb21];
+        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb3, unwind: bb23];
     }
 
     bb2: {
-        switchInt(move _10) -> [0: bb4, otherwise: bb3];
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
     }
 
     bb3: {
-        StorageDead(_12);
-        StorageDead(_11);
-        goto -> bb8;
+        switchInt(move _10) -> [0: bb5, otherwise: bb4];
     }
 
     bb4: {
-        goto -> bb5;
+        StorageDead(_12);
+        StorageDead(_11);
+        goto -> bb9;
     }
 
     bb5: {
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_12);
         StorageDead(_11);
         StorageLive(_14);
@@ -127,10 +132,10 @@ fn main() -> () {
         _19 = &(*_20);
         StorageLive(_21);
         _21 = Option::<Arguments<'_>>::None;
-        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> bb21;
+        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> bb23;
     }
 
-    bb6: {
+    bb7: {
         StorageDead(_21);
         StorageDead(_19);
         StorageDead(_17);
@@ -142,23 +147,23 @@ fn main() -> () {
         unreachable;
     }
 
-    bb7: {
-        goto -> bb9;
-    }
-
     bb8: {
-        _1 = const ();
-        goto -> bb9;
+        goto -> bb10;
     }
 
     bb9: {
-        StorageDead(_10);
-        StorageDead(_9);
-        StorageDead(_8);
+        _1 = const ();
         goto -> bb10;
     }
 
     bb10: {
+        StorageDead(_10);
+        StorageDead(_9);
+        StorageDead(_8);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
@@ -168,10 +173,10 @@ fn main() -> () {
         StorageLive(_23);
         StorageLive(_24);
         StorageLive(_25);
-        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb11, unwind: bb21];
+        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb12, unwind: bb23];
     }
 
-    bb11: {
+    bb12: {
         _24 = &_25;
         StorageLive(_26);
         StorageLive(_27);
@@ -190,24 +195,29 @@ fn main() -> () {
         _31 = &(*_28);
         StorageLive(_32);
         _32 = &(*_29);
-        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb12, unwind: bb21];
-    }
-
-    bb12: {
-        switchInt(move _30) -> [0: bb14, otherwise: bb13];
+        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb14, unwind: bb23];
     }
 
     bb13: {
-        StorageDead(_32);
-        StorageDead(_31);
-        goto -> bb18;
+        FakeRead(ForMatchedPlace(None), _23);
+        unreachable;
     }
 
     bb14: {
-        goto -> bb15;
+        switchInt(move _30) -> [0: bb16, otherwise: bb15];
     }
 
     bb15: {
+        StorageDead(_32);
+        StorageDead(_31);
+        goto -> bb20;
+    }
+
+    bb16: {
+        goto -> bb17;
+    }
+
+    bb17: {
         StorageDead(_32);
         StorageDead(_31);
         StorageLive(_34);
@@ -226,10 +236,10 @@ fn main() -> () {
         _39 = &(*_40);
         StorageLive(_41);
         _41 = Option::<Arguments<'_>>::None;
-        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> bb21;
+        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> bb23;
     }
 
-    bb16: {
+    bb18: {
         StorageDead(_41);
         StorageDead(_39);
         StorageDead(_37);
@@ -241,23 +251,23 @@ fn main() -> () {
         unreachable;
     }
 
-    bb17: {
-        goto -> bb19;
-    }
-
-    bb18: {
-        _22 = const ();
-        goto -> bb19;
-    }
-
     bb19: {
-        StorageDead(_30);
-        StorageDead(_29);
-        StorageDead(_28);
-        goto -> bb20;
+        goto -> bb21;
     }
 
     bb20: {
+        _22 = const ();
+        goto -> bb21;
+    }
+
+    bb21: {
+        StorageDead(_30);
+        StorageDead(_29);
+        StorageDead(_28);
+        goto -> bb22;
+    }
+
+    bb22: {
         StorageDead(_27);
         StorageDead(_25);
         StorageDead(_23);
@@ -266,7 +276,7 @@ fn main() -> () {
         return;
     }
 
-    bb21 (cleanup): {
+    bb23 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_99325.main.built.after.64bit.mir
+++ b/tests/mir-opt/issue_99325.main.built.after.64bit.mir
@@ -67,7 +67,7 @@ fn main() -> () {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb21];
+        _4 = function_with_bytes::<&*b"AAAA">() -> [return: bb1, unwind: bb23];
     }
 
     bb1: {
@@ -91,24 +91,29 @@ fn main() -> () {
         _11 = &(*_8);
         StorageLive(_12);
         _12 = &(*_9);
-        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb2, unwind: bb21];
+        _10 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _11, move _12) -> [return: bb3, unwind: bb23];
     }
 
     bb2: {
-        switchInt(move _10) -> [0: bb4, otherwise: bb3];
+        FakeRead(ForMatchedPlace(None), _2);
+        unreachable;
     }
 
     bb3: {
-        StorageDead(_12);
-        StorageDead(_11);
-        goto -> bb8;
+        switchInt(move _10) -> [0: bb5, otherwise: bb4];
     }
 
     bb4: {
-        goto -> bb5;
+        StorageDead(_12);
+        StorageDead(_11);
+        goto -> bb9;
     }
 
     bb5: {
+        goto -> bb6;
+    }
+
+    bb6: {
         StorageDead(_12);
         StorageDead(_11);
         StorageLive(_14);
@@ -127,10 +132,10 @@ fn main() -> () {
         _19 = &(*_20);
         StorageLive(_21);
         _21 = Option::<Arguments<'_>>::None;
-        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> bb21;
+        _15 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _16, move _17, move _19, move _21) -> bb23;
     }
 
-    bb6: {
+    bb7: {
         StorageDead(_21);
         StorageDead(_19);
         StorageDead(_17);
@@ -142,23 +147,23 @@ fn main() -> () {
         unreachable;
     }
 
-    bb7: {
-        goto -> bb9;
-    }
-
     bb8: {
-        _1 = const ();
-        goto -> bb9;
+        goto -> bb10;
     }
 
     bb9: {
-        StorageDead(_10);
-        StorageDead(_9);
-        StorageDead(_8);
+        _1 = const ();
         goto -> bb10;
     }
 
     bb10: {
+        StorageDead(_10);
+        StorageDead(_9);
+        StorageDead(_8);
+        goto -> bb11;
+    }
+
+    bb11: {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_4);
@@ -168,10 +173,10 @@ fn main() -> () {
         StorageLive(_23);
         StorageLive(_24);
         StorageLive(_25);
-        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb11, unwind: bb21];
+        _25 = function_with_bytes::<&*b"AAAA">() -> [return: bb12, unwind: bb23];
     }
 
-    bb11: {
+    bb12: {
         _24 = &_25;
         StorageLive(_26);
         StorageLive(_27);
@@ -190,24 +195,29 @@ fn main() -> () {
         _31 = &(*_28);
         StorageLive(_32);
         _32 = &(*_29);
-        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb12, unwind: bb21];
-    }
-
-    bb12: {
-        switchInt(move _30) -> [0: bb14, otherwise: bb13];
+        _30 = <&[u8] as PartialEq<&[u8; 4]>>::eq(move _31, move _32) -> [return: bb14, unwind: bb23];
     }
 
     bb13: {
-        StorageDead(_32);
-        StorageDead(_31);
-        goto -> bb18;
+        FakeRead(ForMatchedPlace(None), _23);
+        unreachable;
     }
 
     bb14: {
-        goto -> bb15;
+        switchInt(move _30) -> [0: bb16, otherwise: bb15];
     }
 
     bb15: {
+        StorageDead(_32);
+        StorageDead(_31);
+        goto -> bb20;
+    }
+
+    bb16: {
+        goto -> bb17;
+    }
+
+    bb17: {
         StorageDead(_32);
         StorageDead(_31);
         StorageLive(_34);
@@ -226,10 +236,10 @@ fn main() -> () {
         _39 = &(*_40);
         StorageLive(_41);
         _41 = Option::<Arguments<'_>>::None;
-        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> bb21;
+        _35 = core::panicking::assert_failed::<&[u8], &[u8; 4]>(move _36, move _37, move _39, move _41) -> bb23;
     }
 
-    bb16: {
+    bb18: {
         StorageDead(_41);
         StorageDead(_39);
         StorageDead(_37);
@@ -241,23 +251,23 @@ fn main() -> () {
         unreachable;
     }
 
-    bb17: {
-        goto -> bb19;
-    }
-
-    bb18: {
-        _22 = const ();
-        goto -> bb19;
-    }
-
     bb19: {
-        StorageDead(_30);
-        StorageDead(_29);
-        StorageDead(_28);
-        goto -> bb20;
+        goto -> bb21;
     }
 
     bb20: {
+        _22 = const ();
+        goto -> bb21;
+    }
+
+    bb21: {
+        StorageDead(_30);
+        StorageDead(_29);
+        StorageDead(_28);
+        goto -> bb22;
+    }
+
+    bb22: {
         StorageDead(_27);
         StorageDead(_25);
         StorageDead(_23);
@@ -266,7 +276,7 @@ fn main() -> () {
         return;
     }
 
-    bb21 (cleanup): {
+    bb23 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-abort.diff
@@ -24,18 +24,18 @@
   
       bb1: {
           _4 = discriminant(_1);
-          switchInt(move _4) -> [0: bb4, 1: bb5, 2: bb6, 3: bb2, otherwise: bb3];
+          switchInt(move _4) -> [0: bb4, 1: bb5, 2: bb6, 3: bb3, otherwise: bb2];
       }
   
       bb2: {
+          unreachable;
+      }
+  
+      bb3: {
           _0 = const ();
           StorageDead(_2);
           StorageDead(_1);
           return;
-      }
-  
-      bb3: {
-          unreachable;
       }
   
       bb4: {

--- a/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.dfa.JumpThreading.panic-unwind.diff
@@ -24,18 +24,18 @@
   
       bb1: {
           _4 = discriminant(_1);
-          switchInt(move _4) -> [0: bb4, 1: bb5, 2: bb6, 3: bb2, otherwise: bb3];
+          switchInt(move _4) -> [0: bb4, 1: bb5, 2: bb6, 3: bb3, otherwise: bb2];
       }
   
       bb2: {
+          unreachable;
+      }
+  
+      bb3: {
           _0 = const ();
           StorageDead(_2);
           StorageDead(_1);
           return;
-      }
-  
-      bb3: {
-          unreachable;
       }
   
       bb4: {

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
@@ -56,10 +56,14 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb2];
+          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_9);
           _9 = ((_3 as Continue).0: i32);
           _2 = _9;
@@ -68,10 +72,6 @@
           StorageDead(_2);
           StorageDead(_3);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -103,8 +103,8 @@
           StorageDead(_10);
           StorageDead(_4);
           _5 = discriminant(_3);
--         switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2];
-+         goto -> bb1;
+-         switchInt(move _5) -> [0: bb2, 1: bb3, otherwise: bb1];
++         goto -> bb2;
       }
   
       bb6: {

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
@@ -56,10 +56,14 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb2];
+          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_9);
           _9 = ((_3 as Continue).0: i32);
           _2 = _9;
@@ -68,10 +72,6 @@
           StorageDead(_2);
           StorageDead(_3);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -103,8 +103,8 @@
           StorageDead(_10);
           StorageDead(_4);
           _5 = discriminant(_3);
--         switchInt(move _5) -> [0: bb1, 1: bb3, otherwise: bb2];
-+         goto -> bb1;
+-         switchInt(move _5) -> [0: bb2, 1: bb3, otherwise: bb1];
++         goto -> bb2;
       }
   
       bb6: {

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -12,12 +12,12 @@ use std::ops::ControlFlow;
 fn too_complex(x: Result<i32, usize>) -> Option<i32> {
     // CHECK-LABEL: fn too_complex(
     // CHECK: bb0: {
-    // CHECK:     switchInt(move {{_.*}}) -> [0: bb3, 1: bb1, otherwise: bb2];
+    // CHECK:     switchInt(move {{_.*}}) -> [0: bb3, 1: bb2, otherwise: bb1];
     // CHECK: bb1: {
+    // CHECK:     unreachable;
+    // CHECK: bb2: {
     // CHECK:     [[controlflow:_.*]] = ControlFlow::<usize, i32>::Break(
     // CHECK:     goto -> bb8;
-    // CHECK: bb2: {
-    // CHECK:     unreachable;
     // CHECK: bb3: {
     // CHECK:     [[controlflow]] = ControlFlow::<usize, i32>::Continue(
     // CHECK:     goto -> bb4;
@@ -50,13 +50,13 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK-LABEL: fn identity(
     // CHECK: bb0: {
     // CHECK:     [[x:_.*]] = _1;
-    // CHECK:     switchInt(move {{_.*}}) -> [0: bb7, 1: bb6, otherwise: bb2];
+    // CHECK:     switchInt(move {{_.*}}) -> [0: bb7, 1: bb6, otherwise: bb1];
     // CHECK: bb1: {
+    // CHECK:     unreachable;
+    // CHECK: bb2: {
     // CHECK:     {{_.*}} = (([[controlflow:_.*]] as Continue).0: i32);
     // CHECK:     _0 = Result::<i32, i32>::Ok(
     // CHECK:     goto -> bb4;
-    // CHECK: bb2: {
-    // CHECK:     unreachable;
     // CHECK: bb3: {
     // CHECK:     {{_.*}} = (([[controlflow]] as Break).0: std::result::Result<std::convert::Infallible, i32>);
     // CHECK:     _0 = Result::<i32, i32>::Err(
@@ -64,7 +64,7 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK: bb4: {
     // CHECK:     return;
     // CHECK: bb5: {
-    // CHECK:     goto -> bb1;
+    // CHECK:     goto -> bb2;
     // CHECK: bb6: {
     // CHECK:     {{_.*}} = move (([[x]] as Err).0: i32);
     // CHECK:     [[controlflow]] = ControlFlow::<Result<Infallible, i32>, i32>::Break(
@@ -93,11 +93,11 @@ fn dfa() {
     // CHECK:     {{_.*}} = DFA::A;
     // CHECK:     goto -> bb1;
     // CHECK: bb1: {
-    // CHECK:     switchInt({{.*}}) -> [0: bb4, 1: bb5, 2: bb6, 3: bb2, otherwise: bb3];
+    // CHECK:     switchInt({{.*}}) -> [0: bb4, 1: bb5, 2: bb6, 3: bb3, otherwise: bb2];
     // CHECK: bb2: {
-    // CHECK:     return;
-    // CHECK: bb3: {
     // CHECK:     unreachable;
+    // CHECK: bb3: {
+    // CHECK:     return;
     // CHECK: bb4: {
     // CHECK:     {{_.*}} = DFA::B;
     // CHECK:     goto -> bb1;

--- a/tests/mir-opt/jump_threading.too_complex.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.too_complex.JumpThreading.panic-abort.diff
@@ -30,10 +30,14 @@
       bb0: {
           StorageLive(_2);
           _3 = discriminant(_1);
-          switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_6);
           _6 = ((_1 as Err).0: usize);
           StorageLive(_7);
@@ -43,10 +47,6 @@
           StorageDead(_6);
 -         goto -> bb4;
 +         goto -> bb8;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -62,7 +62,7 @@
   
       bb4: {
           _8 = discriminant(_2);
--         switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb2];
+-         switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb1];
 +         goto -> bb6;
       }
   

--- a/tests/mir-opt/jump_threading.too_complex.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.too_complex.JumpThreading.panic-unwind.diff
@@ -30,10 +30,14 @@
       bb0: {
           StorageLive(_2);
           _3 = discriminant(_1);
-          switchInt(move _3) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _3) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_6);
           _6 = ((_1 as Err).0: usize);
           StorageLive(_7);
@@ -43,10 +47,6 @@
           StorageDead(_6);
 -         goto -> bb4;
 +         goto -> bb8;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -62,7 +62,7 @@
   
       bb4: {
           _8 = discriminant(_2);
--         switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb2];
+-         switchInt(move _8) -> [0: bb6, 1: bb5, otherwise: bb1];
 +         goto -> bb6;
       }
   

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -32,33 +32,25 @@
   
       bb0: {
           PlaceMention(_2);
--         switchInt((_2.0: bool)) -> [0: bb1, otherwise: bb2];
+-         switchInt((_2.0: bool)) -> [0: bb6, otherwise: bb1];
 +         switchInt((_2.0: bool)) -> [0: bb5, otherwise: bb1];
       }
   
       bb1: {
--         falseEdge -> [real: bb8, imaginary: bb3];
+-         switchInt((_2.1: bool)) -> [0: bb5, otherwise: bb2];
 +         switchInt((_2.1: bool)) -> [0: bb10, otherwise: bb2];
       }
   
       bb2: {
--         switchInt((_2.1: bool)) -> [0: bb3, otherwise: bb4];
+-         switchInt((_2.0: bool)) -> [0: bb4, otherwise: bb3];
 +         switchInt((_2.0: bool)) -> [0: bb3, otherwise: bb17];
       }
   
       bb3: {
--         falseEdge -> [real: bb13, imaginary: bb5];
+-         falseEdge -> [real: bb20, imaginary: bb4];
 -     }
 - 
 -     bb4: {
--         switchInt((_2.0: bool)) -> [0: bb6, otherwise: bb5];
--     }
-- 
--     bb5: {
--         falseEdge -> [real: bb20, imaginary: bb6];
--     }
-- 
--     bb6: {
           StorageLive(_15);
           _15 = (_2.1: bool);
           StorageLive(_16);
@@ -67,6 +59,14 @@
 +         goto -> bb16;
       }
   
+-     bb5: {
+-         falseEdge -> [real: bb13, imaginary: bb3];
+-     }
+- 
+-     bb6: {
+-         falseEdge -> [real: bb8, imaginary: bb5];
+-     }
+- 
 -     bb7: {
 +     bb4: {
           _0 = const 1_i32;
@@ -127,7 +127,7 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageDead(_6);
--         falseEdge -> [real: bb2, imaginary: bb3];
+-         falseEdge -> [real: bb1, imaginary: bb5];
 +         goto -> bb1;
       }
   
@@ -184,7 +184,7 @@
           StorageDead(_12);
           StorageDead(_8);
           StorageDead(_6);
--         falseEdge -> [real: bb4, imaginary: bb5];
+-         falseEdge -> [real: bb2, imaginary: bb3];
 +         goto -> bb2;
       }
   

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -32,33 +32,25 @@
   
       bb0: {
           PlaceMention(_2);
--         switchInt((_2.0: bool)) -> [0: bb1, otherwise: bb2];
+-         switchInt((_2.0: bool)) -> [0: bb6, otherwise: bb1];
 +         switchInt((_2.0: bool)) -> [0: bb5, otherwise: bb1];
       }
   
       bb1: {
--         falseEdge -> [real: bb8, imaginary: bb3];
+-         switchInt((_2.1: bool)) -> [0: bb5, otherwise: bb2];
 +         switchInt((_2.1: bool)) -> [0: bb10, otherwise: bb2];
       }
   
       bb2: {
--         switchInt((_2.1: bool)) -> [0: bb3, otherwise: bb4];
+-         switchInt((_2.0: bool)) -> [0: bb4, otherwise: bb3];
 +         switchInt((_2.0: bool)) -> [0: bb3, otherwise: bb17];
       }
   
       bb3: {
--         falseEdge -> [real: bb13, imaginary: bb5];
+-         falseEdge -> [real: bb20, imaginary: bb4];
 -     }
 - 
 -     bb4: {
--         switchInt((_2.0: bool)) -> [0: bb6, otherwise: bb5];
--     }
-- 
--     bb5: {
--         falseEdge -> [real: bb20, imaginary: bb6];
--     }
-- 
--     bb6: {
           StorageLive(_15);
           _15 = (_2.1: bool);
           StorageLive(_16);
@@ -67,6 +59,14 @@
 +         goto -> bb16;
       }
   
+-     bb5: {
+-         falseEdge -> [real: bb13, imaginary: bb3];
+-     }
+- 
+-     bb6: {
+-         falseEdge -> [real: bb8, imaginary: bb5];
+-     }
+- 
 -     bb7: {
 +     bb4: {
           _0 = const 1_i32;
@@ -127,7 +127,7 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageDead(_6);
--         falseEdge -> [real: bb2, imaginary: bb3];
+-         falseEdge -> [real: bb1, imaginary: bb5];
 +         goto -> bb1;
       }
   
@@ -184,7 +184,7 @@
           StorageDead(_12);
           StorageDead(_8);
           StorageDead(_6);
--         falseEdge -> [real: bb4, imaginary: bb5];
+-         falseEdge -> [real: bb2, imaginary: bb3];
 +         goto -> bb2;
       }
   

--- a/tests/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/match_test.main.SimplifyCfg-initial.after.mir
@@ -32,12 +32,12 @@ fn main() -> () {
     }
 
     bb1: {
-        falseEdge -> [real: bb9, imaginary: bb4];
+        _3 = const 3_i32;
+        goto -> bb14;
     }
 
     bb2: {
-        _3 = const 3_i32;
-        goto -> bb14;
+        falseEdge -> [real: bb9, imaginary: bb4];
     }
 
     bb3: {
@@ -50,11 +50,11 @@ fn main() -> () {
     }
 
     bb5: {
-        switchInt(_1) -> [4294967295: bb6, otherwise: bb2];
+        switchInt(_1) -> [4294967295: bb6, otherwise: bb1];
     }
 
     bb6: {
-        falseEdge -> [real: bb13, imaginary: bb2];
+        falseEdge -> [real: bb13, imaginary: bb1];
     }
 
     bb7: {
@@ -64,7 +64,7 @@ fn main() -> () {
 
     bb8: {
         _7 = Lt(_1, const 10_i32);
-        switchInt(move _7) -> [0: bb3, otherwise: bb1];
+        switchInt(move _7) -> [0: bb3, otherwise: bb2];
     }
 
     bb9: {
@@ -83,7 +83,7 @@ fn main() -> () {
 
     bb11: {
         StorageDead(_9);
-        falseEdge -> [real: bb2, imaginary: bb4];
+        falseEdge -> [real: bb1, imaginary: bb4];
     }
 
     bb12: {

--- a/tests/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_u8.exhaustive_match.MatchBranchSimplification.diff
@@ -8,16 +8,16 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
-          _0 = const 1_u8;
-          goto -> bb4;
+          unreachable;
       }
   
       bb2: {
-          unreachable;
+          _0 = const 1_u8;
+          goto -> bb4;
       }
   
       bb3: {

--- a/tests/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_u8.exhaustive_match_i8.MatchBranchSimplification.diff
@@ -8,16 +8,16 @@
   
       bb0: {
           _2 = discriminant(_1);
-          switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
-          _0 = const 1_i8;
-          goto -> bb4;
+          unreachable;
       }
   
       bb2: {
-          unreachable;
+          _0 = const 1_i8;
+          goto -> bb4;
       }
   
       bb3: {

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.panic-abort.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.panic-abort.mir
@@ -15,16 +15,16 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb0: {
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb3, otherwise: bb2];
+        switchInt(move _2) -> [0: bb2, 1: bb3, otherwise: bb1];
     }
 
     bb1: {
-        StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
+        unreachable;
     }
 
     bb2: {
-        unreachable;
+        StorageLive(_4);
+        _4 = begin_panic::<&str>(const "explicit panic") -> unwind unreachable;
     }
 
     bb3: {

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.panic-unwind.mir
@@ -15,16 +15,16 @@ fn unwrap(_1: Option<T>) -> T {
 
     bb0: {
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb3, otherwise: bb2];
+        switchInt(move _2) -> [0: bb2, 1: bb3, otherwise: bb1];
     }
 
     bb1: {
-        StorageLive(_4);
-        _4 = begin_panic::<&str>(const "explicit panic") -> bb4;
+        unreachable;
     }
 
     bb2: {
-        unreachable;
+        StorageLive(_4);
+        _4 = begin_panic::<&str>(const "explicit panic") -> bb4;
     }
 
     bb3: {

--- a/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop.debuginfo.ReferencePropagation.diff
@@ -67,20 +67,20 @@
           StorageLive(_7);
           _7 = Option::<i32>::Some(const 0_i32);
           _8 = discriminant(_7);
-          switchInt(move _8) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _8) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_9);
           _27 = const _;
           _9 = &(((*_27) as Some).0: i32);
 -         _6 = const ();
           StorageDead(_9);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.panic-abort.diff
+++ b/tests/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.panic-abort.diff
@@ -55,10 +55,14 @@
       bb3: {
 -         StorageDead(_8);
           _10 = discriminant(_7);
-          switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5];
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb4];
       }
   
       bb4: {
+          unreachable;
+      }
+  
+      bb5: {
 -         StorageLive(_12);
           _12 = ((_7 as Some).0: i32);
 -         StorageLive(_13);
@@ -72,10 +76,6 @@
 -         StorageDead(_6);
           _5 = const ();
           goto -> bb2;
-      }
-  
-      bb5: {
-          unreachable;
       }
   
       bb6: {

--- a/tests/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.panic-unwind.diff
+++ b/tests/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.panic-unwind.diff
@@ -55,10 +55,14 @@
       bb3: {
 -         StorageDead(_8);
           _10 = discriminant(_7);
-          switchInt(move _10) -> [0: bb6, 1: bb4, otherwise: bb5];
+          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb4];
       }
   
       bb4: {
+          unreachable;
+      }
+  
+      bb5: {
 -         StorageLive(_12);
           _12 = ((_7 as Some).0: i32);
 -         StorageLive(_13);
@@ -72,10 +76,6 @@
 -         StorageDead(_6);
           _5 = const ();
           goto -> bb2;
-      }
-  
-      bb5: {
-          unreachable;
       }
   
       bb6: {

--- a/tests/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff
+++ b/tests/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff
@@ -18,10 +18,14 @@
 -         _5 = const false;
 -         _5 = const true;
           _2 = discriminant(_1);
-          switchInt(move _2) -> [0: bb3, 1: bb1, otherwise: bb2];
+          switchInt(move _2) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_3);
           _3 = move ((_1 as Some).0: std::boxed::Box<()>);
           StorageLive(_4);
@@ -30,10 +34,6 @@
           StorageDead(_4);
           StorageDead(_3);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/uninhabited_enum_branching.byref.UninhabitedEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_enum_branching.byref.UninhabitedEnumBranching.diff
@@ -30,20 +30,20 @@
           StorageLive(_4);
           _4 = &(_1.1: Test3);
           _5 = discriminant((*_4));
--         switchInt(move _5) -> [0: bb3, 1: bb4, 2: bb5, 3: bb1, otherwise: bb2];
-+         switchInt(move _5) -> [0: bb12, 1: bb12, 2: bb5, 3: bb1, otherwise: bb12];
+-         switchInt(move _5) -> [0: bb3, 1: bb4, 2: bb5, 3: bb2, otherwise: bb1];
++         switchInt(move _5) -> [0: bb12, 1: bb12, 2: bb5, 3: bb2, otherwise: bb12];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_8);
           _8 = const "D";
           _3 = &(*_8);
           StorageDead(_8);
           goto -> bb6;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {
@@ -72,7 +72,7 @@
           StorageDead(_3);
           StorageLive(_9);
           _10 = discriminant((_1.1: Test3));
--         switchInt(move _10) -> [0: bb8, 1: bb9, 2: bb10, 3: bb7, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb8, 1: bb9, 2: bb10, 3: bb7, otherwise: bb1];
 +         switchInt(move _10) -> [0: bb12, 1: bb12, 2: bb10, 3: bb7, otherwise: bb12];
       }
   

--- a/tests/mir-opt/uninhabited_enum_branching.custom_discriminant.UninhabitedEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_enum_branching.custom_discriminant.UninhabitedEnumBranching.diff
@@ -13,20 +13,20 @@
           StorageLive(_2);
           _2 = Test2::D;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [4: bb3, 5: bb1, otherwise: bb2];
-+         switchInt(move _3) -> [4: bb3, 5: bb1, otherwise: bb5];
+-         switchInt(move _3) -> [4: bb3, 5: bb2, otherwise: bb1];
++         switchInt(move _3) -> [4: bb3, 5: bb2, otherwise: bb5];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_4);
           _4 = const "E";
           _1 = &(*_4);
           StorageDead(_4);
           goto -> bb4;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/uninhabited_enum_branching.rs
+++ b/tests/mir-opt/uninhabited_enum_branching.rs
@@ -32,7 +32,7 @@ struct Plop {
 fn simple() {
     // CHECK-LABEL: fn simple(
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [0: [[unreachable:bb.*]], 1: [[unreachable]], 2: bb1, otherwise: [[unreachable]]];
+    // CHECK: switchInt(move [[discr]]) -> [0: [[unreachable:bb.*]], 1: [[unreachable]], 2: bb2, otherwise: [[unreachable]]];
     // CHECK: [[unreachable]]: {
     // CHECK-NEXT: unreachable;
     match Test1::C {
@@ -46,7 +46,7 @@ fn simple() {
 fn custom_discriminant() {
     // CHECK-LABEL: fn custom_discriminant(
     // CHECK: [[discr:_.*]] = discriminant(
-    // CHECK: switchInt(move [[discr]]) -> [4: bb3, 5: bb1, otherwise: bb5];
+    // CHECK: switchInt(move [[discr]]) -> [4: bb3, 5: bb2, otherwise: bb5];
     // CHECK: bb5: {
     // CHECK-NEXT: unreachable;
     match Test2::D {
@@ -61,7 +61,7 @@ fn byref() {
     let plop = Plop { xx: 51, test3: Test3::C };
 
     // CHECK: [[ref_discr:_.*]] = discriminant((*
-    // CHECK: switchInt(move [[ref_discr]]) -> [0: [[unreachable:bb.*]], 1: [[unreachable]], 2: bb5, 3: bb1, otherwise: [[unreachable]]];
+    // CHECK: switchInt(move [[ref_discr]]) -> [0: [[unreachable:bb.*]], 1: [[unreachable]], 2: bb5, 3: bb2, otherwise: [[unreachable]]];
     match &plop.test3 {
         Test3::A(_) => "A(Empty)",
         Test3::B(_) => "B(Empty)",

--- a/tests/mir-opt/uninhabited_enum_branching.simple.UninhabitedEnumBranching.diff
+++ b/tests/mir-opt/uninhabited_enum_branching.simple.UninhabitedEnumBranching.diff
@@ -14,20 +14,20 @@
           StorageLive(_2);
           _2 = Test1::C;
           _3 = discriminant(_2);
--         switchInt(move _3) -> [0: bb3, 1: bb4, 2: bb1, otherwise: bb2];
-+         switchInt(move _3) -> [0: bb6, 1: bb6, 2: bb1, otherwise: bb6];
+-         switchInt(move _3) -> [0: bb3, 1: bb4, 2: bb2, otherwise: bb1];
++         switchInt(move _3) -> [0: bb6, 1: bb6, 2: bb2, otherwise: bb6];
       }
   
       bb1: {
+          unreachable;
+      }
+  
+      bb2: {
           StorageLive(_5);
           _5 = const "C";
           _1 = &(*_5);
           StorageDead(_5);
           goto -> bb5;
-      }
-  
-      bb2: {
-          unreachable;
       }
   
       bb3: {

--- a/tests/mir-opt/unreachable.as_match.UnreachablePropagation.panic-abort.diff
+++ b/tests/mir-opt/unreachable.as_match.UnreachablePropagation.panic-abort.diff
@@ -19,20 +19,20 @@
   
       bb1: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [0: bb4, 1: bb2, otherwise: bb3];
+-         switchInt(move _2) -> [0: bb4, 1: bb3, otherwise: bb2];
 +         _5 = Eq(_2, const 0_isize);
 +         assume(move _5);
 +         goto -> bb4;
       }
   
       bb2: {
--         StorageLive(_3);
--         _3 = move ((_1 as Some).0: Empty);
--         StorageLive(_4);
           unreachable;
       }
   
       bb3: {
+-         StorageLive(_3);
+-         _3 = move ((_1 as Some).0: Empty);
+-         StorageLive(_4);
           unreachable;
       }
   

--- a/tests/mir-opt/unreachable.as_match.UnreachablePropagation.panic-unwind.diff
+++ b/tests/mir-opt/unreachable.as_match.UnreachablePropagation.panic-unwind.diff
@@ -19,20 +19,20 @@
   
       bb1: {
           _2 = discriminant(_1);
--         switchInt(move _2) -> [0: bb4, 1: bb2, otherwise: bb3];
+-         switchInt(move _2) -> [0: bb4, 1: bb3, otherwise: bb2];
 +         _5 = Eq(_2, const 0_isize);
 +         assume(move _5);
 +         goto -> bb4;
       }
   
       bb2: {
--         StorageLive(_3);
--         _3 = move ((_1 as Some).0: Empty);
--         StorageLive(_4);
           unreachable;
       }
   
       bb3: {
+-         StorageLive(_3);
+-         _3 = move ((_1 as Some).0: Empty);
+-         StorageLive(_4);
           unreachable;
       }
   


### PR DESCRIPTION
Match lowering was doing complicated things with block creation. As far as I can tell it was trying to avoid creating unneeded blocks, but of the three places that start out with `otherwise = &mut None`, two of them called `otherwise.unwrap_or_else(|| self.cfg.start_new_block())` anyway. As far as I can tell the only place where this PR makes a difference is in `lower_match_tree`, which did indeed sometimes avoid creating the unreachable final block + FakeRead. Unless this is important I propose we do the naive thing instead.

I have not checked all the graph isomorphisms by hand, but at a glance the test diff looks sensible.

r? @matthewjasper 