### PR TITLE
Continue compilation even if inherent impl checks fail

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -178,8 +178,9 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
             let _ = tcx.ensure().coherent_trait(trait_def_id);
         }
         // these queries are executed for side-effects (error reporting):
-        res.and(tcx.ensure().crate_inherent_impls(()))
-            .and(tcx.ensure().crate_inherent_impls_overlap_check(()))
+        let _ = tcx.ensure().crate_inherent_impls(());
+        let _ = tcx.ensure().crate_inherent_impls_overlap_check(());
+        res
     })?;
 
     if tcx.features().rustc_attrs {

--- a/tests/ui/const-generics/wrong-normalization.rs
+++ b/tests/ui/const-generics/wrong-normalization.rs
@@ -15,5 +15,6 @@ pub struct I8<const F: i8>;
 
 impl <I8<{i8::MIN}> as Identity>::Identity {
 //~^ ERROR no nominal type found for inherent implementation
+//~| ERROR no associated item named `MIN` found for type `i8`
     pub fn foo(&self) {}
 }

--- a/tests/ui/const-generics/wrong-normalization.stderr
+++ b/tests/ui/const-generics/wrong-normalization.stderr
@@ -6,6 +6,18 @@ LL | impl <I8<{i8::MIN}> as Identity>::Identity {
    |
    = note: either implement a trait on it or create a newtype to wrap it instead
 
-error: aborting due to 1 previous error
+error[E0599]: no associated item named `MIN` found for type `i8` in the current scope
+  --> $DIR/wrong-normalization.rs:16:15
+   |
+LL | impl <I8<{i8::MIN}> as Identity>::Identity {
+   |               ^^^ associated item not found in `i8`
+   |
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL | impl <I8<{std::i8::MIN}> as Identity>::Identity {
+   |           +++++
 
-For more information about this error, try `rustc --explain E0118`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0118, E0599.
+For more information about an error, try `rustc --explain E0118`.

--- a/tests/ui/impl-trait/where-allowed.rs
+++ b/tests/ui/impl-trait/where-allowed.rs
@@ -44,6 +44,7 @@ fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!() }
 
 // Allowed
 fn in_dyn_Fn_return_in_return() -> &'static dyn Fn() -> impl Debug { panic!() }
+//~^ ERROR: type annotations needed
 
 // Disallowed
 fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
@@ -58,9 +59,11 @@ fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
 fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
 //~^ ERROR `impl Trait` is not allowed in the parameters of `Fn` trait bounds
 //~| ERROR nested `impl Trait` is not allowed
+//~| ERROR: type annotations needed
 
 // Allowed
 fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { panic!() }
+//~^ ERROR: type annotations needed
 
 // Disallowed
 fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
@@ -77,6 +80,7 @@ fn in_impl_Trait_in_parameters(_: impl Iterator<Item = impl Iterator>) { panic!(
 // Allowed
 fn in_impl_Trait_in_return() -> impl IntoIterator<Item = impl IntoIterator> {
     vec![vec![0; 10], vec![12; 7], vec![8; 3]]
+    //~^ ERROR: no function or associated item named `into_vec` found for slice `[_]`
 }
 
 // Disallowed
@@ -118,11 +122,13 @@ trait DummyTrait {
 impl DummyTrait for () {
     type Out = impl Debug;
     //~^ ERROR `impl Trait` in associated types is unstable
+    //~| ERROR unconstrained opaque type
 
     fn in_trait_impl_parameter(_: impl Debug) { }
     // Allowed
 
     fn in_trait_impl_return() -> impl Debug { () }
+    //~^ ERROR `in_trait_impl_return` has an incompatible type for trait
     // Allowed
 }
 

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -1,5 +1,5 @@
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:49:51
+  --> $DIR/where-allowed.rs:50:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           --------^^^^^^^^^^-
@@ -8,7 +8,7 @@ LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                           outer `impl Trait`
 
 error[E0666]: nested `impl Trait` is not allowed
-  --> $DIR/where-allowed.rs:58:57
+  --> $DIR/where-allowed.rs:59:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                 --------^^^^^^^^^^-
@@ -17,7 +17,7 @@ LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic
    |                                                 outer `impl Trait`
 
 error[E0658]: `impl Trait` in associated types is unstable
-  --> $DIR/where-allowed.rs:119:16
+  --> $DIR/where-allowed.rs:123:16
    |
 LL |     type Out = impl Debug;
    |                ^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     type Out = impl Debug;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:154:23
+  --> $DIR/where-allowed.rs:160:23
    |
 LL | type InTypeAlias<R> = impl Debug;
    |                       ^^^^^^^^^^
@@ -37,7 +37,7 @@ LL | type InTypeAlias<R> = impl Debug;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl Trait` in type aliases is unstable
-  --> $DIR/where-allowed.rs:157:39
+  --> $DIR/where-allowed.rs:163:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | fn in_dyn_Fn_parameter_in_return() -> &'static dyn Fn(impl Debug) { panic!(
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the parameters of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:49:51
+  --> $DIR/where-allowed.rs:50:51
    |
 LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    |                                                   ^^^^^^^^^^
@@ -111,7 +111,7 @@ LL | fn in_impl_Fn_parameter_in_parameters(_: &impl Fn(impl Debug)) { panic!() }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the return type of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:54:53
+  --> $DIR/where-allowed.rs:55:53
    |
 LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() }
    |                                                     ^^^^^^^^^^
@@ -119,7 +119,7 @@ LL | fn in_impl_Fn_return_in_parameters(_: &impl Fn() -> impl Debug) { panic!() 
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the parameters of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:58:57
+  --> $DIR/where-allowed.rs:59:57
    |
 LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
    |                                                         ^^^^^^^^^^
@@ -127,7 +127,7 @@ LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the parameters of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:66:38
+  --> $DIR/where-allowed.rs:69:38
    |
 LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    |                                      ^^^^^^^^^^
@@ -135,7 +135,7 @@ LL | fn in_Fn_parameter_in_generics<F: Fn(impl Debug)> (_: F) { panic!() }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the return type of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:70:40
+  --> $DIR/where-allowed.rs:73:40
    |
 LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    |                                        ^^^^^^^^^^
@@ -143,7 +143,7 @@ LL | fn in_Fn_return_in_generics<F: Fn() -> impl Debug> (_: F) { panic!() }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in field types
-  --> $DIR/where-allowed.rs:83:32
+  --> $DIR/where-allowed.rs:87:32
    |
 LL | struct InBraceStructField { x: impl Debug }
    |                                ^^^^^^^^^^
@@ -151,7 +151,7 @@ LL | struct InBraceStructField { x: impl Debug }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in field types
-  --> $DIR/where-allowed.rs:87:41
+  --> $DIR/where-allowed.rs:91:41
    |
 LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    |                                         ^^^^^^^^^^
@@ -159,7 +159,7 @@ LL | struct InAdtInBraceStructField { x: Vec<impl Debug> }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in field types
-  --> $DIR/where-allowed.rs:91:27
+  --> $DIR/where-allowed.rs:95:27
    |
 LL | struct InTupleStructField(impl Debug);
    |                           ^^^^^^^^^^
@@ -167,7 +167,7 @@ LL | struct InTupleStructField(impl Debug);
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in field types
-  --> $DIR/where-allowed.rs:96:25
+  --> $DIR/where-allowed.rs:100:25
    |
 LL |     InBraceVariant { x: impl Debug },
    |                         ^^^^^^^^^^
@@ -175,7 +175,7 @@ LL |     InBraceVariant { x: impl Debug },
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in field types
-  --> $DIR/where-allowed.rs:98:20
+  --> $DIR/where-allowed.rs:102:20
    |
 LL |     InTupleVariant(impl Debug),
    |                    ^^^^^^^^^^
@@ -183,7 +183,7 @@ LL |     InTupleVariant(impl Debug),
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in `extern fn` parameters
-  --> $DIR/where-allowed.rs:138:33
+  --> $DIR/where-allowed.rs:144:33
    |
 LL |     fn in_foreign_parameters(_: impl Debug);
    |                                 ^^^^^^^^^^
@@ -191,7 +191,7 @@ LL |     fn in_foreign_parameters(_: impl Debug);
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in `extern fn` return types
-  --> $DIR/where-allowed.rs:141:31
+  --> $DIR/where-allowed.rs:147:31
    |
 LL |     fn in_foreign_return() -> impl Debug;
    |                               ^^^^^^^^^^
@@ -199,7 +199,7 @@ LL |     fn in_foreign_return() -> impl Debug;
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer return types
-  --> $DIR/where-allowed.rs:157:39
+  --> $DIR/where-allowed.rs:163:39
    |
 LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    |                                       ^^^^^^^^^^
@@ -207,7 +207,7 @@ LL | type InReturnInTypeAlias<R> = fn() -> impl Debug;
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in traits
-  --> $DIR/where-allowed.rs:162:16
+  --> $DIR/where-allowed.rs:168:16
    |
 LL | impl PartialEq<impl Debug> for () {
    |                ^^^^^^^^^^
@@ -215,7 +215,7 @@ LL | impl PartialEq<impl Debug> for () {
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in impl headers
-  --> $DIR/where-allowed.rs:167:24
+  --> $DIR/where-allowed.rs:173:24
    |
 LL | impl PartialEq<()> for impl Debug {
    |                        ^^^^^^^^^^
@@ -223,7 +223,7 @@ LL | impl PartialEq<()> for impl Debug {
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in impl headers
-  --> $DIR/where-allowed.rs:172:6
+  --> $DIR/where-allowed.rs:178:6
    |
 LL | impl impl Debug {
    |      ^^^^^^^^^^
@@ -231,7 +231,7 @@ LL | impl impl Debug {
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in impl headers
-  --> $DIR/where-allowed.rs:178:24
+  --> $DIR/where-allowed.rs:184:24
    |
 LL | impl InInherentImplAdt<impl Debug> {
    |                        ^^^^^^^^^^
@@ -239,7 +239,7 @@ LL | impl InInherentImplAdt<impl Debug> {
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in bounds
-  --> $DIR/where-allowed.rs:184:11
+  --> $DIR/where-allowed.rs:190:11
    |
 LL |     where impl Debug: Debug
    |           ^^^^^^^^^^
@@ -247,7 +247,7 @@ LL |     where impl Debug: Debug
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in bounds
-  --> $DIR/where-allowed.rs:191:15
+  --> $DIR/where-allowed.rs:197:15
    |
 LL |     where Vec<impl Debug>: Debug
    |               ^^^^^^^^^^
@@ -255,7 +255,7 @@ LL |     where Vec<impl Debug>: Debug
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in bounds
-  --> $DIR/where-allowed.rs:198:24
+  --> $DIR/where-allowed.rs:204:24
    |
 LL |     where T: PartialEq<impl Debug>
    |                        ^^^^^^^^^^
@@ -263,7 +263,7 @@ LL |     where T: PartialEq<impl Debug>
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the parameters of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:205:17
+  --> $DIR/where-allowed.rs:211:17
    |
 LL |     where T: Fn(impl Debug)
    |                 ^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |     where T: Fn(impl Debug)
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the return type of `Fn` trait bounds
-  --> $DIR/where-allowed.rs:212:22
+  --> $DIR/where-allowed.rs:218:22
    |
 LL |     where T: Fn() -> impl Debug
    |                      ^^^^^^^^^^
@@ -279,7 +279,7 @@ LL |     where T: Fn() -> impl Debug
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in generic parameter defaults
-  --> $DIR/where-allowed.rs:218:40
+  --> $DIR/where-allowed.rs:224:40
    |
 LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    |                                        ^^^^^^^^^^
@@ -287,7 +287,7 @@ LL | struct InStructGenericParamDefault<T = impl Debug>(T);
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in generic parameter defaults
-  --> $DIR/where-allowed.rs:222:36
+  --> $DIR/where-allowed.rs:228:36
    |
 LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    |                                    ^^^^^^^^^^
@@ -295,7 +295,7 @@ LL | enum InEnumGenericParamDefault<T = impl Debug> { Variant(T) }
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in generic parameter defaults
-  --> $DIR/where-allowed.rs:226:38
+  --> $DIR/where-allowed.rs:232:38
    |
 LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    |                                      ^^^^^^^^^^
@@ -303,7 +303,7 @@ LL | trait InTraitGenericParamDefault<T = impl Debug> {}
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in generic parameter defaults
-  --> $DIR/where-allowed.rs:230:41
+  --> $DIR/where-allowed.rs:236:41
    |
 LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    |                                         ^^^^^^^^^^
@@ -311,7 +311,7 @@ LL | type InTypeAliasGenericParamDefault<T = impl Debug> = T;
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in generic parameter defaults
-  --> $DIR/where-allowed.rs:234:11
+  --> $DIR/where-allowed.rs:240:11
    |
 LL | impl <T = impl Debug> T {}
    |           ^^^^^^^^^^
@@ -319,7 +319,7 @@ LL | impl <T = impl Debug> T {}
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in generic parameter defaults
-  --> $DIR/where-allowed.rs:241:40
+  --> $DIR/where-allowed.rs:247:40
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                        ^^^^^^^^^^
@@ -327,7 +327,7 @@ LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings
-  --> $DIR/where-allowed.rs:247:29
+  --> $DIR/where-allowed.rs:253:29
    |
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
@@ -335,7 +335,7 @@ LL |     let _in_local_variable: impl Fn() = || {};
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0562]: `impl Trait` is not allowed in closure return types
-  --> $DIR/where-allowed.rs:249:46
+  --> $DIR/where-allowed.rs:255:46
    |
 LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    |                                              ^^^^^^^^^
@@ -343,7 +343,7 @@ LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:234:7
+  --> $DIR/where-allowed.rs:240:7
    |
 LL | impl <T = impl Debug> T {}
    |       ^^^^^^^^^^^^^^
@@ -353,7 +353,7 @@ LL | impl <T = impl Debug> T {}
    = note: `#[deny(invalid_type_param_default)]` on by default
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:241:36
+  --> $DIR/where-allowed.rs:247:36
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    |                                    ^^^^^^^^^^^^^^
@@ -362,14 +362,77 @@ LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/where-allowed.rs:234:1
+  --> $DIR/where-allowed.rs:240:1
    |
 LL | impl <T = impl Debug> T {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
    |
    = note: either implement a trait on it or create a newtype to wrap it instead
 
-error: aborting due to 45 previous errors
+error[E0283]: type annotations needed
+  --> $DIR/where-allowed.rs:46:57
+   |
+LL | fn in_dyn_Fn_return_in_return() -> &'static dyn Fn() -> impl Debug { panic!() }
+   |                                                         ^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot satisfy `_: Debug`
 
-Some errors have detailed explanations: E0118, E0562, E0658, E0666.
-For more information about an error, try `rustc --explain E0118`.
+error[E0282]: type annotations needed
+  --> $DIR/where-allowed.rs:59:49
+   |
+LL | fn in_impl_Fn_parameter_in_return() -> &'static impl Fn(impl Debug) { panic!() }
+   |                                                 ^^^^^^^^^^^^^^^^^^^ cannot infer type
+
+error[E0283]: type annotations needed
+  --> $DIR/where-allowed.rs:65:46
+   |
+LL | fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { panic!() }
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: multiple `impl`s satisfying `_: Fn()` found in the following crates: `alloc`, `core`:
+           - impl<A, F> Fn<A> for &F
+             where A: Tuple, F: Fn<A>, F: ?Sized;
+           - impl<Args, F, A> Fn<Args> for Box<F, A>
+             where Args: Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
+
+error[E0599]: no function or associated item named `into_vec` found for slice `[_]` in the current scope
+  --> $DIR/where-allowed.rs:82:5
+   |
+LL |     vec![vec![0; 10], vec![12; 7], vec![8; 3]]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `[_]`
+   |
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0053]: method `in_trait_impl_return` has an incompatible type for trait
+  --> $DIR/where-allowed.rs:130:34
+   |
+LL |     type Out = impl Debug;
+   |                ---------- the expected opaque type
+...
+LL |     fn in_trait_impl_return() -> impl Debug { () }
+   |                                  ^^^^^^^^^^
+   |                                  |
+   |                                  expected opaque type, found a different opaque type
+   |                                  help: change the output type to match the trait: `<() as DummyTrait>::Out`
+   |
+note: type in trait
+  --> $DIR/where-allowed.rs:120:34
+   |
+LL |     fn in_trait_impl_return() -> Self::Out;
+   |                                  ^^^^^^^^^
+   = note: expected signature `fn() -> <() as DummyTrait>::Out`
+              found signature `fn() -> impl Debug`
+   = note: distinct uses of `impl Trait` result in different opaque types
+
+error: unconstrained opaque type
+  --> $DIR/where-allowed.rs:123:16
+   |
+LL |     type Out = impl Debug;
+   |                ^^^^^^^^^^
+   |
+   = note: `Out` must be used in combination with a concrete type within the same impl
+
+error: aborting due to 51 previous errors
+
+Some errors have detailed explanations: E0053, E0118, E0282, E0283, E0562, E0599, E0658, E0666.
+For more information about an error, try `rustc --explain E0053`.

--- a/tests/ui/issues/issue-4265.rs
+++ b/tests/ui/issues/issue-4265.rs
@@ -5,6 +5,7 @@ struct Foo {
 impl Foo {
     fn bar() {
         Foo { baz: 0 }.bar();
+        //~^ ERROR: no method named `bar` found
     }
 
     fn bar() { //~ ERROR duplicate definitions

--- a/tests/ui/issues/issue-4265.stderr
+++ b/tests/ui/issues/issue-4265.stderr
@@ -1,5 +1,5 @@
 error[E0592]: duplicate definitions with name `bar`
-  --> $DIR/issue-4265.rs:10:5
+  --> $DIR/issue-4265.rs:11:5
    |
 LL |     fn bar() {
    |     -------- other definition for `bar`
@@ -7,6 +7,26 @@ LL |     fn bar() {
 LL |     fn bar() {
    |     ^^^^^^^^ duplicate definitions for `bar`
 
-error: aborting due to 1 previous error
+error[E0599]: no method named `bar` found for struct `Foo` in the current scope
+  --> $DIR/issue-4265.rs:7:24
+   |
+LL | struct Foo {
+   | ---------- method `bar` not found for this struct
+...
+LL |         Foo { baz: 0 }.bar();
+   |         ---------------^^^--
+   |         |              |
+   |         |              this is an associated function, not a method
+   |         help: use associated function syntax instead: `Foo::bar()`
+   |
+   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
+note: the candidate is defined in an impl for the type `Foo`
+  --> $DIR/issue-4265.rs:6:5
+   |
+LL |     fn bar() {
+   |     ^^^^^^^^
 
-For more information about this error, try `rustc --explain E0592`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0592, E0599.
+For more information about an error, try `rustc --explain E0592`.

--- a/tests/ui/kinds-of-primitive-impl.rs
+++ b/tests/ui/kinds-of-primitive-impl.rs
@@ -6,7 +6,7 @@ impl u8 {
 impl str {
 //~^ error: cannot define inherent `impl` for primitive types
     fn foo() {}
-    fn bar(self) {}
+    fn bar(self) {} //~ ERROR: size for values of type `str` cannot be known
 }
 
 impl char {

--- a/tests/ui/kinds-of-primitive-impl.stderr
+++ b/tests/ui/kinds-of-primitive-impl.stderr
@@ -31,6 +31,20 @@ LL | impl &MyType {
    = help: consider using an extension trait instead
    = note: you could also try moving the reference to uses of `MyType` (such as `self`) within the implementation
 
-error: aborting due to 4 previous errors
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/kinds-of-primitive-impl.rs:9:12
+   |
+LL |     fn bar(self) {}
+   |            ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = help: unsized fn params are gated as an unstable feature
+help: function arguments must have a statically known size, borrowed types always have a known size
+   |
+LL |     fn bar(&self) {}
+   |            +
 
-For more information about this error, try `rustc --explain E0390`.
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0390.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.rs
@@ -14,8 +14,10 @@ impl X {
     //~^ ERROR associated type in `impl` without body
     //~| ERROR bounds on `type`s in `impl`s have no effect
     //~| ERROR inherent associated types are unstable
+    //~| ERROR `X: Eq` is not satisfied
     type W where Self: Eq;
     //~^ ERROR associated type in `impl` without body
     //~| ERROR inherent associated types are unstable
     //~| ERROR duplicate definitions
+    //~| ERROR `X: Eq` is not satisfied
 }

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -35,7 +35,7 @@ LL |     type W: Ord where Self: Eq;
    |             ^^^
 
 error: associated type in `impl` without body
-  --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:5
    |
 LL |     type W where Self: Eq;
    |     ^^^^^^^^^^^^^^^^^^^^^-
@@ -73,7 +73,7 @@ LL |     type W: Ord where Self: Eq;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: inherent associated types are unstable
-  --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:5
    |
 LL |     type W where Self: Eq;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     type W where Self: Eq;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0592]: duplicate definitions with name `W`
-  --> $DIR/impl-item-type-no-body-semantic-fail.rs:17:5
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:5
    |
 LL |     type W: Ord where Self: Eq;
    |     ------ other definition for `W`
@@ -91,7 +91,35 @@ LL |     type W: Ord where Self: Eq;
 LL |     type W where Self: Eq;
    |     ^^^^^^ duplicate definitions for `W`
 
-error: aborting due to 11 previous errors
+error[E0277]: the trait bound `X: Eq` is not satisfied
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:13:23
+   |
+LL |     type W: Ord where Self: Eq;
+   |                       ^^^^^^^^ the trait `Eq` is not implemented for `X`
+   |
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+help: consider annotating `X` with `#[derive(Eq)]`
+   |
+LL + #[derive(Eq)]
+LL | struct X;
+   |
 
-Some errors have detailed explanations: E0592, E0658.
-For more information about an error, try `rustc --explain E0592`.
+error[E0277]: the trait bound `X: Eq` is not satisfied
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:18
+   |
+LL |     type W where Self: Eq;
+   |                  ^^^^^^^^ the trait `Eq` is not implemented for `X`
+   |
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+help: consider annotating `X` with `#[derive(Eq)]`
+   |
+LL + #[derive(Eq)]
+LL | struct X;
+   |
+
+error: aborting due to 13 previous errors
+
+Some errors have detailed explanations: E0277, E0592, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/issue-33140.rs
+++ b/tests/ui/traits/issue-33140.rs
@@ -43,5 +43,7 @@ fn main() {
     assert_eq!(<dyn Send + Sync>::uvw(), false);
     assert_eq!(<dyn Sync + Send+ Sync>::uvw(), true);
     assert_eq!(<Foo<dyn Send + Sync>>::abc(), false);
+    //~^ ERROR: multiple applicable items in scope
     assert_eq!(<Foo<dyn Sync + Send>>::abc(), true);
+    //~^ ERROR: multiple applicable items in scope
 }

--- a/tests/ui/traits/issue-33140.stderr
+++ b/tests/ui/traits/issue-33140.stderr
@@ -25,7 +25,41 @@ LL |     fn abc() -> bool {
 LL |     fn abc() -> bool {
    |     ---------------- other definition for `abc`
 
-error: aborting due to 3 previous errors
+error[E0034]: multiple applicable items in scope
+  --> $DIR/issue-33140.rs:45:40
+   |
+LL |     assert_eq!(<Foo<dyn Send + Sync>>::abc(), false);
+   |                                        ^^^ multiple `abc` found
+   |
+note: candidate #1 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+  --> $DIR/issue-33140.rs:29:5
+   |
+LL |     fn abc() -> bool {
+   |     ^^^^^^^^^^^^^^^^
+note: candidate #2 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+  --> $DIR/issue-33140.rs:35:5
+   |
+LL |     fn abc() -> bool {
+   |     ^^^^^^^^^^^^^^^^
 
-Some errors have detailed explanations: E0119, E0592.
-For more information about an error, try `rustc --explain E0119`.
+error[E0034]: multiple applicable items in scope
+  --> $DIR/issue-33140.rs:47:40
+   |
+LL |     assert_eq!(<Foo<dyn Sync + Send>>::abc(), true);
+   |                                        ^^^ multiple `abc` found
+   |
+note: candidate #1 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+  --> $DIR/issue-33140.rs:29:5
+   |
+LL |     fn abc() -> bool {
+   |     ^^^^^^^^^^^^^^^^
+note: candidate #2 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+  --> $DIR/issue-33140.rs:35:5
+   |
+LL |     fn abc() -> bool {
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0034, E0119, E0592.
+For more information about an error, try `rustc --explain E0034`.


### PR DESCRIPTION
We should not be hiding errors behind unrelated errors