### PR TITLE
use build.rustc config and skip-stage0-validation flag

### DIFF
--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -11,9 +11,15 @@ use std::{
 };
 
 fn parse(config: &str) -> Config {
-    Config::parse_inner(&["check".to_owned(), "--config=/does/not/exist".to_owned()], |&_| {
-        toml::from_str(config).unwrap()
-    })
+    let config = format!("{config} \r\n build.rustc = \"/does-not-exists\" ");
+    Config::parse_inner(
+        &[
+            "check".to_owned(),
+            "--config=/does/not/exist".to_owned(),
+            "--skip-stage0-validation".to_owned(),
+        ],
+        |&_| toml::from_str(&config).unwrap(),
+    )
 }
 
 #[test]


### PR DESCRIPTION
This change helps us to bypass downloading the beta compiler in bootstrap tests.

more context: https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/tests.20causing.20downloads.20of.20native.20rustc.20for.20other.20platforms/near/421467975