### PR TITLE
Trigger `unsafe_code` lint on invocations of `global_asm`

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -773,7 +773,7 @@ pub(super) fn expand_global_asm<'cx>(
                         kind: ast::VisibilityKind::Inherited,
                         tokens: None,
                     },
-                    span: ecx.with_def_site_ctxt(sp),
+                    span: sp,
                     tokens: None,
                 })])
             } else {

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -72,8 +72,11 @@ lint_builtin_explicit_outlives = outlives requirements can be inferred
 
 lint_builtin_export_name_fn = declaration of a function with `export_name`
 lint_builtin_export_name_method = declaration of a method with `export_name`
-
 lint_builtin_export_name_static = declaration of a static with `export_name`
+
+lint_builtin_global_asm = usage of `core::arch::global_asm`
+lint_builtin_global_macro_unsafety = using this macro is unsafe even though it does not need an `unsafe` block
+
 lint_builtin_impl_unsafe_method = implementation of an `unsafe` method
 
 lint_builtin_incomplete_features = the feature `{$name}` is incomplete and may not be safe to use and/or cause compiler crashes

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -393,6 +393,10 @@ impl EarlyLintPass for UnsafeCode {
                 }
             }
 
+            ast::ItemKind::GlobalAsm(..) => {
+                self.report_unsafe(cx, it.span, BuiltinUnsafe::GlobalAsm);
+            }
+
             _ => {}
         }
     }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -114,6 +114,9 @@ pub enum BuiltinUnsafe {
     DeclUnsafeMethod,
     #[diag(lint_builtin_impl_unsafe_method)]
     ImplUnsafeMethod,
+    #[diag(lint_builtin_global_asm)]
+    #[note(lint_builtin_global_macro_unsafety)]
+    GlobalAsm,
 }
 
 #[derive(LintDiagnostic)]

--- a/tests/ui/asm/bad-arch.stderr
+++ b/tests/ui/asm/bad-arch.stderr
@@ -9,8 +9,6 @@ error[E0472]: inline assembly is unsupported on this target
    |
 LL | global_asm!("");
    | ^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `global_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/unsafe_code/lint-global-asm-as-unsafe.rs
+++ b/tests/ui/lint/unsafe_code/lint-global-asm-as-unsafe.rs
@@ -1,0 +1,20 @@
+//@ needs-asm-support
+#![deny(unsafe_code)]
+
+use std::arch::global_asm;
+
+#[allow(unsafe_code)]
+mod allowed_unsafe {
+    std::arch::global_asm!("");
+}
+
+macro_rules! unsafe_in_macro {
+    () => {
+        global_asm!(""); //~ ERROR: usage of `core::arch::global_asm`
+    };
+}
+
+global_asm!(""); //~ ERROR: usage of `core::arch::global_asm`
+unsafe_in_macro!();
+
+fn main() {}

--- a/tests/ui/lint/unsafe_code/lint-global-asm-as-unsafe.stderr
+++ b/tests/ui/lint/unsafe_code/lint-global-asm-as-unsafe.stderr
@@ -1,0 +1,27 @@
+error: usage of `core::arch::global_asm`
+  --> $DIR/lint-global-asm-as-unsafe.rs:17:1
+   |
+LL | global_asm!("");
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: using this macro is unsafe even though it does not need an `unsafe` block
+note: the lint level is defined here
+  --> $DIR/lint-global-asm-as-unsafe.rs:2:9
+   |
+LL | #![deny(unsafe_code)]
+   |         ^^^^^^^^^^^
+
+error: usage of `core::arch::global_asm`
+  --> $DIR/lint-global-asm-as-unsafe.rs:13:9
+   |
+LL |         global_asm!("");
+   |         ^^^^^^^^^^^^^^^
+...
+LL | unsafe_in_macro!();
+   | ------------------ in this macro invocation
+   |
+   = note: using this macro is unsafe even though it does not need an `unsafe` block
+   = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
`unsafe_code` already warns about things that don't involve the `unsafe` keyword, e.g. `#[no_mangle]`. This makes it warn on `core::arch::global_asm` too.

Fixes #103078