### PR TITLE
Reduce monomorphisation bloat in RawVec::allocate_in

### DIFF
--- a/tests/ui/hygiene/panic-location.run.stderr
+++ b/tests/ui/hygiene/panic-location.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at library/alloc/src/raw_vec.rs:571:5:
+thread 'main' panicked at library/alloc/src/raw_vec.rs:579:5:
 capacity overflow
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This outlines logic that is not reliant on `T`, leading to a small drop in llvm-lines that is amplified across large projects with many many Vecs. Tests are performed with fat LTO in release mode. This ironically seems to cause the binary size to go up, one theory is that more inlining is performed around the call, which may improve runtime performance.

| [TTS Bot](https://github.com/Discord-TTS/Bot) | RawVec::allocate_in llvm lines | Binary Size |
|---------|-----------------------------|-------------|
| Before  | 21642                       | 20,540,688  |
| After   | 17256                       | 20,565,064  |

| [T2FanRD](https://github.com/GnomedDev/t2fanrd) | RawVec::allocate_in llvm lines | Binary Size |
|---------|-----------------------------|-------------|
| Before  | 842                         | 630,744     |
| After   | 646                         | 630,768     |
