### PR TITLE
[WIP] Re-enable the early otherwise branch optimization

### DIFF
--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -334,9 +334,6 @@ fn evaluate_candidate<'tcx>(
         return None;
     };
     let child_ty = child_discr.ty(body.local_decls(), tcx);
-    if child_ty != parent_ty {
-        return None;
-    }
     if bbs[child].statements.len() > 1 {
         return None;
     }
@@ -424,6 +421,9 @@ fn evaluate_candidate<'tcx>(
         }
     }
     if same_target_value.is_none() {
+        if child_ty != parent_ty {
+            return None;
+        }
         for (value, child) in targets.iter() {
             if !verify_candidate_branch(
                 &bbs[child],

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -166,7 +166,8 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
                 };
                 (value, targets.all_targets()[0])
             });
-            let eq_targets = SwitchTargets::new(eq_new_targets, opt_data.destination);
+
+            let eq_targets = SwitchTargets::new(eq_new_targets, parent_targets.otherwise());
 
             // Create `bbEq` in example above
             let eq_switch = BasicBlockData::new(Some(Terminator {

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -96,8 +96,7 @@ pub struct EarlyOtherwiseBranch;
 
 impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        // unsound: https://github.com/rust-lang/rust/issues/95162
-        sess.mir_opt_level() >= 3 && sess.opts.unstable_opts.unsound_mir_opts
+        sess.mir_opt_level() >= 2
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {

--- a/tests/codegen/enum/enum-early-otherwise-branch.rs
+++ b/tests/codegen/enum/enum-early-otherwise-branch.rs
@@ -1,0 +1,25 @@
+//@ compile-flags: -O -Zmir-opt-level=3 -Zunsound-mir-opts
+
+#![crate_type = "lib"]
+
+pub enum Enum {
+    A(u32),
+    B(u32),
+    C(u32),
+}
+
+#[no_mangle]
+pub fn foo(lhs: &Enum, rhs: &Enum) -> bool {
+    // CHECK-LABEL: define{{.*}}i1 @foo(
+    // CHECK-NOT: switch
+    // CHECK-NOT: br
+    // CHECK: [[SELECT:%.*]] = select
+    // CHECK-NEXT: ret i1 [[SELECT]]
+    // CHECK-NEXT: }
+    match (lhs, rhs) {
+        (Enum::A(lhs), Enum::A(rhs)) => lhs == rhs,
+        (Enum::B(lhs), Enum::B(rhs)) => lhs == rhs,
+        (Enum::C(lhs), Enum::C(rhs)) => lhs == rhs,
+        _ => false,
+    }
+}

--- a/tests/codegen/enum/enum-early-otherwise-branch.rs
+++ b/tests/codegen/enum/enum-early-otherwise-branch.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -O -Zmir-opt-level=3 -Zunsound-mir-opts
+//@ compile-flags: -O
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -12,8 +12,6 @@
       let mut _7: isize;
       let _8: u32;
       let _9: u32;
-+     let mut _10: isize;
-+     let mut _11: bool;
       scope 1 {
           debug a => _8;
           debug b => _9;
@@ -29,28 +27,20 @@
           StorageDead(_5);
           StorageDead(_4);
           _7 = discriminant((_3.0: std::option::Option<u32>));
--         switchInt(move _7) -> [1: bb2, otherwise: bb1];
-+         StorageLive(_10);
-+         _10 = discriminant((_3.1: std::option::Option<u32>));
-+         StorageLive(_11);
-+         _11 = Ne(_7, move _10);
-+         StorageDead(_10);
-+         switchInt(move _11) -> [0: bb4, otherwise: bb1];
+          switchInt(move _7) -> [1: bb2, otherwise: bb1];
       }
   
       bb1: {
-+         StorageDead(_11);
           _0 = const 1_u32;
--         goto -> bb4;
-+         goto -> bb3;
+          goto -> bb4;
       }
   
       bb2: {
--         _6 = discriminant((_3.1: std::option::Option<u32>));
--         switchInt(move _6) -> [1: bb3, otherwise: bb1];
--     }
-- 
--     bb3: {
+          _6 = discriminant((_3.1: std::option::Option<u32>));
+          switchInt(move _6) -> [1: bb3, otherwise: bb1];
+      }
+  
+      bb3: {
           StorageLive(_8);
           _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
           StorageLive(_9);
@@ -58,19 +48,12 @@
           _0 = const 0_u32;
           StorageDead(_9);
           StorageDead(_8);
--         goto -> bb4;
-+         goto -> bb3;
+          goto -> bb4;
       }
   
--     bb4: {
-+     bb3: {
+      bb4: {
           StorageDead(_3);
           return;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_11);
-+         switchInt(_7) -> [1: bb2, otherwise: bb1];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt10.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt10.EarlyOtherwiseBranch.diff
@@ -27,7 +27,7 @@
 -         switchInt(move _9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb9];
 +         StorageLive(_10);
 +         _10 = discriminant((_3.1: E16));
-+         switchInt(move _10) -> [0: bb6, otherwise: bb1];
++         switchInt(move _10) -> [0: bb7, otherwise: bb1];
       }
   
       bb1: {
@@ -40,49 +40,51 @@
       bb2: {
 -         _6 = discriminant((_3.1: E16));
 -         switchInt(move _6) -> [0: bb5, otherwise: bb1];
--     }
-- 
--     bb3: {
++         _0 = const 1_u32;
++         goto -> bb5;
+      }
+  
+      bb3: {
 -         _7 = discriminant((_3.1: E16));
 -         switchInt(move _7) -> [0: bb6, otherwise: bb1];
--     }
-- 
--     bb4: {
++         _0 = const 2_u32;
++         goto -> bb5;
+      }
+  
+      bb4: {
 -         _8 = discriminant((_3.1: E16));
 -         switchInt(move _8) -> [0: bb7, otherwise: bb1];
++         _0 = const 3_u32;
++         goto -> bb5;
+      }
+  
+      bb5: {
+-         _0 = const 1_u32;
+-         goto -> bb8;
++         StorageDead(_3);
++         return;
+      }
+  
+      bb6: {
+-         _0 = const 2_u32;
+-         goto -> bb8;
++         unreachable;
+      }
+  
+      bb7: {
+-         _0 = const 3_u32;
+-         goto -> bb8;
 -     }
 - 
--     bb5: {
-          _0 = const 1_u32;
--         goto -> bb8;
-+         goto -> bb5;
-      }
-  
--     bb6: {
-+     bb3: {
-          _0 = const 2_u32;
--         goto -> bb8;
-+         goto -> bb5;
-      }
-  
--     bb7: {
-+     bb4: {
-          _0 = const 3_u32;
--         goto -> bb8;
-+         goto -> bb5;
-      }
-  
 -     bb8: {
-+     bb5: {
-          StorageDead(_3);
-          return;
-      }
-  
+-         StorageDead(_3);
+-         return;
+-     }
+- 
 -     bb9: {
 -         unreachable;
-+     bb6: {
 +         StorageDead(_10);
-+         switchInt(_9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb1];
++         switchInt(_9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb6];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt10.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt10.EarlyOtherwiseBranch.diff
@@ -1,0 +1,88 @@
+- // MIR for `opt10` before EarlyOtherwiseBranch
++ // MIR for `opt10` after EarlyOtherwiseBranch
+  
+  fn opt10(_1: E8, _2: E16) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (E8, E16);
+      let mut _4: E8;
+      let mut _5: E16;
+      let mut _6: u16;
+      let mut _7: u16;
+      let mut _8: u16;
+      let mut _9: u8;
++     let mut _10: u16;
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = move _1;
+          StorageLive(_5);
+          _5 = move _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+          _9 = discriminant((_3.0: E8));
+-         switchInt(move _9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb9];
++         StorageLive(_10);
++         _10 = discriminant((_3.1: E16));
++         switchInt(move _10) -> [0: bb6, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageDead(_10);
+          _0 = const 0_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+      bb2: {
+-         _6 = discriminant((_3.1: E16));
+-         switchInt(move _6) -> [0: bb5, otherwise: bb1];
+-     }
+- 
+-     bb3: {
+-         _7 = discriminant((_3.1: E16));
+-         switchInt(move _7) -> [0: bb6, otherwise: bb1];
+-     }
+- 
+-     bb4: {
+-         _8 = discriminant((_3.1: E16));
+-         switchInt(move _8) -> [0: bb7, otherwise: bb1];
+-     }
+- 
+-     bb5: {
+          _0 = const 1_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+-     bb6: {
++     bb3: {
+          _0 = const 2_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+-     bb7: {
++     bb4: {
+          _0 = const 3_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+-     bb8: {
++     bb5: {
+          StorageDead(_3);
+          return;
+      }
+  
+-     bb9: {
+-         unreachable;
++     bb6: {
++         StorageDead(_10);
++         switchInt(_9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb1];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -30,7 +30,7 @@
           StorageDead(_5);
           StorageDead(_4);
           _8 = discriminant((_3.0: std::option::Option<u32>));
--         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb7];
 +         StorageLive(_11);
 +         _11 = discriminant((_3.1: std::option::Option<u32>));
 +         StorageLive(_12);
@@ -70,7 +70,7 @@
   
 -     bb5: {
 +     bb3: {
-          _0 = const 0_u32;
+          _0 = const 2_u32;
 -         goto -> bb6;
 +         goto -> bb4;
       }
@@ -79,8 +79,10 @@
 +     bb4: {
           StorageDead(_3);
           return;
-+     }
-+ 
+      }
+  
+-     bb7: {
+-         unreachable;
 +     bb5: {
 +         StorageDead(_12);
 +         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1];

--- a/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -36,7 +36,7 @@
 +         StorageLive(_12);
 +         _12 = Ne(_8, move _11);
 +         StorageDead(_11);
-+         switchInt(move _12) -> [0: bb5, otherwise: bb1];
++         switchInt(move _12) -> [0: bb6, otherwise: bb1];
       }
   
       bb1: {
@@ -82,10 +82,13 @@
       }
   
 -     bb7: {
--         unreachable;
 +     bb5: {
+          unreachable;
++     }
++ 
++     bb6: {
 +         StorageDead(_12);
-+         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1];
++         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -10,13 +10,14 @@
       let mut _5: std::option::Option<bool>;
       let mut _6: isize;
       let mut _7: isize;
-      let _8: u32;
-      let _9: bool;
-+     let mut _10: isize;
-+     let mut _11: bool;
+      let mut _8: isize;
+      let _9: u32;
+      let _10: bool;
++     let mut _11: isize;
++     let mut _12: bool;
       scope 1 {
-          debug a => _8;
-          debug b => _9;
+          debug a => _9;
+          debug b => _10;
       }
   
       bb0: {
@@ -28,49 +29,63 @@
           _3 = (move _4, move _5);
           StorageDead(_5);
           StorageDead(_4);
-          _7 = discriminant((_3.0: std::option::Option<u32>));
--         switchInt(move _7) -> [1: bb2, otherwise: bb1];
-+         StorageLive(_10);
-+         _10 = discriminant((_3.1: std::option::Option<bool>));
+          _8 = discriminant((_3.0: std::option::Option<u32>));
+-         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb7];
 +         StorageLive(_11);
-+         _11 = Ne(_7, move _10);
-+         StorageDead(_10);
-+         switchInt(move _11) -> [0: bb4, otherwise: bb1];
++         _11 = discriminant((_3.1: std::option::Option<bool>));
++         StorageLive(_12);
++         _12 = Ne(_8, move _11);
++         StorageDead(_11);
++         switchInt(move _12) -> [0: bb5, otherwise: bb1];
       }
   
       bb1: {
-+         StorageDead(_11);
++         StorageDead(_12);
           _0 = const 1_u32;
--         goto -> bb4;
-+         goto -> bb3;
+-         goto -> bb6;
++         goto -> bb4;
       }
   
       bb2: {
 -         _6 = discriminant((_3.1: std::option::Option<bool>));
--         switchInt(move _6) -> [1: bb3, otherwise: bb1];
+-         switchInt(move _6) -> [0: bb5, otherwise: bb1];
 -     }
 - 
 -     bb3: {
-          StorageLive(_8);
-          _8 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
+-         _7 = discriminant((_3.1: std::option::Option<bool>));
+-         switchInt(move _7) -> [1: bb4, otherwise: bb1];
+-     }
+- 
+-     bb4: {
           StorageLive(_9);
-          _9 = (((_3.1: std::option::Option<bool>) as Some).0: bool);
+          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
+          StorageLive(_10);
+          _10 = (((_3.1: std::option::Option<bool>) as Some).0: bool);
           _0 = const 0_u32;
+          StorageDead(_10);
           StorageDead(_9);
-          StorageDead(_8);
--         goto -> bb4;
-+         goto -> bb3;
+-         goto -> bb6;
++         goto -> bb4;
       }
   
--     bb4: {
+-     bb5: {
 +     bb3: {
+          _0 = const 2_u32;
+-         goto -> bb6;
++         goto -> bb4;
+      }
+  
+-     bb6: {
++     bb4: {
           StorageDead(_3);
           return;
-+     }
-+ 
-+     bb4: {
-+         StorageDead(_11);
-+         switchInt(_7) -> [1: bb2, otherwise: bb1];
+      }
+  
+-     bb7: {
+-         unreachable;
++     bb5: {
++         StorageDead(_12);
++         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -36,7 +36,7 @@
 +         StorageLive(_12);
 +         _12 = Ne(_8, move _11);
 +         StorageDead(_11);
-+         switchInt(move _12) -> [0: bb5, otherwise: bb1];
++         switchInt(move _12) -> [0: bb6, otherwise: bb1];
       }
   
       bb1: {
@@ -82,10 +82,13 @@
       }
   
 -     bb7: {
--         unreachable;
 +     bb5: {
+          unreachable;
++     }
++ 
++     bb6: {
 +         StorageDead(_12);
-+         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1];
++         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
@@ -1,0 +1,77 @@
+- // MIR for `opt4` before EarlyOtherwiseBranch
++ // MIR for `opt4` after EarlyOtherwiseBranch
+  
+  fn opt4(_1: u32, _2: u32) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (u32, u32);
+      let mut _4: u32;
+      let mut _5: u32;
++     let mut _6: bool;
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = _1;
+          StorageLive(_5);
+          _5 = _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+-         switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
++         StorageLive(_6);
++         _6 = Ne((_3.0: u32), (_3.1: u32));
++         switchInt(move _6) -> [0: bb6, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageDead(_6);
+          _0 = const 0_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+      bb2: {
+-         switchInt((_3.1: u32)) -> [1: bb5, otherwise: bb1];
++         _0 = const 4_u32;
++         goto -> bb5;
+      }
+  
+      bb3: {
+-         switchInt((_3.1: u32)) -> [2: bb6, otherwise: bb1];
++         _0 = const 5_u32;
++         goto -> bb5;
+      }
+  
+      bb4: {
+-         switchInt((_3.1: u32)) -> [3: bb7, otherwise: bb1];
++         _0 = const 6_u32;
++         goto -> bb5;
+      }
+  
+      bb5: {
+-         _0 = const 4_u32;
+-         goto -> bb8;
++         StorageDead(_3);
++         return;
+      }
+  
+      bb6: {
+-         _0 = const 5_u32;
+-         goto -> bb8;
+-     }
+- 
+-     bb7: {
+-         _0 = const 6_u32;
+-         goto -> bb8;
+-     }
+- 
+-     bb8: {
+-         StorageDead(_3);
+-         return;
++         StorageDead(_6);
++         switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
@@ -1,0 +1,61 @@
+- // MIR for `opt5` before EarlyOtherwiseBranch
++ // MIR for `opt5` after EarlyOtherwiseBranch
+  
+  fn opt5(_1: u32, _2: u32) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (u32, u32);
+      let mut _4: u32;
+      let mut _5: u32;
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = _1;
+          StorageLive(_5);
+          _5 = _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+          switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
+          _0 = const 0_u32;
+          goto -> bb8;
+      }
+  
+      bb2: {
+          switchInt((_3.1: u32)) -> [1: bb5, otherwise: bb1];
+      }
+  
+      bb3: {
+          switchInt((_3.1: u32)) -> [2: bb6, otherwise: bb1];
+      }
+  
+      bb4: {
+          switchInt((_3.1: u32)) -> [2: bb7, otherwise: bb1];
+      }
+  
+      bb5: {
+          _0 = const 4_u32;
+          goto -> bb8;
+      }
+  
+      bb6: {
+          _0 = const 5_u32;
+          goto -> bb8;
+      }
+  
+      bb7: {
+          _0 = const 6_u32;
+          goto -> bb8;
+      }
+  
+      bb8: {
+          StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.opt6.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt6.EarlyOtherwiseBranch.diff
@@ -1,0 +1,72 @@
+- // MIR for `opt6` before EarlyOtherwiseBranch
++ // MIR for `opt6` after EarlyOtherwiseBranch
+  
+  fn opt6(_1: u32, _2: u32) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (u32, u32);
+      let mut _4: u32;
+      let mut _5: u32;
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = _1;
+          StorageLive(_5);
+          _5 = _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+-         switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
++         switchInt((_3.1: u32)) -> [10: bb6, otherwise: bb1];
+      }
+  
+      bb1: {
+          _0 = const 0_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+      bb2: {
+-         switchInt((_3.1: u32)) -> [10: bb5, otherwise: bb1];
++         _0 = const 4_u32;
++         goto -> bb5;
+      }
+  
+      bb3: {
+-         switchInt((_3.1: u32)) -> [10: bb6, otherwise: bb1];
++         _0 = const 5_u32;
++         goto -> bb5;
+      }
+  
+      bb4: {
+-         switchInt((_3.1: u32)) -> [10: bb7, otherwise: bb1];
++         _0 = const 6_u32;
++         goto -> bb5;
+      }
+  
+      bb5: {
+-         _0 = const 4_u32;
+-         goto -> bb8;
++         StorageDead(_3);
++         return;
+      }
+  
+      bb6: {
+-         _0 = const 5_u32;
+-         goto -> bb8;
+-     }
+- 
+-     bb7: {
+-         _0 = const 6_u32;
+-         goto -> bb8;
+-     }
+- 
+-     bb8: {
+-         StorageDead(_3);
+-         return;
++         switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.opt7.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt7.EarlyOtherwiseBranch.diff
@@ -1,0 +1,94 @@
+- // MIR for `opt7` before EarlyOtherwiseBranch
++ // MIR for `opt7` after EarlyOtherwiseBranch
+  
+  fn opt7(_1: Option<u32>, _2: Option<u32>) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (std::option::Option<u32>, std::option::Option<u32>);
+      let mut _4: std::option::Option<u32>;
+      let mut _5: std::option::Option<u32>;
+      let mut _6: isize;
+      let mut _7: isize;
+      let mut _8: isize;
+      let _9: u32;
+      let _10: u32;
+      let _11: u32;
++     let mut _12: isize;
+      scope 1 {
+          debug a => _9;
+          debug b => _10;
+      }
+      scope 2 {
+          debug b => _11;
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = _1;
+          StorageLive(_5);
+          _5 = _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+          _8 = discriminant((_3.0: std::option::Option<u32>));
+-         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb7];
++         StorageLive(_12);
++         _12 = discriminant((_3.1: std::option::Option<u32>));
++         switchInt(move _12) -> [1: bb5, otherwise: bb1];
+      }
+  
+      bb1: {
++         StorageDead(_12);
+          _0 = const 1_u32;
+-         goto -> bb6;
++         goto -> bb4;
+      }
+  
+      bb2: {
+-         _6 = discriminant((_3.1: std::option::Option<u32>));
+-         switchInt(move _6) -> [1: bb5, otherwise: bb1];
+-     }
+- 
+-     bb3: {
+-         _7 = discriminant((_3.1: std::option::Option<u32>));
+-         switchInt(move _7) -> [1: bb4, otherwise: bb1];
+-     }
+- 
+-     bb4: {
+          StorageLive(_9);
+          _9 = (((_3.0: std::option::Option<u32>) as Some).0: u32);
+          StorageLive(_10);
+          _10 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
+          _0 = const 0_u32;
+          StorageDead(_10);
+          StorageDead(_9);
+-         goto -> bb6;
++         goto -> bb4;
+      }
+  
+-     bb5: {
++     bb3: {
+          StorageLive(_11);
+          _11 = (((_3.1: std::option::Option<u32>) as Some).0: u32);
+          _0 = const 2_u32;
+          StorageDead(_11);
+-         goto -> bb6;
++         goto -> bb4;
+      }
+  
+-     bb6: {
++     bb4: {
+          StorageDead(_3);
+          return;
+      }
+  
+-     bb7: {
+-         unreachable;
++     bb5: {
++         StorageDead(_12);
++         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.opt7.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt7.EarlyOtherwiseBranch.diff
@@ -36,7 +36,7 @@
 -         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb7];
 +         StorageLive(_12);
 +         _12 = discriminant((_3.1: std::option::Option<u32>));
-+         switchInt(move _12) -> [1: bb5, otherwise: bb1];
++         switchInt(move _12) -> [1: bb6, otherwise: bb1];
       }
   
       bb1: {
@@ -85,10 +85,13 @@
       }
   
 -     bb7: {
--         unreachable;
 +     bb5: {
+          unreachable;
++     }
++ 
++     bb6: {
 +         StorageDead(_12);
-+         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb1];
++         switchInt(_8) -> [0: bb3, 1: bb2, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch.opt8.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt8.EarlyOtherwiseBranch.diff
@@ -1,0 +1,72 @@
+- // MIR for `opt8` before EarlyOtherwiseBranch
++ // MIR for `opt8` after EarlyOtherwiseBranch
+  
+  fn opt8(_1: u32, _2: u64) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (u32, u64);
+      let mut _4: u32;
+      let mut _5: u64;
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = _1;
+          StorageLive(_5);
+          _5 = _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+-         switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
++         switchInt((_3.1: u64)) -> [10: bb6, otherwise: bb1];
+      }
+  
+      bb1: {
+          _0 = const 0_u32;
+-         goto -> bb8;
++         goto -> bb5;
+      }
+  
+      bb2: {
+-         switchInt((_3.1: u64)) -> [10: bb5, otherwise: bb1];
++         _0 = const 4_u32;
++         goto -> bb5;
+      }
+  
+      bb3: {
+-         switchInt((_3.1: u64)) -> [10: bb6, otherwise: bb1];
++         _0 = const 5_u32;
++         goto -> bb5;
+      }
+  
+      bb4: {
+-         switchInt((_3.1: u64)) -> [10: bb7, otherwise: bb1];
++         _0 = const 6_u32;
++         goto -> bb5;
+      }
+  
+      bb5: {
+-         _0 = const 4_u32;
+-         goto -> bb8;
++         StorageDead(_3);
++         return;
+      }
+  
+      bb6: {
+-         _0 = const 5_u32;
+-         goto -> bb8;
+-     }
+- 
+-     bb7: {
+-         _0 = const 6_u32;
+-         goto -> bb8;
+-     }
+- 
+-     bb8: {
+-         StorageDead(_3);
+-         return;
++         switchInt((_3.0: u32)) -> [1: bb2, 2: bb3, 3: bb4, otherwise: bb1];
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.opt9.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch.opt9.EarlyOtherwiseBranch.diff
@@ -1,0 +1,73 @@
+- // MIR for `opt9` before EarlyOtherwiseBranch
++ // MIR for `opt9` after EarlyOtherwiseBranch
+  
+  fn opt9(_1: E8, _2: E16) -> u32 {
+      debug x => _1;
+      debug y => _2;
+      let mut _0: u32;
+      let mut _3: (E8, E16);
+      let mut _4: E8;
+      let mut _5: E16;
+      let mut _6: u16;
+      let mut _7: u16;
+      let mut _8: u16;
+      let mut _9: u8;
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = move _1;
+          StorageLive(_5);
+          _5 = move _2;
+          _3 = (move _4, move _5);
+          StorageDead(_5);
+          StorageDead(_4);
+          _9 = discriminant((_3.0: E8));
+          switchInt(move _9) -> [0: bb2, 1: bb3, 2: bb4, otherwise: bb9];
+      }
+  
+      bb1: {
+          _0 = const 0_u32;
+          goto -> bb8;
+      }
+  
+      bb2: {
+          _6 = discriminant((_3.1: E16));
+          switchInt(move _6) -> [0: bb5, otherwise: bb1];
+      }
+  
+      bb3: {
+          _7 = discriminant((_3.1: E16));
+          switchInt(move _7) -> [1: bb6, otherwise: bb1];
+      }
+  
+      bb4: {
+          _8 = discriminant((_3.1: E16));
+          switchInt(move _8) -> [2: bb7, otherwise: bb1];
+      }
+  
+      bb5: {
+          _0 = const 1_u32;
+          goto -> bb8;
+      }
+  
+      bb6: {
+          _0 = const 2_u32;
+          goto -> bb8;
+      }
+  
+      bb7: {
+          _0 = const 3_u32;
+          goto -> bb8;
+      }
+  
+      bb8: {
+          StorageDead(_3);
+          return;
+      }
+  
+      bb9: {
+          unreachable;
+      }
+  }
+  

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -52,8 +52,41 @@ fn opt3(x: Option<u32>, y: Option<bool>) -> u32 {
     }
 }
 
+// EMIT_MIR early_otherwise_branch.opt4.EarlyOtherwiseBranch.diff
+fn opt4(x: u32, y: u32) -> u32 {
+    // CHECK-LABEL: fn opt4(
+    // CHECK: let mut [[CMP_LOCAL:_.*]]: bool;
+    // CHECK: bb0: {
+    // CHECK: [[CMP_LOCAL]] = Ne(
+    // CHECK: switchInt(move [[CMP_LOCAL]]) -> [
+    // CHECK-NEXT: }
+    match (x, y) {
+        (1, 1) => 4,
+        (2, 2) => 5,
+        (3, 3) => 6,
+        _ => 0,
+    }
+}
+
+// EMIT_MIR early_otherwise_branch.opt5.EarlyOtherwiseBranch.diff
+fn opt5(x: u32, y: u32) -> u32 {
+    // CHECK-LABEL: fn opt5(
+    // CHECK: bb0: {
+    // CHECK-NOT: Ne(
+    // CHECK: switchInt(
+    // CHECK-NEXT: }
+    match (x, y) {
+        (1, 1) => 4,
+        (2, 2) => 5,
+        (3, 2) => 6,
+        _ => 0,
+    }
+}
+
 fn main() {
     opt1(None, Some(0));
     opt2(None, Some(0));
     opt3(None, Some(false));
+    opt4(0, 0);
+    opt5(0, 0);
 }

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -83,10 +83,44 @@ fn opt5(x: u32, y: u32) -> u32 {
     }
 }
 
+// EMIT_MIR early_otherwise_branch.opt6.EarlyOtherwiseBranch.diff
+fn opt6(x: u32, y: u32) -> u32 {
+    // CHECK-LABEL: fn opt6(
+    // CHECK: bb0: {
+    // CHECK: switchInt((_{{.*}}: u32)) -> [10: [[SWITCH_BB:bb.*]], otherwise: [[OTHERWISE:bb.*]]];
+    // CHECK-NEXT: }
+    // CHECK: [[SWITCH_BB]]:
+    // CHECK:  switchInt((_{{.*}}: u32)) -> [1: bb{{.*}}, 2: bb{{.*}}, 3: bb{{.*}}, otherwise: [[OTHERWISE]]];
+    // CHECK-NEXT: }
+    match (x, y) {
+        (1, 10) => 4,
+        (2, 10) => 5,
+        (3, 10) => 6,
+        _ => 0,
+    }
+}
+
+// EMIT_MIR early_otherwise_branch.opt7.EarlyOtherwiseBranch.diff
+fn opt7(x: Option<u32>, y: Option<u32>) -> u32 {
+    // CHECK-LABEL: fn opt7(
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK: [[LOCAL2:_.*]] = discriminant({{.*}});
+    // CHECK: switchInt(move [[LOCAL2]]) -> [
+    // CHECK-NEXT: }
+    match (x, y) {
+        (Some(a), Some(b)) => 0,
+        (None, Some(b)) => 2,
+        _ => 1,
+    }
+}
+
 fn main() {
     opt1(None, Some(0));
     opt2(None, Some(0));
     opt3(None, Some(false));
     opt4(0, 0);
     opt5(0, 0);
+    opt6(0, 0);
+    opt7(None, Some(0));
 }

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -170,10 +170,13 @@ fn opt10(x: E8, y: E16) -> u32 {
     // CHECK: bb0: {
     // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
     // CHECK: [[LOCAL2:_.*]] = discriminant({{.*}});
-    // CHECK: switchInt(move [[LOCAL2]]) -> [0: [[SWITCH_BB:bb.*]], otherwise: [[OTHERWISE:bb.*]]];
+    // CHECK: switchInt(move [[LOCAL2]]) -> [0: [[SWITCH_BB:bb.*]], otherwise: {{bb.*}}];
+    // CHECK-NEXT: }
+    // CHECK: [[UNREACHABLE:bb6]]: {
+    // CHECK-NEXT: unreachable;
     // CHECK-NEXT: }
     // CHECK: [[SWITCH_BB]]:
-    // CHECK:  switchInt([[LOCAL1]]) -> [0: bb{{.*}}, 1: bb{{.*}}, 2: bb{{.*}}, otherwise: [[OTHERWISE]]];
+    // CHECK:  switchInt([[LOCAL1]]) -> [0: bb{{.*}}, 1: bb{{.*}}, 2: bb{{.*}}, otherwise: [[UNREACHABLE]]];
     // CHECK-NEXT: }
     match (x, y) {
         (E8::A, E16::A) => 1,

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -1,5 +1,8 @@
 // skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
+//@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
+
+// We can't optimize it because y may be an invalid value.
 // EMIT_MIR early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
 fn opt1(x: Option<u32>, y: Option<u32>) -> u32 {
     match (x, y) {
@@ -12,7 +15,7 @@ fn opt1(x: Option<u32>, y: Option<u32>) -> u32 {
 fn opt2(x: Option<u32>, y: Option<u32>) -> u32 {
     match (x, y) {
         (Some(a), Some(b)) => 0,
-        (None, None) => 0,
+        (None, None) => 2,
         _ => 1,
     }
 }
@@ -22,6 +25,7 @@ fn opt2(x: Option<u32>, y: Option<u32>) -> u32 {
 fn opt3(x: Option<u32>, y: Option<bool>) -> u32 {
     match (x, y) {
         (Some(a), Some(b)) => 0,
+        (None, None) => 2,
         _ => 1,
     }
 }

--- a/tests/mir-opt/early_otherwise_branch.rs
+++ b/tests/mir-opt/early_otherwise_branch.rs
@@ -1,10 +1,16 @@
-// skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
 // We can't optimize it because y may be an invalid value.
 // EMIT_MIR early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
 fn opt1(x: Option<u32>, y: Option<u32>) -> u32 {
+    // CHECK-LABEL: fn opt1(
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK-NOT: Ne
+    // CHECK-NOT: discriminant
+    // CHECK: switchInt(move [[LOCAL1]]) -> [
+    // CHECK-NEXT: }
     match (x, y) {
         (Some(a), Some(b)) => 0,
         _ => 1,
@@ -13,6 +19,14 @@ fn opt1(x: Option<u32>, y: Option<u32>) -> u32 {
 
 // EMIT_MIR early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
 fn opt2(x: Option<u32>, y: Option<u32>) -> u32 {
+    // CHECK-LABEL: fn opt2(
+    // CHECK: let mut [[CMP_LOCAL:_.*]]: bool;
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK: [[LOCAL2:_.*]] = discriminant({{.*}});
+    // CHECK: [[CMP_LOCAL]] = Ne([[LOCAL1]], move [[LOCAL2]]);
+    // CHECK: switchInt(move [[CMP_LOCAL]]) -> [
+    // CHECK-NEXT: }
     match (x, y) {
         (Some(a), Some(b)) => 0,
         (None, None) => 2,
@@ -23,6 +37,14 @@ fn opt2(x: Option<u32>, y: Option<u32>) -> u32 {
 // optimize despite different types
 // EMIT_MIR early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
 fn opt3(x: Option<u32>, y: Option<bool>) -> u32 {
+    // CHECK-LABEL: fn opt3(
+    // CHECK: let mut [[CMP_LOCAL:_.*]]: bool;
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK: [[LOCAL2:_.*]] = discriminant({{.*}});
+    // CHECK: [[CMP_LOCAL]] = Ne([[LOCAL1]], move [[LOCAL2]]);
+    // CHECK: switchInt(move [[CMP_LOCAL]]) -> [
+    // CHECK-NEXT: }
     match (x, y) {
         (Some(a), Some(b)) => 0,
         (None, None) => 2,

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -13,17 +13,17 @@
       let mut _8: isize;
       let mut _9: isize;
       let mut _10: isize;
-      let _11: u32;
-      let _12: u32;
+      let mut _11: isize;
+      let mut _12: isize;
       let _13: u32;
-+     let mut _14: isize;
-+     let mut _15: bool;
+      let _14: u32;
+      let _15: u32;
 +     let mut _16: isize;
 +     let mut _17: bool;
       scope 1 {
-          debug a => _11;
-          debug b => _12;
-          debug c => _13;
+          debug a => _13;
+          debug b => _14;
+          debug c => _15;
       }
   
       bb0: {
@@ -38,60 +38,80 @@
           StorageDead(_7);
           StorageDead(_6);
           StorageDead(_5);
-          _10 = discriminant((_4.0: std::option::Option<u32>));
--         switchInt(move _10) -> [1: bb2, otherwise: bb1];
-+         StorageLive(_14);
-+         _14 = discriminant((_4.1: std::option::Option<u32>));
-+         StorageLive(_15);
-+         _15 = Ne(_10, move _14);
-+         StorageDead(_14);
-+         switchInt(move _15) -> [0: bb5, otherwise: bb1];
+          _12 = discriminant((_4.0: std::option::Option<u32>));
+-         switchInt(move _12) -> [0: bb2, 1: bb4, otherwise: bb9];
++         StorageLive(_16);
++         _16 = discriminant((_4.1: std::option::Option<u32>));
++         StorageLive(_17);
++         _17 = Ne(_12, move _16);
++         StorageDead(_16);
++         switchInt(move _17) -> [0: bb7, otherwise: bb1];
       }
   
       bb1: {
 +         StorageDead(_17);
-+         StorageDead(_15);
           _0 = const 1_u32;
--         goto -> bb5;
-+         goto -> bb4;
+-         goto -> bb8;
++         goto -> bb6;
       }
   
       bb2: {
 -         _9 = discriminant((_4.1: std::option::Option<u32>));
--         switchInt(move _9) -> [1: bb3, otherwise: bb1];
+-         switchInt(move _9) -> [0: bb3, otherwise: bb1];
 -     }
 - 
 -     bb3: {
           _8 = discriminant((_4.2: std::option::Option<u32>));
--         switchInt(move _8) -> [1: bb4, otherwise: bb1];
-+         switchInt(move _8) -> [1: bb3, otherwise: bb1];
+-         switchInt(move _8) -> [0: bb7, otherwise: bb1];
++         switchInt(move _8) -> [0: bb5, otherwise: bb1];
       }
   
 -     bb4: {
+-         _11 = discriminant((_4.1: std::option::Option<u32>));
+-         switchInt(move _11) -> [1: bb5, otherwise: bb1];
+-     }
+- 
+-     bb5: {
 +     bb3: {
-          StorageLive(_11);
-          _11 = (((_4.0: std::option::Option<u32>) as Some).0: u32);
-          StorageLive(_12);
-          _12 = (((_4.1: std::option::Option<u32>) as Some).0: u32);
-          StorageLive(_13);
-          _13 = (((_4.2: std::option::Option<u32>) as Some).0: u32);
-          _0 = const 0_u32;
-          StorageDead(_13);
-          StorageDead(_12);
-          StorageDead(_11);
--         goto -> bb5;
-+         goto -> bb4;
+          _10 = discriminant((_4.2: std::option::Option<u32>));
+-         switchInt(move _10) -> [1: bb6, otherwise: bb1];
++         switchInt(move _10) -> [1: bb4, otherwise: bb1];
       }
   
--     bb5: {
+-     bb6: {
 +     bb4: {
+          StorageLive(_13);
+          _13 = (((_4.0: std::option::Option<u32>) as Some).0: u32);
+          StorageLive(_14);
+          _14 = (((_4.1: std::option::Option<u32>) as Some).0: u32);
+          StorageLive(_15);
+          _15 = (((_4.2: std::option::Option<u32>) as Some).0: u32);
+          _0 = const 0_u32;
+          StorageDead(_15);
+          StorageDead(_14);
+          StorageDead(_13);
+-         goto -> bb8;
++         goto -> bb6;
+      }
+  
+-     bb7: {
++     bb5: {
+          _0 = const 0_u32;
+-         goto -> bb8;
++         goto -> bb6;
+      }
+  
+-     bb8: {
++     bb6: {
           StorageDead(_4);
           return;
-+     }
-+ 
-+     bb5: {
-+         StorageDead(_15);
-+         switchInt(_10) -> [1: bb2, otherwise: bb1];
+      }
+  
+-     bb9: {
+-         unreachable;
++     bb7: {
++         StorageDead(_17);
++         switchInt(_12) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -45,7 +45,7 @@
 +         StorageLive(_17);
 +         _17 = Ne(_12, move _16);
 +         StorageDead(_16);
-+         switchInt(move _17) -> [0: bb7, otherwise: bb1];
++         switchInt(move _17) -> [0: bb8, otherwise: bb1];
       }
   
       bb1: {
@@ -108,10 +108,13 @@
       }
   
 -     bb9: {
--         unreachable;
 +     bb7: {
+          unreachable;
++     }
++ 
++     bb8: {
 +         StorageDead(_17);
-+         switchInt(_12) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(_12) -> [0: bb2, 1: bb3, otherwise: bb7];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.rs
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.rs
@@ -1,9 +1,16 @@
-// skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
 // EMIT_MIR early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
 fn opt1(x: Option<u32>, y: Option<u32>, z: Option<u32>) -> u32 {
+    // CHECK-LABEL: fn opt1(
+    // CHECK: let mut [[CMP_LOCAL:_.*]]: bool;
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK: [[LOCAL2:_.*]] = discriminant({{.*}});
+    // CHECK: [[CMP_LOCAL]] = Ne([[LOCAL1]], move [[LOCAL2]]);
+    // CHECK: switchInt(move [[CMP_LOCAL]]) -> [
+    // CHECK-NEXT: }
     match (x, y, z) {
         (Some(a), Some(b), Some(c)) => 0,
         (None, None, None) => 0,

--- a/tests/mir-opt/early_otherwise_branch_3_element_tuple.rs
+++ b/tests/mir-opt/early_otherwise_branch_3_element_tuple.rs
@@ -1,10 +1,12 @@
 // skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
+//@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
 // EMIT_MIR early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
 fn opt1(x: Option<u32>, y: Option<u32>, z: Option<u32>) -> u32 {
     match (x, y, z) {
         (Some(a), Some(b), Some(c)) => 0,
+        (None, None, None) => 0,
         _ => 1,
     }
 }

--- a/tests/mir-opt/early_otherwise_branch_68867.rs
+++ b/tests/mir-opt/early_otherwise_branch_68867.rs
@@ -1,5 +1,6 @@
 // skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
+//@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
 // FIXME: This test was broken by the derefer change.
 

--- a/tests/mir-opt/early_otherwise_branch_68867.rs
+++ b/tests/mir-opt/early_otherwise_branch_68867.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
@@ -20,6 +19,13 @@ pub extern "C" fn try_sum(
     x: &ViewportPercentageLength,
     other: &ViewportPercentageLength,
 ) -> Result<ViewportPercentageLength, ()> {
+    // CHECK-LABEL: fn try_sum(
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK-NOT: Ne
+    // CHECK-NOT: discriminant
+    // CHECK: switchInt(move [[LOCAL1]]) -> [
+    // CHECK-NEXT: }
     use self::ViewportPercentageLength::*;
     Ok(match (x, other) {
         (&Vw(one), &Vw(other)) => Vw(one + other),

--- a/tests/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -78,7 +78,7 @@
           StorageDead(_5);
           _34 = deref_copy (_4.0: &ViewportPercentageLength);
           _11 = discriminant((*_34));
-          switchInt(move _11) -> [0: bb2, 1: bb3, 2: bb4, 3: bb5, otherwise: bb1];
+          switchInt(move _11) -> [0: bb2, 1: bb3, 2: bb4, 3: bb5, otherwise: bb12];
       }
   
       bb1: {
@@ -212,6 +212,10 @@
   
       bb11: {
           return;
+      }
+  
+      bb12: {
+          unreachable;
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -36,7 +36,7 @@
           StorageDead(_5);
           StorageDead(_4);
           _8 = discriminant((_3.0: std::option::Option<u32>));
-          switchInt(move _8) -> [0: bb2, 1: bb4, otherwise: bb1];
+          switchInt(move _8) -> [0: bb2, 1: bb4, otherwise: bb9];
       }
   
       bb1: {
@@ -45,7 +45,7 @@
   
       bb2: {
           _6 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _6) -> [0: bb3, 1: bb7, otherwise: bb1];
+          switchInt(move _6) -> [0: bb3, 1: bb7, otherwise: bb9];
       }
   
       bb3: {
@@ -55,7 +55,7 @@
   
       bb4: {
           _7 = discriminant((_3.1: std::option::Option<u32>));
-          switchInt(move _7) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _7) -> [0: bb6, 1: bb5, otherwise: bb9];
       }
   
       bb5: {
@@ -88,6 +88,10 @@
       bb8: {
           StorageDead(_3);
           return;
+      }
+  
+      bb9: {
+          unreachable;
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_noopt.rs
+++ b/tests/mir-opt/early_otherwise_branch_noopt.rs
@@ -1,5 +1,6 @@
 // skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
+//@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
 // must not optimize as it does not follow the pattern of
 // left and right hand side being the same variant

--- a/tests/mir-opt/early_otherwise_branch_noopt.rs
+++ b/tests/mir-opt/early_otherwise_branch_noopt.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
@@ -7,6 +6,13 @@
 
 // EMIT_MIR early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
 fn noopt1(x: Option<u32>, y: Option<u32>) -> u32 {
+    // CHECK-LABEL: fn noopt1(
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK-NOT: Ne
+    // CHECK-NOT: discriminant
+    // CHECK: switchInt(move [[LOCAL1]]) -> [
+    // CHECK-NEXT: }
     match (x, y) {
         (Some(a), Some(b)) => 0,
         (Some(a), None) => 1,

--- a/tests/mir-opt/early_otherwise_branch_soundness.rs
+++ b/tests/mir-opt/early_otherwise_branch_soundness.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
 //@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
@@ -12,12 +11,26 @@ enum E<'a> {
 
 // EMIT_MIR early_otherwise_branch_soundness.no_downcast.EarlyOtherwiseBranch.diff
 fn no_downcast(e: &E) -> u32 {
+    // CHECK-LABEL: fn no_downcast(
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK-NOT: Ne
+    // CHECK-NOT: discriminant
+    // CHECK: switchInt(move [[LOCAL1]]) -> [
+    // CHECK-NEXT: }
     if let E::Some(E::Some(_)) = e { 1 } else { 2 }
 }
 
 // SAFETY: if `a` is `Some`, `b` must point to a valid, initialized value
 // EMIT_MIR early_otherwise_branch_soundness.no_deref_ptr.EarlyOtherwiseBranch.diff
 unsafe fn no_deref_ptr(a: Option<i32>, b: *const Option<i32>) -> i32 {
+    // CHECK-LABEL: fn no_deref_ptr(
+    // CHECK: bb0: {
+    // CHECK: [[LOCAL1:_.*]] = discriminant({{.*}});
+    // CHECK-NOT: Ne
+    // CHECK-NOT: discriminant
+    // CHECK: switchInt(move [[LOCAL1]]) -> [
+    // CHECK-NEXT: }
     match a {
         // `*b` being correct depends on `a == Some(_)`
         Some(_) => match *b {

--- a/tests/mir-opt/early_otherwise_branch_soundness.rs
+++ b/tests/mir-opt/early_otherwise_branch_soundness.rs
@@ -1,5 +1,6 @@
 // skip-filecheck
 //@ unit-test: EarlyOtherwiseBranch
+//@ compile-flags: -Zmir-enable-passes=+UninhabitedEnumBranching
 
 // Tests various cases that the `early_otherwise_branch` opt should *not* optimize
 


### PR DESCRIPTION
Fixes #95162. Fixes #119014. Fixes #117970.

An invalid enum discriminant can come from anywhere. We have to check to see if all successors contain the discriminant statement.

It should not be UB that we pass in an invalid enum discriminant when calling a function, this is more like LLVM's poison value. UB only when used. Although miri would consider the following code to be UB. (It's fine for miri.)

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=18602870aaeb07cbdf7dfcd2c28961a2

I extended the scenario with scalars and the same target values.

r? compiler