### PR TITLE
Prevent cycle in implied predicates computation

### DIFF
--- a/tests/ui/associated-type-bounds/implied-bounds-cycle.rs
+++ b/tests/ui/associated-type-bounds/implied-bounds-cycle.rs
@@ -1,0 +1,10 @@
+#![feature(associated_type_bounds)]
+
+trait A {
+    type T;
+}
+
+trait B: A<T: B> {}
+//~^ ERROR cycle detected when computing the implied predicates of `B`
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/implied-bounds-cycle.stderr
+++ b/tests/ui/associated-type-bounds/implied-bounds-cycle.stderr
@@ -1,0 +1,17 @@
+error[E0391]: cycle detected when computing the implied predicates of `B`
+  --> $DIR/implied-bounds-cycle.rs:7:15
+   |
+LL | trait B: A<T: B> {}
+   |               ^
+   |
+   = note: ...which immediately requires computing the implied predicates of `B` again
+note: cycle used when computing normalized predicates of `B`
+  --> $DIR/implied-bounds-cycle.rs:7:1
+   |
+LL | trait B: A<T: B> {}
+   | ^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Makes #65913 from hang -> fail. I believe fail is the correct state for this test to remain for the long term.