### PR TITLE
Fully stop using the HIR in trait impl checks

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -15,7 +15,7 @@ use rustc_infer::infer::{DefineOpaqueTypes, TyCtxtInferExt};
 use rustc_infer::traits::Obligation;
 use rustc_middle::ty::adjustment::CoerceUnsizedInfo;
 use rustc_middle::ty::{self, suggest_constraining_type_params, Ty, TyCtxt, TypeVisitableExt};
-use rustc_span::Span;
+use rustc_span::{Span, DUMMY_SP};
 use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
 use rustc_trait_selection::traits::misc::{
     type_allowed_to_implement_const_param_ty, type_allowed_to_implement_copy,
@@ -95,18 +95,20 @@ fn visit_implementation_of_copy(
     if let ty::ImplPolarity::Negative = tcx.impl_polarity(impl_did) {
         return Ok(());
     }
-    let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
 
-    let cause = traits::ObligationCause::misc(span, impl_did);
+    let cause = traits::ObligationCause::misc(DUMMY_SP, impl_did);
     match type_allowed_to_implement_copy(tcx, param_env, self_type, cause) {
         Ok(()) => Ok(()),
         Err(CopyImplementationError::InfringingFields(fields)) => {
+            let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
             Err(infringing_fields_error(tcx, fields, LangItem::Copy, impl_did, span))
         }
         Err(CopyImplementationError::NotAnAdt) => {
+            let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
             Err(tcx.dcx().emit_err(errors::CopyImplOnNonAdt { span }))
         }
         Err(CopyImplementationError::HasDestructor) => {
+            let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
             Err(tcx.dcx().emit_err(errors::CopyImplOnTypeWithDtor { span }))
         }
     }
@@ -124,15 +126,16 @@ fn visit_implementation_of_const_param_ty(
     if let ty::ImplPolarity::Negative = tcx.impl_polarity(impl_did) {
         return Ok(());
     }
-    let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
 
-    let cause = traits::ObligationCause::misc(span, impl_did);
+    let cause = traits::ObligationCause::misc(DUMMY_SP, impl_did);
     match type_allowed_to_implement_const_param_ty(tcx, param_env, self_type, cause) {
         Ok(()) => Ok(()),
         Err(ConstParamTyImplementationError::InfrigingFields(fields)) => {
+            let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
             Err(infringing_fields_error(tcx, fields, LangItem::ConstParamTy, impl_did, span))
         }
         Err(ConstParamTyImplementationError::NotAnAdtOrBuiltinAllowed) => {
+            let span = tcx.hir().expect_item(impl_did).expect_impl().self_ty.span;
             Err(tcx.dcx().emit_err(errors::ConstParamTyImplOnNonAdt { span }))
         }
     }

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -142,7 +142,7 @@ fn coherent_trait(tcx: TyCtxt<'_>, def_id: DefId) -> Result<(), ErrorGuaranteed>
 
         res = res.and(unsafety::check_item(tcx, impl_def_id, trait_header, trait_def));
         res = res.and(tcx.ensure().orphan_check_impl(impl_def_id));
-        res = res.and(builtin::check_trait(tcx, def_id, impl_def_id));
+        res = res.and(builtin::check_trait(tcx, def_id, impl_def_id, trait_header));
     }
 
     res

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -23,6 +23,7 @@ fn check_impl(
     tcx: TyCtxt<'_>,
     impl_def_id: LocalDefId,
     trait_ref: ty::TraitRef<'_>,
+    trait_def: &ty::TraitDef,
 ) -> Result<(), ErrorGuaranteed> {
     debug!(
         "(checking implementation) adding impl for trait '{:?}', item '{}'",
@@ -36,19 +37,20 @@ fn check_impl(
         return Ok(());
     }
 
-    enforce_trait_manually_implementable(tcx, impl_def_id, trait_ref.def_id)
-        .and(enforce_empty_impls_for_marker_traits(tcx, impl_def_id, trait_ref.def_id))
+    enforce_trait_manually_implementable(tcx, impl_def_id, trait_ref.def_id, trait_def)
+        .and(enforce_empty_impls_for_marker_traits(tcx, impl_def_id, trait_ref.def_id, trait_def))
 }
 
 fn enforce_trait_manually_implementable(
     tcx: TyCtxt<'_>,
     impl_def_id: LocalDefId,
     trait_def_id: DefId,
+    trait_def: &ty::TraitDef,
 ) -> Result<(), ErrorGuaranteed> {
     let impl_header_span = tcx.def_span(impl_def_id);
 
     // Disallow *all* explicit impls of traits marked `#[rustc_deny_explicit_impl]`
-    if tcx.trait_def(trait_def_id).deny_explicit_impl {
+    if trait_def.deny_explicit_impl {
         let trait_name = tcx.item_name(trait_def_id);
         let mut err = struct_span_code_err!(
             tcx.dcx(),
@@ -67,8 +69,7 @@ fn enforce_trait_manually_implementable(
         return Err(err.emit());
     }
 
-    if let ty::trait_def::TraitSpecializationKind::AlwaysApplicable =
-        tcx.trait_def(trait_def_id).specialization_kind
+    if let ty::trait_def::TraitSpecializationKind::AlwaysApplicable = trait_def.specialization_kind
     {
         if !tcx.features().specialization
             && !tcx.features().min_specialization
@@ -87,8 +88,9 @@ fn enforce_empty_impls_for_marker_traits(
     tcx: TyCtxt<'_>,
     impl_def_id: LocalDefId,
     trait_def_id: DefId,
+    trait_def: &ty::TraitDef,
 ) -> Result<(), ErrorGuaranteed> {
-    if !tcx.trait_def(trait_def_id).is_marker {
+    if !trait_def.is_marker {
         return Ok(());
     }
 
@@ -133,11 +135,12 @@ fn coherent_trait(tcx: TyCtxt<'_>, def_id: DefId) -> Result<(), ErrorGuaranteed>
 
     for &impl_def_id in impls {
         let trait_header = tcx.impl_trait_header(impl_def_id).unwrap().instantiate_identity();
+        let trait_def = tcx.trait_def(trait_header.trait_ref.def_id);
 
-        res = res.and(check_impl(tcx, impl_def_id, trait_header.trait_ref));
+        res = res.and(check_impl(tcx, impl_def_id, trait_header.trait_ref, trait_def));
         res = res.and(check_object_overlap(tcx, impl_def_id, trait_header.trait_ref));
 
-        res = res.and(unsafety::check_item(tcx, impl_def_id, trait_header));
+        res = res.and(unsafety::check_item(tcx, impl_def_id, trait_header, trait_def));
         res = res.and(tcx.ensure().orphan_check_impl(impl_def_id));
         res = res.and(builtin::check_trait(tcx, def_id, impl_def_id));
     }

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -132,12 +132,12 @@ fn coherent_trait(tcx: TyCtxt<'_>, def_id: DefId) -> Result<(), ErrorGuaranteed>
     let mut res = tcx.ensure().specialization_graph_of(def_id);
 
     for &impl_def_id in impls {
-        let trait_ref = tcx.impl_trait_ref(impl_def_id).unwrap().instantiate_identity();
+        let trait_header = tcx.impl_trait_header(impl_def_id).unwrap().instantiate_identity();
 
-        res = res.and(check_impl(tcx, impl_def_id, trait_ref));
-        res = res.and(check_object_overlap(tcx, impl_def_id, trait_ref));
+        res = res.and(check_impl(tcx, impl_def_id, trait_header.trait_ref));
+        res = res.and(check_object_overlap(tcx, impl_def_id, trait_header.trait_ref));
 
-        res = res.and(unsafety::check_item(tcx, impl_def_id, trait_ref));
+        res = res.and(unsafety::check_item(tcx, impl_def_id, trait_header));
         res = res.and(tcx.ensure().orphan_check_impl(impl_def_id));
         res = res.and(builtin::check_trait(tcx, def_id, impl_def_id));
     }

--- a/compiler/rustc_hir_analysis/src/coherence/unsafety.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/unsafety.rs
@@ -2,23 +2,23 @@
 //! crate or pertains to a type defined in this crate.
 
 use rustc_errors::{codes::*, struct_span_code_err};
-use rustc_hir as hir;
 use rustc_hir::Unsafety;
-use rustc_middle::ty::{TraitRef, TyCtxt};
+use rustc_middle::ty::{ImplPolarity::*, ImplTraitHeader, TyCtxt};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::ErrorGuaranteed;
 
 pub(super) fn check_item(
     tcx: TyCtxt<'_>,
     def_id: LocalDefId,
-    trait_ref: TraitRef<'_>,
+    trait_header: ImplTraitHeader<'_>,
 ) -> Result<(), ErrorGuaranteed> {
-    let item = tcx.hir().expect_item(def_id);
-    let impl_ = item.expect_impl();
+    let trait_ref = trait_header.trait_ref;
     let trait_def = tcx.trait_def(trait_ref.def_id);
-    let unsafe_attr = impl_.generics.params.iter().find(|p| p.pure_wrt_drop).map(|_| "may_dangle");
-    match (trait_def.unsafety, unsafe_attr, impl_.unsafety, impl_.polarity) {
-        (Unsafety::Normal, None, Unsafety::Unsafe, hir::ImplPolarity::Positive) => {
+    let unsafe_attr =
+        tcx.generics_of(def_id).params.iter().find(|p| p.pure_wrt_drop).map(|_| "may_dangle");
+    match (trait_def.unsafety, unsafe_attr, trait_header.unsafety, trait_header.polarity) {
+        (Unsafety::Normal, None, Unsafety::Unsafe, Positive | Reservation) => {
+            let span = tcx.def_span(def_id);
             return Err(struct_span_code_err!(
                 tcx.dcx(),
                 tcx.def_span(def_id),
@@ -27,7 +27,7 @@ pub(super) fn check_item(
                 trait_ref.print_trait_sugared()
             )
             .with_span_suggestion_verbose(
-                item.span.with_hi(item.span.lo() + rustc_span::BytePos(7)),
+                span.with_hi(span.lo() + rustc_span::BytePos(7)),
                 "remove `unsafe` from this trait implementation",
                 "",
                 rustc_errors::Applicability::MachineApplicable,
@@ -35,10 +35,11 @@ pub(super) fn check_item(
             .emit());
         }
 
-        (Unsafety::Unsafe, _, Unsafety::Normal, hir::ImplPolarity::Positive) => {
+        (Unsafety::Unsafe, _, Unsafety::Normal, Positive | Reservation) => {
+            let span = tcx.def_span(def_id);
             return Err(struct_span_code_err!(
                 tcx.dcx(),
-                tcx.def_span(def_id),
+                span,
                 E0200,
                 "the trait `{}` requires an `unsafe impl` declaration",
                 trait_ref.print_trait_sugared()
@@ -50,7 +51,7 @@ pub(super) fn check_item(
                 trait_ref.print_trait_sugared()
             ))
             .with_span_suggestion_verbose(
-                item.span.shrink_to_lo(),
+                span.shrink_to_lo(),
                 "add `unsafe` to this trait implementation",
                 "unsafe ",
                 rustc_errors::Applicability::MaybeIncorrect,
@@ -58,10 +59,11 @@ pub(super) fn check_item(
             .emit());
         }
 
-        (Unsafety::Normal, Some(attr_name), Unsafety::Normal, hir::ImplPolarity::Positive) => {
+        (Unsafety::Normal, Some(attr_name), Unsafety::Normal, Positive | Reservation) => {
+            let span = tcx.def_span(def_id);
             return Err(struct_span_code_err!(
                 tcx.dcx(),
-                tcx.def_span(def_id),
+                span,
                 E0569,
                 "requires an `unsafe impl` declaration due to `#[{}]` attribute",
                 attr_name
@@ -73,7 +75,7 @@ pub(super) fn check_item(
                 trait_ref.print_trait_sugared()
             ))
             .with_span_suggestion_verbose(
-                item.span.shrink_to_lo(),
+                span.shrink_to_lo(),
                 "add `unsafe` to this trait implementation",
                 "unsafe ",
                 rustc_errors::Applicability::MaybeIncorrect,
@@ -81,14 +83,14 @@ pub(super) fn check_item(
             .emit());
         }
 
-        (_, _, Unsafety::Unsafe, hir::ImplPolarity::Negative(_)) => {
+        (_, _, Unsafety::Unsafe, Negative) => {
             // Reported in AST validation
-            tcx.dcx().span_delayed_bug(item.span, "unsafe negative impl");
+            tcx.dcx().span_delayed_bug(tcx.def_span(def_id), "unsafe negative impl");
             Ok(())
         }
-        (_, _, Unsafety::Normal, hir::ImplPolarity::Negative(_))
-        | (Unsafety::Unsafe, _, Unsafety::Unsafe, hir::ImplPolarity::Positive)
-        | (Unsafety::Normal, Some(_), Unsafety::Unsafe, hir::ImplPolarity::Positive)
+        (_, _, Unsafety::Normal, Negative)
+        | (Unsafety::Unsafe, _, Unsafety::Unsafe, Positive | Reservation)
+        | (Unsafety::Normal, Some(_), Unsafety::Unsafe, Positive | Reservation)
         | (Unsafety::Normal, None, Unsafety::Normal, _) => Ok(()),
     }
 }

--- a/compiler/rustc_hir_analysis/src/coherence/unsafety.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/unsafety.rs
@@ -3,7 +3,7 @@
 
 use rustc_errors::{codes::*, struct_span_code_err};
 use rustc_hir::Unsafety;
-use rustc_middle::ty::{ImplPolarity::*, ImplTraitHeader, TyCtxt};
+use rustc_middle::ty::{ImplPolarity::*, ImplTraitHeader, TraitDef, TyCtxt};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::ErrorGuaranteed;
 
@@ -11,9 +11,9 @@ pub(super) fn check_item(
     tcx: TyCtxt<'_>,
     def_id: LocalDefId,
     trait_header: ImplTraitHeader<'_>,
+    trait_def: &TraitDef,
 ) -> Result<(), ErrorGuaranteed> {
     let trait_ref = trait_header.trait_ref;
-    let trait_def = tcx.trait_def(trait_ref.def_id);
     let unsafe_attr =
         tcx.generics_of(def_id).params.iter().find(|p| p.pure_wrt_drop).map(|_| "may_dangle");
     match (trait_def.unsafety, unsafe_attr, trait_header.unsafety, trait_header.polarity) {

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1539,6 +1539,7 @@ fn impl_trait_header(
             };
             ty::EarlyBinder::bind(ty::ImplTraitHeader {
                 trait_ref,
+                unsafety: impl_.unsafety,
                 polarity: polarity_of_impl(tcx, def_id,  impl_, item.span)
             })
         })

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -252,6 +252,7 @@ pub struct ImplHeader<'tcx> {
 pub struct ImplTraitHeader<'tcx> {
     pub trait_ref: ty::TraitRef<'tcx>,
     pub polarity: ImplPolarity,
+    pub unsafety: hir::Unsafety,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, TypeFoldable, TypeVisitable)]


### PR DESCRIPTION
At least I hope I found all happy path usages. I'll need to check if I can figure out a way to make queries declare that they don't access the HIR except in error paths