### PR TITLE
Deduplicate object safety errors on `impl dyn Trait { .. }`

### DIFF
--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -6,6 +6,7 @@ trait Trait {
 
 impl dyn Trait {
     //~^ ERROR the trait `Trait` cannot be made into an object [E0038]
+    //~| ERROR the trait `Trait` cannot be made into an object [E0038]
     const fn n() -> usize { Self::N }
     //~^ ERROR the trait `Trait` cannot be made into an object [E0038]
 }

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -14,7 +14,23 @@ LL |     const N: usize;
    = help: consider moving `N` to another trait
 
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/associated-const-in-trait.rs:9:29
+  --> $DIR/associated-const-in-trait.rs:7:6
+   |
+LL | impl dyn Trait {
+   |      ^^^^^^^^^ `Trait` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/associated-const-in-trait.rs:4:11
+   |
+LL | trait Trait {
+   |       ----- this trait cannot be made into an object...
+LL |     const N: usize;
+   |           ^ ...because it contains this associated `const`
+   = help: consider moving `N` to another trait
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0038]: the trait `Trait` cannot be made into an object
+  --> $DIR/associated-const-in-trait.rs:10:29
    |
 LL |     const fn n() -> usize { Self::N }
    |                             ^^^^ `Trait` cannot be made into an object
@@ -28,6 +44,6 @@ LL |     const N: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `N` to another trait
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.rs
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.rs
@@ -15,8 +15,8 @@ impl MyTrait for Outer {
 
 impl dyn MyTrait {
     //~^ ERROR the trait `MyTrait` cannot be made into an object
+    //~| ERROR the trait `MyTrait` cannot be made into an object
     fn other(&self) -> impl Marker {
-        //~^ ERROR the trait `MyTrait` cannot be made into an object
         MyTrait::foo(&self)
         //~^ ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
         //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.stderr
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.stderr
@@ -49,10 +49,10 @@ LL |     fn foo(&self) -> impl Marker;
    = help: only type `Outer` implements the trait, consider using it directly instead
 
 error[E0038]: the trait `MyTrait` cannot be made into an object
-  --> $DIR/cycle-effective-visibilities-during-object-safety.rs:18:15
+  --> $DIR/cycle-effective-visibilities-during-object-safety.rs:16:6
    |
-LL |     fn other(&self) -> impl Marker {
-   |               ^^^^ `MyTrait` cannot be made into an object
+LL | impl dyn MyTrait {
+   |      ^^^^^^^^^^^ `MyTrait` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-object-safety.rs:5:22
@@ -63,6 +63,7 @@ LL |     fn foo(&self) -> impl Marker;
    |                      ^^^^^^^^^^^ ...because method `foo` references an `impl Trait` type in its return type
    = help: consider moving `foo` to another trait
    = help: only type `Outer` implements the trait, consider using it directly instead
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
`impl dyn Trait {}` has an implicit `dyn Trait: 'static` bound. We add it in `inferred_outlives_of` for more context in errors. With this we point at `impl dyn Trait` and not to it's associated functions, deduplicating errors to a single one per `impl dyn Trait` instead of one for it plus one for each associated function.

CC #83246, as this is necessary but not sufficient to help with the lack of tracking of `'static` obligations.