### PR TITLE
Remove the `UntranslatableDiagnosticTrivial` lint.

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -550,7 +550,6 @@ fn register_internals(store: &mut LintStore) {
     store.register_lints(&TyTyKind::get_lints());
     store.register_late_mod_pass(|_| Box::new(TyTyKind));
     store.register_lints(&Diagnostics::get_lints());
-    store.register_early_pass(|| Box::new(Diagnostics));
     store.register_late_mod_pass(|_| Box::new(Diagnostics));
     store.register_lints(&BadOptAccess::get_lints());
     store.register_late_mod_pass(|_| Box::new(BadOptAccess));

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -924,10 +924,6 @@ pub struct DiagOutOfImpl;
 pub struct UntranslatableDiag;
 
 #[derive(LintDiagnostic)]
-#[diag(lint_trivial_untranslatable_diag)]
-pub struct UntranslatableDiagnosticTrivial;
-
-#[derive(LintDiagnostic)]
 #[diag(lint_bad_opt_access)]
 pub struct BadOptAccessDiag<'a> {
     pub msg: &'a str,

--- a/src/tools/clippy/clippy_config/src/lib.rs
+++ b/src/tools/clippy/clippy_config/src/lib.rs
@@ -6,7 +6,6 @@
     clippy::missing_panics_doc,
     rustc::diagnostic_outside_of_impl,
     rustc::untranslatable_diagnostic,
-    rustc::untranslatable_diagnostic_trivial
 )]
 
 extern crate rustc_ast;


### PR DESCRIPTION
It's a specialized form of the `UntranslatableDiagnostic` lint that is deny-by-default.

Now that `UntranslatableDiagnostic` has been changed from allow-by-default to deny-by-default, the trivial variant is no longer needed.

r? @davidtwco
