### PR TITLE
ICE when compiling this core change

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -201,14 +201,14 @@ pub trait Write {
         impl<W: Write + ?Sized> SpecWriteFmt for &mut W {
             #[inline]
             default fn spec_write_fmt(mut self, args: Arguments<'_>) -> Result {
-                write(&mut self, args)
+                if let Some(s) = args.as_str() { self.write_str(s) } else { write(&mut self, args) }
             }
         }
 
         impl<W: Write> SpecWriteFmt for &mut W {
             #[inline]
             fn spec_write_fmt(self, args: Arguments<'_>) -> Result {
-                write(self, args)
+                if let Some(s) = args.as_str() { self.write_str(s) } else { write(self, args) }
             }
         }
 
@@ -1582,8 +1582,9 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(format!("{:0>8}", Foo(2)), "Foo 2");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn write_fmt(&mut self, fmt: Arguments<'_>) -> Result {
-        write(self.buf, fmt)
+        if let Some(s) = fmt.as_str() { self.buf.write_str(s) } else { write(self.buf, fmt) }
     }
 
     /// Flags for formatting
@@ -2272,8 +2273,9 @@ impl Write for Formatter<'_> {
         self.buf.write_char(c)
     }
 
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
-        write(self.buf, args)
+        if let Some(s) = args.as_str() { self.buf.write_str(s) } else { write(self.buf, args) }
     }
 }
 


### PR DESCRIPTION
Bug report for this PR: https://github.com/rust-lang/rust/issues/121066

This code causes ICE in rustc when running `./x.py build --stage 1 alloc` -- the error shows up in CI https://github.com/rust-lang/rust/actions/runs/7896056798/job/21549391196?pr=121064#step:26:2201

```
error: internal compiler error: /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/compiler/rustc_codegen_ssa/src/mir/operand.rs:201:18: not immediate: OperandRef(Ref((ptr:  %6 = alloca { { ptr, i64 }, { ptr, i64 }, { ptr, [1 x i64] } }, align 8), None, Align(8 bytes)) @ TyAndLayout { ty: Arguments<'_>, layout: Layout { size: Size(48 bytes), align: AbiAndPrefAlign { abi: Align(8 bytes), pref: Align(8 bytes) }, abi: Aggregate { sized: true }, fields: Arbitrary { offsets: [Size(0 bytes), Size(32 bytes), Size(16 bytes)], memory_index: [0, 2, 1] }, largest_niche: Some(Niche { offset: Size(0 bytes), value: Pointer(AddressSpace(0)), valid_range: 1..=18446744073709551615 }), variants: Single { index: 0 }, max_repr_align: None, unadjusted_abi_align: Align(8 bytes) } })
```

This issue showed up with two code variants:

```
if unsafe { core::intrinsics::is_val_statically_known(args) } {
    if let Some(s) = args.as_str() {
        return self.write_str(s);
    }
}

if unsafe { core::intrinsics::is_val_statically_known(args) }
   && let Some(s) = args.as_str() {
        return self.write_str(s);
}

```

<details><summary>Stacktrace</summary>
<p>

```
thread 'rustc' panicked at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/compiler/rustc_errors/src/lib.rs:932:30:
Box<dyn Any>
stack backtrace:
   0:     0x7f8999fdabee - std::backtrace_rs::backtrace::libunwind::trace::hc987f3c35d55761d
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
   1:     0x7f8999fdabee - std::backtrace_rs::backtrace::trace_unsynchronized::h88acce004bab2451
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7f8999fdabee - std::backtrace::Backtrace::create::ha3010e67ce0df222
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/backtrace.rs:331:13
   3:     0x7f8999fdab30 - std::backtrace::Backtrace::force_capture::h6bbfa084bd4217e5
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/backtrace.rs:312:9
   4:     0x7f8996fa9479 - std[55ab4a542350c755]::panicking::update_hook::<alloc[4da3f6bd47afec24]::boxed::Box<rustc_driver_impl[ef4ee9058c24acfe]::install_ice_hook::{closure#0}>>::{closure#0}
   5:     0x7f8999ff6fd6 - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::hff82162297b64e89
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/alloc/src/boxed.rs:2029:9
   6:     0x7f8999ff6fd6 - std::panicking::rust_panic_with_hook::h8633089b9015a8b7
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/panicking.rs:785:13
   7:     0x7f8996fd81d4 - std[55ab4a542350c755]::panicking::begin_panic::<rustc_errors[68df17d15f76634e]::ExplicitBug>::{closure#0}
   8:     0x7f8996fd48c6 - std[55ab4a542350c755]::sys_common::backtrace::__rust_end_short_backtrace::<std[55ab4a542350c755]::panicking::begin_panic<rustc_errors[68df17d15f76634e]::ExplicitBug>::{closure#0}, !>
   9:     0x7f8996fcfbb6 - std[55ab4a542350c755]::panicking::begin_panic::<rustc_errors[68df17d15f76634e]::ExplicitBug>
  10:     0x7f8996fe3841 - <rustc_errors[68df17d15f76634e]::diagnostic_builder::BugAbort as rustc_errors[68df17d15f76634e]::diagnostic_builder::EmissionGuarantee>::emit_producing_guarantee
  11:     0x7f89973725eb - <rustc_errors[68df17d15f76634e]::DiagCtxt>::bug::<alloc[4da3f6bd47afec24]::string::String>
  12:     0x7f899740b23b - rustc_middle[cfc4b7b04cd03608]::util::bug::opt_span_bug_fmt::<rustc_span[70f6536c5e2f3755]::span_encoding::Span>::{closure#0}
  13:     0x7f89973f3dba - rustc_middle[cfc4b7b04cd03608]::ty::context::tls::with_opt::<rustc_middle[cfc4b7b04cd03608]::util::bug::opt_span_bug_fmt<rustc_span[70f6536c5e2f3755]::span_encoding::Span>::{closure#0}, !>::{closure#0}
  14:     0x7f89973f3c38 - rustc_middle[cfc4b7b04cd03608]::ty::context::tls::with_context_opt::<rustc_middle[cfc4b7b04cd03608]::ty::context::tls::with_opt<rustc_middle[cfc4b7b04cd03608]::util::bug::opt_span_bug_fmt<rustc_span[70f6536c5e2f3755]::span_encoding::Span>::{closure#0}, !>::{closure#0}, !>
  15:     0x7f8995507430 - rustc_middle[cfc4b7b04cd03608]::util::bug::bug_fmt
  16:     0x7f8998d4e82a - <rustc_codegen_llvm[103398a9ca8f425b]::builder::Builder as rustc_codegen_ssa[725a152d682a010f]::traits::intrinsic::IntrinsicCallMethods>::codegen_intrinsic_call
  17:     0x7f8998d551a5 - <rustc_codegen_ssa[725a152d682a010f]::mir::FunctionCx<rustc_codegen_llvm[103398a9ca8f425b]::builder::Builder>>::codegen_intrinsic_call
  18:     0x7f8998b8ea63 - <rustc_codegen_ssa[725a152d682a010f]::mir::FunctionCx<rustc_codegen_llvm[103398a9ca8f425b]::builder::Builder>>::codegen_block
  19:     0x7f8998d404a6 - rustc_codegen_ssa[725a152d682a010f]::mir::codegen_mir::<rustc_codegen_llvm[103398a9ca8f425b]::builder::Builder>
  20:     0x7f8998d2e561 - rustc_codegen_llvm[103398a9ca8f425b]::base::compile_codegen_unit::module_codegen
  21:     0x7f8998fb8324 - <rustc_codegen_llvm[103398a9ca8f425b]::LlvmCodegenBackend as rustc_codegen_ssa[725a152d682a010f]::traits::backend::ExtraBackendMethods>::compile_codegen_unit
  22:     0x7f8999108467 - <rustc_codegen_llvm[103398a9ca8f425b]::LlvmCodegenBackend as rustc_codegen_ssa[725a152d682a010f]::traits::backend::CodegenBackend>::codegen_crate
  23:     0x7f8999106230 - rustc_interface[2106013cc2f5b63c]::passes::start_codegen
  24:     0x7f8999105a06 - <rustc_interface[2106013cc2f5b63c]::queries::Queries>::codegen_and_build_linker
  25:     0x7f8998f93de6 - rustc_interface[2106013cc2f5b63c]::interface::run_compiler::<core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>, rustc_driver_impl[ef4ee9058c24acfe]::run_compiler::{closure#0}>::{closure#0}
  26:     0x7f8999101ba1 - std[55ab4a542350c755]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[2106013cc2f5b63c]::util::run_in_thread_with_globals<rustc_interface[2106013cc2f5b63c]::interface::run_compiler<core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>, rustc_driver_impl[ef4ee9058c24acfe]::run_compiler::{closure#0}>::{closure#0}, core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>>
  27:     0x7f89991019ff - <<std[55ab4a542350c755]::thread::Builder>::spawn_unchecked_<rustc_interface[2106013cc2f5b63c]::util::run_in_thread_with_globals<rustc_interface[2106013cc2f5b63c]::interface::run_compiler<core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>, rustc_driver_impl[ef4ee9058c24acfe]::run_compiler::{closure#0}>::{closure#0}, core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[ce9c323f7905c200]::result::Result<(), rustc_span[70f6536c5e2f3755]::ErrorGuaranteed>>::{closure#1} as core[ce9c323f7905c200]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  28:     0x7f899a000675 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hf8f17589d536646e
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/alloc/src/boxed.rs:2015:9
  29:     0x7f899a000675 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h68da270e7d912a3c
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/alloc/src/boxed.rs:2015:9
  30:     0x7f899a000675 - std::sys::pal::unix::thread::Thread::new::thread_start::he371c43bd596b52d
                               at /rustc/04ba4521971a83d71477a406b5ce7a479e9d7af8/library/std/src/sys/pal/unix/thread.rs:108:17
  31:     0x7f8994094ac3 - start_thread
                               at ./nptl/pthread_create.c:442:8
  32:     0x7f8994126850 - __GI___clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
  33:                0x0 - <unknown>


rustc version: 1.77.0-beta.1 (04ba45219 2024-02-04)
platform: x86_64-unknown-linux-gnu

query stack during panic:
end of query stack
```

</p>
</details> 