### PR TITLE
Improve error messages for generics with default parameters

### DIFF
--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -360,6 +360,33 @@ impl<'tcx> Generics {
         let own = &args[self.parent_count..][..self.params.len()];
         if self.has_self && self.parent.is_none() { &own[1..] } else { own }
     }
+
+    /// Returns true if a concrete type is specified after a default type.
+    /// For example, consider `struct T<W = usize, X = Vec<W>>(W, X)`
+    /// `T<usize, String>` will return true
+    /// `T<usize>` will return false
+    pub fn check_concrete_type_after_default(
+        &'tcx self,
+        tcx: TyCtxt<'tcx>,
+        args: &'tcx [ty::GenericArg<'tcx>],
+    ) -> bool {
+        let mut default_param_seen = false;
+        for param in self.params.iter() {
+            if param
+                .default_value(tcx)
+                .is_some_and(|default| default.instantiate(tcx, args) == args[param.index as usize])
+            {
+                default_param_seen = true;
+            } else if default_param_seen
+                && param.default_value(tcx).is_some_and(|default| {
+                    default.instantiate(tcx, args) != args[param.index as usize]
+                })
+            {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 /// Bounds on generics.

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -372,17 +372,14 @@ impl<'tcx> Generics {
     ) -> bool {
         let mut default_param_seen = false;
         for param in self.params.iter() {
-            if param
-                .default_value(tcx)
-                .is_some_and(|default| default.instantiate(tcx, args) == args[param.index as usize])
+            if let Some(inst) =
+                param.default_value(tcx).map(|default| default.instantiate(tcx, args))
             {
-                default_param_seen = true;
-            } else if default_param_seen
-                && param.default_value(tcx).is_some_and(|default| {
-                    default.instantiate(tcx, args) != args[param.index as usize]
-                })
-            {
-                return true;
+                if inst == args[param.index as usize] {
+                    default_param_seen = true;
+                } else if default_param_seen {
+                    return true;
+                }
             }
         }
         false

--- a/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.rs
+++ b/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.rs
@@ -5,7 +5,7 @@ fn main() {
     let c: What<usize, String> = What(1, String::from("meow"));
     b = c; //~ ERROR mismatched types
 
-    let mut e: What<usize> = What(5, vec![1, 2, 3]);
-    let f: What<usize, Vec<String>> = What(1, vec![String::from("meow")]);
-    e = f; //~ ERROR mismatched types
+    let mut f: What<usize, Vec<String>> = What(1, vec![String::from("meow")]);
+    let e: What<usize> = What(5, vec![1, 2, 3]);
+    f = e; //~ ERROR mismatched types
 }

--- a/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.rs
+++ b/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.rs
@@ -1,0 +1,11 @@
+struct What<W = usize, X = Vec<W>>(W, X);
+
+fn main() {
+    let mut b: What<usize> = What(5, vec![1, 2, 3]);
+    let c: What<usize, String> = What(1, String::from("meow"));
+    b = c; //~ ERROR mismatched types
+
+    let mut e: What<usize> = What(5, vec![1, 2, 3]);
+    let f: What<usize, Vec<String>> = What(1, vec![String::from("meow")]);
+    e = f; //~ ERROR mismatched types
+}

--- a/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.stderr
+++ b/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.stderr
@@ -13,14 +13,14 @@ LL |     b = c;
 error[E0308]: mismatched types
   --> $DIR/clarify-error-for-generics-with-default-issue-120785.rs:10:9
    |
-LL |     let mut e: What<usize> = What(5, vec![1, 2, 3]);
-   |                ----------- expected due to this type
-LL |     let f: What<usize, Vec<String>> = What(1, vec![String::from("meow")]);
-LL |     e = f;
-   |         ^ expected `What`, found `What<usize, Vec<String>>`
+LL |     let mut f: What<usize, Vec<String>> = What(1, vec![String::from("meow")]);
+   |                ------------------------ expected due to this type
+LL |     let e: What<usize> = What(5, vec![1, 2, 3]);
+LL |     f = e;
+   |         ^ expected `What<usize, Vec<String>>`, found `What`
    |
-   = note: expected struct `What<_, Vec<usize>>`
-              found struct `What<_, Vec<String>>`
+   = note: expected struct `What<_, Vec<String>>`
+              found struct `What<_, Vec<usize>>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.stderr
+++ b/tests/ui/type/clarify-error-for-generics-with-default-issue-120785.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/clarify-error-for-generics-with-default-issue-120785.rs:6:9
+   |
+LL |     let mut b: What<usize> = What(5, vec![1, 2, 3]);
+   |                ----------- expected due to this type
+LL |     let c: What<usize, String> = What(1, String::from("meow"));
+LL |     b = c;
+   |         ^ expected `What`, found `What<usize, String>`
+   |
+   = note: expected struct `What<_, Vec<usize>>`
+              found struct `What<_, String>`
+
+error[E0308]: mismatched types
+  --> $DIR/clarify-error-for-generics-with-default-issue-120785.rs:10:9
+   |
+LL |     let mut e: What<usize> = What(5, vec![1, 2, 3]);
+   |                ----------- expected due to this type
+LL |     let f: What<usize, Vec<String>> = What(1, vec![String::from("meow")]);
+LL |     e = f;
+   |         ^ expected `What`, found `What<usize, Vec<String>>`
+   |
+   = note: expected struct `What<_, Vec<usize>>`
+              found struct `What<_, Vec<String>>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #120785

Issue: Previously, all type parameters with default types were deliberately ignored to simplify error messages. For example, an error message for Box type would display `Box<T>` instead of `Box<T, _>`. But, this resulted in unclear error message when a concrete type was used instead of the default type.

Fix: This PR fixes it by checking if a concrete type is specified after a default type to display the entire type name or the simplified type name.  