### PR TITLE
Add vector time complexity

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1493,7 +1493,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Time complexity
     ///
-    /// Takes *O*(`len`) time. All items after the insertion index must be
+    /// Takes *O*([`Vec::len`]) time. All items after the insertion index must be
     /// shifted to the right. In the worst case, all elements are shifted when
     /// the insertion index is 0.
     #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1922,10 +1922,9 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Time complexity
     ///
     /// Takes amortized *O*(1) time. If the vector's length would exceed its
-    /// capacity after the push, the capacity is doubled by allocating
-    /// *O*(*capacity*) space, then *O*(*capacity*) time to copy the vector's
-    /// elements. This expensive operation is offset by the *capacity* *O*(1)
-    /// insertions it allows.
+    /// capacity after the push, *O*(*capacity*) time is taken to copy the
+    /// vector's elements to a larger allocation. This expensive operation is
+    /// offset by the *capacity* *O*(1) insertions it allows.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1490,6 +1490,12 @@ impl<T, A: Allocator> Vec<T, A> {
     /// vec.insert(4, 5);
     /// assert_eq!(vec, [1, 4, 2, 3, 5]);
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(`len`) time. All items after the insertion index must be
+    /// shifted to the right. In the worst case, all elements are shifted when
+    /// the insertion index is 0.
     #[cfg(not(no_global_oom_handling))]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, index: usize, element: T) {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1912,6 +1912,13 @@ impl<T, A: Allocator> Vec<T, A> {
     /// vec.push(3);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes amortized *O*(1) time. If the vector's length would exceed its capacity after
+    /// the push,*O*(*capacity*) space is allocated, doubling the capacity and
+    /// taking *O*(*capacity*) time. This expensive operation is offset by the
+    /// *capacity* *O*(1) insertions it allows.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1922,7 +1922,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Time complexity
     ///
     /// Takes amortized *O*(1) time. If the vector's length would exceed its capacity after
-    /// the push,*O*(*capacity*) space is allocated, doubling the capacity and
+    /// the push, *O*(*capacity*) space is allocated, doubling the capacity and
     /// taking *O*(*capacity*) time. This expensive operation is offset by the
     /// *capacity* *O*(1) insertions it allows.
     #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1921,10 +1921,11 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Time complexity
     ///
-    /// Takes amortized *O*(1) time. If the vector's length would exceed its capacity after
-    /// the push, *O*(*capacity*) space is allocated, doubling the capacity and
-    /// taking *O*(*capacity*) time. This expensive operation is offset by the
-    /// *capacity* *O*(1) insertions it allows.
+    /// Takes amortized *O*(1) time. If the vector's length would exceed its
+    /// capacity after the push, the capacity is doubled by allocating
+    /// *O*(*capacity*) space, then *O*(*capacity*) time to copy the vector's
+    /// elements. This expensive operation is offset by the *capacity* *O*(1)
+    /// insertions it allows.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1999,6 +1999,10 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec.pop(), Some(3));
     /// assert_eq!(vec, [1, 2]);
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(1) time.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn pop(&mut self) -> Option<T> {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1966,6 +1966,10 @@ impl<T, A: Allocator> Vec<T, A> {
     /// }
     /// assert_eq!(from_iter_fallible(0..100), Ok(Vec::from_iter(0..100)));
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(1) time.
     #[inline]
     #[unstable(feature = "vec_push_within_capacity", issue = "100486")]
     pub fn push_within_capacity(&mut self, value: T) -> Result<(), T> {


### PR DESCRIPTION
Added time complexity for `Vec` methods `push`, `push_within_capacity`, `pop`, and `insert`.


<details>

<summary> Reference images </summary>

![`Vec::push` documentation](https://github.com/rust-lang/rust/assets/78604367/dc966bbd-e92e-45a6-af82-35afabfa79a9)

![`Vec::push_within_capacity` documentation](https://github.com/rust-lang/rust/assets/78604367/9aadaf48-46ed-4fad-bdd5-74b98a61f4bb)

![`Vec::pop` documentation](https://github.com/rust-lang/rust/assets/78604367/88ec0389-a346-4ea5-a3b7-17caf514dd8b)

![`Vec::insert` documentation](https://github.com/rust-lang/rust/assets/78604367/960c15c3-ef8e-4aa7-badc-35ce80f6f221)

</details>

I followed a convention to use `#Time complexity` that I found in [the `BinaryHeap` documentation](https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#time-complexity-1). Looking through the rest of standard library collections, there is not a consistent way to handle this. 

[`Vec::swap_remove`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.swap_remove) does not have a dedicated section for time complexity but does list it. 

[`VecDeque::rotate_left`](https://doc.rust-lang.org/std/collections/struct.VecDeque.html#complexity) uses a `#complexity` heading.