### PR TITLE
Fix typo in comment in VecDeque::handle_capacity_increase().

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -486,7 +486,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // L := last element (`self.to_physical_idx(self.len - 1)`)
         //
         //    H           L
-        //   [o o o o o o o . ]
+        //   [o o o o o o o ]
         //    H           L
         // A [o o o o o o o . . . . . . . . . ]
         //        L H


### PR DESCRIPTION
Strategies B and C both show a full buffer before the capacity increase, while strategy A had one empty element left. Deleted the empty element.