### PR TITLE
Print proper relative path for descriptive name check

### DIFF
--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -162,7 +162,7 @@ pub fn check(path: &Path, bless: bool, bad: &mut bool) {
                     if !remaining_issue_names.remove(stripped_path) {
                         tidy_error!(
                             bad,
-                            "file `{stripped_path}` must begin with a descriptive name, consider `{{reason}}-issue-{issue_n}.rs`",
+                            "file `tests/{stripped_path}` must begin with a descriptive name, consider `{{reason}}-issue-{issue_n}.rs`",
                             issue_n = &test_name[1],
                         );
                     }


### PR DESCRIPTION
The `stripped_path` starts with `ui/...`, while we are mostly working in `rust` directory.
print a relative path starting with `tests/ui/...` so that we can copy and use the path when renaming. 

Hardcoding the `tests` maybe not good style, but seems we have a lot of hardcoded `tests/..` paths in tidy check :(.
