### PR TITLE
Don't ICE when hitting overflow limit in fulfillment loop in next solver

### DIFF
--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -109,7 +109,10 @@ impl<'tcx> TraitEngine<'tcx> for FulfillmentCtxt<'tcx> {
         let mut errors = Vec::new();
         for i in 0.. {
             if !infcx.tcx.recursion_limit().value_within_limit(i) {
-                unimplemented!("overflowed on pending obligations: {:?}", self.obligations);
+                // Only return true errors that we have accumulated while processing;
+                // keep ambiguities around, *including overflows*, because they shouldn't
+                // be considered true errors.
+                return errors;
             }
 
             let mut has_changed = false;

--- a/tests/ui/traits/next-solver/coherence-fulfill-overflow.rs
+++ b/tests/ui/traits/next-solver/coherence-fulfill-overflow.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -Znext-solver=coherence
+
+#![recursion_limit = "10"]
+
+trait Trait {}
+
+struct W<T: ?Sized>(*const T);
+trait TwoW {}
+impl<T: ?Sized + TwoW> TwoW for W<W<T>> {}
+
+impl<T: ?Sized + TwoW> Trait for W<T> {}
+impl<T: ?Sized + TwoW> Trait for T {}
+//~^ ERROR conflicting implementations of trait `Trait` for type `W
+
+fn main() {}

--- a/tests/ui/traits/next-solver/coherence-fulfill-overflow.stderr
+++ b/tests/ui/traits/next-solver/coherence-fulfill-overflow.stderr
@@ -1,0 +1,11 @@
+error[E0119]: conflicting implementations of trait `Trait` for type `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>`
+  --> $DIR/coherence-fulfill-overflow.rs:12:1
+   |
+LL | impl<T: ?Sized + TwoW> Trait for W<T> {}
+   | ------------------------------------- first implementation here
+LL | impl<T: ?Sized + TwoW> Trait for T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<W<_>>>>>>>>>>>>>>>>>>>>>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
As the title says, let's not ICE when hitting the overflow limit in fulfill. On the other hand, we don't want to treat these as true errors, since it means that whether something is considered a true error or an ambiguity is dependent on overflow handling in the solver, which seems not worth it.

Now that we use the presence of true errors in fulfillment for implicit negative coherence, we especially don't want to tie together coherence and overflow.

I guess I could also drain these errors out of fulfillment and put them into some `ambiguities` storage so we could return them in `select_all_or_error` without having to re-process them every time we call `select_where_possible`. Let me know if that's desired.

r? lcnr