### PR TITLE
Avoid some unnecessary query invocations.

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -102,8 +102,9 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_middle::middle;
+use rustc_middle::mir::interpret::GlobalId;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{Ty, TyCtxt};
+use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::util;
 use rustc_session::parse::feature_err;
 use rustc_span::{symbol::sym, Span};
@@ -187,7 +188,12 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
         let def_kind = tcx.def_kind(item_def_id);
         match def_kind {
             DefKind::Static { .. } => tcx.ensure().eval_static_initializer(item_def_id),
-            DefKind::Const => tcx.ensure().const_eval_poly(item_def_id.into()),
+            DefKind::Const if tcx.generics_of(item_def_id).params.is_empty() => {
+                let instance = ty::Instance::new(item_def_id.into(), ty::GenericArgs::empty());
+                let cid = GlobalId { instance, promoted: None };
+                let param_env = ty::ParamEnv::reveal_all();
+                tcx.ensure().eval_to_const_value_raw(param_env.and(cid));
+            }
             _ => (),
         }
     });

--- a/tests/ui/generic-const-items/hkl_where_bounds.rs
+++ b/tests/ui/generic-const-items/hkl_where_bounds.rs
@@ -1,0 +1,14 @@
+//! Test that nonsense bounds prevent consts from being evaluated at all.
+//@ check-pass
+
+#![feature(generic_const_items)]
+#![allow(incomplete_features)]
+trait Trait {
+    const ASSOC: u32;
+}
+
+// rustfmt eats the where bound
+#[rustfmt::skip]
+const ASSOC: u32 = <&'static ()>::ASSOC where for<'a> &'a (): Trait;
+
+fn main() {}


### PR DESCRIPTION
Specifically this inlines `const_eval_poly` and avoids computing the generic params, the param env, normalizing the param env and erasing lifetimes on everything.

should fix the perf regression from https://github.com/rust-lang/rust/pull/121087