### PR TITLE
Add new maintainers to nto-qnx.md

### DIFF
--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -13,6 +13,8 @@ and [Blackberry QNX][BlackBerry].
 
 - Florian Bartels, `Florian.Bartels@elektrobit.com`, https://github.com/flba-eb
 - Tristan Roach, `TRoach@blackberry.com`, https://github.com/gh-tr
+- Jonathan Pallant `Jonathan.Pallant@ferrous-systems.com`, https://github.com/jonathanpallant
+- Jorge Aparicio `Jorge.Aparicio@ferrous-systems.com`, https://github.com/japaric
 
 ## Requirements
 


### PR DESCRIPTION
[Ferrous Systems](https://ferrous-systems.com) are volunteering myself and @japaric as co-maintainers of the QNX targets.