### PR TITLE
Reinstate some delayed bugs.

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -323,7 +323,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     )
                 }
                 ExprKind::Yield(opt_expr) => self.lower_expr_yield(e.span, opt_expr.as_deref()),
-                ExprKind::Err => hir::ExprKind::Err(self.dcx().has_errors().unwrap()),
+                ExprKind::Err => {
+                    hir::ExprKind::Err(self.dcx().span_delayed_bug(e.span, "lowered ExprKind::Err"))
+                }
                 ExprKind::Try(sub_expr) => self.lower_expr_try(e.span, sub_expr),
 
                 ExprKind::Paren(_) | ExprKind::ForLoop { .. } => {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -265,7 +265,8 @@ fn mir_const_qualif(tcx: TyCtxt<'_>, def: LocalDefId) -> ConstQualifs {
     let body = &tcx.mir_const(def).borrow();
 
     if body.return_ty().references_error() {
-        assert!(tcx.dcx().has_errors().is_some(), "mir_const_qualif: MIR had errors");
+        // It's possible to reach here without an error being emitted (#121103).
+        tcx.dcx().span_delayed_bug(body.span, "mir_const_qualif: MIR had errors");
         return Default::default();
     }
 

--- a/tests/ui/lowering/issue-121108.rs
+++ b/tests/ui/lowering/issue-121108.rs
@@ -1,0 +1,9 @@
+#![derive(Clone, Copy)] //~ ERROR `derive` attribute cannot be used at crate level
+
+use std::ptr::addr_of;
+
+const UNINHABITED_VARIANT: () = unsafe {
+    let v = *addr_of!(data).cast(); //~ ERROR cannot determine resolution for the macro `addr_of`
+};
+
+fn main() {}

--- a/tests/ui/lowering/issue-121108.stderr
+++ b/tests/ui/lowering/issue-121108.stderr
@@ -1,0 +1,25 @@
+error: `derive` attribute cannot be used at crate level
+  --> $DIR/issue-121108.rs:1:1
+   |
+LL | #![derive(Clone, Copy)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | use std::ptr::addr_of;
+   |               ------- the inner attribute doesn't annotate this `use` import
+   |
+help: perhaps you meant to use an outer attribute
+   |
+LL - #![derive(Clone, Copy)]
+LL + #[derive(Clone, Copy)]
+   |
+
+error: cannot determine resolution for the macro `addr_of`
+  --> $DIR/issue-121108.rs:6:14
+   |
+LL |     let v = *addr_of!(data).cast();
+   |              ^^^^^^^
+   |
+   = note: import resolution is stuck, try simplifying macro imports
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/mir/issue-121103.rs
+++ b/tests/ui/mir/issue-121103.rs
@@ -1,0 +1,3 @@
+fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
+//~^ ERROR failed to resolve: use of undeclared crate or module `lib2`
+//~| ERROR failed to resolve: use of undeclared crate or module `lib2`

--- a/tests/ui/mir/issue-121103.stderr
+++ b/tests/ui/mir/issue-121103.stderr
@@ -1,0 +1,15 @@
+error[E0433]: failed to resolve: use of undeclared crate or module `lib2`
+  --> $DIR/issue-121103.rs:1:38
+   |
+LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
+   |                                      ^^^^ use of undeclared crate or module `lib2`
+
+error[E0433]: failed to resolve: use of undeclared crate or module `lib2`
+  --> $DIR/issue-121103.rs:1:13
+   |
+LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
+   |             ^^^^ use of undeclared crate or module `lib2`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
These were changed to `has_errors` assertions in #121071 because that seemed reasonable, but evidently not.

Fixes #121103.
Fixes #121108.