### PR TITLE
remove `llvm.assertions=true` in compiler profile

### DIFF
--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -19,9 +19,9 @@ lto = "off"
 frame-pointers = true
 
 [llvm]
-# This enables debug-assertions in LLVM,
-# catching logic errors in codegen much earlier in the process.
-assertions = true
+# Having this set to true disrupts compiler development workflows for people who use `llvm.download-ci-llvm = true`
+# because we don't provide ci-llvm on the `rustc-alt-builds` server. Therefore, it is kept off by default.
+assertions = false
 # Enable warnings during the LLVM compilation (when LLVM is changed, causing a compilation)
 enable-warnings = true
 # Will download LLVM from CI if available on your platform.


### PR DESCRIPTION
Having this set to true disrupts compiler development workflows for people who use `llvm.download-ci-llvm = true` because we don't provide ci-llvm on the `rustc-alt-builds` server. Therefore, it is kept off by default.

cc @Nilstrieb @compiler-errors 

For more context, see https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/CI.20LLVM.20for.20aarch64