### PR TITLE
Make --verbose imply -Z write-long-types-to-disk=no

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -369,6 +369,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         if let Some(file) = file {
             err.note(format!("the full type name has been written to '{}'", file.display()));
+            err.note(format!(
+                "consider using `--verbose` to print the full type name to the console"
+            ));
         }
 
         err
@@ -493,6 +496,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if let Some(file) = ty_file {
             err.note(format!("the full type name has been written to '{}'", file.display(),));
+            err.note(format!(
+                "consider using `--verbose` to print the full type name to the console"
+            ));
         }
         if rcvr_ty.references_error() {
             err.downgrade_to_delayed_bug();

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1931,6 +1931,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                                         "the full type name has been written to '{}'",
                                         path.display(),
                                     ));
+                                    diag.note(format!("consider using `--verbose` to print the full type name to the console"));
                                 }
                             }
                         }

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -351,7 +351,7 @@ impl<'tcx> TyCtxt<'tcx> {
         })
         .expect("could not write to `String`");
 
-        if !self.sess.opts.unstable_opts.write_long_types_to_disk {
+        if !self.sess.opts.unstable_opts.write_long_types_to_disk || self.sess.opts.verbose {
             return regular;
         }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1554,6 +1554,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                             "the full type name has been written to '{}'",
                             file.display()
                         ));
+                        err.note(format!(
+                            "consider using `--verbose` to print full type name to the console"
+                        ));
                     }
 
                     if imm_ref_self_ty_satisfies_pred && mut_ref_self_ty_satisfies_pred {
@@ -3133,6 +3136,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         "the full name for the type has been written to '{}'",
                         file.display(),
                     ));
+                    err.note(format!(
+                        "consider using `--verbose` to print the full type name to the console"
+                    ));
                 }
             }
             ObligationCauseCode::RepeatElementCopy {
@@ -3600,6 +3606,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         "the full type name has been written to '{}'",
                         file.display(),
                     ));
+                    err.note(format!(
+                        "consider using `--verbose` to print the full type name to the console"
+                    ));
                 }
                 let mut parent_predicate = parent_trait_pred;
                 let mut data = &data.derived;
@@ -3652,6 +3661,9 @@ impl<'tcx> TypeErrCtxtExt<'tcx> for TypeErrCtxt<'_, 'tcx> {
                         err.note(format!(
                             "the full type name has been written to '{}'",
                             file.display(),
+                        ));
+                        err.note(format!(
+                            "consider using `--verbose` to print the full type name to the console"
                         ));
                     }
                 }

--- a/tests/ui/diagnostic-width/long-E0308.stderr
+++ b/tests/ui/diagnostic-width/long-E0308.stderr
@@ -21,6 +21,7 @@ LL |  |     ))))))))))))))))))))))))))))));
    = note: expected struct `Atype<Btype<..., ...>, ...>`
                 found enum `Result<Result<..., ...>, ...>`
    = note: the full type name has been written to '$TEST_BUILD_DIR/diagnostic-width/long-E0308/long-E0308.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0308]: mismatched types
   --> $DIR/long-E0308.rs:57:26
@@ -36,6 +37,7 @@ LL | |     ))))))))))))))))))))))));
    = note: expected enum `Option<Result<..., ...>>`
               found enum `Result<Result<..., ...>, ...>`
    = note: the full type name has been written to '$TEST_BUILD_DIR/diagnostic-width/long-E0308/long-E0308.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0308]: mismatched types
   --> $DIR/long-E0308.rs:88:9
@@ -55,6 +57,7 @@ LL | |     > = ();
    = note: expected struct `Atype<Btype<..., ...>, ...>`
            found unit type `()`
    = note: the full type name has been written to '$TEST_BUILD_DIR/diagnostic-width/long-E0308/long-E0308.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error[E0308]: mismatched types
   --> $DIR/long-E0308.rs:91:17
@@ -72,6 +75,7 @@ LL | |     ))))))))))))))))))))))));
    = note: expected unit type `()`
                    found enum `Result<Result<..., ...>, ...>`
    = note: the full type name has been written to '$TEST_BUILD_DIR/diagnostic-width/long-E0308/long-E0308.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
When shortening the type it is necessary to take into account the `--verbose` flag, if it is activated, we must always show the entire type and not write it in a file.

Fixes: https://github.com/rust-lang/rust/issues/119130