### PR TITLE
Always emit `native-static-libs` note, even if it is empty

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1536,17 +1536,13 @@ fn print_native_static_libs(
     match out {
         OutFileName::Real(path) => {
             out.overwrite(&lib_args.join(" "), sess);
-            if !lib_args.is_empty() {
-                sess.dcx().emit_note(errors::StaticLibraryNativeArtifactsToFile { path });
-            }
+            sess.dcx().emit_note(errors::StaticLibraryNativeArtifactsToFile { path });
         }
         OutFileName::Stdout => {
-            if !lib_args.is_empty() {
-                sess.dcx().emit_note(errors::StaticLibraryNativeArtifacts);
-                // Prefix for greppability
-                // Note: This must not be translated as tools are allowed to depend on this exact string.
-                sess.dcx().note(format!("native-static-libs: {}", &lib_args.join(" ")));
-            }
+            sess.dcx().emit_note(errors::StaticLibraryNativeArtifacts);
+            // Prefix for greppability
+            // Note: This must not be translated as tools are allowed to depend on this exact string.
+            sess.dcx().note(format!("native-static-libs: {}", &lib_args.join(" ")));
         }
     }
 }

--- a/tests/ui/codegen/empty-static-libs-issue-108825.rs
+++ b/tests/ui/codegen/empty-static-libs-issue-108825.rs
@@ -1,0 +1,14 @@
+// Test that linking a no_std application still outputs the
+// `native-static-libs: ` note, even though it's empty.
+//@ compile-flags: -Cpanic=abort --print=native-static-libs
+//@ build-pass
+//@ ignore-wasm
+//@ ignore-cross-compile This doesn't produce any output on i686-unknown-linux-gnu for some reason?
+
+#![crate_type = "staticlib"]
+#![no_std]
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/tests/ui/codegen/empty-static-libs-issue-108825.stderr
+++ b/tests/ui/codegen/empty-static-libs-issue-108825.stderr
@@ -1,0 +1,4 @@
+note: Link against the following native artifacts when linking against this static library. The order and any duplication can be significant on some platforms.
+
+note: native-static-libs: 
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/108825.

try-job: x86_64-msvc