### PR TITLE
Merge `check_mod_impl_wf` and `check_mod_type_wf`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -248,6 +248,8 @@ fn check_item<'tcx>(tcx: TyCtxt<'tcx>, item: &'tcx hir::Item<'tcx>) -> Result<()
             let header = tcx.impl_trait_header(def_id);
             let is_auto = header
                 .is_some_and(|header| tcx.trait_is_auto(header.skip_binder().trait_ref.def_id));
+
+            crate::impl_wf_check::check_impl_wf(tcx, def_id)?;
             let mut res = Ok(());
             if let (hir::Defaultness::Default { .. }, true) = (impl_.defaultness, is_auto) {
                 let sp = impl_.of_trait.as_ref().map_or(item.span, |t| t.path.span);

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -14,8 +14,7 @@ use min_specialization::check_min_specialization;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{codes::*, struct_span_code_err};
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::{LocalDefId, LocalModDefId};
-use rustc_middle::query::Providers;
+use rustc_hir::def_id::LocalDefId;
 use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt};
 use rustc_span::{ErrorGuaranteed, Span, Symbol};
 
@@ -51,23 +50,16 @@ mod min_specialization;
 /// impl<'a> Trait<Foo> for Bar { type X = &'a i32; }
 /// //   ^ 'a is unused and appears in assoc type, error
 /// ```
-fn check_mod_impl_wf(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) -> Result<(), ErrorGuaranteed> {
+pub fn check_impl_wf(tcx: TyCtxt<'_>, impl_def_id: LocalDefId) -> Result<(), ErrorGuaranteed> {
     let min_specialization = tcx.features().min_specialization;
-    let module = tcx.hir_module_items(module_def_id);
     let mut res = Ok(());
-    for id in module.items() {
-        if matches!(tcx.def_kind(id.owner_id), DefKind::Impl { .. }) {
-            res = res.and(enforce_impl_params_are_constrained(tcx, id.owner_id.def_id));
-            if min_specialization {
-                res = res.and(check_min_specialization(tcx, id.owner_id.def_id));
-            }
-        }
+    debug_assert!(matches!(tcx.def_kind(impl_def_id), DefKind::Impl { .. }));
+    res = res.and(enforce_impl_params_are_constrained(tcx, impl_def_id));
+    if min_specialization {
+        res = res.and(check_min_specialization(tcx, impl_def_id));
     }
-    res
-}
 
-pub fn provide(providers: &mut Providers) {
-    *providers = Providers { check_mod_impl_wf, ..*providers };
+    res
 }
 
 fn enforce_impl_params_are_constrained(

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -955,11 +955,6 @@ rustc_queries! {
         desc { |tcx| "checking deathness of variables in {}", describe_as_module(key, tcx) }
     }
 
-    query check_mod_impl_wf(key: LocalModDefId) -> Result<(), ErrorGuaranteed> {
-        desc { |tcx| "checking that impls are well-formed in {}", describe_as_module(key, tcx) }
-        ensure_forwards_result_if_red
-    }
-
     query check_mod_type_wf(key: LocalModDefId) -> Result<(), ErrorGuaranteed> {
         desc { |tcx| "checking that types are well-formed in {}", describe_as_module(key, tcx) }
         ensure_forwards_result_if_red

--- a/compiler/rustc_traits/src/codegen.rs
+++ b/compiler/rustc_traits/src/codegen.rs
@@ -6,7 +6,7 @@
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::{FulfillmentErrorCode, TraitEngineExt as _};
 use rustc_middle::traits::CodegenObligationError;
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt};
 use rustc_trait_selection::traits::error_reporting::TypeErrCtxtExt;
 use rustc_trait_selection::traits::{
     ImplSource, Obligation, ObligationCause, SelectionContext, TraitEngine, TraitEngineExt,
@@ -72,6 +72,13 @@ pub fn codegen_select_candidate<'tcx>(
 
     let impl_source = infcx.resolve_vars_if_possible(impl_source);
     let impl_source = infcx.tcx.erase_regions(impl_source);
+    if impl_source.has_infer() {
+        // Unused lifetimes on an impl get replaced with inference vars, but never resolved,
+        // causing the return value of a query to contain inference vars. We do not have a concept
+        // for this and will in fact ICE in stable hashing of the return value. So bail out instead.
+        infcx.tcx.dcx().has_errors().unwrap();
+        return Err(CodegenObligationError::FulfillmentError);
+    }
 
     Ok(&*tcx.arena.alloc(impl_source))
 }

--- a/tests/rustdoc-ui/not-wf-ambiguous-normalization.rs
+++ b/tests/rustdoc-ui/not-wf-ambiguous-normalization.rs
@@ -12,7 +12,7 @@ struct DefaultAllocator;
 // `<DefaultAllocator as Allocator>::Buffer` to be ambiguous,
 // which caused an ICE with `-Znormalize-docs`.
 impl<T> Allocator for DefaultAllocator {
-    //~^ ERROR: type annotations needed
+    //~^ ERROR: the type parameter `T` is not constrained
     type Buffer = ();
 }
 

--- a/tests/rustdoc-ui/not-wf-ambiguous-normalization.stderr
+++ b/tests/rustdoc-ui/not-wf-ambiguous-normalization.stderr
@@ -1,9 +1,9 @@
-error[E0282]: type annotations needed
-  --> $DIR/not-wf-ambiguous-normalization.rs:14:23
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/not-wf-ambiguous-normalization.rs:14:6
    |
 LL | impl<T> Allocator for DefaultAllocator {
-   |                       ^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |      ^ unconstrained type parameter
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -1,23 +1,4 @@
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
-  --> $DIR/issue-38821.rs:23:17
-   |
-LL | #[derive(Debug, Copy, Clone)]
-   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
-   |
-note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
-  --> $DIR/issue-38821.rs:9:18
-   |
-LL | impl<T: NotNull> IntoNullable for T {
-   |         -------  ^^^^^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting the associated type
-   |
-LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
-   |                                                                       +++++++++++++++++++++++++++++++++++++++
-
-error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:40:1
    |
 LL | pub enum ColumnInsertValue<Col, Expr> where
@@ -128,6 +109,25 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
+  --> $DIR/issue-38821.rs:23:17
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                 ^^^^ the trait `NotNull` is not implemented for `<Col as Expression>::SqlType`, which is required by `<Col as Expression>::SqlType: IntoNullable`
+   |
+note: required for `<Col as Expression>::SqlType` to implement `IntoNullable`
+  --> $DIR/issue-38821.rs:9:18
+   |
+LL | impl<T: NotNull> IntoNullable for T {
+   |         -------  ^^^^^^^^^^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting the associated type
+   |
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
+   |                                                                       +++++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:17

--- a/tests/ui/coherence/coherence-orphan.stderr
+++ b/tests/ui/coherence/coherence-orphan.stderr
@@ -10,17 +10,6 @@ LL | impl TheTrait<usize> for isize {}
    |
    = note: define and implement a trait or new type instead
 
-error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
-  --> $DIR/coherence-orphan.rs:20:1
-   |
-LL | impl !Send for Vec<isize> {}
-   | ^^^^^^^^^^^^^^^----------
-   | |              |
-   | |              `Vec` is not defined in the current crate
-   | impl doesn't use only types from inside the current crate
-   |
-   = note: define and implement a trait or new type instead
-
 error[E0046]: not all trait items implemented, missing: `the_fn`
   --> $DIR/coherence-orphan.rs:10:1
    |
@@ -44,6 +33,17 @@ LL | impl TheTrait<isize> for TheType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `the_fn` in implementation
    |
    = help: implement the missing item: `fn the_fn(&self) { todo!() }`
+
+error[E0117]: only traits defined in the current crate can be implemented for types defined outside of the crate
+  --> $DIR/coherence-orphan.rs:20:1
+   |
+LL | impl !Send for Vec<isize> {}
+   | ^^^^^^^^^^^^^^^----------
+   | |              |
+   | |              `Vec` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/const-generics/issues/issue-68366.full.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.full.stderr
@@ -1,5 +1,14 @@
+error: `Option<usize>` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-68366.rs:9:25
+   |
+LL | struct Collatz<const N: Option<usize>>;
+   |                         ^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:11:7
+  --> $DIR/issue-68366.rs:12:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |       ^^^^^^^^^^^^^^ unconstrained const parameter
@@ -8,7 +17,7 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:17:6
+  --> $DIR/issue-68366.rs:19:6
    |
 LL | impl<const N: usize> Foo {}
    |      ^^^^^^^^^^^^^^ unconstrained const parameter
@@ -16,6 +25,17 @@ LL | impl<const N: usize> Foo {}
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error: aborting due to 2 previous errors
+error: overly complex generic constant
+  --> $DIR/issue-68366.rs:12:31
+   |
+LL | impl <const N: usize> Collatz<{Some(N)}> {}
+   |                               ^-------^
+   |                                |
+   |                                struct/enum construction is not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/issue-68366.rs:11:37
+  --> $DIR/issue-68366.rs:12:37
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |                                     ^ cannot perform const operation using `N`
@@ -7,8 +7,17 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    = help: const parameters may only be used as standalone arguments, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
+error: `Option<usize>` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-68366.rs:9:25
+   |
+LL | struct Collatz<const N: Option<usize>>;
+   |                         ^^^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
+
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:11:7
+  --> $DIR/issue-68366.rs:12:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |       ^^^^^^^^^^^^^^ unconstrained const parameter
@@ -17,7 +26,7 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:17:6
+  --> $DIR/issue-68366.rs:19:6
    |
 LL | impl<const N: usize> Foo {}
    |      ^^^^^^^^^^^^^^ unconstrained const parameter
@@ -25,6 +34,6 @@ LL | impl<const N: usize> Foo {}
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/const-generics/issues/issue-68366.rs
+++ b/tests/ui/const-generics/issues/issue-68366.rs
@@ -7,10 +7,12 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Collatz<const N: Option<usize>>;
+//~^ ERROR: `Option<usize>` is forbidden
 
 impl <const N: usize> Collatz<{Some(N)}> {}
 //~^ ERROR the const parameter
 //[min]~^^ generic parameters may not be used in const operations
+//[full]~^^^ ERROR overly complex
 
 struct Foo;
 

--- a/tests/ui/duplicate/duplicate-type-parameter.rs
+++ b/tests/ui/duplicate/duplicate-type-parameter.rs
@@ -23,7 +23,6 @@ trait Qux<T,T> {}
 
 impl<T,T> Qux<T,T> for Option<T> {}
 //~^ ERROR the name `T` is already used
-//~^^ ERROR the type parameter `T` is not constrained
 
 fn main() {
 }

--- a/tests/ui/duplicate/duplicate-type-parameter.stderr
+++ b/tests/ui/duplicate/duplicate-type-parameter.stderr
@@ -54,13 +54,6 @@ LL | impl<T,T> Qux<T,T> for Option<T> {}
    |      |
    |      first use of `T`
 
-error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/duplicate-type-parameter.rs:24:8
-   |
-LL | impl<T,T> Qux<T,T> for Option<T> {}
-   |        ^ unconstrained type parameter
+error: aborting due to 7 previous errors
 
-error: aborting due to 8 previous errors
-
-Some errors have detailed explanations: E0207, E0403.
-For more information about an error, try `rustc --explain E0207`.
+For more information about this error, try `rustc --explain E0403`.

--- a/tests/ui/error-codes/E0374.stderr
+++ b/tests/ui/error-codes/E0374.stderr
@@ -1,3 +1,11 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/E0374.rs:4:12
+   |
+LL | struct Foo<T: ?Sized> {
+   |            ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
 error[E0374]: the trait `CoerceUnsized` may only be implemented for a coercion between structures
   --> $DIR/E0374.rs:8:1
    |
@@ -6,14 +14,6 @@ LL | |     where T: CoerceUnsized<U> {}
    | |_____________________________^
    |
    = note: expected a single field to be coerced, none found
-
-error[E0392]: type parameter `T` is never used
-  --> $DIR/E0374.rs:4:12
-   |
-LL | struct Foo<T: ?Sized> {
-   |            ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0375.stderr
+++ b/tests/ui/error-codes/E0375.stderr
@@ -1,12 +1,3 @@
-error[E0375]: implementing the trait `CoerceUnsized` requires multiple coercions
-  --> $DIR/E0375.rs:10:12
-   |
-LL | impl<T, U> CoerceUnsized<Foo<U, T>> for Foo<T, U> {}
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^ requires multiple coercions
-   |
-   = note: `CoerceUnsized` may only be implemented for a coercion between structures with one field being coerced
-   = note: currently, 2 fields need coercions: `b` (`T` to `U`), `c` (`U` to `T`)
-
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/E0375.rs:6:8
    |
@@ -31,6 +22,15 @@ help: the `Box` type always has a statically known size and allocates its conten
    |
 LL |     b: Box<T>,
    |        ++++ +
+
+error[E0375]: implementing the trait `CoerceUnsized` requires multiple coercions
+  --> $DIR/E0375.rs:10:12
+   |
+LL | impl<T, U> CoerceUnsized<Foo<U, T>> for Foo<T, U> {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^ requires multiple coercions
+   |
+   = note: `CoerceUnsized` may only be implemented for a coercion between structures with one field being coerced
+   = note: currently, 2 fields need coercions: `b` (`T` to `U`), `c` (`U` to `T`)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/bugs/issue-87735.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-87735.stderr
@@ -4,6 +4,91 @@ error[E0207]: the type parameter `U` is not constrained by the impl trait, self 
 LL | impl<'b, T, U> AsRef2 for Foo<T>
    |             ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0309]: the parameter type `U` may not live long enough
+  --> $DIR/issue-87735.rs:34:21
+   |
+LL |   type Output<'a> = FooRef<'a, U> where Self: 'a;
+   |               --    ^^^^^^^^^^^^^ ...so that the type `U` will meet its required lifetime bounds...
+   |               |
+   |               the parameter type `U` must be valid for the lifetime `'a` as defined here...
+   |
+note: ...that is required by this bound
+  --> $DIR/issue-87735.rs:23:22
+   |
+LL | struct FooRef<'a, U>(&'a [U]);
+   |                      ^^^^^^^
+help: consider adding an explicit lifetime bound
+   |
+LL |   type Output<'a> = FooRef<'a, U> where Self: 'a, U: 'a;
+   |                                                 +++++++
 
-For more information about this error, try `rustc --explain E0207`.
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/issue-87735.rs:31:15
+   |
+LL | impl<'b, T, U> AsRef2 for Foo<T>
+   |      -- the parameter type `T` must be valid for the lifetime `'b` as defined here...
+...
+LL |     T: AsRef2<Output<'b> = &'b [U]>,
+   |               ^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |
+note: ...that is required by this bound
+  --> $DIR/issue-87735.rs:7:31
+   |
+LL |   type Output<'a> where Self: 'a;
+   |                               ^^
+help: consider adding an explicit lifetime bound
+   |
+LL |     T: AsRef2<Output<'b> = &'b [U]> + 'b,
+   |                                     ++++
+
+error[E0309]: the parameter type `T` may not live long enough
+  --> $DIR/issue-87735.rs:36:31
+   |
+LL | impl<'b, T, U> AsRef2 for Foo<T>
+   |      -- the parameter type `T` must be valid for the lifetime `'b` as defined here...
+...
+LL |   fn as_ref2<'a>(&'a self) -> Self::Output<'a> {
+   |                               ^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds...
+   |
+note: ...that is required by this bound
+  --> $DIR/issue-87735.rs:7:31
+   |
+LL |   type Output<'a> where Self: 'a;
+   |                               ^^
+help: consider adding an explicit lifetime bound
+   |
+LL |     T: AsRef2<Output<'b> = &'b [U]> + 'b,
+   |                                     ++++
+
+error: lifetime may not live long enough
+  --> $DIR/issue-87735.rs:37:5
+   |
+LL | impl<'b, T, U> AsRef2 for Foo<T>
+   |      -- lifetime `'b` defined here
+...
+LL |   fn as_ref2<'a>(&'a self) -> Self::Output<'a> {
+   |              -- lifetime `'a` defined here
+LL |     FooRef(self.0.as_ref2())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ method was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-87735.rs:37:12
+   |
+LL | impl<'b, T, U> AsRef2 for Foo<T>
+   |      -- lifetime `'b` defined here
+...
+LL |   fn as_ref2<'a>(&'a self) -> Self::Output<'a> {
+   |              -- lifetime `'a` defined here
+LL |     FooRef(self.0.as_ref2())
+   |            ^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+help: `'b` and `'a` must be the same: replace one with the other
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0207, E0309.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/generic-associated-types/bugs/issue-88526.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88526.stderr
@@ -4,6 +4,20 @@ error[E0207]: the type parameter `I` is not constrained by the impl trait, self 
 LL | impl<'q, Q, I, F> A for TestB<Q, F>
    |             ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0309]: the parameter type `F` may not live long enough
+  --> $DIR/issue-88526.rs:16:18
+   |
+LL |     type I<'a> = &'a F;
+   |            --    ^^^^^ ...so that the reference type `&'a F` does not outlive the data it points at
+   |            |
+   |            the parameter type `F` must be valid for the lifetime `'a` as defined here...
+   |
+help: consider adding an explicit lifetime bound
+   |
+LL |     type I<'a> = &'a F where F: 'a;
+   |                        +++++++++++
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0309.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/impl-trait/issues/issue-87340.rs
+++ b/tests/ui/impl-trait/issues/issue-87340.rs
@@ -9,6 +9,8 @@ impl<T> X for () {
     //~^ ERROR `T` is not constrained by the impl trait, self type, or predicates
     type I = impl Sized;
     fn f() -> Self::I {}
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-87340.stderr
+++ b/tests/ui/impl-trait/issues/issue-87340.stderr
@@ -4,6 +4,19 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T> X for () {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-87340.rs:11:23
+   |
+LL |     fn f() -> Self::I {}
+   |                       ^^ cannot infer type for type parameter `T`
 
-For more information about this error, try `rustc --explain E0207`.
+error[E0282]: type annotations needed
+  --> $DIR/issue-87340.rs:11:15
+   |
+LL |     fn f() -> Self::I {}
+   |               ^^^^^^^ cannot infer type for type parameter `T`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0207, E0282.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -361,14 +361,6 @@ LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
-error[E0118]: no nominal type found for inherent implementation
-  --> $DIR/where-allowed.rs:239:1
-   |
-LL | impl <T = impl Debug> T {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
-   |
-   = note: either implement a trait on it or create a newtype to wrap it instead
-
 error[E0283]: type annotations needed
   --> $DIR/where-allowed.rs:46:57
    |
@@ -388,6 +380,14 @@ LL | fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { pani
              where A: Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
+
+error[E0118]: no nominal type found for inherent implementation
+  --> $DIR/where-allowed.rs:239:1
+   |
+LL | impl <T = impl Debug> T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^ impl requires a nominal type
+   |
+   = note: either implement a trait on it or create a newtype to wrap it instead
 
 error[E0599]: no function or associated item named `into_vec` found for slice `[_]` in the current scope
   --> $DIR/where-allowed.rs:81:5

--- a/tests/ui/impl-unused-tps.stderr
+++ b/tests/ui/impl-unused-tps.stderr
@@ -1,3 +1,25 @@
+error[E0119]: conflicting implementations of trait `Foo<_>` for type `[isize; 0]`
+  --> $DIR/impl-unused-tps.rs:27:1
+   |
+LL | impl<T> Foo<T> for [isize;0] {
+   | ---------------------------- first implementation here
+...
+LL | impl<T,U> Foo<T> for U {
+   | ^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `[isize; 0]`
+
+error[E0275]: overflow evaluating the requirement `([isize; 0], _): Sized`
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`impl_unused_tps`)
+note: required for `([isize; 0], _)` to implement `Bar`
+  --> $DIR/impl-unused-tps.rs:31:11
+   |
+LL | impl<T,U> Bar for T {
+   |      -    ^^^     ^
+   |      |
+   |      unsatisfied trait bound introduced here
+   = note: 126 redundant requirements hidden
+   = note: required for `([isize; 0], _)` to implement `Bar`
+
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/impl-unused-tps.rs:15:8
    |
@@ -27,28 +49,6 @@ error[E0207]: the type parameter `V` is not constrained by the impl trait, self 
    |
 LL | impl<T,U,V> Foo<T> for T
    |          ^ unconstrained type parameter
-
-error[E0119]: conflicting implementations of trait `Foo<_>` for type `[isize; 0]`
-  --> $DIR/impl-unused-tps.rs:27:1
-   |
-LL | impl<T> Foo<T> for [isize;0] {
-   | ---------------------------- first implementation here
-...
-LL | impl<T,U> Foo<T> for U {
-   | ^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `[isize; 0]`
-
-error[E0275]: overflow evaluating the requirement `([isize; 0], _): Sized`
-   |
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`impl_unused_tps`)
-note: required for `([isize; 0], _)` to implement `Bar`
-  --> $DIR/impl-unused-tps.rs:31:11
-   |
-LL | impl<T,U> Bar for T {
-   |      -    ^^^     ^
-   |      |
-   |      unsatisfied trait bound introduced here
-   = note: 126 redundant requirements hidden
-   = note: required for `([isize; 0], _)` to implement `Bar`
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/issues/issue-29861.rs
+++ b/tests/ui/issues/issue-29861.rs
@@ -14,6 +14,7 @@ impl<'a, T: 'a> MakeRef2 for T {
 }
 
 fn foo() -> <String as MakeRef2>::Ref2 { &String::from("foo") }
+//~^ ERROR temporary value dropped while borrowed
 
 fn main() {
     println!("{}", foo());

--- a/tests/ui/issues/issue-29861.stderr
+++ b/tests/ui/issues/issue-29861.stderr
@@ -4,6 +4,18 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
 LL | impl<'a, T: 'a> MakeRef2 for T {
    |      ^^ unconstrained lifetime parameter
 
-error: aborting due to 1 previous error
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/issue-29861.rs:16:43
+   |
+LL | fn foo() -> <String as MakeRef2>::Ref2 { &String::from("foo") }
+   |                                           ^^^^^^^^^^^^^^^^^^^ -- borrow later used here
+   |                                           |                   |
+   |                                           |                   temporary value is freed at the end of this statement
+   |                                           creates a temporary value which is freed while still in use
+   |
+   = note: consider using a `let` binding to create a longer lived value
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0716.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.rs
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.rs
@@ -3,6 +3,6 @@
 
 impl<T> Loop<T> {} //~ ERROR the type parameter `T` is not constrained
 
-type Loop<T> = Loop<T>;
+type Loop<T> = Loop<T>; //~ ERROR overflow
 
 fn main() {}

--- a/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
+++ b/tests/ui/lazy-type-alias/unconstrained-params-in-impl-due-to-overflow.stderr
@@ -4,6 +4,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T> Loop<T> {}
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0275]: overflow normalizing the type alias `Loop<T>`
+  --> $DIR/unconstrained-params-in-impl-due-to-overflow.rs:6:16
+   |
+LL | type Loop<T> = Loop<T>;
+   |                ^^^^^^^
+   |
+   = note: in case this is a recursive type alias, consider using a struct, enum, or union instead
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0275.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/marker_trait_attr/override-item-on-marker-trait.stderr
+++ b/tests/ui/marker_trait_attr/override-item-on-marker-trait.stderr
@@ -1,15 +1,3 @@
-error[E0715]: impls for marker traits cannot contain items
-  --> $DIR/override-item-on-marker-trait.rs:12:1
-   |
-LL | impl Marker for OverrideConst {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0715]: impls for marker traits cannot contain items
-  --> $DIR/override-item-on-marker-trait.rs:18:1
-   |
-LL | impl Marker for OverrideFn {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0714]: marker traits cannot have associated items
   --> $DIR/override-item-on-marker-trait.rs:5:5
    |
@@ -21,6 +9,18 @@ error[E0714]: marker traits cannot have associated items
    |
 LL |     fn do_something() {}
    |     ^^^^^^^^^^^^^^^^^
+
+error[E0715]: impls for marker traits cannot contain items
+  --> $DIR/override-item-on-marker-trait.rs:12:1
+   |
+LL | impl Marker for OverrideConst {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0715]: impls for marker traits cannot contain items
+  --> $DIR/override-item-on-marker-trait.rs:18:1
+   |
+LL | impl Marker for OverrideFn {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -82,15 +82,6 @@ LL |     type W where Self: Eq;
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0592]: duplicate definitions with name `W`
-  --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:5
-   |
-LL |     type W: Ord where Self: Eq;
-   |     ------ other definition for `W`
-...
-LL |     type W where Self: Eq;
-   |     ^^^^^^ duplicate definitions for `W`
-
 error[E0277]: the trait bound `X: Eq` is not satisfied
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:13:23
    |
@@ -118,6 +109,15 @@ help: consider annotating `X` with `#[derive(Eq)]`
 LL + #[derive(Eq)]
 LL | struct X;
    |
+
+error[E0592]: duplicate definitions with name `W`
+  --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:5
+   |
+LL |     type W: Ord where Self: Eq;
+   |     ------ other definition for `W`
+...
+LL |     type W where Self: Eq;
+   |     ^^^^^^ duplicate definitions for `W`
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
@@ -37,7 +37,19 @@ error[E0207]: the const parameter `host` is not constrained by the impl trait, s
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error: aborting due to 5 previous errors
+error[E0308]: mismatched types
+  --> $DIR/derive-const-use.rs:16:14
+   |
+LL | #[derive_const(Default, PartialEq)]
+   |                         --------- in this derive macro expansion
+LL | pub struct S((), A);
+   |              ^^ expected `host`, found `true`
+   |
+   = note: expected constant `host`
+              found constant `true`
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Some errors have detailed explanations: E0207, E0635.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0207, E0308, E0635.
 For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/span-bug-issue-121418.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/span-bug-issue-121418.rs
@@ -8,6 +8,8 @@ impl const dyn T {
     //~^ ERROR inherent impls cannot be `const`
     //~| ERROR the const parameter `host` is not constrained by the impl trait, self type, or
     pub const fn new() -> std::sync::Mutex<dyn T> {}
+    //~^ ERROR mismatched types
+    //~| ERROR cannot be known at compilation time
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/span-bug-issue-121418.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/span-bug-issue-121418.stderr
@@ -17,6 +17,29 @@ LL | impl const dyn T {
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/span-bug-issue-121418.rs:10:27
+   |
+LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
+   |                  ---      ^^^^^^^^^^^^^^^^^^^^^^^ expected `Mutex<dyn T>`, found `()`
+   |                  |
+   |                  implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected struct `Mutex<(dyn T + 'static)>`
+           found unit type `()`
 
-For more information about this error, try `rustc --explain E0207`.
+error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
+  --> $DIR/span-bug-issue-121418.rs:10:27
+   |
+LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Mutex<(dyn T + 'static)>`, the trait `Sized` is not implemented for `(dyn T + 'static)`, which is required by `Mutex<(dyn T + 'static)>: Sized`
+note: required because it appears within the type `Mutex<(dyn T + 'static)>`
+  --> $SRC_DIR/std/src/sync/mutex.rs:LL:COL
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0207, E0277, E0308.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.rs
@@ -20,6 +20,7 @@ impl<T, S> Trait<T, S> for () {}
 fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
 //~^ ERROR trait takes 1 generic argument but 2 generic arguments were supplied
 //~| ERROR trait takes 1 generic argument but 2 generic arguments were supplied
+//~| ERROR type annotations needed
     3
 }
 

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -43,7 +43,7 @@ LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), Assoc = i32> {
    |                                                        +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:18
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:27:18
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |                  ^^^^^ expected 1 generic argument
@@ -59,7 +59,7 @@ LL | struct Struct<T: Trait<u32, Assoc = String>> {
    |                             +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:31:23
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:32:23
    |
 LL | trait AnotherTrait<T: Trait<T, i32>> {}
    |                       ^^^^^ expected 1 generic argument
@@ -75,7 +75,7 @@ LL | trait AnotherTrait<T: Trait<T, Assoc = i32>> {}
    |                                +++++++
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:34:9
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:35:9
    |
 LL | impl<T: Trait<u32, String>> Struct<T> {}
    |         ^^^^^ expected 1 generic argument
@@ -91,7 +91,7 @@ LL | impl<T: Trait<u32, Assoc = String>> Struct<T> {}
    |                    +++++++
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:58
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:41:58
    |
 LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          ^^^^^^    - help: remove this generic argument
@@ -99,7 +99,7 @@ LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
    |                                                          expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:8
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:27:8
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
@@ -116,7 +116,13 @@ error[E0207]: the type parameter `S` is not constrained by the impl trait, self 
 LL | impl<T, S> Trait<T, S> for () {}
    |         ^ unconstrained type parameter
 
-error: aborting due to 9 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:41
+   |
+LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
+   |                                         ^^^^^^^^^^^^^^^^^^^ cannot infer type
 
-Some errors have detailed explanations: E0107, E0207.
+error: aborting due to 10 previous errors
+
+Some errors have detailed explanations: E0107, E0207, E0282.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/traits/issue-105231.rs
+++ b/tests/ui/traits/issue-105231.rs
@@ -1,7 +1,9 @@
 //~ ERROR overflow evaluating the requirement `A<A<A<A<A<A<A<...>>>>>>>: Send`
 struct A<T>(B<T>);
 //~^ ERROR recursive types `A` and `B` have infinite size
+//~| ERROR `T` is never used
 struct B<T>(A<A<T>>);
+//~^ ERROR `T` is never used
 trait Foo {}
 impl<T> Foo for T where T: Send {}
 impl Foo for B<u8> {}

--- a/tests/ui/traits/issue-105231.stderr
+++ b/tests/ui/traits/issue-105231.stderr
@@ -3,7 +3,7 @@ error[E0072]: recursive types `A` and `B` have infinite size
    |
 LL | struct A<T>(B<T>);
    | ^^^^^^^^^^^ ---- recursive without indirection
-LL |
+...
 LL | struct B<T>(A<A<T>>);
    | ^^^^^^^^^^^ ------- recursive without indirection
    |
@@ -11,19 +11,38 @@ help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
    |
 LL ~ struct A<T>(Box<B<T>>);
 LL |
+LL |
 LL ~ struct B<T>(Box<A<A<T>>>);
    |
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/issue-105231.rs:2:10
+   |
+LL | struct A<T>(B<T>);
+   |          ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/issue-105231.rs:5:10
+   |
+LL | struct B<T>(A<A<T>>);
+   |          ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error[E0275]: overflow evaluating the requirement `A<A<A<A<A<A<A<...>>>>>>>: Send`
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_105231`)
 note: required because it appears within the type `B<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<A<u8>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>`
-  --> $DIR/issue-105231.rs:4:8
+  --> $DIR/issue-105231.rs:5:8
    |
 LL | struct B<T>(A<A<T>>);
    |        ^
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0072, E0275.
+Some errors have detailed explanations: E0072, E0275, E0392.
 For more information about an error, try `rustc --explain E0072`.

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -60,6 +60,14 @@ error[E0412]: cannot find type `NotDefined` in this scope
 LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                     ^^^^^^^^^^ not found in this scope
 
+error[E0277]: `i32` is not an iterator
+  --> $DIR/issue-50480.rs:3:27
+   |
+LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `i32`
+
 error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/issue-50480.rs:1:17
    |
@@ -85,14 +93,6 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                                          this field does not implement `Copy`
    |
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `i32` is not an iterator
-  --> $DIR/issue-50480.rs:3:27
-   |
-LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `i32`
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:14:33

--- a/tests/ui/traits/next-solver/coherence/trait_ref_is_knowable-norm-overflow.stderr
+++ b/tests/ui/traits/next-solver/coherence/trait_ref_is_knowable-norm-overflow.stderr
@@ -1,15 +1,3 @@
-error[E0119]: conflicting implementations of trait `Trait`
-  --> $DIR/trait_ref_is_knowable-norm-overflow.rs:18:1
-   |
-LL | impl<T: Copy> Trait for T {}
-   | ------------------------- first implementation here
-LL | struct LocalTy;
-LL | impl Trait for <LocalTy as Overflow>::Assoc {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
-   |
-   = note: overflow evaluating the requirement `_ == <LocalTy as Overflow>::Assoc`
-   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`trait_ref_is_knowable_norm_overflow`)
-
 error[E0275]: overflow evaluating the requirement `<T as Overflow>::Assoc: Sized`
   --> $DIR/trait_ref_is_knowable-norm-overflow.rs:10:18
    |
@@ -26,6 +14,18 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL |     type Assoc: ?Sized;
    |               ++++++++
+
+error[E0119]: conflicting implementations of trait `Trait`
+  --> $DIR/trait_ref_is_knowable-norm-overflow.rs:18:1
+   |
+LL | impl<T: Copy> Trait for T {}
+   | ------------------------- first implementation here
+LL | struct LocalTy;
+LL | impl Trait for <LocalTy as Overflow>::Assoc {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
+   |
+   = note: overflow evaluating the requirement `_ == <LocalTy as Overflow>::Assoc`
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`trait_ref_is_knowable_norm_overflow`)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -13,6 +13,12 @@ LL | #![feature(lazy_type_alias)]
    = note: see issue #112792 <https://github.com/rust-lang/rust/issues/112792> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
+error: the type `<*const T as ToUnit<'a>>::Unit` is not well-formed
+  --> $DIR/issue-118950-root-region.rs:14:21
+   |
+LL | type Assoc<'a, T> = <*const T as ToUnit<'a>>::Unit;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [ReBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrNamed(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a), 'a) }), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc) }
 WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [ReBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrNamed(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a), 'a) }), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc) }
 WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [ReBound(DebruijnIndex(0), BoundRegion { var: 0, kind: BrNamed(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a), 'a) }), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc) }
@@ -25,12 +31,6 @@ LL | impl<T> Overlap<T> for T {}
 LL |
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `fn(_)`
-
-error: the type `<*const T as ToUnit<'a>>::Unit` is not well-formed
-  --> $DIR/issue-118950-root-region.rs:14:21
-   |
-LL | type Assoc<'a, T> = <*const T as ToUnit<'a>>::Unit;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.rs
+++ b/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.rs
@@ -20,6 +20,7 @@ impl<'a, I> UnwrapItemsExt for I {
 
     fn unwrap_items(self) -> Self::Iter {
         MyStruct {}
+        //~^ ERROR expected generic lifetime parameter
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.stderr
+++ b/tests/ui/type-alias-impl-trait/assoc-type-lifetime-unconstrained.stderr
@@ -4,6 +4,16 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
 LL | impl<'a, I> UnwrapItemsExt for I {
    |      ^^ unconstrained lifetime parameter
 
-error: aborting due to 1 previous error
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/assoc-type-lifetime-unconstrained.rs:22:9
+   |
+LL | impl<'a, I> UnwrapItemsExt for I {
+   |      -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |         MyStruct {}
+   |         ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0792.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.rs
+++ b/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.rs
@@ -12,6 +12,8 @@ impl<T> X for () {
     //~^ ERROR the type parameter `T` is not constrained
     type I = impl Sized;
     fn f() -> Self::I {}
+    //~^ ERROR type annotations needed
+    //~| ERROR type annotations needed
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.stderr
+++ b/tests/ui/type-alias-impl-trait/impl-with-unconstrained-param.stderr
@@ -4,6 +4,19 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T> X for () {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/impl-with-unconstrained-param.rs:14:23
+   |
+LL |     fn f() -> Self::I {}
+   |                       ^^ cannot infer type for type parameter `T`
 
-For more information about this error, try `rustc --explain E0207`.
+error[E0282]: type annotations needed
+  --> $DIR/impl-with-unconstrained-param.rs:14:15
+   |
+LL |     fn f() -> Self::I {}
+   |               ^^^^^^^ cannot infer type for type parameter `T`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0207, E0282.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/issue-74244.rs
+++ b/tests/ui/type-alias-impl-trait/issue-74244.rs
@@ -14,6 +14,7 @@ impl<T> Allocator for DefaultAllocator {
 type A = impl Fn(<DefaultAllocator as Allocator>::Buffer);
 
 fn foo() -> A {
+    //~^ ERROR: type annotations needed
     |_| ()
 }
 

--- a/tests/ui/type-alias-impl-trait/issue-74244.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74244.stderr
@@ -4,6 +4,13 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T> Allocator for DefaultAllocator {
    |      ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/issue-74244.rs:16:13
+   |
+LL | fn foo() -> A {
+   |             ^ cannot infer type for type parameter `T`
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0282.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/issue-74761-2.rs
+++ b/tests/ui/type-alias-impl-trait/issue-74761-2.rs
@@ -10,6 +10,7 @@ impl<'a, 'b> A for () {
     type B = impl core::fmt::Debug;
 
     fn f(&self) -> Self::B {}
+    //~^ ERROR expected generic lifetime parameter
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-74761-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74761-2.stderr
@@ -10,6 +10,16 @@ error[E0207]: the lifetime parameter `'b` is not constrained by the impl trait, 
 LL | impl<'a, 'b> A for () {
    |          ^^ unconstrained lifetime parameter
 
-error: aborting due to 2 previous errors
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/issue-74761-2.rs:12:28
+   |
+LL | impl<'a, 'b> A for () {
+   |      -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     fn f(&self) -> Self::B {}
+   |                            ^^
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0207, E0792.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/issue-74761.rs
+++ b/tests/ui/type-alias-impl-trait/issue-74761.rs
@@ -10,6 +10,7 @@ impl<'a, 'b> A for () {
     type B = impl core::fmt::Debug;
 
     fn f(&self) -> Self::B {}
+    //~^ ERROR expected generic lifetime parameter
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-74761.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74761.stderr
@@ -10,6 +10,16 @@ error[E0207]: the lifetime parameter `'b` is not constrained by the impl trait, 
 LL | impl<'a, 'b> A for () {
    |          ^^ unconstrained lifetime parameter
 
-error: aborting due to 2 previous errors
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/issue-74761.rs:12:28
+   |
+LL | impl<'a, 'b> A for () {
+   |      -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     fn f(&self) -> Self::B {}
+   |                            ^^
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0207, E0792.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.rs
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.rs
@@ -12,6 +12,7 @@ impl<'a, I: Iterator<Item = i32>> Trait for (i32, I) {
     type Associated = (i32, impl Iterator<Item = i32>);
     fn into(self) -> Self::Associated {
         (0_i32, [0_i32].iter().copied())
+        //~^ ERROR: expected generic lifetime parameter, found `'_`
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.stderr
+++ b/tests/ui/type-alias-impl-trait/type-alias-impl-trait-unconstrained-lifetime.stderr
@@ -4,6 +4,16 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
 LL | impl<'a, I: Iterator<Item = i32>> Trait for (i32, I) {
    |      ^^ unconstrained lifetime parameter
 
-error: aborting due to 1 previous error
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/type-alias-impl-trait-unconstrained-lifetime.rs:14:9
+   |
+LL | impl<'a, I: Iterator<Item = i32>> Trait for (i32, I) {
+   |      -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |         (0_i32, [0_i32].iter().copied())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0792.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/type-alias-impl-trait/variance.rs
+++ b/tests/ui/type-alias-impl-trait/variance.rs
@@ -6,16 +6,21 @@ trait Captures<'a> {}
 impl<T> Captures<'_> for T {}
 
 type NotCapturedEarly<'a> = impl Sized; //~ [o]
+//~^ ERROR: unconstrained opaque type
 
 type CapturedEarly<'a> = impl Sized + Captures<'a>; //~ [o]
+//~^ ERROR: unconstrained opaque type
 
 // TAIT does *not* capture `'b`
 type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>; //~ [o]
+//~^ ERROR: unconstrained opaque type
 
 // TAIT does *not* capture `'b`
 type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>; //~ [o]
+//~^ ERROR: unconstrained opaque type
 
 type Bar<'a, 'b: 'b, T> = impl Sized; //~ ERROR [o, o, o]
+//~^ ERROR: unconstrained opaque type
 
 trait Foo<'i> {
     type ImplicitCapture<'a>;
@@ -27,18 +32,24 @@ trait Foo<'i> {
 
 impl<'i> Foo<'i> for &'i () {
     type ImplicitCapture<'a> = impl Sized; //~ [o, o]
+    //~^ ERROR: unconstrained opaque type
 
     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>; //~ [o, o]
+    //~^ ERROR: unconstrained opaque type
 
     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>; //~ [o, o]
+    //~^ ERROR: unconstrained opaque type
 }
 
 impl<'i> Foo<'i> for () {
     type ImplicitCapture<'a> = impl Sized; //~ [o, o]
+    //~^ ERROR: unconstrained opaque type
 
     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>; //~ [o, o]
+    //~^ ERROR: unconstrained opaque type
 
     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>; //~ [o, o]
+    //~^ ERROR: unconstrained opaque type
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/variance.stderr
+++ b/tests/ui/type-alias-impl-trait/variance.stderr
@@ -1,3 +1,91 @@
+error: unconstrained opaque type
+  --> $DIR/variance.rs:8:29
+   |
+LL | type NotCapturedEarly<'a> = impl Sized;
+   |                             ^^^^^^^^^^
+   |
+   = note: `NotCapturedEarly` must be used in combination with a concrete type within the same module
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:11:26
+   |
+LL | type CapturedEarly<'a> = impl Sized + Captures<'a>;
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `CapturedEarly` must be used in combination with a concrete type within the same module
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:15:56
+   |
+LL | type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>;
+   |                                                        ^^^^^^^^^^
+   |
+   = note: `NotCapturedLate` must be used in combination with a concrete type within the same module
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:19:49
+   |
+LL | type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>;
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Captured` must be used in combination with a concrete type within the same module
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:22:27
+   |
+LL | type Bar<'a, 'b: 'b, T> = impl Sized;
+   |                           ^^^^^^^^^^
+   |
+   = note: `Bar` must be used in combination with a concrete type within the same module
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:34:32
+   |
+LL |     type ImplicitCapture<'a> = impl Sized;
+   |                                ^^^^^^^^^^
+   |
+   = note: `ImplicitCapture` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:37:42
+   |
+LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `ExplicitCaptureFromHeader` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:40:39
+   |
+LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `ExplicitCaptureFromGat` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:45:32
+   |
+LL |     type ImplicitCapture<'a> = impl Sized;
+   |                                ^^^^^^^^^^
+   |
+   = note: `ImplicitCapture` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:48:42
+   |
+LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `ExplicitCaptureFromHeader` must be used in combination with a concrete type within the same impl
+
+error: unconstrained opaque type
+  --> $DIR/variance.rs:51:39
+   |
+LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `ExplicitCaptureFromGat` must be used in combination with a concrete type within the same impl
+
 error: [o]
   --> $DIR/variance.rs:8:29
    |
@@ -5,64 +93,64 @@ LL | type NotCapturedEarly<'a> = impl Sized;
    |                             ^^^^^^^^^^
 
 error: [o]
-  --> $DIR/variance.rs:10:26
+  --> $DIR/variance.rs:11:26
    |
 LL | type CapturedEarly<'a> = impl Sized + Captures<'a>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o]
-  --> $DIR/variance.rs:13:56
+  --> $DIR/variance.rs:15:56
    |
 LL | type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>;
    |                                                        ^^^^^^^^^^
 
 error: [o]
-  --> $DIR/variance.rs:16:49
+  --> $DIR/variance.rs:19:49
    |
 LL | type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>;
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o, o, o]
-  --> $DIR/variance.rs:18:27
+  --> $DIR/variance.rs:22:27
    |
 LL | type Bar<'a, 'b: 'b, T> = impl Sized;
    |                           ^^^^^^^^^^
 
 error: [o, o]
-  --> $DIR/variance.rs:29:32
+  --> $DIR/variance.rs:34:32
    |
 LL |     type ImplicitCapture<'a> = impl Sized;
    |                                ^^^^^^^^^^
 
 error: [o, o]
-  --> $DIR/variance.rs:31:42
+  --> $DIR/variance.rs:37:42
    |
 LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o, o]
-  --> $DIR/variance.rs:33:39
+  --> $DIR/variance.rs:40:39
    |
 LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o, o]
-  --> $DIR/variance.rs:37:32
+  --> $DIR/variance.rs:45:32
    |
 LL |     type ImplicitCapture<'a> = impl Sized;
    |                                ^^^^^^^^^^
 
 error: [o, o]
-  --> $DIR/variance.rs:39:42
+  --> $DIR/variance.rs:48:42
    |
 LL |     type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>;
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o, o]
-  --> $DIR/variance.rs:41:39
+  --> $DIR/variance.rs:51:39
    |
 LL |     type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 11 previous errors
+error: aborting due to 22 previous errors
 

--- a/tests/ui/typeck/issue-13853-5.rs
+++ b/tests/ui/typeck/issue-13853-5.rs
@@ -7,6 +7,7 @@ trait Deserializable {
 impl<'a, T: Deserializable> Deserializable for &'a str {
     //~^ ERROR type parameter `T` is not constrained
     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
+        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/typeck/issue-13853-5.stderr
+++ b/tests/ui/typeck/issue-13853-5.stderr
@@ -4,6 +4,22 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<'a, T: Deserializable> Deserializable for &'a str {
    |          ^ unconstrained type parameter
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/issue-13853-5.rs:9:70
+   |
+LL |     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
+   |        -----------------                                             ^^^^^^^ expected `&str`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+   |
+help: consider returning the local binding `_y`
+   |
+LL ~     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
+LL +         _y
+LL ~
+   |
 
-For more information about this error, try `rustc --explain E0207`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0207, E0308.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/variance/variance-associated-consts.rs
+++ b/tests/ui/variance/variance-associated-consts.rs
@@ -12,6 +12,7 @@ trait Trait {
 #[rustc_variance]
 struct Foo<T: Trait> { //~ ERROR [o]
     field: [u8; <T as Trait>::Const]
+    //~^ ERROR: unconstrained generic constant
 }
 
 fn main() { }

--- a/tests/ui/variance/variance-associated-consts.stderr
+++ b/tests/ui/variance/variance-associated-consts.stderr
@@ -1,8 +1,16 @@
+error: unconstrained generic constant
+  --> $DIR/variance-associated-consts.rs:14:12
+   |
+LL |     field: [u8; <T as Trait>::Const]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); <T as Trait>::Const]:`
+
 error: [o]
   --> $DIR/variance-associated-consts.rs:13:1
    |
 LL | struct Foo<T: Trait> {
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 

--- a/tests/ui/variance/variance-regions-direct.rs
+++ b/tests/ui/variance/variance-regions-direct.rs
@@ -50,6 +50,7 @@ struct Test6<'a, 'b:'a> { //~ ERROR [+, o]
 
 #[rustc_variance]
 struct Test7<'a> { //~ ERROR [*]
+    //~^ ERROR: `'a` is never used
     x: isize
 }
 

--- a/tests/ui/variance/variance-regions-direct.stderr
+++ b/tests/ui/variance/variance-regions-direct.stderr
@@ -1,3 +1,11 @@
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/variance-regions-direct.rs:52:14
+   |
+LL | struct Test7<'a> {
+   |              ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
 error: [+, +, +]
   --> $DIR/variance-regions-direct.rs:9:1
    |
@@ -35,10 +43,11 @@ LL | struct Test7<'a> {
    | ^^^^^^^^^^^^^^^^
 
 error: [-, +, o]
-  --> $DIR/variance-regions-direct.rs:59:1
+  --> $DIR/variance-regions-direct.rs:60:1
    |
 LL | enum Test8<'a, 'b, 'c:'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 
+For more information about this error, try `rustc --explain E0392`.

--- a/tests/ui/variance/variance-regions-indirect.rs
+++ b/tests/ui/variance/variance-regions-indirect.rs
@@ -6,6 +6,7 @@
 
 #[rustc_variance]
 enum Base<'a, 'b, 'c:'b, 'd> { //~ ERROR [-, +, o, *]
+    //~^ ERROR: `'d` is never used
     Test8A(extern "Rust" fn(&'a isize)),
     Test8B(&'b [isize]),
     Test8C(&'b mut &'c str),
@@ -13,16 +14,19 @@ enum Base<'a, 'b, 'c:'b, 'd> { //~ ERROR [-, +, o, *]
 
 #[rustc_variance]
 struct Derived1<'w, 'x:'y, 'y, 'z> { //~ ERROR [*, o, +, -]
+    //~^ ERROR: `'w` is never used
     f: Base<'z, 'y, 'x, 'w>
 }
 
 #[rustc_variance] // Combine - and + to yield o
 struct Derived2<'a, 'b:'a, 'c> { //~ ERROR [o, o, *]
+    //~^ ERROR: `'c` is never used
     f: Base<'a, 'a, 'b, 'c>
 }
 
 #[rustc_variance] // Combine + and o to yield o (just pay attention to 'a here)
 struct Derived3<'a:'b, 'b, 'c> { //~ ERROR [o, +, *]
+    //~^ ERROR: `'c` is never used
     f: Base<'a, 'b, 'a, 'c>
 }
 

--- a/tests/ui/variance/variance-regions-indirect.stderr
+++ b/tests/ui/variance/variance-regions-indirect.stderr
@@ -1,3 +1,35 @@
+error[E0392]: lifetime parameter `'d` is never used
+  --> $DIR/variance-regions-indirect.rs:8:26
+   |
+LL | enum Base<'a, 'b, 'c:'b, 'd> {
+   |                          ^^ unused lifetime parameter
+   |
+   = help: consider removing `'d`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: lifetime parameter `'w` is never used
+  --> $DIR/variance-regions-indirect.rs:16:17
+   |
+LL | struct Derived1<'w, 'x:'y, 'y, 'z> {
+   |                 ^^ unused lifetime parameter
+   |
+   = help: consider removing `'w`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: lifetime parameter `'c` is never used
+  --> $DIR/variance-regions-indirect.rs:22:28
+   |
+LL | struct Derived2<'a, 'b:'a, 'c> {
+   |                            ^^ unused lifetime parameter
+   |
+   = help: consider removing `'c`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: lifetime parameter `'c` is never used
+  --> $DIR/variance-regions-indirect.rs:28:28
+   |
+LL | struct Derived3<'a:'b, 'b, 'c> {
+   |                            ^^ unused lifetime parameter
+   |
+   = help: consider removing `'c`, referring to it in a field, or using a marker such as `PhantomData`
+
 error: [-, +, o, *]
   --> $DIR/variance-regions-indirect.rs:8:1
    |
@@ -5,28 +37,29 @@ LL | enum Base<'a, 'b, 'c:'b, 'd> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [*, o, +, -]
-  --> $DIR/variance-regions-indirect.rs:15:1
+  --> $DIR/variance-regions-indirect.rs:16:1
    |
 LL | struct Derived1<'w, 'x:'y, 'y, 'z> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o, o, *]
-  --> $DIR/variance-regions-indirect.rs:20:1
+  --> $DIR/variance-regions-indirect.rs:22:1
    |
 LL | struct Derived2<'a, 'b:'a, 'c> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [o, +, *]
-  --> $DIR/variance-regions-indirect.rs:25:1
+  --> $DIR/variance-regions-indirect.rs:28:1
    |
 LL | struct Derived3<'a:'b, 'b, 'c> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [-, +, o]
-  --> $DIR/variance-regions-indirect.rs:30:1
+  --> $DIR/variance-regions-indirect.rs:34:1
    |
 LL | struct Derived4<'a, 'b, 'c:'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 9 previous errors
 
+For more information about this error, try `rustc --explain E0392`.

--- a/tests/ui/variance/variance-trait-bounds.rs
+++ b/tests/ui/variance/variance-trait-bounds.rs
@@ -19,16 +19,19 @@ struct TestStruct<U,T:Setter<U>> { //~ ERROR [+, +]
 
 #[rustc_variance]
 enum TestEnum<U,T:Setter<U>> { //~ ERROR [*, +]
+    //~^ ERROR: `U` is never used
     Foo(T)
 }
 
 #[rustc_variance]
 struct TestContraStruct<U,T:Setter<U>> { //~ ERROR [*, +]
+    //~^ ERROR: `U` is never used
     t: T
 }
 
 #[rustc_variance]
 struct TestBox<U,T:Getter<U>+Setter<U>> { //~ ERROR [*, +]
+    //~^ ERROR: `U` is never used
     t: T
 }
 

--- a/tests/ui/variance/variance-trait-bounds.stderr
+++ b/tests/ui/variance/variance-trait-bounds.stderr
@@ -1,3 +1,30 @@
+error[E0392]: type parameter `U` is never used
+  --> $DIR/variance-trait-bounds.rs:21:15
+   |
+LL | enum TestEnum<U,T:Setter<U>> {
+   |               ^ unused type parameter
+   |
+   = help: consider removing `U`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `U` to be a const parameter, use `const U: /* Type */` instead
+
+error[E0392]: type parameter `U` is never used
+  --> $DIR/variance-trait-bounds.rs:27:25
+   |
+LL | struct TestContraStruct<U,T:Setter<U>> {
+   |                         ^ unused type parameter
+   |
+   = help: consider removing `U`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `U` to be a const parameter, use `const U: /* Type */` instead
+
+error[E0392]: type parameter `U` is never used
+  --> $DIR/variance-trait-bounds.rs:33:16
+   |
+LL | struct TestBox<U,T:Getter<U>+Setter<U>> {
+   |                ^ unused type parameter
+   |
+   = help: consider removing `U`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `U` to be a const parameter, use `const U: /* Type */` instead
+
 error: [+, +]
   --> $DIR/variance-trait-bounds.rs:16:1
    |
@@ -11,16 +38,17 @@ LL | enum TestEnum<U,T:Setter<U>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [*, +]
-  --> $DIR/variance-trait-bounds.rs:26:1
+  --> $DIR/variance-trait-bounds.rs:27:1
    |
 LL | struct TestContraStruct<U,T:Setter<U>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: [*, +]
-  --> $DIR/variance-trait-bounds.rs:31:1
+  --> $DIR/variance-trait-bounds.rs:33:1
    |
 LL | struct TestBox<U,T:Getter<U>+Setter<U>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 7 previous errors
 
+For more information about this error, try `rustc --explain E0392`.


### PR DESCRIPTION
This still causes some funny diagnostics, but I'm not sure they can be fixed without a larger change, which I'd like to avoid here.

Reducing the number of times we iterate over the same items at this high level helps avoid parallel-compiler bottlenecks. 