### PR TITLE
[perf experiment] Ignore inline(always) in unoptimized builds

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -41,7 +41,13 @@ fn inline_attr<'ll>(cx: &CodegenCx<'ll, '_>, inline: InlineAttr) -> Option<&'ll 
     }
     match inline {
         InlineAttr::Hint => Some(AttributeKind::InlineHint.create_attr(cx.llcx)),
-        InlineAttr::Always => Some(AttributeKind::AlwaysInline.create_attr(cx.llcx)),
+        InlineAttr::Always => {
+            if matches!(cx.sess().opts.optimize, OptLevel::No) {
+                Some(AttributeKind::InlineHint.create_attr(cx.llcx))
+            } else {
+                Some(AttributeKind::AlwaysInline.create_attr(cx.llcx))
+            }
+        }
         InlineAttr::Never => {
             if cx.sess().target.arch != "amdgpu" {
                 Some(AttributeKind::NoInline.create_attr(cx.llcx))


### PR DESCRIPTION
Yes I know we have a codegen test for this. But based on this perf run I'm concerned this is having unexpected perf implications so I want to measure what they are: https://github.com/rust-lang/rust/pull/121369#issuecomment-1955826947

r? @ghost