### PR TITLE
Refactor the way interpreters handle special functions

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -398,7 +398,6 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
     fn find_mir_or_extra_fn(
         ecx: &mut InterpCx<'mir, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
-        _abi: CallAbi,
     ) -> InterpResult<'tcx, Either<&'mir mir::Body<'tcx>, Self::ExtraFnVal>> {
         debug!("find_mir_or_extra_fn: {:?}", instance);
 

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -184,14 +184,11 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
 
     /// Entry point to all function calls.
     ///
-    /// Returns either the mir to use for the call, or `None` if execution should
-    /// just proceed (which usually means this hook did all the work that the
-    /// called function should usually have done). In the latter case, it is
-    /// this hook's responsibility to advance the instruction pointer!
-    /// (This is to support functions like `__rust_maybe_catch_panic` that neither find a MIR
-    /// nor just jump to `ret`, but instead push their own stack frame.)
-    /// Passing `dest`and `ret` in the same `Option` proved very annoying when only one of them
-    /// was used.
+    /// Returns either the mir to use for the call, or an [`ExtraFnVal`] for special functions
+    /// handled by [`call_extra_fn`].
+    ///
+    /// [`ExtraFnVal`]: Machine::ExtraFnVal
+    /// [`call_extra_fn`]: Machine::call_extra_fn
     fn find_mir_or_extra_fn(
         ecx: &mut InterpCx<'mir, 'tcx, Self>,
         instance: ty::Instance<'tcx>,

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -195,7 +195,6 @@ pub trait Machine<'mir, 'tcx: 'mir>: Sized {
     fn find_mir_or_extra_fn(
         ecx: &mut InterpCx<'mir, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
-        abi: CallAbi,
     ) -> InterpResult<'tcx, Either<&'mir mir::Body<'tcx>, Self::ExtraFnVal>>;
 
     /// Execute `fn_val`. It is the hook's responsibility to advance the instruction

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -550,7 +550,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             | ty::InstanceDef::ThreadLocalShim(..)
             | ty::InstanceDef::Item(_) => {
                 // We need MIR for this fn
-                let body = match M::find_mir_or_extra_fn(self, instance, caller_abi)? {
+                let body = match M::find_mir_or_extra_fn(self, instance)? {
                     Either::Left(b) => b,
                     Either::Right(f) => {
                         return M::call_extra_fn(

--- a/compiler/rustc_const_eval/src/interpret/terminator.rs
+++ b/compiler/rustc_const_eval/src/interpret/terminator.rs
@@ -498,7 +498,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// `with_caller_location` indicates whether the caller passed a caller location. Miri
     /// implements caller locations without argument passing, but to match `FnAbi` we need to know
     /// when those arguments are present.
-    pub(crate) fn eval_fn_call(
+    pub fn eval_fn_call(
         &mut self,
         fn_val: FnVal<'tcx, M::ExtraFnVal>,
         (caller_abi, caller_fn_abi): (Abi, &FnAbi<'tcx, Ty<'tcx>>),

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -2,6 +2,7 @@
 //!
 //! Currently, this pass only propagates scalar values.
 
+use either::Either;
 use rustc_const_eval::interpret::{
     ImmTy, Immediate, InterpCx, OpTy, PlaceTy, PointerArithmetic, Projectable,
 };
@@ -867,6 +868,7 @@ pub(crate) struct DummyMachine;
 impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for DummyMachine {
     rustc_const_eval::interpret::compile_time_machine!(<'mir, 'tcx>);
     type MemoryKind = !;
+    type ExtraFnVal = !;
     const PANIC_ON_ALLOC_FAIL: bool = true;
 
     #[inline(always)]
@@ -899,15 +901,11 @@ impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for Dumm
         Ok(())
     }
 
-    fn find_mir_or_eval_fn(
+    fn find_mir_or_extra_fn(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _instance: ty::Instance<'tcx>,
         _abi: rustc_target::spec::abi::Abi,
-        _args: &[rustc_const_eval::interpret::FnArg<'tcx, Self::Provenance>],
-        _destination: &rustc_const_eval::interpret::PlaceTy<'tcx, Self::Provenance>,
-        _target: Option<BasicBlock>,
-        _unwind: UnwindAction,
-    ) -> interpret::InterpResult<'tcx, Option<(&'mir Body<'tcx>, ty::Instance<'tcx>)>> {
+    ) -> interpret::InterpResult<'tcx, Either<&'mir Body<'tcx>, Self::ExtraFnVal>> {
         unimplemented!()
     }
 
@@ -1015,5 +1013,17 @@ impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for Dumm
         rustc_const_eval::interpret::Frame<'mir, 'tcx, Self::Provenance, Self::FrameExtra>,
     > {
         unimplemented!()
+    }
+
+    fn call_extra_fn(
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        fn_val: Self::ExtraFnVal,
+        _: (rustc_target::spec::abi::Abi, &rustc_target::abi::call::FnAbi<'tcx, Ty<'tcx>>),
+        _args: &[rustc_const_eval::interpret::FnArg<'tcx, Self::Provenance>],
+        _destination: &PlaceTy<'tcx, Self::Provenance>,
+        _target: Option<rustc_middle::mir::BasicBlock>,
+        _unwind: rustc_middle::mir::UnwindAction,
+    ) -> InterpResult<'tcx> {
+        match fn_val {}
     }
 }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -904,7 +904,6 @@ impl<'mir, 'tcx: 'mir> rustc_const_eval::interpret::Machine<'mir, 'tcx> for Dumm
     fn find_mir_or_extra_fn(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _instance: ty::Instance<'tcx>,
-        _abi: rustc_target::spec::abi::Abi,
     ) -> interpret::InterpResult<'tcx, Either<&'mir Body<'tcx>, Self::ExtraFnVal>> {
         unimplemented!()
     }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -258,6 +258,7 @@ fn panic_in_cleanup() -> ! {
 
 /// This function is used instead of panic_fmt in const eval.
 #[lang = "const_panic_fmt"]
+#[track_caller]
 #[rustc_const_unstable(feature = "panic_internals", issue = "none")]
 pub const fn const_panic_fmt(fmt: fmt::Arguments<'_>) -> ! {
     if let Some(msg) = fmt.as_str() {

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -997,7 +997,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         link_name: Symbol,
     ) -> InterpResult<'tcx, ()> {
         self.check_abi(abi, exp_abi)?;
-        if let Some((body, instance)) = self.eval_context_mut().lookup_exported_symbol(link_name)? {
+        if let Some(instance) = self.eval_context_mut().lookup_exported_symbol(link_name)? {
             // If compiler-builtins is providing the symbol, then don't treat it as a clash.
             // We'll use our built-in implementation in `emulate_foreign_item_inner` for increased
             // performance. Note that this means we won't catch any undefined behavior in
@@ -1006,6 +1006,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             if self.eval_context_ref().tcx.is_compiler_builtins(instance.def_id().krate) {
                 return Ok(());
             }
+
+            let body = self.eval_context_mut().load_mir(instance.def, None)?;
 
             throw_machine_stop!(TerminationInfo::SymbolShimClashing {
                 link_name,

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -943,7 +943,6 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for MiriMachine<'mir, 'tcx> {
     fn find_mir_or_extra_fn(
         ecx: &mut MiriInterpCx<'mir, 'tcx>,
         instance: ty::Instance<'tcx>,
-        abi: Abi,
     ) -> InterpResult<'tcx, Either<&'mir mir::Body<'tcx>, ExtraFnVal>> {
         // For foreign items, we return `ExtraFnVal::ForeignFn` to later try to see if we can
         // emulate them.

--- a/src/tools/miri/src/shims/extern_static.rs
+++ b/src/tools/miri/src/shims/extern_static.rs
@@ -1,6 +1,6 @@
 //! Provides the `extern static` that this platform expects.
 
-use crate::*;
+use crate::{shims::foreign_items::ExtraFnVal, *};
 
 impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
     fn alloc_extern_static(
@@ -62,7 +62,7 @@ impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
                 // "signal" -- just needs a non-zero pointer value (function does not even get called),
                 // but we arrange for this to call the `signal` function anyway.
                 let layout = this.machine.layouts.const_raw_ptr;
-                let ptr = this.fn_ptr(FnVal::Other(DynSym::from_str("signal")));
+                let ptr = this.fn_ptr(FnVal::Other(ExtraFnVal::DynSym(DynSym::from_str("signal"))));
                 let val = ImmTy::from_scalar(Scalar::from_pointer(ptr, this), layout);
                 Self::alloc_extern_static(this, "signal", val)?;
             }

--- a/src/tools/miri/src/shims/unix/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/foreign_items.rs
@@ -6,6 +6,7 @@ use rustc_span::Symbol;
 use rustc_target::abi::{Align, Size};
 use rustc_target::spec::abi::Abi;
 
+use crate::shims::foreign_items::ExtraFnVal;
 use crate::*;
 use shims::foreign_items::EmulateForeignItemResult;
 use shims::unix::fs::EvalContextExt as _;
@@ -308,7 +309,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let symbol = this.read_pointer(symbol)?;
                 let name = this.read_c_str(symbol)?;
                 if let Ok(name) = str::from_utf8(name) && is_dyn_sym(name, &this.tcx.sess.target.os) {
-                    let ptr = this.fn_ptr(FnVal::Other(DynSym::from_str(name)));
+                    let ptr = this.fn_ptr(FnVal::Other(ExtraFnVal::DynSym(DynSym::from_str(name))));
                     this.write_pointer(ptr, dest)?;
                 } else {
                     this.write_null(dest)?;

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -5,6 +5,7 @@ use rustc_span::Symbol;
 use rustc_target::abi::Size;
 use rustc_target::spec::abi::Abi;
 
+use crate::shims::foreign_items::ExtraFnVal;
 use crate::*;
 use shims::foreign_items::EmulateForeignItemResult;
 use shims::windows::handle::{EvalContextExt as _, Handle, PseudoHandle};
@@ -366,7 +367,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 if let Ok(name) = str::from_utf8(name)
                     && is_dyn_sym(name)
                 {
-                    let ptr = this.fn_ptr(FnVal::Other(DynSym::from_str(name)));
+                    let ptr = this.fn_ptr(FnVal::Other(ExtraFnVal::DynSym(DynSym::from_str(name))));
                     this.write_pointer(ptr, dest)?;
                 } else {
                     this.write_null(dest)?;


### PR DESCRIPTION
... by reusing the `ExtraFnVal` type.

This changes `find_mir_or_eval_fn` into `find_mir_or_extra_fn`, which helps structure code a little bit better. Having separate "find info for evaluation" and "evaluate" steps is nice on its own, but it's also required for tail calls.

(this is needed for #113128, as otherwise correctly implementing tail calls in the interpreter creates a dependency loop)

r? @oli-obk 