### PR TITLE
Add a fast-path to `Debug` ASCII `&str`

### DIFF
--- a/library/core/benches/str/debug.rs
+++ b/library/core/benches/str/debug.rs
@@ -44,7 +44,7 @@ fn ascii_escapes(b: &mut Bencher) {
     assert_fmt(
         s,
         r#""some\tmore\tascii\ttext\nthis time with some \"escapes\", also 64 byte""#,
-        21,
+        15,
     );
     b.iter(|| {
         black_box(format!("{:?}", black_box(s)));
@@ -72,7 +72,7 @@ fn mostly_unicode(b: &mut Bencher) {
 #[bench]
 fn mixed(b: &mut Bencher) {
     let s = "\"❤️\"\n\"hűha ez betű\"\n\"кириллических букв\".";
-    assert_fmt(s, r#""\"❤\u{fe0f}\"\n\"hűha ez betű\"\n\"кириллических букв\".""#, 36);
+    assert_fmt(s, r#""\"❤\u{fe0f}\"\n\"hűha ez betű\"\n\"кириллических букв\".""#, 21);
     b.iter(|| {
         black_box(format!("{:?}", black_box(s)));
     });

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2407,8 +2407,8 @@ impl Debug for str {
             b > 0x7E || b < 0x20 || b == b'\\' || b == b'"'
         }
 
-        // the outer loop here splits the string into chunks of printable ASCII, which is just skipped over,
-        // and chunks of other chars (unicode, or ASCII that needs escaping), which is handler per-`char`.
+        // the loop here first skips over runs of printable ASCII as a fast path.
+        // other chars (unicode, or ASCII that needs escaping) are then handled per-`char`.
         let mut rest = self;
         while rest.len() > 0 {
             let Some(non_printable_start) = rest.as_bytes().iter().position(|&b| needs_escape(b))
@@ -2421,12 +2421,8 @@ impl Debug for str {
             // SAFETY: the position was derived from an iterator, so is known to be within bounds, and at a char boundary
             rest = unsafe { rest.get_unchecked(non_printable_start..) };
 
-            let printable_start =
-                rest.as_bytes().iter().position(|&b| !needs_escape(b)).unwrap_or(rest.len());
-            let prefix;
-            (prefix, rest) = rest.split_at(printable_start);
-
-            for c in prefix.chars() {
+            let mut chars = rest.chars();
+            if let Some(c) = chars.next() {
                 let esc = c.escape_debug_ext(EscapeDebugExtArgs {
                     escape_grapheme_extended: true,
                     escape_single_quote: false,
@@ -2439,6 +2435,7 @@ impl Debug for str {
                 }
                 printable_range.end += c.len_utf8();
             }
+            rest = chars.as_str();
         }
 
         f.write_str(&self[printable_range])?;

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2401,6 +2401,11 @@ impl Debug for str {
         f.write_char('"')?;
         let mut from = 0;
         for (i, c) in self.char_indices() {
+            // a fast path for ASCII chars that do not need escapes:
+            if matches!(c, ' '..='~') && !matches!(c, '\\' | '\"') {
+                continue;
+            }
+
             let esc = c.escape_debug_ext(EscapeDebugExtArgs {
                 escape_grapheme_extended: true,
                 escape_single_quote: false,

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2409,9 +2409,7 @@ impl Debug for str {
             // If char needs escaping, flush backlog so far and write, else skip
             if esc.len() != 1 {
                 f.write_str(&self[from..i])?;
-                for c in esc {
-                    f.write_char(c)?;
-                }
+                Display::fmt(&esc, f)?;
                 from = i + c.len_utf8();
             }
         }
@@ -2431,13 +2429,12 @@ impl Display for str {
 impl Debug for char {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.write_char('\'')?;
-        for c in self.escape_debug_ext(EscapeDebugExtArgs {
+        let esc = self.escape_debug_ext(EscapeDebugExtArgs {
             escape_grapheme_extended: true,
             escape_single_quote: true,
             escape_double_quote: false,
-        }) {
-            f.write_char(c)?
-        }
+        });
+        Display::fmt(&esc, f)?;
         f.write_char('\'')
     }
 }


### PR DESCRIPTION
Instead of going through the `EscapeDebug` machinery, we can just skip over ASCII chars that don’t need any escaping.

---

This is an alternative / a companion to https://github.com/rust-lang/rust/pull/121138.

The other PR is adding the fast path deep within `EscapeDebug`, whereas this skips as early as possible.