### PR TITLE
Make `is_nonoverlapping` `#[inline]`

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2693,6 +2693,7 @@ pub(crate) fn is_valid_allocation_size(size: usize, len: usize) -> bool {
 
 /// Checks whether the regions of memory starting at `src` and `dst` of size
 /// `count * size` do *not* overlap.
+#[inline]
 pub(crate) fn is_nonoverlapping(src: *const (), dst: *const (), size: usize, count: usize) -> bool {
     let src_usize = src.addr();
     let dst_usize = dst.addr();


### PR DESCRIPTION
It showed up with 3% execution time in a compiler profile.

backlink to #120848

r? @saethlin 