### PR TITLE
Generate `getelementptr` instead of `inttoptr` for `ptr::invalid`

### DIFF
--- a/tests/codegen/strict-provenance.rs
+++ b/tests/codegen/strict-provenance.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: -O
+
+#![crate_type = "lib"]
+#![feature(strict_provenance)]
+
+use std::ptr;
+
+// CHECK-LABEL: ptr @without_provenance(
+// CHECK-SAME: [[USIZE:i[0-9]+]] noundef %addr)
+#[no_mangle]
+fn without_provenance(addr: usize) -> *const () {
+    // CHECK: start
+    // CHECK-NEXT: %0 = getelementptr i8, ptr null, [[USIZE]] %addr
+    // CHECK-NEXT: ret ptr %0
+    ptr::without_provenance(addr)
+}


### PR DESCRIPTION
Currently, `ptr::invalid` [generates an `inttoptr`](https://godbolt.org/z/3cj15dEG1), which means LLVM doesn't know that the pointer shouldn't have provenance. This PR changes the implementation so that a `getelementptr` relative to the null pointer is generated, which LLVM knows not to have provenance.