### PR TITLE
test that we do not support higher-ranked regions in opaque type inference

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -154,7 +154,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 if prev.ty != ty {
                     let guar = ty.error_reported().err().unwrap_or_else(|| {
                         let (Ok(e) | Err(e)) = prev
-                            .report_mismatch(
+                            .build_mismatch_error(
                                 &OpaqueHiddenType { ty, span: concrete_type.span },
                                 opaque_type_key.def_id,
                                 infcx.tcx,

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -153,12 +153,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             if let Some(prev) = result.get_mut(&opaque_type_key.def_id) {
                 if prev.ty != ty {
                     let guar = ty.error_reported().err().unwrap_or_else(|| {
-                        prev.report_mismatch(
-                            &OpaqueHiddenType { ty, span: concrete_type.span },
-                            opaque_type_key.def_id,
-                            infcx.tcx,
-                        )
-                        .emit()
+                        let (Ok(e) | Err(e)) = prev
+                            .report_mismatch(
+                                &OpaqueHiddenType { ty, span: concrete_type.span },
+                                opaque_type_key.def_id,
+                                infcx.tcx,
+                            )
+                            .map(|d| d.emit());
+                        e
                     });
                     prev.ty = Ty::new_error(infcx.tcx, guar);
                 }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -478,7 +478,7 @@ fn sanity_check_found_hidden_type<'tcx>(
     } else {
         let span = tcx.def_span(key.def_id);
         let other = ty::OpaqueHiddenType { ty: hidden_ty, span };
-        Err(ty.report_mismatch(&other, key.def_id, tcx)?.emit())
+        Err(ty.build_mismatch_error(&other, key.def_id, tcx)?.emit())
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -478,7 +478,7 @@ fn sanity_check_found_hidden_type<'tcx>(
     } else {
         let span = tcx.def_span(key.def_id);
         let other = ty::OpaqueHiddenType { ty: hidden_ty, span };
-        Err(ty.report_mismatch(&other, key.def_id, tcx).emit())
+        Err(ty.report_mismatch(&other, key.def_id, tcx)?.emit())
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
@@ -58,10 +58,10 @@ pub(super) fn find_opaque_ty_constraints_for_impl_trait_in_assoc_type(
         // Only check against typeck if we didn't already error
         if !hidden.ty.references_error() {
             for concrete_type in locator.typeck_types {
-                if concrete_type.ty != tcx.erase_regions(hidden.ty)
-                    && !(concrete_type, hidden).references_error()
-                {
-                    hidden.report_mismatch(&concrete_type, def_id, tcx).emit();
+                if concrete_type.ty != tcx.erase_regions(hidden.ty) {
+                    if let Ok(d) = hidden.report_mismatch(&concrete_type, def_id, tcx) {
+                        d.emit();
+                    }
                 }
             }
         }
@@ -134,10 +134,10 @@ pub(super) fn find_opaque_ty_constraints_for_tait(tcx: TyCtxt<'_>, def_id: Local
         // Only check against typeck if we didn't already error
         if !hidden.ty.references_error() {
             for concrete_type in locator.typeck_types {
-                if concrete_type.ty != tcx.erase_regions(hidden.ty)
-                    && !(concrete_type, hidden).references_error()
-                {
-                    hidden.report_mismatch(&concrete_type, def_id, tcx).emit();
+                if concrete_type.ty != tcx.erase_regions(hidden.ty) {
+                    if let Ok(d) = hidden.report_mismatch(&concrete_type, def_id, tcx) {
+                        d.emit();
+                    }
                 }
             }
         }
@@ -287,8 +287,10 @@ impl TaitConstraintLocator<'_> {
         if let Some(&concrete_type) = borrowck_results.concrete_opaque_types.get(&self.def_id) {
             debug!(?concrete_type, "found constraint");
             if let Some(prev) = &mut self.found {
-                if concrete_type.ty != prev.ty && !(concrete_type, prev.ty).references_error() {
-                    let guar = prev.report_mismatch(&concrete_type, self.def_id, self.tcx).emit();
+                if concrete_type.ty != prev.ty {
+                    let (Ok(guar) | Err(guar)) = prev
+                        .report_mismatch(&concrete_type, self.def_id, self.tcx)
+                        .map(|d| d.emit());
                     prev.ty = Ty::new_error(self.tcx, guar);
                 }
             } else {
@@ -361,11 +363,13 @@ pub(super) fn find_opaque_ty_constraints_for_rpit<'tcx>(
                 hidden_type.remap_generic_params_to_declaration_params(opaque_type_key, tcx, true),
             );
             if let Some(prev) = &mut hir_opaque_ty {
-                if concrete_type.ty != prev.ty && !(concrete_type, prev.ty).references_error() {
-                    prev.report_mismatch(&concrete_type, def_id, tcx).stash(
-                        tcx.def_span(opaque_type_key.def_id),
-                        StashKey::OpaqueHiddenTypeMismatch,
-                    );
+                if concrete_type.ty != prev.ty {
+                    if let Ok(d) = prev.report_mismatch(&concrete_type, def_id, tcx) {
+                        d.stash(
+                            tcx.def_span(opaque_type_key.def_id),
+                            StashKey::OpaqueHiddenTypeMismatch,
+                        );
+                    }
                 }
             } else {
                 hir_opaque_ty = Some(concrete_type);
@@ -436,9 +440,10 @@ impl RpitConstraintChecker<'_> {
 
             debug!(?concrete_type, "found constraint");
 
-            if concrete_type.ty != self.found.ty && !(concrete_type, self.found).references_error()
-            {
-                self.found.report_mismatch(&concrete_type, self.def_id, self.tcx).emit();
+            if concrete_type.ty != self.found.ty {
+                if let Ok(d) = self.found.report_mismatch(&concrete_type, self.def_id, self.tcx) {
+                    d.emit();
+                }
             }
         }
     }

--- a/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
@@ -59,7 +59,7 @@ pub(super) fn find_opaque_ty_constraints_for_impl_trait_in_assoc_type(
         if !hidden.ty.references_error() {
             for concrete_type in locator.typeck_types {
                 if concrete_type.ty != tcx.erase_regions(hidden.ty) {
-                    if let Ok(d) = hidden.report_mismatch(&concrete_type, def_id, tcx) {
+                    if let Ok(d) = hidden.build_mismatch_error(&concrete_type, def_id, tcx) {
                         d.emit();
                     }
                 }
@@ -135,7 +135,7 @@ pub(super) fn find_opaque_ty_constraints_for_tait(tcx: TyCtxt<'_>, def_id: Local
         if !hidden.ty.references_error() {
             for concrete_type in locator.typeck_types {
                 if concrete_type.ty != tcx.erase_regions(hidden.ty) {
-                    if let Ok(d) = hidden.report_mismatch(&concrete_type, def_id, tcx) {
+                    if let Ok(d) = hidden.build_mismatch_error(&concrete_type, def_id, tcx) {
                         d.emit();
                     }
                 }
@@ -289,7 +289,7 @@ impl TaitConstraintLocator<'_> {
             if let Some(prev) = &mut self.found {
                 if concrete_type.ty != prev.ty {
                     let (Ok(guar) | Err(guar)) = prev
-                        .report_mismatch(&concrete_type, self.def_id, self.tcx)
+                        .build_mismatch_error(&concrete_type, self.def_id, self.tcx)
                         .map(|d| d.emit());
                     prev.ty = Ty::new_error(self.tcx, guar);
                 }
@@ -364,7 +364,7 @@ pub(super) fn find_opaque_ty_constraints_for_rpit<'tcx>(
             );
             if let Some(prev) = &mut hir_opaque_ty {
                 if concrete_type.ty != prev.ty {
-                    if let Ok(d) = prev.report_mismatch(&concrete_type, def_id, tcx) {
+                    if let Ok(d) = prev.build_mismatch_error(&concrete_type, def_id, tcx) {
                         d.stash(
                             tcx.def_span(opaque_type_key.def_id),
                             StashKey::OpaqueHiddenTypeMismatch,
@@ -441,7 +441,9 @@ impl RpitConstraintChecker<'_> {
             debug!(?concrete_type, "found constraint");
 
             if concrete_type.ty != self.found.ty {
-                if let Ok(d) = self.found.report_mismatch(&concrete_type, self.def_id, self.tcx) {
+                if let Ok(d) =
+                    self.found.build_mismatch_error(&concrete_type, self.def_id, self.tcx)
+                {
                     d.emit();
                 }
             }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -589,12 +589,14 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 && last_opaque_ty.ty != hidden_type.ty
             {
                 assert!(!self.fcx.next_trait_solver());
-                hidden_type
-                    .report_mismatch(&last_opaque_ty, opaque_type_key.def_id, self.tcx())
-                    .stash(
+                if let Ok(d) =
+                    hidden_type.report_mismatch(&last_opaque_ty, opaque_type_key.def_id, self.tcx())
+                {
+                    d.stash(
                         self.tcx().def_span(opaque_type_key.def_id),
                         StashKey::OpaqueHiddenTypeMismatch,
                     );
+                }
             }
         }
     }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -589,9 +589,11 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 && last_opaque_ty.ty != hidden_type.ty
             {
                 assert!(!self.fcx.next_trait_solver());
-                if let Ok(d) =
-                    hidden_type.report_mismatch(&last_opaque_ty, opaque_type_key.def_id, self.tcx())
-                {
+                if let Ok(d) = hidden_type.build_mismatch_error(
+                    &last_opaque_ty,
+                    opaque_type_key.def_id,
+                    self.tcx(),
+                ) {
                     d.stash(
                         self.tcx().def_span(opaque_type_key.def_id),
                         StashKey::OpaqueHiddenTypeMismatch,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -840,7 +840,7 @@ pub struct OpaqueHiddenType<'tcx> {
 }
 
 impl<'tcx> OpaqueHiddenType<'tcx> {
-    pub fn report_mismatch(
+    pub fn build_mismatch_error(
         &self,
         other: &Self,
         opaque_def_id: LocalDefId,

--- a/tests/ui/generic-associated-types/issue-90014-tait2.stderr
+++ b/tests/ui/generic-associated-types/issue-90014-tait2.stderr
@@ -1,4 +1,11 @@
 error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/issue-90014-tait2.rs:27:9
+   |
+LL | type Fut<'a> = impl Future<Output = ()>;
+   |          -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |         Box::new((async { () },))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.rs
+++ b/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.rs
@@ -1,0 +1,25 @@
+// Regression test for #97099.
+// This was an ICE because `impl Sized` captures the lifetime 'a.
+
+// check-fail
+
+trait Trait<E> {
+    type Assoc;
+}
+
+struct Foo;
+
+impl<'a> Trait<&'a ()> for Foo {
+    type Assoc = ();
+}
+
+fn foo() -> impl for<'a> Trait<&'a ()> {
+    Foo
+}
+
+fn bar() -> impl for<'a> Trait<&'a (), Assoc = impl Sized> {
+    foo()
+    //~^ ERROR hidden type for `impl Sized` captures lifetime that does not appear in bounds
+}
+
+fn main() {}

--- a/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.rs
+++ b/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.rs
@@ -1,8 +1,6 @@
 // Regression test for #97099.
 // This was an ICE because `impl Sized` captures the lifetime 'a.
 
-// check-fail
-
 trait Trait<E> {
     type Assoc;
 }

--- a/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.stderr
+++ b/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.stderr
@@ -1,5 +1,5 @@
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/higher-ranked-regions-diag.rs:21:5
+  --> $DIR/higher-ranked-regions-diag.rs:19:5
    |
 LL | fn bar() -> impl for<'a> Trait<&'a (), Assoc = impl Sized> {
    |                      --                        ---------- opaque type defined here

--- a/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.stderr
+++ b/tests/ui/rfcs/impl-trait/higher-ranked-regions-diag.stderr
@@ -1,0 +1,13 @@
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-diag.rs:21:5
+   |
+LL | fn bar() -> impl for<'a> Trait<&'a (), Assoc = impl Sized> {
+   |                      --                        ---------- opaque type defined here
+   |                      |
+   |                      hidden type `<impl for<'a> Trait<&'a ()> as Trait<&'a ()>>::Assoc` captures the lifetime `'a` as defined here
+LL |     foo()
+   |     ^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0700`.

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.rs
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.rs
@@ -1,0 +1,84 @@
+// Basic tests for opaque type inference under for<_> binders.
+
+// check-fail
+
+#![feature(type_alias_impl_trait)]
+
+trait Trait<'a> {
+    type Ty;
+}
+impl<'a, T> Trait<'a> for T {
+    type Ty = &'a ();
+}
+
+mod basic_pass {
+    use super::*;
+    type Opq<'a> = impl Sized + 'a;
+    fn test() -> impl for<'a> Trait<'a, Ty = Opq<'a>> {}
+    //~^ ERROR: expected generic lifetime parameter, found `'a`
+}
+
+mod capture_rpit {
+    use super::*;
+    fn test() -> impl for<'a> Trait<'a, Ty = impl Sized> {}
+    //~^ ERROR hidden type for `impl Sized` captures lifetime that does not appear in bounds
+}
+
+mod capture_tait {
+    use super::*;
+    type Opq0 = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0>;
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+    //~^ ERROR hidden type for `capture_tait::Opq0` captures lifetime that does not appear in bounds
+}
+
+mod capture_tait_complex_pass {
+    use super::*;
+    type Opq0<'a> = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
+    //~^ ERROR: concrete type differs from previous defining opaque type use
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+    //~^ ERROR: expected generic lifetime parameter, found `'a`
+}
+
+// Same as the above, but make sure that different placeholder regions are not equal.
+mod capture_tait_complex_fail {
+    use super::*;
+    type Opq0<'a> = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a>>; // <- Note 'a
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+    //~^ ERROR hidden type for `capture_tait_complex_fail::Opq0<'a>` captures lifetime that does not appear in bounds
+}
+
+// non-defining use because 'static is used.
+mod constrain_fail0 {
+    use super::*;
+    type Opq0<'a, 'b> = impl Sized;
+    fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
+    //~^ ERROR non-defining opaque type use in defining scope
+    //~| ERROR: expected generic lifetime parameter, found `'a`
+}
+
+// non-defining use because generic lifetime is used multiple times.
+mod constrain_fail {
+    use super::*;
+    type Opq0<'a, 'b> = impl Sized;
+    fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
+    //~^ ERROR non-defining opaque type use in defining scope
+    //~| ERROR: expected generic lifetime parameter, found `'a`
+}
+
+mod constrain_pass {
+    use super::*;
+    type Opq0<'a, 'b> = impl Sized;
+    type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
+    //~^ ERROR concrete type differs
+    type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+    fn test() -> Opq2 {}
+    //~^ ERROR: expected generic lifetime parameter, found `'a`
+}
+
+fn main() {}

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.rs
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.rs
@@ -1,7 +1,5 @@
 // Basic tests for opaque type inference under for<_> binders.
 
-// check-fail
-
 #![feature(type_alias_impl_trait)]
 
 trait Trait<'a> {

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.rs
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.rs
@@ -37,7 +37,6 @@ mod capture_tait_complex_pass {
     use super::*;
     type Opq0<'a> = impl Sized;
     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
-    //~^ ERROR: concrete type differs from previous defining opaque type use
     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
     fn test() -> Opq2 {}
     //~^ ERROR: expected generic lifetime parameter, found `'a`
@@ -75,7 +74,6 @@ mod constrain_pass {
     use super::*;
     type Opq0<'a, 'b> = impl Sized;
     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
-    //~^ ERROR concrete type differs
     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
     fn test() -> Opq2 {}
     //~^ ERROR: expected generic lifetime parameter, found `'a`

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.stderr
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.stderr
@@ -27,28 +27,16 @@ LL |     fn test() -> Opq2 {}
    |                       ^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:42:23
+  --> $DIR/higher-ranked-regions-basic.rs:41:23
    |
 LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
    |               -- this generic parameter must be used with a generic lifetime parameter
-...
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
 LL |     fn test() -> Opq2 {}
    |                       ^^
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/higher-ranked-regions-basic.rs:39:21
-   |
-LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a ()`, got `{type error}`
-   |
-note: previous use here
-  --> $DIR/higher-ranked-regions-basic.rs:41:17
-   |
-LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0700]: hidden type for `capture_tait_complex_fail::Opq0<'a>` captures lifetime that does not appear in bounds
-  --> $DIR/higher-ranked-regions-basic.rs:52:23
+  --> $DIR/higher-ranked-regions-basic.rs:51:23
    |
 LL |     type Opq0<'a> = impl Sized;
    |                     ---------- opaque type defined here
@@ -59,19 +47,19 @@ LL |     fn test() -> Opq2 {}
    |                       ^^
 
 error[E0792]: non-defining opaque type use in defining scope
-  --> $DIR/higher-ranked-regions-basic.rs:60:41
+  --> $DIR/higher-ranked-regions-basic.rs:59:41
    |
 LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
    |                                         ^^^^^^^^^^^^^^^^^^^^^^ argument `'static` is not a generic parameter
    |
 note: for this opaque type
-  --> $DIR/higher-ranked-regions-basic.rs:59:25
+  --> $DIR/higher-ranked-regions-basic.rs:58:25
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |                         ^^^^^^^^^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:60:65
+  --> $DIR/higher-ranked-regions-basic.rs:59:65
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |               -- this generic parameter must be used with a generic lifetime parameter
@@ -79,19 +67,19 @@ LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
    |                                                                 ^^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/higher-ranked-regions-basic.rs:69:41
+  --> $DIR/higher-ranked-regions-basic.rs:68:41
    |
 LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
    |                                         ^^^^^^^^^^^^^^^^^ generic argument `'a` used twice
    |
 note: for this opaque type
-  --> $DIR/higher-ranked-regions-basic.rs:68:25
+  --> $DIR/higher-ranked-regions-basic.rs:67:25
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |                         ^^^^^^^^^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:69:60
+  --> $DIR/higher-ranked-regions-basic.rs:68:60
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |               -- this generic parameter must be used with a generic lifetime parameter
@@ -99,27 +87,15 @@ LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
    |                                                            ^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:80:23
+  --> $DIR/higher-ranked-regions-basic.rs:78:23
    |
 LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
    |               -- this generic parameter must be used with a generic lifetime parameter
-...
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
 LL |     fn test() -> Opq2 {}
    |                       ^^
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/higher-ranked-regions-basic.rs:77:21
-   |
-LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a ()`, got `{type error}`
-   |
-note: previous use here
-  --> $DIR/higher-ranked-regions-basic.rs:79:17
-   |
-LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 12 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0700, E0792.
 For more information about an error, try `rustc --explain E0700`.

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.stderr
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.stderr
@@ -1,5 +1,5 @@
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:17:55
+  --> $DIR/higher-ranked-regions-basic.rs:15:55
    |
 LL |     type Opq<'a> = impl Sized + 'a;
    |              -- this generic parameter must be used with a generic lifetime parameter
@@ -7,7 +7,7 @@ LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq<'a>> {}
    |                                                       ^^
 
 error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
-  --> $DIR/higher-ranked-regions-basic.rs:23:58
+  --> $DIR/higher-ranked-regions-basic.rs:21:58
    |
 LL |     fn test() -> impl for<'a> Trait<'a, Ty = impl Sized> {}
    |                           --                 ----------  ^^
@@ -16,7 +16,7 @@ LL |     fn test() -> impl for<'a> Trait<'a, Ty = impl Sized> {}
    |                           hidden type `&'a ()` captures the lifetime `'a` as defined here
 
 error[E0700]: hidden type for `capture_tait::Opq0` captures lifetime that does not appear in bounds
-  --> $DIR/higher-ranked-regions-basic.rs:32:23
+  --> $DIR/higher-ranked-regions-basic.rs:30:23
    |
 LL |     type Opq0 = impl Sized;
    |                 ---------- opaque type defined here
@@ -27,7 +27,7 @@ LL |     fn test() -> Opq2 {}
    |                       ^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:41:23
+  --> $DIR/higher-ranked-regions-basic.rs:39:23
    |
 LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
    |               -- this generic parameter must be used with a generic lifetime parameter
@@ -36,7 +36,7 @@ LL |     fn test() -> Opq2 {}
    |                       ^^
 
 error[E0700]: hidden type for `capture_tait_complex_fail::Opq0<'a>` captures lifetime that does not appear in bounds
-  --> $DIR/higher-ranked-regions-basic.rs:51:23
+  --> $DIR/higher-ranked-regions-basic.rs:49:23
    |
 LL |     type Opq0<'a> = impl Sized;
    |                     ---------- opaque type defined here
@@ -47,19 +47,19 @@ LL |     fn test() -> Opq2 {}
    |                       ^^
 
 error[E0792]: non-defining opaque type use in defining scope
-  --> $DIR/higher-ranked-regions-basic.rs:59:41
+  --> $DIR/higher-ranked-regions-basic.rs:57:41
    |
 LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
    |                                         ^^^^^^^^^^^^^^^^^^^^^^ argument `'static` is not a generic parameter
    |
 note: for this opaque type
-  --> $DIR/higher-ranked-regions-basic.rs:58:25
+  --> $DIR/higher-ranked-regions-basic.rs:56:25
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |                         ^^^^^^^^^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:59:65
+  --> $DIR/higher-ranked-regions-basic.rs:57:65
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |               -- this generic parameter must be used with a generic lifetime parameter
@@ -67,19 +67,19 @@ LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
    |                                                                 ^^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/higher-ranked-regions-basic.rs:68:41
+  --> $DIR/higher-ranked-regions-basic.rs:66:41
    |
 LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
    |                                         ^^^^^^^^^^^^^^^^^ generic argument `'a` used twice
    |
 note: for this opaque type
-  --> $DIR/higher-ranked-regions-basic.rs:67:25
+  --> $DIR/higher-ranked-regions-basic.rs:65:25
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |                         ^^^^^^^^^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:68:60
+  --> $DIR/higher-ranked-regions-basic.rs:66:60
    |
 LL |     type Opq0<'a, 'b> = impl Sized;
    |               -- this generic parameter must be used with a generic lifetime parameter
@@ -87,7 +87,7 @@ LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
    |                                                            ^^
 
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-basic.rs:78:23
+  --> $DIR/higher-ranked-regions-basic.rs:76:23
    |
 LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
    |               -- this generic parameter must be used with a generic lifetime parameter

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.stderr
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-basic.stderr
@@ -1,0 +1,125 @@
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/higher-ranked-regions-basic.rs:17:55
+   |
+LL |     type Opq<'a> = impl Sized + 'a;
+   |              -- this generic parameter must be used with a generic lifetime parameter
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq<'a>> {}
+   |                                                       ^^
+
+error[E0700]: hidden type for `impl Sized` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-basic.rs:23:58
+   |
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = impl Sized> {}
+   |                           --                 ----------  ^^
+   |                           |                  |
+   |                           |                  opaque type defined here
+   |                           hidden type `&'a ()` captures the lifetime `'a` as defined here
+
+error[E0700]: hidden type for `capture_tait::Opq0` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-basic.rs:32:23
+   |
+LL |     type Opq0 = impl Sized;
+   |                 ---------- opaque type defined here
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0>;
+   |                              -- hidden type `&'b ()` captures the lifetime `'b` as defined here
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+LL |     fn test() -> Opq2 {}
+   |                       ^^
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/higher-ranked-regions-basic.rs:42:23
+   |
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
+   |               -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     fn test() -> Opq2 {}
+   |                       ^^
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/higher-ranked-regions-basic.rs:39:21
+   |
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'b>>; // <- Note 'b
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a ()`, got `{type error}`
+   |
+note: previous use here
+  --> $DIR/higher-ranked-regions-basic.rs:41:17
+   |
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0700]: hidden type for `capture_tait_complex_fail::Opq0<'a>` captures lifetime that does not appear in bounds
+  --> $DIR/higher-ranked-regions-basic.rs:52:23
+   |
+LL |     type Opq0<'a> = impl Sized;
+   |                     ---------- opaque type defined here
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a>>; // <- Note 'a
+   |                              -- hidden type `&'b ()` captures the lifetime `'b` as defined here
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+LL |     fn test() -> Opq2 {}
+   |                       ^^
+
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/higher-ranked-regions-basic.rs:60:41
+   |
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^ argument `'static` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/higher-ranked-regions-basic.rs:59:25
+   |
+LL |     type Opq0<'a, 'b> = impl Sized;
+   |                         ^^^^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/higher-ranked-regions-basic.rs:60:65
+   |
+LL |     type Opq0<'a, 'b> = impl Sized;
+   |               -- this generic parameter must be used with a generic lifetime parameter
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'static>> {}
+   |                                                                 ^^
+
+error: non-defining opaque type use in defining scope
+  --> $DIR/higher-ranked-regions-basic.rs:69:41
+   |
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
+   |                                         ^^^^^^^^^^^^^^^^^ generic argument `'a` used twice
+   |
+note: for this opaque type
+  --> $DIR/higher-ranked-regions-basic.rs:68:25
+   |
+LL |     type Opq0<'a, 'b> = impl Sized;
+   |                         ^^^^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/higher-ranked-regions-basic.rs:69:60
+   |
+LL |     type Opq0<'a, 'b> = impl Sized;
+   |               -- this generic parameter must be used with a generic lifetime parameter
+LL |     fn test() -> impl for<'a> Trait<'a, Ty = Opq0<'a, 'a>> {}
+   |                                                            ^^
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/higher-ranked-regions-basic.rs:80:23
+   |
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
+   |               -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     fn test() -> Opq2 {}
+   |                       ^^
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/higher-ranked-regions-basic.rs:77:21
+   |
+LL |     type Opq1<'a> = impl for<'b> Trait<'b, Ty = Opq0<'a, 'b>>;
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a ()`, got `{type error}`
+   |
+note: previous use here
+  --> $DIR/higher-ranked-regions-basic.rs:79:17
+   |
+LL |     type Opq2 = impl for<'a> Trait<'a, Ty = Opq1<'a>>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0700, E0792.
+For more information about an error, try `rustc --explain E0700`.

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.rs
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.rs
@@ -1,0 +1,21 @@
+// Regression test for #97098.
+
+#![feature(type_alias_impl_trait)]
+
+pub trait Trait {
+    type Assoc<'a>;
+}
+
+pub type Foo = impl for<'a> Trait<Assoc<'a> = FooAssoc<'a>>;
+pub type FooAssoc<'a> = impl Sized;
+//~^ ERROR: concrete type differs from previous defining opaque type use
+
+struct Struct;
+impl Trait for Struct {
+    type Assoc<'a> = &'a u32;
+}
+
+const FOO: Foo = Struct;
+//~^ ERROR: expected generic lifetime parameter, found `'a`
+
+fn main() {}

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.rs
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.rs
@@ -8,7 +8,6 @@ pub trait Trait {
 
 pub type Foo = impl for<'a> Trait<Assoc<'a> = FooAssoc<'a>>;
 pub type FooAssoc<'a> = impl Sized;
-//~^ ERROR: concrete type differs from previous defining opaque type use
 
 struct Struct;
 impl Trait for Struct {

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.stderr
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.stderr
@@ -1,5 +1,5 @@
 error[E0792]: expected generic lifetime parameter, found `'a`
-  --> $DIR/higher-ranked-regions-gat.rs:18:18
+  --> $DIR/higher-ranked-regions-gat.rs:17:18
    |
 LL | pub type FooAssoc<'a> = impl Sized;
    |                   -- this generic parameter must be used with a generic lifetime parameter
@@ -7,18 +7,6 @@ LL | pub type FooAssoc<'a> = impl Sized;
 LL | const FOO: Foo = Struct;
    |                  ^^^^^^
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/higher-ranked-regions-gat.rs:10:25
-   |
-LL | pub type FooAssoc<'a> = impl Sized;
-   |                         ^^^^^^^^^^ expected `&'a u32`, got `{type error}`
-   |
-note: previous use here
-  --> $DIR/higher-ranked-regions-gat.rs:9:16
-   |
-LL | pub type Foo = impl for<'a> Trait<Assoc<'a> = FooAssoc<'a>>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.stderr
+++ b/tests/ui/rfcs/type-alias-impl-trait/higher-ranked-regions-gat.stderr
@@ -1,0 +1,24 @@
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/higher-ranked-regions-gat.rs:18:18
+   |
+LL | pub type FooAssoc<'a> = impl Sized;
+   |                   -- this generic parameter must be used with a generic lifetime parameter
+...
+LL | const FOO: Foo = Struct;
+   |                  ^^^^^^
+
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/higher-ranked-regions-gat.rs:10:25
+   |
+LL | pub type FooAssoc<'a> = impl Sized;
+   |                         ^^^^^^^^^^ expected `&'a u32`, got `{type error}`
+   |
+note: previous use here
+  --> $DIR/higher-ranked-regions-gat.rs:9:16
+   |
+LL | pub type Foo = impl for<'a> Trait<Assoc<'a> = FooAssoc<'a>>;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden.rs
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden.rs
@@ -1,0 +1,39 @@
+#![feature(type_alias_impl_trait)]
+
+fn id(s: &str) -> &str {
+    s
+}
+
+type Opaque<'a> = impl Sized + 'a;
+
+fn test(s: &str) -> (impl Fn(&str) -> Opaque<'_>, impl Fn(&str) -> Opaque<'_>) {
+    (id, id) //~ ERROR expected generic lifetime parameter, found `'_`
+}
+
+fn id2<'a, 'b>(s: (&'a str, &'b str)) -> (&'a str, &'b str) {
+    s
+}
+
+type Opaque2<'a> = impl Sized + 'a;
+
+fn test2() -> impl for<'a, 'b> Fn((&'a str, &'b str)) -> (Opaque2<'a>, Opaque2<'b>) {
+    id2 //~ ERROR expected generic lifetime parameter, found `'a`
+}
+
+type Opaque3<'a> = impl Sized + 'a;
+
+fn test3(s: &str) -> (impl Fn(&str) -> Opaque3<'_>, Opaque3<'_>) {
+    (id, s) //~ ERROR expected generic lifetime parameter, found `'_`
+}
+
+type Opaque4<'a> = impl Sized + 'a;
+fn test4(s: &str) -> (Opaque4<'_>, impl Fn(&str) -> Opaque4<'_>) {
+    (s, id) //~ ERROR expected generic lifetime parameter, found `'_`
+}
+
+type Inner<'a> = impl Sized;
+fn outer_impl() -> impl for<'a> Fn(&'a ()) -> Inner<'a> {
+    |x| x //~ ERROR expected generic lifetime parameter, found `'a`
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden.stderr
@@ -1,0 +1,48 @@
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/hkl_forbidden.rs:10:5
+   |
+LL | type Opaque<'a> = impl Sized + 'a;
+   |             -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     (id, id)
+   |     ^^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/hkl_forbidden.rs:20:5
+   |
+LL | type Opaque2<'a> = impl Sized + 'a;
+   |              -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     id2
+   |     ^^^
+
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/hkl_forbidden.rs:26:5
+   |
+LL | type Opaque3<'a> = impl Sized + 'a;
+   |              -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     (id, s)
+   |     ^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/hkl_forbidden.rs:31:5
+   |
+LL | type Opaque4<'a> = impl Sized + 'a;
+   |              -- this generic parameter must be used with a generic lifetime parameter
+LL | fn test4(s: &str) -> (Opaque4<'_>, impl Fn(&str) -> Opaque4<'_>) {
+LL |     (s, id)
+   |     ^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/hkl_forbidden.rs:36:5
+   |
+LL | type Inner<'a> = impl Sized;
+   |            -- this generic parameter must be used with a generic lifetime parameter
+LL | fn outer_impl() -> impl for<'a> Fn(&'a ()) -> Inner<'a> {
+LL |     |x| x
+   |     ^^^^^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden2.rs
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden2.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_impl_trait)]
-//~^ ERROR: expected generic lifetime parameter, found `'a`
 
 type Opaque<'a> = impl Sized + 'a;
 
@@ -13,6 +12,7 @@ impl<'a> Trait<'a> for () {
 
 fn test() -> &'static dyn for<'a> Trait<'a, Assoc = Opaque<'a>> {
     &()
+    //~^ ERROR: expected generic lifetime parameter, found `'a`
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden2.rs
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden2.rs
@@ -1,0 +1,18 @@
+#![feature(type_alias_impl_trait)]
+//~^ ERROR: expected generic lifetime parameter, found `'a`
+
+type Opaque<'a> = impl Sized + 'a;
+
+trait Trait<'a> {
+    type Assoc;
+}
+
+impl<'a> Trait<'a> for () {
+    type Assoc = ();
+}
+
+fn test() -> &'static dyn for<'a> Trait<'a, Assoc = Opaque<'a>> {
+    &()
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden2.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden2.stderr
@@ -1,0 +1,5 @@
+error[E0792]: expected generic lifetime parameter, found `'a`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden2.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden2.stderr
@@ -1,4 +1,11 @@
 error[E0792]: expected generic lifetime parameter, found `'a`
+  --> $DIR/hkl_forbidden2.rs:14:5
+   |
+LL | type Opaque<'a> = impl Sized + 'a;
+   |             -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     &()
+   |     ^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden3.rs
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden3.rs
@@ -1,0 +1,13 @@
+#![feature(type_alias_impl_trait)]
+
+type Opaque<'a> = impl Sized + 'a;
+
+fn foo<'a>(x: &'a ()) -> &'a () {
+    x
+}
+
+fn test() -> for<'a> fn(&'a ()) -> Opaque<'a> {
+    foo //~ ERROR: mismatched types
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden3.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden3.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/hkl_forbidden3.rs:10:5
+   |
+LL | type Opaque<'a> = impl Sized + 'a;
+   |                   --------------- the expected opaque type
+...
+LL |     foo
+   |     ^^^ one type is more general than the other
+   |
+   = note: expected fn pointer `for<'a> fn(&'a ()) -> Opaque<'a>`
+              found fn pointer `for<'a> fn(&'a ()) -> &'a ()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
We already do all the right checks in `check_opaque_type_parameter_valid`, and we have done so since at least 2 years.

I collected the tests from https://github.com/rust-lang/rust/pull/116935 and https://github.com/rust-lang/rust/pull/100503 and added some more

cc https://github.com/rust-lang/rust/issues/96146 

r? @lcnr