### PR TITLE
Ensure we only feed def ids via create_def or within eval_always queries

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -62,7 +62,7 @@ use rustc_session::config::CrateType;
 use rustc_session::cstore::{CrateStoreDyn, Untracked};
 use rustc_session::lint::Lint;
 use rustc_session::{Limit, MetadataKind, Session};
-use rustc_span::def_id::{DefPathHash, StableCrateId};
+use rustc_span::def_id::{DefPathHash, StableCrateId, CRATE_DEF_ID};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::abi::{FieldIdx, Layout, LayoutS, TargetDataLayout, VariantIdx};
@@ -522,7 +522,14 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn feed_local_crate(self) -> TyCtxtFeed<'tcx, CrateNum> {
         TyCtxtFeed { tcx: self, key: LOCAL_CRATE }
     }
+
+    /// Do not use outside the resolver, use `create_def` instead.
     pub fn feed_local_def_id(self, key: LocalDefId) -> TyCtxtFeed<'tcx, LocalDefId> {
+        if key != CRATE_DEF_ID {
+            // Ensure we will re-feed this query by ensuring that the feeding query is
+            // reexecuted.
+            self.dep_graph.assert_eval_always();
+        }
         TyCtxtFeed { tcx: self, key }
     }
 

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -212,6 +212,18 @@ impl<D: Deps> DepGraph<D> {
         }
     }
 
+    pub fn assert_eval_always(&self) {
+        if let Some(..) = self.data {
+            D::read_deps(|task_deps| {
+                assert_matches!(
+                    task_deps,
+                    TaskDepsRef::EvalAlways,
+                    "expected an eval always query"
+                );
+            })
+        }
+    }
+
     pub fn with_ignore<OP, R>(&self, op: OP) -> R
     where
         OP: FnOnce() -> R,


### PR DESCRIPTION
feeding def ids from queries other than the one that created them is very fragile and requires documentation at each site... unless the query is `eval_always`, then it will just get rerun every single time.

At least I think so. Or do eval_always queries not get rerun if all their inputs are green and their output is not needed?

r? @cjgillot