### PR TITLE
Fix `IPHONEOS_DEPLOYMENT_TARGET` on Mac Catalyst

### DIFF
--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -311,7 +311,8 @@ fn ios_deployment_target(arch: Arch, abi: &str) -> (u32, u32) {
     // If you are looking for the default deployment target, prefer `rustc --print deployment-target`.
     let (major, minor) = match (arch, abi) {
         (Arm64e, _) => (14, 0),
-        (_, "macabi") => (14, 0),
+        // Mac Catalyst defaults to 13.1 in Clang.
+        (_, "macabi") => (13, 1),
         _ => (10, 0),
     };
     from_set_deployment_target("IPHONEOS_DEPLOYMENT_TARGET").unwrap_or((major, minor))

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -131,7 +131,7 @@ pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
         abi: abi.into(),
         os: os.into(),
         cpu: arch.target_cpu().into(),
-        link_env_remove: link_env_remove(arch, os),
+        link_env_remove: link_env_remove(os),
         vendor: "apple".into(),
         linker_flavor: LinkerFlavor::Darwin(Cc::Yes, Lld::No),
         // macOS has -dead_strip, which doesn't rely on function_sections
@@ -270,7 +270,7 @@ pub fn macos_llvm_target(arch: Arch) -> String {
     format!("{}-apple-macosx{}.{}.0", arch.target_name(), major, minor)
 }
 
-fn link_env_remove(arch: Arch, os: &'static str) -> StaticCow<[StaticCow<str>]> {
+fn link_env_remove(os: &'static str) -> StaticCow<[StaticCow<str>]> {
     // Apple platforms only officially support macOS as a host for any compilation.
     //
     // If building for macOS, we go ahead and remove any erroneous environment state
@@ -298,15 +298,9 @@ fn link_env_remove(arch: Arch, os: &'static str) -> StaticCow<[StaticCow<str>]> 
         env_remove.push("TVOS_DEPLOYMENT_TARGET".into());
         env_remove.into()
     } else {
-        // Otherwise if cross-compiling for a different OS/SDK, remove any part
+        // Otherwise if cross-compiling for a different OS/SDK (including Mac Catalyst), remove any part
         // of the linking environment that's wrong and reversed.
-        match arch {
-            Armv7k | Armv7s | Arm64 | Arm64e | Arm64_32 | I386 | I386_sim | I686 | X86_64
-            | X86_64_sim | X86_64h | Arm64_sim => {
-                cvs!["MACOSX_DEPLOYMENT_TARGET"]
-            }
-            X86_64_macabi | Arm64_macabi => cvs!["IPHONEOS_DEPLOYMENT_TARGET"],
-        }
+        cvs!["MACOSX_DEPLOYMENT_TARGET"]
     }
 }
 

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_ios_macabi.rs
@@ -1,16 +1,13 @@
-use crate::spec::base::apple::{opts, Arch};
-use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, Target, TargetOptions};
+use crate::spec::base::apple::{mac_catalyst_llvm_target, opts, Arch};
+use crate::spec::{FramePointer, SanitizerSet, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let llvm_target = "arm64-apple-ios14.0-macabi";
-
     let arch = Arch::Arm64_macabi;
     let mut base = opts("ios", arch);
-    base.add_pre_link_args(LinkerFlavor::Darwin(Cc::Yes, Lld::No), &["-target", llvm_target]);
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::LEAK | SanitizerSet::THREAD;
 
     Target {
-        llvm_target: llvm_target.into(),
+        llvm_target: mac_catalyst_llvm_target(arch).into(),
         pointer_width: 64,
         data_layout: "e-m:o-i64:64-i128:128-n32:64-S128".into(),
         arch: arch.target_arch(),

--- a/compiler/rustc_target/src/spec/targets/x86_64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_apple_ios_macabi.rs
@@ -1,16 +1,13 @@
-use crate::spec::base::apple::{opts, Arch};
-use crate::spec::{Cc, LinkerFlavor, Lld, SanitizerSet, Target, TargetOptions};
+use crate::spec::base::apple::{mac_catalyst_llvm_target, opts, Arch};
+use crate::spec::{SanitizerSet, Target, TargetOptions};
 
 pub fn target() -> Target {
-    let llvm_target = "x86_64-apple-ios14.0-macabi";
-
     let arch = Arch::X86_64_macabi;
     let mut base = opts("ios", arch);
-    base.add_pre_link_args(LinkerFlavor::Darwin(Cc::Yes, Lld::No), &["-target", llvm_target]);
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::LEAK | SanitizerSet::THREAD;
 
     Target {
-        llvm_target: llvm_target.into(),
+        llvm_target: mac_catalyst_llvm_target(arch).into(),
         pointer_width: 64,
         data_layout:
             "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128".into(),


### PR DESCRIPTION
Some of the target code invalidly assumed that the deployment target variable on Mac Catalyst is `MACOSX_DEPLOYMENT_TARGET`, which is wrong, Mac Catalyst uses the same environment variable as iOS.

Additionally, the deployment target was hardcoded to `14.0`, I've lowered this to `13.1` ([same default as Clang](https://github.com/llvm/llvm-project/blob/d022f32c73c57b59a9121eba909f5034e89c628e/clang/lib/Driver/ToolChains/Darwin.cpp#L2038)), and made it properly load from the environment.

This shouldn't require any changes to the `cc` crate, as that uses `rustc --print=deployment-target` to get this information automatically.

CC @BlackHoleFox
r? @rust-lang/macos
