### PR TITLE
Allow AST and HIR visitors to return `ControlFlow`

### DIFF
--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -12,10 +12,12 @@
 #![allow(internal_features)]
 #![feature(rustdoc_internals)]
 #![feature(associated_type_bounds)]
+#![feature(associated_type_defaults)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![cfg_attr(bootstrap, feature(min_specialization))]
+#![feature(never_type)]
 #![feature(negative_impls)]
 #![feature(stmt_expr_attributes)]
 

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -15,6 +15,8 @@
 
 use crate::ast::*;
 
+use core::ops::ControlFlow;
+
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
 
@@ -99,6 +101,51 @@ pub enum LifetimeCtxt {
     GenericArg,
 }
 
+/// Similar to the `Try` trait, but also implemented for `()`.
+pub trait VisitorResult {
+    type Residual;
+    fn output() -> Self;
+    fn from_residual(residual: Self::Residual) -> Self;
+    fn branch(self) -> ControlFlow<Self::Residual>;
+}
+
+impl VisitorResult for () {
+    type Residual = !;
+
+    fn output() -> Self {}
+    fn from_residual(_: !) -> Self {}
+    fn branch(self) -> ControlFlow<!> {
+        ControlFlow::Continue(())
+    }
+}
+
+impl<T> VisitorResult for ControlFlow<T> {
+    type Residual = T;
+
+    fn output() -> Self {
+        ControlFlow::Continue(())
+    }
+    fn from_residual(residual: Self::Residual) -> Self {
+        ControlFlow::Break(residual)
+    }
+    fn branch(self) -> ControlFlow<T> {
+        self
+    }
+}
+
+#[macro_export]
+macro_rules! try_visit {
+    ($e:expr) => {
+        match $crate::visit::VisitorResult::branch($e) {
+            core::ops::ControlFlow::Continue(()) => (),
+            #[allow(unreachable_code)]
+            core::ops::ControlFlow::Break(r) => {
+                return $crate::visit::VisitorResult::from_residual(r);
+            }
+        }
+    };
+}
+
 /// Each method of the `Visitor` trait is a hook to be potentially
 /// overridden. Each method's default implementation recursively visits
 /// the substructure of the input via the corresponding `walk` method;
@@ -109,240 +156,259 @@ pub enum LifetimeCtxt {
 /// to monitor future changes to `Visitor` in case a new method with a
 /// new default implementation gets introduced.)
 pub trait Visitor<'ast>: Sized {
-    fn visit_ident(&mut self, _ident: Ident) {}
-    fn visit_foreign_item(&mut self, i: &'ast ForeignItem) {
+    /// The result type of the `visit_*` methods. Can be either `()`,
+    /// or `ControlFlow<T>`.
+    type Result: VisitorResult = ();
+
+    fn visit_ident(&mut self, _ident: Ident) -> Self::Result {
+        Self::Result::output()
+    }
+    fn visit_foreign_item(&mut self, i: &'ast ForeignItem) -> Self::Result {
         walk_foreign_item(self, i)
     }
-    fn visit_item(&mut self, i: &'ast Item) {
+    fn visit_item(&mut self, i: &'ast Item) -> Self::Result {
         walk_item(self, i)
     }
-    fn visit_local(&mut self, l: &'ast Local) {
+    fn visit_local(&mut self, l: &'ast Local) -> Self::Result {
         walk_local(self, l)
     }
-    fn visit_block(&mut self, b: &'ast Block) {
+    fn visit_block(&mut self, b: &'ast Block) -> Self::Result {
         walk_block(self, b)
     }
-    fn visit_stmt(&mut self, s: &'ast Stmt) {
+    fn visit_stmt(&mut self, s: &'ast Stmt) -> Self::Result {
         walk_stmt(self, s)
     }
-    fn visit_param(&mut self, param: &'ast Param) {
+    fn visit_param(&mut self, param: &'ast Param) -> Self::Result {
         walk_param(self, param)
     }
-    fn visit_arm(&mut self, a: &'ast Arm) {
+    fn visit_arm(&mut self, a: &'ast Arm) -> Self::Result {
         walk_arm(self, a)
     }
-    fn visit_pat(&mut self, p: &'ast Pat) {
+    fn visit_pat(&mut self, p: &'ast Pat) -> Self::Result {
         walk_pat(self, p)
     }
-    fn visit_anon_const(&mut self, c: &'ast AnonConst) {
+    fn visit_anon_const(&mut self, c: &'ast AnonConst) -> Self::Result {
         walk_anon_const(self, c)
     }
-    fn visit_expr(&mut self, ex: &'ast Expr) {
+    fn visit_expr(&mut self, ex: &'ast Expr) -> Self::Result {
         walk_expr(self, ex)
     }
     /// This method is a hack to workaround unstable of `stmt_expr_attributes`.
     /// It can be removed once that feature is stabilized.
-    fn visit_method_receiver_expr(&mut self, ex: &'ast Expr) {
+    fn visit_method_receiver_expr(&mut self, ex: &'ast Expr) -> Self::Result {
         self.visit_expr(ex)
     }
-    fn visit_expr_post(&mut self, _ex: &'ast Expr) {}
-    fn visit_ty(&mut self, t: &'ast Ty) {
+    fn visit_expr_post(&mut self, _ex: &'ast Expr) -> Self::Result {
+        Self::Result::output()
+    }
+    fn visit_ty(&mut self, t: &'ast Ty) -> Self::Result {
         walk_ty(self, t)
     }
-    fn visit_generic_param(&mut self, param: &'ast GenericParam) {
+    fn visit_generic_param(&mut self, param: &'ast GenericParam) -> Self::Result {
         walk_generic_param(self, param)
     }
-    fn visit_generics(&mut self, g: &'ast Generics) {
+    fn visit_generics(&mut self, g: &'ast Generics) -> Self::Result {
         walk_generics(self, g)
     }
-    fn visit_closure_binder(&mut self, b: &'ast ClosureBinder) {
+    fn visit_closure_binder(&mut self, b: &'ast ClosureBinder) -> Self::Result {
         walk_closure_binder(self, b)
     }
-    fn visit_where_predicate(&mut self, p: &'ast WherePredicate) {
+    fn visit_where_predicate(&mut self, p: &'ast WherePredicate) -> Self::Result {
         walk_where_predicate(self, p)
     }
-    fn visit_fn(&mut self, fk: FnKind<'ast>, _: Span, _: NodeId) {
+    fn visit_fn(&mut self, fk: FnKind<'ast>, _: Span, _: NodeId) -> Self::Result {
         walk_fn(self, fk)
     }
-    fn visit_assoc_item(&mut self, i: &'ast AssocItem, ctxt: AssocCtxt) {
+    fn visit_assoc_item(&mut self, i: &'ast AssocItem, ctxt: AssocCtxt) -> Self::Result {
         walk_assoc_item(self, i, ctxt)
     }
-    fn visit_trait_ref(&mut self, t: &'ast TraitRef) {
+    fn visit_trait_ref(&mut self, t: &'ast TraitRef) -> Self::Result {
         walk_trait_ref(self, t)
     }
-    fn visit_param_bound(&mut self, bounds: &'ast GenericBound, _ctxt: BoundKind) {
+    fn visit_param_bound(&mut self, bounds: &'ast GenericBound, _ctxt: BoundKind) -> Self::Result {
         walk_param_bound(self, bounds)
     }
-    fn visit_poly_trait_ref(&mut self, t: &'ast PolyTraitRef) {
+    fn visit_poly_trait_ref(&mut self, t: &'ast PolyTraitRef) -> Self::Result {
         walk_poly_trait_ref(self, t)
     }
-    fn visit_variant_data(&mut self, s: &'ast VariantData) {
+    fn visit_variant_data(&mut self, s: &'ast VariantData) -> Self::Result {
         walk_struct_def(self, s)
     }
-    fn visit_field_def(&mut self, s: &'ast FieldDef) {
+    fn visit_field_def(&mut self, s: &'ast FieldDef) -> Self::Result {
         walk_field_def(self, s)
     }
-    fn visit_enum_def(&mut self, enum_definition: &'ast EnumDef) {
+    fn visit_enum_def(&mut self, enum_definition: &'ast EnumDef) -> Self::Result {
         walk_enum_def(self, enum_definition)
     }
-    fn visit_variant(&mut self, v: &'ast Variant) {
+    fn visit_variant(&mut self, v: &'ast Variant) -> Self::Result {
         walk_variant(self, v)
     }
-    fn visit_variant_discr(&mut self, discr: &'ast AnonConst) {
-        self.visit_anon_const(discr);
+    fn visit_variant_discr(&mut self, discr: &'ast AnonConst) -> Self::Result {
+        self.visit_anon_const(discr)
     }
-    fn visit_label(&mut self, label: &'ast Label) {
+    fn visit_label(&mut self, label: &'ast Label) -> Self::Result {
         walk_label(self, label)
     }
-    fn visit_lifetime(&mut self, lifetime: &'ast Lifetime, _: LifetimeCtxt) {
+    fn visit_lifetime(&mut self, lifetime: &'ast Lifetime, _: LifetimeCtxt) -> Self::Result {
         walk_lifetime(self, lifetime)
     }
-    fn visit_mac_call(&mut self, mac: &'ast MacCall) {
+    fn visit_mac_call(&mut self, mac: &'ast MacCall) -> Self::Result {
         walk_mac(self, mac)
     }
-    fn visit_mac_def(&mut self, _mac: &'ast MacroDef, _id: NodeId) {
-        // Nothing to do
+    fn visit_mac_def(&mut self, _mac: &'ast MacroDef, _id: NodeId) -> Self::Result {
+        Self::Result::output()
     }
-    fn visit_path(&mut self, path: &'ast Path, _id: NodeId) {
+    fn visit_path(&mut self, path: &'ast Path, _id: NodeId) -> Self::Result {
         walk_path(self, path)
     }
-    fn visit_use_tree(&mut self, use_tree: &'ast UseTree, id: NodeId, _nested: bool) {
+    fn visit_use_tree(
+        &mut self,
+        use_tree: &'ast UseTree,
+        id: NodeId,
+        _nested: bool,
+    ) -> Self::Result {
         walk_use_tree(self, use_tree, id)
     }
-    fn visit_path_segment(&mut self, path_segment: &'ast PathSegment) {
+    fn visit_path_segment(&mut self, path_segment: &'ast PathSegment) -> Self::Result {
         walk_path_segment(self, path_segment)
     }
-    fn visit_generic_args(&mut self, generic_args: &'ast GenericArgs) {
+    fn visit_generic_args(&mut self, generic_args: &'ast GenericArgs) -> Self::Result {
         walk_generic_args(self, generic_args)
     }
-    fn visit_generic_arg(&mut self, generic_arg: &'ast GenericArg) {
+    fn visit_generic_arg(&mut self, generic_arg: &'ast GenericArg) -> Self::Result {
         walk_generic_arg(self, generic_arg)
     }
-    fn visit_assoc_constraint(&mut self, constraint: &'ast AssocConstraint) {
+    fn visit_assoc_constraint(&mut self, constraint: &'ast AssocConstraint) -> Self::Result {
         walk_assoc_constraint(self, constraint)
     }
-    fn visit_attribute(&mut self, attr: &'ast Attribute) {
+    fn visit_attribute(&mut self, attr: &'ast Attribute) -> Self::Result {
         walk_attribute(self, attr)
     }
-    fn visit_vis(&mut self, vis: &'ast Visibility) {
+    fn visit_vis(&mut self, vis: &'ast Visibility) -> Self::Result {
         walk_vis(self, vis)
     }
-    fn visit_fn_ret_ty(&mut self, ret_ty: &'ast FnRetTy) {
+    fn visit_fn_ret_ty(&mut self, ret_ty: &'ast FnRetTy) -> Self::Result {
         walk_fn_ret_ty(self, ret_ty)
     }
-    fn visit_fn_header(&mut self, _header: &'ast FnHeader) {
-        // Nothing to do
+    fn visit_fn_header(&mut self, _header: &'ast FnHeader) -> Self::Result {
+        Self::Result::output()
     }
-    fn visit_expr_field(&mut self, f: &'ast ExprField) {
+    fn visit_expr_field(&mut self, f: &'ast ExprField) -> Self::Result {
         walk_expr_field(self, f)
     }
-    fn visit_pat_field(&mut self, fp: &'ast PatField) {
+    fn visit_pat_field(&mut self, fp: &'ast PatField) -> Self::Result {
         walk_pat_field(self, fp)
     }
-    fn visit_crate(&mut self, krate: &'ast Crate) {
+    fn visit_crate(&mut self, krate: &'ast Crate) -> Self::Result {
         walk_crate(self, krate)
     }
-    fn visit_inline_asm(&mut self, asm: &'ast InlineAsm) {
+    fn visit_inline_asm(&mut self, asm: &'ast InlineAsm) -> Self::Result {
         walk_inline_asm(self, asm)
     }
-    fn visit_format_args(&mut self, fmt: &'ast FormatArgs) {
+    fn visit_format_args(&mut self, fmt: &'ast FormatArgs) -> Self::Result {
         walk_format_args(self, fmt)
     }
-    fn visit_inline_asm_sym(&mut self, sym: &'ast InlineAsmSym) {
+    fn visit_inline_asm_sym(&mut self, sym: &'ast InlineAsmSym) -> Self::Result {
         walk_inline_asm_sym(self, sym)
     }
-    fn visit_capture_by(&mut self, _capture_by: &'ast CaptureBy) {
-        // Nothing to do
+    fn visit_capture_by(&mut self, _capture_by: &'ast CaptureBy) -> Self::Result {
+        Self::Result::output()
     }
 }
 
 #[macro_export]
 macro_rules! walk_list {
     ($visitor: expr, $method: ident, $list: expr $(, $($extra_args: expr),* )?) => {
-        {
-            #[allow(for_loops_over_fallibles)]
-            for elem in $list {
-                $visitor.$method(elem $(, $($extra_args,)* )?)
-            }
+        for elem in $list {
+            $crate::try_visit!($visitor.$method(elem $(, $($extra_args,)* )?));
         }
     }
 }
 
-pub fn walk_crate<'a, V: Visitor<'a>>(visitor: &mut V, krate: &'a Crate) {
+#[macro_export]
+macro_rules! visit_opt {
+    ($visitor: expr, $method: ident, $opt: expr $(, $($extra_args: expr),* )?) => {
+        if let Some(x) = $opt {
+            $crate::try_visit!($visitor.$method(x $(, $($extra_args,)* )?));
+        }
+    }
+}
+
+pub fn walk_crate<'a, V: Visitor<'a>>(visitor: &mut V, krate: &'a Crate) -> V::Result {
     walk_list!(visitor, visit_item, &krate.items);
     walk_list!(visitor, visit_attribute, &krate.attrs);
+    V::Result::output()
 }
 
-pub fn walk_local<'a, V: Visitor<'a>>(visitor: &mut V, local: &'a Local) {
-    for attr in local.attrs.iter() {
-        visitor.visit_attribute(attr);
-    }
-    visitor.visit_pat(&local.pat);
-    walk_list!(visitor, visit_ty, &local.ty);
+pub fn walk_local<'a, V: Visitor<'a>>(visitor: &mut V, local: &'a Local) -> V::Result {
+    walk_list!(visitor, visit_attribute, &local.attrs);
+    try_visit!(visitor.visit_pat(&local.pat));
+    visit_opt!(visitor, visit_ty, &local.ty);
     if let Some((init, els)) = local.kind.init_else_opt() {
-        visitor.visit_expr(init);
-        walk_list!(visitor, visit_block, els);
+        try_visit!(visitor.visit_expr(init));
+        visit_opt!(visitor, visit_block, els);
     }
+    V::Result::output()
 }
 
-pub fn walk_label<'a, V: Visitor<'a>>(visitor: &mut V, label: &'a Label) {
-    visitor.visit_ident(label.ident);
+pub fn walk_label<'a, V: Visitor<'a>>(visitor: &mut V, label: &'a Label) -> V::Result {
+    visitor.visit_ident(label.ident)
 }
 
-pub fn walk_lifetime<'a, V: Visitor<'a>>(visitor: &mut V, lifetime: &'a Lifetime) {
-    visitor.visit_ident(lifetime.ident);
+pub fn walk_lifetime<'a, V: Visitor<'a>>(visitor: &mut V, lifetime: &'a Lifetime) -> V::Result {
+    visitor.visit_ident(lifetime.ident)
 }
 
-pub fn walk_poly_trait_ref<'a, V>(visitor: &mut V, trait_ref: &'a PolyTraitRef)
+pub fn walk_poly_trait_ref<'a, V>(visitor: &mut V, trait_ref: &'a PolyTraitRef) -> V::Result
 where
     V: Visitor<'a>,
 {
     walk_list!(visitor, visit_generic_param, &trait_ref.bound_generic_params);
-    visitor.visit_trait_ref(&trait_ref.trait_ref);
+    visitor.visit_trait_ref(&trait_ref.trait_ref)
 }
 
-pub fn walk_trait_ref<'a, V: Visitor<'a>>(visitor: &mut V, trait_ref: &'a TraitRef) {
+pub fn walk_trait_ref<'a, V: Visitor<'a>>(visitor: &mut V, trait_ref: &'a TraitRef) -> V::Result {
     visitor.visit_path(&trait_ref.path, trait_ref.ref_id)
 }
 
-pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
-    visitor.visit_vis(&item.vis);
-    visitor.visit_ident(item.ident);
+pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) -> V::Result {
+    try_visit!(visitor.visit_vis(&item.vis));
+    try_visit!(visitor.visit_ident(item.ident));
     match &item.kind {
         ItemKind::ExternCrate(_) => {}
-        ItemKind::Use(use_tree) => visitor.visit_use_tree(use_tree, item.id, false),
+        ItemKind::Use(use_tree) => try_visit!(visitor.visit_use_tree(use_tree, item.id, false)),
         ItemKind::Static(box StaticItem { ty, mutability: _, expr }) => {
-            visitor.visit_ty(ty);
-            walk_list!(visitor, visit_expr, expr);
+            try_visit!(visitor.visit_ty(ty));
+            visit_opt!(visitor, visit_expr, expr);
         }
         ItemKind::Const(box ConstItem { defaultness: _, generics, ty, expr }) => {
-            visitor.visit_generics(generics);
-            visitor.visit_ty(ty);
-            walk_list!(visitor, visit_expr, expr);
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_ty(ty));
+            visit_opt!(visitor, visit_expr, expr);
         }
         ItemKind::Fn(box Fn { defaultness: _, generics, sig, body }) => {
             let kind =
                 FnKind::Fn(FnCtxt::Free, item.ident, sig, &item.vis, generics, body.as_deref());
-            visitor.visit_fn(kind, item.span, item.id)
+            try_visit!(visitor.visit_fn(kind, item.span, item.id));
         }
         ItemKind::Mod(_unsafety, mod_kind) => match mod_kind {
             ModKind::Loaded(items, _inline, _inner_span) => {
-                walk_list!(visitor, visit_item, items)
+                walk_list!(visitor, visit_item, items);
             }
             ModKind::Unloaded => {}
         },
         ItemKind::ForeignMod(foreign_module) => {
             walk_list!(visitor, visit_foreign_item, &foreign_module.items);
         }
-        ItemKind::GlobalAsm(asm) => visitor.visit_inline_asm(asm),
+        ItemKind::GlobalAsm(asm) => try_visit!(visitor.visit_inline_asm(asm)),
         ItemKind::TyAlias(box TyAlias { generics, bounds, ty, .. }) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
-            walk_list!(visitor, visit_ty, ty);
+            visit_opt!(visitor, visit_ty, ty);
         }
         ItemKind::Enum(enum_definition, generics) => {
-            visitor.visit_generics(generics);
-            visitor.visit_enum_def(enum_definition)
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_enum_def(enum_definition));
         }
         ItemKind::Impl(box Impl {
             defaultness: _,
@@ -354,91 +420,97 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             self_ty,
             items,
         }) => {
-            visitor.visit_generics(generics);
-            walk_list!(visitor, visit_trait_ref, of_trait);
-            visitor.visit_ty(self_ty);
+            try_visit!(visitor.visit_generics(generics));
+            visit_opt!(visitor, visit_trait_ref, of_trait);
+            try_visit!(visitor.visit_ty(self_ty));
             walk_list!(visitor, visit_assoc_item, items, AssocCtxt::Impl);
         }
         ItemKind::Struct(struct_definition, generics)
         | ItemKind::Union(struct_definition, generics) => {
-            visitor.visit_generics(generics);
-            visitor.visit_variant_data(struct_definition);
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_variant_data(struct_definition));
         }
         ItemKind::Trait(box Trait { unsafety: _, is_auto: _, generics, bounds, items }) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::SuperTraits);
             walk_list!(visitor, visit_assoc_item, items, AssocCtxt::Trait);
         }
         ItemKind::TraitAlias(generics, bounds) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
         }
-        ItemKind::MacCall(mac) => visitor.visit_mac_call(mac),
-        ItemKind::MacroDef(ts) => visitor.visit_mac_def(ts, item.id),
+        ItemKind::MacCall(mac) => try_visit!(visitor.visit_mac_call(mac)),
+        ItemKind::MacroDef(ts) => try_visit!(visitor.visit_mac_def(ts, item.id)),
         ItemKind::Delegation(box Delegation { id, qself, path, body }) => {
             if let Some(qself) = qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(path, *id);
-            if let Some(body) = body {
-                visitor.visit_block(body);
-            }
+            try_visit!(visitor.visit_path(path, *id));
+            visit_opt!(visitor, visit_block, body);
         }
     }
     walk_list!(visitor, visit_attribute, &item.attrs);
+    V::Result::output()
 }
 
-pub fn walk_enum_def<'a, V: Visitor<'a>>(visitor: &mut V, enum_definition: &'a EnumDef) {
+pub fn walk_enum_def<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    enum_definition: &'a EnumDef,
+) -> V::Result {
     walk_list!(visitor, visit_variant, &enum_definition.variants);
+    V::Result::output()
 }
 
-pub fn walk_variant<'a, V: Visitor<'a>>(visitor: &mut V, variant: &'a Variant)
+pub fn walk_variant<'a, V: Visitor<'a>>(visitor: &mut V, variant: &'a Variant) -> V::Result
 where
     V: Visitor<'a>,
 {
-    visitor.visit_ident(variant.ident);
-    visitor.visit_vis(&variant.vis);
-    visitor.visit_variant_data(&variant.data);
-    walk_list!(visitor, visit_variant_discr, &variant.disr_expr);
+    try_visit!(visitor.visit_ident(variant.ident));
+    try_visit!(visitor.visit_vis(&variant.vis));
+    try_visit!(visitor.visit_variant_data(&variant.data));
+    visit_opt!(visitor, visit_variant_discr, &variant.disr_expr);
     walk_list!(visitor, visit_attribute, &variant.attrs);
+    V::Result::output()
 }
 
-pub fn walk_expr_field<'a, V: Visitor<'a>>(visitor: &mut V, f: &'a ExprField) {
-    visitor.visit_expr(&f.expr);
-    visitor.visit_ident(f.ident);
-    walk_list!(visitor, visit_attribute, f.attrs.iter());
+pub fn walk_expr_field<'a, V: Visitor<'a>>(visitor: &mut V, f: &'a ExprField) -> V::Result {
+    try_visit!(visitor.visit_expr(&f.expr));
+    try_visit!(visitor.visit_ident(f.ident));
+    walk_list!(visitor, visit_attribute, &f.attrs);
+    V::Result::output()
 }
 
-pub fn walk_pat_field<'a, V: Visitor<'a>>(visitor: &mut V, fp: &'a PatField) {
-    visitor.visit_ident(fp.ident);
-    visitor.visit_pat(&fp.pat);
-    walk_list!(visitor, visit_attribute, fp.attrs.iter());
+pub fn walk_pat_field<'a, V: Visitor<'a>>(visitor: &mut V, fp: &'a PatField) -> V::Result {
+    try_visit!(visitor.visit_ident(fp.ident));
+    try_visit!(visitor.visit_pat(&fp.pat));
+    walk_list!(visitor, visit_attribute, &fp.attrs);
+    V::Result::output()
 }
 
-pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) {
+pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) -> V::Result {
     match &typ.kind {
-        TyKind::Slice(ty) | TyKind::Paren(ty) => visitor.visit_ty(ty),
-        TyKind::Ptr(mutable_type) => visitor.visit_ty(&mutable_type.ty),
+        TyKind::Slice(ty) | TyKind::Paren(ty) => try_visit!(visitor.visit_ty(ty)),
+        TyKind::Ptr(mutable_type) => try_visit!(visitor.visit_ty(&mutable_type.ty)),
         TyKind::Ref(opt_lifetime, mutable_type) => {
-            walk_list!(visitor, visit_lifetime, opt_lifetime, LifetimeCtxt::Ref);
-            visitor.visit_ty(&mutable_type.ty)
+            visit_opt!(visitor, visit_lifetime, opt_lifetime, LifetimeCtxt::Ref);
+            try_visit!(visitor.visit_ty(&mutable_type.ty));
         }
         TyKind::Tup(tuple_element_types) => {
             walk_list!(visitor, visit_ty, tuple_element_types);
         }
         TyKind::BareFn(function_declaration) => {
             walk_list!(visitor, visit_generic_param, &function_declaration.generic_params);
-            walk_fn_decl(visitor, &function_declaration.decl);
+            try_visit!(walk_fn_decl(visitor, &function_declaration.decl));
         }
         TyKind::Path(maybe_qself, path) => {
             if let Some(qself) = maybe_qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(path, typ.id);
+            try_visit!(visitor.visit_path(path, typ.id));
         }
         TyKind::Array(ty, length) => {
-            visitor.visit_ty(ty);
-            visitor.visit_anon_const(length)
+            try_visit!(visitor.visit_ty(ty));
+            try_visit!(visitor.visit_anon_const(length));
         }
         TyKind::TraitObject(bounds, ..) => {
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::TraitObject);
@@ -446,48 +518,53 @@ pub fn walk_ty<'a, V: Visitor<'a>>(visitor: &mut V, typ: &'a Ty) {
         TyKind::ImplTrait(_, bounds) => {
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Impl);
         }
-        TyKind::Typeof(expression) => visitor.visit_anon_const(expression),
+        TyKind::Typeof(expression) => try_visit!(visitor.visit_anon_const(expression)),
         TyKind::Infer | TyKind::ImplicitSelf | TyKind::Dummy | TyKind::Err(_) => {}
-        TyKind::MacCall(mac) => visitor.visit_mac_call(mac),
+        TyKind::MacCall(mac) => try_visit!(visitor.visit_mac_call(mac)),
         TyKind::Never | TyKind::CVarArgs => {}
         TyKind::AnonStruct(_, ref fields) | TyKind::AnonUnion(_, ref fields) => {
-            walk_list!(visitor, visit_field_def, fields)
+            walk_list!(visitor, visit_field_def, fields);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_path<'a, V: Visitor<'a>>(visitor: &mut V, path: &'a Path) {
-    for segment in &path.segments {
-        visitor.visit_path_segment(segment);
-    }
+pub fn walk_path<'a, V: Visitor<'a>>(visitor: &mut V, path: &'a Path) -> V::Result {
+    walk_list!(visitor, visit_path_segment, &path.segments);
+    V::Result::output()
 }
 
-pub fn walk_use_tree<'a, V: Visitor<'a>>(visitor: &mut V, use_tree: &'a UseTree, id: NodeId) {
-    visitor.visit_path(&use_tree.prefix, id);
-    match &use_tree.kind {
+pub fn walk_use_tree<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    use_tree: &'a UseTree,
+    id: NodeId,
+) -> V::Result {
+    try_visit!(visitor.visit_path(&use_tree.prefix, id));
+    match use_tree.kind {
         UseTreeKind::Simple(rename) => {
             // The extra IDs are handled during HIR lowering.
-            if let &Some(rename) = rename {
-                visitor.visit_ident(rename);
-            }
+            visit_opt!(visitor, visit_ident, rename);
         }
         UseTreeKind::Glob => {}
-        UseTreeKind::Nested(use_trees) => {
+        UseTreeKind::Nested(ref use_trees) => {
             for &(ref nested_tree, nested_id) in use_trees {
-                visitor.visit_use_tree(nested_tree, nested_id, true);
+                try_visit!(visitor.visit_use_tree(nested_tree, nested_id, true));
             }
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_path_segment<'a, V: Visitor<'a>>(visitor: &mut V, segment: &'a PathSegment) {
-    visitor.visit_ident(segment.ident);
-    if let Some(args) = &segment.args {
-        visitor.visit_generic_args(args);
-    }
+pub fn walk_path_segment<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    segment: &'a PathSegment,
+) -> V::Result {
+    try_visit!(visitor.visit_ident(segment.ident));
+    visit_opt!(visitor, visit_generic_args, &segment.args);
+    V::Result::output()
 }
 
-pub fn walk_generic_args<'a, V>(visitor: &mut V, generic_args: &'a GenericArgs)
+pub fn walk_generic_args<'a, V>(visitor: &mut V, generic_args: &'a GenericArgs) -> V::Result
 where
     V: Visitor<'a>,
 {
@@ -495,19 +572,22 @@ where
         GenericArgs::AngleBracketed(data) => {
             for arg in &data.args {
                 match arg {
-                    AngleBracketedArg::Arg(a) => visitor.visit_generic_arg(a),
-                    AngleBracketedArg::Constraint(c) => visitor.visit_assoc_constraint(c),
+                    AngleBracketedArg::Arg(a) => try_visit!(visitor.visit_generic_arg(a)),
+                    AngleBracketedArg::Constraint(c) => {
+                        try_visit!(visitor.visit_assoc_constraint(c))
+                    }
                 }
             }
         }
         GenericArgs::Parenthesized(data) => {
             walk_list!(visitor, visit_ty, &data.inputs);
-            visitor.visit_fn_ret_ty(&data.output);
+            try_visit!(visitor.visit_fn_ret_ty(&data.output));
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_generic_arg<'a, V>(visitor: &mut V, generic_arg: &'a GenericArg)
+pub fn walk_generic_arg<'a, V>(visitor: &mut V, generic_arg: &'a GenericArg) -> V::Result
 where
     V: Visitor<'a>,
 {
@@ -518,127 +598,141 @@ where
     }
 }
 
-pub fn walk_assoc_constraint<'a, V: Visitor<'a>>(visitor: &mut V, constraint: &'a AssocConstraint) {
-    visitor.visit_ident(constraint.ident);
-    if let Some(gen_args) = &constraint.gen_args {
-        visitor.visit_generic_args(gen_args);
-    }
+pub fn walk_assoc_constraint<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    constraint: &'a AssocConstraint,
+) -> V::Result {
+    try_visit!(visitor.visit_ident(constraint.ident));
+    visit_opt!(visitor, visit_generic_args, &constraint.gen_args);
     match &constraint.kind {
         AssocConstraintKind::Equality { term } => match term {
-            Term::Ty(ty) => visitor.visit_ty(ty),
-            Term::Const(c) => visitor.visit_anon_const(c),
+            Term::Ty(ty) => try_visit!(visitor.visit_ty(ty)),
+            Term::Const(c) => try_visit!(visitor.visit_anon_const(c)),
         },
         AssocConstraintKind::Bound { bounds } => {
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) {
+pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) -> V::Result {
     match &pattern.kind {
         PatKind::TupleStruct(opt_qself, path, elems) => {
             if let Some(qself) = opt_qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(path, pattern.id);
+            try_visit!(visitor.visit_path(path, pattern.id));
             walk_list!(visitor, visit_pat, elems);
         }
         PatKind::Path(opt_qself, path) => {
             if let Some(qself) = opt_qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(path, pattern.id)
+            try_visit!(visitor.visit_path(path, pattern.id))
         }
         PatKind::Struct(opt_qself, path, fields, _) => {
             if let Some(qself) = opt_qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(path, pattern.id);
+            try_visit!(visitor.visit_path(path, pattern.id));
             walk_list!(visitor, visit_pat_field, fields);
         }
         PatKind::Box(subpattern) | PatKind::Ref(subpattern, _) | PatKind::Paren(subpattern) => {
-            visitor.visit_pat(subpattern)
+            try_visit!(visitor.visit_pat(subpattern));
         }
         PatKind::Ident(_, ident, optional_subpattern) => {
-            visitor.visit_ident(*ident);
-            walk_list!(visitor, visit_pat, optional_subpattern);
+            try_visit!(visitor.visit_ident(*ident));
+            visit_opt!(visitor, visit_pat, optional_subpattern);
         }
-        PatKind::Lit(expression) => visitor.visit_expr(expression),
+        PatKind::Lit(expression) => try_visit!(visitor.visit_expr(expression)),
         PatKind::Range(lower_bound, upper_bound, _) => {
-            walk_list!(visitor, visit_expr, lower_bound);
-            walk_list!(visitor, visit_expr, upper_bound);
+            visit_opt!(visitor, visit_expr, lower_bound);
+            visit_opt!(visitor, visit_expr, upper_bound);
         }
         PatKind::Wild | PatKind::Rest | PatKind::Never | PatKind::Err(_) => {}
         PatKind::Tuple(elems) | PatKind::Slice(elems) | PatKind::Or(elems) => {
             walk_list!(visitor, visit_pat, elems);
         }
-        PatKind::MacCall(mac) => visitor.visit_mac_call(mac),
+        PatKind::MacCall(mac) => try_visit!(visitor.visit_mac_call(mac)),
     }
+    V::Result::output()
 }
 
-pub fn walk_foreign_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a ForeignItem) {
+pub fn walk_foreign_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a ForeignItem) -> V::Result {
     let &Item { id, span, ident, ref vis, ref attrs, ref kind, tokens: _ } = item;
-    visitor.visit_vis(vis);
-    visitor.visit_ident(ident);
+    try_visit!(visitor.visit_vis(vis));
+    try_visit!(visitor.visit_ident(ident));
     walk_list!(visitor, visit_attribute, attrs);
     match kind {
         ForeignItemKind::Static(ty, _, expr) => {
-            visitor.visit_ty(ty);
-            walk_list!(visitor, visit_expr, expr);
+            try_visit!(visitor.visit_ty(ty));
+            visit_opt!(visitor, visit_expr, expr);
         }
         ForeignItemKind::Fn(box Fn { defaultness: _, generics, sig, body }) => {
             let kind = FnKind::Fn(FnCtxt::Foreign, ident, sig, vis, generics, body.as_deref());
-            visitor.visit_fn(kind, span, id);
+            try_visit!(visitor.visit_fn(kind, span, id));
         }
         ForeignItemKind::TyAlias(box TyAlias { generics, bounds, ty, .. }) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
-            walk_list!(visitor, visit_ty, ty);
+            visit_opt!(visitor, visit_ty, ty);
         }
         ForeignItemKind::MacCall(mac) => {
-            visitor.visit_mac_call(mac);
+            try_visit!(visitor.visit_mac_call(mac));
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_param_bound<'a, V: Visitor<'a>>(visitor: &mut V, bound: &'a GenericBound) {
+pub fn walk_param_bound<'a, V: Visitor<'a>>(visitor: &mut V, bound: &'a GenericBound) -> V::Result {
     match bound {
         GenericBound::Trait(typ, _modifier) => visitor.visit_poly_trait_ref(typ),
         GenericBound::Outlives(lifetime) => visitor.visit_lifetime(lifetime, LifetimeCtxt::Bound),
     }
 }
 
-pub fn walk_generic_param<'a, V: Visitor<'a>>(visitor: &mut V, param: &'a GenericParam) {
-    visitor.visit_ident(param.ident);
-    walk_list!(visitor, visit_attribute, param.attrs.iter());
+pub fn walk_generic_param<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    param: &'a GenericParam,
+) -> V::Result {
+    try_visit!(visitor.visit_ident(param.ident));
+    walk_list!(visitor, visit_attribute, &param.attrs);
     walk_list!(visitor, visit_param_bound, &param.bounds, BoundKind::Bound);
     match &param.kind {
         GenericParamKind::Lifetime => (),
-        GenericParamKind::Type { default } => walk_list!(visitor, visit_ty, default),
+        GenericParamKind::Type { default } => visit_opt!(visitor, visit_ty, default),
         GenericParamKind::Const { ty, default, .. } => {
-            visitor.visit_ty(ty);
-            if let Some(default) = default {
-                visitor.visit_anon_const(default);
-            }
+            try_visit!(visitor.visit_ty(ty));
+            visit_opt!(visitor, visit_anon_const, default);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_generics<'a, V: Visitor<'a>>(visitor: &mut V, generics: &'a Generics) {
+pub fn walk_generics<'a, V: Visitor<'a>>(visitor: &mut V, generics: &'a Generics) -> V::Result {
     walk_list!(visitor, visit_generic_param, &generics.params);
     walk_list!(visitor, visit_where_predicate, &generics.where_clause.predicates);
+    V::Result::output()
 }
 
-pub fn walk_closure_binder<'a, V: Visitor<'a>>(visitor: &mut V, binder: &'a ClosureBinder) {
+pub fn walk_closure_binder<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    binder: &'a ClosureBinder,
+) -> V::Result {
     match binder {
         ClosureBinder::NotPresent => {}
         ClosureBinder::For { generic_params, span: _ } => {
             walk_list!(visitor, visit_generic_param, generic_params)
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_where_predicate<'a, V: Visitor<'a>>(visitor: &mut V, predicate: &'a WherePredicate) {
+pub fn walk_where_predicate<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    predicate: &'a WherePredicate,
+) -> V::Result {
     match predicate {
         WherePredicate::BoundPredicate(WhereBoundPredicate {
             bounded_ty,
@@ -646,181 +740,196 @@ pub fn walk_where_predicate<'a, V: Visitor<'a>>(visitor: &mut V, predicate: &'a 
             bound_generic_params,
             ..
         }) => {
-            visitor.visit_ty(bounded_ty);
+            try_visit!(visitor.visit_ty(bounded_ty));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
             walk_list!(visitor, visit_generic_param, bound_generic_params);
         }
         WherePredicate::RegionPredicate(WhereRegionPredicate { lifetime, bounds, .. }) => {
-            visitor.visit_lifetime(lifetime, LifetimeCtxt::Bound);
+            try_visit!(visitor.visit_lifetime(lifetime, LifetimeCtxt::Bound));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
         }
         WherePredicate::EqPredicate(WhereEqPredicate { lhs_ty, rhs_ty, .. }) => {
-            visitor.visit_ty(lhs_ty);
-            visitor.visit_ty(rhs_ty);
+            try_visit!(visitor.visit_ty(lhs_ty));
+            try_visit!(visitor.visit_ty(rhs_ty));
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_fn_ret_ty<'a, V: Visitor<'a>>(visitor: &mut V, ret_ty: &'a FnRetTy) {
+pub fn walk_fn_ret_ty<'a, V: Visitor<'a>>(visitor: &mut V, ret_ty: &'a FnRetTy) -> V::Result {
     if let FnRetTy::Ty(output_ty) = ret_ty {
-        visitor.visit_ty(output_ty)
+        try_visit!(visitor.visit_ty(output_ty));
     }
+    V::Result::output()
 }
 
-pub fn walk_fn_decl<'a, V: Visitor<'a>>(visitor: &mut V, function_declaration: &'a FnDecl) {
-    for param in &function_declaration.inputs {
-        visitor.visit_param(param);
-    }
-    visitor.visit_fn_ret_ty(&function_declaration.output);
+pub fn walk_fn_decl<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    function_declaration: &'a FnDecl,
+) -> V::Result {
+    walk_list!(visitor, visit_param, &function_declaration.inputs);
+    visitor.visit_fn_ret_ty(&function_declaration.output)
 }
 
-pub fn walk_fn<'a, V: Visitor<'a>>(visitor: &mut V, kind: FnKind<'a>) {
+pub fn walk_fn<'a, V: Visitor<'a>>(visitor: &mut V, kind: FnKind<'a>) -> V::Result {
     match kind {
         FnKind::Fn(_, _, sig, _, generics, body) => {
-            visitor.visit_generics(generics);
-            visitor.visit_fn_header(&sig.header);
-            walk_fn_decl(visitor, &sig.decl);
-            walk_list!(visitor, visit_block, body);
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_fn_header(&sig.header));
+            try_visit!(walk_fn_decl(visitor, &sig.decl));
+            visit_opt!(visitor, visit_block, body);
         }
         FnKind::Closure(binder, decl, body) => {
-            visitor.visit_closure_binder(binder);
-            walk_fn_decl(visitor, decl);
-            visitor.visit_expr(body);
+            try_visit!(visitor.visit_closure_binder(binder));
+            try_visit!(walk_fn_decl(visitor, decl));
+            try_visit!(visitor.visit_expr(body));
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_assoc_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a AssocItem, ctxt: AssocCtxt) {
+pub fn walk_assoc_item<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    item: &'a AssocItem,
+    ctxt: AssocCtxt,
+) -> V::Result {
     let &Item { id, span, ident, ref vis, ref attrs, ref kind, tokens: _ } = item;
-    visitor.visit_vis(vis);
-    visitor.visit_ident(ident);
+    try_visit!(visitor.visit_vis(vis));
+    try_visit!(visitor.visit_ident(ident));
     walk_list!(visitor, visit_attribute, attrs);
     match kind {
         AssocItemKind::Const(box ConstItem { defaultness: _, generics, ty, expr }) => {
-            visitor.visit_generics(generics);
-            visitor.visit_ty(ty);
-            walk_list!(visitor, visit_expr, expr);
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_ty(ty));
+            visit_opt!(visitor, visit_expr, expr);
         }
         AssocItemKind::Fn(box Fn { defaultness: _, generics, sig, body }) => {
             let kind = FnKind::Fn(FnCtxt::Assoc(ctxt), ident, sig, vis, generics, body.as_deref());
-            visitor.visit_fn(kind, span, id);
+            try_visit!(visitor.visit_fn(kind, span, id));
         }
         AssocItemKind::Type(box TyAlias { generics, bounds, ty, .. }) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
-            walk_list!(visitor, visit_ty, ty);
+            visit_opt!(visitor, visit_ty, ty);
         }
         AssocItemKind::MacCall(mac) => {
-            visitor.visit_mac_call(mac);
+            try_visit!(visitor.visit_mac_call(mac));
         }
         AssocItemKind::Delegation(box Delegation { id, qself, path, body }) => {
             if let Some(qself) = qself {
                 visitor.visit_ty(&qself.ty);
             }
-            visitor.visit_path(path, *id);
-            if let Some(body) = body {
-                visitor.visit_block(body);
-            }
+            try_visit!(visitor.visit_path(path, *id));
+            visit_opt!(visitor, visit_block, body);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_struct_def<'a, V: Visitor<'a>>(visitor: &mut V, struct_definition: &'a VariantData) {
+pub fn walk_struct_def<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    struct_definition: &'a VariantData,
+) -> V::Result {
     walk_list!(visitor, visit_field_def, struct_definition.fields());
+    V::Result::output()
 }
 
-pub fn walk_field_def<'a, V: Visitor<'a>>(visitor: &mut V, field: &'a FieldDef) {
-    visitor.visit_vis(&field.vis);
-    if let Some(ident) = field.ident {
-        visitor.visit_ident(ident);
-    }
-    visitor.visit_ty(&field.ty);
+pub fn walk_field_def<'a, V: Visitor<'a>>(visitor: &mut V, field: &'a FieldDef) -> V::Result {
+    try_visit!(visitor.visit_vis(&field.vis));
+    visit_opt!(visitor, visit_ident, field.ident);
+    try_visit!(visitor.visit_ty(&field.ty));
     walk_list!(visitor, visit_attribute, &field.attrs);
+    V::Result::output()
 }
 
-pub fn walk_block<'a, V: Visitor<'a>>(visitor: &mut V, block: &'a Block) {
+pub fn walk_block<'a, V: Visitor<'a>>(visitor: &mut V, block: &'a Block) -> V::Result {
     walk_list!(visitor, visit_stmt, &block.stmts);
+    V::Result::output()
 }
 
-pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) {
+pub fn walk_stmt<'a, V: Visitor<'a>>(visitor: &mut V, statement: &'a Stmt) -> V::Result {
     match &statement.kind {
-        StmtKind::Local(local) => visitor.visit_local(local),
-        StmtKind::Item(item) => visitor.visit_item(item),
-        StmtKind::Expr(expr) | StmtKind::Semi(expr) => visitor.visit_expr(expr),
+        StmtKind::Local(local) => try_visit!(visitor.visit_local(local)),
+        StmtKind::Item(item) => try_visit!(visitor.visit_item(item)),
+        StmtKind::Expr(expr) | StmtKind::Semi(expr) => try_visit!(visitor.visit_expr(expr)),
         StmtKind::Empty => {}
         StmtKind::MacCall(mac) => {
             let MacCallStmt { mac, attrs, style: _, tokens: _ } = &**mac;
-            visitor.visit_mac_call(mac);
-            for attr in attrs.iter() {
-                visitor.visit_attribute(attr);
-            }
+            try_visit!(visitor.visit_mac_call(mac));
+            walk_list!(visitor, visit_attribute, attrs);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_mac<'a, V: Visitor<'a>>(visitor: &mut V, mac: &'a MacCall) {
-    visitor.visit_path(&mac.path, DUMMY_NODE_ID);
+pub fn walk_mac<'a, V: Visitor<'a>>(visitor: &mut V, mac: &'a MacCall) -> V::Result {
+    visitor.visit_path(&mac.path, DUMMY_NODE_ID)
 }
 
-pub fn walk_anon_const<'a, V: Visitor<'a>>(visitor: &mut V, constant: &'a AnonConst) {
-    visitor.visit_expr(&constant.value);
+pub fn walk_anon_const<'a, V: Visitor<'a>>(visitor: &mut V, constant: &'a AnonConst) -> V::Result {
+    visitor.visit_expr(&constant.value)
 }
 
-pub fn walk_inline_asm<'a, V: Visitor<'a>>(visitor: &mut V, asm: &'a InlineAsm) {
+pub fn walk_inline_asm<'a, V: Visitor<'a>>(visitor: &mut V, asm: &'a InlineAsm) -> V::Result {
     for (op, _) in &asm.operands {
         match op {
             InlineAsmOperand::In { expr, .. }
             | InlineAsmOperand::Out { expr: Some(expr), .. }
-            | InlineAsmOperand::InOut { expr, .. } => visitor.visit_expr(expr),
+            | InlineAsmOperand::InOut { expr, .. } => try_visit!(visitor.visit_expr(expr)),
             InlineAsmOperand::Out { expr: None, .. } => {}
             InlineAsmOperand::SplitInOut { in_expr, out_expr, .. } => {
-                visitor.visit_expr(in_expr);
-                if let Some(out_expr) = out_expr {
-                    visitor.visit_expr(out_expr);
-                }
+                try_visit!(visitor.visit_expr(in_expr));
+                visit_opt!(visitor, visit_expr, out_expr);
             }
-            InlineAsmOperand::Const { anon_const, .. } => visitor.visit_anon_const(anon_const),
-            InlineAsmOperand::Sym { sym } => visitor.visit_inline_asm_sym(sym),
+            InlineAsmOperand::Const { anon_const, .. } => {
+                try_visit!(visitor.visit_anon_const(anon_const))
+            }
+            InlineAsmOperand::Sym { sym } => try_visit!(visitor.visit_inline_asm_sym(sym)),
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_inline_asm_sym<'a, V: Visitor<'a>>(visitor: &mut V, sym: &'a InlineAsmSym) {
+pub fn walk_inline_asm_sym<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    sym: &'a InlineAsmSym,
+) -> V::Result {
     if let Some(qself) = &sym.qself {
-        visitor.visit_ty(&qself.ty);
+        try_visit!(visitor.visit_ty(&qself.ty));
     }
-    visitor.visit_path(&sym.path, sym.id);
+    visitor.visit_path(&sym.path, sym.id)
 }
 
-pub fn walk_format_args<'a, V: Visitor<'a>>(visitor: &mut V, fmt: &'a FormatArgs) {
+pub fn walk_format_args<'a, V: Visitor<'a>>(visitor: &mut V, fmt: &'a FormatArgs) -> V::Result {
     for arg in fmt.arguments.all_args() {
         if let FormatArgumentKind::Named(name) = arg.kind {
-            visitor.visit_ident(name);
+            try_visit!(visitor.visit_ident(name));
         }
-        visitor.visit_expr(&arg.expr);
+        try_visit!(visitor.visit_expr(&arg.expr));
     }
+    V::Result::output()
 }
 
-pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
-    walk_list!(visitor, visit_attribute, expression.attrs.iter());
+pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) -> V::Result {
+    walk_list!(visitor, visit_attribute, &expression.attrs);
 
     match &expression.kind {
         ExprKind::Array(subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);
         }
-        ExprKind::ConstBlock(anon_const) => visitor.visit_anon_const(anon_const),
+        ExprKind::ConstBlock(anon_const) => try_visit!(visitor.visit_anon_const(anon_const)),
         ExprKind::Repeat(element, count) => {
-            visitor.visit_expr(element);
-            visitor.visit_anon_const(count)
+            try_visit!(visitor.visit_expr(element));
+            try_visit!(visitor.visit_anon_const(count));
         }
         ExprKind::Struct(se) => {
             if let Some(qself) = &se.qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(&se.path, expression.id);
+            try_visit!(visitor.visit_path(&se.path, expression.id));
             walk_list!(visitor, visit_expr_field, &se.fields);
             match &se.rest {
-                StructRest::Base(expr) => visitor.visit_expr(expr),
+                StructRest::Base(expr) => try_visit!(visitor.visit_expr(expr)),
                 StructRest::Rest(_span) => {}
                 StructRest::None => {}
             }
@@ -829,51 +938,51 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             walk_list!(visitor, visit_expr, subexpressions);
         }
         ExprKind::Call(callee_expression, arguments) => {
-            visitor.visit_expr(callee_expression);
+            try_visit!(visitor.visit_expr(callee_expression));
             walk_list!(visitor, visit_expr, arguments);
         }
         ExprKind::MethodCall(box MethodCall { seg, receiver, args, span: _ }) => {
-            visitor.visit_path_segment(seg);
-            visitor.visit_expr(receiver);
+            try_visit!(visitor.visit_path_segment(seg));
+            try_visit!(visitor.visit_expr(receiver));
             walk_list!(visitor, visit_expr, args);
         }
         ExprKind::Binary(_, left_expression, right_expression) => {
-            visitor.visit_expr(left_expression);
-            visitor.visit_expr(right_expression)
+            try_visit!(visitor.visit_expr(left_expression));
+            try_visit!(visitor.visit_expr(right_expression));
         }
         ExprKind::AddrOf(_, _, subexpression) | ExprKind::Unary(_, subexpression) => {
-            visitor.visit_expr(subexpression)
+            try_visit!(visitor.visit_expr(subexpression));
         }
         ExprKind::Cast(subexpression, typ) | ExprKind::Type(subexpression, typ) => {
-            visitor.visit_expr(subexpression);
-            visitor.visit_ty(typ)
+            try_visit!(visitor.visit_expr(subexpression));
+            try_visit!(visitor.visit_ty(typ));
         }
         ExprKind::Let(pat, expr, _, _) => {
-            visitor.visit_pat(pat);
-            visitor.visit_expr(expr);
+            try_visit!(visitor.visit_pat(pat));
+            try_visit!(visitor.visit_expr(expr));
         }
         ExprKind::If(head_expression, if_block, optional_else) => {
-            visitor.visit_expr(head_expression);
-            visitor.visit_block(if_block);
-            walk_list!(visitor, visit_expr, optional_else);
+            try_visit!(visitor.visit_expr(head_expression));
+            try_visit!(visitor.visit_block(if_block));
+            visit_opt!(visitor, visit_expr, optional_else);
         }
         ExprKind::While(subexpression, block, opt_label) => {
-            walk_list!(visitor, visit_label, opt_label);
-            visitor.visit_expr(subexpression);
-            visitor.visit_block(block);
+            visit_opt!(visitor, visit_label, opt_label);
+            try_visit!(visitor.visit_expr(subexpression));
+            try_visit!(visitor.visit_block(block));
         }
         ExprKind::ForLoop { pat, iter, body, label, kind: _ } => {
-            walk_list!(visitor, visit_label, label);
-            visitor.visit_pat(pat);
-            visitor.visit_expr(iter);
-            visitor.visit_block(body);
+            visit_opt!(visitor, visit_label, label);
+            try_visit!(visitor.visit_pat(pat));
+            try_visit!(visitor.visit_expr(iter));
+            try_visit!(visitor.visit_block(body));
         }
         ExprKind::Loop(block, opt_label, _) => {
-            walk_list!(visitor, visit_label, opt_label);
-            visitor.visit_block(block);
+            visit_opt!(visitor, visit_label, opt_label);
+            try_visit!(visitor.visit_block(block));
         }
         ExprKind::Match(subexpression, arms) => {
-            visitor.visit_expr(subexpression);
+            try_visit!(visitor.visit_expr(subexpression));
             walk_list!(visitor, visit_arm, arms);
         }
         ExprKind::Closure(box Closure {
@@ -887,112 +996,117 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             fn_decl_span: _,
             fn_arg_span: _,
         }) => {
-            visitor.visit_capture_by(capture_clause);
-            visitor.visit_fn(FnKind::Closure(binder, fn_decl, body), expression.span, expression.id)
+            try_visit!(visitor.visit_capture_by(capture_clause));
+            try_visit!(visitor.visit_fn(
+                FnKind::Closure(binder, fn_decl, body),
+                expression.span,
+                expression.id
+            ))
         }
         ExprKind::Block(block, opt_label) => {
-            walk_list!(visitor, visit_label, opt_label);
-            visitor.visit_block(block);
+            visit_opt!(visitor, visit_label, opt_label);
+            try_visit!(visitor.visit_block(block));
         }
-        ExprKind::Gen(_, body, _) => {
-            visitor.visit_block(body);
-        }
-        ExprKind::Await(expr, _) => visitor.visit_expr(expr),
+        ExprKind::Gen(_, body, _) => try_visit!(visitor.visit_block(body)),
+        ExprKind::Await(expr, _) => try_visit!(visitor.visit_expr(expr)),
         ExprKind::Assign(lhs, rhs, _) => {
-            visitor.visit_expr(lhs);
-            visitor.visit_expr(rhs);
+            try_visit!(visitor.visit_expr(lhs));
+            try_visit!(visitor.visit_expr(rhs));
         }
         ExprKind::AssignOp(_, left_expression, right_expression) => {
-            visitor.visit_expr(left_expression);
-            visitor.visit_expr(right_expression);
+            try_visit!(visitor.visit_expr(left_expression));
+            try_visit!(visitor.visit_expr(right_expression));
         }
         ExprKind::Field(subexpression, ident) => {
-            visitor.visit_expr(subexpression);
-            visitor.visit_ident(*ident);
+            try_visit!(visitor.visit_expr(subexpression));
+            try_visit!(visitor.visit_ident(*ident));
         }
         ExprKind::Index(main_expression, index_expression, _) => {
-            visitor.visit_expr(main_expression);
-            visitor.visit_expr(index_expression)
+            try_visit!(visitor.visit_expr(main_expression));
+            try_visit!(visitor.visit_expr(index_expression));
         }
         ExprKind::Range(start, end, _) => {
-            walk_list!(visitor, visit_expr, start);
-            walk_list!(visitor, visit_expr, end);
+            visit_opt!(visitor, visit_expr, start);
+            visit_opt!(visitor, visit_expr, end);
         }
         ExprKind::Underscore => {}
         ExprKind::Path(maybe_qself, path) => {
             if let Some(qself) = maybe_qself {
-                visitor.visit_ty(&qself.ty);
+                try_visit!(visitor.visit_ty(&qself.ty));
             }
-            visitor.visit_path(path, expression.id)
+            try_visit!(visitor.visit_path(path, expression.id));
         }
         ExprKind::Break(opt_label, opt_expr) => {
-            walk_list!(visitor, visit_label, opt_label);
-            walk_list!(visitor, visit_expr, opt_expr);
+            visit_opt!(visitor, visit_label, opt_label);
+            visit_opt!(visitor, visit_expr, opt_expr);
         }
         ExprKind::Continue(opt_label) => {
-            walk_list!(visitor, visit_label, opt_label);
+            visit_opt!(visitor, visit_label, opt_label);
         }
         ExprKind::Ret(optional_expression) => {
-            walk_list!(visitor, visit_expr, optional_expression);
+            visit_opt!(visitor, visit_expr, optional_expression);
         }
         ExprKind::Yeet(optional_expression) => {
-            walk_list!(visitor, visit_expr, optional_expression);
+            visit_opt!(visitor, visit_expr, optional_expression);
         }
-        ExprKind::Become(expr) => visitor.visit_expr(expr),
-        ExprKind::MacCall(mac) => visitor.visit_mac_call(mac),
-        ExprKind::Paren(subexpression) => visitor.visit_expr(subexpression),
-        ExprKind::InlineAsm(asm) => visitor.visit_inline_asm(asm),
-        ExprKind::FormatArgs(f) => visitor.visit_format_args(f),
+        ExprKind::Become(expr) => try_visit!(visitor.visit_expr(expr)),
+        ExprKind::MacCall(mac) => try_visit!(visitor.visit_mac_call(mac)),
+        ExprKind::Paren(subexpression) => try_visit!(visitor.visit_expr(subexpression)),
+        ExprKind::InlineAsm(asm) => try_visit!(visitor.visit_inline_asm(asm)),
+        ExprKind::FormatArgs(f) => try_visit!(visitor.visit_format_args(f)),
         ExprKind::OffsetOf(container, fields) => {
             visitor.visit_ty(container);
-            for &field in fields {
-                visitor.visit_ident(field);
-            }
+            walk_list!(visitor, visit_ident, fields.iter().copied());
         }
         ExprKind::Yield(optional_expression) => {
-            walk_list!(visitor, visit_expr, optional_expression);
+            visit_opt!(visitor, visit_expr, optional_expression);
         }
-        ExprKind::Try(subexpression) => visitor.visit_expr(subexpression),
-        ExprKind::TryBlock(body) => visitor.visit_block(body),
+        ExprKind::Try(subexpression) => try_visit!(visitor.visit_expr(subexpression)),
+        ExprKind::TryBlock(body) => try_visit!(visitor.visit_block(body)),
         ExprKind::Lit(_) | ExprKind::IncludedBytes(..) | ExprKind::Err => {}
     }
 
     visitor.visit_expr_post(expression)
 }
 
-pub fn walk_param<'a, V: Visitor<'a>>(visitor: &mut V, param: &'a Param) {
-    walk_list!(visitor, visit_attribute, param.attrs.iter());
-    visitor.visit_pat(&param.pat);
-    visitor.visit_ty(&param.ty);
+pub fn walk_param<'a, V: Visitor<'a>>(visitor: &mut V, param: &'a Param) -> V::Result {
+    walk_list!(visitor, visit_attribute, &param.attrs);
+    try_visit!(visitor.visit_pat(&param.pat));
+    try_visit!(visitor.visit_ty(&param.ty));
+    V::Result::output()
 }
 
-pub fn walk_arm<'a, V: Visitor<'a>>(visitor: &mut V, arm: &'a Arm) {
-    visitor.visit_pat(&arm.pat);
-    walk_list!(visitor, visit_expr, &arm.guard);
-    walk_list!(visitor, visit_expr, &arm.body);
+pub fn walk_arm<'a, V: Visitor<'a>>(visitor: &mut V, arm: &'a Arm) -> V::Result {
+    try_visit!(visitor.visit_pat(&arm.pat));
+    visit_opt!(visitor, visit_expr, &arm.guard);
+    visit_opt!(visitor, visit_expr, &arm.body);
     walk_list!(visitor, visit_attribute, &arm.attrs);
+    V::Result::output()
 }
 
-pub fn walk_vis<'a, V: Visitor<'a>>(visitor: &mut V, vis: &'a Visibility) {
+pub fn walk_vis<'a, V: Visitor<'a>>(visitor: &mut V, vis: &'a Visibility) -> V::Result {
     if let VisibilityKind::Restricted { ref path, id, shorthand: _ } = vis.kind {
-        visitor.visit_path(path, id);
+        try_visit!(visitor.visit_path(path, id));
     }
+    V::Result::output()
 }
 
-pub fn walk_attribute<'a, V: Visitor<'a>>(visitor: &mut V, attr: &'a Attribute) {
+pub fn walk_attribute<'a, V: Visitor<'a>>(visitor: &mut V, attr: &'a Attribute) -> V::Result {
     match &attr.kind {
-        AttrKind::Normal(normal) => walk_attr_args(visitor, &normal.item.args),
+        AttrKind::Normal(normal) => try_visit!(walk_attr_args(visitor, &normal.item.args)),
         AttrKind::DocComment(..) => {}
     }
+    V::Result::output()
 }
 
-pub fn walk_attr_args<'a, V: Visitor<'a>>(visitor: &mut V, args: &'a AttrArgs) {
+pub fn walk_attr_args<'a, V: Visitor<'a>>(visitor: &mut V, args: &'a AttrArgs) -> V::Result {
     match args {
         AttrArgs::Empty => {}
         AttrArgs::Delimited(_) => {}
-        AttrArgs::Eq(_eq_span, AttrArgsEq::Ast(expr)) => visitor.visit_expr(expr),
+        AttrArgs::Eq(_eq_span, AttrArgsEq::Ast(expr)) => try_visit!(visitor.visit_expr(expr)),
         AttrArgs::Eq(_, AttrArgsEq::Hir(lit)) => {
             unreachable!("in literal form when walking mac args eq: {:?}", lit)
         }
     }
+    V::Result::output()
 }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -96,7 +96,7 @@ impl Annotatable {
         }
     }
 
-    pub fn visit_with<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) {
+    pub fn visit_with<'a, V: Visitor<'a>>(&'a self, visitor: &mut V) -> V::Result {
         match self {
             Annotatable::Item(item) => visitor.visit_item(item),
             Annotatable::TraitItem(item) => visitor.visit_assoc_item(item, AssocCtxt::Trait),

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -65,7 +65,8 @@
 //! example coroutine inference, and possibly also HIR borrowck.
 
 use crate::hir::*;
-use rustc_ast::walk_list;
+use rustc_ast::visit::VisitorResult;
+use rustc_ast::{try_visit, visit_opt, walk_list};
 use rustc_ast::{Attribute, Label};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::symbol::{Ident, Symbol};
@@ -216,6 +217,10 @@ pub trait Visitor<'v>: Sized {
     /// and fixed appropriately.
     type NestedFilter: NestedFilter<'v> = nested_filter::None;
 
+    /// The result type of the `visit_*` methods. Can be either `()`,
+    /// or `ControlFlow<T>`.
+    type Result: VisitorResult = ();
+
     /// If `type NestedFilter` is set to visit nested items, this method
     /// must also be overridden to provide a map to retrieve nested items.
     fn nested_visit_map(&mut self) -> Self::Map {
@@ -233,287 +238,299 @@ pub trait Visitor<'v>: Sized {
     /// [`rustc_hir::intravisit`]. The only reason to override
     /// this method is if you want a nested pattern but cannot supply a
     /// [`Map`]; see `nested_visit_map` for advice.
-    fn visit_nested_item(&mut self, id: ItemId) {
+    fn visit_nested_item(&mut self, id: ItemId) -> Self::Result {
         if Self::NestedFilter::INTER {
             let item = self.nested_visit_map().item(id);
-            self.visit_item(item);
+            try_visit!(self.visit_item(item));
         }
+        Self::Result::output()
     }
 
     /// Like `visit_nested_item()`, but for trait items. See
     /// `visit_nested_item()` for advice on when to override this
     /// method.
-    fn visit_nested_trait_item(&mut self, id: TraitItemId) {
+    fn visit_nested_trait_item(&mut self, id: TraitItemId) -> Self::Result {
         if Self::NestedFilter::INTER {
             let item = self.nested_visit_map().trait_item(id);
-            self.visit_trait_item(item);
+            try_visit!(self.visit_trait_item(item));
         }
+        Self::Result::output()
     }
 
     /// Like `visit_nested_item()`, but for impl items. See
     /// `visit_nested_item()` for advice on when to override this
     /// method.
-    fn visit_nested_impl_item(&mut self, id: ImplItemId) {
+    fn visit_nested_impl_item(&mut self, id: ImplItemId) -> Self::Result {
         if Self::NestedFilter::INTER {
             let item = self.nested_visit_map().impl_item(id);
-            self.visit_impl_item(item);
+            try_visit!(self.visit_impl_item(item));
         }
+        Self::Result::output()
     }
 
     /// Like `visit_nested_item()`, but for foreign items. See
     /// `visit_nested_item()` for advice on when to override this
     /// method.
-    fn visit_nested_foreign_item(&mut self, id: ForeignItemId) {
+    fn visit_nested_foreign_item(&mut self, id: ForeignItemId) -> Self::Result {
         if Self::NestedFilter::INTER {
             let item = self.nested_visit_map().foreign_item(id);
-            self.visit_foreign_item(item);
+            try_visit!(self.visit_foreign_item(item));
         }
+        Self::Result::output()
     }
 
     /// Invoked to visit the body of a function, method or closure. Like
     /// `visit_nested_item`, does nothing by default unless you override
     /// `Self::NestedFilter`.
-    fn visit_nested_body(&mut self, id: BodyId) {
+    fn visit_nested_body(&mut self, id: BodyId) -> Self::Result {
         if Self::NestedFilter::INTRA {
             let body = self.nested_visit_map().body(id);
-            self.visit_body(body);
+            try_visit!(self.visit_body(body));
         }
+        Self::Result::output()
     }
 
-    fn visit_param(&mut self, param: &'v Param<'v>) {
+    fn visit_param(&mut self, param: &'v Param<'v>) -> Self::Result {
         walk_param(self, param)
     }
 
     /// Visits the top-level item and (optionally) nested items / impl items. See
     /// `visit_nested_item` for details.
-    fn visit_item(&mut self, i: &'v Item<'v>) {
+    fn visit_item(&mut self, i: &'v Item<'v>) -> Self::Result {
         walk_item(self, i)
     }
 
-    fn visit_body(&mut self, b: &'v Body<'v>) {
-        walk_body(self, b);
+    fn visit_body(&mut self, b: &'v Body<'v>) -> Self::Result {
+        walk_body(self, b)
     }
 
     ///////////////////////////////////////////////////////////////////////////
 
-    fn visit_id(&mut self, _hir_id: HirId) {
-        // Nothing to do.
+    fn visit_id(&mut self, _hir_id: HirId) -> Self::Result {
+        Self::Result::output()
     }
-    fn visit_name(&mut self, _name: Symbol) {
-        // Nothing to do.
+    fn visit_name(&mut self, _name: Symbol) -> Self::Result {
+        Self::Result::output()
     }
-    fn visit_ident(&mut self, ident: Ident) {
+    fn visit_ident(&mut self, ident: Ident) -> Self::Result {
         walk_ident(self, ident)
     }
-    fn visit_mod(&mut self, m: &'v Mod<'v>, _s: Span, n: HirId) {
+    fn visit_mod(&mut self, m: &'v Mod<'v>, _s: Span, n: HirId) -> Self::Result {
         walk_mod(self, m, n)
     }
-    fn visit_foreign_item(&mut self, i: &'v ForeignItem<'v>) {
+    fn visit_foreign_item(&mut self, i: &'v ForeignItem<'v>) -> Self::Result {
         walk_foreign_item(self, i)
     }
-    fn visit_local(&mut self, l: &'v Local<'v>) {
+    fn visit_local(&mut self, l: &'v Local<'v>) -> Self::Result {
         walk_local(self, l)
     }
-    fn visit_block(&mut self, b: &'v Block<'v>) {
+    fn visit_block(&mut self, b: &'v Block<'v>) -> Self::Result {
         walk_block(self, b)
     }
-    fn visit_stmt(&mut self, s: &'v Stmt<'v>) {
+    fn visit_stmt(&mut self, s: &'v Stmt<'v>) -> Self::Result {
         walk_stmt(self, s)
     }
-    fn visit_arm(&mut self, a: &'v Arm<'v>) {
+    fn visit_arm(&mut self, a: &'v Arm<'v>) -> Self::Result {
         walk_arm(self, a)
     }
-    fn visit_pat(&mut self, p: &'v Pat<'v>) {
+    fn visit_pat(&mut self, p: &'v Pat<'v>) -> Self::Result {
         walk_pat(self, p)
     }
-    fn visit_pat_field(&mut self, f: &'v PatField<'v>) {
+    fn visit_pat_field(&mut self, f: &'v PatField<'v>) -> Self::Result {
         walk_pat_field(self, f)
     }
-    fn visit_array_length(&mut self, len: &'v ArrayLen) {
+    fn visit_array_length(&mut self, len: &'v ArrayLen) -> Self::Result {
         walk_array_len(self, len)
     }
-    fn visit_anon_const(&mut self, c: &'v AnonConst) {
+    fn visit_anon_const(&mut self, c: &'v AnonConst) -> Self::Result {
         walk_anon_const(self, c)
     }
-    fn visit_inline_const(&mut self, c: &'v ConstBlock) {
+    fn visit_inline_const(&mut self, c: &'v ConstBlock) -> Self::Result {
         walk_inline_const(self, c)
     }
-    fn visit_expr(&mut self, ex: &'v Expr<'v>) {
+    fn visit_expr(&mut self, ex: &'v Expr<'v>) -> Self::Result {
         walk_expr(self, ex)
     }
-    fn visit_expr_field(&mut self, field: &'v ExprField<'v>) {
+    fn visit_expr_field(&mut self, field: &'v ExprField<'v>) -> Self::Result {
         walk_expr_field(self, field)
     }
-    fn visit_ty(&mut self, t: &'v Ty<'v>) {
+    fn visit_ty(&mut self, t: &'v Ty<'v>) -> Self::Result {
         walk_ty(self, t)
     }
-    fn visit_generic_param(&mut self, p: &'v GenericParam<'v>) {
+    fn visit_generic_param(&mut self, p: &'v GenericParam<'v>) -> Self::Result {
         walk_generic_param(self, p)
     }
-    fn visit_const_param_default(&mut self, _param: HirId, ct: &'v AnonConst) {
+    fn visit_const_param_default(&mut self, _param: HirId, ct: &'v AnonConst) -> Self::Result {
         walk_const_param_default(self, ct)
     }
-    fn visit_generics(&mut self, g: &'v Generics<'v>) {
+    fn visit_generics(&mut self, g: &'v Generics<'v>) -> Self::Result {
         walk_generics(self, g)
     }
-    fn visit_where_predicate(&mut self, predicate: &'v WherePredicate<'v>) {
+    fn visit_where_predicate(&mut self, predicate: &'v WherePredicate<'v>) -> Self::Result {
         walk_where_predicate(self, predicate)
     }
-    fn visit_fn_ret_ty(&mut self, ret_ty: &'v FnRetTy<'v>) {
+    fn visit_fn_ret_ty(&mut self, ret_ty: &'v FnRetTy<'v>) -> Self::Result {
         walk_fn_ret_ty(self, ret_ty)
     }
-    fn visit_fn_decl(&mut self, fd: &'v FnDecl<'v>) {
+    fn visit_fn_decl(&mut self, fd: &'v FnDecl<'v>) -> Self::Result {
         walk_fn_decl(self, fd)
     }
-    fn visit_fn(&mut self, fk: FnKind<'v>, fd: &'v FnDecl<'v>, b: BodyId, _: Span, id: LocalDefId) {
+    fn visit_fn(
+        &mut self,
+        fk: FnKind<'v>,
+        fd: &'v FnDecl<'v>,
+        b: BodyId,
+        _: Span,
+        id: LocalDefId,
+    ) -> Self::Result {
         walk_fn(self, fk, fd, b, id)
     }
-    fn visit_use(&mut self, path: &'v UsePath<'v>, hir_id: HirId) {
+    fn visit_use(&mut self, path: &'v UsePath<'v>, hir_id: HirId) -> Self::Result {
         walk_use(self, path, hir_id)
     }
-    fn visit_trait_item(&mut self, ti: &'v TraitItem<'v>) {
+    fn visit_trait_item(&mut self, ti: &'v TraitItem<'v>) -> Self::Result {
         walk_trait_item(self, ti)
     }
-    fn visit_trait_item_ref(&mut self, ii: &'v TraitItemRef) {
+    fn visit_trait_item_ref(&mut self, ii: &'v TraitItemRef) -> Self::Result {
         walk_trait_item_ref(self, ii)
     }
-    fn visit_impl_item(&mut self, ii: &'v ImplItem<'v>) {
+    fn visit_impl_item(&mut self, ii: &'v ImplItem<'v>) -> Self::Result {
         walk_impl_item(self, ii)
     }
-    fn visit_foreign_item_ref(&mut self, ii: &'v ForeignItemRef) {
+    fn visit_foreign_item_ref(&mut self, ii: &'v ForeignItemRef) -> Self::Result {
         walk_foreign_item_ref(self, ii)
     }
-    fn visit_impl_item_ref(&mut self, ii: &'v ImplItemRef) {
+    fn visit_impl_item_ref(&mut self, ii: &'v ImplItemRef) -> Self::Result {
         walk_impl_item_ref(self, ii)
     }
-    fn visit_trait_ref(&mut self, t: &'v TraitRef<'v>) {
+    fn visit_trait_ref(&mut self, t: &'v TraitRef<'v>) -> Self::Result {
         walk_trait_ref(self, t)
     }
-    fn visit_param_bound(&mut self, bounds: &'v GenericBound<'v>) {
+    fn visit_param_bound(&mut self, bounds: &'v GenericBound<'v>) -> Self::Result {
         walk_param_bound(self, bounds)
     }
-    fn visit_poly_trait_ref(&mut self, t: &'v PolyTraitRef<'v>) {
+    fn visit_poly_trait_ref(&mut self, t: &'v PolyTraitRef<'v>) -> Self::Result {
         walk_poly_trait_ref(self, t)
     }
-    fn visit_variant_data(&mut self, s: &'v VariantData<'v>) {
+    fn visit_variant_data(&mut self, s: &'v VariantData<'v>) -> Self::Result {
         walk_struct_def(self, s)
     }
-    fn visit_field_def(&mut self, s: &'v FieldDef<'v>) {
+    fn visit_field_def(&mut self, s: &'v FieldDef<'v>) -> Self::Result {
         walk_field_def(self, s)
     }
-    fn visit_enum_def(&mut self, enum_definition: &'v EnumDef<'v>, item_id: HirId) {
+    fn visit_enum_def(&mut self, enum_definition: &'v EnumDef<'v>, item_id: HirId) -> Self::Result {
         walk_enum_def(self, enum_definition, item_id)
     }
-    fn visit_variant(&mut self, v: &'v Variant<'v>) {
+    fn visit_variant(&mut self, v: &'v Variant<'v>) -> Self::Result {
         walk_variant(self, v)
     }
-    fn visit_label(&mut self, label: &'v Label) {
+    fn visit_label(&mut self, label: &'v Label) -> Self::Result {
         walk_label(self, label)
     }
-    fn visit_infer(&mut self, inf: &'v InferArg) {
-        walk_inf(self, inf);
+    fn visit_infer(&mut self, inf: &'v InferArg) -> Self::Result {
+        walk_inf(self, inf)
     }
-    fn visit_generic_arg(&mut self, generic_arg: &'v GenericArg<'v>) {
-        walk_generic_arg(self, generic_arg);
+    fn visit_generic_arg(&mut self, generic_arg: &'v GenericArg<'v>) -> Self::Result {
+        walk_generic_arg(self, generic_arg)
     }
-    fn visit_lifetime(&mut self, lifetime: &'v Lifetime) {
+    fn visit_lifetime(&mut self, lifetime: &'v Lifetime) -> Self::Result {
         walk_lifetime(self, lifetime)
     }
     // The span is that of the surrounding type/pattern/expr/whatever.
-    fn visit_qpath(&mut self, qpath: &'v QPath<'v>, id: HirId, _span: Span) {
+    fn visit_qpath(&mut self, qpath: &'v QPath<'v>, id: HirId, _span: Span) -> Self::Result {
         walk_qpath(self, qpath, id)
     }
-    fn visit_path(&mut self, path: &Path<'v>, _id: HirId) {
+    fn visit_path(&mut self, path: &Path<'v>, _id: HirId) -> Self::Result {
         walk_path(self, path)
     }
-    fn visit_path_segment(&mut self, path_segment: &'v PathSegment<'v>) {
+    fn visit_path_segment(&mut self, path_segment: &'v PathSegment<'v>) -> Self::Result {
         walk_path_segment(self, path_segment)
     }
-    fn visit_generic_args(&mut self, generic_args: &'v GenericArgs<'v>) {
+    fn visit_generic_args(&mut self, generic_args: &'v GenericArgs<'v>) -> Self::Result {
         walk_generic_args(self, generic_args)
     }
-    fn visit_assoc_type_binding(&mut self, type_binding: &'v TypeBinding<'v>) {
+    fn visit_assoc_type_binding(&mut self, type_binding: &'v TypeBinding<'v>) -> Self::Result {
         walk_assoc_type_binding(self, type_binding)
     }
-    fn visit_attribute(&mut self, _attr: &'v Attribute) {}
-    fn visit_associated_item_kind(&mut self, kind: &'v AssocItemKind) {
-        walk_associated_item_kind(self, kind);
+    fn visit_attribute(&mut self, _attr: &'v Attribute) -> Self::Result {
+        Self::Result::output()
     }
-    fn visit_defaultness(&mut self, defaultness: &'v Defaultness) {
-        walk_defaultness(self, defaultness);
+    fn visit_associated_item_kind(&mut self, kind: &'v AssocItemKind) -> Self::Result {
+        walk_associated_item_kind(self, kind)
     }
-    fn visit_inline_asm(&mut self, asm: &'v InlineAsm<'v>, id: HirId) {
-        walk_inline_asm(self, asm, id);
+    fn visit_defaultness(&mut self, defaultness: &'v Defaultness) -> Self::Result {
+        walk_defaultness(self, defaultness)
+    }
+    fn visit_inline_asm(&mut self, asm: &'v InlineAsm<'v>, id: HirId) -> Self::Result {
+        walk_inline_asm(self, asm, id)
     }
 }
 
-pub fn walk_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Param<'v>) {
-    visitor.visit_id(param.hir_id);
-    visitor.visit_pat(param.pat);
+pub fn walk_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Param<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(param.hir_id));
+    visitor.visit_pat(param.pat)
 }
 
-pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item<'v>) {
-    visitor.visit_ident(item.ident);
+pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item<'v>) -> V::Result {
+    try_visit!(visitor.visit_ident(item.ident));
     match item.kind {
         ItemKind::ExternCrate(orig_name) => {
-            visitor.visit_id(item.hir_id());
-            if let Some(orig_name) = orig_name {
-                visitor.visit_name(orig_name);
-            }
+            try_visit!(visitor.visit_id(item.hir_id()));
+            visit_opt!(visitor, visit_name, orig_name);
         }
         ItemKind::Use(ref path, _) => {
-            visitor.visit_use(path, item.hir_id());
+            try_visit!(visitor.visit_use(path, item.hir_id()));
         }
         ItemKind::Static(ref typ, _, body) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_ty(typ);
-            visitor.visit_nested_body(body);
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_ty(typ));
+            try_visit!(visitor.visit_nested_body(body));
         }
         ItemKind::Const(ref typ, ref generics, body) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_ty(typ);
-            visitor.visit_generics(generics);
-            visitor.visit_nested_body(body);
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_ty(typ));
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_nested_body(body));
         }
         ItemKind::Fn(ref sig, ref generics, body_id) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_fn(
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_fn(
                 FnKind::ItemFn(item.ident, generics, sig.header),
                 sig.decl,
                 body_id,
                 item.span,
                 item.owner_id.def_id,
-            )
+            ));
         }
         ItemKind::Macro(..) => {
-            visitor.visit_id(item.hir_id());
+            try_visit!(visitor.visit_id(item.hir_id()));
         }
         ItemKind::Mod(ref module) => {
             // `visit_mod()` takes care of visiting the `Item`'s `HirId`.
-            visitor.visit_mod(module, item.span, item.hir_id())
+            try_visit!(visitor.visit_mod(module, item.span, item.hir_id()));
         }
         ItemKind::ForeignMod { abi: _, items } => {
-            visitor.visit_id(item.hir_id());
+            try_visit!(visitor.visit_id(item.hir_id()));
             walk_list!(visitor, visit_foreign_item_ref, items);
         }
         ItemKind::GlobalAsm(asm) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_inline_asm(asm, item.hir_id());
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_inline_asm(asm, item.hir_id()));
         }
         ItemKind::TyAlias(ref ty, ref generics) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_ty(ty);
-            visitor.visit_generics(generics)
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_ty(ty));
+            try_visit!(visitor.visit_generics(generics));
         }
         ItemKind::OpaqueTy(&OpaqueTy { generics, bounds, .. }) => {
-            visitor.visit_id(item.hir_id());
-            walk_generics(visitor, generics);
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(walk_generics(visitor, generics));
             walk_list!(visitor, visit_param_bound, bounds);
         }
         ItemKind::Enum(ref enum_definition, ref generics) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
             // `visit_enum_def()` takes care of visiting the `Item`'s `HirId`.
-            visitor.visit_enum_def(enum_definition, item.hir_id())
+            try_visit!(visitor.visit_enum_def(enum_definition, item.hir_id()));
         }
         ItemKind::Impl(Impl {
             unsafety: _,
@@ -525,85 +542,91 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item<'v>) {
             ref self_ty,
             items,
         }) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_generics(generics);
-            walk_list!(visitor, visit_trait_ref, of_trait);
-            visitor.visit_ty(self_ty);
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_generics(generics));
+            visit_opt!(visitor, visit_trait_ref, of_trait);
+            try_visit!(visitor.visit_ty(self_ty));
             walk_list!(visitor, visit_impl_item_ref, *items);
         }
         ItemKind::Struct(ref struct_definition, ref generics)
         | ItemKind::Union(ref struct_definition, ref generics) => {
-            visitor.visit_generics(generics);
-            visitor.visit_id(item.hir_id());
-            visitor.visit_variant_data(struct_definition);
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_variant_data(struct_definition));
         }
         ItemKind::Trait(.., ref generics, bounds, trait_item_refs) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds);
             walk_list!(visitor, visit_trait_item_ref, trait_item_refs);
         }
         ItemKind::TraitAlias(ref generics, bounds) => {
-            visitor.visit_id(item.hir_id());
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_id(item.hir_id()));
+            try_visit!(visitor.visit_generics(generics));
             walk_list!(visitor, visit_param_bound, bounds);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_body<'v, V: Visitor<'v>>(visitor: &mut V, body: &'v Body<'v>) {
+pub fn walk_body<'v, V: Visitor<'v>>(visitor: &mut V, body: &'v Body<'v>) -> V::Result {
     walk_list!(visitor, visit_param, body.params);
-    visitor.visit_expr(body.value);
+    visitor.visit_expr(body.value)
 }
 
-pub fn walk_ident<'v, V: Visitor<'v>>(visitor: &mut V, ident: Ident) {
-    visitor.visit_name(ident.name);
+pub fn walk_ident<'v, V: Visitor<'v>>(visitor: &mut V, ident: Ident) -> V::Result {
+    visitor.visit_name(ident.name)
 }
 
-pub fn walk_mod<'v, V: Visitor<'v>>(visitor: &mut V, module: &'v Mod<'v>, mod_hir_id: HirId) {
-    visitor.visit_id(mod_hir_id);
-    for &item_id in module.item_ids {
-        visitor.visit_nested_item(item_id);
-    }
+pub fn walk_mod<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    module: &'v Mod<'v>,
+    mod_hir_id: HirId,
+) -> V::Result {
+    try_visit!(visitor.visit_id(mod_hir_id));
+    walk_list!(visitor, visit_nested_item, module.item_ids.iter().copied());
+    V::Result::output()
 }
 
-pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V, foreign_item: &'v ForeignItem<'v>) {
-    visitor.visit_id(foreign_item.hir_id());
-    visitor.visit_ident(foreign_item.ident);
+pub fn walk_foreign_item<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    foreign_item: &'v ForeignItem<'v>,
+) -> V::Result {
+    try_visit!(visitor.visit_id(foreign_item.hir_id()));
+    try_visit!(visitor.visit_ident(foreign_item.ident));
 
     match foreign_item.kind {
         ForeignItemKind::Fn(ref function_declaration, param_names, ref generics) => {
-            visitor.visit_generics(generics);
-            visitor.visit_fn_decl(function_declaration);
-            for &param_name in param_names {
-                visitor.visit_ident(param_name);
-            }
+            try_visit!(visitor.visit_generics(generics));
+            try_visit!(visitor.visit_fn_decl(function_declaration));
+            walk_list!(visitor, visit_ident, param_names.iter().copied());
         }
-        ForeignItemKind::Static(ref typ, _) => visitor.visit_ty(typ),
+        ForeignItemKind::Static(ref typ, _) => try_visit!(visitor.visit_ty(typ)),
         ForeignItemKind::Type => (),
     }
+    V::Result::output()
 }
 
-pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local<'v>) {
+pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local<'v>) -> V::Result {
     // Intentionally visiting the expr first - the initialization expr
     // dominates the local's definition.
-    walk_list!(visitor, visit_expr, &local.init);
-    visitor.visit_id(local.hir_id);
-    visitor.visit_pat(local.pat);
-    if let Some(els) = local.els {
-        visitor.visit_block(els);
-    }
-    walk_list!(visitor, visit_ty, &local.ty);
+    visit_opt!(visitor, visit_expr, local.init);
+    try_visit!(visitor.visit_id(local.hir_id));
+    try_visit!(visitor.visit_pat(local.pat));
+    visit_opt!(visitor, visit_block, local.els);
+    visit_opt!(visitor, visit_ty, local.ty);
+    V::Result::output()
 }
 
-pub fn walk_block<'v, V: Visitor<'v>>(visitor: &mut V, block: &'v Block<'v>) {
-    visitor.visit_id(block.hir_id);
+pub fn walk_block<'v, V: Visitor<'v>>(visitor: &mut V, block: &'v Block<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(block.hir_id));
     walk_list!(visitor, visit_stmt, block.stmts);
-    walk_list!(visitor, visit_expr, &block.expr);
+    visit_opt!(visitor, visit_expr, block.expr);
+    V::Result::output()
 }
 
-pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt<'v>) {
-    visitor.visit_id(statement.hir_id);
+pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(statement.hir_id));
     match statement.kind {
         StmtKind::Local(ref local) => visitor.visit_local(local),
         StmtKind::Item(item) => visitor.visit_nested_item(item),
@@ -613,27 +636,25 @@ pub fn walk_stmt<'v, V: Visitor<'v>>(visitor: &mut V, statement: &'v Stmt<'v>) {
     }
 }
 
-pub fn walk_arm<'v, V: Visitor<'v>>(visitor: &mut V, arm: &'v Arm<'v>) {
-    visitor.visit_id(arm.hir_id);
-    visitor.visit_pat(arm.pat);
-    if let Some(ref e) = arm.guard {
-        visitor.visit_expr(e);
-    }
-    visitor.visit_expr(arm.body);
+pub fn walk_arm<'v, V: Visitor<'v>>(visitor: &mut V, arm: &'v Arm<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(arm.hir_id));
+    try_visit!(visitor.visit_pat(arm.pat));
+    visit_opt!(visitor, visit_expr, arm.guard);
+    visitor.visit_expr(arm.body)
 }
 
-pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat<'v>) {
-    visitor.visit_id(pattern.hir_id);
+pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(pattern.hir_id));
     match pattern.kind {
         PatKind::TupleStruct(ref qpath, children, _) => {
-            visitor.visit_qpath(qpath, pattern.hir_id, pattern.span);
+            try_visit!(visitor.visit_qpath(qpath, pattern.hir_id, pattern.span));
             walk_list!(visitor, visit_pat, children);
         }
         PatKind::Path(ref qpath) => {
-            visitor.visit_qpath(qpath, pattern.hir_id, pattern.span);
+            try_visit!(visitor.visit_qpath(qpath, pattern.hir_id, pattern.span));
         }
         PatKind::Struct(ref qpath, fields, _) => {
-            visitor.visit_qpath(qpath, pattern.hir_id, pattern.span);
+            try_visit!(visitor.visit_qpath(qpath, pattern.hir_id, pattern.span));
             walk_list!(visitor, visit_pat_field, fields);
         }
         PatKind::Or(pats) => walk_list!(visitor, visit_pat, pats),
@@ -641,33 +662,34 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat<'v>) {
             walk_list!(visitor, visit_pat, tuple_elements);
         }
         PatKind::Box(ref subpattern) | PatKind::Ref(ref subpattern, _) => {
-            visitor.visit_pat(subpattern)
+            try_visit!(visitor.visit_pat(subpattern));
         }
         PatKind::Binding(_, _hir_id, ident, ref optional_subpattern) => {
-            visitor.visit_ident(ident);
-            walk_list!(visitor, visit_pat, optional_subpattern);
+            try_visit!(visitor.visit_ident(ident));
+            visit_opt!(visitor, visit_pat, optional_subpattern);
         }
-        PatKind::Lit(ref expression) => visitor.visit_expr(expression),
+        PatKind::Lit(ref expression) => try_visit!(visitor.visit_expr(expression)),
         PatKind::Range(ref lower_bound, ref upper_bound, _) => {
-            walk_list!(visitor, visit_expr, lower_bound);
-            walk_list!(visitor, visit_expr, upper_bound);
+            visit_opt!(visitor, visit_expr, lower_bound);
+            visit_opt!(visitor, visit_expr, upper_bound);
         }
         PatKind::Never | PatKind::Wild | PatKind::Err(_) => (),
         PatKind::Slice(prepatterns, ref slice_pattern, postpatterns) => {
             walk_list!(visitor, visit_pat, prepatterns);
-            walk_list!(visitor, visit_pat, slice_pattern);
+            visit_opt!(visitor, visit_pat, slice_pattern);
             walk_list!(visitor, visit_pat, postpatterns);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_pat_field<'v, V: Visitor<'v>>(visitor: &mut V, field: &'v PatField<'v>) {
-    visitor.visit_id(field.hir_id);
-    visitor.visit_ident(field.ident);
+pub fn walk_pat_field<'v, V: Visitor<'v>>(visitor: &mut V, field: &'v PatField<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(field.hir_id));
+    try_visit!(visitor.visit_ident(field.ident));
     visitor.visit_pat(field.pat)
 }
 
-pub fn walk_array_len<'v, V: Visitor<'v>>(visitor: &mut V, len: &'v ArrayLen) {
+pub fn walk_array_len<'v, V: Visitor<'v>>(visitor: &mut V, len: &'v ArrayLen) -> V::Result {
     match len {
         // FIXME: Use `visit_infer` here.
         ArrayLen::Infer(InferArg { hir_id, span: _ }) => visitor.visit_id(*hir_id),
@@ -675,75 +697,80 @@ pub fn walk_array_len<'v, V: Visitor<'v>>(visitor: &mut V, len: &'v ArrayLen) {
     }
 }
 
-pub fn walk_anon_const<'v, V: Visitor<'v>>(visitor: &mut V, constant: &'v AnonConst) {
-    visitor.visit_id(constant.hir_id);
-    visitor.visit_nested_body(constant.body);
+pub fn walk_anon_const<'v, V: Visitor<'v>>(visitor: &mut V, constant: &'v AnonConst) -> V::Result {
+    try_visit!(visitor.visit_id(constant.hir_id));
+    visitor.visit_nested_body(constant.body)
 }
 
-pub fn walk_inline_const<'v, V: Visitor<'v>>(visitor: &mut V, constant: &'v ConstBlock) {
-    visitor.visit_id(constant.hir_id);
-    visitor.visit_nested_body(constant.body);
+pub fn walk_inline_const<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    constant: &'v ConstBlock,
+) -> V::Result {
+    try_visit!(visitor.visit_id(constant.hir_id));
+    visitor.visit_nested_body(constant.body)
 }
 
-pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) {
-    visitor.visit_id(expression.hir_id);
+pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(expression.hir_id));
     match expression.kind {
         ExprKind::Array(subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);
         }
-        ExprKind::ConstBlock(ref const_block) => visitor.visit_inline_const(const_block),
+        ExprKind::ConstBlock(ref const_block) => {
+            try_visit!(visitor.visit_inline_const(const_block))
+        }
         ExprKind::Repeat(ref element, ref count) => {
-            visitor.visit_expr(element);
-            visitor.visit_array_length(count)
+            try_visit!(visitor.visit_expr(element));
+            try_visit!(visitor.visit_array_length(count));
         }
         ExprKind::Struct(ref qpath, fields, ref optional_base) => {
-            visitor.visit_qpath(qpath, expression.hir_id, expression.span);
+            try_visit!(visitor.visit_qpath(qpath, expression.hir_id, expression.span));
             walk_list!(visitor, visit_expr_field, fields);
-            walk_list!(visitor, visit_expr, optional_base);
+            visit_opt!(visitor, visit_expr, optional_base);
         }
         ExprKind::Tup(subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);
         }
         ExprKind::Call(ref callee_expression, arguments) => {
-            visitor.visit_expr(callee_expression);
+            try_visit!(visitor.visit_expr(callee_expression));
             walk_list!(visitor, visit_expr, arguments);
         }
         ExprKind::MethodCall(ref segment, receiver, arguments, _) => {
-            visitor.visit_path_segment(segment);
-            visitor.visit_expr(receiver);
+            try_visit!(visitor.visit_path_segment(segment));
+            try_visit!(visitor.visit_expr(receiver));
             walk_list!(visitor, visit_expr, arguments);
         }
         ExprKind::Binary(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(left_expression);
-            visitor.visit_expr(right_expression)
+            try_visit!(visitor.visit_expr(left_expression));
+            try_visit!(visitor.visit_expr(right_expression));
         }
         ExprKind::AddrOf(_, _, ref subexpression) | ExprKind::Unary(_, ref subexpression) => {
-            visitor.visit_expr(subexpression)
+            try_visit!(visitor.visit_expr(subexpression));
         }
         ExprKind::Cast(ref subexpression, ref typ) | ExprKind::Type(ref subexpression, ref typ) => {
-            visitor.visit_expr(subexpression);
-            visitor.visit_ty(typ)
+            try_visit!(visitor.visit_expr(subexpression));
+            try_visit!(visitor.visit_ty(typ));
         }
         ExprKind::DropTemps(ref subexpression) => {
-            visitor.visit_expr(subexpression);
+            try_visit!(visitor.visit_expr(subexpression));
         }
         ExprKind::Let(Let { span: _, pat, ty, init, is_recovered: _ }) => {
             // match the visit order in walk_local
-            visitor.visit_expr(init);
-            visitor.visit_pat(pat);
-            walk_list!(visitor, visit_ty, ty);
+            try_visit!(visitor.visit_expr(init));
+            try_visit!(visitor.visit_pat(pat));
+            visit_opt!(visitor, visit_ty, ty);
         }
         ExprKind::If(ref cond, ref then, ref else_opt) => {
-            visitor.visit_expr(cond);
-            visitor.visit_expr(then);
-            walk_list!(visitor, visit_expr, else_opt);
+            try_visit!(visitor.visit_expr(cond));
+            try_visit!(visitor.visit_expr(then));
+            visit_opt!(visitor, visit_expr, else_opt);
         }
         ExprKind::Loop(ref block, ref opt_label, _, _) => {
-            walk_list!(visitor, visit_label, opt_label);
-            visitor.visit_block(block);
+            visit_opt!(visitor, visit_label, opt_label);
+            try_visit!(visitor.visit_block(block));
         }
         ExprKind::Match(ref subexpression, arms, _) => {
-            visitor.visit_expr(subexpression);
+            try_visit!(visitor.visit_expr(subexpression));
             walk_list!(visitor, visit_arm, arms);
         }
         ExprKind::Closure(&Closure {
@@ -759,71 +786,72 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
             constness: _,
         }) => {
             walk_list!(visitor, visit_generic_param, bound_generic_params);
-            visitor.visit_fn(FnKind::Closure, fn_decl, body, expression.span, def_id)
+            try_visit!(visitor.visit_fn(FnKind::Closure, fn_decl, body, expression.span, def_id));
         }
         ExprKind::Block(ref block, ref opt_label) => {
-            walk_list!(visitor, visit_label, opt_label);
-            visitor.visit_block(block);
+            visit_opt!(visitor, visit_label, opt_label);
+            try_visit!(visitor.visit_block(block));
         }
         ExprKind::Assign(ref lhs, ref rhs, _) => {
-            visitor.visit_expr(rhs);
-            visitor.visit_expr(lhs)
+            try_visit!(visitor.visit_expr(rhs));
+            try_visit!(visitor.visit_expr(lhs));
         }
         ExprKind::AssignOp(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(right_expression);
-            visitor.visit_expr(left_expression);
+            try_visit!(visitor.visit_expr(right_expression));
+            try_visit!(visitor.visit_expr(left_expression));
         }
         ExprKind::Field(ref subexpression, ident) => {
-            visitor.visit_expr(subexpression);
-            visitor.visit_ident(ident);
+            try_visit!(visitor.visit_expr(subexpression));
+            try_visit!(visitor.visit_ident(ident));
         }
         ExprKind::Index(ref main_expression, ref index_expression, _) => {
-            visitor.visit_expr(main_expression);
-            visitor.visit_expr(index_expression)
+            try_visit!(visitor.visit_expr(main_expression));
+            try_visit!(visitor.visit_expr(index_expression));
         }
         ExprKind::Path(ref qpath) => {
-            visitor.visit_qpath(qpath, expression.hir_id, expression.span);
+            try_visit!(visitor.visit_qpath(qpath, expression.hir_id, expression.span));
         }
         ExprKind::Break(ref destination, ref opt_expr) => {
-            walk_list!(visitor, visit_label, &destination.label);
-            walk_list!(visitor, visit_expr, opt_expr);
+            visit_opt!(visitor, visit_label, &destination.label);
+            visit_opt!(visitor, visit_expr, opt_expr);
         }
         ExprKind::Continue(ref destination) => {
-            walk_list!(visitor, visit_label, &destination.label);
+            visit_opt!(visitor, visit_label, &destination.label);
         }
         ExprKind::Ret(ref optional_expression) => {
-            walk_list!(visitor, visit_expr, optional_expression);
+            visit_opt!(visitor, visit_expr, optional_expression);
         }
-        ExprKind::Become(ref expr) => visitor.visit_expr(expr),
+        ExprKind::Become(ref expr) => try_visit!(visitor.visit_expr(expr)),
         ExprKind::InlineAsm(ref asm) => {
-            visitor.visit_inline_asm(asm, expression.hir_id);
+            try_visit!(visitor.visit_inline_asm(asm, expression.hir_id));
         }
         ExprKind::OffsetOf(ref container, ref fields) => {
-            visitor.visit_ty(container);
+            try_visit!(visitor.visit_ty(container));
             walk_list!(visitor, visit_ident, fields.iter().copied());
         }
         ExprKind::Yield(ref subexpression, _) => {
-            visitor.visit_expr(subexpression);
+            try_visit!(visitor.visit_expr(subexpression));
         }
         ExprKind::Lit(_) | ExprKind::Err(_) => {}
     }
+    V::Result::output()
 }
 
-pub fn walk_expr_field<'v, V: Visitor<'v>>(visitor: &mut V, field: &'v ExprField<'v>) {
-    visitor.visit_id(field.hir_id);
-    visitor.visit_ident(field.ident);
+pub fn walk_expr_field<'v, V: Visitor<'v>>(visitor: &mut V, field: &'v ExprField<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(field.hir_id));
+    try_visit!(visitor.visit_ident(field.ident));
     visitor.visit_expr(field.expr)
 }
 
-pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty<'v>) {
-    visitor.visit_id(typ.hir_id);
+pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(typ.hir_id));
 
     match typ.kind {
-        TyKind::Slice(ref ty) => visitor.visit_ty(ty),
-        TyKind::Ptr(ref mutable_type) => visitor.visit_ty(mutable_type.ty),
+        TyKind::Slice(ref ty) => try_visit!(visitor.visit_ty(ty)),
+        TyKind::Ptr(ref mutable_type) => try_visit!(visitor.visit_ty(mutable_type.ty)),
         TyKind::Ref(ref lifetime, ref mutable_type) => {
-            visitor.visit_lifetime(lifetime);
-            visitor.visit_ty(mutable_type.ty)
+            try_visit!(visitor.visit_lifetime(lifetime));
+            try_visit!(visitor.visit_ty(mutable_type.ty));
         }
         TyKind::Never => {}
         TyKind::Tup(tuple_element_types) => {
@@ -831,64 +859,71 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty<'v>) {
         }
         TyKind::BareFn(ref function_declaration) => {
             walk_list!(visitor, visit_generic_param, function_declaration.generic_params);
-            visitor.visit_fn_decl(function_declaration.decl);
+            try_visit!(visitor.visit_fn_decl(function_declaration.decl));
         }
         TyKind::Path(ref qpath) => {
-            visitor.visit_qpath(qpath, typ.hir_id, typ.span);
+            try_visit!(visitor.visit_qpath(qpath, typ.hir_id, typ.span));
         }
         TyKind::OpaqueDef(item_id, lifetimes, _in_trait) => {
-            visitor.visit_nested_item(item_id);
+            try_visit!(visitor.visit_nested_item(item_id));
             walk_list!(visitor, visit_generic_arg, lifetimes);
         }
         TyKind::Array(ref ty, ref length) => {
-            visitor.visit_ty(ty);
-            visitor.visit_array_length(length)
+            try_visit!(visitor.visit_ty(ty));
+            try_visit!(visitor.visit_array_length(length));
         }
         TyKind::TraitObject(bounds, ref lifetime, _syntax) => {
-            for bound in bounds {
-                visitor.visit_poly_trait_ref(bound);
-            }
-            visitor.visit_lifetime(lifetime);
+            walk_list!(visitor, visit_poly_trait_ref, bounds);
+            try_visit!(visitor.visit_lifetime(lifetime));
         }
-        TyKind::Typeof(ref expression) => visitor.visit_anon_const(expression),
+        TyKind::Typeof(ref expression) => try_visit!(visitor.visit_anon_const(expression)),
         TyKind::Infer | TyKind::InferDelegation(..) | TyKind::Err(_) => {}
         TyKind::AnonAdt(item_id) => {
-            visitor.visit_nested_item(item_id);
+            try_visit!(visitor.visit_nested_item(item_id));
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_generic_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v GenericParam<'v>) {
-    visitor.visit_id(param.hir_id);
+pub fn walk_generic_param<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    param: &'v GenericParam<'v>,
+) -> V::Result {
+    try_visit!(visitor.visit_id(param.hir_id));
     match param.name {
-        ParamName::Plain(ident) => visitor.visit_ident(ident),
+        ParamName::Plain(ident) => try_visit!(visitor.visit_ident(ident)),
         ParamName::Error | ParamName::Fresh => {}
     }
     match param.kind {
         GenericParamKind::Lifetime { .. } => {}
-        GenericParamKind::Type { ref default, .. } => walk_list!(visitor, visit_ty, default),
+        GenericParamKind::Type { ref default, .. } => visit_opt!(visitor, visit_ty, default),
         GenericParamKind::Const { ref ty, ref default, is_host_effect: _ } => {
-            visitor.visit_ty(ty);
+            try_visit!(visitor.visit_ty(ty));
             if let Some(ref default) = default {
                 visitor.visit_const_param_default(param.hir_id, default);
             }
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_const_param_default<'v, V: Visitor<'v>>(visitor: &mut V, ct: &'v AnonConst) {
+pub fn walk_const_param_default<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    ct: &'v AnonConst,
+) -> V::Result {
     visitor.visit_anon_const(ct)
 }
 
-pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics<'v>) {
+pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics<'v>) -> V::Result {
     walk_list!(visitor, visit_generic_param, generics.params);
     walk_list!(visitor, visit_where_predicate, generics.predicates);
+    V::Result::output()
 }
 
 pub fn walk_where_predicate<'v, V: Visitor<'v>>(
     visitor: &mut V,
     predicate: &'v WherePredicate<'v>,
-) {
+) -> V::Result {
     match *predicate {
         WherePredicate::BoundPredicate(WhereBoundPredicate {
             hir_id,
@@ -898,8 +933,8 @@ pub fn walk_where_predicate<'v, V: Visitor<'v>>(
             origin: _,
             span: _,
         }) => {
-            visitor.visit_id(hir_id);
-            visitor.visit_ty(bounded_ty);
+            try_visit!(visitor.visit_id(hir_id));
+            try_visit!(visitor.visit_ty(bounded_ty));
             walk_list!(visitor, visit_param_bound, bounds);
             walk_list!(visitor, visit_generic_param, bound_generic_params);
         }
@@ -909,27 +944,30 @@ pub fn walk_where_predicate<'v, V: Visitor<'v>>(
             span: _,
             in_where_clause: _,
         }) => {
-            visitor.visit_lifetime(lifetime);
+            try_visit!(visitor.visit_lifetime(lifetime));
             walk_list!(visitor, visit_param_bound, bounds);
         }
         WherePredicate::EqPredicate(WhereEqPredicate { ref lhs_ty, ref rhs_ty, span: _ }) => {
-            visitor.visit_ty(lhs_ty);
-            visitor.visit_ty(rhs_ty);
+            try_visit!(visitor.visit_ty(lhs_ty));
+            try_visit!(visitor.visit_ty(rhs_ty));
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_fn_decl<'v, V: Visitor<'v>>(visitor: &mut V, function_declaration: &'v FnDecl<'v>) {
-    for ty in function_declaration.inputs {
-        visitor.visit_ty(ty)
-    }
+pub fn walk_fn_decl<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    function_declaration: &'v FnDecl<'v>,
+) -> V::Result {
+    walk_list!(visitor, visit_ty, function_declaration.inputs);
     visitor.visit_fn_ret_ty(&function_declaration.output)
 }
 
-pub fn walk_fn_ret_ty<'v, V: Visitor<'v>>(visitor: &mut V, ret_ty: &'v FnRetTy<'v>) {
-    if let FnRetTy::Return(ref output_ty) = *ret_ty {
-        visitor.visit_ty(output_ty)
+pub fn walk_fn_ret_ty<'v, V: Visitor<'v>>(visitor: &mut V, ret_ty: &'v FnRetTy<'v>) -> V::Result {
+    if let FnRetTy::Return(output_ty) = *ret_ty {
+        try_visit!(visitor.visit_ty(output_ty));
     }
+    V::Result::output()
 }
 
 pub fn walk_fn<'v, V: Visitor<'v>>(
@@ -938,73 +976,87 @@ pub fn walk_fn<'v, V: Visitor<'v>>(
     function_declaration: &'v FnDecl<'v>,
     body_id: BodyId,
     _: LocalDefId,
-) {
-    visitor.visit_fn_decl(function_declaration);
-    walk_fn_kind(visitor, function_kind);
+) -> V::Result {
+    try_visit!(visitor.visit_fn_decl(function_declaration));
+    try_visit!(walk_fn_kind(visitor, function_kind));
     visitor.visit_nested_body(body_id)
 }
 
-pub fn walk_fn_kind<'v, V: Visitor<'v>>(visitor: &mut V, function_kind: FnKind<'v>) {
+pub fn walk_fn_kind<'v, V: Visitor<'v>>(visitor: &mut V, function_kind: FnKind<'v>) -> V::Result {
     match function_kind {
         FnKind::ItemFn(_, generics, ..) => {
-            visitor.visit_generics(generics);
+            try_visit!(visitor.visit_generics(generics));
         }
         FnKind::Closure | FnKind::Method(..) => {}
     }
+    V::Result::output()
 }
 
-pub fn walk_use<'v, V: Visitor<'v>>(visitor: &mut V, path: &'v UsePath<'v>, hir_id: HirId) {
-    visitor.visit_id(hir_id);
+pub fn walk_use<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    path: &'v UsePath<'v>,
+    hir_id: HirId,
+) -> V::Result {
+    try_visit!(visitor.visit_id(hir_id));
     let UsePath { segments, ref res, span } = *path;
     for &res in res {
-        visitor.visit_path(&Path { segments, res, span }, hir_id);
+        try_visit!(visitor.visit_path(&Path { segments, res, span }, hir_id));
     }
+    V::Result::output()
 }
 
-pub fn walk_trait_item<'v, V: Visitor<'v>>(visitor: &mut V, trait_item: &'v TraitItem<'v>) {
+pub fn walk_trait_item<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    trait_item: &'v TraitItem<'v>,
+) -> V::Result {
     // N.B., deliberately force a compilation error if/when new fields are added.
     let TraitItem { ident, generics, ref defaultness, ref kind, span, owner_id: _ } = *trait_item;
     let hir_id = trait_item.hir_id();
-    visitor.visit_ident(ident);
-    visitor.visit_generics(&generics);
-    visitor.visit_defaultness(&defaultness);
-    visitor.visit_id(hir_id);
+    try_visit!(visitor.visit_ident(ident));
+    try_visit!(visitor.visit_generics(&generics));
+    try_visit!(visitor.visit_defaultness(&defaultness));
+    try_visit!(visitor.visit_id(hir_id));
     match *kind {
         TraitItemKind::Const(ref ty, default) => {
-            visitor.visit_ty(ty);
-            walk_list!(visitor, visit_nested_body, default);
+            try_visit!(visitor.visit_ty(ty));
+            visit_opt!(visitor, visit_nested_body, default);
         }
         TraitItemKind::Fn(ref sig, TraitFn::Required(param_names)) => {
-            visitor.visit_fn_decl(sig.decl);
-            for &param_name in param_names {
-                visitor.visit_ident(param_name);
-            }
+            try_visit!(visitor.visit_fn_decl(sig.decl));
+            walk_list!(visitor, visit_ident, param_names.iter().copied());
         }
         TraitItemKind::Fn(ref sig, TraitFn::Provided(body_id)) => {
-            visitor.visit_fn(
+            try_visit!(visitor.visit_fn(
                 FnKind::Method(ident, sig),
                 sig.decl,
                 body_id,
                 span,
                 trait_item.owner_id.def_id,
-            );
+            ));
         }
         TraitItemKind::Type(bounds, ref default) => {
             walk_list!(visitor, visit_param_bound, bounds);
-            walk_list!(visitor, visit_ty, default);
+            visit_opt!(visitor, visit_ty, default);
         }
     }
+    V::Result::output()
 }
 
-pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, trait_item_ref: &'v TraitItemRef) {
+pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    trait_item_ref: &'v TraitItemRef,
+) -> V::Result {
     // N.B., deliberately force a compilation error if/when new fields are added.
     let TraitItemRef { id, ident, ref kind, span: _ } = *trait_item_ref;
-    visitor.visit_nested_trait_item(id);
-    visitor.visit_ident(ident);
-    visitor.visit_associated_item_kind(kind);
+    try_visit!(visitor.visit_nested_trait_item(id));
+    try_visit!(visitor.visit_ident(ident));
+    visitor.visit_associated_item_kind(kind)
 }
 
-pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplItem<'v>) {
+pub fn walk_impl_item<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    impl_item: &'v ImplItem<'v>,
+) -> V::Result {
     // N.B., deliberately force a compilation error if/when new fields are added.
     let ImplItem {
         owner_id: _,
@@ -1016,106 +1068,118 @@ pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplIt
         vis_span: _,
     } = *impl_item;
 
-    visitor.visit_ident(ident);
-    visitor.visit_generics(generics);
-    visitor.visit_defaultness(defaultness);
-    visitor.visit_id(impl_item.hir_id());
+    try_visit!(visitor.visit_ident(ident));
+    try_visit!(visitor.visit_generics(generics));
+    try_visit!(visitor.visit_defaultness(defaultness));
+    try_visit!(visitor.visit_id(impl_item.hir_id()));
     match *kind {
         ImplItemKind::Const(ref ty, body) => {
-            visitor.visit_ty(ty);
-            visitor.visit_nested_body(body);
+            try_visit!(visitor.visit_ty(ty));
+            visitor.visit_nested_body(body)
         }
-        ImplItemKind::Fn(ref sig, body_id) => {
-            visitor.visit_fn(
-                FnKind::Method(impl_item.ident, sig),
-                sig.decl,
-                body_id,
-                impl_item.span,
-                impl_item.owner_id.def_id,
-            );
-        }
-        ImplItemKind::Type(ref ty) => {
-            visitor.visit_ty(ty);
-        }
+        ImplItemKind::Fn(ref sig, body_id) => visitor.visit_fn(
+            FnKind::Method(impl_item.ident, sig),
+            sig.decl,
+            body_id,
+            impl_item.span,
+            impl_item.owner_id.def_id,
+        ),
+        ImplItemKind::Type(ref ty) => visitor.visit_ty(ty),
     }
 }
 
 pub fn walk_foreign_item_ref<'v, V: Visitor<'v>>(
     visitor: &mut V,
     foreign_item_ref: &'v ForeignItemRef,
-) {
+) -> V::Result {
     // N.B., deliberately force a compilation error if/when new fields are added.
     let ForeignItemRef { id, ident, span: _ } = *foreign_item_ref;
-    visitor.visit_nested_foreign_item(id);
-    visitor.visit_ident(ident);
+    try_visit!(visitor.visit_nested_foreign_item(id));
+    visitor.visit_ident(ident)
 }
 
-pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, impl_item_ref: &'v ImplItemRef) {
+pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    impl_item_ref: &'v ImplItemRef,
+) -> V::Result {
     // N.B., deliberately force a compilation error if/when new fields are added.
     let ImplItemRef { id, ident, ref kind, span: _, trait_item_def_id: _ } = *impl_item_ref;
-    visitor.visit_nested_impl_item(id);
-    visitor.visit_ident(ident);
-    visitor.visit_associated_item_kind(kind);
+    try_visit!(visitor.visit_nested_impl_item(id));
+    try_visit!(visitor.visit_ident(ident));
+    visitor.visit_associated_item_kind(kind)
 }
 
-pub fn walk_trait_ref<'v, V: Visitor<'v>>(visitor: &mut V, trait_ref: &'v TraitRef<'v>) {
-    visitor.visit_id(trait_ref.hir_ref_id);
+pub fn walk_trait_ref<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    trait_ref: &'v TraitRef<'v>,
+) -> V::Result {
+    try_visit!(visitor.visit_id(trait_ref.hir_ref_id));
     visitor.visit_path(trait_ref.path, trait_ref.hir_ref_id)
 }
 
-pub fn walk_param_bound<'v, V: Visitor<'v>>(visitor: &mut V, bound: &'v GenericBound<'v>) {
+pub fn walk_param_bound<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    bound: &'v GenericBound<'v>,
+) -> V::Result {
     match *bound {
-        GenericBound::Trait(ref typ, _modifier) => {
-            visitor.visit_poly_trait_ref(typ);
-        }
+        GenericBound::Trait(ref typ, _modifier) => visitor.visit_poly_trait_ref(typ),
         GenericBound::Outlives(ref lifetime) => visitor.visit_lifetime(lifetime),
     }
 }
 
-pub fn walk_poly_trait_ref<'v, V: Visitor<'v>>(visitor: &mut V, trait_ref: &'v PolyTraitRef<'v>) {
+pub fn walk_poly_trait_ref<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    trait_ref: &'v PolyTraitRef<'v>,
+) -> V::Result {
     walk_list!(visitor, visit_generic_param, trait_ref.bound_generic_params);
-    visitor.visit_trait_ref(&trait_ref.trait_ref);
+    visitor.visit_trait_ref(&trait_ref.trait_ref)
 }
 
 pub fn walk_struct_def<'v, V: Visitor<'v>>(
     visitor: &mut V,
     struct_definition: &'v VariantData<'v>,
-) {
-    walk_list!(visitor, visit_id, struct_definition.ctor_hir_id());
+) -> V::Result {
+    visit_opt!(visitor, visit_id, struct_definition.ctor_hir_id());
     walk_list!(visitor, visit_field_def, struct_definition.fields());
+    V::Result::output()
 }
 
-pub fn walk_field_def<'v, V: Visitor<'v>>(visitor: &mut V, field: &'v FieldDef<'v>) {
-    visitor.visit_id(field.hir_id);
-    visitor.visit_ident(field.ident);
-    visitor.visit_ty(field.ty);
+pub fn walk_field_def<'v, V: Visitor<'v>>(visitor: &mut V, field: &'v FieldDef<'v>) -> V::Result {
+    try_visit!(visitor.visit_id(field.hir_id));
+    try_visit!(visitor.visit_ident(field.ident));
+    visitor.visit_ty(field.ty)
 }
 
 pub fn walk_enum_def<'v, V: Visitor<'v>>(
     visitor: &mut V,
     enum_definition: &'v EnumDef<'v>,
     item_id: HirId,
-) {
-    visitor.visit_id(item_id);
+) -> V::Result {
+    try_visit!(visitor.visit_id(item_id));
     walk_list!(visitor, visit_variant, enum_definition.variants);
+    V::Result::output()
 }
 
-pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V, variant: &'v Variant<'v>) {
-    visitor.visit_ident(variant.ident);
-    visitor.visit_id(variant.hir_id);
-    visitor.visit_variant_data(&variant.data);
-    walk_list!(visitor, visit_anon_const, &variant.disr_expr);
+pub fn walk_variant<'v, V: Visitor<'v>>(visitor: &mut V, variant: &'v Variant<'v>) -> V::Result {
+    try_visit!(visitor.visit_ident(variant.ident));
+    try_visit!(visitor.visit_id(variant.hir_id));
+    try_visit!(visitor.visit_variant_data(&variant.data));
+    visit_opt!(visitor, visit_anon_const, &variant.disr_expr);
+    V::Result::output()
 }
 
-pub fn walk_label<'v, V: Visitor<'v>>(visitor: &mut V, label: &'v Label) {
-    visitor.visit_ident(label.ident);
+pub fn walk_label<'v, V: Visitor<'v>>(visitor: &mut V, label: &'v Label) -> V::Result {
+    visitor.visit_ident(label.ident)
 }
 
-pub fn walk_inf<'v, V: Visitor<'v>>(visitor: &mut V, inf: &'v InferArg) {
-    visitor.visit_id(inf.hir_id);
+pub fn walk_inf<'v, V: Visitor<'v>>(visitor: &mut V, inf: &'v InferArg) -> V::Result {
+    visitor.visit_id(inf.hir_id)
 }
 
-pub fn walk_generic_arg<'v, V: Visitor<'v>>(visitor: &mut V, generic_arg: &'v GenericArg<'v>) {
+pub fn walk_generic_arg<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    generic_arg: &'v GenericArg<'v>,
+) -> V::Result {
     match generic_arg {
         GenericArg::Lifetime(lt) => visitor.visit_lifetime(lt),
         GenericArg::Type(ty) => visitor.visit_ty(ty),
@@ -1124,92 +1188,109 @@ pub fn walk_generic_arg<'v, V: Visitor<'v>>(visitor: &mut V, generic_arg: &'v Ge
     }
 }
 
-pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime) {
-    visitor.visit_id(lifetime.hir_id);
-    visitor.visit_ident(lifetime.ident);
+pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime) -> V::Result {
+    try_visit!(visitor.visit_id(lifetime.hir_id));
+    visitor.visit_ident(lifetime.ident)
 }
 
-pub fn walk_qpath<'v, V: Visitor<'v>>(visitor: &mut V, qpath: &'v QPath<'v>, id: HirId) {
+pub fn walk_qpath<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    qpath: &'v QPath<'v>,
+    id: HirId,
+) -> V::Result {
     match *qpath {
         QPath::Resolved(ref maybe_qself, ref path) => {
-            walk_list!(visitor, visit_ty, maybe_qself);
+            visit_opt!(visitor, visit_ty, maybe_qself);
             visitor.visit_path(path, id)
         }
         QPath::TypeRelative(ref qself, ref segment) => {
-            visitor.visit_ty(qself);
-            visitor.visit_path_segment(segment);
+            try_visit!(visitor.visit_ty(qself));
+            visitor.visit_path_segment(segment)
         }
-        QPath::LangItem(..) => {}
+        QPath::LangItem(..) => V::Result::output(),
     }
 }
 
-pub fn walk_path<'v, V: Visitor<'v>>(visitor: &mut V, path: &Path<'v>) {
-    for segment in path.segments {
-        visitor.visit_path_segment(segment);
-    }
+pub fn walk_path<'v, V: Visitor<'v>>(visitor: &mut V, path: &Path<'v>) -> V::Result {
+    walk_list!(visitor, visit_path_segment, path.segments);
+    V::Result::output()
 }
 
-pub fn walk_path_segment<'v, V: Visitor<'v>>(visitor: &mut V, segment: &'v PathSegment<'v>) {
-    visitor.visit_ident(segment.ident);
-    visitor.visit_id(segment.hir_id);
-    if let Some(ref args) = segment.args {
-        visitor.visit_generic_args(args);
-    }
+pub fn walk_path_segment<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    segment: &'v PathSegment<'v>,
+) -> V::Result {
+    try_visit!(visitor.visit_ident(segment.ident));
+    try_visit!(visitor.visit_id(segment.hir_id));
+    visit_opt!(visitor, visit_generic_args, segment.args);
+    V::Result::output()
 }
 
-pub fn walk_generic_args<'v, V: Visitor<'v>>(visitor: &mut V, generic_args: &'v GenericArgs<'v>) {
+pub fn walk_generic_args<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    generic_args: &'v GenericArgs<'v>,
+) -> V::Result {
     walk_list!(visitor, visit_generic_arg, generic_args.args);
     walk_list!(visitor, visit_assoc_type_binding, generic_args.bindings);
+    V::Result::output()
 }
 
 pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(
     visitor: &mut V,
     type_binding: &'v TypeBinding<'v>,
-) {
-    visitor.visit_id(type_binding.hir_id);
-    visitor.visit_ident(type_binding.ident);
-    visitor.visit_generic_args(type_binding.gen_args);
+) -> V::Result {
+    try_visit!(visitor.visit_id(type_binding.hir_id));
+    try_visit!(visitor.visit_ident(type_binding.ident));
+    try_visit!(visitor.visit_generic_args(type_binding.gen_args));
     match type_binding.kind {
         TypeBindingKind::Equality { ref term } => match term {
-            Term::Ty(ref ty) => visitor.visit_ty(ty),
-            Term::Const(ref c) => visitor.visit_anon_const(c),
+            Term::Ty(ref ty) => try_visit!(visitor.visit_ty(ty)),
+            Term::Const(ref c) => try_visit!(visitor.visit_anon_const(c)),
         },
         TypeBindingKind::Constraint { bounds } => walk_list!(visitor, visit_param_bound, bounds),
     }
+    V::Result::output()
 }
 
-pub fn walk_associated_item_kind<'v, V: Visitor<'v>>(_: &mut V, _: &'v AssocItemKind) {
+pub fn walk_associated_item_kind<'v, V: Visitor<'v>>(_: &mut V, _: &'v AssocItemKind) -> V::Result {
     // No visitable content here: this fn exists so you can call it if
     // the right thing to do, should content be added in the future,
     // would be to walk it.
+    V::Result::output()
 }
 
-pub fn walk_defaultness<'v, V: Visitor<'v>>(_: &mut V, _: &'v Defaultness) {
+pub fn walk_defaultness<'v, V: Visitor<'v>>(_: &mut V, _: &'v Defaultness) -> V::Result {
     // No visitable content here: this fn exists so you can call it if
     // the right thing to do, should content be added in the future,
     // would be to walk it.
+    V::Result::output()
 }
 
-pub fn walk_inline_asm<'v, V: Visitor<'v>>(visitor: &mut V, asm: &'v InlineAsm<'v>, id: HirId) {
+pub fn walk_inline_asm<'v, V: Visitor<'v>>(
+    visitor: &mut V,
+    asm: &'v InlineAsm<'v>,
+    id: HirId,
+) -> V::Result {
     for (op, op_sp) in asm.operands {
         match op {
             InlineAsmOperand::In { expr, .. } | InlineAsmOperand::InOut { expr, .. } => {
-                visitor.visit_expr(expr)
+                try_visit!(visitor.visit_expr(expr));
             }
             InlineAsmOperand::Out { expr, .. } => {
-                if let Some(expr) = expr {
-                    visitor.visit_expr(expr);
-                }
+                visit_opt!(visitor, visit_expr, expr);
             }
             InlineAsmOperand::SplitInOut { in_expr, out_expr, .. } => {
-                visitor.visit_expr(in_expr);
-                if let Some(out_expr) = out_expr {
-                    visitor.visit_expr(out_expr);
-                }
+                try_visit!(visitor.visit_expr(in_expr));
+                visit_opt!(visitor, visit_expr, out_expr);
             }
             InlineAsmOperand::Const { anon_const, .. }
-            | InlineAsmOperand::SymFn { anon_const, .. } => visitor.visit_anon_const(anon_const),
-            InlineAsmOperand::SymStatic { path, .. } => visitor.visit_qpath(path, id, *op_sp),
+            | InlineAsmOperand::SymFn { anon_const, .. } => {
+                try_visit!(visitor.visit_anon_const(anon_const));
+            }
+            InlineAsmOperand::SymStatic { path, .. } => {
+                try_visit!(visitor.visit_qpath(path, id, *op_sp));
+            }
         }
     }
+    V::Result::output()
 }


### PR DESCRIPTION
Alternative to #108598.

Since rust-lang/libs-team#187 was rejected, this implements our own version of the `Try` trait (`VisitorResult`) and the `try` macro (`try_visit`). Since this change still allows visitors to return `()`, no changes have been made to the existing ones. They can be done in a separate PR.
