### PR TITLE
Skip coroutines in jump threading to avoid query cycles

### DIFF
--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -68,6 +68,12 @@ impl<'tcx> MirPass<'tcx> for JumpThreading {
         let def_id = body.source.def_id();
         debug!(?def_id);
 
+        // Optimizing coroutines creates query cycles.
+        if tcx.is_coroutine(def_id) {
+            trace!("Skipped for coroutine {:?}", def_id);
+            return;
+        }
+
         let param_env = tcx.param_env_reveal_all_normalized(def_id);
         let map = Map::new(tcx, body, Some(MAX_PLACES));
         let loop_headers = loop_headers(body);

--- a/tests/ui/mir/mir_query_cycle.rs
+++ b/tests/ui/mir/mir_query_cycle.rs
@@ -1,0 +1,14 @@
+// Regression test for #121094.
+// build-pass
+// compile-flags: -O --crate-type=lib
+// edition: 2021
+use std::{future::Future, pin::Pin};
+
+pub async fn foo(count: u32) {
+    if count == 0 {
+        return
+    } else {
+        let fut: Pin<Box<dyn Future<Output = ()>>> = Box::pin(foo(count - 1));
+        fut.await;
+    }
+}


### PR DESCRIPTION
Fixes #121094