### PR TITLE
stop leaking inference variables from snapshots

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1058,7 +1058,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let coerce = Coerce::new(self, cause, AllowTwoPhase::No);
         coerce
             .autoderef(rustc_span::DUMMY_SP, expr_ty)
-            .find_map(|(ty, steps)| self.probe(|_| coerce.unify(ty, target)).ok().map(|_| steps))
+            .find_map(|(ty, steps)| self.probe(|_| coerce.unify(ty, target).ok().map(|_| steps)))
     }
 
     /// Given a type, this function will calculate and return the type given

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -163,7 +163,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if fn_sig.has_escaping_bound_vars() {
                     return fn_sig;
                 }
-                self.probe(|_| {
+                // We only return the normalized `fn_sig` if it does not contain infer vars.
+                self.probe_unchecked(|_| {
                     let ocx = ObligationCtxt::new(self);
                     let normalized_fn_sig =
                         ocx.normalize(&ObligationCause::dummy(), self.param_env, fn_sig);

--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -15,7 +15,7 @@ use rustc_errors::{Applicability, DiagnosticBuilder, SubdiagnosticMessage};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Namespace};
 use rustc_hir::def_id::DefId;
-use rustc_infer::infer::{self, InferOk};
+use rustc_infer::infer::{self, InferCtxt, InferOk, PlugSnapshotLeaks};
 use rustc_middle::query::Providers;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::{self, GenericParamDefKind, Ty, TypeVisitableExt};
@@ -67,6 +67,13 @@ pub enum MethodError<'tcx> {
     BadReturnType,
 }
 
+impl<'tcx> PlugSnapshotLeaks<'tcx> for MethodError<'tcx> {
+    fn plug_leaks(self, infcx: &InferCtxt<'tcx>) -> Self {
+        // TODO
+        self
+    }
+}
+
 // Contains a list of static methods that may apply, a list of unsatisfied trait predicates which
 // could lead to matches if satisfied, and a list of not-in-scope traits which may work.
 #[derive(Debug)]
@@ -85,6 +92,11 @@ pub struct NoMatchData<'tcx> {
 pub enum CandidateSource {
     Impl(DefId),
     Trait(DefId /* trait id */),
+}
+impl<'tcx> PlugSnapshotLeaks<'tcx> for CandidateSource {
+    fn plug_leaks(self, _: &InferCtxt<'tcx>) -> Self {
+        self
+    }
 }
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {

--- a/compiler/rustc_infer/src/infer/fudge.rs
+++ b/compiler/rustc_infer/src/infer/fudge.rs
@@ -109,7 +109,7 @@ impl<'tcx> InferCtxt<'tcx> {
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
         let variable_lengths = self.variable_lengths();
-        let (mut fudger, value) = self.probe(|_| {
+        let (mut fudger, value) = self.probe_unchecked(|_| {
             match f() {
                 Ok(value) => {
                     let value = self.resolve_vars_if_possible(value);

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(extend_one)]
 #![feature(let_chains)]
 #![feature(if_let_guard)]
+#![feature(never_type)]
 #![feature(iterator_try_collect)]
 #![cfg_attr(bootstrap, feature(min_specialization))]
 #![feature(try_blocks)]

--- a/compiler/rustc_infer/src/traits/project.rs
+++ b/compiler/rustc_infer/src/traits/project.rs
@@ -2,7 +2,7 @@
 
 use super::PredicateObligation;
 
-use crate::infer::InferCtxtUndoLogs;
+use crate::infer::{InferCtxt, InferCtxtUndoLogs, PlugSnapshotLeaks};
 
 use rustc_data_structures::{
     snapshot_map::{self, SnapshotMapRef, SnapshotMapStorage},
@@ -18,6 +18,11 @@ pub(crate) type UndoLog<'tcx> =
 #[derive(Clone)]
 pub struct MismatchedProjectionTypes<'tcx> {
     pub err: ty::error::TypeError<'tcx>,
+}
+impl<'tcx> PlugSnapshotLeaks<'tcx> for MismatchedProjectionTypes<'tcx> {
+    fn plug_leaks(self, infcx: &InferCtxt<'tcx>) -> Self {
+        MismatchedProjectionTypes { err: self.err.plug_leaks(infcx) }
+    }
 }
 
 #[derive(Clone)]

--- a/compiler/rustc_trait_selection/src/infer.rs
+++ b/compiler/rustc_trait_selection/src/infer.rs
@@ -86,22 +86,20 @@ impl<'tcx> InferCtxt<'tcx> {
         ty: Ty<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> Option<Vec<traits::FulfillmentError<'tcx>>> {
-        self.probe(|_snapshot| {
-            let mut selcx = SelectionContext::new(self);
-            match selcx.select(&Obligation::new(
-                self.tcx,
-                ObligationCause::dummy(),
-                param_env,
-                ty::TraitRef::new(self.tcx, trait_def_id, [ty]),
-            )) {
-                Ok(Some(selection)) => {
-                    let mut fulfill_cx = <dyn TraitEngine<'tcx>>::new(self);
-                    fulfill_cx.register_predicate_obligations(self, selection.nested_obligations());
-                    Some(fulfill_cx.select_all_or_error(self))
-                }
-                Ok(None) | Err(_) => None,
+        let mut selcx = SelectionContext::new(self);
+        match selcx.select(&Obligation::new(
+            self.tcx,
+            ObligationCause::dummy(),
+            param_env,
+            ty::TraitRef::new(self.tcx, trait_def_id, [ty]),
+        )) {
+            Ok(Some(selection)) => {
+                let mut fulfill_cx = <dyn TraitEngine<'tcx>>::new(self);
+                fulfill_cx.register_predicate_obligations(self, selection.nested_obligations());
+                Some(fulfill_cx.select_all_or_error(self))
             }
-        })
+            Ok(None) | Err(_) => None,
+        }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/probe.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/probe.rs
@@ -1,6 +1,7 @@
 use crate::solve::assembly::Candidate;
 
 use super::EvalCtxt;
+use rustc_infer::infer::PlugSnapshotLeaks;
 use rustc_middle::traits::{
     query::NoSolution,
     solve::{inspect, CandidateSource, QueryResult},
@@ -17,7 +18,10 @@ impl<'tcx, F, T> ProbeCtxt<'_, '_, 'tcx, F, T>
 where
     F: FnOnce(&T) -> inspect::ProbeKind<'tcx>,
 {
-    pub(in crate::solve) fn enter(self, f: impl FnOnce(&mut EvalCtxt<'_, 'tcx>) -> T) -> T {
+    pub(in crate::solve) fn enter(self, f: impl FnOnce(&mut EvalCtxt<'_, 'tcx>) -> T) -> T
+    where
+        T: PlugSnapshotLeaks<'tcx>,
+    {
         let ProbeCtxt { ecx: outer_ecx, probe_kind, _result } = self;
 
         let mut nested_ecx = EvalCtxt {

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -10,7 +10,7 @@
 /// as is until we start using it for something else.
 use std::ops::ControlFlow;
 
-use rustc_infer::infer::InferCtxt;
+use rustc_infer::infer::{InferCtxt, PlugSnapshotLeaks};
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::traits::solve::{inspect, QueryResult};
 use rustc_middle::traits::solve::{Certainty, Goal};
@@ -211,7 +211,7 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
 
 /// The public API to interact with proof trees.
 pub trait ProofTreeVisitor<'tcx> {
-    type BreakTy;
+    type BreakTy: PlugSnapshotLeaks<'tcx>;
 
     fn visit_goal(&mut self, goal: &InspectGoal<'_, 'tcx>) -> ControlFlow<Self::BreakTy>;
 }

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -893,7 +893,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         ty: Ty<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         cause: &ObligationCause<'tcx>,
-    ) -> Option<ty::PolyExistentialTraitRef<'tcx>> {
+    ) -> Option<DefId> {
         let tcx = self.tcx();
         if tcx.features().trait_upcasting {
             return None;
@@ -922,7 +922,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             .ty()
             .unwrap();
 
-            if let ty::Dynamic(data, ..) = ty.kind() { data.principal() } else { None }
+            if let ty::Dynamic(data, ..) = ty.kind() { data.principal_def_id() } else { None }
         })
     }
 
@@ -993,12 +993,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     let principal_a = a_data.principal().unwrap();
                     let target_trait_did = principal_def_id_b.unwrap();
                     let source_trait_ref = principal_a.with_self_ty(self.tcx(), source);
-                    if let Some(deref_trait_ref) = self.need_migrate_deref_output_trait_object(
+                    if let Some(principal_def_id) = self.need_migrate_deref_output_trait_object(
                         source,
                         obligation.param_env,
                         &obligation.cause,
                     ) {
-                        if deref_trait_ref.def_id() == target_trait_did {
+                        if principal_def_id == target_trait_did {
                             return;
                         }
                     }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -34,6 +34,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_infer::infer::BoundRegionConversionTime;
 use rustc_infer::infer::DefineOpaqueTypes;
+use rustc_infer::infer::PlugSnapshotLeaks;
 use rustc_infer::traits::TraitObligation;
 use rustc_middle::dep_graph::dep_kinds;
 use rustc_middle::dep_graph::DepNodeIndex;
@@ -3083,6 +3084,11 @@ pub enum ProjectionMatchesProjection {
     Yes,
     Ambiguous,
     No,
+}
+impl PlugSnapshotLeaks<'_> for ProjectionMatchesProjection {
+    fn plug_leaks(self, _: &InferCtxt<'_>) -> Self {
+        self
+    }
 }
 
 /// Replace all regions inside the coroutine interior with late bound regions.


### PR DESCRIPTION
a revival of #100745. Right now we can very easily ICE when trying to use the returned values from `probe` and `commit_if_ok`.

I closed that PR as this check detected issues but we didn't get any unexpected ICEs from this, so I thought:

> so afaict inference variables actually remain valid, we just drop any unifications from inside of the snapshot 🤔 so i guess while still weird, this isn't a soundness issue?

nah, we just tend to not use the leaked inference vars in any way that causes ICEs. A slight change to `coercion` which I am working on separately did result in such an ICE.

r? @compiler-errors  