### PR TITLE
Improve codegen diagnostic handling

### DIFF
--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -103,8 +103,7 @@ impl<G: EmissionGuarantee> IntoDiagnostic<'_, G> for ParseTargetMachineConfig<'_
     fn into_diagnostic(self, dcx: &'_ DiagCtxt, level: Level) -> DiagnosticBuilder<'_, G> {
         let diag: DiagnosticBuilder<'_, G> = self.0.into_diagnostic(dcx, level);
         let (message, _) = diag.messages.first().expect("`LlvmError` with no message");
-        let message = dcx.eagerly_translate_to_string(message.clone(), diag.args());
-
+        let message = dcx.eagerly_translate_to_string(message.clone(), diag.args.iter());
         DiagnosticBuilder::new(dcx, level, fluent::codegen_llvm_parse_target_machine_config)
             .with_arg("error", message)
     }

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -437,7 +437,7 @@ pub trait ReportErrorExt {
             let mut diag = dcx.struct_allow(DiagnosticMessage::Str(String::new().into()));
             let message = self.diagnostic_message();
             self.add_args(&mut diag);
-            let s = dcx.eagerly_translate_to_string(message, diag.args());
+            let s = dcx.eagerly_translate_to_string(message, diag.args.iter());
             diag.cancel();
             s
         })
@@ -864,7 +864,7 @@ impl<'tcx> ReportErrorExt for InvalidProgramInfo<'tcx> {
                 let dummy_level = Level::Bug;
                 let dummy_diag: DiagnosticBuilder<'_, ()> =
                     e.into_diagnostic().into_diagnostic(diag.dcx, dummy_level);
-                for (name, val) in dummy_diag.args() {
+                for (name, val) in dummy_diag.args.iter() {
                     diag.arg(name.clone(), val.clone());
                 }
                 dummy_diag.cancel();

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -446,7 +446,7 @@ pub fn format_interp_error<'tcx>(dcx: &DiagCtxt, e: InterpErrorInfo<'tcx>) -> St
     let mut diag = dcx.struct_allow("");
     let msg = e.diagnostic_message();
     e.add_args(&mut diag);
-    let s = dcx.eagerly_translate_to_string(msg, diag.args());
+    let s = dcx.eagerly_translate_to_string(msg, diag.args.iter());
     diag.cancel();
     s
 }

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -45,7 +45,7 @@ impl Translate for AnnotateSnippetEmitter {
 impl Emitter for AnnotateSnippetEmitter {
     /// The entry point for the diagnostics generation
     fn emit_diagnostic(&mut self, mut diag: Diagnostic) {
-        let fluent_args = to_fluent_args(diag.args());
+        let fluent_args = to_fluent_args(diag.args.iter());
 
         let mut suggestions = diag.suggestions.unwrap_or(vec![]);
         self.primary_span_formatted(&mut diag.span, &mut suggestions, &fluent_args);

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -519,7 +519,7 @@ impl Emitter for HumanEmitter {
     }
 
     fn emit_diagnostic(&mut self, mut diag: Diagnostic) {
-        let fluent_args = to_fluent_args(diag.args());
+        let fluent_args = to_fluent_args(diag.args.iter());
 
         let mut suggestions = diag.suggestions.unwrap_or(vec![]);
         self.primary_span_formatted(&mut diag.span, &mut suggestions, &fluent_args);

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -341,7 +341,7 @@ struct UnusedExterns<'a, 'b, 'c> {
 
 impl Diagnostic {
     fn from_errors_diagnostic(diag: crate::Diagnostic, je: &JsonEmitter) -> Diagnostic {
-        let args = to_fluent_args(diag.args());
+        let args = to_fluent_args(diag.args.iter());
         let sugg = diag.suggestions.iter().flatten().map(|sugg| {
             let translated_message =
                 je.translate_message(&sugg.msg, &args).map_err(Report::new).unwrap();

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -37,9 +37,10 @@ extern crate self as rustc_errors;
 
 pub use codes::*;
 pub use diagnostic::{
-    AddToDiagnostic, BugAbort, DecorateLint, Diagnostic, DiagnosticArg, DiagnosticArgName,
-    DiagnosticArgValue, DiagnosticBuilder, DiagnosticStyledString, EmissionGuarantee, FatalAbort,
-    IntoDiagnostic, IntoDiagnosticArg, StringPart, SubDiagnostic, SubdiagnosticMessageOp,
+    AddToDiagnostic, BugAbort, DecorateLint, Diagnostic, DiagnosticArg, DiagnosticArgMap,
+    DiagnosticArgName, DiagnosticArgValue, DiagnosticBuilder, DiagnosticStyledString,
+    EmissionGuarantee, FatalAbort, IntoDiagnostic, IntoDiagnosticArg, StringPart, SubDiagnostic,
+    SubdiagnosticMessageOp,
 };
 pub use diagnostic_impls::{
     DiagnosticArgFromDisplay, DiagnosticSymbolList, ExpectedLifetimeParameter,
@@ -1482,9 +1483,8 @@ impl DiagCtxtInner {
         diag: &Diagnostic,
         msg: impl Into<SubdiagnosticMessage>,
     ) -> SubdiagnosticMessage {
-        let args = diag.args();
         let msg = diag.subdiagnostic_message_to_diagnostic_message(msg);
-        self.eagerly_translate(msg, args)
+        self.eagerly_translate(msg, diag.args.iter())
     }
 
     fn flush_delayed(&mut self) {

--- a/src/librustdoc/passes/lint/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/lint/check_code_block_syntax.rs
@@ -159,7 +159,7 @@ impl Emitter for BufferEmitter {
     fn emit_diagnostic(&mut self, diag: Diagnostic) {
         let mut buffer = self.buffer.borrow_mut();
 
-        let fluent_args = to_fluent_args(diag.args());
+        let fluent_args = to_fluent_args(diag.args.iter());
         let translated_main_message = self
             .translate_message(&diag.messages[0].0, &fluent_args)
             .unwrap_or_else(|e| panic!("{e}"));

--- a/tests/ui/lto/issue-11154.stderr
+++ b/tests/ui/lto/issue-11154.stderr
@@ -1,6 +1,6 @@
 error: cannot prefer dynamic linking when performing LTO
-
-note: only 'staticlib', 'bin', and 'cdylib' outputs are supported with LTO
+   |
+   = note: only 'staticlib', 'bin', and 'cdylib' outputs are supported with LTO
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Clarify the workings of the temporary `Diagnostic` type used to send diagnostics from codegen threads to the main thread.

r? @estebank 