### PR TITLE
Ignore unsized types when trying to determine the size of the original type

### DIFF
--- a/compiler/rustc_lint/src/reference_casting.rs
+++ b/compiler/rustc_lint/src/reference_casting.rs
@@ -207,6 +207,13 @@ fn is_cast_to_bigger_memory_layout<'tcx>(
     }
 
     let from_layout = cx.layout_of(*inner_start_ty).ok()?;
+
+    // if the type isn't sized, we bail out, instead of potentially giving
+    // the user a meaningless warning.
+    if from_layout.is_unsized() {
+        return None;
+    }
+
     let alloc_layout = cx.layout_of(alloc_ty).ok()?;
     let to_layout = cx.layout_of(*inner_end_ty).ok()?;
 

--- a/tests/ui/lint/reference_casting.rs
+++ b/tests/ui/lint/reference_casting.rs
@@ -239,6 +239,11 @@ unsafe fn bigger_layout() {
         //~^ ERROR casting references to a bigger memory layout
     }
 
+    {
+        let x: Box<dyn Send> = Box::new(0i32);
+        let _z = unsafe { &*(&*x as *const dyn Send as *const i32) };
+    }
+
     unsafe fn from_ref(this: &i32) -> &i64 {
         &*(this as *const i32 as *const i64)
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/121074 a regression from https://github.com/rust-lang/rust/pull/118983