### PR TITLE
Update host LLVM on x64 Linux to LLVM 18

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-17.0.4
+LLVM=llvmorg-18.1.0
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
Updates host LLVM on Linux to `18.1.0`.