### PR TITLE
link.exe: Don't embed full path to PDB file in binary.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -929,6 +929,15 @@ impl<'a> Linker for MsvcLinker<'a> {
                 // from the CodeView line tables in the object files.
                 self.cmd.arg("/DEBUG");
 
+                // Default to emitting only the file name of the PDB file into
+                // the binary instead of the full path. Emitting the full path
+                // may leak private information (such as user names).
+                // See https://github.com/rust-lang/rust/issues/87825.
+                //
+                // This default behavior can be overridden by explicitly passing
+                // `-Clink-arg=/PDBALTPATH:...` to rustc.
+                self.cmd.arg("/PDBALTPATH:%_PDB%");
+
                 // This will cause the Microsoft linker to embed .natvis info into the PDB file
                 let natvis_dir_path = self.sess.sysroot.join("lib\\rustlib\\etc");
                 if let Ok(natvis_dir) = fs::read_dir(&natvis_dir_path) {

--- a/tests/run-make/pdb-alt-path/Makefile
+++ b/tests/run-make/pdb-alt-path/Makefile
@@ -4,7 +4,7 @@ include ../tools.mk
 
 all:
 	# Test that we don't have the full path to the PDB file in the binary
-	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin
+	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin -Cforce-frame-pointers
 	$(CGREP) "my_crate_name.pdb" < $(TMPDIR)/my_crate_name.exe
 	$(CGREP) -v "\\my_crate_name.pdb" < $(TMPDIR)/my_crate_name.exe
 
@@ -15,6 +15,6 @@ all:
 	$(CGREP) "pdb-alt-path\\main.rs:2" < $(TMPDIR)/backtrace.txt
 
 	# Test that explicitly passed `-Clink-arg=/PDBALTPATH:...` is respected
-	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin -Clink-arg=/PDBALTPATH:abcdefg.pdb
+	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin -Clink-arg=/PDBALTPATH:abcdefg.pdb -Cforce-frame-pointers
 	$(CGREP) "abcdefg.pdb" < $(TMPDIR)/my_crate_name.exe
 	$(CGREP) -v "my_crate_name.pdb" < $(TMPDIR)/my_crate_name.exe

--- a/tests/run-make/pdb-alt-path/Makefile
+++ b/tests/run-make/pdb-alt-path/Makefile
@@ -10,9 +10,9 @@ all:
 
 	# Test that backtraces still can find debuginfo by checking that they contain symbol names and
 	# source locations.
-	RUST_BACKTRACE="full" $(TMPDIR)/my_crate_name.exe &> $(TMPDIR)/backtrace.txt || exit 0
-	$(CGREP) "my_crate_name::main" < $(TMPDIR)/backtrace.txt
-	$(CGREP) "pdb-alt-path\\main.rs:2" < $(TMPDIR)/backtrace.txt
+	$(TMPDIR)/my_crate_name.exe &> $(TMPDIR)/backtrace.txt
+	$(CGREP) "my_crate_name::fn_in_backtrace" < $(TMPDIR)/backtrace.txt
+	$(CGREP) "main.rs:15" < $(TMPDIR)/backtrace.txt
 
 	# Test that explicitly passed `-Clink-arg=/PDBALTPATH:...` is respected
 	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin -Clink-arg=/PDBALTPATH:abcdefg.pdb -Cforce-frame-pointers

--- a/tests/run-make/pdb-alt-path/Makefile
+++ b/tests/run-make/pdb-alt-path/Makefile
@@ -1,0 +1,20 @@
+include ../tools.mk
+
+# only-windows-msvc
+
+all:
+	# Test that we don't have the full path to the PDB file in the binary
+	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin
+	$(CGREP) "my_crate_name.pdb" < $(TMPDIR)/my_crate_name.exe
+	$(CGREP) -v "\\my_crate_name.pdb" < $(TMPDIR)/my_crate_name.exe
+
+	# Test that backtraces still can find debuginfo by checking that they contain symbol names and
+	# source locations.
+	RUST_BACKTRACE="full" $(TMPDIR)/my_crate_name.exe &> $(TMPDIR)/backtrace.txt || exit 0
+	$(CGREP) "my_crate_name::main" < $(TMPDIR)/backtrace.txt
+	$(CGREP) "pdb-alt-path\\main.rs:2" < $(TMPDIR)/backtrace.txt
+
+	# Test that explicitly passed `-Clink-arg=/PDBALTPATH:...` is respected
+	$(RUSTC) main.rs -g --crate-name my_crate_name --crate-type bin -Clink-arg=/PDBALTPATH:abcdefg.pdb
+	$(CGREP) "abcdefg.pdb" < $(TMPDIR)/my_crate_name.exe
+	$(CGREP) -v "my_crate_name.pdb" < $(TMPDIR)/my_crate_name.exe

--- a/tests/run-make/pdb-alt-path/main.rs
+++ b/tests/run-make/pdb-alt-path/main.rs
@@ -1,3 +1,24 @@
+// The various #[inline(never)] annotations and std::hint::black_box calls are
+// an attempt to make unwinding as non-flaky as possible on i686-pc-windows-msvc.
+
+#[inline(never)]
+fn generate_backtrace(x: &u32) {
+    std::hint::black_box(x);
+    let bt = std::backtrace::Backtrace::force_capture();
+    println!("{}", bt);
+    std::hint::black_box(x);
+}
+
+#[inline(never)]
+fn fn_in_backtrace(x: &u32) {
+    std::hint::black_box(x);
+    generate_backtrace(x);
+    std::hint::black_box(x);
+}
+
 fn main() {
-    panic!("backtrace please");
+    let x = &41;
+    std::hint::black_box(x);
+    fn_in_backtrace(x);
+    std::hint::black_box(x);
 }

--- a/tests/run-make/pdb-alt-path/main.rs
+++ b/tests/run-make/pdb-alt-path/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    panic!("backtrace please");
+}


### PR DESCRIPTION
This PR makes `rustc` unconditionally pass `/PDBALTPATH:%_PDB%` to MSVC-style linkers, causing the linker to only embed the filename of the PDB in the binary instead of the full path. This will help implement the [trim-paths RFC](https://github.com/rust-lang/rust/issues/111540) for `*-msvc` targets.

Passing `/PDBALTPATH:%_PDB%` to the linker is already done by many projects that need reproducible builds and [debugger's should still be able to find the PDB](https://learn.microsoft.com/cpp/build/reference/pdbpath) if it is in the same directory as the binary.

r? @ghost

Fixes https://github.com/rust-lang/rust/issues/87825