### PR TITLE
Account for RPITIT in E0310 explicit lifetime constraint suggestion

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2434,6 +2434,14 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let suggestion =
                     if has_lifetimes { format!(" + {lt_name}") } else { format!(": {lt_name}") };
                 suggs.push((sp, suggestion))
+            } else if let GenericKind::Alias(ref p) = bound_kind
+                && let ty::Projection = p.kind(self.tcx)
+                && let DefKind::AssocTy = self.tcx.def_kind(p.def_id)
+                && let Some(ty::ImplTraitInTraitData::Trait { .. }) =
+                    self.tcx.opt_rpitit_info(p.def_id)
+            {
+                // The lifetime found in the `impl` is longer than the one on the RPITIT.
+                // Do not suggest `<Type as Trait>::{opaque}: 'static`.
             } else if let Some(generics) = self.tcx.hir().get_generics(suggestion_scope) {
                 let pred = format!("{bound_kind}: {lt_name}");
                 let suggestion = format!("{} {}", generics.add_where_or_trailing_comma(), pred);

--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
@@ -6,8 +6,6 @@ LL |     async fn foo() -> &'static impl T;
    |     |
    |     the associated type `<Self as MyTrait>::{opaque#0}` must be valid for the static lifetime...
    |     ...so that the reference type `&'static impl T` does not outlive the data it points at
-   |
-   = help: consider adding an explicit lifetime bound `<Self as MyTrait>::{opaque#0}: 'static`...
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.rs
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.rs
@@ -1,0 +1,16 @@
+trait Original {
+    fn f() -> impl Fn();
+}
+
+trait Erased {
+    fn f(&self) -> Box<dyn Fn()>;
+}
+
+impl<T: Original> Erased for T {
+    fn f(&self) -> Box<dyn Fn()> {
+        Box::new(<T as Original>::f())
+        //~^ ERROR the associated type `<T as Original>::{opaque#0}` may not live long enough
+    }
+}
+
+fn main () {}

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
@@ -1,0 +1,12 @@
+error[E0310]: the associated type `<T as Original>::{opaque#0}` may not live long enough
+  --> $DIR/missing-static-bound-from-impl.rs:11:9
+   |
+LL |         Box::new(<T as Original>::f())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         the associated type `<T as Original>::{opaque#0}` must be valid for the static lifetime...
+   |         ...so that the type `impl Fn()` will meet its required lifetime bounds
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
When given

```rust
trait Original {
    fn f() -> impl Fn();
}

trait Erased {
    fn f(&self) -> Box<dyn Fn()>;
}

impl<T: Original> Erased for T {
    fn f(&self) -> Box<dyn Fn()> {
        Box::new(<T as Original>::f())
    }
}
```

emit do not emit an invalid suggestion restricting the `Trait::{opaque}` type in a `where` clause:

```
error[E0310]: the associated type `<T as Original>::{opaque#0}` may not live long enough
  --> $DIR/missing-static-bound-from-impl.rs:11:9
   |
LL |         Box::new(<T as Original>::f())
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |         |
   |         the associated type `<T as Original>::{opaque#0}` must be valid for the static lifetime...
   |         ...so that the type `impl Fn()` will meet its required lifetime bounds
```

Partially address #119773. Ideally we'd suggest modifying `Erased::f` instead.

r? @compiler-errors 