### PR TITLE
[perf experiment] Only emit gep not gepi

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -777,7 +777,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         indices: &[&'ll Value],
     ) -> &'ll Value {
         unsafe {
-            llvm::LLVMBuildInBoundsGEP2(
+            llvm::LLVMBuildGEP2(
                 self.llbuilder,
                 ty,
                 ptr,


### PR DESCRIPTION
r? @ghost

Re-creating https://github.com/rust-lang/rust/pull/120483, trying to measure the perf impact of `gep` vs `gepi`. That previous PR was with LLVM 17 and it found a runtime perf _improvement_, so in part this PR is assessing if that was fixed in LLVM 18.

Codegen tests will fail.