### PR TITLE
perf: improve write_fmt to handle simple strings

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -430,6 +430,19 @@ impl<'a> Arguments<'a> {
             _ => None,
         }
     }
+
+    /// Same as `as_str`, but will only return a `Some` value if it can be determined at compile time.
+    #[inline]
+    const fn as_const_str(&self) -> Option<&'static str> {
+        let s = self.as_str();
+        // if unsafe { core::intrinsics::is_val_statically_known(matches!((self.pieces, self.args), ([], []) | ([_], []))) } {
+        if unsafe { core::intrinsics::is_val_statically_known(s) } {
+            s
+        } else {
+            None
+        }
+
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -1108,7 +1108,7 @@ pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
     if let Some(s) = args.as_str() { output.write_str(s) } else { write_internal(output, args) }
 }
 
-/// Actual implementation of the [`write`], but without the simple string optimization.
+/// Actual implementation of the [`write()`], but without the simple string optimization.
 fn write_internal(output: &mut dyn Write, args: Arguments<'_>) -> Result {
     let mut formatter = Formatter::new(output);
     let mut idx = 0;

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -442,7 +442,7 @@ impl<'a> Arguments<'a> {
     /// Same as [`Arguments::as_str`], but will only return `Some(s)` if it can be determined at compile time.
     #[must_use]
     #[inline]
-    const fn as_const_str(&self) -> Option<&'static str> {
+    fn as_const_str(&self) -> Option<&'static str> {
         let s = self.as_str();
         // SAFETY: both cases are valid as the result
         if unsafe { core::intrinsics::is_val_statically_known(s.is_some()) } { s } else { None }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -444,6 +444,7 @@ impl<'a> Arguments<'a> {
     #[inline]
     const fn as_const_str(&self) -> Option<&'static str> {
         let s = self.as_str();
+        // SAFETY: both cases are valid as the result
         if unsafe { core::intrinsics::is_val_statically_known(s.is_some()) } { s } else { None }
     }
 }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -201,14 +201,14 @@ pub trait Write {
         impl<W: Write + ?Sized> SpecWriteFmt for &mut W {
             #[inline]
             default fn spec_write_fmt(mut self, args: Arguments<'_>) -> Result {
-                write(&mut self, args)
+                if let Some(s) = args.as_str() { self.write_str(s) } else { write(&mut self, args) }
             }
         }
 
         impl<W: Write> SpecWriteFmt for &mut W {
             #[inline]
             fn spec_write_fmt(self, args: Arguments<'_>) -> Result {
-                write(self, args)
+                if let Some(s) = args.as_str() { self.write_str(s) } else { write(self, args) }
             }
         }
 
@@ -1582,8 +1582,9 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(format!("{:0>8}", Foo(2)), "Foo 2");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn write_fmt(&mut self, fmt: Arguments<'_>) -> Result {
-        write(self.buf, fmt)
+        if let Some(s) = fmt.as_str() { self.buf.write_str(s) } else { write(self.buf, fmt) }
     }
 
     /// Flags for formatting
@@ -2272,8 +2273,9 @@ impl Write for Formatter<'_> {
         self.buf.write_char(c)
     }
 
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
-        write(self.buf, args)
+        if let Some(s) = args.as_str() { self.buf.write_str(s) } else { write(self.buf, args) }
     }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -176,7 +176,6 @@
 #![feature(ip)]
 #![feature(ip_bits)]
 #![feature(is_ascii_octdigit)]
-#![feature(is_val_statically_known)]
 #![feature(isqrt)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(non_null_convenience)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -176,6 +176,7 @@
 #![feature(ip)]
 #![feature(ip_bits)]
 #![feature(is_ascii_octdigit)]
+#![feature(is_val_statically_known)]
 #![feature(isqrt)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(non_null_convenience)]


### PR DESCRIPTION
In case format string has no arguments, simplify its implementation with a direct call to `output.write_str(value)`. This builds on @dtolnay original [suggestion](https://github.com/serde-rs/serde/pull/2697#issuecomment-1940376414). This does not change any expectations because the original `fn write()` implementation calls `write_str` for parts of the format string.

```rust
write!(f, "text")  ->  f.write_str("text")
```

```diff
 /// [`write!`]: crate::write!
+#[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
+    if let Some(s) = args.as_str() { output.write_str(s) } else { write_internal(output, args) }
+}
+
+/// Actual implementation of the [`write`], but without the simple string optimization.
+fn write_internal(output: &mut dyn Write, args: Arguments<'_>) -> Result {
     let mut formatter = Formatter::new(output);
     let mut idx = 0;
```

* Hopefully it will improve the simple case for the https://github.com/rust-lang/rust/issues/99012
* Another related (original?) issues #10761
* Previous similar attempt to fix it by by @Kobzol #100700

CC: @m-ou-se as probably the biggest expert in everything `format!`