### PR TITLE
Use fulfillment in next trait solver coherence

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -230,8 +230,10 @@ impl<'tcx> ProofTreeInferCtxtExt<'tcx> for InferCtxt<'tcx> {
         goal: Goal<'tcx, ty::Predicate<'tcx>>,
         visitor: &mut V,
     ) -> ControlFlow<V::BreakTy> {
-        let (_, proof_tree) = self.evaluate_root_goal(goal, GenerateProofTree::Yes);
-        let proof_tree = proof_tree.unwrap();
-        visitor.visit_goal(&InspectGoal::new(self, 0, &proof_tree))
+        self.probe(|_| {
+            let (_, proof_tree) = self.evaluate_root_goal(goal, GenerateProofTree::Yes);
+            let proof_tree = proof_tree.unwrap();
+            visitor.visit_goal(&InspectGoal::new(self, 0, &proof_tree))
+        })
     }
 }

--- a/tests/ui/coherence/coherent-due-to-fulfill.rs
+++ b/tests/ui/coherence/coherent-due-to-fulfill.rs
@@ -1,0 +1,20 @@
+//@ compile-flags: -Znext-solver=coherence
+//@ check-pass
+
+trait Mirror {
+    type Assoc;
+}
+impl<T> Mirror for T {
+    type Assoc = T;
+}
+
+trait Foo {}
+trait Bar {}
+
+// self type starts out as `?0` but is constrained to `()`
+// due to the where clause below. Because `(): Bar` does not
+// hold in intercrate mode, we can prove the impls disjoint.
+impl<T> Foo for T where (): Mirror<Assoc = T> {}
+impl<T> Foo for T where T: Bar {}
+
+fn main() {}

--- a/tests/ui/coherence/incoherent-even-though-we-fulfill.rs
+++ b/tests/ui/coherence/incoherent-even-though-we-fulfill.rs
@@ -1,0 +1,22 @@
+//@ compile-flags: -Znext-solver=coherence
+
+trait Mirror {
+    type Assoc;
+}
+impl<T> Mirror for T {
+    type Assoc = T;
+}
+
+trait Foo {}
+
+// Even though using fulfillment in coherence allows us to figure out that
+// `?T = ()`, we still treat it as incoherent because `(): Iterator` may be
+// added upstream.
+impl<T> Foo for T where (): Mirror<Assoc = T> {}
+//~^ NOTE first implementation here
+impl<T> Foo for T where T: Iterator {}
+//~^ ERROR conflicting implementations of trait `Foo` for type `()`
+//~| NOTE conflicting implementation for `()`
+//~| NOTE upstream crates may add a new impl of trait `std::iter::Iterator` for type `()` in future versions
+
+fn main() {}

--- a/tests/ui/coherence/incoherent-even-though-we-fulfill.stderr
+++ b/tests/ui/coherence/incoherent-even-though-we-fulfill.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `Foo` for type `()`
+  --> $DIR/incoherent-even-though-we-fulfill.rs:17:1
+   |
+LL | impl<T> Foo for T where (): Mirror<Assoc = T> {}
+   | --------------------------------------------- first implementation here
+LL |
+LL | impl<T> Foo for T where T: Iterator {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
+   |
+   = note: upstream crates may add a new impl of trait `std::iter::Iterator` for type `()` in future versions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
Use fulfillment in the new trait solver's `impl_intersection_has_impossible_obligation` routine. This means that inference that falls out of processing other obligations can influence whether we can determine if an obligation is impossible to satisfy. See the committed test.

This should be completely sound, since evaluation and fulfillment both respect intercrate mode equally.

We run the risk of breaking coherence later if we were to change the rules of fulfillment and/or inference during coherence, but this is a problem which affects evaluation, as nested obligations from a trait goal are processed together and can influence each other in the same way.

r? lcnr
cc #114862

Also changed obligationctxt -> fulfillmentctxt because it feels kind of redundant to use an ocx here. I don't really care enough and can change it back if it really matters much.