### PR TITLE
Add `rust.frame-pointers` config option

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -612,6 +612,10 @@
 # Indicates whether symbols should be stripped using `-Cstrip=symbols`.
 #strip = false
 
+# Forces frame pointers to be used with `-Cforce-frame-pointers`.
+# This can be helpful for profiling at a small performance cost.
+# frame-pointers = false
+
 # Indicates whether stack protectors should be used
 # via the unstable option `-Zstack-protector`.
 #

--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -23,3 +23,6 @@ incremental = true
 backtrace-on-ice = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
+# Forces frame pointers to be used with `-Cforce-frame-pointers`.
+# This can be helpful for profiling at a small performance cost.
+frame-pointers = true

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -14,6 +14,9 @@ incremental = true
 backtrace-on-ice = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
+# Forces frame pointers to be used with `-Cforce-frame-pointers`.
+# This can be helpful for profiling at a small performance cost.
+frame-pointers = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1870,6 +1870,10 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Wrustc::internal");
         }
 
+        if self.config.rust_frame_pointers {
+            rustflags.arg("-Cforce-frame-pointers=true");
+        }
+
         // If Control Flow Guard is enabled, pass the `control-flow-guard` flag to rustc
         // when compiling the standard library, since this might be linked into the final outputs
         // produced by rustc. Since this mitigation is only available on Windows, only enable it

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -256,6 +256,7 @@ pub struct Config {
     pub rust_split_debuginfo: SplitDebuginfo,
     pub rust_rpath: bool,
     pub rust_strip: bool,
+    pub rust_frame_pointers: bool,
     pub rust_stack_protector: Option<String>,
     pub rustc_parallel: bool,
     pub rustc_default_linker: Option<String>,
@@ -1083,6 +1084,7 @@ define_config! {
         musl_root: Option<String> = "musl-root",
         rpath: Option<bool> = "rpath",
         strip: Option<bool> = "strip",
+        frame_pointers: Option<bool> = "frame-pointers",
         stack_protector: Option<String> = "stack-protector",
         verbose_tests: Option<bool> = "verbose-tests",
         optimize_tests: Option<bool> = "optimize-tests",
@@ -1561,6 +1563,7 @@ impl Config {
                 download_rustc,
                 lto,
                 validate_mir_opts,
+                frame_pointers,
                 stack_protector,
                 strip,
                 lld_mode,
@@ -1609,6 +1612,7 @@ impl Config {
             set(&mut config.codegen_tests, codegen_tests);
             set(&mut config.rust_rpath, rpath);
             set(&mut config.rust_strip, strip);
+            set(&mut config.rust_frame_pointers, frame_pointers);
             config.rust_stack_protector = stack_protector;
             set(&mut config.jemalloc, jemalloc);
             set(&mut config.test_compare_mode, test_compare_mode);

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -119,4 +119,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New option `target.<triple>.codegen-backends` added to config.toml.",
     },
+    ChangeInfo {
+        change_id: 121203,
+        severity: ChangeSeverity::Info,
+        summary: "A new `rust.frame-pointers` option has been introduced and made the default in the compiler and codegen profiles.",
+    },
 ];


### PR DESCRIPTION
This is very helpful for profiling. I've hacked this in many times, so let's add it properly.