### PR TITLE
Implement `#[skip]` for builtin derives

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -110,6 +110,12 @@ builtin_macros_derive_path_args_list = traits in `#[derive(...)]` don't accept a
 builtin_macros_derive_path_args_value = traits in `#[derive(...)]` don't accept values
     .suggestion = remove the value
 
+builtin_macros_derive_skip_bad_argument = incorrect usage of the `#[skip]` attribute
+    .note = the `#[skip]` attribute accepts an optional list of traits
+    .help = try using `#[skip]` or `#[skip(Trait)]`
+
+builtin_macros_derive_skip_unsupported = the `#[skip]` attribute does not support this trait
+
 builtin_macros_env_not_defined = environment variable `{$var}` not defined at compile time
     .cargo = Cargo sets build script variables at run time. Use `std::env::var({$var_expr})` instead
     .custom = use `std::env::var({$var_expr})` to read the variable at run time

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -38,9 +38,7 @@ pub fn expand_deriving_eq(
                 cx.attr_nested_word(sym::coverage, sym::off, span)
             ],
             fieldless_variants_strategy: FieldlessVariantsStrategy::Unify,
-            combine_substructure: combine_substructure(Box::new(|a, b, c| {
-                cs_total_eq_assert(a, b, c)
-            })),
+            combine_substructure: combine_substructure(Box::new(cs_total_eq_assert)),
         }],
         associated_types: Vec::new(),
         is_const,

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -30,7 +30,7 @@ pub fn expand_deriving_ord(
             ret_ty: Path(path_std!(cmp::Ordering)),
             attributes: thin_vec![cx.attr_word(sym::inline, span)],
             fieldless_variants_strategy: FieldlessVariantsStrategy::Unify,
-            combine_substructure: combine_substructure(Box::new(|a, b, c| cs_cmp(a, b, c))),
+            combine_substructure: combine_substructure(Box::new(cs_cmp)),
         }],
         associated_types: Vec::new(),
         is_const,
@@ -58,6 +58,7 @@ pub fn cs_cmp(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> BlockO
         cx,
         span,
         substr,
+        sym::Ord,
         |cx, fold| match fold {
             CsFold::Single(field) => {
                 let [other_expr] = &field.other_selflike_exprs[..] else {

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
@@ -23,6 +23,7 @@ pub fn expand_deriving_partial_eq(
             cx,
             span,
             substr,
+            sym::PartialEq,
             |cx, fold| match fold {
                 CsFold::Single(field) => {
                     let [other_expr] = &field.other_selflike_exprs[..] else {
@@ -98,7 +99,7 @@ pub fn expand_deriving_partial_eq(
         ret_ty: Path(path_local!(bool)),
         attributes: thin_vec![cx.attr_word(sym::inline, span)],
         fieldless_variants_strategy: FieldlessVariantsStrategy::Unify,
-        combine_substructure: combine_substructure(Box::new(|a, b, c| cs_eq(a, b, c))),
+        combine_substructure: combine_substructure(Box::new(cs_eq)),
     }];
 
     let trait_def = TraitDef {

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -92,6 +92,7 @@ fn cs_partial_cmp(
         cx,
         span,
         substr,
+        sym::PartialOrd,
         |cx, fold| match fold {
             CsFold::Single(field) => {
                 let [other_expr] = &field.other_selflike_exprs[..] else {

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -35,9 +35,7 @@ pub fn expand_deriving_debug(
             attributes: thin_vec![cx.attr_word(sym::inline, span)],
             fieldless_variants_strategy:
                 FieldlessVariantsStrategy::SpecializeIfAllVariantsFieldless,
-            combine_substructure: combine_substructure(Box::new(|a, b, c| {
-                show_substructure(a, b, c)
-            })),
+            combine_substructure: combine_substructure(Box::new(show_substructure)),
         }],
         associated_types: Vec::new(),
         is_const,
@@ -90,6 +88,10 @@ fn show_substructure(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) ->
             cx.expr_addr_of(field.span, field.self_expr.clone())
         }
     }
+    let fields = fields
+        .iter()
+        .filter(|fi| !fi.skipped_derives.is_skipped(sym::Debug))
+        .collect::<ThinVec<_>>();
 
     if fields.is_empty() {
         // Special case for no fields.

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -320,7 +320,7 @@ impl SkippedDerives {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum IsTuple {
     No,
     Yes,
@@ -1250,7 +1250,7 @@ impl<'a> MethodDef<'a> {
                 .collect();
 
             let self_expr = discr_exprs.remove(0);
-            let other_selflike_exprs = descr_exprs;
+            let other_selflike_exprs = discr_exprs;
             let discr_field = FieldInfo {
                 span,
                 name: None,
@@ -1629,12 +1629,12 @@ impl<'a> TraitDef<'a> {
                                     skipped_derives.add(path.segments[0].ident.name)
                                 } else {
                                     let traits = SUPPORTED_TRAITS.iter().map(|s| format!("`{s}`")).collect::<Vec<_>>().join(", ");
-                                    cx.parse_sess().buffer_lint_with_diagnostic(
+                                    cx.psess().buffer_lint_with_diagnostic(
                                         rustc_session::lint::builtin::UNSUPPORTED_DERIVE_SKIP,
                                         span,
                                         cx.current_expansion.lint_node_id,
                                         crate::fluent_generated::builtin_macros_derive_skip_unsupported,
-                                        rustc_session::lint::BuiltinLintDiagnostics::DeriveSkipUnsupported { traits },
+                                        rustc_session::lint::BuiltinLintDiag::DeriveSkipUnsupported { traits },
                                     )
                                 }
                             }

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -296,6 +296,15 @@ pub(crate) struct DerivePathArgsValue {
 }
 
 #[derive(Diagnostic)]
+#[diag(builtin_macros_derive_skip_bad_argument)]
+pub(crate) struct DeriveSkipBadArgument {
+    #[note]
+    #[help]
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(builtin_macros_no_default_variant)]
 #[help]
 pub(crate) struct NoDefaultVariant {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -442,6 +442,8 @@ declare_features! (
     (unstable, deprecated_suggestion, "1.61.0", Some(94785)),
     /// Allows deref patterns.
     (incomplete, deref_patterns, "CURRENT_RUSTC_VERSION", Some(87121)),
+    /// Allows using the `#[skip]` attribute in derives
+    (unstable, derive_skip, "CURRENT_RUSTC_VERSION", Some(121050)),
     /// Controls errors in trait implementations.
     (unstable, do_not_recommend, "1.67.0", Some(51992)),
     /// Tells rustdoc to automatically generate `#[doc(cfg(...))]`.

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -347,5 +347,8 @@ pub(super) fn builtin(sess: &Session, diagnostic: BuiltinLintDiag, diag: &mut Di
                 "reduce the glob import's visibility or increase visibility of imported items",
             );
         }
+        BuiltinLintDiagnostics::DeriveSkipUnsupported { traits } => {
+            db.help(format!("the supported traits are {traits}"));
+        }
     }
 }

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -347,8 +347,8 @@ pub(super) fn builtin(sess: &Session, diagnostic: BuiltinLintDiag, diag: &mut Di
                 "reduce the glob import's visibility or increase visibility of imported items",
             );
         }
-        BuiltinLintDiagnostics::DeriveSkipUnsupported { traits } => {
-            db.help(format!("the supported traits are {traits}"));
+        BuiltinLintDiag::DeriveSkipUnsupported { traits } => {
+            diag.help(format!("the supported traits are {traits}"));
         }
     }
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -116,6 +116,7 @@ declare_lint_pass! {
         UNSTABLE_NAME_COLLISIONS,
         UNSTABLE_SYNTAX_PRE_EXPANSION,
         UNSUPPORTED_CALLING_CONVENTIONS,
+        UNSUPPORTED_DERIVE_SKIP,
         UNUSED_ASSIGNMENTS,
         UNUSED_ASSOCIATED_TYPE_BOUNDS,
         UNUSED_ATTRIBUTES,
@@ -4740,4 +4741,32 @@ declare_lint! {
         reference: "issue #71871 <https://github.com/rust-lang/rust/issues/71871>",
     };
     crate_level_only
+}
+
+declare_lint! {
+    /// The `unsupported_derive_skip` lint detects the use of `#[skip]` specifying
+    /// an unsupported trait.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// # #![allow(unused)]
+    /// #[derive(Clone)]
+    /// struct Unsupported {
+    ///     #[skip(Clone)]
+    ///     field: usize,
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// The `#[skip]` attribute allows ignoring a field during the derivation
+    /// of specific traits. This is not supported for other traits, e.g. it wouldd
+    /// not be possible to clone a structure without cloning all fields..
+    pub UNSUPPORTED_DERIVE_SKIP,
+    Warn,
+    "an unsupported trait was passed to `#[skip]`",
+    @feature_gate = sym::derive_skip;
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -664,6 +664,9 @@ pub enum BuiltinLintDiag {
         span: Span,
         max_vis: String,
     },
+    DeriveSkipUnsupported {
+        traits: String,
+    },
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -698,6 +698,7 @@ symbols! {
         derive,
         derive_const,
         derive_default_enum,
+        derive_skip,
         destruct,
         destructuring_assignment,
         diagnostic,

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -267,7 +267,7 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
 
 /// Derive macro generating an impl of the trait [`PartialEq`].
 /// The behavior of this macro is described in detail [here](PartialEq#derivable).
-#[rustc_builtin_macro]
+#[rustc_builtin_macro(PartialEq, attributes(skip))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow_internal_unstable(core_intrinsics, structural_match)]
 pub macro PartialEq($item:item) {
@@ -917,7 +917,7 @@ pub trait Ord: Eq + PartialOrd<Self> {
 
 /// Derive macro generating an impl of the trait [`Ord`].
 /// The behavior of this macro is described in detail [here](Ord#derivable).
-#[rustc_builtin_macro]
+#[rustc_builtin_macro(Ord, attributes(skip))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow_internal_unstable(core_intrinsics)]
 pub macro Ord($item:item) {
@@ -1236,7 +1236,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
 
 /// Derive macro generating an impl of the trait [`PartialOrd`].
 /// The behavior of this macro is described in detail [here](PartialOrd#derivable).
-#[rustc_builtin_macro]
+#[rustc_builtin_macro(PartialOrd, attributes(skip))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow_internal_unstable(core_intrinsics)]
 pub macro PartialOrd($item:item) {

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -622,7 +622,7 @@ pub trait Debug {
 // Separate module to reexport the macro `Debug` from prelude without the trait `Debug`.
 pub(crate) mod macros {
     /// Derive macro generating an impl of the trait `Debug`.
-    #[rustc_builtin_macro]
+    #[rustc_builtin_macro(Debug, attributes(skip))]
     #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
     #[allow_internal_unstable(core_intrinsics, fmt_helpers_for_derive)]
     pub macro Debug($item:item) {

--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -248,7 +248,7 @@ pub trait Hash {
 // Separate module to reexport the macro `Hash` from prelude without the trait `Hash`.
 pub(crate) mod macros {
     /// Derive macro generating an impl of the trait `Hash`.
-    #[rustc_builtin_macro]
+    #[rustc_builtin_macro(Hash, attributes(skip))]
     #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
     #[allow_internal_unstable(core_intrinsics)]
     pub macro Hash($item:item) {

--- a/tests/ui/deriving/skip/derive-skip-invalid.rs
+++ b/tests/ui/deriving/skip/derive-skip-invalid.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+#![feature(derive_skip)]
+
+#[derive(Debug)]
+struct KeyVal(#[skip = "Debug"] usize); //~ ERROR invalid skip attribute
+
+#[derive(Debug)]
+struct BadArg(#[skip("Debug")] usize);  //~ ERROR incorrect skip argument
+
+// FIXME: better error for derives not supporting `skip`
+#[derive(Clone)]
+struct SkipClone(#[skip] usize);  //~ ERROR cannot find attribute `skip` in this scope

--- a/tests/ui/deriving/skip/derive-skip-invalid.rs
+++ b/tests/ui/deriving/skip/derive-skip-invalid.rs
@@ -2,11 +2,24 @@
 #![feature(derive_skip)]
 
 #[derive(Debug)]
-struct KeyVal(#[skip = "Debug"] usize); //~ ERROR invalid skip attribute
+struct KeyVal(#[skip = "Debug"] usize);
+//~^ ERROR incorrect usage of the `#[skip]` attribute
+//~| NOTE the `#[skip]` attribute accepts an optional list of traits
 
 #[derive(Debug)]
-struct BadArg(#[skip("Debug")] usize);  //~ ERROR incorrect skip argument
+struct BadArg(#[skip("Debug")] usize);
+//~^ ERROR incorrect usage of the `#[skip]` attribute
+//~| NOTE the `#[skip]` attribute accepts an optional list of traits
 
 // FIXME: better error for derives not supporting `skip`
-#[derive(Clone)]
-struct SkipClone(#[skip] usize);  //~ ERROR cannot find attribute `skip` in this scope
+// #[derive(Clone)]
+// struct SkipClone(#[skip] usize);
+
+// FIXME: derives don't get a useful lint_node_id so the lint is at the crate level
+#[derive(Debug, Clone)]
+#[deny(unsupported_derive_skip)]
+struct SkipClone2(#[skip(Clone)] usize);
+//~^ WARN the `#[skip]` attribute does not support this trait
+//~| WARN the `#[skip]` attribute does not support this trait
+//~| NOTE #[warn(unsupported_derive_skip)]` on by default
+//~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`

--- a/tests/ui/deriving/skip/derive-skip-invalid.stderr
+++ b/tests/ui/deriving/skip/derive-skip-invalid.stderr
@@ -1,0 +1,20 @@
+error: invalid skip attribute
+  --> $DIR/derive-skip-invalid.rs:5:24
+   |
+LL | struct KeyVal(#[skip = "Debug"] usize);
+   |                        ^^^^^^^
+
+error: incorrect skip argument
+  --> $DIR/derive-skip-invalid.rs:8:22
+   |
+LL | struct BadArg(#[skip("Debug")] usize);
+   |                      ^^^^^^^
+
+error: cannot find attribute `skip` in this scope
+  --> $DIR/derive-skip-invalid.rs:12:20
+   |
+LL | struct SkipClone(#[skip] usize);
+   |                    ^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/deriving/skip/derive-skip-invalid.stderr
+++ b/tests/ui/deriving/skip/derive-skip-invalid.stderr
@@ -1,20 +1,54 @@
-error: invalid skip attribute
+error: incorrect usage of the `#[skip]` attribute
+  --> $DIR/derive-skip-invalid.rs:5:24
+   |
+LL | struct KeyVal(#[skip = "Debug"] usize);
+   |                        ^^^^^^^
+   |
+note: the `#[skip]` attribute accepts an optional list of traits
+  --> $DIR/derive-skip-invalid.rs:5:24
+   |
+LL | struct KeyVal(#[skip = "Debug"] usize);
+   |                        ^^^^^^^
+help: try using `#[skip]` or `#[skip(Trait)]`
   --> $DIR/derive-skip-invalid.rs:5:24
    |
 LL | struct KeyVal(#[skip = "Debug"] usize);
    |                        ^^^^^^^
 
-error: incorrect skip argument
-  --> $DIR/derive-skip-invalid.rs:8:22
+error: incorrect usage of the `#[skip]` attribute
+  --> $DIR/derive-skip-invalid.rs:10:22
+   |
+LL | struct BadArg(#[skip("Debug")] usize);
+   |                      ^^^^^^^
+   |
+note: the `#[skip]` attribute accepts an optional list of traits
+  --> $DIR/derive-skip-invalid.rs:10:22
+   |
+LL | struct BadArg(#[skip("Debug")] usize);
+   |                      ^^^^^^^
+help: try using `#[skip]` or `#[skip(Trait)]`
+  --> $DIR/derive-skip-invalid.rs:10:22
    |
 LL | struct BadArg(#[skip("Debug")] usize);
    |                      ^^^^^^^
 
-error: cannot find attribute `skip` in this scope
-  --> $DIR/derive-skip-invalid.rs:12:20
+warning: the `#[skip]` attribute does not support this trait
+  --> $DIR/derive-skip-invalid.rs:21:26
    |
-LL | struct SkipClone(#[skip] usize);
-   |                    ^^^^
+LL | struct SkipClone2(#[skip(Clone)] usize);
+   |                          ^^^^^
+   |
+   = help: the supported traits are `PartialEq`, `PartialOrd`, `Ord`, `Hash`, `Debug`
+   = note: `#[warn(unsupported_derive_skip)]` on by default
 
-error: aborting due to 3 previous errors
+warning: the `#[skip]` attribute does not support this trait
+  --> $DIR/derive-skip-invalid.rs:21:26
+   |
+LL | struct SkipClone2(#[skip(Clone)] usize);
+   |                          ^^^^^
+   |
+   = help: the supported traits are `PartialEq`, `PartialOrd`, `Ord`, `Hash`, `Debug`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/deriving/skip/derive-skip.rs
+++ b/tests/ui/deriving/skip/derive-skip.rs
@@ -1,4 +1,4 @@
-// run-pass
+//@ run-pass
 #![feature(derive_skip)]
 #![allow(unused)]
 

--- a/tests/ui/deriving/skip/derive-skip.rs
+++ b/tests/ui/deriving/skip/derive-skip.rs
@@ -1,0 +1,57 @@
+// run-pass
+#![feature(derive_skip)]
+#![allow(unused)]
+
+#[derive(PartialEq, Debug)]
+struct SkipPartialEq {
+    f1: usize,
+    #[skip(PartialEq)]
+    f2: usize,
+}
+
+#[derive(PartialEq, PartialOrd, Debug)]
+struct SkipPartialOrd {
+    #[skip(PartialOrd, PartialEq)]
+    f1: usize,
+    f2: usize,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct SkipOrd {
+    #[skip(Ord, PartialOrd, PartialEq)]
+    f1: usize,
+    f2: usize,
+}
+
+#[derive(Hash, Debug)]
+struct SkipHash {
+    f1: usize,
+    #[skip(Hash)]
+    f2: usize,
+}
+
+#[derive(Debug)]
+struct SkipDebug {
+    f1: usize,
+    #[skip(Debug)]
+    f2: usize,
+}
+
+#[derive(Debug)]
+struct SkipDebugTuple(#[skip(Debug)] usize);
+
+fn main() {
+    assert_eq!(SkipPartialEq { f1: 0, f2: 1 }, SkipPartialEq { f1: 0, f2: 5 });
+    assert!(SkipPartialOrd { f1: 10, f2: 1 } <= SkipPartialOrd { f1: 0, f2: 5 });
+    assert_eq!(SkipOrd { f1: 0, f2: 1 }.cmp(&SkipOrd { f1: 0, f2: 5 }), std::cmp::Ordering::Less);
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut h1 = DefaultHasher::new();
+    SkipHash { f1: 0, f2: 1 }.hash(&mut h1);
+    let h1 = h1.finish();
+    let mut h2 = DefaultHasher::new();
+    SkipHash { f1: 0, f2: 5 }.hash(&mut h2);
+    let h2 = h2.finish();
+    assert_eq!(h1, h2);
+    assert_eq!(format!("{:?}", SkipDebug { f1: 0, f2: 5 }), "SkipDebug { f1: 0 }");
+    assert_eq!(format!("{:?}", SkipDebugTuple(0)), "SkipDebugTuple");
+}

--- a/tests/ui/feature-gates/feature-gate-derive-skip.rs
+++ b/tests/ui/feature-gates/feature-gate-derive-skip.rs
@@ -1,0 +1,7 @@
+#[derive(Debug)]
+struct Demo {
+    #[skip] //~ ERROR the `#[skip]` attribute is experimental
+    f1: (),
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-derive-skip.stderr
+++ b/tests/ui/feature-gates/feature-gate-derive-skip.stderr
@@ -1,0 +1,13 @@
+error[E0658]: the `#[skip]` attribute is experimental
+  --> $DIR/feature-gate-derive-skip.rs:3:5
+   |
+LL |     #[skip]
+   |     ^^^^^^^
+   |
+   = note: see issue #121050 <https://github.com/rust-lang/rust/issues/121050> for more information
+   = help: add `#![feature(derive_skip)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/121053)*
<!-- homu-ignore:end -->

Implement rust-lang/rust#121050

Still needs some work but here's an initial working implementation to get feedback on the strategy.

ACP: https://github.com/rust-lang/libs-team/issues/334