### PR TITLE
Downgrade ambiguous_wide_pointer_comparisons suggestions to MaybeIncorrect

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1543,7 +1543,8 @@ pub enum AmbiguousWidePointerComparisons<'a> {
 #[multipart_suggestion(
     lint_addr_metadata_suggestion,
     style = "verbose",
-    applicability = "machine-applicable"
+    // FIXME(#53934): make machine-applicable again
+    applicability = "maybe-incorrect"
 )]
 pub struct AmbiguousWidePointerComparisonsAddrMetadataSuggestion<'a> {
     pub ne: &'a str,
@@ -1562,7 +1563,8 @@ pub enum AmbiguousWidePointerComparisonsAddrSuggestion<'a> {
     #[multipart_suggestion(
         lint_addr_suggestion,
         style = "verbose",
-        applicability = "machine-applicable"
+        // FIXME(#53934): make machine-applicable again
+        applicability = "maybe-incorrect"
     )]
     AddrEq {
         ne: &'a str,
@@ -1578,7 +1580,8 @@ pub enum AmbiguousWidePointerComparisonsAddrSuggestion<'a> {
     #[multipart_suggestion(
         lint_addr_suggestion,
         style = "verbose",
-        applicability = "machine-applicable"
+        // FIXME(#53934): make machine-applicable again
+        applicability = "maybe-incorrect"
     )]
     Cast {
         deref_left: &'a str,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3938,10 +3938,15 @@ impl<'test> TestCx<'test> {
                 self.props.compare_output_lines_by_subset,
             );
         } else if !expected_fixed.is_empty() {
-            panic!(
-                "the `// run-rustfix` directive wasn't found but a `*.fixed` \
-                 file was found"
-            );
+            if self.config.suite == "ui" {
+                panic!(
+                    "the `//@ run-rustfix` directive wasn't found but a `*.fixed` file was found"
+                );
+            } else {
+                panic!(
+                    "the `// run-rustfix` directive wasn't found but a `*.fixed` file was found"
+                );
+            }
         }
 
         if errors > 0 {

--- a/tests/ui/lint/ambiguous_wide_pointer_comparisons_suggestions.fixed
+++ b/tests/ui/lint/ambiguous_wide_pointer_comparisons_suggestions.fixed
@@ -1,0 +1,13 @@
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+//@ check-pass
+
+// See <https://github.com/rust-lang/rust/issues/121330>.
+
+fn cmp<T: ?Sized>(a: *mut T, b: *mut T) -> bool {
+    let _ = a == b;
+    //~^ WARN ambiguous wide pointer comparison
+    panic!();
+}
+
+fn main() {}

--- a/tests/ui/lint/ambiguous_wide_pointer_comparisons_suggestions.rs
+++ b/tests/ui/lint/ambiguous_wide_pointer_comparisons_suggestions.rs
@@ -1,0 +1,13 @@
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+//@ check-pass
+
+// See <https://github.com/rust-lang/rust/issues/121330>.
+
+fn cmp<T: ?Sized>(a: *mut T, b: *mut T) -> bool {
+    let _ = a == b;
+    //~^ WARN ambiguous wide pointer comparison
+    panic!();
+}
+
+fn main() {}

--- a/tests/ui/lint/ambiguous_wide_pointer_comparisons_suggestions.stderr
+++ b/tests/ui/lint/ambiguous_wide_pointer_comparisons_suggestions.stderr
@@ -1,0 +1,18 @@
+warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
+  --> $DIR/ambiguous_wide_pointer_comparisons_suggestions.rs:8:13
+   |
+LL |     let _ = a == b;
+   |             ^^^^^^
+   |
+   = note: `#[warn(ambiguous_wide_pointer_comparisons)]` on by default
+help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
+   |
+LL |     let _ = std::ptr::addr_eq(a, b);
+   |             ++++++++++++++++++ ~  +
+help: use explicit `std::ptr::eq` method to compare metadata and addresses
+   |
+LL |     let _ = std::ptr::eq(a, b);
+   |             +++++++++++++ ~  +
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
In certain cases like #121330, it is possible to have more than one suggestion from the `ambiguous_wide_pointer_comparisons` lint (which before this PR are `MachineApplicable`). When this gets passed to rustfix, rustfix makes *multiple* changes according to the suggestions which result in incorrect code.

This is a temporary workaround. The real long term solution to problems like these is to address <https://github.com/rust-lang/rust/issues/53934>.

This PR also includes a drive-by edit to the panic message emitted by compiletest because "ui" test suite now uses `//@` directives.

Fixes #121330.