### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -362,8 +362,11 @@ impl<G: EmissionGuarantee> IntoDiagnostic<'_, G> for LinkingFailed<'_> {
         // which by now we have no way to translate.
         if contains_undefined_ref {
             diag.note(fluent::codegen_ssa_extern_funcs_not_found)
-                .note(fluent::codegen_ssa_specify_libraries_to_link)
-                .note(fluent::codegen_ssa_use_cargo_directive);
+                .note(fluent::codegen_ssa_specify_libraries_to_link);
+
+            if rustc_session::utils::was_invoked_from_cargo() {
+                diag.note(fluent::codegen_ssa_use_cargo_directive);
+            }
         }
         diag
     }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2998,6 +2998,12 @@ impl<'hir> Item<'hir> {
         ItemId { owner_id: self.owner_id }
     }
 
+    /// Check if this is an [`ItemKind::Enum`], [`ItemKind::Struct`] or
+    /// [`ItemKind::Union`].
+    pub fn is_adt(&self) -> bool {
+        matches!(self.kind, ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Union(..))
+    }
+
     expect_methods_self_kind! {
         expect_extern_crate, Option<Symbol>, ItemKind::ExternCrate(s), *s;
 

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -198,6 +198,8 @@ hir_analysis_invalid_union_field =
 hir_analysis_invalid_union_field_sugg =
     wrap the field type in `ManuallyDrop<...>`
 
+hir_analysis_invalid_unnamed_field_ty = unnamed fields can only have struct or union types
+
 hir_analysis_late_bound_const_in_apit = `impl Trait` can only mention const parameters from an fn or impl
     .label = const parameter declared here
 

--- a/compiler/rustc_hir_analysis/src/astconv/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/bounds.rs
@@ -9,9 +9,7 @@ use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::traits;
 use smallvec::SmallVec;
 
-use crate::astconv::{
-    AstConv, ConvertedBinding, ConvertedBindingKind, OnlySelfBounds, PredicateFilter,
-};
+use crate::astconv::{AstConv, OnlySelfBounds, PredicateFilter};
 use crate::bounds::Bounds;
 use crate::errors;
 
@@ -238,7 +236,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
         &self,
         hir_ref_id: hir::HirId,
         trait_ref: ty::PolyTraitRef<'tcx>,
-        binding: &ConvertedBinding<'_, 'tcx>,
+        binding: &hir::TypeBinding<'tcx>,
         bounds: &mut Bounds<'tcx>,
         speculative: bool,
         dup_bindings: &mut FxIndexMap<DefId, Span>,
@@ -263,21 +261,20 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
 
         let tcx = self.tcx();
 
-        let assoc_kind =
-            if binding.gen_args.parenthesized == hir::GenericArgsParentheses::ReturnTypeNotation {
-                ty::AssocKind::Fn
-            } else if let ConvertedBindingKind::Equality(term) = binding.kind
-                && let ty::TermKind::Const(_) = term.node.unpack()
-            {
-                ty::AssocKind::Const
-            } else {
-                ty::AssocKind::Type
-            };
+        let assoc_kind = if binding.gen_args.parenthesized
+            == hir::GenericArgsParentheses::ReturnTypeNotation
+        {
+            ty::AssocKind::Fn
+        } else if let hir::TypeBindingKind::Equality { term: hir::Term::Const(_) } = binding.kind {
+            ty::AssocKind::Const
+        } else {
+            ty::AssocKind::Type
+        };
 
         let candidate = if self.trait_defines_associated_item_named(
             trait_ref.def_id(),
             assoc_kind,
-            binding.item_name,
+            binding.ident,
         ) {
             // Simple case: The assoc item is defined in the current trait.
             trait_ref
@@ -289,14 +286,14 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                 trait_ref.skip_binder().print_only_trait_name(),
                 None,
                 assoc_kind,
-                binding.item_name,
+                binding.ident,
                 path_span,
-                Some(&binding),
+                Some(binding),
             )?
         };
 
         let (assoc_ident, def_scope) =
-            tcx.adjust_ident_and_get_scope(binding.item_name, candidate.def_id(), hir_ref_id);
+            tcx.adjust_ident_and_get_scope(binding.ident, candidate.def_id(), hir_ref_id);
 
         // We have already adjusted the item name above, so compare with `.normalize_to_macros_2_0()`
         // instead of calling `filter_by_name_and_kind` which would needlessly normalize the
@@ -312,7 +309,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                 .dcx()
                 .struct_span_err(
                     binding.span,
-                    format!("{} `{}` is private", assoc_item.kind, binding.item_name),
+                    format!("{} `{}` is private", assoc_item.kind, binding.ident),
                 )
                 .with_span_label(binding.span, format!("private {}", assoc_item.kind))
                 .emit();
@@ -327,7 +324,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
                     tcx.dcx().emit_err(errors::ValueOfAssociatedStructAlreadySpecified {
                         span: binding.span,
                         prev_span: *prev_span,
-                        item_name: binding.item_name,
+                        item_name: binding.ident,
                         def_path: tcx.def_path_str(assoc_item.container_id(tcx)),
                     });
                 })
@@ -412,7 +409,7 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             // parent arguments (the arguments of the trait) and the own arguments (the ones of
             // the associated item itself) and construct an alias type using them.
             candidate.map_bound(|trait_ref| {
-                let ident = Ident::new(assoc_item.name, binding.item_name.span);
+                let ident = Ident::new(assoc_item.name, binding.ident.span);
                 let item_segment = hir::PathSegment {
                     ident,
                     hir_id: binding.hir_id,
@@ -436,66 +433,67 @@ impl<'tcx> dyn AstConv<'tcx> + '_ {
             })
         };
 
-        if !speculative {
-            // Find any late-bound regions declared in `ty` that are not
-            // declared in the trait-ref or assoc_item. These are not well-formed.
-            //
-            // Example:
-            //
-            //     for<'a> <T as Iterator>::Item = &'a str // <-- 'a is bad
-            //     for<'a> <T as FnMut<(&'a u32,)>>::Output = &'a str // <-- 'a is ok
-            if let ConvertedBindingKind::Equality(term) = binding.kind {
-                let late_bound_in_projection_ty =
-                    tcx.collect_constrained_late_bound_regions(&projection_ty);
-                let late_bound_in_term =
-                    tcx.collect_referenced_late_bound_regions(&trait_ref.rebind(term.node));
-                debug!(?late_bound_in_projection_ty);
-                debug!(?late_bound_in_term);
-
-                // NOTE(associated_const_equality): This error should be impossible to trigger
-                //                                  with associated const equality bounds.
-                // FIXME: point at the type params that don't have appropriate lifetimes:
-                // struct S1<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
-                //                         ----  ----     ^^^^^^^
-                self.validate_late_bound_regions(
-                    late_bound_in_projection_ty,
-                    late_bound_in_term,
-                    |br_name| {
-                        struct_span_code_err!(
-                            tcx.dcx(),
-                            binding.span,
-                            E0582,
-                            "binding for associated type `{}` references {}, \
-                             which does not appear in the trait input types",
-                            binding.item_name,
-                            br_name
-                        )
-                    },
-                );
-            }
-        }
-
         match binding.kind {
-            ConvertedBindingKind::Equality(..) if let ty::AssocKind::Fn = assoc_kind => {
+            hir::TypeBindingKind::Equality { .. } if let ty::AssocKind::Fn = assoc_kind => {
                 return Err(tcx.dcx().emit_err(crate::errors::ReturnTypeNotationEqualityBound {
                     span: binding.span,
                 }));
             }
-            ConvertedBindingKind::Equality(term) => {
+            hir::TypeBindingKind::Equality { term } => {
+                let term = match term {
+                    hir::Term::Ty(ty) => self.ast_ty_to_ty(ty).into(),
+                    hir::Term::Const(ct) => ty::Const::from_anon_const(tcx, ct.def_id).into(),
+                };
+
+                if !speculative {
+                    // Find any late-bound regions declared in `ty` that are not
+                    // declared in the trait-ref or assoc_item. These are not well-formed.
+                    //
+                    // Example:
+                    //
+                    //     for<'a> <T as Iterator>::Item = &'a str // <-- 'a is bad
+                    //     for<'a> <T as FnMut<(&'a u32,)>>::Output = &'a str // <-- 'a is ok
+                    let late_bound_in_projection_ty =
+                        tcx.collect_constrained_late_bound_regions(&projection_ty);
+                    let late_bound_in_term =
+                        tcx.collect_referenced_late_bound_regions(&trait_ref.rebind(term));
+                    debug!(?late_bound_in_projection_ty);
+                    debug!(?late_bound_in_term);
+
+                    // FIXME: point at the type params that don't have appropriate lifetimes:
+                    // struct S1<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
+                    //                         ----  ----     ^^^^^^^
+                    // NOTE(associated_const_equality): This error should be impossible to trigger
+                    //                                  with associated const equality bounds.
+                    self.validate_late_bound_regions(
+                        late_bound_in_projection_ty,
+                        late_bound_in_term,
+                        |br_name| {
+                            struct_span_code_err!(
+                                tcx.dcx(),
+                                binding.span,
+                                E0582,
+                                "binding for associated type `{}` references {}, \
+                                 which does not appear in the trait input types",
+                                binding.ident,
+                                br_name
+                            )
+                        },
+                    );
+                }
+
                 // "Desugar" a constraint like `T: Iterator<Item = u32>` this to
                 // the "projection predicate" for:
                 //
                 // `<T as Iterator>::Item = u32`
                 bounds.push_projection_bound(
                     tcx,
-                    projection_ty.map_bound(|projection_ty| ty::ProjectionPredicate {
-                        projection_ty,
-                        term: term.node,
-                    }),
+                    projection_ty
+                        .map_bound(|projection_ty| ty::ProjectionPredicate { projection_ty, term }),
                     binding.span,
                 );
             }
-            ConvertedBindingKind::Constraint(ast_bounds) => {
+            hir::TypeBindingKind::Constraint { bounds: ast_bounds } => {
                 // "Desugar" a constraint like `T: Iterator<Item: Debug>` to
                 //
                 // `<T as Iterator>::Item: Debug`

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -943,7 +943,15 @@ impl<'tcx> FieldUniquenessCheckContext<'tcx> {
                 }
             }
             hir::TyKind::Path(hir::QPath::Resolved(_, hir::Path { res, .. })) => {
-                self.check_field_in_nested_adt(self.tcx.adt_def(res.def_id()), field.span);
+                // If this is a direct path to an ADT, we can check it
+                // If this is a type alias or non-ADT, `check_unnamed_fields` should verify it
+                if let Some(def_id) = res.opt_def_id()
+                    && let Some(local) = def_id.as_local()
+                    && let Node::Item(item) = self.tcx.hir_node_by_def_id(local)
+                    && item.is_adt()
+                {
+                    self.check_field_in_nested_adt(self.tcx.adt_def(def_id), field.span);
+                }
             }
             // Abort due to errors (there must be an error if an unnamed field
             //  has any type kind other than an anonymous adt or a named adt)

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -662,6 +662,13 @@ pub(crate) struct InvalidUnionField {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_invalid_unnamed_field_ty)]
+pub struct InvalidUnnamedFieldTy {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_return_type_notation_on_non_rpitit)]
 pub(crate) struct ReturnTypeNotationOnNonRpitit<'tcx> {
     #[primary_span]

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -293,7 +293,7 @@ pub enum HelpUseLatestEdition {
 impl HelpUseLatestEdition {
     pub fn new() -> Self {
         let edition = LATEST_STABLE_EDITION;
-        if std::env::var_os("CARGO").is_some() {
+        if rustc_session::utils::was_invoked_from_cargo() {
             Self::Cargo { edition }
         } else {
             Self::Standalone { edition }

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -492,7 +492,7 @@ fn lock_directory(
                 lock_err,
                 session_dir,
                 is_unsupported_lock,
-                is_cargo: std::env::var_os("CARGO").map(|_| ()),
+                is_cargo: rustc_session::utils::was_invoked_from_cargo().then_some(()),
             }))
         }
     }

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -205,7 +205,7 @@ pub(super) fn builtin(
                 Vec::new()
             };
 
-            let is_from_cargo = std::env::var_os("CARGO").is_some();
+            let is_from_cargo = rustc_session::utils::was_invoked_from_cargo();
             let mut is_feature_cfg = name == sym::feature;
 
             if is_feature_cfg && is_from_cargo {
@@ -340,7 +340,7 @@ pub(super) fn builtin(
                 .copied()
                 .flatten()
                 .collect();
-            let is_from_cargo = std::env::var_os("CARGO").is_some();
+            let is_from_cargo = rustc_session::utils::was_invoked_from_cargo();
 
             // Show the full list if all possible values for a given name, but don't do it
             // for names as the possibilities could be very long

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2545,7 +2545,7 @@ pub enum HelpUseLatestEdition {
 impl HelpUseLatestEdition {
     pub fn new() -> Self {
         let edition = LATEST_STABLE_EDITION;
-        if std::env::var_os("CARGO").is_some() {
+        if rustc_session::utils::was_invoked_from_cargo() {
             Self::Cargo { edition }
         } else {
             Self::Standalone { edition }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -3961,6 +3961,24 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
         if let Node::Expr(expr) = tcx.hir_node(arg_hir_id)
             && let Some(typeck_results) = &self.typeck_results
         {
+            if let hir::Expr { kind: hir::ExprKind::MethodCall(_, rcvr, _, _), .. } = expr
+                && let Some(ty) = typeck_results.node_type_opt(rcvr.hir_id)
+                && let Some(failed_pred) = failed_pred.to_opt_poly_trait_pred()
+                && let pred = failed_pred.map_bound(|pred| pred.with_self_ty(tcx, ty))
+                && self.predicate_must_hold_modulo_regions(&Obligation::misc(
+                    tcx, expr.span, body_id, param_env, pred,
+                ))
+            {
+                err.span_suggestion_verbose(
+                    expr.span.with_lo(rcvr.span.hi()),
+                    format!(
+                        "consider removing this method call, as the receiver has type `{ty}` and \
+                         `{pred}` trivially holds",
+                    ),
+                    "",
+                    Applicability::MaybeIncorrect,
+                );
+            }
             if let hir::Expr { kind: hir::ExprKind::Block(block, _), .. } = expr {
                 let inner_expr = expr.peel_blocks();
                 let ty = typeck_results
@@ -4096,7 +4114,7 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
             }
         }
 
-        if let Node::Expr(expr) = tcx.hir_node(call_hir_id) {
+        if let Node::Expr(expr) = call_node {
             if let hir::ExprKind::Call(hir::Expr { span, .. }, _)
             | hir::ExprKind::MethodCall(
                 hir::PathSegment { ident: Ident { span, .. }, .. },

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -443,11 +443,13 @@ pub(crate) fn build_impl(
             return;
         }
 
-        if let Some(stab) = tcx.lookup_stability(did)
-            && stab.is_unstable()
-            && stab.feature == sym::rustc_private
-        {
-            return;
+        if !tcx.features().rustc_private && !cx.render_options.force_unstable_if_unmarked {
+            if let Some(stab) = tcx.lookup_stability(did)
+                && stab.is_unstable()
+                && stab.feature == sym::rustc_private
+            {
+                return;
+            }
         }
     }
 
@@ -477,8 +479,11 @@ pub(crate) fn build_impl(
                 return;
             }
 
-            if let Some(stab) = tcx.lookup_stability(did) {
-                if stab.is_unstable() && stab.feature == sym::rustc_private {
+            if !tcx.features().rustc_private && !cx.render_options.force_unstable_if_unmarked {
+                if let Some(stab) = tcx.lookup_stability(did)
+                    && stab.is_unstable()
+                    && stab.feature == sym::rustc_private
+                {
                     return;
                 }
             }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -281,6 +281,8 @@ pub(crate) struct RenderOptions {
     pub(crate) no_emit_shared: bool,
     /// If `true`, HTML source code pages won't be generated.
     pub(crate) html_no_source: bool,
+    /// Whether `-Zforce-unstable-if-unmarked` unstable option is set
+    pub(crate) force_unstable_if_unmarked: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -347,6 +349,7 @@ impl Options {
 
         let codegen_options = CodegenOptions::build(early_dcx, matches);
         let unstable_opts = UnstableOptions::build(early_dcx, matches);
+        let force_unstable_if_unmarked = unstable_opts.force_unstable_if_unmarked;
 
         let dcx = new_dcx(error_format, None, diagnostic_width, &unstable_opts);
 
@@ -760,6 +763,7 @@ impl Options {
             call_locations,
             no_emit_shared: false,
             html_no_source,
+            force_unstable_if_unmarked,
         };
         Some((options, render_options))
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1943,13 +1943,8 @@ in src-script.js and main.js
 		   pixels to avoid overflowing the topbar when the user sets a bigger
 		   font size. */
 		font-size: 24px;
-	}
-
-	.mobile-topbar h2 a {
-		display: block;
-		text-overflow: ellipsis;
-		overflow: hidden;
 		white-space: nowrap;
+		text-overflow: ellipsis;
 	}
 
 	.mobile-topbar .logo-container > img {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -45,7 +45,7 @@ function setMobileTopbar() {
         const mobileTitle = document.createElement("h2");
         mobileTitle.className = "location";
         if (hasClass(document.querySelector(".rustdoc"), "crate")) {
-            mobileTitle.innerText = `Crate ${window.currentCrate}`;
+            mobileTitle.innerHTML = `Crate <a href="#">${window.currentCrate}</a>`;
         } else if (locationTitle) {
             mobileTitle.innerHTML = locationTitle.innerHTML;
         }

--- a/tests/rustdoc-gui/mobile-crate-name.goml
+++ b/tests/rustdoc-gui/mobile-crate-name.goml
@@ -1,0 +1,22 @@
+// Checks that if the crate name is too long on mobile, it will not grow and overflow its parent
+// (thanks to text overflow ellipsis).
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
+// First we change the title to make it big.
+set-window-size: (350, 800)
+// We ensure that the "format" of the title is the same as the one we'll use.
+assert-text: (".mobile-topbar .location a", "test_docs")
+// We store the height we know is correct.
+store-property: (".mobile-topbar .location", {"offsetHeight": height})
+// We change the crate name to something longer.
+set-text: (".mobile-topbar .location a", "cargo_packager_resource_resolver")
+// And we check that the size remained the same.
+assert-property: (".mobile-topbar .location", {"offsetHeight": |height|})
+
+// Now we check if it works for the non-crate pages as well.
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
+// We store the height we know is correct.
+store-property: (".mobile-topbar .location", {"offsetHeight": height})
+set-text: (".mobile-topbar .location a", "Something_incredibly_long_because")
+// And we check that the size remained the same.
+assert-property: (".mobile-topbar .location", {"offsetHeight": |height|})

--- a/tests/rustdoc-gui/type-declation-overflow.goml
+++ b/tests/rustdoc-gui/type-declation-overflow.goml
@@ -39,8 +39,8 @@ assert-property: ("pre.item-decl", {"scrollWidth": "950"})
 set-window-size: (600, 600)
 go-to: "file://" + |DOC_PATH| + "/lib2/too_long/struct.SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName.html"
 // It shouldn't have an overflow in the topbar either.
-store-property: (".mobile-topbar h2", {"scrollWidth": scrollWidth})
-assert-property: (".mobile-topbar h2", {"clientWidth": |scrollWidth|})
+store-property: (".mobile-topbar", {"scrollWidth": scrollWidth})
+assert-property: (".mobile-topbar", {"clientWidth": |scrollWidth|})
 assert-css: (".mobile-topbar h2", {"overflow-x": "hidden"})
 
 // Check wrapping for top main-heading h1 and out-of-band.

--- a/tests/rustdoc/bounds.rs
+++ b/tests/rustdoc/bounds.rs
@@ -18,3 +18,15 @@ pub trait T2 {
     fn f<T: Eq>()
         where Self: Eq, Self: Eq2, T: Eq2;
 }
+
+// Checking that we support empty bounds (we used to crash on empty outlives-bounds).
+// Note that we don't want to hide them since they have a semantic effect.
+// For outlives-bounds, they force the lifetime param to be early-bound instead of late-bound.
+// For trait bounds, it can affect well-formedness (see `ClauseKind::WellFormed`).
+// @has 'foo/fn.empty.html'
+// @has - '//pre[@class="rust item-decl"]' "empty<'a, T>()where T:, 'a:,"
+pub fn empty<'a, T>()
+    where
+        T:,
+        'a:,
+{}

--- a/tests/rustdoc/const-generics/generic_const_exprs.rs
+++ b/tests/rustdoc/const-generics/generic_const_exprs.rs
@@ -3,5 +3,5 @@
 #![allow(incomplete_features)]
 // make sure that `ConstEvaluatable` predicates dont cause rustdoc to ICE #77647
 // @has foo/struct.Ice.html '//pre[@class="rust item-decl"]' \
-//      'pub struct Ice<const N: usize>;'
+//      'pub struct Ice<const N: usize> where [(); { _ }]:;'
 pub struct Ice<const N: usize> where [(); N + 1]:;

--- a/tests/rustdoc/inline_cross/auxiliary/issue-76736-1.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/issue-76736-1.rs
@@ -1,0 +1,6 @@
+#![feature(staged_api)]
+#![unstable(feature = "rustc_private", issue = "none")]
+
+pub trait MaybeResult<T> {}
+
+impl<T> MaybeResult<T> for T {}

--- a/tests/rustdoc/inline_cross/auxiliary/issue-76736-2.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/issue-76736-2.rs
@@ -1,0 +1,5 @@
+#![feature(rustc_private)]
+
+extern crate issue_76736_1;
+
+pub struct Bar;

--- a/tests/rustdoc/inline_cross/issue-76736-1.rs
+++ b/tests/rustdoc/inline_cross/issue-76736-1.rs
@@ -1,0 +1,15 @@
+// aux-build:issue-76736-1.rs
+// aux-build:issue-76736-2.rs
+
+#![crate_name = "foo"]
+
+extern crate issue_76736_1;
+extern crate issue_76736_2;
+
+// @has foo/struct.Foo.html
+// @!has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+pub struct Foo;
+
+// @has foo/struct.Bar.html
+// @!has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+pub use issue_76736_2::Bar;

--- a/tests/rustdoc/inline_cross/issue-76736-2.rs
+++ b/tests/rustdoc/inline_cross/issue-76736-2.rs
@@ -1,0 +1,16 @@
+// aux-build:issue-76736-1.rs
+// aux-build:issue-76736-2.rs
+
+#![crate_name = "foo"]
+#![feature(rustc_private)]
+
+extern crate issue_76736_1;
+extern crate issue_76736_2;
+
+// @has foo/struct.Foo.html
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+pub struct Foo;
+
+// @has foo/struct.Bar.html
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+pub use issue_76736_2::Bar;

--- a/tests/rustdoc/inline_cross/issue-76736-3.rs
+++ b/tests/rustdoc/inline_cross/issue-76736-3.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Zforce-unstable-if-unmarked
+// aux-build:issue-76736-1.rs
+// aux-build:issue-76736-2.rs
+
+#![crate_name = "foo"]
+
+extern crate issue_76736_1;
+extern crate issue_76736_2;
+
+// @has foo/struct.Foo.html
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+pub struct Foo;
+
+// @has foo/struct.Bar.html
+// @has - '//*[@class="impl"]//h3[@class="code-header"]' 'MaybeResult'
+pub use issue_76736_2::Bar;

--- a/tests/ui/async-await/issue-72442.stderr
+++ b/tests/ui/async-await/issue-72442.stderr
@@ -8,6 +8,11 @@ LL |             let mut f = File::open(path.to_str())?;
    |
 note: required by a bound in `File::open`
   --> $SRC_DIR/std/src/fs.rs:LL:COL
+help: consider removing this method call, as the receiver has type `&Path` and `&Path: AsRef<Path>` trivially holds
+   |
+LL -             let mut f = File::open(path.to_str())?;
+LL +             let mut f = File::open(path)?;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
@@ -1,4 +1,4 @@
-//@ rustc-env:CARGO=/usr/bin/cargo
+//@ rustc-env:CARGO_CRATE_NAME=foo
 
 use std::pin::Pin;
 use std::future::Future;

--- a/tests/ui/check-cfg/cargo-feature.rs
+++ b/tests/ui/check-cfg/cargo-feature.rs
@@ -4,7 +4,7 @@
 //
 //@ check-pass
 //@ revisions: some none
-//@ rustc-env:CARGO=/usr/bin/cargo
+//@ rustc-env:CARGO_CRATE_NAME=foo
 //@ compile-flags: -Z unstable-options
 //@ [none]compile-flags: --check-cfg=cfg(feature,values())
 //@ [some]compile-flags: --check-cfg=cfg(feature,values("bitcode"))

--- a/tests/ui/check-cfg/diagnotics.rs
+++ b/tests/ui/check-cfg/diagnotics.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 //@ revisions: cargo rustc
-//@ [rustc]unset-rustc-env:CARGO
-//@ [cargo]rustc-env:CARGO=/usr/bin/cargo
+//@ [rustc]unset-rustc-env:CARGO_CRATE_NAME
+//@ [cargo]rustc-env:CARGO_CRATE_NAME=foo
 //@ compile-flags: --check-cfg=cfg(feature,values("foo")) --check-cfg=cfg(no_values) -Z unstable-options
 
 #[cfg(featur)]

--- a/tests/ui/crate-loading/missing-std.rs
+++ b/tests/ui/crate-loading/missing-std.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: --target x86_64-unknown-uefi
 //@ needs-llvm-components: x86
-//@ rustc-env:CARGO=/usr/bin/cargo
+//@ rustc-env:CARGO_CRATE_NAME=foo
 #![feature(no_core)]
 #![no_core]
 extern crate core;

--- a/tests/ui/error-should-say-copy-not-pod.stderr
+++ b/tests/ui/error-should-say-copy-not-pod.stderr
@@ -11,6 +11,11 @@ note: required by a bound in `check_bound`
    |
 LL | fn check_bound<T:Copy>(_: T) {}
    |                  ^^^^ required by this bound in `check_bound`
+help: consider removing this method call, as the receiver has type `&'static str` and `&'static str: Copy` trivially holds
+   |
+LL -     check_bound("nocopy".to_string());
+LL +     check_bound("nocopy");
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -11,6 +11,11 @@ note: required by a bound in `f_copy`
    |
 LL | fn f_copy<T: Copy>(t: T) {}
    |              ^^^^ required by this bound in `f_copy`
+help: consider removing this method call, as the receiver has type `&'static str` and `&'static str: Copy` trivially holds
+   |
+LL -     f_copy("".to_string());
+LL +     f_copy("");
+   |
 
 error[E0277]: the trait bound `S: Clone` is not satisfied
   --> $DIR/issue-84973-blacklist.rs:16:13

--- a/tests/ui/trait-bounds/argument-with-unnecessary-method-call.rs
+++ b/tests/ui/trait-bounds/argument-with-unnecessary-method-call.rs
@@ -1,0 +1,11 @@
+struct Foo;
+struct Bar;
+impl From<Bar> for Foo {
+    fn from(_: Bar) -> Self { Foo }
+}
+fn qux(_: impl From<Bar>) {}
+fn main() {
+    qux(Bar.into()); //~ ERROR type annotations needed
+    //~| HELP try using a fully qualified path to specify the expected types
+    //~| HELP consider removing this method call, as the receiver has type `Bar` and `Bar: From<Bar>` trivially holds
+}

--- a/tests/ui/trait-bounds/argument-with-unnecessary-method-call.stderr
+++ b/tests/ui/trait-bounds/argument-with-unnecessary-method-call.stderr
@@ -1,0 +1,27 @@
+error[E0283]: type annotations needed
+  --> $DIR/argument-with-unnecessary-method-call.rs:8:13
+   |
+LL |     qux(Bar.into());
+   |     ---     ^^^^
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: cannot satisfy `_: From<Bar>`
+note: required by a bound in `qux`
+  --> $DIR/argument-with-unnecessary-method-call.rs:6:16
+   |
+LL | fn qux(_: impl From<Bar>) {}
+   |                ^^^^^^^^^ required by this bound in `qux`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     qux(<Bar as Into<T>>::into(Bar));
+   |         +++++++++++++++++++++++   ~
+help: consider removing this method call, as the receiver has type `Bar` and `Bar: From<Bar>` trivially holds
+   |
+LL -     qux(Bar.into());
+LL +     qux(Bar);
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/union/unnamed-fields/auxiliary/dep.rs
+++ b/tests/ui/union/unnamed-fields/auxiliary/dep.rs
@@ -1,0 +1,18 @@
+#[repr(C)]
+pub struct GoodStruct(());
+
+pub struct BadStruct(());
+
+pub enum BadEnum {
+    A,
+    B,
+}
+
+#[repr(C)]
+pub enum BadEnum2 {
+    A,
+    B,
+}
+
+pub type GoodAlias = GoodStruct;
+pub type BadAlias = i32;

--- a/tests/ui/union/unnamed-fields/restrict_type_hir.rs
+++ b/tests/ui/union/unnamed-fields/restrict_type_hir.rs
@@ -1,0 +1,44 @@
+//@ aux-build:dep.rs
+
+// test for #121151
+
+#![allow(incomplete_features)]
+#![feature(unnamed_fields)]
+
+extern crate dep;
+
+#[repr(C)]
+struct A {
+    a: u8,
+}
+
+enum BadEnum {
+    A,
+    B,
+}
+
+#[repr(C)]
+enum BadEnum2 {
+    A,
+    B,
+}
+
+type MyStruct = A;
+type MyI32 = i32;
+
+#[repr(C)]
+struct L {
+    _: i32, //~ ERROR unnamed fields can only have struct or union types
+    _: MyI32, //~ ERROR unnamed fields can only have struct or union types
+    _: BadEnum, //~ ERROR unnamed fields can only have struct or union types
+    _: BadEnum2, //~ ERROR unnamed fields can only have struct or union types
+    _: MyStruct,
+    _: dep::BadStruct, //~ ERROR named type of unnamed field must have `#[repr(C)]` representation
+    _: dep::BadEnum, //~ ERROR unnamed fields can only have struct or union types
+    _: dep::BadEnum2, //~ ERROR unnamed fields can only have struct or union types
+    _: dep::BadAlias, //~ ERROR unnamed fields can only have struct or union types
+    _: dep::GoodAlias,
+    _: dep::GoodStruct,
+}
+
+fn main() {}

--- a/tests/ui/union/unnamed-fields/restrict_type_hir.stderr
+++ b/tests/ui/union/unnamed-fields/restrict_type_hir.stderr
@@ -1,0 +1,62 @@
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:31:5
+   |
+LL |     _: i32,
+   |     ^^^^^^
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:32:5
+   |
+LL |     _: MyI32,
+   |     ^^^^^^^^
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:33:5
+   |
+LL |     _: BadEnum,
+   |     ^^^^^^^^^^
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:34:5
+   |
+LL |     _: BadEnum2,
+   |     ^^^^^^^^^^^
+
+error: named type of unnamed field must have `#[repr(C)]` representation
+  --> $DIR/restrict_type_hir.rs:36:5
+   |
+LL |     _: dep::BadStruct,
+   |     ^^^^^^^^^^^^^^^^^ unnamed field defined here
+   |
+  ::: $DIR/auxiliary/dep.rs:4:1
+   |
+LL | pub struct BadStruct(());
+   | -------------------- `BadStruct` defined here
+   |
+help: add `#[repr(C)]` to this struct
+  --> $DIR/auxiliary/dep.rs:4:1
+   |
+LL + #[repr(C)]
+LL | pub struct BadStruct(());
+   |
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:37:5
+   |
+LL |     _: dep::BadEnum,
+   |     ^^^^^^^^^^^^^^^
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:38:5
+   |
+LL |     _: dep::BadEnum2,
+   |     ^^^^^^^^^^^^^^^^
+
+error: unnamed fields can only have struct or union types
+  --> $DIR/restrict_type_hir.rs:39:5
+   |
+LL |     _: dep::BadAlias,
+   |     ^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #120526 (rustdoc: Correctly handle long crate names on mobile)
 - #121100 (Detect when method call on argument could be removed to fulfill failed trait bound)
 - #121160 (rustdoc: fix and refactor HTML rendering a bit)
 - #121198 (Add more checks for `unnamed_fields` during HIR analysis)
 - #121218 (Fix missing trait impls for type in rustc docs)
 - #121221 (AstConv: Refactor lowering of associated item bindings a bit)
 - #121237 (Use better heuristic for printing Cargo specific diagnostics)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=120526,121100,121160,121198,121218,121221,121237)
<!-- homu-ignore:end -->