### PR TITLE
Add test cases for inlining compiler-private items

### DIFF
--- a/tests/rustdoc/auxiliary/issue-106421-force-unstable.rs
+++ b/tests/rustdoc/auxiliary/issue-106421-force-unstable.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: -Zforce-unstable-if-unmarked
+#![crate_name="foo"]
+pub struct FatalError;
+
+impl FatalError {
+    pub fn raise(self) -> ! {
+        loop {}
+    }
+}

--- a/tests/rustdoc/issue-106421-not-internal.rs
+++ b/tests/rustdoc/issue-106421-not-internal.rs
@@ -1,0 +1,8 @@
+//@ aux-build:issue-106421-force-unstable.rs
+//@ ignore-cross-compile
+// This is the version where a non-compiler-internal crate inlines a compiler-internal one.
+// In this case, the item shouldn't be documented, because regular users can't get at it.
+extern crate foo;
+
+// @!has issue_106421_not_internal/struct.FatalError.html '//*[@id="method.raise"]' 'fn raise'
+pub use foo::FatalError;

--- a/tests/rustdoc/issue-106421.rs
+++ b/tests/rustdoc/issue-106421.rs
@@ -1,0 +1,8 @@
+//@ aux-build:issue-106421-force-unstable.rs
+//@ ignore-cross-compile
+//@ compile-flags: -Zforce-unstable-if-unmarked
+
+extern crate foo;
+
+// @has issue_106421/struct.FatalError.html '//*[@id="method.raise"]' 'fn raise'
+pub use foo::FatalError;


### PR DESCRIPTION
Closes #106421

This was already fixed by #121218, but now the test cases are added.