### PR TITLE
Fix SmallCStr conversion from CStr

### DIFF
--- a/compiler/rustc_data_structures/src/small_c_str.rs
+++ b/compiler/rustc_data_structures/src/small_c_str.rs
@@ -82,6 +82,6 @@ impl<'a> FromIterator<&'a str> for SmallCStr {
 
 impl From<&ffi::CStr> for SmallCStr {
     fn from(s: &ffi::CStr) -> Self {
-        Self { data: SmallVec::from_slice(s.to_bytes()) }
+        Self { data: SmallVec::from_slice(s.to_bytes_with_nul()) }
     }
 }

--- a/compiler/rustc_data_structures/src/small_c_str/tests.rs
+++ b/compiler/rustc_data_structures/src/small_c_str/tests.rs
@@ -43,3 +43,11 @@ fn long() {
 fn internal_nul() {
     let _ = SmallCStr::new("abcd\0def");
 }
+
+#[test]
+fn from_cstr() {
+    let c = c"foo";
+    let s: SmallCStr = c.into();
+    assert_eq!(s.len_with_nul(), 4);
+    assert_eq!(s.as_c_str(), c"foo");
+}


### PR DESCRIPTION
The conversion from CStr to SmallCStr was not including the null byte. SmallCStr requires a trailing null. This caused `as_c_str` to either panic if std is built with debug assertions, or to have some corrupt memory behavior.
