### PR TITLE
Remove unnecessary else block from `thread_local!` expanded code

### DIFF
--- a/library/std/src/sys/pal/common/thread_local/fast_local.rs
+++ b/library/std/src/sys/pal/common/thread_local/fast_local.rs
@@ -94,7 +94,8 @@ pub macro thread_local_inner {
                         if let $crate::option::Option::Some(init) = init {
                             if let $crate::option::Option::Some(value) = init.take() {
                                 return value;
-                            } else if $crate::cfg!(debug_assertions) {
+                            }
+                            if $crate::cfg!(debug_assertions) {
                                 $crate::unreachable!("missing default value");
                             }
                         }


### PR DESCRIPTION
Some expanded codes make ["unnecessary else block" warnings](https://github.com/rust-lang/rust-analyzer/issues/16556#issuecomment-1944271716) for Rust Analyzer