### PR TITLE
Implement `-C link-self-contained=(+/-)sanitizers`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1202,6 +1202,8 @@ fn add_sanitizer_libraries(
     // Everywhere else the runtimes are currently distributed as static
     // libraries which should be linked to executables only.
     let needs_runtime = !sess.target.is_like_android
+        && (!sess.opts.cg.link_self_contained.is_sanitizers_disabled()
+            || sess.opts.cg.link_self_contained.is_sanitizers_enabled())
         && match crate_type {
             CrateType::Executable => true,
             CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro => {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -278,15 +278,27 @@ impl LinkSelfContained {
     }
 
     /// Returns whether the self-contained linker component was enabled on the CLI, using the
-    /// `-C link-self-contained=+linker` syntax, or one of the `true` shorcuts.
+    /// `-C link-self-contained=+linker` syntax, or one of the `true` shortcuts.
     pub fn is_linker_enabled(&self) -> bool {
         self.enabled_components.contains(LinkSelfContainedComponents::LINKER)
     }
 
     /// Returns whether the self-contained linker component was disabled on the CLI, using the
-    /// `-C link-self-contained=-linker` syntax, or one of the `false` shorcuts.
+    /// `-C link-self-contained=-linker` syntax, or one of the `false` shortcuts.
     pub fn is_linker_disabled(&self) -> bool {
         self.disabled_components.contains(LinkSelfContainedComponents::LINKER)
+    }
+
+    // Returns whether the self-contained sanitizer component was enabled on the CLI, using the
+    // `-C link-self-contained=+sanitizers` syntax, or one of the `true` shortcuts.
+    pub fn is_sanitizers_enabled(&self) -> bool {
+        self.enabled_components.contains(LinkSelfContainedComponents::SANITIZERS)
+    }
+
+    /// Returns whether the self-contained linker component was disabled on the CLI, using the
+    /// `-C link-self-contained=-sanitizers` syntax, or one of the `false` shortcuts.
+    pub fn is_sanitizers_disabled(&self) -> bool {
+        self.disabled_components.contains(LinkSelfContainedComponents::SANITIZERS)
     }
 
     /// Returns CLI inconsistencies to emit errors: individual components were both enabled and

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -295,7 +295,7 @@ impl LinkSelfContained {
         self.enabled_components.contains(LinkSelfContainedComponents::SANITIZERS)
     }
 
-    /// Returns whether the self-contained linker component was disabled on the CLI, using the
+    /// Returns whether the self-contained sanitizer component was disabled on the CLI, using the
     /// `-C link-self-contained=-sanitizers` syntax, or one of the `false` shortcuts.
     pub fn is_sanitizers_disabled(&self) -> bool {
         self.disabled_components.contains(LinkSelfContainedComponents::SANITIZERS)


### PR DESCRIPTION
This PR adds support for enabling/disabling self-contained sanitizer runtimes.

This is an alternative to https://github.com/rust-lang/rust/pull/121207.

r? @michaelwoerister