### PR TITLE
Add `#[rustc_no_mir_inline]` for standard library UB checks

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -792,6 +792,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_intrinsic, Normal, template!(Word), ErrorFollowing,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics with function bodies",
     ),
+    rustc_attr!(
+        rustc_no_mir_inline, Normal, template!(Word), WarnFollowing,
+        "#[rustc_no_mir_inline] prevents the MIR inliner from inlining a function while not affecting codegen"
+    ),
 
     // ==========================================================================
     // Internal attributes, Testing:

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -421,6 +421,10 @@ impl<'tcx> Inliner<'tcx> {
         callee_attrs: &CodegenFnAttrs,
         cross_crate_inlinable: bool,
     ) -> Result<(), &'static str> {
+        if self.tcx.has_attr(callsite.callee.def_id(), sym::rustc_no_mir_inline) {
+            return Err("#[rustc_no_mir_inline]");
+        }
+
         if let InlineAttr::Never = callee_attrs.inline {
             return Err("never inline hint");
         }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1441,6 +1441,7 @@ symbols! {
         rustc_mir,
         rustc_must_implement_one_of,
         rustc_never_returns_null_ptr,
+        rustc_no_mir_inline,
         rustc_nonnull_optimization_guaranteed,
         rustc_nounwind,
         rustc_object_lifetime_default,

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-abort.diff
@@ -1,0 +1,19 @@
+- // MIR for `caller` before Inline
++ // MIR for `caller` after Inline
+  
+  fn caller() -> () {
+      let mut _0: ();
+      let _1: ();
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = callee() -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-unwind.diff
@@ -1,0 +1,19 @@
+- // MIR for `caller` before Inline
++ // MIR for `caller` after Inline
+  
+  fn caller() -> () {
+      let mut _0: ();
+      let _1: ();
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = callee() -> [return: bb1, unwind continue];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,14 @@
+// MIR for `caller` after PreCodegen
+
+fn caller() -> () {
+    let mut _0: ();
+    let _1: ();
+
+    bb0: {
+        _1 = callee() -> [return: bb1, unwind unreachable];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,14 @@
+// MIR for `caller` after PreCodegen
+
+fn caller() -> () {
+    let mut _0: ();
+    let _1: ();
+
+    bb0: {
+        _1 = callee() -> [return: bb1, unwind continue];
+    }
+
+    bb1: {
+        return;
+    }
+}

--- a/tests/mir-opt/inline/rustc_no_mir_inline.rs
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.rs
@@ -1,0 +1,17 @@
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+#![crate_type = "lib"]
+#![feature(rustc_attrs)]
+
+//@ compile-flags: -Zmir-opt-level=2 -Zinline-mir
+
+#[inline]
+#[rustc_no_mir_inline]
+pub fn callee() {}
+
+// EMIT_MIR rustc_no_mir_inline.caller.Inline.diff
+// EMIT_MIR rustc_no_mir_inline.caller.PreCodegen.after.mir
+pub fn caller() {
+    // CHECK-LABEL: fn caller(
+    // CHECK: callee()
+    callee();
+}


### PR DESCRIPTION
should help with #121110 and also with #120848

Because the MIR inliner cannot know whether the checks are enabled or not, so inlining is an unnecessary compile time pessimization when debug assertions are disabled. LLVM knows whether they are enabled or not, so it can optimize accordingly without wasting time.

r? @saethlin 