### PR TITLE
Delayed bug audit

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -103,12 +103,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         span: Span,
     ) -> Result<DefId, ErrorGuaranteed> {
         let sig_id = if self.is_in_trait_impl { item_id } else { path_id };
-        let sig_id = self
-            .resolver
-            .get_partial_res(sig_id)
-            .map(|r| r.expect_full_res().opt_def_id())
-            .unwrap_or(None);
-
+        let sig_id =
+            self.resolver.get_partial_res(sig_id).and_then(|r| r.expect_full_res().opt_def_id());
         sig_id.ok_or_else(|| {
             self.tcx
                 .dcx()

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -184,12 +184,9 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
     let (closure_region_requirements, nll_errors) =
         regioncx.solve(infcx, body, polonius_output.clone());
 
-    if !nll_errors.is_empty() {
+    if let Some(guar) = nll_errors.has_errors() {
         // Suppress unhelpful extra errors in `infer_opaque_types`.
-        infcx.set_tainted_by_errors(infcx.dcx().span_delayed_bug(
-            body.span,
-            "`compute_regions` tainted `infcx` with errors but did not emit any errors",
-        ));
+        infcx.set_tainted_by_errors(guar);
     }
 
     let remapped_opaque_tys = regioncx.infer_opaque_types(infcx, opaque_type_values);

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -760,7 +760,7 @@ fn convert_enum_variant_types(tcx: TyCtxt<'_>, def_id: DefId) {
         let wrapped_discr = prev_discr.map_or(initial, |d| d.wrap_incr(tcx));
         prev_discr = Some(
             if let ty::VariantDiscr::Explicit(const_def_id) = variant.discr {
-                def.eval_explicit_discr(tcx, const_def_id)
+                def.eval_explicit_discr(tcx, const_def_id).ok()
             } else if let Some(discr) = repr_type.disr_incr(tcx, prev_discr) {
                 Some(discr)
             } else {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
@@ -21,8 +21,11 @@ pub use static_impl_trait::{suggest_new_region_bound, HirTraitObjectVisitor, Tra
 pub use util::find_param_with_region;
 
 impl<'cx, 'tcx> TypeErrCtxt<'cx, 'tcx> {
-    pub fn try_report_nice_region_error(&'cx self, error: &RegionResolutionError<'tcx>) -> bool {
-        NiceRegionError::new(self, error.clone()).try_report().is_some()
+    pub fn try_report_nice_region_error(
+        &'cx self,
+        error: &RegionResolutionError<'tcx>,
+    ) -> Option<ErrorGuaranteed> {
+        NiceRegionError::new(self, error.clone()).try_report()
     }
 }
 

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -7,6 +7,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::stable_hasher::HashingControls;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::def_id::DefId;
@@ -475,7 +476,11 @@ impl<'tcx> AdtDef<'tcx> {
     }
 
     #[inline]
-    pub fn eval_explicit_discr(self, tcx: TyCtxt<'tcx>, expr_did: DefId) -> Option<Discr<'tcx>> {
+    pub fn eval_explicit_discr(
+        self,
+        tcx: TyCtxt<'tcx>,
+        expr_did: DefId,
+    ) -> Result<Discr<'tcx>, ErrorGuaranteed> {
         assert!(self.is_enum());
         let param_env = tcx.param_env(expr_did);
         let repr_type = self.repr().discr_type();
@@ -484,22 +489,24 @@ impl<'tcx> AdtDef<'tcx> {
                 let ty = repr_type.to_ty(tcx);
                 if let Some(b) = val.try_to_bits_for_ty(tcx, param_env, ty) {
                     trace!("discriminants: {} ({:?})", b, repr_type);
-                    Some(Discr { val: b, ty })
+                    Ok(Discr { val: b, ty })
                 } else {
                     info!("invalid enum discriminant: {:#?}", val);
-                    tcx.dcx().emit_err(crate::error::ConstEvalNonIntError {
+                    let guar = tcx.dcx().emit_err(crate::error::ConstEvalNonIntError {
                         span: tcx.def_span(expr_did),
                     });
-                    None
+                    Err(guar)
                 }
             }
             Err(err) => {
-                let msg = match err {
-                    ErrorHandled::Reported(..) => "enum discriminant evaluation failed",
-                    ErrorHandled::TooGeneric(..) => "enum discriminant depends on generics",
+                let guar = match err {
+                    ErrorHandled::Reported(info, _) => info.into(),
+                    ErrorHandled::TooGeneric(..) => tcx.dcx().span_delayed_bug(
+                        tcx.def_span(expr_did),
+                        "enum discriminant depends on generics",
+                    ),
                 };
-                tcx.dcx().span_delayed_bug(tcx.def_span(expr_did), msg);
-                None
+                Err(guar)
             }
         }
     }
@@ -516,7 +523,7 @@ impl<'tcx> AdtDef<'tcx> {
         self.variants().iter_enumerated().map(move |(i, v)| {
             let mut discr = prev_discr.map_or(initial, |d| d.wrap_incr(tcx));
             if let VariantDiscr::Explicit(expr_did) = v.discr {
-                if let Some(new_discr) = self.eval_explicit_discr(tcx, expr_did) {
+                if let Ok(new_discr) = self.eval_explicit_discr(tcx, expr_did) {
                     discr = new_discr;
                 }
             }
@@ -544,9 +551,13 @@ impl<'tcx> AdtDef<'tcx> {
     ) -> Discr<'tcx> {
         assert!(self.is_enum());
         let (val, offset) = self.discriminant_def_for_variant(variant_index);
-        let explicit_value = val
-            .and_then(|expr_did| self.eval_explicit_discr(tcx, expr_did))
-            .unwrap_or_else(|| self.repr().discr_type().initial_discriminant(tcx));
+        let explicit_value = if let Some(expr_did) = val
+            && let Ok(val) = self.eval_explicit_discr(tcx, expr_did)
+        {
+            val
+        } else {
+            self.repr().discr_type().initial_discriminant(tcx)
+        };
         explicit_value.checked_add(tcx, offset as u128).0
     }
 

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -230,8 +230,7 @@ impl<'a> Parser<'a> {
     /// Also error if the previous token was a doc comment.
     fn error_outer_attrs(&self, attrs: AttrWrapper) {
         if !attrs.is_empty()
-            && let attrs = attrs.take_for_recovery(self.sess)
-            && let attrs @ [.., last] = &*attrs
+            && let attrs @ [.., last] = &*attrs.take_for_recovery(self.sess)
         {
             if last.is_doc_comment() {
                 self.dcx().emit_err(errors::DocCommentDoesNotDocumentAnything {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -554,8 +554,12 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     ///
     /// This takes the error provided, combines it with the span and any additional spans inside the
     /// error and emits it.
-    pub(crate) fn report_error(&mut self, span: Span, resolution_error: ResolutionError<'a>) {
-        self.into_struct_error(span, resolution_error).emit();
+    pub(crate) fn report_error(
+        &mut self,
+        span: Span,
+        resolution_error: ResolutionError<'a>,
+    ) -> ErrorGuaranteed {
+        self.into_struct_error(span, resolution_error).emit()
     }
 
     pub(crate) fn into_struct_error(

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1,4 +1,5 @@
 use rustc_ast::{self as ast, NodeId};
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir::def::{DefKind, Namespace, NonMacroAttrKind, PartialRes, PerNS};
 use rustc_middle::bug;
 use rustc_middle::ty;
@@ -1066,7 +1067,6 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         original_rib_ident_def: Ident,
         all_ribs: &[Rib<'a>],
     ) -> Res {
-        const CG_BUG_STR: &str = "min_const_generics resolve check didn't stop compilation";
         debug!("validate_res_from_ribs({:?})", res);
         let ribs = &all_ribs[rib_index + 1..];
 
@@ -1209,8 +1209,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                                                 }
                                             }
                                         };
-                                        self.report_error(span, error);
-                                        self.dcx().span_delayed_bug(span, CG_BUG_STR);
+                                        let _: ErrorGuaranteed = self.report_error(span, error);
                                     }
 
                                     return Res::Err;


### PR DESCRIPTION
I went through all the calls to `delayed_bug` and `span_delayed_bug` and found a few places where they could be avoided.

r? @compiler-errors 