### PR TITLE
RFC 3550 data gathering

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -589,3 +589,5 @@ lint_unused_result = unused result of type `{$ty}`
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
+
+lint_explicit_range = explicit usage of range type

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -595,3 +595,5 @@ lint_explicit_range = explicit usage of range type
 lint_trait_impl_range = public trait impl involving range type
 
 lint_range_syntax = usage of range syntax
+
+lint_range_bounds = usage of `RangeBounds` trait

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -593,3 +593,5 @@ lint_variant_size_differences =
 lint_explicit_range = explicit usage of range type
 
 lint_trait_impl_range = public trait impl involving range type
+
+lint_range_syntax = usage of range syntax

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -590,10 +590,10 @@ lint_unused_result = unused result of type `{$ty}`
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
 
-lint_explicit_range = explicit usage of range type
+lint_explicit_range = explicit usage of `{$ty}` type in public {$kind}
 
-lint_trait_impl_range = public trait impl involving range type
+lint_trait_impl_range = public trait impl involving `{$ty}` type
 
-lint_range_syntax = usage of range syntax
+lint_range_syntax = usage of `{$ty}` range syntax
 
-lint_range_bounds = usage of `RangeBounds` trait
+lint_range_bounds = usage of `RangeBounds` trait bound in public {$kind}

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -591,3 +591,5 @@ lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
 
 lint_explicit_range = explicit usage of range type
+
+lint_trait_impl_range = public trait impl involving range type

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -211,6 +211,8 @@ lint_expectation = this lint expectation is unfulfilled
     .note = the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
     .rationale = {$rationale}
 
+lint_explicit_range = explicit usage of `{$ty}` type in public {$kind}
+
 lint_for_loops_over_fallibles =
     for loop over {$article} `{$ty}`. This is more readably written as an `if let` statement
     .suggestion = consider using `if let` to clear intent
@@ -471,7 +473,11 @@ lint_ptr_null_checks_ref = references are not nullable, so checking them for nul
 lint_query_instability = using `{$query}` can result in unstable query results
     .note = if you believe this case to be fine, allow this lint and add a comment explaining your rationale
 
+lint_range_bounds = usage of `RangeBounds` trait bound in public {$kind}
+
 lint_range_endpoint_out_of_range = range endpoint is out of range for `{$ty}`
+
+lint_range_syntax = usage of `{$ty}` range syntax
 
 lint_range_use_inclusive_range = use an inclusive range instead
 
@@ -510,6 +516,8 @@ lint_suspicious_double_ref_clone =
 
 lint_suspicious_double_ref_deref =
     using `.deref()` on a double reference, which returns `{$ty}` instead of dereferencing the inner type
+
+lint_trait_impl_range = public trait impl involving `{$ty}` type
 
 lint_trivial_untranslatable_diag = diagnostic with static strings only
 
@@ -589,11 +597,3 @@ lint_unused_result = unused result of type `{$ty}`
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
-
-lint_explicit_range = explicit usage of `{$ty}` type in public {$kind}
-
-lint_trait_impl_range = public trait impl involving `{$ty}` type
-
-lint_range_syntax = usage of `{$ty}` range syntax
-
-lint_range_bounds = usage of `RangeBounds` trait bound in public {$kind}

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -81,7 +81,6 @@ mod traits;
 mod types;
 mod unit_bindings;
 mod unused;
-mod rfc3550_range;
 
 pub use array_into_iter::ARRAY_INTO_ITER;
 
@@ -116,6 +115,9 @@ use traits::*;
 use types::*;
 use unit_bindings::*;
 use unused::*;
+
+// Data gathering for RFC 3550
+mod rfc3550_range;
 use rfc3550_range::*;
 
 /// Useful for other parts of the compiler / Clippy.

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -172,6 +172,8 @@ early_lint_methods!(
             IncompleteInternalFeatures: IncompleteInternalFeatures,
             RedundantSemicolons: RedundantSemicolons,
             UnusedDocComment: UnusedDocComment,
+            // Range data gathering
+            RangeSyntax: RangeSyntax,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -232,8 +232,9 @@ late_lint_methods!(
             MissingDebugImplementations: MissingDebugImplementations,
             MissingDoc: MissingDoc,
             AsyncFnInTrait: AsyncFnInTrait,
-            // Explicit Range
+            // Range data gathering
             ExplicitRange: ExplicitRange,
+            TraitImplRange: TraitImplRange,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -237,6 +237,7 @@ late_lint_methods!(
             // Range data gathering
             ExplicitRange: ExplicitRange,
             TraitImplRange: TraitImplRange,
+            RangeBounds: RangeBounds,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -81,6 +81,7 @@ mod traits;
 mod types;
 mod unit_bindings;
 mod unused;
+mod rfc3550_range;
 
 pub use array_into_iter::ARRAY_INTO_ITER;
 
@@ -115,6 +116,7 @@ use traits::*;
 use types::*;
 use unit_bindings::*;
 use unused::*;
+use rfc3550_range::*;
 
 /// Useful for other parts of the compiler / Clippy.
 pub use builtin::{MissingDoc, SoftLints};
@@ -230,6 +232,8 @@ late_lint_methods!(
             MissingDebugImplementations: MissingDebugImplementations,
             MissingDoc: MissingDoc,
             AsyncFnInTrait: AsyncFnInTrait,
+            // Explicit Range
+            ExplicitRange: ExplicitRange,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1838,3 +1838,7 @@ pub struct UnitBindingsDiag {
     #[label]
     pub label: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(lint_explicit_range)]
+pub struct ExplicitRangeDiag;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1841,16 +1841,30 @@ pub struct UnitBindingsDiag {
 
 #[derive(LintDiagnostic)]
 #[diag(lint_explicit_range)]
-pub struct ExplicitRangeDiag;
+pub struct ExplicitRangeDiag {
+    /// function | trait impl | struct impl
+    pub kind: &'static str,
+    /// Range, RangeInclusive, RangeFrom
+    pub ty: &'static str,
+}
 
 #[derive(LintDiagnostic)]
 #[diag(lint_trait_impl_range)]
-pub struct TraitImplRangeDiag;
+pub struct TraitImplRangeDiag {
+    /// Range, RangeInclusive, RangeFrom
+    pub ty: &'static str,
+}
 
 #[derive(LintDiagnostic)]
 #[diag(lint_range_syntax)]
-pub struct RangeSyntaxDiag;
+pub struct RangeSyntaxDiag {
+    /// Range, RangeInclusive, RangeFrom
+    pub ty: &'static str,
+}
 
 #[derive(LintDiagnostic)]
 #[diag(lint_range_bounds)]
-pub struct RangeBoundsDiag;
+pub struct RangeBoundsDiag {
+    /// function | trait impl | struct impl
+    pub kind: &'static str,
+}

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1850,3 +1850,7 @@ pub struct TraitImplRangeDiag;
 #[derive(LintDiagnostic)]
 #[diag(lint_range_syntax)]
 pub struct RangeSyntaxDiag;
+
+#[derive(LintDiagnostic)]
+#[diag(lint_range_bounds)]
+pub struct RangeBoundsDiag;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1846,3 +1846,7 @@ pub struct ExplicitRangeDiag;
 #[derive(LintDiagnostic)]
 #[diag(lint_trait_impl_range)]
 pub struct TraitImplRangeDiag;
+
+#[derive(LintDiagnostic)]
+#[diag(lint_range_syntax)]
+pub struct RangeSyntaxDiag;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1842,3 +1842,7 @@ pub struct UnitBindingsDiag {
 #[derive(LintDiagnostic)]
 #[diag(lint_explicit_range)]
 pub struct ExplicitRangeDiag;
+
+#[derive(LintDiagnostic)]
+#[diag(lint_trait_impl_range)]
+pub struct TraitImplRangeDiag;

--- a/compiler/rustc_lint/src/rfc3550_range.rs
+++ b/compiler/rustc_lint/src/rfc3550_range.rs
@@ -1,0 +1,179 @@
+use crate::lints::{ ExplicitRangeDiag };
+use crate::{LateContext, LateLintPass, LintContext};
+use rustc_hir as hir;
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::{Ty, Binder, FnSig};
+use rustc_middle::ty;
+use std::iter;
+
+declare_lint! {
+    /// The `explicit_range` lint detects uses of `Range`, `RangeInclusive`, 
+    /// or `RangeFrom` as parameter types in public APIs.
+    /// 
+    /// ### Examples
+    /// 
+    /// ```rust
+    /// pub fn takes_range(range: Range<usize>)
+    /// 
+    /// pub trait Foo {
+    ///     fn foo(self, range: Range<u8>) {}
+    /// }
+    /// impl Foo for Thing {
+    ///     fn foo(self, range: Range<u8>) {}
+    /// }
+    /// 
+    /// pub trait Bar
+    /// impl Bar for Range<usize>
+    /// pub fn bar(b: impl Bar)
+    /// 
+    /// pub struct Thing
+    /// impl Index<Range<usize>> for Thing
+    /// ```
+    /// 
+    /// ### Explanation
+    /// 
+    /// Gather data for [concerns in RFC 3550].
+    /// 
+    /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
+    pub(super) EXPLICIT_RANGE,
+    Allow,
+    "explicit usage of range type in public API"
+}
+
+declare_lint_pass!(ExplicitRange => [EXPLICIT_RANGE]);
+
+impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        kind: hir::intravisit::FnKind<'tcx>,
+        decl: &'tcx hir::FnDecl<'tcx>,
+        _body: &'tcx hir::Body<'tcx>,
+        _span: rustc_span::Span,
+        def_id: rustc_span::def_id::LocalDefId
+    ) {
+        if !cx.effective_visibilities.is_exported(def_id) {
+            return;
+        }
+        if let hir::intravisit::FnKind::Closure = kind {
+            return;
+        }
+
+        let ranges = [
+            hir::LangItem::Range,
+            hir::LangItem::RangeFrom,
+            hir::LangItem::RangeInclusiveStruct,
+        ].map(|x| cx.tcx.lang_items().get(x).unwrap());
+
+        // Recursively search for instances of `Range` in the type
+        fn search_range<'hir, 'tcx>(cx: &LateContext<'tcx>, ranges: &[DefId; 3], hir_ty: hir::Ty<'hir>, ty: Ty<'tcx>) -> Result<(), rustc_span::Span> {
+            match (hir_ty.kind, ty.kind()) {
+                (hir::TyKind::Path(hir::QPath::Resolved(_, path)), ty::Adt(adt_def, args)) => {
+                    // Ignore `param: Self`, which is covered by `trait_impl_range`
+                    match path.res {
+                        hir::def::Res::Def(_, _) |
+                        hir::def::Res::Local(_) => (),
+                        // SelfTyParam, SelfTyAlias, etc
+                        _ => return Ok(()),
+                    }
+                    
+                    if ranges.contains(&adt_def.did()) {
+                        return Err(hir_ty.span);
+                    }
+
+                    let hir_args = path.segments.last().unwrap().args().args;
+
+                    if let Some(span) = iter::zip(hir_args, args.iter()).find_map(|(hir_arg, arg)| {
+                        if let (hir::GenericArg::Type(&hir_ty), Some(ty)) = (hir_arg, arg.as_type()) {
+                            search_range(cx, ranges, hir_ty, ty).err()
+                        } else {
+                            None
+                        }
+                    }) {
+                        Err(span)
+                    } else {
+                        Ok(())
+                    }
+                }
+                (hir::TyKind::Array(hir_ty, _), ty::Array(ty, _)) |
+                (hir::TyKind::Slice(hir_ty), ty::Slice(ty)) |
+                (hir::TyKind::Ptr(hir::MutTy { ty: hir_ty, .. }), ty::RawPtr(ty::TypeAndMut { ty, .. })) |
+                (hir::TyKind::Ref(_, hir::MutTy { ty: hir_ty, .. }), ty::Ref(_, ty, _)) => search_range(cx, ranges, *hir_ty, *ty),
+                // ty::FnPtr(sig) => sig.skip_binder().inputs_and_output.iter().any(|ty| search_range(cx, ranges, ty)),
+                // ty::Dynamic(_, _, _) => todo!(),
+                (hir::TyKind::Tup(hir_tys), ty::Tuple(tys)) => {
+                    if let Some(span) = iter::zip(hir_tys, tys.iter()).find_map(|(hir_ty, ty)| search_range(cx, ranges, *hir_ty, ty).err()) {
+                        Err(span)
+                    } else {
+                        Ok(())
+                    }
+                }
+                // ty::Alias(_, alias) => search_range(cx, ranges, alias.to_ty(cx.tcx)),
+                // ty::Param(param) => param.,
+
+                _ => Ok(()),
+            }
+        }
+
+        let sig: Binder<'_, FnSig<'_>> = cx.tcx.fn_sig(def_id).instantiate_identity();
+        
+        let mut inputs = iter::zip(decl.inputs, sig.skip_binder().inputs());
+        // Skip implicit `self` arg
+        if decl.implicit_self.has_implicit_self() {
+            inputs.next();
+        }
+
+        for (h, ty) in inputs {
+            if let Err(span) = search_range(cx, &ranges, *h, *ty) {
+                cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag)
+            }
+        }
+    }
+}
+
+declare_lint! {
+    /// The `range_syntax` lint detects uses of `a..b`, `a..=b`, or `a..` syntax.
+    /// 
+    /// ### Examples
+    /// 
+    /// ```rust
+    /// 1..5
+    /// 
+    /// 0..=255
+    /// 
+    /// 1..
+    /// ```
+    /// 
+    /// ### Explanation
+    /// 
+    /// Gather data for [concerns in RFC 3550].
+    /// 
+    /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
+    pub(super) RANGE_SYNTAX,
+    Deny,
+    "usage of range syntax"
+}
+
+declare_lint! {
+    /// The `range_bounds` lint detects uses of the `RangeBounds` trait in public APIs.
+    /// This includes in generic bounds or `impl` parameters.
+    /// 
+    /// ### Examples
+    /// 
+    /// ```rust
+    /// pub fn takes_range_1(range: impl RangeBounds<usize>)
+    /// 
+    /// pub fn takes_range_2<I, R>(range: R) where R: RangeBounds<I>
+    /// 
+    /// impl<R: RangeBounds<usize>> Index<R> for Foo
+    /// ```
+    /// 
+    /// ### Explanation
+    /// 
+    /// Gather data for [concerns in RFC 3550].
+    /// 
+    /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
+    pub(super) RANGE_BOUNDS,
+    Deny,
+    "usage of `RangeBounds` trait"
+}

--- a/compiler/rustc_lint/src/rfc3550_range.rs
+++ b/compiler/rustc_lint/src/rfc3550_range.rs
@@ -1,9 +1,10 @@
-use crate::lints::{ ExplicitRangeDiag };
+use crate::lints::{ ExplicitRangeDiag, TraitImplRangeDiag };
 use crate::{LateContext, LateLintPass, LintContext};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::{Ty, Binder, FnSig};
 use rustc_middle::ty;
+use rustc_session::config::CrateType;
 use std::iter;
 
 declare_lint! {
@@ -52,6 +53,11 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
         _span: rustc_span::Span,
         def_id: rustc_span::def_id::LocalDefId
     ) {
+        // Only run for libraries
+        if cx.tcx.crate_types().iter().any(|&t| matches!(t, CrateType::Executable | CrateType::ProcMacro)) {
+            return;
+        }
+
         if !cx.effective_visibilities.is_exported(def_id) {
             return;
         }
@@ -127,6 +133,171 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
             if let Err(span) = search_range(cx, &ranges, *h, *ty) {
                 cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag)
             }
+        }
+    }
+}
+
+declare_lint! {
+    /// The `trait_impl_range` lint detects trait impls involving `Range`, 
+    /// `RangeInclusive`, or `RangeFrom` if the trait are used in public APIs.
+    /// 
+    /// ### Examples
+    /// 
+    /// ```rust
+    /// pub trait Bar
+    /// impl Bar for Range<usize>
+    /// 
+    /// pub struct Thing
+    /// impl Index<Range<usize>> for Thing
+    /// ```
+    /// 
+    /// ### Explanation
+    /// 
+    /// Gather data for [concerns in RFC 3550].
+    /// 
+    /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
+    pub(super) TRAIT_IMPL_RANGE,
+    Allow,
+    "public trait impl involving range type"
+}
+
+declare_lint_pass!(TraitImplRange => [TRAIT_IMPL_RANGE]);
+
+impl<'tcx> LateLintPass<'tcx> for TraitImplRange {
+    fn check_item(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        item: &'tcx hir::Item<'tcx>
+    ) {
+        // Only run for libraries
+        if cx.tcx.crate_types().iter().any(|&t| matches!(t, CrateType::Executable | CrateType::ProcMacro)) {
+            return;
+        }
+
+        let ranges = [
+            hir::LangItem::Range,
+            hir::LangItem::RangeFrom,
+            hir::LangItem::RangeInclusiveStruct,
+        ].map(|x| cx.tcx.lang_items().get(x).unwrap());
+
+        // Recursively search for instances of `Range` in the type
+        fn search_range<'hir, 'tcx>(cx: &LateContext<'tcx>, ranges: &[DefId; 3], hir_ty: hir::Ty<'hir>) -> Result<(), rustc_span::Span> {
+            match hir_ty.kind {
+                hir::TyKind::Path(qpath) => {
+                    match cx.qpath_res(&qpath, hir_ty.hir_id) {
+                        hir::def::Res::Def(_, def_id) => {
+                            if let Some(local_id) = def_id.as_local()
+                            && !cx.effective_visibilities.is_exported(local_id) {
+                                return Ok(());
+                            }
+
+                            if ranges.contains(&def_id) {
+                                return Err(hir_ty.span);
+                            }
+                        }
+                        // hir::def::Res::PrimTy(_) => todo!(),
+                        // hir::def::Res::SelfTyParam { trait_ } => todo!(),
+                        // hir::def::Res::SelfTyAlias { alias_to, forbid_generic, is_trait_impl } => todo!(),
+                        // hir::def::Res::SelfCtor(_) => todo!(),
+                        // hir::def::Res::Local(_) => todo!(),
+                        // hir::def::Res::ToolMod => todo!(),
+                        // hir::def::Res::NonMacroAttr(_) => todo!(),
+                        // hir::def::Res::Err => todo!(),
+                        _ => (),
+                    }
+
+                    let hir::QPath::Resolved(_, path) = qpath else { return Ok(()); };
+
+                    for segment in path.segments {
+                        for hir_arg in segment.args().args {
+                            if let hir::GenericArg::Type(&hir_ty) = hir_arg {
+                                search_range(cx, ranges, hir_ty)?;
+                            }
+                        }
+                    }
+
+                    Ok(())
+                }
+                hir::TyKind::Array(hir_ty, _) |
+                hir::TyKind::Slice(hir_ty) |
+                hir::TyKind::Ptr(hir::MutTy { ty: hir_ty, .. }) |
+                hir::TyKind::Ref(_, hir::MutTy { ty: hir_ty, .. }) => search_range(cx, ranges, *hir_ty),
+                // ty::FnPtr(sig) => sig.skip_binder().inputs_and_output.iter().any(|ty| search_range(cx, ranges, ty)),
+                // ty::Dynamic(_, _, _) => todo!(),
+                hir::TyKind::Tup(hir_tys) => {
+                    if let Some(span) = hir_tys.iter().find_map(|hir_ty| search_range(cx, ranges, *hir_ty).err()) {
+                        Err(span)
+                    } else {
+                        Ok(())
+                    }
+                }
+                // ty::Alias(_, alias) => search_range(cx, ranges, alias.to_ty(cx.tcx)),
+                // ty::Param(param) => param.,
+
+                _ => Ok(()),
+            }
+        }
+
+        match item.kind {
+            hir::ItemKind::Static(ty, _, _) |
+            hir::ItemKind::Const(ty, _, _) |
+            hir::ItemKind::TyAlias(ty, _) => {
+                if !cx.effective_visibilities.is_exported(item.owner_id.def_id) {
+                    return;
+                }
+
+                if let Err(span) = search_range(cx, &ranges, *ty) {
+                    cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag)
+                }
+            },
+            // hir::ItemKind::Enum(_, _) => todo!(),
+            // hir::ItemKind::Struct(_, _) => todo!(),
+            // hir::ItemKind::Union(_, _) => todo!(),
+            // hir::ItemKind::Trait(_, _, _, _, _) => todo!(),
+            hir::ItemKind::Impl(imp) => {
+                let Some(of_trait) = imp.of_trait else { return };
+                let Some(trait_def_id) = of_trait.trait_def_id() else { return };
+                
+                if let Some(trait_local_id) = trait_def_id.as_local() &&
+                    !cx.effective_visibilities.is_exported(trait_local_id)
+                {
+                    // Trait is local but not public
+                    return;
+                }
+
+                // Skip if private self type
+                if let hir::TyKind::Path(qpath) = imp.self_ty.kind
+                && let hir::def::Res::Def(_, def_id) = cx.qpath_res(&qpath, imp.self_ty.hir_id)
+                && let Some(local_id) = def_id.as_local()
+                && !cx.effective_visibilities.is_exported(local_id) {
+                    return;
+                }
+
+                if let Err(span) = search_range(cx, &ranges, *imp.self_ty) {
+                    cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag);
+                }
+
+                for segment in of_trait.path.segments {
+                    for hir_arg in segment.args().args {
+                        if let hir::GenericArg::Type(&hir_ty) = hir_arg {
+                            if let Err(span) = search_range(cx, &ranges, hir_ty) {
+                                cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag);
+                            }
+                        }
+                    }
+                }
+            },
+            
+            // hir::ItemKind::ForeignMod { abi, items } => todo!(),
+            // hir::ItemKind::ExternCrate(_) => todo!(),
+            // hir::ItemKind::Use(_, _) => todo!(),
+            // hir::ItemKind::Fn(_, _, _) => todo!(),
+            // hir::ItemKind::Macro(_, _) => todo!(),
+            // hir::ItemKind::Mod(_) => todo!(),
+            // hir::ItemKind::GlobalAsm(_) => todo!(),
+            // hir::ItemKind::OpaqueTy(_) => todo!(),
+            // hir::ItemKind::TraitAlias(_, _) => todo!(),
+            _ => (),
         }
     }
 }

--- a/compiler/rustc_lint/src/rfc3550_range.rs
+++ b/compiler/rustc_lint/src/rfc3550_range.rs
@@ -26,12 +26,10 @@ impl<'cx, 'tcx> TyVisitor<'cx, 'tcx> {
             (hir::LangItem::Range, "Range"),
             (hir::LangItem::RangeFrom, "RangeFrom"),
             (hir::LangItem::RangeInclusiveStruct, "RangeInclusive"),
-        ].map(|(x, s)| (cx.tcx.lang_items().get(x).unwrap(), s));
+        ]
+        .map(|(x, s)| (cx.tcx.lang_items().get(x).unwrap(), s));
 
-        Self {
-            cx,
-            ranges,
-        }
+        Self { cx, ranges }
     }
 
     fn matches(&self, def_id: DefId) -> Option<&'static str> {
@@ -40,20 +38,23 @@ impl<'cx, 'tcx> TyVisitor<'cx, 'tcx> {
 
     // Recursively search for instances of `Range` in the type
     fn check_ty<F>(&self, hir_ty: hir::Ty<'_>, lint: F)
-    where F: Fn(rustc_span::Span, &'static str),
+    where
+        F: Fn(rustc_span::Span, &'static str),
     {
         self.check_ty_impl(hir_ty, &lint);
     }
 
     fn check_ty_impl<F>(&self, hir_ty: hir::Ty<'_>, lint: &F)
-    where F: Fn(rustc_span::Span, &'static str),
+    where
+        F: Fn(rustc_span::Span, &'static str),
     {
         match hir_ty.kind {
             hir::TyKind::Path(qpath) => {
                 match self.cx.qpath_res(&qpath, hir_ty.hir_id) {
                     hir::def::Res::Def(_, def_id) => {
                         if let Some(local_id) = def_id.as_local()
-                        && !self.cx.effective_visibilities.is_exported(local_id) {
+                            && !self.cx.effective_visibilities.is_exported(local_id)
+                        {
                             return;
                         }
 
@@ -82,10 +83,12 @@ impl<'cx, 'tcx> TyVisitor<'cx, 'tcx> {
                     }
                 }
             }
-            hir::TyKind::Array(hir_ty, _) |
-            hir::TyKind::Slice(hir_ty) |
-            hir::TyKind::Ptr(hir::MutTy { ty: hir_ty, .. }) |
-            hir::TyKind::Ref(_, hir::MutTy { ty: hir_ty, .. }) => self.check_ty_impl(*hir_ty, lint),
+            hir::TyKind::Array(hir_ty, _)
+            | hir::TyKind::Slice(hir_ty)
+            | hir::TyKind::Ptr(hir::MutTy { ty: hir_ty, .. })
+            | hir::TyKind::Ref(_, hir::MutTy { ty: hir_ty, .. }) => {
+                self.check_ty_impl(*hir_ty, lint)
+            }
             // ty::FnPtr(sig) => sig.skip_binder().inputs_and_output.iter().any(|ty| check_ty(cx, ranges, ty)),
             // ty::Dynamic(_, _, _) => todo!(),
             hir::TyKind::Tup(hir_tys) => {
@@ -95,40 +98,39 @@ impl<'cx, 'tcx> TyVisitor<'cx, 'tcx> {
             }
             // ty::Alias(_, alias) => check_ty(cx, ranges, alias.to_ty(cx.tcx)),
             // ty::Param(param) => param.,
-
             _ => (),
         }
     }
 }
 
 declare_lint! {
-    /// The `explicit_range` lint detects uses of `Range`, `RangeInclusive`, 
+    /// The `explicit_range` lint detects uses of `Range`, `RangeInclusive`,
     /// or `RangeFrom` as parameter types in public APIs.
-    /// 
+    ///
     /// ### Examples
-    /// 
+    ///
     /// ```rust
     /// pub fn takes_range(range: Range<usize>)
-    /// 
+    ///
     /// pub trait Foo {
     ///     fn foo(self, range: Range<u8>) {}
     /// }
     /// impl Foo for Thing {
     ///     fn foo(self, range: Range<u8>) {}
     /// }
-    /// 
+    ///
     /// pub trait Bar
     /// impl Bar for Range<usize>
     /// pub fn bar(b: impl Bar)
-    /// 
+    ///
     /// pub struct Thing
     /// impl Index<Range<usize>> for Thing
     /// ```
-    /// 
+    ///
     /// ### Explanation
-    /// 
+    ///
     /// Gather data for [concerns in RFC 3550].
-    /// 
+    ///
     /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
     pub(super) EXPLICIT_RANGE,
     Allow,
@@ -145,7 +147,7 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
         decl: &'tcx hir::FnDecl<'tcx>,
         _body: &'tcx hir::Body<'tcx>,
         _span: rustc_span::Span,
-        def_id: rustc_span::def_id::LocalDefId
+        def_id: rustc_span::def_id::LocalDefId,
     ) {
         // Only run for libraries
         if !crate_is_library(cx) {
@@ -160,7 +162,7 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
         }
 
         let visitor = TyVisitor::new(cx);
-        
+
         let mut inputs = decl.inputs.iter();
         // Skip implicit `self` arg
         if decl.implicit_self.has_implicit_self() {
@@ -168,19 +170,13 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
         }
 
         for &hir_ty in inputs {
-            visitor.check_ty(hir_ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                kind: "function",
-                ty,
-            }));
+            visitor.check_ty(hir_ty, |span, ty| {
+                cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag { kind: "function", ty })
+            });
         }
     }
 
-
-    fn check_item(
-        &mut self,
-        cx: &LateContext<'tcx>,
-        item: &'tcx hir::Item<'tcx>
-    ) {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'tcx>) {
         // Only run for libraries
         if !crate_is_library(cx) {
             return;
@@ -193,22 +189,27 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
 
         match item.kind {
             hir::ItemKind::Static(ty, _, _) => {
-                visitor.check_ty(*ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                    kind: "static",
-                    ty
-                }));
+                visitor.check_ty(*ty, |span, ty| {
+                    cx.emit_span_lint(
+                        EXPLICIT_RANGE,
+                        span,
+                        ExplicitRangeDiag { kind: "static", ty },
+                    )
+                });
             }
             hir::ItemKind::Const(ty, _, _) => {
-                visitor.check_ty(*ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                    kind: "const",
-                    ty
-                }));
+                visitor.check_ty(*ty, |span, ty| {
+                    cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag { kind: "const", ty })
+                });
             }
             hir::ItemKind::TyAlias(ty, _) => {
-                visitor.check_ty(*ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                    kind: "type alias",
-                    ty
-                }));
+                visitor.check_ty(*ty, |span, ty| {
+                    cx.emit_span_lint(
+                        EXPLICIT_RANGE,
+                        span,
+                        ExplicitRangeDiag { kind: "type alias", ty },
+                    )
+                });
             }
             hir::ItemKind::Enum(enu, _) => {
                 for v in enu.variants {
@@ -217,23 +218,29 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
                             continue;
                         }
 
-                        visitor.check_ty(*field.ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                            kind: "enum definition",
-                            ty
-                        }));
+                        visitor.check_ty(*field.ty, |span, ty| {
+                            cx.emit_span_lint(
+                                EXPLICIT_RANGE,
+                                span,
+                                ExplicitRangeDiag { kind: "enum definition", ty },
+                            )
+                        });
                     }
                 }
-            },
+            }
             hir::ItemKind::Struct(data, _) => {
                 for field in data.fields() {
                     if !cx.effective_visibilities.is_exported(field.def_id) {
                         continue;
                     }
 
-                    visitor.check_ty(*field.ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                        kind: "struct field",
-                        ty
-                    }));
+                    visitor.check_ty(*field.ty, |span, ty| {
+                        cx.emit_span_lint(
+                            EXPLICIT_RANGE,
+                            span,
+                            ExplicitRangeDiag { kind: "struct field", ty },
+                        )
+                    });
                 }
             }
             hir::ItemKind::Union(data, _) => {
@@ -242,10 +249,13 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
                         continue;
                     }
 
-                    visitor.check_ty(*field.ty, |span, ty| cx.emit_span_lint(EXPLICIT_RANGE, span, ExplicitRangeDiag {
-                        kind: "union field",
-                        ty
-                    }));
+                    visitor.check_ty(*field.ty, |span, ty| {
+                        cx.emit_span_lint(
+                            EXPLICIT_RANGE,
+                            span,
+                            ExplicitRangeDiag { kind: "union field", ty },
+                        )
+                    });
                 }
             }
 
@@ -255,23 +265,23 @@ impl<'tcx> LateLintPass<'tcx> for ExplicitRange {
 }
 
 declare_lint! {
-    /// The `trait_impl_range` lint detects trait impls involving `Range`, 
+    /// The `trait_impl_range` lint detects trait impls involving `Range`,
     /// `RangeInclusive`, or `RangeFrom` if the trait are used in public APIs.
-    /// 
+    ///
     /// ### Examples
-    /// 
+    ///
     /// ```rust
     /// pub trait Bar
     /// impl Bar for Range<usize>
-    /// 
+    ///
     /// pub struct Thing
     /// impl Index<Range<usize>> for Thing
     /// ```
-    /// 
+    ///
     /// ### Explanation
-    /// 
+    ///
     /// Gather data for [concerns in RFC 3550].
-    /// 
+    ///
     /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
     pub(super) TRAIT_IMPL_RANGE,
     Allow,
@@ -281,11 +291,7 @@ declare_lint! {
 declare_lint_pass!(TraitImplRange => [TRAIT_IMPL_RANGE]);
 
 impl<'tcx> LateLintPass<'tcx> for TraitImplRange {
-    fn check_item(
-        &mut self,
-        cx: &LateContext<'tcx>,
-        item: &'tcx hir::Item<'tcx>
-    ) {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'tcx>) {
         // Only run for libraries
         if !crate_is_library(cx) {
             return;
@@ -297,9 +303,9 @@ impl<'tcx> LateLintPass<'tcx> for TraitImplRange {
             hir::ItemKind::Impl(imp) => {
                 let Some(of_trait) = imp.of_trait else { return };
                 let Some(trait_def_id) = of_trait.trait_def_id() else { return };
-                
-                if let Some(trait_local_id) = trait_def_id.as_local() &&
-                    !cx.effective_visibilities.is_exported(trait_local_id)
+
+                if let Some(trait_local_id) = trait_def_id.as_local()
+                    && !cx.effective_visibilities.is_exported(trait_local_id)
                 {
                     // Trait is local but not public
                     return;
@@ -307,23 +313,28 @@ impl<'tcx> LateLintPass<'tcx> for TraitImplRange {
 
                 // Skip if private self type
                 if let hir::TyKind::Path(qpath) = imp.self_ty.kind
-                && let hir::def::Res::Def(_, def_id) = cx.qpath_res(&qpath, imp.self_ty.hir_id)
-                && let Some(local_id) = def_id.as_local()
-                && !cx.effective_visibilities.is_exported(local_id) {
+                    && let hir::def::Res::Def(_, def_id) = cx.qpath_res(&qpath, imp.self_ty.hir_id)
+                    && let Some(local_id) = def_id.as_local()
+                    && !cx.effective_visibilities.is_exported(local_id)
+                {
                     return;
                 }
 
-                visitor.check_ty(*imp.self_ty, |span, ty| cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag { ty }));
+                visitor.check_ty(*imp.self_ty, |span, ty| {
+                    cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag { ty })
+                });
 
                 for segment in of_trait.path.segments {
                     for hir_arg in segment.args().args {
                         if let hir::GenericArg::Type(&hir_ty) = hir_arg {
-                            visitor.check_ty(hir_ty, |span, ty| cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag { ty }));
+                            visitor.check_ty(hir_ty, |span, ty| {
+                                cx.emit_span_lint(TRAIT_IMPL_RANGE, span, TraitImplRangeDiag { ty })
+                            });
                         }
                     }
                 }
-            },
-            
+            }
+
             // hir::ItemKind::ForeignMod { abi, items } => todo!(),
             // hir::ItemKind::ExternCrate(_) => todo!(),
             // hir::ItemKind::Use(_, _) => todo!(),
@@ -340,21 +351,21 @@ impl<'tcx> LateLintPass<'tcx> for TraitImplRange {
 
 declare_lint! {
     /// The `range_syntax` lint detects uses of `a..b`, `a..=b`, or `a..` syntax.
-    /// 
+    ///
     /// ### Examples
-    /// 
+    ///
     /// ```rust
     /// 1..5
-    /// 
+    ///
     /// 0..=255
-    /// 
+    ///
     /// 1..
     /// ```
-    /// 
+    ///
     /// ### Explanation
-    /// 
+    ///
     /// Gather data for [concerns in RFC 3550].
-    /// 
+    ///
     /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
     pub(super) RANGE_SYNTAX,
     Allow,
@@ -367,9 +378,13 @@ impl EarlyLintPass for RangeSyntax {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &rustc_ast::Expr) {
         let ty = match expr.kind {
             // Range - a..=b
-            rustc_ast::ExprKind::Range(Some(_), Some(_), rustc_ast::RangeLimits::HalfOpen) => "Range",
+            rustc_ast::ExprKind::Range(Some(_), Some(_), rustc_ast::RangeLimits::HalfOpen) => {
+                "Range"
+            }
             // RangeInclusive - a..=b
-            rustc_ast::ExprKind::Range(Some(_), Some(_), rustc_ast::RangeLimits::Closed) => "RangeInclusive",
+            rustc_ast::ExprKind::Range(Some(_), Some(_), rustc_ast::RangeLimits::Closed) => {
+                "RangeInclusive"
+            }
             // RangeFrom - a..
             rustc_ast::ExprKind::Range(Some(_), None, _) => "RangeFrom",
 
@@ -383,21 +398,21 @@ impl EarlyLintPass for RangeSyntax {
 declare_lint! {
     /// The `range_bounds` lint detects uses of the `RangeBounds` trait in public APIs.
     /// This includes in generic bounds or `impl` parameters.
-    /// 
+    ///
     /// ### Examples
-    /// 
+    ///
     /// ```rust
     /// pub fn takes_range_1(range: impl RangeBounds<usize>)
-    /// 
+    ///
     /// pub fn takes_range_2<I, R>(range: R) where R: RangeBounds<I>
-    /// 
+    ///
     /// impl<R: RangeBounds<usize>> Index<R> for Foo
     /// ```
-    /// 
+    ///
     /// ### Explanation
-    /// 
+    ///
     /// Gather data for [concerns in RFC 3550].
-    /// 
+    ///
     /// [concerns in RFC 3550](https://github.com/rust-lang/rfcs/pull/3550#issuecomment-1935112286)
     pub(super) RANGE_BOUNDS,
     Allow,
@@ -415,10 +430,7 @@ impl<'cx, 'tcx> BoundsVisitor<'cx, 'tcx> {
     fn new(cx: &'cx LateContext<'tcx>) -> Self {
         let range_bounds = ["core", "ops", "range", "RangeBounds"].map(|x| Symbol::intern(x));
 
-        Self {
-            cx,
-            range_bounds,
-        }
+        Self { cx, range_bounds }
     }
 
     fn is_range_bounds(&self, def_id: DefId) -> bool {
@@ -430,7 +442,8 @@ impl<'cx, 'tcx> BoundsVisitor<'cx, 'tcx> {
             let hir::GenericBound::Trait(of_trait, _) = bound else { continue };
 
             if let Some(def_id) = of_trait.trait_ref.trait_def_id()
-            && self.is_range_bounds(def_id) {
+                && self.is_range_bounds(def_id)
+            {
                 self.cx.emit_span_lint(RANGE_BOUNDS, of_trait.span, RangeBoundsDiag { kind });
             }
         }
@@ -438,7 +451,7 @@ impl<'cx, 'tcx> BoundsVisitor<'cx, 'tcx> {
 
     fn check_generics(&self, generics: &'tcx hir::Generics<'_>, kind: &'static str) {
         for pred in generics.predicates {
-            let hir::WherePredicate::BoundPredicate(pred) = pred else { continue }; 
+            let hir::WherePredicate::BoundPredicate(pred) = pred else { continue };
 
             self.check_bounds(pred.bounds, kind);
         }
@@ -453,7 +466,7 @@ impl<'tcx> LateLintPass<'tcx> for RangeBounds {
         _decl: &'tcx hir::FnDecl<'tcx>,
         _body: &'tcx hir::Body<'tcx>,
         _span: rustc_span::Span,
-        def_id: rustc_span::def_id::LocalDefId
+        def_id: rustc_span::def_id::LocalDefId,
     ) {
         // Only run for libraries
         if !crate_is_library(cx) {
@@ -466,18 +479,14 @@ impl<'tcx> LateLintPass<'tcx> for RangeBounds {
         if let hir::intravisit::FnKind::Closure = kind {
             return;
         }
-        
+
         let Some(generics) = cx.generics else { return };
 
         let visitor = BoundsVisitor::new(cx);
         visitor.check_generics(generics, "function");
     }
 
-    fn check_item(
-        &mut self,
-        cx: &LateContext<'tcx>,
-        item: &'tcx hir::Item<'tcx>
-    ) {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'tcx>) {
         // Only run for libraries
         if !crate_is_library(cx) {
             return;
@@ -490,8 +499,12 @@ impl<'tcx> LateLintPass<'tcx> for RangeBounds {
 
         match item.kind {
             hir::ItemKind::Enum(_, generics) => visitor.check_generics(generics, "enum definition"),
-            hir::ItemKind::Struct(_, generics) => visitor.check_generics(generics, "struct definition"),
-            hir::ItemKind::Union(_, generics) => visitor.check_generics(generics, "union definition"),
+            hir::ItemKind::Struct(_, generics) => {
+                visitor.check_generics(generics, "struct definition")
+            }
+            hir::ItemKind::Union(_, generics) => {
+                visitor.check_generics(generics, "union definition")
+            }
             hir::ItemKind::Trait(_, _, generics, bounds, _) => {
                 visitor.check_generics(generics, "trait definition");
                 visitor.check_bounds(bounds, "trait definition");
@@ -501,7 +514,10 @@ impl<'tcx> LateLintPass<'tcx> for RangeBounds {
                     "trait impl"
                 } else {
                     let hir::TyKind::Path(qpath) = imp.self_ty.kind else { return };
-                    let hir::def::Res::Def(kind, _) = cx.qpath_res(&qpath, imp.self_ty.hir_id) else { return };
+                    let hir::def::Res::Def(kind, _) = cx.qpath_res(&qpath, imp.self_ty.hir_id)
+                    else {
+                        return;
+                    };
                     match kind {
                         hir::def::DefKind::Struct => "struct impl",
                         hir::def::DefKind::Union => "union impl",

--- a/tests/ui/lint/rfc3550_range/explicit_range.rs
+++ b/tests/ui/lint/rfc3550_range/explicit_range.rs
@@ -7,18 +7,18 @@ use std::ops::{Range, RangeInclusive, RangeFrom};
 
 fn p(_: Range<usize>) { } // Private, no error.
 
-pub fn f_std(_: Range<usize>) { } //~ ERROR explicit usage of range type
-pub fn f_inc(_: RangeInclusive<usize>) { } //~ ERROR explicit usage of range type
-pub fn f_from(_: RangeFrom<usize>) { } //~ ERROR explicit usage of range type
+pub fn f_std(_: Range<usize>) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_inc(_: RangeInclusive<usize>) { } //~ ERROR explicit usage of `RangeInclusive` type in public function
+pub fn f_from(_: RangeFrom<usize>) { } //~ ERROR explicit usage of `RangeFrom` type in public function
 
-pub fn f_core(_: core::ops::Range<usize>) { } //~ ERROR explicit usage of range type
-pub fn f_arr(_: [Range<usize>; 2]) { } //~ ERROR explicit usage of range type
-pub fn f_slice(_: &[Range<usize>]) { } //~ ERROR explicit usage of range type
-pub fn f_ptr(_: *const Range<usize>) { } //~ ERROR explicit usage of range type
-pub fn f_ref(_: &Range<usize>) { } //~ ERROR explicit usage of range type
-pub fn f_tup(_: (u8, Range<usize>)) { } //~ ERROR explicit usage of range type
-pub fn f_wrapped(_: std::mem::MaybeUninit<Range<usize>>) {} //~ ERROR explicit usage of range type
-pub fn f_generic<T>(_: Range<T>) {} //~ ERROR explicit usage of range type
+pub fn f_core(_: core::ops::Range<usize>) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_arr(_: [Range<usize>; 2]) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_slice(_: &[Range<usize>]) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_ptr(_: *const Range<usize>) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_ref(_: &Range<usize>) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_tup(_: (u8, Range<usize>)) { } //~ ERROR explicit usage of `Range` type in public function
+pub fn f_wrapped(_: std::mem::MaybeUninit<Range<usize>>) {} //~ ERROR explicit usage of `Range` type in public function
+pub fn f_generic<T>(_: Range<T>) {} //~ ERROR explicit usage of `Range` type in public function
 
 pub trait Foo {
     fn foo(self);
@@ -29,16 +29,16 @@ pub trait Foo {
 impl Foo for Range<u8> {
     fn foo(self) {} // Detected by `trait_impl_range`
     fn goo(this: Self) {} // Detected by `trait_impl_range`
-    fn bar(range: Range<usize>) {} //~ ERROR explicit usage of range type
+    fn bar(range: Range<usize>) {} //~ ERROR explicit usage of `Range` type in public function
 }
 
 const PRIV_CONST: Range<usize> = 1..3;
 static PRIV_STATIC: Range<usize> = 1..3;
 type PrivAlias = Range<u8>;
 
-pub const PUB_CONST: Range<usize> = 1..3; //~ ERROR explicit usage of range type
-pub static PUB_STATIC: Range<usize> = 1..3; //~ ERROR explicit usage of range type
-pub type PubAlias = Range<u8>; //~ ERROR explicit usage of range type
+pub const PUB_CONST: Range<usize> = 1..3; //~ ERROR explicit usage of `Range` type in public const
+pub static PUB_STATIC: Range<usize> = 1..3; //~ ERROR explicit usage of `Range` type in public static
+pub type PubAlias = Range<u8>; //~ ERROR explicit usage of `Range` type in public type alias
 
 enum PrivEnumPubField {
     A(Range<u32>),
@@ -53,10 +53,10 @@ pub struct PubStructPrivField {
 }
 
 pub enum PubEnum {
-    A(Range<u32>), //~ ERROR explicit usage of range type
+    A(Range<u32>), //~ ERROR explicit usage of `Range` type in public enum definition
     B(u8),
 }
 pub struct PubStruct {
-    pub pub_field: Range<u32>, //~ ERROR explicit usage of range type
-    pub wrapped: std::mem::MaybeUninit<Range<usize>>, //~ ERROR explicit usage of range type
+    pub pub_field: Range<u32>, //~ ERROR explicit usage of `Range` type in public struct field
+    pub wrapped: std::mem::MaybeUninit<Range<usize>>, //~ ERROR explicit usage of `Range` type in public struct field
 }

--- a/tests/ui/lint/rfc3550_range/explicit_range.rs
+++ b/tests/ui/lint/rfc3550_range/explicit_range.rs
@@ -31,3 +31,32 @@ impl Foo for Range<u8> {
     fn goo(this: Self) {} // Detected by `trait_impl_range`
     fn bar(range: Range<usize>) {} //~ ERROR explicit usage of range type
 }
+
+const PRIV_CONST: Range<usize> = 1..3;
+static PRIV_STATIC: Range<usize> = 1..3;
+type PrivAlias = Range<u8>;
+
+pub const PUB_CONST: Range<usize> = 1..3; //~ ERROR explicit usage of range type
+pub static PUB_STATIC: Range<usize> = 1..3; //~ ERROR explicit usage of range type
+pub type PubAlias = Range<u8>; //~ ERROR explicit usage of range type
+
+enum PrivEnumPubField {
+    A(Range<u32>),
+    B(u8),
+}
+struct PrivStructPubField {
+    pub pub_field: Range<u32>,
+}
+
+pub struct PubStructPrivField {
+    priv_field: Range<u32>,
+}
+
+pub enum PubEnum {
+    A(Range<u32>), //~ ERROR explicit usage of range type
+    B(u8),
+}
+pub struct PubStruct {
+    pub pub_field: Range<u32>, //~ ERROR explicit usage of range type
+    pub wrapped: std::mem::MaybeUninit<Range<usize>>, //~ ERROR explicit usage of range type
+}

--- a/tests/ui/lint/rfc3550_range/explicit_range.rs
+++ b/tests/ui/lint/rfc3550_range/explicit_range.rs
@@ -1,0 +1,33 @@
+#![crate_type="lib"]
+
+#![deny(explicit_range)]
+#![allow(dead_code)]
+
+use std::ops::{Range, RangeInclusive, RangeFrom};
+
+fn p(_: Range<usize>) { } // Private, no error.
+
+pub fn f_std(_: Range<usize>) { } //~ ERROR explicit usage of range type
+pub fn f_inc(_: RangeInclusive<usize>) { } //~ ERROR explicit usage of range type
+pub fn f_from(_: RangeFrom<usize>) { } //~ ERROR explicit usage of range type
+
+pub fn f_core(_: core::ops::Range<usize>) { } //~ ERROR explicit usage of range type
+pub fn f_arr(_: [Range<usize>; 2]) { } //~ ERROR explicit usage of range type
+pub fn f_slice(_: &[Range<usize>]) { } //~ ERROR explicit usage of range type
+pub fn f_ptr(_: *const Range<usize>) { } //~ ERROR explicit usage of range type
+pub fn f_ref(_: &Range<usize>) { } //~ ERROR explicit usage of range type
+pub fn f_tup(_: (u8, Range<usize>)) { } //~ ERROR explicit usage of range type
+pub fn f_wrapped(_: std::mem::MaybeUninit<Range<usize>>) {} //~ ERROR explicit usage of range type
+pub fn f_generic<T>(_: Range<T>) {} //~ ERROR explicit usage of range type
+
+pub trait Foo {
+    fn foo(self);
+    fn goo(this: Self);
+    fn bar(range: Range<usize>);
+}
+
+impl Foo for Range<u8> {
+    fn foo(self) {} // Detected by `trait_impl_range`
+    fn goo(this: Self) {} // Detected by `trait_impl_range`
+    fn bar(range: Range<usize>) {} //~ ERROR explicit usage of range type
+}

--- a/tests/ui/lint/rfc3550_range/explicit_range.stderr
+++ b/tests/ui/lint/rfc3550_range/explicit_range.stderr
@@ -1,4 +1,4 @@
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:10:17
    |
 LL | pub fn f_std(_: Range<usize>) { }
@@ -10,103 +10,103 @@ note: the lint level is defined here
 LL | #![deny(explicit_range)]
    |         ^^^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `RangeInclusive` type in public function
   --> $DIR/explicit_range.rs:11:17
    |
 LL | pub fn f_inc(_: RangeInclusive<usize>) { }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `RangeFrom` type in public function
   --> $DIR/explicit_range.rs:12:18
    |
 LL | pub fn f_from(_: RangeFrom<usize>) { }
    |                  ^^^^^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:14:18
    |
 LL | pub fn f_core(_: core::ops::Range<usize>) { }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:15:18
    |
 LL | pub fn f_arr(_: [Range<usize>; 2]) { }
    |                  ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:16:21
    |
 LL | pub fn f_slice(_: &[Range<usize>]) { }
    |                     ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:17:24
    |
 LL | pub fn f_ptr(_: *const Range<usize>) { }
    |                        ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:18:18
    |
 LL | pub fn f_ref(_: &Range<usize>) { }
    |                  ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:19:22
    |
 LL | pub fn f_tup(_: (u8, Range<usize>)) { }
    |                      ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:20:43
    |
 LL | pub fn f_wrapped(_: std::mem::MaybeUninit<Range<usize>>) {}
    |                                           ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:21:24
    |
 LL | pub fn f_generic<T>(_: Range<T>) {}
    |                        ^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public function
   --> $DIR/explicit_range.rs:32:19
    |
 LL |     fn bar(range: Range<usize>) {}
    |                   ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public const
   --> $DIR/explicit_range.rs:39:22
    |
 LL | pub const PUB_CONST: Range<usize> = 1..3;
    |                      ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public static
   --> $DIR/explicit_range.rs:40:24
    |
 LL | pub static PUB_STATIC: Range<usize> = 1..3;
    |                        ^^^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public type alias
   --> $DIR/explicit_range.rs:41:21
    |
 LL | pub type PubAlias = Range<u8>;
    |                     ^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public enum definition
   --> $DIR/explicit_range.rs:56:7
    |
 LL |     A(Range<u32>),
    |       ^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public struct field
   --> $DIR/explicit_range.rs:60:20
    |
 LL |     pub pub_field: Range<u32>,
    |                    ^^^^^^^^^^
 
-error: explicit usage of range type
+error: explicit usage of `Range` type in public struct field
   --> $DIR/explicit_range.rs:61:40
    |
 LL |     pub wrapped: std::mem::MaybeUninit<Range<usize>>,

--- a/tests/ui/lint/rfc3550_range/explicit_range.stderr
+++ b/tests/ui/lint/rfc3550_range/explicit_range.stderr
@@ -76,5 +76,41 @@ error: explicit usage of range type
 LL |     fn bar(range: Range<usize>) {}
    |                   ^^^^^^^^^^^^
 
-error: aborting due to 12 previous errors
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:39:22
+   |
+LL | pub const PUB_CONST: Range<usize> = 1..3;
+   |                      ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:40:24
+   |
+LL | pub static PUB_STATIC: Range<usize> = 1..3;
+   |                        ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:41:21
+   |
+LL | pub type PubAlias = Range<u8>;
+   |                     ^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:56:7
+   |
+LL |     A(Range<u32>),
+   |       ^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:60:20
+   |
+LL |     pub pub_field: Range<u32>,
+   |                    ^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:61:40
+   |
+LL |     pub wrapped: std::mem::MaybeUninit<Range<usize>>,
+   |                                        ^^^^^^^^^^^^
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/lint/rfc3550_range/explicit_range.stderr
+++ b/tests/ui/lint/rfc3550_range/explicit_range.stderr
@@ -1,0 +1,80 @@
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:10:17
+   |
+LL | pub fn f_std(_: Range<usize>) { }
+   |                 ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/explicit_range.rs:3:9
+   |
+LL | #![deny(explicit_range)]
+   |         ^^^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:11:17
+   |
+LL | pub fn f_inc(_: RangeInclusive<usize>) { }
+   |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:12:18
+   |
+LL | pub fn f_from(_: RangeFrom<usize>) { }
+   |                  ^^^^^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:14:18
+   |
+LL | pub fn f_core(_: core::ops::Range<usize>) { }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:15:18
+   |
+LL | pub fn f_arr(_: [Range<usize>; 2]) { }
+   |                  ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:16:21
+   |
+LL | pub fn f_slice(_: &[Range<usize>]) { }
+   |                     ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:17:24
+   |
+LL | pub fn f_ptr(_: *const Range<usize>) { }
+   |                        ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:18:18
+   |
+LL | pub fn f_ref(_: &Range<usize>) { }
+   |                  ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:19:22
+   |
+LL | pub fn f_tup(_: (u8, Range<usize>)) { }
+   |                      ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:20:43
+   |
+LL | pub fn f_wrapped(_: std::mem::MaybeUninit<Range<usize>>) {}
+   |                                           ^^^^^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:21:24
+   |
+LL | pub fn f_generic<T>(_: Range<T>) {}
+   |                        ^^^^^^^^
+
+error: explicit usage of range type
+  --> $DIR/explicit_range.rs:32:19
+   |
+LL |     fn bar(range: Range<usize>) {}
+   |                   ^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+

--- a/tests/ui/lint/rfc3550_range/range_bounds.rs
+++ b/tests/ui/lint/rfc3550_range/range_bounds.rs
@@ -8,11 +8,11 @@ use std::ops::RangeBounds;
 // Private, no error.
 fn p<R: RangeBounds<usize>>(range: R) {}
 
-pub fn f_std<R: RangeBounds<usize>>(range: R) {} //~ ERROR usage of `RangeBounds` trait
-pub fn f_core<R: core::ops::RangeBounds<usize>>(range: R) {} //~ ERROR usage of `RangeBounds` trait
-pub fn f_impl_trait(range: impl RangeBounds<usize>) {} //~ ERROR usage of `RangeBounds` trait
-pub fn f_generic<B, R: RangeBounds<B>>(range: R) {} //~ ERROR usage of `RangeBounds` trait
-pub fn f_where<R>(range: R) where R: RangeBounds<usize> {} //~ ERROR usage of `RangeBounds` trait
+pub fn f_std<R: RangeBounds<usize>>(range: R) {} //~ ERROR usage of `RangeBounds` trait bound in public function
+pub fn f_core<R: core::ops::RangeBounds<usize>>(range: R) {} //~ ERROR usage of `RangeBounds` trait bound in public function
+pub fn f_impl_trait(range: impl RangeBounds<usize>) {} //~ ERROR usage of `RangeBounds` trait bound in public function
+pub fn f_generic<B, R: RangeBounds<B>>(range: R) {} //~ ERROR usage of `RangeBounds` trait bound in public function
+pub fn f_where<R>(range: R) where R: RangeBounds<usize> {} //~ ERROR usage of `RangeBounds` trait bound in public function
 
 struct Priv<R>(R);
 impl<R: RangeBounds<usize>> Priv<R> {
@@ -22,7 +22,7 @@ impl<R: RangeBounds<usize>> Priv<R> {
 }
 
 pub struct Pub<R>(R);
-impl<R: RangeBounds<usize>> Pub<R> { //~ ERROR usage of `RangeBounds` trait
+impl<R: RangeBounds<usize>> Pub<R> { //~ ERROR usage of `RangeBounds` trait bound in public struct impl
     pub fn new(range: R) -> Self {
         Self(range)
     }
@@ -31,10 +31,10 @@ impl<R: RangeBounds<usize>> Pub<R> { //~ ERROR usage of `RangeBounds` trait
 pub struct Thing;
 impl Thing {
     fn p(range: impl RangeBounds<usize>) {}
-    pub fn bar(range: impl RangeBounds<usize>) {} //~ ERROR usage of `RangeBounds` trait
+    pub fn bar(range: impl RangeBounds<usize>) {} //~ ERROR usage of `RangeBounds` trait bound in public function
 }
 
-pub struct Wrapper<R: RangeBounds<usize>>(R); //~ ERROR usage of `RangeBounds` trait
+pub struct Wrapper<R: RangeBounds<usize>>(R); //~ ERROR usage of `RangeBounds` trait bound in public struct definition
 
-pub trait Action<R: RangeBounds<usize>> {} //~ ERROR usage of `RangeBounds` trait
-pub trait Super: RangeBounds<usize> {} //~ ERROR usage of `RangeBounds` trait
+pub trait Action<R: RangeBounds<usize>> {} //~ ERROR usage of `RangeBounds` trait bound in public trait definition
+pub trait Super: RangeBounds<usize> {} //~ ERROR usage of `RangeBounds` trait bound in public trait definition

--- a/tests/ui/lint/rfc3550_range/range_bounds.rs
+++ b/tests/ui/lint/rfc3550_range/range_bounds.rs
@@ -1,0 +1,40 @@
+#![crate_type="lib"]
+
+#![deny(range_bounds)]
+#![allow(dead_code)]
+
+use std::ops::RangeBounds;
+
+// Private, no error.
+fn p<R: RangeBounds<usize>>(range: R) {}
+
+pub fn f_std<R: RangeBounds<usize>>(range: R) {} //~ ERROR usage of `RangeBounds` trait
+pub fn f_core<R: core::ops::RangeBounds<usize>>(range: R) {} //~ ERROR usage of `RangeBounds` trait
+pub fn f_impl_trait(range: impl RangeBounds<usize>) {} //~ ERROR usage of `RangeBounds` trait
+pub fn f_generic<B, R: RangeBounds<B>>(range: R) {} //~ ERROR usage of `RangeBounds` trait
+pub fn f_where<R>(range: R) where R: RangeBounds<usize> {} //~ ERROR usage of `RangeBounds` trait
+
+struct Priv<R>(R);
+impl<R: RangeBounds<usize>> Priv<R> {
+    pub fn new(range: R) -> Self {
+        Self(range)
+    }
+}
+
+pub struct Pub<R>(R);
+impl<R: RangeBounds<usize>> Pub<R> { //~ ERROR usage of `RangeBounds` trait
+    pub fn new(range: R) -> Self {
+        Self(range)
+    }
+}
+
+pub struct Thing;
+impl Thing {
+    fn p(range: impl RangeBounds<usize>) {}
+    pub fn bar(range: impl RangeBounds<usize>) {} //~ ERROR usage of `RangeBounds` trait
+}
+
+pub struct Wrapper<R: RangeBounds<usize>>(R); //~ ERROR usage of `RangeBounds` trait
+
+pub trait Action<R: RangeBounds<usize>> {} //~ ERROR usage of `RangeBounds` trait
+pub trait Super: RangeBounds<usize> {} //~ ERROR usage of `RangeBounds` trait

--- a/tests/ui/lint/rfc3550_range/range_bounds.stderr
+++ b/tests/ui/lint/rfc3550_range/range_bounds.stderr
@@ -1,0 +1,68 @@
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:11:17
+   |
+LL | pub fn f_std<R: RangeBounds<usize>>(range: R) {}
+   |                 ^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/range_bounds.rs:3:9
+   |
+LL | #![deny(range_bounds)]
+   |         ^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:12:18
+   |
+LL | pub fn f_core<R: core::ops::RangeBounds<usize>>(range: R) {}
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:13:33
+   |
+LL | pub fn f_impl_trait(range: impl RangeBounds<usize>) {}
+   |                                 ^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:14:24
+   |
+LL | pub fn f_generic<B, R: RangeBounds<B>>(range: R) {}
+   |                        ^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:15:38
+   |
+LL | pub fn f_where<R>(range: R) where R: RangeBounds<usize> {}
+   |                                      ^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:25:9
+   |
+LL | impl<R: RangeBounds<usize>> Pub<R> {
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:34:28
+   |
+LL |     pub fn bar(range: impl RangeBounds<usize>) {}
+   |                            ^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:37:23
+   |
+LL | pub struct Wrapper<R: RangeBounds<usize>>(R);
+   |                       ^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:39:21
+   |
+LL | pub trait Action<R: RangeBounds<usize>> {}
+   |                     ^^^^^^^^^^^^^^^^^^
+
+error: usage of `RangeBounds` trait
+  --> $DIR/range_bounds.rs:40:18
+   |
+LL | pub trait Super: RangeBounds<usize> {}
+   |                  ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/lint/rfc3550_range/range_bounds.stderr
+++ b/tests/ui/lint/rfc3550_range/range_bounds.stderr
@@ -1,4 +1,4 @@
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public function
   --> $DIR/range_bounds.rs:11:17
    |
 LL | pub fn f_std<R: RangeBounds<usize>>(range: R) {}
@@ -10,55 +10,55 @@ note: the lint level is defined here
 LL | #![deny(range_bounds)]
    |         ^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public function
   --> $DIR/range_bounds.rs:12:18
    |
 LL | pub fn f_core<R: core::ops::RangeBounds<usize>>(range: R) {}
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public function
   --> $DIR/range_bounds.rs:13:33
    |
 LL | pub fn f_impl_trait(range: impl RangeBounds<usize>) {}
    |                                 ^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public function
   --> $DIR/range_bounds.rs:14:24
    |
 LL | pub fn f_generic<B, R: RangeBounds<B>>(range: R) {}
    |                        ^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public function
   --> $DIR/range_bounds.rs:15:38
    |
 LL | pub fn f_where<R>(range: R) where R: RangeBounds<usize> {}
    |                                      ^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public struct impl
   --> $DIR/range_bounds.rs:25:9
    |
 LL | impl<R: RangeBounds<usize>> Pub<R> {
    |         ^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public function
   --> $DIR/range_bounds.rs:34:28
    |
 LL |     pub fn bar(range: impl RangeBounds<usize>) {}
    |                            ^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public struct definition
   --> $DIR/range_bounds.rs:37:23
    |
 LL | pub struct Wrapper<R: RangeBounds<usize>>(R);
    |                       ^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public trait definition
   --> $DIR/range_bounds.rs:39:21
    |
 LL | pub trait Action<R: RangeBounds<usize>> {}
    |                     ^^^^^^^^^^^^^^^^^^
 
-error: usage of `RangeBounds` trait
+error: usage of `RangeBounds` trait bound in public trait definition
   --> $DIR/range_bounds.rs:40:18
    |
 LL | pub trait Super: RangeBounds<usize> {}

--- a/tests/ui/lint/rfc3550_range/range_syntax.rs
+++ b/tests/ui/lint/rfc3550_range/range_syntax.rs
@@ -2,15 +2,14 @@
 #![allow(dead_code)]
 
 fn main() {
-    0..1; //~ ERROR usage of range syntax
+    0..1; //~ ERROR usage of `Range` range syntax
     
-    2..=3; //~ ERROR usage of range syntax
+    2..=3; //~ ERROR usage of `RangeInclusive` range syntax
 
-    4..; //~ ERROR usage of range syntax
+    4..; //~ ERROR usage of `RangeFrom` range syntax
 
+    // Should no trigger for others.
     ..5;
-
     ..=6;
-
     ..;
 }

--- a/tests/ui/lint/rfc3550_range/range_syntax.rs
+++ b/tests/ui/lint/rfc3550_range/range_syntax.rs
@@ -1,0 +1,16 @@
+#![deny(range_syntax)]
+#![allow(dead_code)]
+
+fn main() {
+    0..1; //~ ERROR usage of range syntax
+    
+    2..=3; //~ ERROR usage of range syntax
+
+    4..; //~ ERROR usage of range syntax
+
+    ..5;
+
+    ..=6;
+
+    ..;
+}

--- a/tests/ui/lint/rfc3550_range/range_syntax.rs
+++ b/tests/ui/lint/rfc3550_range/range_syntax.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     0..1; //~ ERROR usage of `Range` range syntax
-    
+
     2..=3; //~ ERROR usage of `RangeInclusive` range syntax
 
     4..; //~ ERROR usage of `RangeFrom` range syntax

--- a/tests/ui/lint/rfc3550_range/range_syntax.stderr
+++ b/tests/ui/lint/rfc3550_range/range_syntax.stderr
@@ -1,4 +1,4 @@
-error: usage of range syntax
+error: usage of `Range` range syntax
   --> $DIR/range_syntax.rs:5:5
    |
 LL |     0..1;
@@ -10,13 +10,13 @@ note: the lint level is defined here
 LL | #![deny(range_syntax)]
    |         ^^^^^^^^^^^^
 
-error: usage of range syntax
+error: usage of `RangeInclusive` range syntax
   --> $DIR/range_syntax.rs:7:5
    |
 LL |     2..=3;
    |     ^^^^^
 
-error: usage of range syntax
+error: usage of `RangeFrom` range syntax
   --> $DIR/range_syntax.rs:9:5
    |
 LL |     4..;

--- a/tests/ui/lint/rfc3550_range/range_syntax.stderr
+++ b/tests/ui/lint/rfc3550_range/range_syntax.stderr
@@ -1,0 +1,26 @@
+error: usage of range syntax
+  --> $DIR/range_syntax.rs:5:5
+   |
+LL |     0..1;
+   |     ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/range_syntax.rs:1:9
+   |
+LL | #![deny(range_syntax)]
+   |         ^^^^^^^^^^^^
+
+error: usage of range syntax
+  --> $DIR/range_syntax.rs:7:5
+   |
+LL |     2..=3;
+   |     ^^^^^
+
+error: usage of range syntax
+  --> $DIR/range_syntax.rs:9:5
+   |
+LL |     4..;
+   |     ^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/lint/rfc3550_range/trait_impl_range.rs
+++ b/tests/ui/lint/rfc3550_range/trait_impl_range.rs
@@ -1,0 +1,42 @@
+#![crate_type="lib"]
+
+#![deny(trait_impl_range)]
+#![allow(dead_code)]
+
+use std::ops::{Range, RangeInclusive, RangeFrom};
+
+// Private trait, no error.
+trait Private {}
+impl Private for Range<usize> {}
+
+// Public trait.
+pub trait Foo {}
+impl Foo for Range<usize> {} //~ ERROR public trait impl involving range type
+impl Foo for core::ops::RangeInclusive<usize> {} //~ ERROR public trait impl involving range type
+impl Foo for [Range<usize>; 2] {} //~ ERROR public trait impl involving range type
+impl Foo for &[Range<usize>] {} //~ ERROR public trait impl involving range type
+impl Foo for *const Range<usize> {} //~ ERROR public trait impl involving range type
+impl Foo for &Range<usize> {} //~ ERROR public trait impl involving range type
+impl Foo for (u8, Range<usize>) {} //~ ERROR public trait impl involving range type
+impl Foo for std::mem::MaybeUninit<Range<usize>> {} //~ ERROR public trait impl involving range type
+impl<T> Foo for RangeFrom<T> {} //~ ERROR public trait impl involving range type
+
+pub struct Thing;
+impl std::ops::Index<Range<usize>> for Thing { //~ ERROR public trait impl involving range type
+    type Output = ();
+    fn index(&self, _: Range<usize>) -> &Self::Output {
+        &()
+    }
+}
+
+// Private adt, no error.
+struct Wrapper<T>(T);
+impl Foo for Wrapper<Range<usize>> {}
+
+struct PrivateThing;
+impl std::ops::Index<Range<usize>> for PrivateThing {
+    type Output = ();
+    fn index(&self, _: Range<usize>) -> &Self::Output {
+        &()
+    }
+}

--- a/tests/ui/lint/rfc3550_range/trait_impl_range.rs
+++ b/tests/ui/lint/rfc3550_range/trait_impl_range.rs
@@ -11,18 +11,18 @@ impl Private for Range<usize> {}
 
 // Public trait.
 pub trait Foo {}
-impl Foo for Range<usize> {} //~ ERROR public trait impl involving range type
-impl Foo for core::ops::RangeInclusive<usize> {} //~ ERROR public trait impl involving range type
-impl Foo for [Range<usize>; 2] {} //~ ERROR public trait impl involving range type
-impl Foo for &[Range<usize>] {} //~ ERROR public trait impl involving range type
-impl Foo for *const Range<usize> {} //~ ERROR public trait impl involving range type
-impl Foo for &Range<usize> {} //~ ERROR public trait impl involving range type
-impl Foo for (u8, Range<usize>) {} //~ ERROR public trait impl involving range type
-impl Foo for std::mem::MaybeUninit<Range<usize>> {} //~ ERROR public trait impl involving range type
-impl<T> Foo for RangeFrom<T> {} //~ ERROR public trait impl involving range type
+impl Foo for Range<usize> {} //~ ERROR public trait impl involving `Range` type
+impl Foo for core::ops::RangeInclusive<usize> {} //~ ERROR public trait impl involving `RangeInclusive` type
+impl Foo for [Range<usize>; 2] {} //~ ERROR public trait impl involving `Range` type
+impl Foo for &[Range<usize>] {} //~ ERROR public trait impl involving `Range` type
+impl Foo for *const Range<usize> {} //~ ERROR public trait impl involving `Range` type
+impl Foo for &Range<usize> {} //~ ERROR public trait impl involving `Range` type
+impl Foo for (u8, Range<usize>) {} //~ ERROR public trait impl involving `Range` type
+impl Foo for std::mem::MaybeUninit<Range<usize>> {} //~ ERROR public trait impl involving `Range` type
+impl<T> Foo for RangeFrom<T> {} //~ ERROR public trait impl involving `RangeFrom` type
 
 pub struct Thing;
-impl std::ops::Index<Range<usize>> for Thing { //~ ERROR public trait impl involving range type
+impl std::ops::Index<Range<usize>> for Thing { //~ ERROR public trait impl involving `Range` type
     type Output = ();
     fn index(&self, _: Range<usize>) -> &Self::Output {
         &()

--- a/tests/ui/lint/rfc3550_range/trait_impl_range.stderr
+++ b/tests/ui/lint/rfc3550_range/trait_impl_range.stderr
@@ -1,4 +1,4 @@
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:14:14
    |
 LL | impl Foo for Range<usize> {}
@@ -10,55 +10,55 @@ note: the lint level is defined here
 LL | #![deny(trait_impl_range)]
    |         ^^^^^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `RangeInclusive` type
   --> $DIR/trait_impl_range.rs:15:14
    |
 LL | impl Foo for core::ops::RangeInclusive<usize> {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:16:15
    |
 LL | impl Foo for [Range<usize>; 2] {}
    |               ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:17:16
    |
 LL | impl Foo for &[Range<usize>] {}
    |                ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:18:21
    |
 LL | impl Foo for *const Range<usize> {}
    |                     ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:19:15
    |
 LL | impl Foo for &Range<usize> {}
    |               ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:20:19
    |
 LL | impl Foo for (u8, Range<usize>) {}
    |                   ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:21:36
    |
 LL | impl Foo for std::mem::MaybeUninit<Range<usize>> {}
    |                                    ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `RangeFrom` type
   --> $DIR/trait_impl_range.rs:22:17
    |
 LL | impl<T> Foo for RangeFrom<T> {}
    |                 ^^^^^^^^^^^^
 
-error: public trait impl involving range type
+error: public trait impl involving `Range` type
   --> $DIR/trait_impl_range.rs:25:22
    |
 LL | impl std::ops::Index<Range<usize>> for Thing {

--- a/tests/ui/lint/rfc3550_range/trait_impl_range.stderr
+++ b/tests/ui/lint/rfc3550_range/trait_impl_range.stderr
@@ -1,0 +1,68 @@
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:14:14
+   |
+LL | impl Foo for Range<usize> {}
+   |              ^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/trait_impl_range.rs:3:9
+   |
+LL | #![deny(trait_impl_range)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:15:14
+   |
+LL | impl Foo for core::ops::RangeInclusive<usize> {}
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:16:15
+   |
+LL | impl Foo for [Range<usize>; 2] {}
+   |               ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:17:16
+   |
+LL | impl Foo for &[Range<usize>] {}
+   |                ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:18:21
+   |
+LL | impl Foo for *const Range<usize> {}
+   |                     ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:19:15
+   |
+LL | impl Foo for &Range<usize> {}
+   |               ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:20:19
+   |
+LL | impl Foo for (u8, Range<usize>) {}
+   |                   ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:21:36
+   |
+LL | impl Foo for std::mem::MaybeUninit<Range<usize>> {}
+   |                                    ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:22:17
+   |
+LL | impl<T> Foo for RangeFrom<T> {}
+   |                 ^^^^^^^^^^^^
+
+error: public trait impl involving range type
+  --> $DIR/trait_impl_range.rs:25:22
+   |
+LL | impl std::ops::Index<Range<usize>> for Thing {
+   |                      ^^^^^^^^^^^^
+
+error: aborting due to 10 previous errors
+


### PR DESCRIPTION
I have implemented four lints to gather data for rust-lang/rfcs#3550

r? traviscross

Please initiate a crater run. `check-only` seems appropriate, and the following lints need to be enabled:

- `deny(explicit_range)`
- `deny(trait_impl_range)`
- `warn(range_syntax)`
- `warn(range_bounds)`

I believe that equates to the following command, but please double check as I've never used crater myself.

```
@craterbot run mode=check-only +rustflags=-Dexplicit_range -Dtrait_impl_range -Wrange_syntax -Wrange_bounds
```
