### PR TITLE
Don't show suggestion if slice pattern is not top-level

### DIFF
--- a/tests/ui/suggestions/suppress-consider-slicing-issue-120605.rs
+++ b/tests/ui/suggestions/suppress-consider-slicing-issue-120605.rs
@@ -1,0 +1,20 @@
+pub struct Struct {
+    a: Vec<Struct>,
+}
+
+impl Struct {
+    pub fn test(&self) {
+        if let [Struct { a: [] }] = &self.a {
+            //~^ ERROR expected an array or slice
+            //~| ERROR expected an array or slice
+            println!("matches!")
+        }
+
+        if let [Struct { a: [] }] = &self.a[..] {
+            //~^ ERROR expected an array or slice
+            println!("matches!")
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/suppress-consider-slicing-issue-120605.stderr
+++ b/tests/ui/suggestions/suppress-consider-slicing-issue-120605.stderr
@@ -1,0 +1,23 @@
+error[E0529]: expected an array or slice, found `Vec<Struct>`
+  --> $DIR/suppress-consider-slicing-issue-120605.rs:7:16
+   |
+LL |         if let [Struct { a: [] }] = &self.a {
+   |                ^^^^^^^^^^^^^^^^^^   ------- help: consider slicing here: `&self.a[..]`
+   |                |
+   |                pattern cannot match with input type `Vec<Struct>`
+
+error[E0529]: expected an array or slice, found `Vec<Struct>`
+  --> $DIR/suppress-consider-slicing-issue-120605.rs:7:29
+   |
+LL |         if let [Struct { a: [] }] = &self.a {
+   |                             ^^ pattern cannot match with input type `Vec<Struct>`
+
+error[E0529]: expected an array or slice, found `Vec<Struct>`
+  --> $DIR/suppress-consider-slicing-issue-120605.rs:13:29
+   |
+LL |         if let [Struct { a: [] }] = &self.a[..] {
+   |                             ^^ pattern cannot match with input type `Vec<Struct>`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0529`.


### PR DESCRIPTION
Close #120605

Don't show suggestion to add slicing (`[..]`) if the slice pattern is enclosed by struct like `Struct { a: [] }`.

For example, current rustc makes a suggestion as a comment. However, the pattern `a: []` is wrong, not scrutinee `&self.a`.
In this case, the structure type `a: Vec<Struct>` and the pattern `a: []` are different so I think the pattern should be fixed, not the scrutinee.
If the parent of the pattern that was the target of the error is a structure, I made the compiler not show a suggestion.

```rs
pub struct Struct {
    a: Vec<Struct>,
}

impl Struct {
    pub fn test(&self) {
        if let [Struct { a: [] }] = &self.a {
//             ^^^^^^^^^^^^^^^^^^   ------- help: consider slicing here: `&self.a[..]`
            println!("matches!")   
        }
    }
}
```

Note:

* ~~I created `PatInfo.history` to store parent-child relationships for patterns, but this may be inefficient.~~
  * I use two fields `parent_kind` and `current_kind` instead of vec. It may not performance issue.
* Currently only looking at direct parents, but may need to look at deeper ancestry.
