### PR TITLE
Avoid an ICE in diagnostics

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -698,7 +698,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                                     ),
                                 ..
                             }) => {
-                                let hir::Ty { span, .. } = inputs[local.index() - 1];
+                                let hir::Ty { span, .. } = *inputs.get(local.index() - 1)?;
                                 Some(span)
                             }
                             _ => None,

--- a/tests/ui/borrowck/argument_number_mismatch_ice.rs
+++ b/tests/ui/borrowck/argument_number_mismatch_ice.rs
@@ -1,0 +1,15 @@
+trait Hello {
+    fn example(val: ());
+}
+
+struct Test1(i32);
+
+impl Hello for Test1 {
+    fn example(&self, input: &i32) {
+        //~^ ERROR `&self` declaration in the impl, but not in the trait
+        *input = self.0;
+        //~^ ERROR cannot assign to `*input`, which is behind a `&` reference
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/argument_number_mismatch_ice.stderr
+++ b/tests/ui/borrowck/argument_number_mismatch_ice.stderr
@@ -1,0 +1,19 @@
+error[E0185]: method `example` has a `&self` declaration in the impl, but not in the trait
+  --> $DIR/argument_number_mismatch_ice.rs:8:5
+   |
+LL |     fn example(val: ());
+   |     -------------------- trait method declared without `&self`
+...
+LL |     fn example(&self, input: &i32) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&self` used in impl
+
+error[E0594]: cannot assign to `*input`, which is behind a `&` reference
+  --> $DIR/argument_number_mismatch_ice.rs:10:9
+   |
+LL |         *input = self.0;
+   |         ^^^^^^^^^^^^^^^ `input` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0185, E0594.
+For more information about an error, try `rustc --explain E0185`.


### PR DESCRIPTION
fixes #121004

just a slice usage in diagnostics code. Sadly we can't yet bubble the `ErrorGuaranteed` from wf check to borrowck for these cases, as that causes cycle errors iirc