### PR TITLE
Always evaluate free constants and statics, even if previous errors occurred

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -249,7 +249,7 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
         let secondary_errors = mem::take(&mut self.secondary_errors);
         if self.error_emitted.is_none() {
             for error in secondary_errors {
-                error.emit();
+                self.error_emitted = Some(error.emit());
             }
         } else {
             assert!(self.tcx.dcx().has_errors().is_some());

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1542,32 +1542,6 @@ impl<'tcx> LateLintPass<'tcx> for TypeAliasBounds {
     }
 }
 
-declare_lint_pass!(
-    /// Lint constants that are erroneous.
-    /// Without this lint, we might not get any diagnostic if the constant is
-    /// unused within this crate, even though downstream crates can't use it
-    /// without producing an error.
-    UnusedBrokenConst => []
-);
-
-impl<'tcx> LateLintPass<'tcx> for UnusedBrokenConst {
-    fn check_item(&mut self, cx: &LateContext<'_>, it: &hir::Item<'_>) {
-        match it.kind {
-            hir::ItemKind::Const(_, _, body_id) => {
-                let def_id = cx.tcx.hir().body_owner_def_id(body_id).to_def_id();
-                // trigger the query once for all constants since that will already report the errors
-                // FIXME(generic_const_items): Does this work properly with generic const items?
-                cx.tcx.ensure().const_eval_poly(def_id);
-            }
-            hir::ItemKind::Static(_, _, body_id) => {
-                let def_id = cx.tcx.hir().body_owner_def_id(body_id).to_def_id();
-                cx.tcx.ensure().eval_static_initializer(def_id);
-            }
-            _ => {}
-        }
-    }
-}
-
 declare_lint! {
     /// The `trivial_bounds` lint detects trait bounds that don't depend on
     /// any type parameters.

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -213,8 +213,6 @@ late_lint_methods!(
             ExplicitOutlivesRequirements: ExplicitOutlivesRequirements,
             InvalidValue: InvalidValue,
             DerefNullPtr: DerefNullPtr,
-            // May Depend on constants elsewhere
-            UnusedBrokenConst: UnusedBrokenConst,
             UnstableFeatures: UnstableFeatures,
             UngatedAsyncFnTrackCaller: UngatedAsyncFnTrackCaller,
             ArrayIntoIter: ArrayIntoIter::default(),

--- a/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.rs
+++ b/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.rs
@@ -13,8 +13,6 @@
 
 const ARR: [i32; 2] = [1, 2];
 const REF: &i32 = &ARR[idx()]; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
-//~^ ERROR: failed
 
 const fn idx() -> usize {
     1
@@ -35,9 +33,6 @@ fn main() {
     x[const { idx() }]; // Ok, should not produce stderr.
     x[const { idx4() }]; // Ok, let rustc's `unconditional_panic` lint handle `usize` indexing on arrays.
     const { &ARR[idx()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-    const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-    //
-    //~^^ ERROR: failed
 
     let y = &x;
     y[0]; // Ok, referencing shouldn't affect this lint. See the issue 6021

--- a/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.stderr
+++ b/src/tools/clippy/tests/ui-toml/suppress_lint_in_const/test.stderr
@@ -1,17 +1,5 @@
-error[E0080]: evaluation of `main::{constant#3}` failed
-  --> $DIR/test.rs:38:14
-   |
-LL |     const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-   |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
-
-note: erroneous constant encountered
-  --> $DIR/test.rs:38:5
-   |
-LL |     const { &ARR[idx4()] }; // Ok, should not produce stderr, since `suppress-restriction-lint-in-const` is set true.
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
 error: indexing may panic
-  --> $DIR/test.rs:29:5
+  --> $DIR/test.rs:27:5
    |
 LL |     x[index];
    |     ^^^^^^^^
@@ -21,7 +9,7 @@ LL |     x[index];
    = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
 
 error: indexing may panic
-  --> $DIR/test.rs:47:5
+  --> $DIR/test.rs:42:5
    |
 LL |     v[0];
    |     ^^^^
@@ -29,7 +17,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:48:5
+  --> $DIR/test.rs:43:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -37,7 +25,7 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:49:5
+  --> $DIR/test.rs:44:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
@@ -45,7 +33,7 @@ LL |     v[1 << 3];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:55:5
+  --> $DIR/test.rs:50:5
    |
 LL |     v[N];
    |     ^^^^
@@ -53,19 +41,12 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/test.rs:56:5
+  --> $DIR/test.rs:51:5
    |
 LL |     v[M];
    |     ^^^^
    |
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/test.rs:16:24
-   |
-LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
-   |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
+error: aborting due to 6 previous errors
 
-error: aborting due to 8 previous errors
-
-For more information about this error, try `rustc --explain E0080`.

--- a/src/tools/clippy/tests/ui/indexing_slicing_index.rs
+++ b/src/tools/clippy/tests/ui/indexing_slicing_index.rs
@@ -13,8 +13,6 @@
 const ARR: [i32; 2] = [1, 2];
 const REF: &i32 = &ARR[idx()]; // This should be linted, since `suppress-restriction-lint-in-const` default is false.
 //~^ ERROR: indexing may panic
-const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
-//~^ ERROR: indexing may panic
 
 const fn idx() -> usize {
     1

--- a/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
+++ b/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
@@ -9,29 +9,20 @@ LL | const REF: &i32 = &ARR[idx()]; // This should be linted, since `suppress-re
    = note: `-D clippy::indexing-slicing` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::indexing_slicing)]`
 
-error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:16:24
-   |
-LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
-   |                        ^^^^^^^^^^^
-   |
-   = help: consider using `.get(n)` or `.get_mut(n)` instead
-   = note: the suggestion might not be applicable in constant blocks
-
 error[E0080]: evaluation of `main::{constant#3}` failed
-  --> $DIR/indexing_slicing_index.rs:48:14
+  --> $DIR/indexing_slicing_index.rs:46:14
    |
 LL |     const { &ARR[idx4()] };
    |              ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
 
 note: erroneous constant encountered
-  --> $DIR/indexing_slicing_index.rs:48:5
+  --> $DIR/indexing_slicing_index.rs:46:5
    |
 LL |     const { &ARR[idx4()] };
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:29:5
+  --> $DIR/indexing_slicing_index.rs:27:5
    |
 LL |     x[index];
    |     ^^^^^^^^
@@ -39,7 +30,7 @@ LL |     x[index];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: index is out of bounds
-  --> $DIR/indexing_slicing_index.rs:32:5
+  --> $DIR/indexing_slicing_index.rs:30:5
    |
 LL |     x[4];
    |     ^^^^
@@ -48,13 +39,13 @@ LL |     x[4];
    = help: to override `-D warnings` add `#[allow(clippy::out_of_bounds_indexing)]`
 
 error: index is out of bounds
-  --> $DIR/indexing_slicing_index.rs:34:5
+  --> $DIR/indexing_slicing_index.rs:32:5
    |
 LL |     x[1 << 3];
    |     ^^^^^^^^^
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:45:14
+  --> $DIR/indexing_slicing_index.rs:43:14
    |
 LL |     const { &ARR[idx()] };
    |              ^^^^^^^^^^
@@ -63,7 +54,7 @@ LL |     const { &ARR[idx()] };
    = note: the suggestion might not be applicable in constant blocks
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:48:14
+  --> $DIR/indexing_slicing_index.rs:46:14
    |
 LL |     const { &ARR[idx4()] };
    |              ^^^^^^^^^^^
@@ -72,13 +63,13 @@ LL |     const { &ARR[idx4()] };
    = note: the suggestion might not be applicable in constant blocks
 
 error: index is out of bounds
-  --> $DIR/indexing_slicing_index.rs:55:5
+  --> $DIR/indexing_slicing_index.rs:53:5
    |
 LL |     y[4];
    |     ^^^^
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:58:5
+  --> $DIR/indexing_slicing_index.rs:56:5
    |
 LL |     v[0];
    |     ^^^^
@@ -86,7 +77,7 @@ LL |     v[0];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:60:5
+  --> $DIR/indexing_slicing_index.rs:58:5
    |
 LL |     v[10];
    |     ^^^^^
@@ -94,7 +85,7 @@ LL |     v[10];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:62:5
+  --> $DIR/indexing_slicing_index.rs:60:5
    |
 LL |     v[1 << 3];
    |     ^^^^^^^^^
@@ -102,13 +93,13 @@ LL |     v[1 << 3];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: index is out of bounds
-  --> $DIR/indexing_slicing_index.rs:70:5
+  --> $DIR/indexing_slicing_index.rs:68:5
    |
 LL |     x[N];
    |     ^^^^
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:73:5
+  --> $DIR/indexing_slicing_index.rs:71:5
    |
 LL |     v[N];
    |     ^^^^
@@ -116,7 +107,7 @@ LL |     v[N];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: indexing may panic
-  --> $DIR/indexing_slicing_index.rs:75:5
+  --> $DIR/indexing_slicing_index.rs:73:5
    |
 LL |     v[M];
    |     ^^^^
@@ -124,17 +115,11 @@ LL |     v[M];
    = help: consider using `.get(n)` or `.get_mut(n)` instead
 
 error: index is out of bounds
-  --> $DIR/indexing_slicing_index.rs:79:13
+  --> $DIR/indexing_slicing_index.rs:77:13
    |
 LL |     let _ = x[4];
    |             ^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/indexing_slicing_index.rs:16:24
-   |
-LL | const REF_ERR: &i32 = &ARR[idx4()]; // Ok, let rustc handle const contexts.
-   |                        ^^^^^^^^^^^ index out of bounds: the length is 2 but the index is 4
-
-error: aborting due to 17 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/mir-opt/dataflow-const-prop/enum.rs
+++ b/tests/mir-opt/dataflow-const-prop/enum.rs
@@ -62,7 +62,7 @@ fn statics() {
 
     static RC: &E = &E::V2(4);
 
-    // CHECK: [[t:_.*]] = const {alloc2: &&E};
+    // CHECK: [[t:_.*]] = const {alloc5: &&E};
     // CHECK: [[e2]] = (*[[t]]);
     let e2 = RC;
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.rs
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.rs
@@ -4,12 +4,12 @@ trait Foo {
     const BAR: u32;
 }
 
-const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
+const IMPL_REF_BAR: u32 = GlobalImplRef::BAR; //~ ERROR E0391
 
 struct GlobalImplRef;
 
 impl GlobalImplRef {
-    const BAR: u32 = IMPL_REF_BAR; //~ ERROR E0391
+    const BAR: u32 = IMPL_REF_BAR;
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -1,14 +1,9 @@
-error[E0391]: cycle detected when elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:22
-   |
-LL |     const BAR: u32 = IMPL_REF_BAR;
-   |                      ^^^^^^^^^^^^
-   |
-note: ...which requires simplifying constant for the type system `IMPL_REF_BAR`...
+error[E0391]: cycle detected when simplifying constant for the type system `IMPL_REF_BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
 note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:27
    |
@@ -29,7 +24,12 @@ note: ...which requires caching mir of `<impl at $DIR/issue-24949-assoc-const-st
    |
 LL |     const BAR: u32 = IMPL_REF_BAR;
    |     ^^^^^^^^^^^^^^
-   = note: ...which again requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`, completing the cycle
+note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:22
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |                      ^^^^^^^^^^^^
+   = note: ...which again requires simplifying constant for the type system `IMPL_REF_BAR`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -1,9 +1,14 @@
-error[E0391]: cycle detected when elaborating drops for `FooDefault::BAR`
+error[E0391]: cycle detected when caching mir of `FooDefault::BAR` for CTFE
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^
+   |
+note: ...which requires elaborating drops for `FooDefault::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:22
    |
 LL |     const BAR: u32 = DEFAULT_REF_BAR;
    |                      ^^^^^^^^^^^^^^^
-   |
 note: ...which requires simplifying constant for the type system `DEFAULT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
    |
@@ -24,13 +29,12 @@ note: ...which requires const-evaluating + checking `FooDefault::BAR`...
    |
 LL |     const BAR: u32 = DEFAULT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-note: ...which requires caching mir of `FooDefault::BAR` for CTFE...
+   = note: ...which again requires caching mir of `FooDefault::BAR` for CTFE, completing the cycle
+note: cycle used when const-evaluating + checking `FooDefault::BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
    |
 LL |     const BAR: u32 = DEFAULT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-   = note: ...which again requires elaborating drops for `FooDefault::BAR`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.rs
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.rs
@@ -4,12 +4,12 @@ trait Foo {
     const BAR: u32;
 }
 
-const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR; //~ ERROR E0391
 
 struct GlobalTraitRef;
 
 impl Foo for GlobalTraitRef {
-    const BAR: u32 = TRAIT_REF_BAR; //~ ERROR E0391
+    const BAR: u32 = TRAIT_REF_BAR;
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -1,14 +1,9 @@
-error[E0391]: cycle detected when elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:22
-   |
-LL |     const BAR: u32 = TRAIT_REF_BAR;
-   |                      ^^^^^^^^^^^^^
-   |
-note: ...which requires simplifying constant for the type system `TRAIT_REF_BAR`...
+error[E0391]: cycle detected when simplifying constant for the type system `TRAIT_REF_BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:28
    |
@@ -29,7 +24,12 @@ note: ...which requires caching mir of `<impl at $DIR/issue-24949-assoc-const-st
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-   = note: ...which again requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`, completing the cycle
+note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:22
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |                      ^^^^^^^^^^^^^
+   = note: ...which again requires simplifying constant for the type system `TRAIT_REF_BAR`, completing the cycle
    = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 

--- a/tests/ui/check-static-values-constraints.stderr
+++ b/tests/ui/check-static-values-constraints.stderr
@@ -129,17 +129,6 @@ LL | static STATIC19: Vec<isize> = vec![3];
    = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0507]: cannot move out of static item `x`
-  --> $DIR/check-static-values-constraints.rs:119:9
-   |
-LL |         x
-   |         ^ move occurs because `x` has type `Vec<isize>`, which does not implement the `Copy` trait
-   |
-help: consider borrowing here
-   |
-LL |         &x
-   |         +
-
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-static-values-constraints.rs:117:32
    |
@@ -157,6 +146,17 @@ LL |         static x: Vec<isize> = vec![3];
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0507]: cannot move out of static item `x`
+  --> $DIR/check-static-values-constraints.rs:119:9
+   |
+LL |         x
+   |         ^ move occurs because `x` has type `Vec<isize>`, which does not implement the `Copy` trait
+   |
+help: consider borrowing here
+   |
+LL |         &x
+   |         +
 
 error: aborting due to 17 previous errors
 

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -9,7 +9,6 @@ impl <const B: &'static bool> T<B> {
         unsafe {
             *(B as *const bool as *mut bool) = false;
             //~^ ERROR evaluation of constant value failed [E0080]
-            //~| ERROR assigning to `&T` is undefined behavior
         }
     }
 }

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -1,12 +1,3 @@
-error: assigning to `&T` is undefined behavior, consider using an `UnsafeCell`
-  --> $DIR/issue-100313.rs:10:13
-   |
-LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: for more information, visit <https://doc.rust-lang.org/book/ch15-05-interior-mutability.html>
-   = note: `#[deny(invalid_reference_casting)]` on by default
-
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-100313.rs:10:13
    |
@@ -19,11 +10,11 @@ note: inside `T::<&true>::set_false`
 LL |             *(B as *const bool as *mut bool) = false;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: inside `_`
-  --> $DIR/issue-100313.rs:19:5
+  --> $DIR/issue-100313.rs:18:5
    |
 LL |     x.set_false();
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-array-oob.rs
+++ b/tests/ui/consts/const-array-oob.rs
@@ -1,5 +1,6 @@
 const FOO: [usize; 3] = [1, 2, 3];
-const BAR: usize = FOO[5]; // no error, because the error below occurs before regular const eval
+const BAR: usize = FOO[5];
+//~^ ERROR: evaluation of constant value failed
 
 const BLUB: [u32; FOO[4]] = [5, 6];
 //~^ ERROR evaluation of constant value failed [E0080]

--- a/tests/ui/consts/const-array-oob.stderr
+++ b/tests/ui/consts/const-array-oob.stderr
@@ -1,9 +1,15 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-array-oob.rs:4:19
+  --> $DIR/const-array-oob.rs:5:19
    |
 LL | const BLUB: [u32; FOO[4]] = [5, 6];
    |                   ^^^^^^ index out of bounds: the length is 3 but the index is 4
 
-error: aborting due to 1 previous error
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-array-oob.rs:2:20
+   |
+LL | const BAR: usize = FOO[5];
+   |                    ^^^^^^ index out of bounds: the length is 3 but the index is 5
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/tests/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -7,6 +7,5 @@ LL | const X: i32 = 1 / 0;
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `X`
 #1 [eval_to_const_value_raw] simplifying constant for the type system `X`
-#2 [lint_mod] linting top-level module
-#3 [analysis] running analysis passes on this crate
+#2 [analysis] running analysis passes on this crate
 end of query stack

--- a/tests/ui/consts/const-eval/const_fn_ptr.stderr
+++ b/tests/ui/consts/const-eval/const_fn_ptr.stderr
@@ -1,11 +1,6 @@
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_fn_ptr.rs:11:5
-   |
-LL |     X(x)
-   |     ^^^^
-help: skipping check that does not even have a feature gate
   --> $DIR/const_fn_ptr.rs:15:5
    |
 LL |     X_CONST(x)
@@ -14,6 +9,11 @@ help: skipping check that does not even have a feature gate
   --> $DIR/const_fn_ptr.rs:19:5
    |
 LL |     x(y)
+   |     ^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_fn_ptr.rs:11:5
+   |
+LL |     X(x)
    |     ^^^^
 
 warning: 1 warning emitted

--- a/tests/ui/consts/const-eval/generic-slice.stderr
+++ b/tests/ui/consts/const-eval/generic-slice.stderr
@@ -1,4 +1,18 @@
 error[E0597]: `x` does not live long enough
+  --> $DIR/generic-slice.rs:27:5
+   |
+LL |     let x: &[_] = &[];
+   |         - binding `x` declared here
+LL |     &x
+   |     ^^
+   |     |
+   |     borrowed value does not live long enough
+   |     using this value as a static requires that `x` is borrowed for `'static`
+LL |
+LL | };
+   | - `x` dropped here while still borrowed
+
+error[E0597]: `x` does not live long enough
   --> $DIR/generic-slice.rs:15:9
    |
 LL | impl<'a, T: 'static> Generic<'a, T> {
@@ -14,20 +28,6 @@ LL |         &x
 LL |
 LL |     };
    |     - `x` dropped here while still borrowed
-
-error[E0597]: `x` does not live long enough
-  --> $DIR/generic-slice.rs:27:5
-   |
-LL |     let x: &[_] = &[];
-   |         - binding `x` declared here
-LL |     &x
-   |     ^^
-   |     |
-   |     borrowed value does not live long enough
-   |     using this value as a static requires that `x` is borrowed for `'static`
-LL |
-LL | };
-   | - `x` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,7 +1,6 @@
 const fn foo() -> ! {
     unsafe { std::mem::transmute(()) }
     //~^ ERROR evaluation of constant value failed
-    //~| WARN the type `!` does not permit zero-initialization [invalid_value]
 }
 
 // Type defined in a submodule, so that it is not "visibly"
@@ -18,7 +17,6 @@ const FOO: [empty::Empty; 3] = [foo(); 3];
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
 //~^ ERROR evaluation of constant value failed
-//~| WARN the type `empty::Empty` does not permit zero-initialization
 
 fn main() {
     FOO;

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,12 +1,3 @@
-warning: the type `!` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:2:14
-   |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
-   |
-   = note: the `!` type has no valid value
-   = note: `#[warn(invalid_value)]` on by default
-
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:2:14
    |
@@ -19,34 +10,17 @@ note: inside `foo`
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^
 note: inside `FOO`
-  --> $DIR/validate_uninhabited_zsts.rs:17:33
+  --> $DIR/validate_uninhabited_zsts.rs:16:33
    |
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
    |                                 ^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:19:42
+  --> $DIR/validate_uninhabited_zsts.rs:18:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered a value of uninhabited type `Void`
 
-warning: the type `empty::Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:19:42
-   |
-LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
-   |
-note: in this struct field
-  --> $DIR/validate_uninhabited_zsts.rs:14:22
-   |
-LL |     pub struct Empty(Void);
-   |                      ^^^^
-note: enums with no inhabited variants have no valid value
-  --> $DIR/validate_uninhabited_zsts.rs:11:5
-   |
-LL |     enum Void {}
-   |     ^^^^^^^^^
-
-error: aborting due to 2 previous errors; 2 warnings emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const-mut-refs/issue-76510.rs
+++ b/tests/ui/consts/const-mut-refs/issue-76510.rs
@@ -3,7 +3,6 @@ use std::mem::{transmute, ManuallyDrop};
 const S: &'static mut str = &mut " hello ";
 //~^ ERROR: mutable references are not allowed in the final value of constants
 //~| ERROR: mutation through a reference is not allowed in constants
-//~| ERROR: cannot borrow data in a `&` reference as mutable
 
 const fn trigger() -> [(); unsafe {
         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));

--- a/tests/ui/consts/const-mut-refs/issue-76510.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.stderr
@@ -14,13 +14,7 @@ LL | const S: &'static mut str = &mut " hello ";
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/issue-76510.rs:3:29
-   |
-LL | const S: &'static mut str = &mut " hello ";
-   |                             ^^^^^^^^^^^^^^ cannot borrow as mutable
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0596, E0658, E0764.
-For more information about an error, try `rustc --explain E0596`.
+Some errors have detailed explanations: E0658, E0764.
+For more information about an error, try `rustc --explain E0658`.

--- a/tests/ui/consts/const_cmp_type_id.stderr
+++ b/tests/ui/consts/const_cmp_type_id.stderr
@@ -4,6 +4,12 @@ error[E0131]: `main` function is not allowed to have generic parameters
 LL | const fn main() {
    |              ^ `main` cannot have generic parameters
 
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_cmp_type_id.rs:10:22
+   |
+LL |     const _A: bool = TypeId::of::<u8>() < TypeId::of::<u16>();
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling non-const function `<TypeId as PartialOrd>::lt`
+
 error[E0308]: mismatched types
   --> $DIR/const_cmp_type_id.rs:8:13
    |
@@ -22,7 +28,7 @@ LL |     assert!(TypeId::of::<()>() != TypeId::of::<u8>());
    = note: expected constant `host`
               found constant `true`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0131, E0308.
-For more information about an error, try `rustc --explain E0131`.
+Some errors have detailed explanations: E0080, E0131, E0308.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/consts/const_let_assign3.stderr
+++ b/tests/ui/consts/const_let_assign3.stderr
@@ -1,18 +1,18 @@
-error[E0658]: mutable references are not allowed in constant functions
-  --> $DIR/const_let_assign3.rs:6:18
-   |
-LL |     const fn foo(&mut self, x: u32) {
-   |                  ^^^^^^^^^
-   |
-   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
-   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: mutable references are not allowed in constants
   --> $DIR/const_let_assign3.rs:14:5
    |
 LL |     s.foo(3);
    |     ^
+   |
+   = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
+   = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: mutable references are not allowed in constant functions
+  --> $DIR/const_let_assign3.rs:6:18
+   |
+LL |     const fn foo(&mut self, x: u32) {
+   |                  ^^^^^^^^^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -9,12 +9,6 @@ LL |     const C: &bool = unsafe { std::mem::transmute(&S) };
                HEX_DUMP
            }
 
-error: could not evaluate constant pattern
-  --> $DIR/const_refs_to_static_fail_invalid.rs:15:9
-   |
-LL |         C => {}
-   |         ^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refs_to_static_fail_invalid.rs:25:5
    |
@@ -26,12 +20,6 @@ LL |     const C: &i8 = unsafe { &S };
                HEX_DUMP
            }
 
-error: could not evaluate constant pattern
-  --> $DIR/const_refs_to_static_fail_invalid.rs:31:9
-   |
-LL |         C => {}
-   |         ^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refs_to_static_fail_invalid.rs:39:5
    |
@@ -42,6 +30,18 @@ LL |     const C: &i32 = unsafe { &S_MUT };
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
                HEX_DUMP
            }
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refs_to_static_fail_invalid.rs:15:9
+   |
+LL |         C => {}
+   |         ^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refs_to_static_fail_invalid.rs:31:9
+   |
+LL |         C => {}
+   |         ^
 
 error: could not evaluate constant pattern
   --> $DIR/const_refs_to_static_fail_invalid.rs:46:9

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -74,6 +74,24 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/fn_trait_refs.rs:72:17
+   |
+LL |         assert!(test_one == (1, 1, 1));
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const operator in constants
+  --> $DIR/fn_trait_refs.rs:75:17
+   |
+LL |         assert!(test_two == (2, 2));
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/fn_trait_refs.rs:17:5
    |
@@ -148,24 +166,6 @@ LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
 ...
 LL | }
    | - value is dropped here
-
-error[E0015]: cannot call non-const operator in constants
-  --> $DIR/fn_trait_refs.rs:72:17
-   |
-LL |         assert!(test_one == (1, 1, 1));
-   |                 ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = help: add `#![feature(effects)]` to the crate attributes to enable
-
-error[E0015]: cannot call non-const operator in constants
-  --> $DIR/fn_trait_refs.rs:75:17
-   |
-LL |         assert!(test_two == (2, 2));
-   |                 ^^^^^^^^^^^^^^^^^^
-   |
-   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = help: add `#![feature(effects)]` to the crate attributes to enable
 
 error: aborting due to 20 previous errors
 

--- a/tests/ui/consts/issue-16538.stderr
+++ b/tests/ui/consts/issue-16538.stderr
@@ -1,3 +1,12 @@
+error[E0015]: cannot call non-const fn `Y::foo` in statics
+  --> $DIR/issue-16538.rs:11:23
+   |
+LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
+
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
   --> $DIR/issue-16538.rs:11:22
    |
@@ -13,15 +22,6 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                              ^^^^ use of extern static
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
-
-error[E0015]: cannot call non-const fn `Y::foo` in statics
-  --> $DIR/issue-16538.rs:11:23
-   |
-LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
-   = note: consider wrapping this expression in `Lazy::new(|| ...)` from the `once_cell` crate: https://crates.io/crates/once_cell
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/issue-66693.rs
+++ b/tests/ui/consts/issue-66693.rs
@@ -12,9 +12,11 @@ const fn _foo() {
     //~^ ERROR: argument to `panic!()` in a const context must have type `&str`
 }
 
-// ensure that conforming panics don't cause an error
+// ensure that conforming panics don't cause an error beyond the failure to const eval
 const _: () = panic!();
+//~^ ERROR: evaluation of constant value failed
 static _BAR: () = panic!("panic in static");
+//~^ ERROR could not evaluate static initializer
 
 const fn _bar() {
     panic!("panic in const fn");

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -14,6 +14,22 @@ LL | static _FOO: () = panic!(true);
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-66693.rs:16:15
+   |
+LL | const _: () = panic!();
+   |               ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693.rs:16:15
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/issue-66693.rs:18:19
+   |
+LL | static _BAR: () = panic!("panic in static");
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic in static', $DIR/issue-66693.rs:18:19
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:11:5
    |
@@ -22,5 +38,6 @@ LL |     panic!(&1);
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -9,12 +9,6 @@ LL | const SLICE_MUT: &[u8; 1] = {
                HEX_DUMP
            }
 
-error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
-   |
-LL |         SLICE_MUT => true,
-   |         ^^^^^^^^^
-
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:17:1
    |
@@ -25,12 +19,6 @@ LL | const U8_MUT: &u8 = {
    = note: the raw bytes of the constant (size: $SIZE, align: $ALIGN) {
                HEX_DUMP
            }
-
-error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:48:9
-   |
-LL |         U8_MUT => true,
-   |         ^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const_refers_to_static_cross_crate.rs:23:1
@@ -43,17 +31,29 @@ LL | const U8_MUT2: &u8 = {
                HEX_DUMP
            }
 
-error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:58:9
-   |
-LL |         U8_MUT2 => true,
-   |         ^^^^^^^
-
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_refers_to_static_cross_crate.rs:29:15
    |
 LL |         match static_cross_crate::OPT_ZERO {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses mutable global memory
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
+   |
+LL |         SLICE_MUT => true,
+   |         ^^^^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:48:9
+   |
+LL |         U8_MUT => true,
+   |         ^^^^^^
+
+error: could not evaluate constant pattern
+  --> $DIR/const_refers_to_static_cross_crate.rs:58:9
+   |
+LL |         U8_MUT2 => true,
+   |         ^^^^^^^
 
 error: could not evaluate constant pattern
   --> $DIR/const_refers_to_static_cross_crate.rs:65:9

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -4,29 +4,26 @@ use std::cell::UnsafeCell;
 
 // a test demonstrating what things we could allow with a smarter const qualification
 
-// this is fine because is not possible to mutate through an immutable reference.
 static FOO: &&mut u32 = &&mut 42;
+//~^ ERROR encountered mutable pointer in final value of static
 
-// this is fine because accessing an immutable static `BAR` is equivalent to accessing `*&BAR`
-// which puts the mutable reference behind an immutable one.
 static BAR: &mut () = &mut ();
+//~^ ERROR encountered mutable pointer in final value of static
 
 struct Foo<T>(T);
 
-// this is fine for the same reason as `BAR`.
 static BOO: &mut Foo<()> = &mut Foo(());
+//~^ ERROR encountered mutable pointer in final value of static
 
-// interior mutability is fine
 struct Meh {
     x: &'static UnsafeCell<i32>,
 }
 unsafe impl Sync for Meh {}
-static MEH: Meh = Meh {
-    x: &UnsafeCell::new(42),
-};
+static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
+//~^ ERROR encountered mutable pointer in final value of static
 
-// this is fine for the same reason as `BAR`.
 static OH_YES: &mut i32 = &mut 42;
+//~^ ERROR encountered mutable pointer in final value of static
 
 fn main() {
     unsafe {

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,5 +1,35 @@
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:7:1
+   |
+LL | static FOO: &&mut u32 = &&mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:10:1
+   |
+LL | static BAR: &mut () = &mut ();
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:15:1
+   |
+LL | static BOO: &mut Foo<()> = &mut Foo(());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:22:1
+   |
+LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
+   | ^^^^^^^^^^^^^^^
+
+error: encountered mutable pointer in final value of static
+  --> $DIR/mutable_references.rs:25:1
+   |
+LL | static OH_YES: &mut i32 = &mut 42;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:35:5
+  --> $DIR/mutable_references.rs:32:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
@@ -7,31 +37,31 @@ LL |     *OH_YES = 99;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:8:26
+  --> $DIR/mutable_references.rs:7:26
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    |                          ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:12:23
+  --> $DIR/mutable_references.rs:10:23
    |
 LL | static BAR: &mut () = &mut ();
    |                       ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:17:28
+  --> $DIR/mutable_references.rs:15:28
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:25:8
+  --> $DIR/mutable_references.rs:22:28
    |
-LL |     x: &UnsafeCell::new(42),
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
+   |                            ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:29:27
+  --> $DIR/mutable_references.rs:25:27
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    |                           ^^^^^^^
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 6 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/consts/promote-not.stderr
+++ b/tests/ui/consts/promote-not.stderr
@@ -19,26 +19,6 @@ LL | };
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:20:32
-   |
-LL |         let _x: &'static () = &foo();
-   |                 -----------    ^^^^^ creates a temporary value which is freed while still in use
-   |                 |
-   |                 type annotation requires that borrow lasts for `'static`
-LL |     }
-   |     - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promote-not.rs:28:29
-   |
-LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
-   |             ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |             |
-   |             type annotation requires that borrow lasts for `'static`
-LL | }
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:33:29
    |
 LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
@@ -56,6 +36,26 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               |
    |               type annotation requires that borrow lasts for `'static`
 LL | };
+   | - temporary value is freed at the end of this statement
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-not.rs:20:32
+   |
+LL |         let _x: &'static () = &foo();
+   |                 -----------    ^^^^^ creates a temporary value which is freed while still in use
+   |                 |
+   |                 type annotation requires that borrow lasts for `'static`
+LL |     }
+   |     - temporary value is freed at the end of this statement
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/promote-not.rs:28:29
+   |
+LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
+   |             ------------    ^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
+   |             |
+   |             type annotation requires that borrow lasts for `'static`
+LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed

--- a/tests/ui/consts/promoted_const_call2.stderr
+++ b/tests/ui/consts/promoted_const_call2.stderr
@@ -18,6 +18,12 @@ LL |     let _: &'static _ = &id(&String::new());
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
 
+error[E0493]: destructor of `String` cannot be evaluated at compile-time
+  --> $DIR/promoted_const_call2.rs:4:30
+   |
+LL |     let _: &'static _ = &id(&String::new());
+   |                              ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
+
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call2.rs:11:26
    |
@@ -37,12 +43,6 @@ LL |     let _: &'static _ = &id(&String::new());
    |            |                 |
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
-
-error[E0493]: destructor of `String` cannot be evaluated at compile-time
-  --> $DIR/promoted_const_call2.rs:4:30
-   |
-LL |     let _: &'static _ = &id(&String::new());
-   |                              ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -1,20 +1,54 @@
-error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time
-  --> $DIR/qualif-indirect-mutation-fail.rs:9:9
-   |
-LL |     let mut a: (u32, Option<String>) = (0, None);
-   |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
-
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:15:9
    |
 LL |     let mut x = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constants
 
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `A1`
+  --> $DIR/qualif-indirect-mutation-fail.rs:21:1
+   |
+LL | };
+   | ^
+
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:31:9
    |
 LL |     let _z = x;
    |         ^^ the destructor for this type cannot be evaluated in constants
+
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `A2`
+  --> $DIR/qualif-indirect-mutation-fail.rs:32:1
+   |
+LL | };
+   | ^
+
+error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time
+  --> $DIR/qualif-indirect-mutation-fail.rs:9:9
+   |
+LL |     let mut a: (u32, Option<String>) = (0, None);
+   |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
 
 error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:36:9
@@ -52,6 +86,7 @@ error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
 LL |     let x: Option<String> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 9 previous errors
+error: aborting due to 11 previous errors
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0080, E0493.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/consts/recursive-zst-static.default.stderr
+++ b/tests/ui/consts/recursive-zst-static.default.stderr
@@ -16,17 +16,7 @@ note: ...which requires evaluating initializer of static `B`...
 LL | static B: () = A;
    |                ^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
-note: cycle used when linting top-level module
-  --> $DIR/recursive-zst-static.rs:10:1
-   |
-LL | / static FOO: () = FOO;
-LL | |
-LL | |
-LL | | static A: () = B;
-...  |
-LL | |     FOO
-LL | | }
-   | |_^
+   = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/recursive-zst-static.unleash.stderr
+++ b/tests/ui/consts/recursive-zst-static.unleash.stderr
@@ -16,17 +16,7 @@ note: ...which requires evaluating initializer of static `B`...
 LL | static B: () = A;
    |                ^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
-note: cycle used when linting top-level module
-  --> $DIR/recursive-zst-static.rs:10:1
-   |
-LL | / static FOO: () = FOO;
-LL | |
-LL | |
-LL | | static A: () = B;
-...  |
-LL | |     FOO
-LL | | }
-   | |_^
+   = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 2 previous errors

--- a/tests/ui/drop/repeat-drop-2.stderr
+++ b/tests/ui/drop/repeat-drop-2.stderr
@@ -1,3 +1,12 @@
+error[E0493]: destructor of `String` cannot be evaluated at compile-time
+  --> $DIR/repeat-drop-2.rs:7:25
+   |
+LL | const _: [String; 0] = [String::new(); 0];
+   |                        -^^^^^^^^^^^^^----
+   |                        ||
+   |                        |the destructor for this type cannot be evaluated in constants
+   |                        value is dropped here
+
 error[E0382]: use of moved value: `foo`
   --> $DIR/repeat-drop-2.rs:4:17
    |
@@ -12,15 +21,6 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     let _bar = foo.clone();
    |                   ++++++++
-
-error[E0493]: destructor of `String` cannot be evaluated at compile-time
-  --> $DIR/repeat-drop-2.rs:7:25
-   |
-LL | const _: [String; 0] = [String::new(); 0];
-   |                        -^^^^^^^^^^^^^----
-   |                        ||
-   |                        |the destructor for this type cannot be evaluated in constants
-   |                        value is dropped here
 
 error[E0381]: used binding `x` isn't initialized
   --> $DIR/repeat-drop-2.rs:12:14

--- a/tests/ui/error-codes/E0017.rs
+++ b/tests/ui/error-codes/E0017.rs
@@ -1,5 +1,8 @@
 #![feature(const_mut_refs)]
 
+//@ normalize-stderr-test "\(size: ., align: .\)" -> ""
+//@ normalize-stderr-test " +│ ╾─+╼" -> ""
+
 static X: i32 = 1;
 const C: i32 = 2;
 static mut M: i32 = 3;
@@ -14,5 +17,6 @@ static CONST_REF: &'static mut i32 = &mut C; //~ ERROR mutable references are no
 
 static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
 //~^ WARN mutable reference to mutable static is discouraged [static_mut_refs]
+//~| ERROR undefined behavior
 
 fn main() {}

--- a/tests/ui/error-codes/E0017.stderr
+++ b/tests/ui/error-codes/E0017.stderr
@@ -1,5 +1,5 @@
 warning: creating a mutable reference to mutable static is discouraged
-  --> $DIR/E0017.rs:15:52
+  --> $DIR/E0017.rs:18:52
    |
 LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
    |                                                    ^^^^^^ mutable reference to mutable static
@@ -14,7 +14,7 @@ LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { addr_of_mut!(M) };
    |                                                    ~~~~~~~~~~~~~~~
 
 warning: taking a mutable reference to a `const` item
-  --> $DIR/E0017.rs:7:30
+  --> $DIR/E0017.rs:10:30
    |
 LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^
@@ -22,26 +22,26 @@ LL | const CR: &'static mut i32 = &mut C;
    = note: each usage of a `const` item creates a new temporary
    = note: the mutable reference will refer to this temporary, not the original `const` item
 note: `const` item defined here
-  --> $DIR/E0017.rs:4:1
+  --> $DIR/E0017.rs:7:1
    |
 LL | const C: i32 = 2;
    | ^^^^^^^^^^^^
    = note: `#[warn(const_item_mutation)]` on by default
 
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/E0017.rs:7:30
+  --> $DIR/E0017.rs:10:30
    |
 LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^
 
 error[E0596]: cannot borrow immutable static item `X` as mutable
-  --> $DIR/E0017.rs:10:39
+  --> $DIR/E0017.rs:13:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^ cannot borrow as mutable
 
 warning: taking a mutable reference to a `const` item
-  --> $DIR/E0017.rs:12:38
+  --> $DIR/E0017.rs:15:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^
@@ -49,18 +49,29 @@ LL | static CONST_REF: &'static mut i32 = &mut C;
    = note: each usage of a `const` item creates a new temporary
    = note: the mutable reference will refer to this temporary, not the original `const` item
 note: `const` item defined here
-  --> $DIR/E0017.rs:4:1
+  --> $DIR/E0017.rs:7:1
    |
 LL | const C: i32 = 2;
    | ^^^^^^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/E0017.rs:12:38
+  --> $DIR/E0017.rs:15:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^
 
-error: aborting due to 3 previous errors; 3 warnings emitted
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/E0017.rs:18:1
+   |
+LL | static STATIC_MUT_REF: &'static mut i32 = unsafe { &mut M };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference in a `const` or `static`
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant  {
+               ╾ALLOC0╼
+           }
 
-Some errors have detailed explanations: E0596, E0764.
-For more information about an error, try `rustc --explain E0596`.
+error: aborting due to 4 previous errors; 3 warnings emitted
+
+Some errors have detailed explanations: E0080, E0596, E0764.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/error-codes/E0388.rs
+++ b/tests/ui/error-codes/E0388.rs
@@ -2,10 +2,12 @@ static X: i32 = 1;
 const C: i32 = 2;
 
 const CR: &'static mut i32 = &mut C; //~ ERROR mutable references are not allowed
-                                     //~| WARN taking a mutable
+
+//~| WARN taking a mutable
 static STATIC_REF: &'static mut i32 = &mut X; //~ ERROR E0658
 
 static CONST_REF: &'static mut i32 = &mut C; //~ ERROR mutable references are not allowed
-                                             //~| WARN taking a mutable
+
+//~| WARN taking a mutable
 
 fn main() {}

--- a/tests/ui/error-codes/E0388.stderr
+++ b/tests/ui/error-codes/E0388.stderr
@@ -20,7 +20,7 @@ LL | const CR: &'static mut i32 = &mut C;
    |                              ^^^^^^
 
 error[E0658]: mutable references are not allowed in statics
-  --> $DIR/E0388.rs:6:39
+  --> $DIR/E0388.rs:7:39
    |
 LL | static STATIC_REF: &'static mut i32 = &mut X;
    |                                       ^^^^^^
@@ -30,7 +30,7 @@ LL | static STATIC_REF: &'static mut i32 = &mut X;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: taking a mutable reference to a `const` item
-  --> $DIR/E0388.rs:8:38
+  --> $DIR/E0388.rs:9:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^
@@ -44,7 +44,7 @@ LL | const C: i32 = 2;
    | ^^^^^^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/E0388.rs:8:38
+  --> $DIR/E0388.rs:9:38
    |
 LL | static CONST_REF: &'static mut i32 = &mut C;
    |                                      ^^^^^^

--- a/tests/ui/error-codes/E0396.stderr
+++ b/tests/ui/error-codes/E0396.stderr
@@ -8,42 +8,42 @@ LL | const VALUE: u8 = unsafe { *REG_ADDR };
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
-  --> $DIR/E0396.rs:10:11
+error[E0658]: dereferencing raw mutable pointers in constants is unstable
+  --> $DIR/E0396.rs:14:36
    |
-LL |     match *INFALLIBLE {}
-   |           ^^^^^^^^^^^
+LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
+   |                                    ^^^^^^^^^^^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
-  --> $DIR/E0396.rs:10:11
+error[E0658]: dereferencing raw mutable pointers in constants is unstable
+  --> $DIR/E0396.rs:14:36
    |
-LL |     match *INFALLIBLE {}
-   |           ^^^^^^^^^^^
+LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
+   |                                    ^^^^^^^^^^^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0658]: dereferencing raw mutable pointers in constants is unstable
-  --> $DIR/E0396.rs:14:36
+error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
+  --> $DIR/E0396.rs:10:11
    |
-LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
-   |                                    ^^^^^^^^^^^
+LL |     match *INFALLIBLE {}
+   |           ^^^^^^^^^^^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: dereferencing raw mutable pointers in constants is unstable
-  --> $DIR/E0396.rs:14:36
+error[E0658]: dereferencing raw mutable pointers in constant functions is unstable
+  --> $DIR/E0396.rs:10:11
    |
-LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
-   |                                    ^^^^^^^^^^^
+LL |     match *INFALLIBLE {}
+   |           ^^^^^^^^^^^
    |
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable

--- a/tests/ui/extern/issue-28324.rs
+++ b/tests/ui/extern/issue-28324.rs
@@ -4,5 +4,6 @@ extern "C" {
 
 pub static BAZ: u32 = *&error_message_count;
 //~^ ERROR use of extern static is unsafe and requires
+//~| ERROR could not evaluate static initializer
 
 fn main() {}

--- a/tests/ui/extern/issue-28324.stderr
+++ b/tests/ui/extern/issue-28324.stderr
@@ -1,3 +1,9 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/issue-28324.rs:5:23
+   |
+LL | pub static BAZ: u32 = *&error_message_count;
+   |                       ^^^^^^^^^^^^^^^^^^^^^ cannot access extern static (DefId(0:4 ~ issue_28324[8ec4]::{extern#0}::error_message_count))
+
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-28324.rs:5:25
    |
@@ -6,6 +12,7 @@ LL | pub static BAZ: u32 = *&error_message_count;
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0133`.
+Some errors have detailed explanations: E0080, E0133.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/generic-const-items/trivially-unsatisfied-bounds-0.rs
+++ b/tests/ui/generic-const-items/trivially-unsatisfied-bounds-0.rs
@@ -3,7 +3,7 @@
 
 // Ensure that we check if trivial bounds on const items hold or not.
 
-const UNUSABLE: () = ()
+const UNUSABLE: () = () //~ ERROR evaluation of constant value failed
 where
     String: Copy;
 

--- a/tests/ui/generic-const-items/trivially-unsatisfied-bounds-0.stderr
+++ b/tests/ui/generic-const-items/trivially-unsatisfied-bounds-0.stderr
@@ -1,3 +1,11 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/trivially-unsatisfied-bounds-0.rs:6:1
+   |
+LL | / const UNUSABLE: () = ()
+LL | | where
+LL | |     String: Copy;
+   | |_________________^ entering unreachable code
+
 error[E0277]: the trait bound `String: Copy` is not satisfied
   --> $DIR/trivially-unsatisfied-bounds-0.rs:11:13
    |
@@ -13,6 +21,7 @@ LL | where
 LL |     String: Copy;
    |             ^^^^ required by this bound in `UNUSABLE`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0080, E0277.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/issues/issue-17252.rs
+++ b/tests/ui/issues/issue-17252.rs
@@ -4,6 +4,7 @@ fn main() {
     let _x: [u8; FOO]; // caused stack overflow prior to fix
     let _y: usize = 1 + {
         const BAR: usize = BAR;
+        //~^ ERROR: cycle
         let _z: [u8; BAR]; // caused stack overflow prior to fix
         1
     };

--- a/tests/ui/issues/issue-17252.stderr
+++ b/tests/ui/issues/issue-17252.stderr
@@ -10,13 +10,24 @@ note: ...which requires const-evaluating + checking `FOO`...
 LL | const FOO: usize = FOO;
    |                    ^^^
    = note: ...which again requires simplifying constant for the type system `FOO`, completing the cycle
-note: cycle used when const-evaluating + checking `main::{constant#0}`
-  --> $DIR/issue-17252.rs:4:18
-   |
-LL |     let _x: [u8; FOO]; // caused stack overflow prior to fix
-   |                  ^^^
+   = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when simplifying constant for the type system `main::BAR`
+  --> $DIR/issue-17252.rs:6:9
+   |
+LL |         const BAR: usize = BAR;
+   |         ^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `main::BAR`...
+  --> $DIR/issue-17252.rs:6:28
+   |
+LL |         const BAR: usize = BAR;
+   |                            ^^^
+   = note: ...which again requires simplifying constant for the type system `main::BAR`, completing the cycle
+   = note: cycle used when running analysis passes on this crate
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/issues/issue-23302-enum-infinite-recursion/issue-23302-3.stderr
+++ b/tests/ui/issues/issue-23302-enum-infinite-recursion/issue-23302-3.stderr
@@ -20,15 +20,7 @@ note: ...which requires const-evaluating + checking `B`...
 LL | const B: i32 = A;
    |                ^
    = note: ...which again requires simplifying constant for the type system `A`, completing the cycle
-note: cycle used when linting top-level module
-  --> $DIR/issue-23302-3.rs:1:1
-   |
-LL | / const A: i32 = B;
-LL | |
-LL | | const B: i32 = A;
-LL | |
-LL | | fn main() { }
-   | |_____________^
+   = note: cycle used when running analysis passes on this crate
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-76191.rs
+++ b/tests/ui/issues/issue-76191.rs
@@ -6,6 +6,7 @@ use std::ops::RangeInclusive;
 const RANGE: RangeInclusive<i32> = 0..=255;
 
 const RANGE2: RangeInclusive<i32> = panic!();
+//~^ ERROR evaluation of constant value failed
 
 fn main() {
     let n: i32 = 1;

--- a/tests/ui/issues/issue-76191.stderr
+++ b/tests/ui/issues/issue-76191.stderr
@@ -1,5 +1,13 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-76191.rs:8:37
+   |
+LL | const RANGE2: RangeInclusive<i32> = panic!();
+   |                                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-76191.rs:8:37
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0308]: mismatched types
-  --> $DIR/issue-76191.rs:13:9
+  --> $DIR/issue-76191.rs:14:9
    |
 LL | const RANGE: RangeInclusive<i32> = 0..=255;
    | -------------------------------- constant defined here
@@ -20,7 +28,7 @@ LL |         0..=255 => {}
    |         ~~~~~~~
 
 error[E0308]: mismatched types
-  --> $DIR/issue-76191.rs:15:9
+  --> $DIR/issue-76191.rs:16:9
    |
 LL | const RANGE2: RangeInclusive<i32> = panic!();
    | --------------------------------- constant defined here
@@ -38,6 +46,7 @@ LL |         RANGE2 => {}
             found struct `RangeInclusive<i32>`
    = note: constants only support matching by type, if you meant to match against a range of values, consider using a range pattern like `min ..= max` in the match block
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0080, E0308.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/liveness/liveness-consts.stderr
+++ b/tests/ui/liveness/liveness-consts.stderr
@@ -23,12 +23,6 @@ warning: unused variable: `z`
 LL | pub fn f(x: [u8; { let s = 17; 100 }]) -> [u8;  { let z = 18; 100 }] {
    |                                                       ^ help: if this is intentional, prefix it with an underscore: `_z`
 
-warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:60:13
-   |
-LL |         let z = 42;
-   |             ^ help: if this is intentional, prefix it with an underscore: `_z`
-
 warning: variable `a` is assigned to, but never used
   --> $DIR/liveness-consts.rs:7:13
    |
@@ -45,6 +39,12 @@ LL |     b += 1;
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
+
+warning: unused variable: `z`
+  --> $DIR/liveness-consts.rs:60:13
+   |
+LL |         let z = 42;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_z`
 
 warning: value assigned to `t` is never read
   --> $DIR/liveness-consts.rs:42:9

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/call-const-trait-method-pass.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/call-const-trait-method-pass.stderr
@@ -1,12 +1,3 @@
-error[E0015]: cannot call non-const fn `<i32 as Plus>::plus` in constant functions
-  --> $DIR/call-const-trait-method-pass.rs:36:7
-   |
-LL |     a.plus(b)
-   |       ^^^^^^^
-   |
-   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = help: add `#![feature(effects)]` to the crate attributes to enable
-
 error[E0015]: cannot call non-const operator in constants
   --> $DIR/call-const-trait-method-pass.rs:39:22
    |
@@ -19,6 +10,15 @@ note: impl defined here, but it is not `const`
 LL | impl const std::ops::Add for Int {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+
+error[E0015]: cannot call non-const fn `<i32 as Plus>::plus` in constant functions
+  --> $DIR/call-const-trait-method-pass.rs:36:7
+   |
+LL |     a.plus(b)
+   |       ^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = help: add `#![feature(effects)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-closures.stderr
@@ -23,19 +23,6 @@ LL | const fn answer<F: ~const Fn() -> u8>(f: &F) -> u8 {
    |                           ^^^^^^^^^^
 
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/const-closures.rs:12:5
-   |
-LL |     f() * 7
-   |     ^^^
-   |
-   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = help: add `#![feature(effects)]` to the crate attributes to enable
-help: consider further restricting this bound
-   |
-LL |         F: ~const FnOnce() -> u8 + ~const std::ops::Fn<()>,
-   |                                  +++++++++++++++++++++++++
-
-error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/const-closures.rs:24:5
    |
 LL |     f() + f()
@@ -60,6 +47,19 @@ help: consider further restricting this bound
    |
 LL | const fn answer<F: ~const Fn() -> u8 + ~const std::ops::Fn<()>>(f: &F) -> u8 {
    |                                      +++++++++++++++++++++++++
+
+error[E0015]: cannot call non-const closure in constant functions
+  --> $DIR/const-closures.rs:12:5
+   |
+LL |     f() * 7
+   |     ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = help: add `#![feature(effects)]` to the crate attributes to enable
+help: consider further restricting this bound
+   |
+LL |         F: ~const FnOnce() -> u8 + ~const std::ops::Fn<()>,
+   |                                  +++++++++++++++++++++++++
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop-fail.precise.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop-fail.precise.stderr
@@ -4,6 +4,57 @@ error[E0493]: destructor of `T` cannot be evaluated at compile-time
 LL | const fn check<T: ~const Destruct>(_: T) {}
    |                                    ^ the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 1 previous error
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<NonTrivialDrop as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<NonTrivialDrop> - shim(Some(NonTrivialDrop))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `check::<NonTrivialDrop>`
+  --> $DIR/const-drop-fail.rs:24:43
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                                           ^
+note: inside `_`
+  --> $DIR/const-drop-fail.rs:28:23
+   |
+LL |           const _: () = check($exp);
+   |                         ^^^^^^^^^^^
+...
+LL | / check_all! {
+LL | |     NonTrivialDrop,
+LL | |     ConstImplWithDropGlue(NonTrivialDrop),
+LL | | }
+   | |_- in this macro invocation
+   = note: this error originates in the macro `check_all` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-For more information about this error, try `rustc --explain E0493`.
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<ConstImplWithDropGlue as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<ConstImplWithDropGlue> - shim(Some(ConstImplWithDropGlue))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `check::<ConstImplWithDropGlue>`
+  --> $DIR/const-drop-fail.rs:24:43
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                                           ^
+note: inside `_`
+  --> $DIR/const-drop-fail.rs:28:23
+   |
+LL |           const _: () = check($exp);
+   |                         ^^^^^^^^^^^
+...
+LL | / check_all! {
+LL | |     NonTrivialDrop,
+LL | |     ConstImplWithDropGlue(NonTrivialDrop),
+LL | | }
+   | |_- in this macro invocation
+   = note: this error originates in the macro `check_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0080, E0493.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
@@ -1,15 +1,92 @@
-error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/const-drop.rs:19:32
-   |
-LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                                ^ the destructor for this type cannot be evaluated in constant functions
-
 error[E0493]: destructor of `S<'_>` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:24:13
    |
 LL |     let _ = S(&mut c);
    |             ^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 2 previous errors
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<S<'_> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<S<'_>> - shim(Some(S<'_>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `b`
+  --> $DIR/const-drop.rs:24:22
+   |
+LL |     let _ = S(&mut c);
+   |                      ^
+note: inside `C`
+  --> $DIR/const-drop.rs:30:15
+   |
+LL | const C: u8 = b();
+   |               ^^^
 
-For more information about this error, try `rustc --explain E0493`.
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/const-drop.rs:19:32
+   |
+LL | const fn a<T: ~const Destruct>(_: T) {}
+   |                                ^ the destructor for this type cannot be evaluated in constant functions
+
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<t::ConstDrop as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<t::ConstDrop> - shim(Some(t::ConstDrop))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `a::<t::ConstDrop>`
+  --> $DIR/const-drop.rs:19:39
+   |
+LL | const fn a<T: ~const Destruct>(_: T) {}
+   |                                       ^
+note: inside `_`
+  --> $DIR/const-drop.rs:35:27
+   |
+LL |               const _: () = a($exp);
+   |                             ^^^^^^^
+...
+LL | / implements_const_drop! {
+LL | |     1u8,
+LL | |     2,
+LL | |     3.0,
+...  |
+LL | |     Result::<i32, !>::Ok(1),
+LL | | }
+   | |_- in this macro invocation
+   = note: this error originates in the macro `implements_const_drop` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+   = note: calling non-const function `<t::ConstDrop as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<t::ConstDrop> - shim(Some(t::ConstDrop))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<t::HasConstDrop> - shim(Some(t::HasConstDrop))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `a::<t::HasConstDrop>`
+  --> $DIR/const-drop.rs:19:39
+   |
+LL | const fn a<T: ~const Destruct>(_: T) {}
+   |                                       ^
+note: inside `_`
+  --> $DIR/const-drop.rs:35:27
+   |
+LL |               const _: () = a($exp);
+   |                             ^^^^^^^
+...
+LL | / implements_const_drop! {
+LL | |     1u8,
+LL | |     2,
+LL | |     3.0,
+...  |
+LL | |     Result::<i32, !>::Ok(1),
+LL | | }
+   | |_- in this macro invocation
+   = note: this error originates in the macro `implements_const_drop` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0080, E0493.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.stock.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.stock.stderr
@@ -1,11 +1,3 @@
-error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/const-drop.rs:19:32
-   |
-LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                                ^      - value is dropped here
-   |                                |
-   |                                the destructor for this type cannot be evaluated in constant functions
-
 error[E0493]: destructor of `S<'_>` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:24:13
    |
@@ -13,6 +5,14 @@ LL |     let _ = S(&mut c);
    |             ^^^^^^^^^- value is dropped here
    |             |
    |             the destructor for this type cannot be evaluated in constant functions
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/const-drop.rs:19:32
+   |
+LL | const fn a<T: ~const Destruct>(_: T) {}
+   |                                ^      - value is dropped here
+   |                                |
+   |                                the destructor for this type cannot be evaluated in constant functions
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/static/static-drop-scope.stderr
+++ b/tests/ui/static/static-drop-scope.stderr
@@ -30,6 +30,22 @@ LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
    |                           |
    |                           the destructor for this type cannot be evaluated in constants
 
+error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
+  --> $DIR/static-drop-scope.rs:27:34
+   |
+LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
+   |                                  ^^^^^^^^^^^^^^^^^^^ - value is dropped here
+   |                                  |
+   |                                  the destructor for this type cannot be evaluated in constants
+
+error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
+  --> $DIR/static-drop-scope.rs:32:43
+   |
+LL | const EARLY_DROP_C_OPTION_CONSTANT: i32 = (HELPER, 0).1;
+   |                                           ^^^^^^^^^^^ - value is dropped here
+   |                                           |
+   |                                           the destructor for this type cannot be evaluated in constants
+
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:19:24
    |
@@ -46,22 +62,6 @@ LL |     (x, ()).1
 LL |
 LL | }
    | - value is dropped here
-
-error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:27:34
-   |
-LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
-   |                                  ^^^^^^^^^^^^^^^^^^^ - value is dropped here
-   |                                  |
-   |                                  the destructor for this type cannot be evaluated in constants
-
-error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at compile-time
-  --> $DIR/static-drop-scope.rs:32:43
-   |
-LL | const EARLY_DROP_C_OPTION_CONSTANT: i32 = (HELPER, 0).1;
-   |                                           ^^^^^^^^^^^ - value is dropped here
-   |                                           |
-   |                                           the destructor for this type cannot be evaluated in constants
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/statics/issue-14227.rs
+++ b/tests/ui/statics/issue-14227.rs
@@ -3,5 +3,6 @@ extern "C" {
 }
 static CRASH: u32 = symbol;
 //~^ ERROR use of extern static is unsafe and requires
+//~| ERROR could not evaluate static initializer
 
 fn main() {}

--- a/tests/ui/statics/issue-14227.stderr
+++ b/tests/ui/statics/issue-14227.stderr
@@ -1,3 +1,9 @@
+error[E0080]: could not evaluate static initializer
+  --> $DIR/issue-14227.rs:4:21
+   |
+LL | static CRASH: u32 = symbol;
+   |                     ^^^^^^ cannot access extern static (DefId(0:4 ~ issue_14227[1133]::{extern#0}::symbol))
+
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-14227.rs:4:21
    |
@@ -6,6 +12,7 @@ LL | static CRASH: u32 = symbol;
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0133`.
+Some errors have detailed explanations: E0080, E0133.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/statics/uninhabited-static.rs
+++ b/tests/ui/statics/uninhabited-static.rs
@@ -12,10 +12,8 @@ extern {
 static VOID2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
 //~| WARN: previously accepted
 //~| ERROR could not evaluate static initializer
-//~| WARN: type `Void` does not permit zero-initialization
 static NEVER2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
 //~| WARN: previously accepted
 //~| ERROR could not evaluate static initializer
-//~| WARN: type `Void` does not permit zero-initialization
 
 fn main() {}

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -34,7 +34,7 @@ LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    = note: uninhabited statics cannot be initialized, and any access would be an immediate error
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:16:1
+  --> $DIR/uninhabited-static.rs:15:1
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^
@@ -49,37 +49,12 @@ error[E0080]: could not evaluate static initializer
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of uninhabited type `Void`
 
-warning: the type `Void` does not permit zero-initialization
-  --> $DIR/uninhabited-static.rs:12:31
-   |
-LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
-   |
-note: enums with no inhabited variants have no valid value
-  --> $DIR/uninhabited-static.rs:4:1
-   |
-LL | enum Void {}
-   | ^^^^^^^^^
-   = note: `#[warn(invalid_value)]` on by default
-
 error[E0080]: could not evaluate static initializer
-  --> $DIR/uninhabited-static.rs:16:32
+  --> $DIR/uninhabited-static.rs:15:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of uninhabited type `Void`
 
-warning: the type `Void` does not permit zero-initialization
-  --> $DIR/uninhabited-static.rs:16:32
-   |
-LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^ this code causes undefined behavior when executed
-   |
-note: enums with no inhabited variants have no valid value
-  --> $DIR/uninhabited-static.rs:4:1
-   |
-LL | enum Void {}
-   | ^^^^^^^^^
-
-error: aborting due to 6 previous errors; 2 warnings emitted
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/treat-err-as-bug/err.stderr
+++ b/tests/ui/treat-err-as-bug/err.stderr
@@ -8,5 +8,5 @@ error: the compiler unexpectedly panicked. this is a bug.
 
 query stack during panic:
 #0 [eval_static_initializer] evaluating initializer of static `C`
-#1 [lint_mod] linting top-level module
+#1 [analysis] running analysis passes on this crate
 end of query stack

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -666,12 +666,6 @@ LL |     type F: std::ops::Fn(_);
 LL | impl Qux for Struct {
    | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
-error[E0515]: cannot return reference to function parameter `x`
-  --> $DIR/typeck_type_placeholder_item.rs:50:5
-   |
-LL |     &x
-   |     ^^ returns a reference to data owned by the current function
-
 error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}>` in constants
   --> $DIR/typeck_type_placeholder_item.rs:230:22
    |
@@ -689,6 +683,12 @@ LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+
+error[E0515]: cannot return reference to function parameter `x`
+  --> $DIR/typeck_type_placeholder_item.rs:50:5
+   |
+LL |     &x
+   |     ^^ returns a reference to data owned by the current function
 
 error: aborting due to 75 previous errors
 


### PR DESCRIPTION
work towards https://github.com/rust-lang/rust/issues/79738

We will need to evaluate static items before the `definitions.freeze()` below, as we will start creating new `DefId`s (for nested allocations) within the `eval_static_initializer` query.

But even without that motivation, this is a good change. Hard errors should always be reported and not silenced if other errors happened earlier.