### PR TITLE
Add myself to review rotation (and a rustbot ping)

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -480,12 +480,16 @@ cc = ["@lcnr", "@compiler-errors"]
 message = "Some changes occurred in diagnostic error codes"
 cc = ["@GuillaumeGomez"]
 
+[mentions."compiler/rustc_mir_build/src/build/matches"]
+message = "Some changes occurred in match lowering"
+cc = ["@Nadrieril"]
+
 [mentions."compiler/rustc_mir_build/src/thir/pattern"]
-message = "Some changes might have occurred in exhaustiveness checking"
+message = "Some changes occurred in match checking"
 cc = ["@Nadrieril"]
 
 [mentions."compiler/rustc_pattern_analysis"]
-message = "Some changes might have occurred in exhaustiveness checking"
+message = "Some changes occurred in exhaustiveness checking"
 cc = ["@Nadrieril"]
 
 [mentions."library/core/src/intrinsics/simd.rs"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -662,6 +662,7 @@ compiler-team = [
 ]
 compiler-team-contributors = [
     "@TaKO8Ki",
+    "@Nadrieril",
     "@nnethercote",
     "@fmease",
 ]


### PR DESCRIPTION
I've still got a ~month of unemployment ( :crossed_fingers: ), so I'll put some of that time into reviewing.

Unrelatedly, I've now poked enough at match lowering that I want to follow what happens to it, so I added a rustbot ping.