### PR TITLE
Tweak inlining attributes for slice indexing

### DIFF
--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -13,7 +13,7 @@ where
 {
     type Output = I::Output;
 
-    #[inline(always)]
+    #[inline]
     fn index(&self, index: I) -> &I::Output {
         index.index(self)
     }
@@ -24,7 +24,7 @@ impl<T, I> ops::IndexMut<I> for [T]
 where
     I: SliceIndex<[T]>,
 {
-    #[inline(always)]
+    #[inline]
     fn index_mut(&mut self, index: I) -> &mut I::Output {
         index.index_mut(self)
     }
@@ -390,7 +390,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn index(self, slice: &[T]) -> &[T] {
         if self.start > self.end {
             slice_index_order_fail(self.start, self.end);
@@ -440,7 +440,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeTo<usize> {
         unsafe { (0..self.end).get_unchecked_mut(slice) }
     }
 
-    #[inline(always)]
+    #[inline]
     fn index(self, slice: &[T]) -> &[T] {
         (0..self.end).index(slice)
     }


### PR DESCRIPTION
Doing some experiments in response to this unexpected regression: https://github.com/rust-lang/rust/pull/120863#issuecomment-1954713907

I expect the opt changes to be addressed by something like reviving https://github.com/rust-lang/rust/pull/91222. The debug changes are what I'm interested in.

Codegen tests will probably fail from time to time in this PR, I will fix them up later but also I don't trust the opt-level-z one: https://github.com/rust-lang/rust/pull/119878#issuecomment-1955241667

r? @ghost