### PR TITLE
Bump `memchr` to 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,10 +585,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: dist-x86_64-linux
+          - name: x86_64-mingw
             env:
-              CODEGEN_BACKENDS: "llvm,cranelift"
-            os: ubuntu-20.04-16core-64gb
+              SCRIPT: make ci-mingw
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
+              NO_DOWNLOAD_CI_LLVM: 1
+              CUSTOM_MINGW: 1
+            os: windows-2019-8core-32gb
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # FIXME: bumping memchr to 2.7.1 causes linker errors in MSVC thin-lto
 # tidy-alphabetical-start
 bitflags = "2.4.1"
-memchr = "=2.5.0"
+memchr = "=2.6.0"
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_index = { path = "../rustc_index" }
 rustc_lexer = { path = "../rustc_lexer" }

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -734,13 +734,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - &dist-x86_64-linux
-            name: dist-x86_64-linux
+          - &x86_64-mingw
+            name: x86_64-mingw
             env:
-              CODEGEN_BACKENDS: llvm,cranelift
-            <<: *job-linux-16c
-
-
+              SCRIPT: make ci-mingw
+              RUST_CONFIGURE_ARGS: >-
+                --build=x86_64-pc-windows-gnu
+                --enable-profiler
+              # We are intentionally allowing an old toolchain on this builder (and that's
+              # incompatible with LLVM downloads today).
+              NO_DOWNLOAD_CI_LLVM: 1
+              CUSTOM_MINGW: 1
+            <<: *job-windows-8c
   master:
     name: master
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/.60ui_test.60.20v0.2E22.2E1.20version.20bump.20causes.20dep.20conflict

cc @flip1995 

Going to try this on the job that failed with 2.7.1