### PR TITLE
Don't use raw parameter types in `find_builder_fn`

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -34,8 +34,8 @@ use rustc_middle::ty::IsSuggestable;
 use rustc_middle::ty::{self, GenericArgKind, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::def_id::DefIdSet;
 use rustc_span::symbol::{kw, sym, Ident};
-use rustc_span::Symbol;
 use rustc_span::{edit_distance, ExpnKind, FileName, MacroKind, Span};
+use rustc_span::{Symbol, DUMMY_SP};
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::error_reporting::on_unimplemented::OnUnimplementedNote;
 use rustc_trait_selection::traits::error_reporting::on_unimplemented::TypeErrCtxtExt as _;
@@ -1597,7 +1597,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .filter(|item| matches!(item.kind, ty::AssocKind::Fn) && !item.fn_has_self_parameter)
             .filter_map(|item| {
                 // Only assoc fns that return `Self`, `Option<Self>` or `Result<Self, _>`.
-                let ret_ty = self.tcx.fn_sig(item.def_id).skip_binder().output();
+                let ret_ty = self
+                    .tcx
+                    .fn_sig(item.def_id)
+                    .instantiate(self.tcx, self.fresh_args_for_item(DUMMY_SP, item.def_id))
+                    .output();
                 let ret_ty = self.tcx.instantiate_bound_regions_with_erased(ret_ty);
                 let ty::Adt(def, args) = ret_ty.kind() else {
                     return None;

--- a/tests/ui/issues/issue-30123.stderr
+++ b/tests/ui/issues/issue-30123.stderr
@@ -4,6 +4,11 @@ error[E0599]: no function or associated item named `new_undirected` found for st
 LL |     let ug = Graph::<i32, i32>::new_undirected();
    |                                 ^^^^^^^^^^^^^^ function or associated item not found in `Graph<i32, i32>`
    |
+note: if you're trying to build a new `issue_30123_aux::Graph<i32, i32>`, consider using `issue_30123_aux::Graph::<N, E>::new` which returns `issue_30123_aux::Graph<_, _>`
+  --> $DIR/auxiliary/issue-30123-aux.rs:14:5
+   |
+LL |     pub fn new() -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^
    = note: the function or associated item was found for
            - `issue_30123_aux::Graph<N, E, Undirected>`
 

--- a/tests/ui/ufcs/bad-builder.rs
+++ b/tests/ui/ufcs/bad-builder.rs
@@ -1,0 +1,6 @@
+fn hello<Q>() -> Vec<Q> {
+    Vec::<Q>::mew()
+    //~^ ERROR no function or associated item named `mew` found for struct `Vec<Q>` in the current scope
+}
+
+fn main() {}

--- a/tests/ui/ufcs/bad-builder.stderr
+++ b/tests/ui/ufcs/bad-builder.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no function or associated item named `mew` found for struct `Vec<Q>` in the current scope
+  --> $DIR/bad-builder.rs:2:15
+   |
+LL |     Vec::<Q>::mew()
+   |               ^^^
+   |               |
+   |               function or associated item not found in `Vec<Q>`
+   |               help: there is an associated function with a similar name: `new`
+   |
+note: if you're trying to build a new `Vec<Q>` consider using one of the following associated functions:
+      Vec::<T>::new
+      Vec::<T>::with_capacity
+      Vec::<T>::from_raw_parts
+      Vec::<T, A>::new_in
+      and 2 others
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
We shouldn't really ever be using `EarlyBinder::skip_binder` then performing type equality, since param types will never be equal to other types. When checking compatibility with the signature, we instead create some fresh args.

Fixes #121314