### PR TITLE
Lower transmutes from int to pointer type as gep on null

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -306,11 +306,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 bx.bitcast(imm, to_backend_ty)
             }
             (Pointer(..), Pointer(..)) => bx.pointercast(imm, to_backend_ty),
-            (Int(..), Pointer(..)) => bx.inttoptr(imm, to_backend_ty),
+            (Int(..), Pointer(..)) => bx.ptradd(bx.const_null(bx.type_ptr()), imm),
             (Pointer(..), Int(..)) => bx.ptrtoint(imm, to_backend_ty),
             (F16 | F32 | F64 | F128, Pointer(..)) => {
                 let int_imm = bx.bitcast(imm, bx.cx().type_isize());
-                bx.inttoptr(int_imm, to_backend_ty)
+                bx.ptradd(bx.const_null(bx.type_ptr()), int_imm)
             }
             (Pointer(..), F16 | F32 | F64 | F128) => {
                 let int_imm = bx.ptrtoint(imm, bx.cx().type_isize());

--- a/tests/codegen/intrinsics/transmute.rs
+++ b/tests/codegen/intrinsics/transmute.rs
@@ -296,7 +296,7 @@ pub unsafe fn check_pair_with_bool(x: (u8, bool)) -> (bool, i8) {
 pub unsafe fn check_float_to_pointer(x: f64) -> *const () {
     // CHECK-NOT: alloca
     // CHECK: %0 = bitcast double %x to i64
-    // CHECK: %_0 = inttoptr i64 %0 to ptr
+    // CHECK: %_0 = getelementptr i8, ptr null, i64 %0
     // CHECK: ret ptr %_0
     transmute(x)
 }
@@ -371,7 +371,7 @@ pub unsafe fn check_issue_110005(x: (usize, bool)) -> Option<Box<[u8]>> {
 // CHECK-LABEL: @check_pair_to_dst_ref(
 #[no_mangle]
 pub unsafe fn check_pair_to_dst_ref<'a>(x: (usize, usize)) -> &'a [u8] {
-    // CHECK: %_0.0 = inttoptr i64 %x.0 to ptr
+    // CHECK: %_0.0 = getelementptr i8, ptr null, i64 %x.0
     // CHECK: %0 = insertvalue { ptr, i64 } poison, ptr %_0.0, 0
     // CHECK: %1 = insertvalue { ptr, i64 } %0, i64 %x.1, 1
     // CHECK: ret { ptr, i64 } %1

--- a/tests/codegen/transmute-scalar.rs
+++ b/tests/codegen/transmute-scalar.rs
@@ -49,7 +49,7 @@ pub fn ptr_to_int(p: *mut u16) -> usize {
 }
 
 // CHECK: define{{.*}}ptr @int_to_ptr([[USIZE]] %i)
-// CHECK: %_0 = inttoptr [[USIZE]] %i to ptr
+// CHECK: %_0 = getelementptr i8, ptr null, [[USIZE]] %i
 // CHECK-NEXT: ret ptr %_0
 #[no_mangle]
 pub fn int_to_ptr(i: usize) -> *mut u16 {

--- a/tests/ui/abi/foreign/foreign-call-no-runtime.rs
+++ b/tests/ui/abi/foreign/foreign-call-no-runtime.rs
@@ -40,21 +40,21 @@ pub fn main() {
 
 extern "C" fn callback_isize(data: libc::uintptr_t) {
     unsafe {
-        let data: *const isize = mem::transmute(data);
+        let data = data as *const isize;
         assert_eq!(*data, 100);
     }
 }
 
 extern "C" fn callback_i64(data: libc::uintptr_t) {
     unsafe {
-        let data: *const i64 = mem::transmute(data);
+        let data = data as *const i64;
         assert_eq!(*data, 100);
     }
 }
 
 extern "C" fn callback_i32(data: libc::uintptr_t) {
     unsafe {
-        let data: *const i32 = mem::transmute(data);
+        let data = data as *const i32;
         assert_eq!(*data, 100);
     }
 }


### PR DESCRIPTION
I thought of this while looking at https://github.com/rust-lang/rust/pull/121242. See that PR's description for why this lowering is preferable.

The UI test that's being changed here crashes without changing the transmutes into casts. Based on that, this PR should not be merged without a crater build-and-test run.