### PR TITLE
RustWrapper: adapt for llvm/llvm-project@a38152e2156

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1814,9 +1814,7 @@ extern "C" LLVMRustResult LLVMRustWriteImportLibrary(
     Path,
     ConvertedExports,
   #if LLVM_VERSION_GE(19, 0)
-  // FIXME: on everything but ARM64EC this argument is ignored. On that
-  // platform passing this value _may_ be incorrect.
-    ConvertedExports,
+    std::nullopt,
   #endif
     static_cast<llvm::COFF::MachineTypes>(Machine),
     MinGW);

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1813,6 +1813,11 @@ extern "C" LLVMRustResult LLVMRustWriteImportLibrary(
     ImportName,
     Path,
     ConvertedExports,
+  #if LLVM_VERSION_GE(19, 0)
+  // FIXME: on everything but ARM64EC this argument is ignored. On that
+  // platform passing this value _may_ be incorrect.
+    ConvertedExports,
+  #endif
     static_cast<llvm::COFF::MachineTypes>(Machine),
     MinGW);
   if (Error) {


### PR DESCRIPTION
I am only partially confident this is reasonable, and the argument is ignored on targets other than ARM64EC which appears to be some Windows 11 thing, and therefore I have no way to test.

@rustbot label: +llvm-main