### PR TITLE
Inline cfg(bootstrap) version of `debug_assertions` intrinsic

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2589,6 +2589,7 @@ extern "rust-intrinsic" {
 }
 
 #[cfg(bootstrap)]
+#[inline(always)]
 #[rustc_const_unstable(feature = "delayed_debug_assertions", issue = "none")]
 pub(crate) const fn debug_assertions() -> bool {
     cfg!(debug_assertions)


### PR DESCRIPTION
This speeds up the stage1 build of the library by about 10s on my computer.

helps with #121110