### PR TITLE
Report a specialized error when a `'static` obligation comes from an `impl dyn Trait`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,6 +3580,7 @@ dependencies = [
  "either",
  "itertools 0.12.1",
  "polonius-engine",
+ "rustc_ast",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_fluent_macro",

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 either = "1.5.0"
 itertools = "0.12"
 polonius-engine = "0.13.0"
+rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -643,7 +643,9 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         let mut parent = tcx.parent(def_id);
         debug!(?def_id, ?parent);
         let trait_preds = match tcx.def_kind(parent) {
-            hir::def::DefKind::Impl { .. } => &[],
+            hir::def::DefKind::Impl { .. } => {
+                tcx.trait_id_of_impl(parent).map_or(&[][..], |id| tcx.predicates_of(id).predicates)
+            }
             hir::def::DefKind::Trait => {
                 let Some(ty) = args.get(0).and_then(|arg| arg.as_type()) else {
                     return;

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -745,6 +745,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 diag.span_suggestion_verbose(span, msg, sugg, Applicability::MachineApplicable);
                 // This is redundant but needed because we won't enter the section with the
                 // additional note, so we point at the method call here too.
+                diag.replace_span_with(*call_span, false);
                 diag.span_label(
                     *call_span,
                     "calling this method introduces a `'static` lifetime requirement",
@@ -765,6 +766,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             predicates.push(tcx.def_span(parent));
         }
         if !predicates.is_empty() {
+            diag.replace_span_with(*call_span, false);
             diag.span_label(
                 *call_span,
                 "calling this method introduces a `'static` lifetime requirement",

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -616,6 +616,8 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
     /// LL |         fn hello(&self) where Self: 'static {}
     ///    |                                     ^^^^^^^
     /// ```
+    #[allow(rustc::diagnostic_outside_of_impl)]
+    #[allow(rustc::untranslatable_diagnostic)]
     fn explain_impl_static_obligation(
         &self,
         diag: &mut Diag<'_>,

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -675,12 +675,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         if self.to_error_region(outlived_fr) != Some(tcx.lifetimes.re_static) {
             return;
         }
-        // FIXME: there's a case that's yet to be handled: `impl dyn Trait + '_ where Self: '_`
-        // causes *two* errors to be produded, one about `where Self: '_` not being allowed,
-        // and the regular error with no additional information about "lifetime may not live
-        // long enough for `'static`" without mentioning where it came from. This is because
-        // our error recovery fallback is indeed `ReStatic`. We should at some point introduce
-        // a `ReError` instead to avoid this and other similar issues.
 
         // Look for `'static` bounds in the generics of the method and the `impl`.
         // ```

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -2051,6 +2051,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         CRATE_DEF_ID.to_def_id(),
                         predicate_span,
                     ))
+                } else if let ConstraintCategory::CallArgument(Some(fn_def)) = constraint.category {
+                    Some(ObligationCauseCode::MethodCallConstraint(fn_def, constraint.span))
                 } else {
                     None
                 }

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -2057,7 +2057,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     None
                 }
             })
-            .unwrap_or_else(|| ObligationCauseCode::MiscObligation);
+            .unwrap_or(ObligationCauseCode::MiscObligation);
 
         // Classify each of the constraints along the path.
         let mut categorized_path: Vec<BlameConstraint<'tcx>> = path

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -481,7 +481,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                 // couldn't be met.
                                 err.span_note(
                                     relevant_bindings,
-                                    format!("unmet `{sub}` obligations introduced here"),
+                                    format!("`{sub}` requirement introduced here"),
                                 );
                             }
                         }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -485,7 +485,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                     )) = pred.kind().no_bound_vars()
                                         && r == sub
                                         && let ty::Param(param) = pred_ty.kind()
-                                        && param.name.as_str() == "Self"
+                                        && param.name == kw::SelfUpper
                                     {
                                         Some(*span)
                                     } else {

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -4,6 +4,7 @@ use crate::infer::outlives::components::{push_outlives_components, Component};
 use crate::traits::{self, Obligation, PredicateObligation};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::ty::{self, ToPredicate, Ty, TyCtxt};
+use rustc_span::def_id::DefId;
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
 
@@ -233,6 +234,16 @@ pub fn elaborate<'tcx, O: Elaboratable<'tcx>>(
         Elaborator { stack: Vec::new(), visited: PredicateSet::new(tcx), mode: Filter::All };
     elaborator.extend_deduped(obligations);
     elaborator
+}
+
+pub fn elaborate_predicates_of<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+) -> Elaborator<'tcx, (ty::Predicate<'tcx>, Span)> {
+    elaborate(
+        tcx,
+        tcx.predicates_of(def_id).predicates.iter().map(|(p, sp)| (p.as_predicate(), *sp)),
+    )
 }
 
 impl<'tcx, O: Elaboratable<'tcx>> Elaborator<'tcx, O> {

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -451,6 +451,9 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// Obligations emitted during the normalization of a weak type alias.
     TypeAlias(InternedObligationCauseCode<'tcx>, Span, DefId),
+
+    /// During borrowck we've found a method call that could have introduced a lifetime requirement.
+    MethodCallConstraint(Ty<'tcx>, Span),
 }
 
 /// Whether a value can be extracted into a const.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2726,6 +2726,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             | ObligationCauseCode::MethodReceiver
             | ObligationCauseCode::ReturnNoExpression
             | ObligationCauseCode::UnifyReceiver(..)
+            | ObligationCauseCode::MethodCallConstraint(..)
             | ObligationCauseCode::MiscObligation
             | ObligationCauseCode::WellFormed(..)
             | ObligationCauseCode::MatchImpl(..)

--- a/src/tools/clippy/tests/ui/crashes/ice-6256.fixed
+++ b/src/tools/clippy/tests/ui/crashes/ice-6256.fixed
@@ -1,0 +1,15 @@
+// originally from rustc ./tests/ui/regions/issue-78262.rs
+// ICE: to get the signature of a closure, use args.as_closure().sig() not fn_sig()
+#![allow(clippy::upper_case_acronyms)]
+
+trait TT {}
+
+impl dyn TT + '_ {
+    fn func(&self) {}
+}
+
+#[rustfmt::skip]
+fn main() {
+    let f = |x: &dyn TT| x.func();
+    //~^ ERROR: borrowed data escapes outside of closure
+}

--- a/src/tools/clippy/tests/ui/crashes/ice-6256.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6256.stderr
@@ -8,6 +8,11 @@ LL |     let f = |x: &dyn TT| x.func();
    |              |  |        argument requires that `'1` must outlive `'static`
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
+   |
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL | impl dyn TT + '_ {
+   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0478.stderr
+++ b/tests/ui/error-codes/E0478.stderr
@@ -1,8 +1,8 @@
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/E0478.rs:4:12
+  --> $DIR/E0478.rs:4:37
    |
 LL |     child: Box<dyn Wedding<'kiss> + 'SnowWhite>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     ^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'SnowWhite` as defined here
   --> $DIR/E0478.rs:3:22

--- a/tests/ui/error-codes/E0478.stderr
+++ b/tests/ui/error-codes/E0478.stderr
@@ -2,7 +2,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/E0478.rs:4:37
    |
 LL |     child: Box<dyn Wedding<'kiss> + 'SnowWhite>,
-   |                                     ^^^^^^^^^^
+   |                                     ^^^^^^^^^^ lifetime bound not satisfied
    |
 note: lifetime parameter instantiated with the lifetime `'SnowWhite` as defined here
   --> $DIR/E0478.rs:3:22

--- a/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.stderr
+++ b/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.stderr
@@ -32,10 +32,10 @@ LL |     type Y<'a> = &'a () where 'a: 'static;
    |                         +++++++++++++++++
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:14:8
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:14:20
    |
 LL |     f: <T as X>::Y<'a>,
-   |        ^^^^^^^^^^^^^^^
+   |                    ^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatisfied-item-lifetime-bound.rs:13:10
@@ -43,12 +43,17 @@ note: lifetime parameter instantiated with the lifetime `'a` as defined here
 LL | struct B<'a, T: for<'r> X<Y<'r> = &'r ()>> {
    |          ^^
    = note: but lifetime parameter must outlive the static lifetime
+note: `'static` requirement introduced here
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:4:16
+   |
+LL |     type Y<'a: 'static>;
+   |                ^^^^^^^
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:19:8
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:19:20
    |
 LL |     f: <T as X>::Y<'a>,
-   |        ^^^^^^^^^^^^^^^
+   |                    ^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatisfied-item-lifetime-bound.rs:18:10
@@ -56,12 +61,17 @@ note: lifetime parameter instantiated with the lifetime `'a` as defined here
 LL | struct C<'a, T: X> {
    |          ^^
    = note: but lifetime parameter must outlive the static lifetime
+note: `'static` requirement introduced here
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:4:16
+   |
+LL |     type Y<'a: 'static>;
+   |                ^^^^^^^
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/unsatisfied-item-lifetime-bound.rs:24:8
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:24:21
    |
 LL |     f: <() as X>::Y<'a>,
-   |        ^^^^^^^^^^^^^^^^
+   |                     ^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatisfied-item-lifetime-bound.rs:23:10
@@ -69,6 +79,11 @@ note: lifetime parameter instantiated with the lifetime `'a` as defined here
 LL | struct D<'a> {
    |          ^^
    = note: but lifetime parameter must outlive the static lifetime
+note: `'static` requirement introduced here
+  --> $DIR/unsatisfied-item-lifetime-bound.rs:4:16
+   |
+LL |     type Y<'a: 'static>;
+   |                ^^^^^^^
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.stderr
+++ b/tests/ui/generic-associated-types/unsatisfied-item-lifetime-bound.stderr
@@ -35,7 +35,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/unsatisfied-item-lifetime-bound.rs:14:20
    |
 LL |     f: <T as X>::Y<'a>,
-   |                    ^^
+   |                    ^^ lifetime bound not satisfied
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatisfied-item-lifetime-bound.rs:13:10
@@ -53,7 +53,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/unsatisfied-item-lifetime-bound.rs:19:20
    |
 LL |     f: <T as X>::Y<'a>,
-   |                    ^^
+   |                    ^^ lifetime bound not satisfied
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatisfied-item-lifetime-bound.rs:18:10
@@ -71,7 +71,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/unsatisfied-item-lifetime-bound.rs:24:21
    |
 LL |     f: <() as X>::Y<'a>,
-   |                     ^^
+   |                     ^^ lifetime bound not satisfied
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/unsatisfied-item-lifetime-bound.rs:23:10

--- a/tests/ui/lifetimes/dyn-trait-static-obligation.rs
+++ b/tests/ui/lifetimes/dyn-trait-static-obligation.rs
@@ -1,0 +1,47 @@
+use std::cell::*;
+
+#[derive(Default)]
+struct Test {
+    pub foo: u32,
+}
+
+trait FooSetter {
+    fn set_foo(&mut self, value: u32);
+}
+
+impl FooSetter for Test {
+    fn set_foo(&mut self, value: u32) {
+        self.foo = value;
+    }
+}
+
+trait BaseSetter{
+    fn set(&mut self, value: u32);
+}
+impl BaseSetter for dyn FooSetter {
+    fn set(&mut self, value: u32){
+        self.set_foo(value);
+    }
+}
+
+struct TestHolder<'a> {
+    pub holder: Option<RefCell<&'a mut dyn FooSetter>>,
+}
+
+impl <'a>TestHolder<'a>{
+    pub fn test_foo(&self){
+       self.holder.as_ref().unwrap().borrow_mut().set(20);
+       //~^ ERROR borrowed data escapes outside of method
+    }
+}
+
+fn main() {
+    let mut test = Test::default();
+    test.foo = 10;
+    {
+        let holder = TestHolder { holder: Some(RefCell::from(&mut test))};
+
+        holder.test_foo();
+    }
+    test.foo = 30;
+}

--- a/tests/ui/lifetimes/dyn-trait-static-obligation.stderr
+++ b/tests/ui/lifetimes/dyn-trait-static-obligation.stderr
@@ -1,0 +1,24 @@
+error[E0521]: borrowed data escapes outside of method
+  --> $DIR/dyn-trait-static-obligation.rs:33:8
+   |
+LL | impl <'a>TestHolder<'a>{
+   |       -- lifetime `'a` defined here
+LL |     pub fn test_foo(&self){
+   |                     ----- `self` is a reference that is only valid in the method body
+LL |        self.holder.as_ref().unwrap().borrow_mut().set(20);
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        `self` escapes the method body here
+   |        argument requires that `'a` must outlive `'static`
+   |
+   = note: requirement occurs because of a mutable reference to `dyn FooSetter`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL | impl BaseSetter for dyn FooSetter + '_ {
+   |                                   ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.rs
+++ b/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.rs
@@ -1,0 +1,6 @@
+use std::any::Any;
+
+struct Something<'a> {
+    broken: Box<dyn Any + 'a> //~ ERROR lifetime bound not satisfied
+}
+fn main() {}

--- a/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.stderr
+++ b/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.stderr
@@ -10,7 +10,7 @@ note: lifetime parameter instantiated with the lifetime `'a` as defined here
 LL | struct Something<'a> {
    |                  ^^
    = note: but lifetime parameter must outlive the static lifetime
-note: unmet `'static` obligations introduced here
+note: `'static` requirement introduced here
   --> $SRC_DIR/core/src/any.rs:LL:COL
 
 error: aborting due to 1 previous error

--- a/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.stderr
+++ b/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.stderr
@@ -1,0 +1,18 @@
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/point-at-lifetime-obligation-from-trait-in-trait-object.rs:4:21
+   |
+LL |     broken: Box<dyn Any + 'a>
+   |                     ^^^   ^^
+   |
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
+  --> $DIR/point-at-lifetime-obligation-from-trait-in-trait-object.rs:3:18
+   |
+LL | struct Something<'a> {
+   |                  ^^
+   = note: but lifetime parameter must outlive the static lifetime
+note: unmet `'static` obligations introduced here
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0478`.

--- a/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.stderr
+++ b/tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.stderr
@@ -1,8 +1,10 @@
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/point-at-lifetime-obligation-from-trait-in-trait-object.rs:4:21
+  --> $DIR/point-at-lifetime-obligation-from-trait-in-trait-object.rs:4:27
    |
 LL |     broken: Box<dyn Any + 'a>
-   |                     ^^^   ^^
+   |                     ---   ^^ lifetime bound not satisfied
+   |                     |
+   |                     this requires `'static`
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/point-at-lifetime-obligation-from-trait-in-trait-object.rs:3:18

--- a/tests/ui/lifetimes/static-impl-obligation.rs
+++ b/tests/ui/lifetimes/static-impl-obligation.rs
@@ -272,8 +272,8 @@ mod w {
 
     }
     fn convert<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 fn main() {}

--- a/tests/ui/lifetimes/static-impl-obligation.rs
+++ b/tests/ui/lifetimes/static-impl-obligation.rs
@@ -207,4 +207,73 @@ mod s {
         y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
+mod t {
+    trait OtherTrait<'a> {}
+    impl<'a> OtherTrait<'a> for &'a () {}
+
+    trait ObjectTrait {}
+    trait MyTrait where Self: 'static {
+        fn use_self(&self) -> &() where Self: 'static { panic!() }
+    }
+    trait Irrelevant {
+        fn use_self(&self) -> &() { panic!() }
+    }
+
+    impl MyTrait for dyn ObjectTrait + '_ {} //~ ERROR lifetime bound not satisfied
+
+    fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
+        val.use_self() //~ ERROR borrowed data escapes
+    }
+}
+mod u {
+    trait OtherTrait<'a> {}
+    impl<'a> OtherTrait<'a> for &'a () {}
+
+    trait ObjectTrait {}
+    trait MyTrait {
+        fn use_self(&self) -> &() where Self: 'static { panic!() }
+    }
+    trait Irrelevant {
+        fn use_self(&self) -> &() { panic!() }
+    }
+
+    impl MyTrait for dyn ObjectTrait + '_ {}
+
+    fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
+        val.use_self() //~ ERROR borrowed data escapes
+    }
+}
+mod v {
+    trait OtherTrait<'a> {}
+    impl<'a> OtherTrait<'a> for &'a () {}
+
+    trait ObjectTrait {}
+    trait MyTrait where Self: 'static {
+        fn use_self(&'static self) -> &() { panic!() }
+    }
+    trait Irrelevant {
+        fn use_self(&self) -> &() { panic!() }
+    }
+
+    impl MyTrait for dyn ObjectTrait {}
+
+    fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
+        val.use_self() //~ ERROR borrowed data escapes
+    }
+}
+mod w {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+
+    trait Trait where Self: 'static { fn hello(&self) {} }
+
+    impl Trait for dyn Foo + '_ { //~ERROR lifetime bound not satisfied
+        fn hello(&self) {}
+
+    }
+    fn convert<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
 fn main() {}

--- a/tests/ui/lifetimes/static-impl-obligation.rs
+++ b/tests/ui/lifetimes/static-impl-obligation.rs
@@ -276,4 +276,16 @@ mod w {
         y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
+mod x {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + '_ where Self: '_ { //~ ERROR `'_` cannot be used here
+        fn hello(&self) {}
+
+    }
+    fn convert<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
 fn main() {}

--- a/tests/ui/lifetimes/static-impl-obligation.rs
+++ b/tests/ui/lifetimes/static-impl-obligation.rs
@@ -45,7 +45,7 @@ mod d {
 mod e {
     trait Foo {}
     impl<'a> Foo for &'a u32 {}
-    impl dyn Foo + 'static { //~ HELP consider replacing this `'static` requirement
+    impl dyn Foo + 'static { //~ HELP consider relaxing this `'static` requirement
         fn hello(&self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {

--- a/tests/ui/lifetimes/static-impl-obligation.rs
+++ b/tests/ui/lifetimes/static-impl-obligation.rs
@@ -5,8 +5,8 @@ mod a {
         fn hello(&self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod b {
@@ -16,8 +16,8 @@ mod b {
         fn hello(&'static self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod c {
@@ -27,8 +27,8 @@ mod c {
         fn hello(&'static self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod d {
@@ -38,8 +38,8 @@ mod d {
         fn hello(&self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod e {
@@ -49,8 +49,8 @@ mod e {
         fn hello(&self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod f {
@@ -60,8 +60,8 @@ mod f {
         fn hello(&'static self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod g {
@@ -71,8 +71,8 @@ mod g {
         fn hello(&'static self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod h {
@@ -82,8 +82,8 @@ mod h {
         fn hello(&self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod i {
@@ -93,8 +93,8 @@ mod i {
         fn hello(&self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod j {
@@ -104,8 +104,8 @@ mod j {
         fn hello(&'static self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod k {
@@ -115,8 +115,8 @@ mod k {
         fn hello(&'static self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod l {
@@ -126,8 +126,8 @@ mod l {
         fn hello(&self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod m {
@@ -137,8 +137,8 @@ mod m {
         fn hello(&self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod n {
@@ -148,8 +148,8 @@ mod n {
         fn hello(&'static self) {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod o {
@@ -159,8 +159,8 @@ mod o {
         fn hello(&'static self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod p {
@@ -170,8 +170,8 @@ mod p {
         fn hello(&self) where Self: 'static {}
     }
     fn bar<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 mod q {
@@ -203,8 +203,8 @@ mod s {
 
     }
     fn convert<'a>(x: &'a &'a u32) {
-        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
-        y.hello();
+        let y: &dyn Foo = x;
+        y.hello(); //~ ERROR lifetime may not live long enough
     }
 }
 fn main() {}

--- a/tests/ui/lifetimes/static-impl-obligation.rs
+++ b/tests/ui/lifetimes/static-impl-obligation.rs
@@ -1,0 +1,210 @@
+mod a {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo { //~ HELP consider relaxing the implicit `'static` requirement
+        fn hello(&self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod b {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo {
+        fn hello(&'static self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod c {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo {
+        fn hello(&'static self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod d {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo {
+        fn hello(&self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod e {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static { //~ HELP consider replacing this `'static` requirement
+        fn hello(&self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod f {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static {
+        fn hello(&'static self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod g {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static {
+        fn hello(&'static self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod h {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static {
+        fn hello(&self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod i {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo where Self: 'static {
+        fn hello(&self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod j {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo where Self: 'static {
+        fn hello(&'static self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod k {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo where Self: 'static {
+        fn hello(&'static self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod l {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo where Self: 'static {
+        fn hello(&self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod m {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static where Self: 'static {
+        fn hello(&self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod n {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static where Self: 'static {
+        fn hello(&'static self) {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod o {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static where Self: 'static {
+        fn hello(&'static self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod p {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+    impl dyn Foo + 'static where Self: 'static {
+        fn hello(&self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+mod q {
+    struct Foo {}
+    impl Foo {
+        fn hello(&'static self) {}
+    }
+    fn bar<'a>(x: &'a &'a Foo) {
+        x.hello(); //~ ERROR borrowed data escapes outside of function
+    }
+}
+mod r {
+    struct Foo {}
+    impl Foo {
+        fn hello(&'static self) where Self: 'static {}
+    }
+    fn bar<'a>(x: &'a &'a Foo) {
+        x.hello(); //~ ERROR borrowed data escapes outside of function
+    }
+}
+mod s {
+    trait Foo {}
+    impl<'a> Foo for &'a u32 {}
+
+    trait Trait { fn hello(&self) {} }
+
+    impl Trait for dyn Foo { //~ HELP consider relaxing the implicit `'static` requirement on the impl
+        fn hello(&self) {}
+
+    }
+    fn convert<'a>(x: &'a &'a u32) {
+        let y: &dyn Foo = x; //~ ERROR lifetime may not live long enough
+        y.hello();
+    }
+}
+fn main() {}

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -28,6 +28,12 @@ LL |         val.use_self()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
+   |
+note: the `impl` on `dyn t::ObjectTrait` has a `'static` lifetime requirement
+  --> $DIR/static-impl-obligation.rs:216:47
+   |
+LL |         fn use_self(&self) -> &() where Self: 'static { panic!() }
+   |                                               ^^^^^^^
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/static-impl-obligation.rs:243:9
@@ -41,6 +47,12 @@ LL |         val.use_self()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
+   |
+note: the `impl` on `dyn u::ObjectTrait` has a `'static` lifetime requirement
+  --> $DIR/static-impl-obligation.rs:234:47
+   |
+LL |         fn use_self(&self) -> &() where Self: 'static { panic!() }
+   |                                               ^^^^^^^
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/static-impl-obligation.rs:261:9

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -77,7 +77,7 @@ LL |         let y: &dyn Foo = x;
 LL |         y.hello();
    |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
-help: consider replacing this `'static` requirement
+help: consider relaxing this `'static` requirement
    |
 LL |     impl dyn Foo + '_ {
    |                    ~~
@@ -288,7 +288,6 @@ LL |         x.hello();
    |         |
    |         `x` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
-   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `q::Foo` has a `'static` lifetime requirement
   --> $DIR/static-impl-obligation.rs:180:18
@@ -308,7 +307,6 @@ LL |         x.hello();
    |         |
    |         `x` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
-   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `r::Foo` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:189:18

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -438,12 +438,20 @@ LL |     impl Trait for dyn Foo + '_ {
    |                            ++++
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:275:27
+  --> $DIR/static-impl-obligation.rs:276:9
    |
 LL |     fn convert<'a>(x: &'a &'a u32) {
    |                -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `dyn w::Foo` has a `'static` lifetime requirement
+  --> $DIR/static-impl-obligation.rs:268:29
+   |
+LL |     trait Trait where Self: 'static { fn hello(&self) {} }
+   |                             ^^^^^^^
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -1,12 +1,12 @@
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:8:27
+  --> $DIR/static-impl-obligation.rs:9:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 help: consider relaxing the implicit `'static` requirement on the impl
    |
@@ -14,14 +14,14 @@ LL |     impl dyn Foo + '_ {
    |                  ++++
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:19:27
+  --> $DIR/static-impl-obligation.rs:20:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn b::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:15:10
@@ -32,14 +32,14 @@ LL |         fn hello(&'static self) {}
    |                  ^^^^^^^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:30:27
+  --> $DIR/static-impl-obligation.rs:31:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn c::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:26:10
@@ -50,14 +50,14 @@ LL |         fn hello(&'static self) where Self: 'static {}
    |                  ^^^^^^^^^^^^^              ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:41:27
+  --> $DIR/static-impl-obligation.rs:42:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn d::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:37:10
@@ -68,14 +68,14 @@ LL |         fn hello(&self) where Self: 'static {}
    |                                     ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:52:27
+  --> $DIR/static-impl-obligation.rs:53:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 help: consider replacing this `'static` requirement
    |
@@ -83,14 +83,14 @@ LL |     impl dyn Foo + '_ {
    |                    ~~
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:63:27
+  --> $DIR/static-impl-obligation.rs:64:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn f::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:59:20
@@ -101,14 +101,14 @@ LL |         fn hello(&'static self) {}
    |                  ^^^^^^^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:74:27
+  --> $DIR/static-impl-obligation.rs:75:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn g::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:70:20
@@ -119,14 +119,14 @@ LL |         fn hello(&'static self) where Self: 'static {}
    |                  ^^^^^^^^^^^^^              ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:85:27
+  --> $DIR/static-impl-obligation.rs:86:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn h::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:81:20
@@ -137,14 +137,14 @@ LL |         fn hello(&self) where Self: 'static {}
    |                                     ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:96:27
+  --> $DIR/static-impl-obligation.rs:97:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn i::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:92:10
@@ -153,14 +153,14 @@ LL |     impl dyn Foo where Self: 'static {
    |          ^^^^^^^             ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:107:27
+  --> $DIR/static-impl-obligation.rs:108:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn j::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:103:10
@@ -171,14 +171,14 @@ LL |         fn hello(&'static self) {}
    |                  ^^^^^^^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:118:27
+  --> $DIR/static-impl-obligation.rs:119:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn k::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:114:10
@@ -189,14 +189,14 @@ LL |         fn hello(&'static self) where Self: 'static {}
    |                  ^^^^^^^^^^^^^              ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:129:27
+  --> $DIR/static-impl-obligation.rs:130:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn l::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:125:10
@@ -207,14 +207,14 @@ LL |         fn hello(&self) where Self: 'static {}
    |                                     ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:140:27
+  --> $DIR/static-impl-obligation.rs:141:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn m::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:136:20
@@ -223,14 +223,14 @@ LL |     impl dyn Foo + 'static where Self: 'static {
    |                    ^^^^^^^             ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:151:27
+  --> $DIR/static-impl-obligation.rs:152:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn n::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:147:20
@@ -241,14 +241,14 @@ LL |         fn hello(&'static self) {}
    |                  ^^^^^^^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:162:27
+  --> $DIR/static-impl-obligation.rs:163:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn o::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:158:20
@@ -259,14 +259,14 @@ LL |         fn hello(&'static self) where Self: 'static {}
    |                  ^^^^^^^^^^^^^              ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:173:27
+  --> $DIR/static-impl-obligation.rs:174:9
    |
 LL |     fn bar<'a>(x: &'a &'a u32) {
    |            -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 note: the `impl` on `(dyn p::Foo + 'static)` has `'static` lifetime requirements
   --> $DIR/static-impl-obligation.rs:169:20
@@ -317,14 +317,14 @@ LL |         fn hello(&'static self) where Self: 'static {}
    |                  ^^^^^^^^^^^^^              ^^^^^^^
 
 error: lifetime may not live long enough
-  --> $DIR/static-impl-obligation.rs:206:27
+  --> $DIR/static-impl-obligation.rs:207:9
    |
 LL |     fn convert<'a>(x: &'a &'a u32) {
    |                -- lifetime `'a` defined here
 LL |         let y: &dyn Foo = x;
-   |                           ^ cast requires that `'a` must outlive `'static`
+   |                           - cast requires that `'a` must outlive `'static`
 LL |         y.hello();
-   |         --------- calling this method introduces a `'static` lifetime requirement
+   |         ^^^^^^^^^ calling this method introduces a `'static` lifetime requirement
    |
 help: consider relaxing the implicit `'static` requirement on the impl
    |

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -29,9 +29,11 @@ LL |         val.use_self()
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
    |
-note: the `impl` on `dyn t::ObjectTrait` has a `'static` lifetime requirement
-  --> $DIR/static-impl-obligation.rs:216:47
+note: the `impl` on `dyn t::ObjectTrait` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:215:31
    |
+LL |     trait MyTrait where Self: 'static {
+   |                               ^^^^^^^
 LL |         fn use_self(&self) -> &() where Self: 'static { panic!() }
    |                                               ^^^^^^^
 
@@ -76,8 +78,10 @@ LL |         fn use_self(&'static self) -> &() { panic!() }
 LL |     impl MyTrait for dyn ObjectTrait {}
    |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
 note: the `impl` on `(dyn v::ObjectTrait + 'static)` has `'static` lifetime requirements
-  --> $DIR/static-impl-obligation.rs:252:21
+  --> $DIR/static-impl-obligation.rs:251:31
    |
+LL |     trait MyTrait where Self: 'static {
+   |                               ^^^^^^^
 LL |         fn use_self(&'static self) -> &() { panic!() }
    |                     ^^^^^^^^^^^^^
 ...

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -1,0 +1,336 @@
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:8:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL |     impl dyn Foo + '_ {
+   |                  ++++
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:19:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn b::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:15:10
+   |
+LL |     impl dyn Foo {
+   |          ^^^^^^^
+LL |         fn hello(&'static self) {}
+   |                  ^^^^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:30:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn c::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:26:10
+   |
+LL |     impl dyn Foo {
+   |          ^^^^^^^
+LL |         fn hello(&'static self) where Self: 'static {}
+   |                  ^^^^^^^^^^^^^              ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:41:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn d::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:37:10
+   |
+LL |     impl dyn Foo {
+   |          ^^^^^^^
+LL |         fn hello(&self) where Self: 'static {}
+   |                                     ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:52:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+help: consider replacing this `'static` requirement
+   |
+LL |     impl dyn Foo + '_ {
+   |                    ~~
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:63:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn f::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:59:20
+   |
+LL |     impl dyn Foo + 'static {
+   |                    ^^^^^^^
+LL |         fn hello(&'static self) {}
+   |                  ^^^^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:74:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn g::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:70:20
+   |
+LL |     impl dyn Foo + 'static {
+   |                    ^^^^^^^
+LL |         fn hello(&'static self) where Self: 'static {}
+   |                  ^^^^^^^^^^^^^              ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:85:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn h::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:81:20
+   |
+LL |     impl dyn Foo + 'static {
+   |                    ^^^^^^^
+LL |         fn hello(&self) where Self: 'static {}
+   |                                     ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:96:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn i::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:92:10
+   |
+LL |     impl dyn Foo where Self: 'static {
+   |          ^^^^^^^             ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:107:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn j::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:103:10
+   |
+LL |     impl dyn Foo where Self: 'static {
+   |          ^^^^^^^             ^^^^^^^
+LL |         fn hello(&'static self) {}
+   |                  ^^^^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:118:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn k::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:114:10
+   |
+LL |     impl dyn Foo where Self: 'static {
+   |          ^^^^^^^             ^^^^^^^
+LL |         fn hello(&'static self) where Self: 'static {}
+   |                  ^^^^^^^^^^^^^              ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:129:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn l::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:125:10
+   |
+LL |     impl dyn Foo where Self: 'static {
+   |          ^^^^^^^             ^^^^^^^
+LL |         fn hello(&self) where Self: 'static {}
+   |                                     ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:140:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn m::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:136:20
+   |
+LL |     impl dyn Foo + 'static where Self: 'static {
+   |                    ^^^^^^^             ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:151:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn n::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:147:20
+   |
+LL |     impl dyn Foo + 'static where Self: 'static {
+   |                    ^^^^^^^             ^^^^^^^
+LL |         fn hello(&'static self) {}
+   |                  ^^^^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:162:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn o::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:158:20
+   |
+LL |     impl dyn Foo + 'static where Self: 'static {
+   |                    ^^^^^^^             ^^^^^^^
+LL |         fn hello(&'static self) where Self: 'static {}
+   |                  ^^^^^^^^^^^^^              ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:173:27
+   |
+LL |     fn bar<'a>(x: &'a &'a u32) {
+   |            -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `(dyn p::Foo + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:169:20
+   |
+LL |     impl dyn Foo + 'static where Self: 'static {
+   |                    ^^^^^^^             ^^^^^^^
+LL |         fn hello(&self) where Self: 'static {}
+   |                                     ^^^^^^^
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/static-impl-obligation.rs:183:9
+   |
+LL |     fn bar<'a>(x: &'a &'a Foo) {
+   |            --  - `x` is a reference that is only valid in the function body
+   |            |
+   |            lifetime `'a` defined here
+LL |         x.hello();
+   |         ^^^^^^^^^
+   |         |
+   |         `x` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |         calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `q::Foo` has a `'static` lifetime requirement
+  --> $DIR/static-impl-obligation.rs:180:18
+   |
+LL |         fn hello(&'static self) {}
+   |                  ^^^^^^^^^^^^^
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/static-impl-obligation.rs:192:9
+   |
+LL |     fn bar<'a>(x: &'a &'a Foo) {
+   |            --  - `x` is a reference that is only valid in the function body
+   |            |
+   |            lifetime `'a` defined here
+LL |         x.hello();
+   |         ^^^^^^^^^
+   |         |
+   |         `x` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |         calling this method introduces a `'static` lifetime requirement
+   |
+note: the `impl` on `r::Foo` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:189:18
+   |
+LL |         fn hello(&'static self) where Self: 'static {}
+   |                  ^^^^^^^^^^^^^              ^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:206:27
+   |
+LL |     fn convert<'a>(x: &'a &'a u32) {
+   |                -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
+LL |         y.hello();
+   |         --------- calling this method introduces a `'static` lifetime requirement
+   |
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL |     impl Trait for dyn Foo + '_ {
+   |                            ++++
+
+error: aborting due to 19 previous errors
+
+For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -1,3 +1,95 @@
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/static-impl-obligation.rs:222:10
+   |
+LL |     impl MyTrait for dyn ObjectTrait + '_ {}
+   |          ^^^^^^^
+   |
+note: lifetime parameter instantiated with the anonymous lifetime as defined here
+  --> $DIR/static-impl-obligation.rs:222:40
+   |
+LL |     impl MyTrait for dyn ObjectTrait + '_ {}
+   |                                        ^^
+   = note: but lifetime parameter must outlive the static lifetime
+note: `'static` requirement introduced here
+  --> $DIR/static-impl-obligation.rs:215:31
+   |
+LL |     trait MyTrait where Self: 'static {
+   |                               ^^^^^^^
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/static-impl-obligation.rs:225:9
+   |
+LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/static-impl-obligation.rs:243:9
+   |
+LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/static-impl-obligation.rs:261:9
+   |
+LL |     fn use_it<'a>(val: &'a dyn ObjectTrait) -> impl OtherTrait<'a> + 'a {
+   |               --  --- `val` is a reference that is only valid in the function body
+   |               |
+   |               lifetime `'a` defined here
+LL |         val.use_self()
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         `val` escapes the function body here
+   |         argument requires that `'a` must outlive `'static`
+   |
+note: the used `impl` has a `'static` requirement
+  --> $DIR/static-impl-obligation.rs:258:26
+   |
+LL |         fn use_self(&'static self) -> &() { panic!() }
+   |            -------- calling this method introduces the `impl`'s `'static` requirement
+...
+LL |     impl MyTrait for dyn ObjectTrait {}
+   |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+note: the `impl` on `(dyn v::ObjectTrait + 'static)` has `'static` lifetime requirements
+  --> $DIR/static-impl-obligation.rs:252:21
+   |
+LL |         fn use_self(&'static self) -> &() { panic!() }
+   |                     ^^^^^^^^^^^^^
+...
+LL |     impl MyTrait for dyn ObjectTrait {}
+   |                      ^^^^^^^^^^^^^^^
+
+error[E0478]: lifetime bound not satisfied
+  --> $DIR/static-impl-obligation.rs:270:10
+   |
+LL |     impl Trait for dyn Foo + '_ {
+   |          ^^^^^
+   |
+note: lifetime parameter instantiated with the anonymous lifetime as defined here
+  --> $DIR/static-impl-obligation.rs:270:30
+   |
+LL |     impl Trait for dyn Foo + '_ {
+   |                              ^^
+   = note: but lifetime parameter must outlive the static lifetime
+note: `'static` requirement introduced here
+  --> $DIR/static-impl-obligation.rs:268:29
+   |
+LL |     trait Trait where Self: 'static { fn hello(&self) {} }
+   |                             ^^^^^^^
+
 error: lifetime may not live long enough
   --> $DIR/static-impl-obligation.rs:9:9
    |
@@ -329,6 +421,15 @@ help: consider relaxing the implicit `'static` requirement on the impl
 LL |     impl Trait for dyn Foo + '_ {
    |                            ++++
 
-error: aborting due to 19 previous errors
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:275:27
+   |
+LL |     fn convert<'a>(x: &'a &'a u32) {
+   |                -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
 
-For more information about this error, try `rustc --explain E0521`.
+error: aborting due to 25 previous errors
+
+Some errors have detailed explanations: E0478, E0521.
+For more information about an error, try `rustc --explain E0478`.

--- a/tests/ui/lifetimes/static-impl-obligation.stderr
+++ b/tests/ui/lifetimes/static-impl-obligation.stderr
@@ -1,3 +1,9 @@
+error[E0637]: `'_` cannot be used here
+  --> $DIR/static-impl-obligation.rs:282:35
+   |
+LL |     impl dyn Foo + '_ where Self: '_ {
+   |                                   ^^ `'_` is a reserved lifetime name
+
 error[E0478]: lifetime bound not satisfied
   --> $DIR/static-impl-obligation.rs:222:10
    |
@@ -453,7 +459,15 @@ note: the `impl` on `dyn w::Foo` has a `'static` lifetime requirement
 LL |     trait Trait where Self: 'static { fn hello(&self) {} }
    |                             ^^^^^^^
 
-error: aborting due to 25 previous errors
+error: lifetime may not live long enough
+  --> $DIR/static-impl-obligation.rs:287:27
+   |
+LL |     fn convert<'a>(x: &'a &'a u32) {
+   |                -- lifetime `'a` defined here
+LL |         let y: &dyn Foo = x;
+   |                           ^ cast requires that `'a` must outlive `'static`
 
-Some errors have detailed explanations: E0478, E0521.
+error: aborting due to 27 previous errors
+
+Some errors have detailed explanations: E0478, E0521, E0637.
 For more information about an error, try `rustc --explain E0478`.

--- a/tests/ui/regions/issue-78262.base.stderr
+++ b/tests/ui/regions/issue-78262.base.stderr
@@ -6,8 +6,14 @@ LL |     let f = |x: &dyn TT| x.func();
    |              |  |        |
    |              |  |        `x` escapes the closure body here
    |              |  |        argument requires that `'1` must outlive `'static`
+   |              |  |        calling this method introduces a `'static` lifetime requirement
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
+   |
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL | impl dyn TT + '_ {
+   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/issue-78262.base.stderr
+++ b/tests/ui/regions/issue-78262.base.stderr
@@ -6,7 +6,6 @@ LL |     let f = |x: &dyn TT| x.func();
    |              |  |        |
    |              |  |        `x` escapes the closure body here
    |              |  |        argument requires that `'1` must outlive `'static`
-   |              |  |        calling this method introduces a `'static` lifetime requirement
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
    |

--- a/tests/ui/regions/issue-78262.polonius.stderr
+++ b/tests/ui/regions/issue-78262.polonius.stderr
@@ -6,8 +6,14 @@ LL |     let f = |x: &dyn TT| x.func();
    |              |  |        |
    |              |  |        `x` escapes the closure body here
    |              |  |        argument requires that `'1` must outlive `'static`
+   |              |  |        calling this method introduces a `'static` lifetime requirement
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
+   |
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL | impl dyn TT + '_ {
+   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/issue-78262.polonius.stderr
+++ b/tests/ui/regions/issue-78262.polonius.stderr
@@ -6,7 +6,6 @@ LL |     let f = |x: &dyn TT| x.func();
    |              |  |        |
    |              |  |        `x` escapes the closure body here
    |              |  |        argument requires that `'1` must outlive `'static`
-   |              |  |        calling this method introduces a `'static` lifetime requirement
    |              |  let's call the lifetime of this reference `'1`
    |              `x` is a reference that is only valid in the closure body
    |

--- a/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -8,7 +8,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:21:23
    |
 LL |     z: Box<dyn Is<'a>+'b+'c>,
-   |                       ^^
+   |                       ^^ lifetime bound not satisfied
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:15

--- a/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/tests/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -5,10 +5,10 @@ LL |     z: Box<dyn Is<'a>+'b+'c>,
    |                          ^^
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/region-bounds-on-objects-and-type-parameters.rs:21:8
+  --> $DIR/region-bounds-on-objects-and-type-parameters.rs:21:23
    |
 LL |     z: Box<dyn Is<'a>+'b+'c>,
-   |        ^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:15

--- a/tests/ui/regions/regions-wf-trait-object.stderr
+++ b/tests/ui/regions/regions-wf-trait-object.stderr
@@ -1,8 +1,8 @@
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/regions-wf-trait-object.rs:7:8
+  --> $DIR/regions-wf-trait-object.rs:7:29
    |
 LL |     x: Box<dyn TheTrait<'a>+'b>
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/regions-wf-trait-object.rs:6:15

--- a/tests/ui/regions/regions-wf-trait-object.stderr
+++ b/tests/ui/regions/regions-wf-trait-object.stderr
@@ -2,7 +2,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/regions-wf-trait-object.rs:7:29
    |
 LL |     x: Box<dyn TheTrait<'a>+'b>
-   |                             ^^
+   |                             ^^ lifetime bound not satisfied
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined here
   --> $DIR/regions-wf-trait-object.rs:6:15

--- a/tests/ui/static/static-lifetime.stderr
+++ b/tests/ui/static/static-lifetime.stderr
@@ -10,6 +10,11 @@ note: lifetime parameter instantiated with the lifetime `'a` as defined here
 LL | impl<'a, A: Clone> Arbitrary for ::std::borrow::Cow<'a, A> {}
    |      ^^
    = note: but lifetime parameter must outlive the static lifetime
+note: `'static` requirement introduced here
+  --> $DIR/static-lifetime.rs:1:30
+   |
+LL | pub trait Arbitrary: Sized + 'static {}
+   |                              ^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -69,6 +69,10 @@ LL |         fn use_self(&self) -> &() { panic!() }
 ...
 LL |     impl MyTrait for dyn ObjectTrait {}
    |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL |     impl MyTrait for dyn ObjectTrait + '_ {}
+   |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:112:9
@@ -91,6 +95,10 @@ LL |         fn use_self(&self) -> &() { panic!() }
 ...
 LL |     impl MyTrait for dyn ObjectTrait {}
    |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
+help: consider relaxing the implicit `'static` requirement on the impl
+   |
+LL |     impl MyTrait for dyn ObjectTrait + '_ {}
+   |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:38:9

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -10,6 +10,7 @@ LL |         val.use_self::<T>()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
+   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:15:32
@@ -18,7 +19,7 @@ LL |     impl<T> MyTrait<T> for dyn ObjectTrait<T> {
    |                                ^^^^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
 LL |         fn use_self<K>(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
-help: consider relaxing the implicit `'static` requirement
+help: consider relaxing the implicit `'static` requirement on the impl
    |
 LL |     impl<T> MyTrait<T> for dyn ObjectTrait<T> + '_ {
    |                                               ++++
@@ -35,6 +36,7 @@ LL |         val.use_self()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
+   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:67:14
@@ -43,7 +45,7 @@ LL |     impl dyn ObjectTrait {
    |              ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
 LL |         fn use_self(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
-help: consider relaxing the implicit `'static` requirement
+help: consider relaxing the implicit `'static` requirement on the impl
    |
 LL |     impl dyn ObjectTrait + '_ {
    |                          ++++
@@ -69,10 +71,6 @@ LL |         fn use_self(&self) -> &() { panic!() }
 ...
 LL |     impl MyTrait for dyn ObjectTrait {}
    |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
-help: consider relaxing the implicit `'static` requirement
-   |
-LL |     impl MyTrait for dyn ObjectTrait + '_ {}
-   |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:112:9
@@ -95,10 +93,6 @@ LL |         fn use_self(&self) -> &() { panic!() }
 ...
 LL |     impl MyTrait for dyn ObjectTrait {}
    |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
-help: consider relaxing the implicit `'static` requirement
-   |
-LL |     impl MyTrait for dyn ObjectTrait + '_ {}
-   |                                      ++++
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:38:9
@@ -112,6 +106,7 @@ LL |         val.use_self()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
+   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:32:26
@@ -120,7 +115,7 @@ LL |     impl MyTrait for dyn ObjectTrait {
    |                          ^^^^^^^^^^^ this has an implicit `'static` lifetime requirement
 LL |         fn use_self(&self) -> &() { panic!() }
    |            -------- calling this method introduces the `impl`'s `'static` requirement
-help: consider relaxing the implicit `'static` requirement
+help: consider relaxing the implicit `'static` requirement on the impl
    |
 LL |     impl MyTrait for dyn ObjectTrait + '_ {
    |                                      ++++

--- a/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
+++ b/tests/ui/suggestions/impl-on-dyn-trait-with-implicit-static-bound.stderr
@@ -10,7 +10,6 @@ LL |         val.use_self::<T>()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
-   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:15:32
@@ -36,7 +35,6 @@ LL |         val.use_self()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
-   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:67:14
@@ -106,7 +104,6 @@ LL |         val.use_self()
    |         |
    |         `val` escapes the function body here
    |         argument requires that `'a` must outlive `'static`
-   |         calling this method introduces a `'static` lifetime requirement
    |
 note: the used `impl` has a `'static` requirement
   --> $DIR/impl-on-dyn-trait-with-implicit-static-bound.rs:32:26


### PR DESCRIPTION
```text
error: lifetime may not live long enough
  --> $DIR/static-impl-obligation.rs:8:27
   |
LL |     fn bar<'a>(x: &'a &'a u32) {
   |            -- lifetime `'a` defined here
LL |         let y: &dyn Foo = x;
   |                           ^ cast requires that `'a` must outlive `'static`
LL |         y.hello();
   |         --------- calling this method introduces a `'static` lifetime requirement
   |
help: relax the implicit `'static` bound on the impl
   |
LL |     impl dyn Foo + '_ {
   |                  ++++
```
```text
error: lifetime may not live long enough
  --> $DIR/static-impl-obligation.rs:173:27
   |
LL |     fn bar<'a>(x: &'a &'a u32) {
   |            -- lifetime `'a` defined here
LL |         let y: &dyn Foo = x;
   |                           ^ cast requires that `'a` must outlive `'static`
LL |         y.hello();
   |         --------- calling this method introduces a `'static` lifetime requirement
   |
note: the `impl` on `(dyn p::Foo + 'static)` has `'static` lifetime requirements
  --> $DIR/static-impl-obligation.rs:169:20
   |
LL |     impl dyn Foo + 'static where Self: 'static {
   |                    ^^^^^^^             ^^^^^^^
LL |         fn hello(&self) where Self: 'static {}
   |                                     ^^^^^^^
```

Fix #83246, fix #80701.

```
error[E0478]: lifetime bound not satisfied
   --> tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.rs:4:21
    |
4   |     broken: Box<dyn Any + 'a>
    |                     ^^^   ^^
    |
note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> tests/ui/lifetimes/point-at-lifetime-obligation-from-trait-in-trait-object.rs:3:18
    |
3   | struct Something<'a> {
    |                  ^^
    = note: but lifetime parameter must outlive the static lifetime
note: unmet `'static` obligations introduced here
   --> rust/library/core/src/any.rs:115:16
    |
115 | pub trait Any: 'static {
    |                ^^^^^^^
```

Fix #83325.