### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -740,8 +740,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         });
 
         // We're done if we found errors, but we already emitted them.
-        if let Some(reported) = reported {
-            assert!(errors.is_empty());
+        if let Some(reported) = reported
+            && errors.is_empty()
+        {
             return reported;
         }
         assert!(!errors.is_empty());

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -227,8 +227,8 @@ impl Level {
     }
 
     /// Converts a lower-case string to a level. This will never construct the expect
-    /// level as that would require a [`LintExpectationId`]
-    pub fn from_str(x: &str) -> Option<Level> {
+    /// level as that would require a [`LintExpectationId`].
+    pub fn from_str(x: &str) -> Option<Self> {
         match x {
             "allow" => Some(Level::Allow),
             "warn" => Some(Level::Warn),
@@ -238,17 +238,21 @@ impl Level {
         }
     }
 
-    /// Converts a symbol to a level.
-    pub fn from_attr(attr: &Attribute) -> Option<Level> {
-        match attr.name_or_empty() {
-            sym::allow => Some(Level::Allow),
-            sym::expect => Some(Level::Expect(LintExpectationId::Unstable {
-                attr_id: attr.id,
-                lint_index: None,
-            })),
-            sym::warn => Some(Level::Warn),
-            sym::deny => Some(Level::Deny),
-            sym::forbid => Some(Level::Forbid),
+    /// Converts an `Attribute` to a level.
+    pub fn from_attr(attr: &Attribute) -> Option<Self> {
+        Self::from_symbol(attr.name_or_empty(), Some(attr.id))
+    }
+
+    /// Converts a `Symbol` to a level.
+    pub fn from_symbol(s: Symbol, id: Option<AttrId>) -> Option<Self> {
+        match (s, id) {
+            (sym::allow, _) => Some(Level::Allow),
+            (sym::expect, Some(attr_id)) => {
+                Some(Level::Expect(LintExpectationId::Unstable { attr_id, lint_index: None }))
+            }
+            (sym::warn, _) => Some(Level::Warn),
+            (sym::deny, _) => Some(Level::Deny),
+            (sym::forbid, _) => Some(Level::Forbid),
             _ => None,
         }
     }

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -87,6 +87,10 @@ resolve_consider_declaring_with_pub =
 resolve_consider_marking_as_pub =
     consider marking `{$ident}` as `pub` in the imported module
 
+resolve_consider_move_macro_position =
+    consider moving the definition of `{$ident}` before this call
+
+
 resolve_const_not_member_of_trait =
     const `{$const_}` is not a member of trait `{$trait_}`
     .label = not a member of trait `{$trait_}`
@@ -185,6 +189,9 @@ resolve_lifetime_param_in_ty_of_const_param =
 resolve_lowercase_self =
     attempt to use a non-constant value in a constant
     .suggestion = try using `Self`
+
+resolve_macro_defined_later =
+    a macro with the same name exists, but it appears later at here
 
 resolve_macro_expected_found =
     expected {$expected}, found {$found} `{$macro_path}`

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -30,7 +30,10 @@ use rustc_span::{BytePos, Span, SyntaxContext};
 use thin_vec::{thin_vec, ThinVec};
 
 use crate::errors::{AddedMacroUse, ChangeImportBinding, ChangeImportBindingSuggestion};
-use crate::errors::{ConsiderAddingADerive, ExplicitUnsafeTraits, MaybeMissingMacroRulesName};
+use crate::errors::{
+    ConsiderAddingADerive, ExplicitUnsafeTraits, MacroDefinedLater, MacroSuggMovePosition,
+    MaybeMissingMacroRulesName,
+};
 use crate::imports::{Import, ImportKind};
 use crate::late::{PatternSource, Rib};
 use crate::path_names_to_string;
@@ -1437,6 +1440,24 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         if macro_kind == MacroKind::Derive && (ident.name == sym::Send || ident.name == sym::Sync) {
             err.subdiagnostic(ExplicitUnsafeTraits { span: ident.span, ident });
             return;
+        }
+
+        let unused_macro = self.unused_macros.iter().find_map(|(def_id, (_, unused_ident))| {
+            if unused_ident.name == ident.name {
+                Some((def_id.clone(), unused_ident.clone()))
+            } else {
+                None
+            }
+        });
+
+        if let Some((def_id, unused_ident)) = unused_macro {
+            let scope = self.local_macro_def_scopes[&def_id];
+            let parent_nearest = parent_scope.module.nearest_parent_mod();
+            if Some(parent_nearest) == scope.opt_def_id() {
+                err.subdiagnostic(MacroDefinedLater { span: unused_ident.span });
+                err.subdiagnostic(MacroSuggMovePosition { span: ident.span, ident });
+                return;
+            }
         }
 
         if self.macro_names.contains(&ident.normalize_to_macros_2_0()) {

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -686,6 +686,21 @@ pub(crate) struct ExplicitUnsafeTraits {
 }
 
 #[derive(Subdiagnostic)]
+#[note(resolve_macro_defined_later)]
+pub(crate) struct MacroDefinedLater {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
+#[derive(Subdiagnostic)]
+#[label(resolve_consider_move_macro_position)]
+pub(crate) struct MacroSuggMovePosition {
+    #[primary_span]
+    pub(crate) span: Span,
+    pub(crate) ident: Ident,
+}
+
+#[derive(Subdiagnostic)]
 #[note(resolve_missing_macro_rules_name)]
 pub(crate) struct MaybeMissingMacroRulesName {
     #[primary_span]

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -32,6 +32,7 @@ use crate::num::FpCategory;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `RADIX` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_radix"]
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
@@ -52,6 +53,7 @@ pub const RADIX: u32 = f32::RADIX;
     since = "TBD",
     note = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`"
 )]
+#[rustc_diagnostic_item = "f32_legacy_const_mantissa_dig"]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -69,6 +71,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `DIGITS` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_digits"]
 pub const DIGITS: u32 = f32::DIGITS;
 
 /// [Machine epsilon] value for `f32`.
@@ -90,6 +93,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `EPSILON` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_epsilon"]
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
@@ -107,6 +111,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_min"]
 pub const MIN: f32 = f32::MIN;
 
 /// Smallest positive normal `f32` value.
@@ -124,6 +129,7 @@ pub const MIN: f32 = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN_POSITIVE` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_min_positive"]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
 /// Largest finite `f32` value.
@@ -141,6 +147,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_max"]
 pub const MAX: f32 = f32::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -158,6 +165,7 @@ pub const MAX: f32 = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN_EXP` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_min_exp"]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -175,6 +183,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MAX_EXP` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_max_exp"]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -192,6 +201,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN_10_EXP` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_min_10_exp"]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -209,6 +219,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MAX_10_EXP` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_max_10_exp"]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -226,6 +237,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `NAN` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_nan"]
 pub const NAN: f32 = f32::NAN;
 
 /// Infinity (∞).
@@ -243,6 +255,7 @@ pub const NAN: f32 = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `INFINITY` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_infinity"]
 pub const INFINITY: f32 = f32::INFINITY;
 
 /// Negative infinity (−∞).
@@ -260,6 +273,7 @@ pub const INFINITY: f32 = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `NEG_INFINITY` associated constant on `f32`")]
+#[rustc_diagnostic_item = "f32_legacy_const_neg_infinity"]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -32,6 +32,7 @@ use crate::num::FpCategory;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `RADIX` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_radix"]
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
@@ -52,6 +53,7 @@ pub const RADIX: u32 = f64::RADIX;
     since = "TBD",
     note = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`"
 )]
+#[rustc_diagnostic_item = "f64_legacy_const_mantissa_dig"]
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -69,6 +71,7 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `DIGITS` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_digits"]
 pub const DIGITS: u32 = f64::DIGITS;
 
 /// [Machine epsilon] value for `f64`.
@@ -90,6 +93,7 @@ pub const DIGITS: u32 = f64::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `EPSILON` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_epsilon"]
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
@@ -107,6 +111,7 @@ pub const EPSILON: f64 = f64::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_min"]
 pub const MIN: f64 = f64::MIN;
 
 /// Smallest positive normal `f64` value.
@@ -124,6 +129,7 @@ pub const MIN: f64 = f64::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN_POSITIVE` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_min_positive"]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
 /// Largest finite `f64` value.
@@ -141,6 +147,7 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_max"]
 pub const MAX: f64 = f64::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -158,6 +165,7 @@ pub const MAX: f64 = f64::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN_EXP` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_min_exp"]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -175,6 +183,7 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MAX_EXP` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_max_exp"]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -192,6 +201,7 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MIN_10_EXP` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_min_10_exp"]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -209,6 +219,7 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `MAX_10_EXP` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_max_10_exp"]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -226,6 +237,7 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `NAN` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_nan"]
 pub const NAN: f64 = f64::NAN;
 
 /// Infinity (∞).
@@ -243,6 +255,7 @@ pub const NAN: f64 = f64::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `INFINITY` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_infinity"]
 pub const INFINITY: f64 = f64::INFINITY;
 
 /// Negative infinity (−∞).
@@ -260,6 +273,7 @@ pub const INFINITY: f64 = f64::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[deprecated(since = "TBD", note = "replaced by the `NEG_INFINITY` associated constant on `f64`")]
+#[rustc_diagnostic_item = "f64_legacy_const_neg_infinity"]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3507,6 +3507,7 @@ macro_rules! int_impl {
         #[rustc_promotable]
         #[rustc_const_stable(feature = "const_min_value", since = "1.32.0")]
         #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on this type")]
+        #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_min_value")]
         pub const fn min_value() -> Self {
             Self::MIN
         }
@@ -3520,6 +3521,7 @@ macro_rules! int_impl {
         #[rustc_promotable]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
         #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
+        #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_max_value")]
         pub const fn max_value() -> Self {
             Self::MAX
         }

--- a/library/core/src/num/shells/int_macros.rs
+++ b/library/core/src/num/shells/int_macros.rs
@@ -20,6 +20,7 @@ macro_rules! int_module {
         ///
         #[$attr]
         #[deprecated(since = "TBD", note = "replaced by the `MIN` associated constant on this type")]
+        #[rustc_diagnostic_item = concat!(stringify!($T), "_legacy_const_min")]
         pub const MIN: $T = $T::MIN;
 
         #[doc = concat!(
@@ -39,6 +40,7 @@ macro_rules! int_module {
         ///
         #[$attr]
         #[deprecated(since = "TBD", note = "replaced by the `MAX` associated constant on this type")]
+        #[rustc_diagnostic_item = concat!(stringify!($T), "_legacy_const_max")]
         pub const MAX: $T = $T::MAX;
     )
 }

--- a/library/core/src/prelude/mod.rs
+++ b/library/core/src/prelude/mod.rs
@@ -49,9 +49,13 @@ pub mod rust_2021 {
 /// The 2024 edition of the core prelude.
 ///
 /// See the [module-level documentation](self) for more.
-#[unstable(feature = "prelude_2024", issue = "none")]
+#[unstable(feature = "prelude_2024", issue = "121042")]
 pub mod rust_2024 {
-    #[unstable(feature = "prelude_2024", issue = "none")]
+    #[unstable(feature = "prelude_2024", issue = "121042")]
     #[doc(no_inline)]
     pub use super::rust_2021::*;
+
+    #[unstable(feature = "prelude_2024", issue = "121042")]
+    #[doc(no_inline)]
+    pub use crate::future::{Future, IntoFuture};
 }

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -40,6 +40,7 @@
 
 use crate::cmp;
 use crate::cmp::Ordering;
+use crate::convert::TryInto as _;
 use crate::fmt;
 use crate::slice::memchr;
 
@@ -370,9 +371,15 @@ pub struct CharSearcher<'a> {
 
     // safety invariant: `utf8_size` must be less than 5
     /// The number of bytes `needle` takes up when encoded in utf8.
-    utf8_size: usize,
+    utf8_size: u8,
     /// A utf8 encoded copy of the `needle`
     utf8_encoded: [u8; 4],
+}
+
+impl CharSearcher<'_> {
+    fn utf8_size(&self) -> usize {
+        self.utf8_size.into()
+    }
 }
 
 unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
@@ -414,7 +421,7 @@ unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
             let bytes = self.haystack.as_bytes().get(self.finger..self.finger_back)?;
             // the last byte of the utf8 encoded needle
             // SAFETY: we have an invariant that `utf8_size < 5`
-            let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size - 1) };
+            let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size() - 1) };
             if let Some(index) = memchr::memchr(last_byte, bytes) {
                 // The new finger is the index of the byte we found,
                 // plus one, since we memchr'd for the last byte of the character.
@@ -434,10 +441,10 @@ unsafe impl<'a> Searcher<'a> for CharSearcher<'a> {
                 // find something. When we find something the `finger` will be set
                 // to a UTF8 boundary.
                 self.finger += index + 1;
-                if self.finger >= self.utf8_size {
-                    let found_char = self.finger - self.utf8_size;
+                if self.finger >= self.utf8_size() {
+                    let found_char = self.finger - self.utf8_size();
                     if let Some(slice) = self.haystack.as_bytes().get(found_char..self.finger) {
-                        if slice == &self.utf8_encoded[0..self.utf8_size] {
+                        if slice == &self.utf8_encoded[0..self.utf8_size()] {
                             return Some((found_char, self.finger));
                         }
                     }
@@ -482,7 +489,7 @@ unsafe impl<'a> ReverseSearcher<'a> for CharSearcher<'a> {
             let bytes = haystack.get(self.finger..self.finger_back)?;
             // the last byte of the utf8 encoded needle
             // SAFETY: we have an invariant that `utf8_size < 5`
-            let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size - 1) };
+            let last_byte = unsafe { *self.utf8_encoded.get_unchecked(self.utf8_size() - 1) };
             if let Some(index) = memchr::memrchr(last_byte, bytes) {
                 // we searched a slice that was offset by self.finger,
                 // add self.finger to recoup the original index
@@ -493,14 +500,14 @@ unsafe impl<'a> ReverseSearcher<'a> for CharSearcher<'a> {
                 // char in the paradigm of reverse iteration). For
                 // multibyte chars we need to skip down by the number of more
                 // bytes they have than ASCII
-                let shift = self.utf8_size - 1;
+                let shift = self.utf8_size() - 1;
                 if index >= shift {
                     let found_char = index - shift;
-                    if let Some(slice) = haystack.get(found_char..(found_char + self.utf8_size)) {
-                        if slice == &self.utf8_encoded[0..self.utf8_size] {
+                    if let Some(slice) = haystack.get(found_char..(found_char + self.utf8_size())) {
+                        if slice == &self.utf8_encoded[0..self.utf8_size()] {
                             // move finger to before the character found (i.e., at its start index)
                             self.finger_back = found_char;
-                            return Some((self.finger_back, self.finger_back + self.utf8_size));
+                            return Some((self.finger_back, self.finger_back + self.utf8_size()));
                         }
                     }
                 }
@@ -542,7 +549,12 @@ impl<'a> Pattern<'a> for char {
     #[inline]
     fn into_searcher(self, haystack: &'a str) -> Self::Searcher {
         let mut utf8_encoded = [0; 4];
-        let utf8_size = self.encode_utf8(&mut utf8_encoded).len();
+        let utf8_size = self
+            .encode_utf8(&mut utf8_encoded)
+            .len()
+            .try_into()
+            .expect("char len should be less than 255");
+
         CharSearcher {
             haystack,
             finger: 0,

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -132,13 +132,13 @@ pub mod rust_2021 {
 /// The 2024 version of the prelude of The Rust Standard Library.
 ///
 /// See the [module-level documentation](self) for more.
-#[unstable(feature = "prelude_2024", issue = "none")]
+#[unstable(feature = "prelude_2024", issue = "121042")]
 pub mod rust_2024 {
-    #[unstable(feature = "prelude_2024", issue = "none")]
+    #[unstable(feature = "prelude_2024", issue = "121042")]
     #[doc(no_inline)]
     pub use super::v1::*;
 
-    #[unstable(feature = "prelude_2024", issue = "none")]
+    #[unstable(feature = "prelude_2024", issue = "121042")]
     #[doc(no_inline)]
     pub use core::prelude::rust_2024::*;
 }

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -16,7 +16,7 @@ const ENTRY_LIMIT: usize = 900;
 // FIXME: The following limits should be reduced eventually.
 
 const ISSUES_ENTRY_LIMIT: usize = 1781;
-const ROOT_ENTRY_LIMIT: usize = 871;
+const ROOT_ENTRY_LIMIT: usize = 872;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/async-await/for-await-passthrough.rs
+++ b/tests/ui/async-await/for-await-passthrough.rs
@@ -4,8 +4,6 @@
 #![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker,
            gen_blocks)]
 
-use std::future::Future;
-
 async gen fn async_iter() -> i32 {
     let iter = core::async_iter::from_iter(0..3);
     for await i in iter {

--- a/tests/ui/coroutine/async_gen_fn_iter.rs
+++ b/tests/ui/coroutine/async_gen_fn_iter.rs
@@ -46,7 +46,6 @@ async fn async_main() {
 use std::pin::{Pin, pin};
 use std::task::*;
 use std::async_iter::AsyncIterator;
-use std::future::Future;
 
 trait AsyncIterExt {
     fn next(&mut self) -> Next<'_, Self>;

--- a/tests/ui/macros/issue-121061-defined-later-2.rs
+++ b/tests/ui/macros/issue-121061-defined-later-2.rs
@@ -1,0 +1,13 @@
+mod demo {
+    fn hello() {
+        something_later!(); //~ ERROR cannot find macro `something_later` in this scope
+    }
+
+    macro_rules! something_later {
+        () => {
+            println!("successfully expanded!");
+        };
+    }
+}
+
+fn main() {}

--- a/tests/ui/macros/issue-121061-defined-later-2.stderr
+++ b/tests/ui/macros/issue-121061-defined-later-2.stderr
@@ -1,0 +1,14 @@
+error: cannot find macro `something_later` in this scope
+  --> $DIR/issue-121061-defined-later-2.rs:3:9
+   |
+LL |         something_later!();
+   |         ^^^^^^^^^^^^^^^ consider moving the definition of `something_later` before this call
+   |
+note: a macro with the same name exists, but it appears later at here
+  --> $DIR/issue-121061-defined-later-2.rs:6:18
+   |
+LL |     macro_rules! something_later {
+   |                  ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/macros/issue-121061-defined-later.rs
+++ b/tests/ui/macros/issue-121061-defined-later.rs
@@ -1,0 +1,9 @@
+fn main() {
+    something_later!(); //~ ERROR cannot find macro `something_later` in this scope
+}
+
+macro_rules! something_later {
+    () => {
+        println!("successfully expanded!");
+    };
+}

--- a/tests/ui/macros/issue-121061-defined-later.stderr
+++ b/tests/ui/macros/issue-121061-defined-later.stderr
@@ -1,0 +1,14 @@
+error: cannot find macro `something_later` in this scope
+  --> $DIR/issue-121061-defined-later.rs:2:5
+   |
+LL |     something_later!();
+   |     ^^^^^^^^^^^^^^^ consider moving the definition of `something_later` before this call
+   |
+note: a macro with the same name exists, but it appears later at here
+  --> $DIR/issue-121061-defined-later.rs:5:14
+   |
+LL | macro_rules! something_later {
+   |              ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/proc-macro/custom-attr-panic.rs
+++ b/tests/ui/proc-macro/custom-attr-panic.rs
@@ -1,0 +1,8 @@
+//@ aux-build: test-macros.rs
+
+extern crate test_macros;
+
+#[test_macros::panic_attr] //~ ERROR custom attribute panicked
+fn foo() {}
+
+fn main() {}

--- a/tests/ui/proc-macro/custom-attr-panic.stderr
+++ b/tests/ui/proc-macro/custom-attr-panic.stderr
@@ -1,0 +1,10 @@
+error: custom attribute panicked
+  --> $DIR/custom-attr-panic.rs:5:1
+   |
+LL | #[test_macros::panic_attr]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: panic-attr
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rust-2024/prelude2024.rs
+++ b/tests/ui/rust-2024/prelude2024.rs
@@ -1,0 +1,9 @@
+//@ check-pass
+//@ compile-flags: -Zunstable-options
+//@ edition:2024
+
+fn main() {
+    fut(async {}.into_future(), async {});
+}
+
+fn fut(_: impl Future, _: impl IntoFuture) {}

--- a/tests/ui/typeck/cyclic_type_ice.rs
+++ b/tests/ui/typeck/cyclic_type_ice.rs
@@ -1,0 +1,7 @@
+fn thing() {
+    let f = |_, _| ();
+    f(f); //~ ERROR: closure/coroutine type that references itself
+    //~^ ERROR: this function takes 2 arguments but 1 argument was supplied
+}
+
+fn main() {}

--- a/tests/ui/typeck/cyclic_type_ice.stderr
+++ b/tests/ui/typeck/cyclic_type_ice.stderr
@@ -1,0 +1,31 @@
+error[E0644]: closure/coroutine type that references itself
+  --> $DIR/cyclic_type_ice.rs:3:7
+   |
+LL |     f(f);
+   |       ^ cyclic type of infinite size
+   |
+   = note: closures cannot capture themselves or take themselves as argument;
+           this error may be the result of a recent compiler bug-fix,
+           see issue #46062 <https://github.com/rust-lang/rust/issues/46062>
+           for more information
+
+error[E0057]: this function takes 2 arguments but 1 argument was supplied
+  --> $DIR/cyclic_type_ice.rs:3:5
+   |
+LL |     f(f);
+   |     ^--- an argument is missing
+   |
+note: closure defined here
+  --> $DIR/cyclic_type_ice.rs:2:13
+   |
+LL |     let f = |_, _| ();
+   |             ^^^^^^
+help: provide the argument
+   |
+LL |     f(/*  */, /*  */);
+   |      ~~~~~~~~~~~~~~~~
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0057, E0644.
+For more information about an error, try `rustc --explain E0057`.


### PR DESCRIPTION
Successful merges:

 - #119808 (Store core::str::CharSearcher::utf8_size as u8)
 - #121032 (Continue reporting remaining errors instead of silently dropping them)
 - #121041 (Add `Future` and `IntoFuture` to the 2024 prelude)
 - #121130 (Suggest moving definition if non-found macro_rules! is defined later)
 - #121230 (Extend Level API)
 - #121272 (Add diagnostic items for legacy numeric constants)
 - #121275 (add test for panicking attribute macros)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119808,121032,121041,121130,121230,121272,121275)
<!-- homu-ignore:end -->