### PR TITLE
Add suggest Vec::push when the wrong method is used

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2005,6 +2005,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 self.suggest_accessing_field_where_appropriate(cause, &exp_found, diag);
                 self.suggest_await_on_expect_found(cause, span, &exp_found, diag);
                 self.suggest_function_pointers(cause, span, &exp_found, diag);
+                self.suggest_push_for_append(cause, span, &exp_found, diag);
             }
         }
 

--- a/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/suggest.rs
@@ -559,10 +559,6 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     }
                     walk_stmt(self, ex);
                 }
-
-                fn visit_body(&mut self, body: &'v hir::Body<'v>) {
-                    hir::intravisit::walk_body(self, body);
-                }
             }
 
             let mut visitor = IfVisitor { err_span: span, found_if: false, result: false };

--- a/tests/ui/inference/issue-87212-suggest-push.rs
+++ b/tests/ui/inference/issue-87212-suggest-push.rs
@@ -1,0 +1,20 @@
+struct Thing;
+fn t1() {
+    let mut stuff: Vec<Thing> = Vec::new();
+    // suggest push
+    stuff.append(Thing); //~ ERROR mismatched types
+}
+
+fn t2() {
+    let mut stuff = vec![];
+    // suggest push
+    stuff.append(Thing); //~ ERROR mismatched types
+}
+
+fn t3() {
+    let mut stuff: Vec<i32> = Vec::new();
+    // don't suggest push
+    stuff.append(Thing); //~ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/inference/issue-87212-suggest-push.stderr
+++ b/tests/ui/inference/issue-87212-suggest-push.stderr
@@ -1,0 +1,50 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-87212-suggest-push.rs:5:18
+   |
+LL |     stuff.append(Thing);
+   |           ------ ^^^^^ expected `&mut Vec<Thing>`, found `Thing`
+   |           |
+   |           arguments to this method are incorrect
+   |
+   = note: expected mutable reference `&mut Vec<Thing>`
+                         found struct `Thing`
+note: method defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: you might want to use `push` to add new element to `Vec`
+   |
+LL |     stuff.push(Thing);
+   |           ~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/issue-87212-suggest-push.rs:11:18
+   |
+LL |     stuff.append(Thing);
+   |           ------ ^^^^^ expected `&mut Vec<_>`, found `Thing`
+   |           |
+   |           arguments to this method are incorrect
+   |
+   = note: expected mutable reference `&mut Vec<_>`
+                         found struct `Thing`
+note: method defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+help: you might want to use `push` to add new element to `Vec`
+   |
+LL |     stuff.push(Thing);
+   |           ~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/issue-87212-suggest-push.rs:17:18
+   |
+LL |     stuff.append(Thing);
+   |           ------ ^^^^^ expected `&mut Vec<i32>`, found `Thing`
+   |           |
+   |           arguments to this method are incorrect
+   |
+   = note: expected mutable reference `&mut Vec<i32>`
+                         found struct `Thing`
+note: method defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #87212

`append` is commonly used in Python, suggest `push` if possible.