### PR TITLE
Add `MapWindows` compile fail check for N=0

### DIFF
--- a/library/core/src/iter/adapters/map_windows.rs
+++ b/library/core/src/iter/adapters/map_windows.rs
@@ -49,8 +49,11 @@ struct Buffer<T, const N: usize> {
 }
 
 impl<I: Iterator, F, const N: usize> MapWindows<I, F, N> {
-    pub(in crate::iter) fn new(iter: I, f: F) -> Self {
+    const N_NOT_ZERO: () =
         assert!(N != 0, "array in `Iterator::map_windows` must contain more than 0 elements");
+
+    pub(in crate::iter) fn new(iter: I, f: F) -> Self {
+        let _ = Self::N_NOT_ZERO;
 
         // Only ZST arrays' length can be so large.
         if mem::size_of::<I::Item>() == 0 {

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1609,12 +1609,9 @@ pub trait Iterator {
     /// [`slice::windows()`]: slice::windows
     /// [`FusedIterator`]: crate::iter::FusedIterator
     ///
-    /// # Panics
+    /// If `N` is 0, then the code will not compile.
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a
-    /// compile time error before this method gets stabilized.
-    ///
-    /// ```should_panic
+    /// ```compile_fail
     /// #![feature(iter_map_windows)]
     ///
     /// let iter = std::iter::repeat(0).map_windows(|&[]| ());

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1617,6 +1617,12 @@ pub trait Iterator {
     /// let iter = std::iter::repeat(0).map_windows(|&[]| ());
     /// ```
     ///
+    /// ```compile_fail
+    /// #![feature(iter_map_windows)]
+    ///
+    /// let iter = std::iter::repeat(0).map_windows(|_: &[_; 0]| ());
+    /// ```
+    ///
     /// # Examples
     ///
     /// Building the sums of neighboring numbers.

--- a/library/core/tests/iter/adapters/map_windows.rs
+++ b/library/core/tests/iter/adapters/map_windows.rs
@@ -168,12 +168,6 @@ fn test_case_from_pr_82413_comment() {
 }
 
 #[test]
-#[should_panic = "array in `Iterator::map_windows` must contain more than 0 elements"]
-fn check_zero_window() {
-    let _ = std::iter::repeat(0).map_windows(|_: &[_; 0]| ());
-}
-
-#[test]
 fn test_zero_sized_type() {
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     struct Data;


### PR DESCRIPTION
Related to issue #87155. Adds a constant assertion to `MapWindows` to check if generic `N`, representing the size of the window array, is not zero. Before, a zero-length window array would cause `MapWindows` to panic at runtime. With the const assert, if `N=0`, the code will not compile.

A map window test that dealt with a zero-width array is moved to the `Iterator::map_windows` doc-tests in order to check for compilation failure. Before this change, the test was meant to panic.