### PR TITLE
Allow for a missing `adt_def` in `NamePrivacyVisitor`.

### DIFF
--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -988,7 +988,10 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::Struct(qpath, fields, ref base) = expr.kind {
             let res = self.typeck_results().qpath_res(qpath, expr.hir_id);
-            let adt = self.typeck_results().expr_ty(expr).ty_adt_def().unwrap();
+            let Some(adt) = self.typeck_results().expr_ty(expr).ty_adt_def() else {
+                self.tcx.dcx().span_delayed_bug(expr.span, "no adt_def for expression");
+                return;
+            };
             let variant = adt.variant_of_res(res);
             if let Some(base) = *base {
                 // If the expression uses FRU we need to make sure all the unmentioned fields

--- a/tests/ui/privacy/unreachable-issue-121455.rs
+++ b/tests/ui/privacy/unreachable-issue-121455.rs
@@ -1,0 +1,6 @@
+fn test(s: &Self::Id) {
+//~^ ERROR failed to resolve: `Self` is only available in impls, traits, and type definitions
+    match &s[0..3] {}
+}
+
+fn main() {}

--- a/tests/ui/privacy/unreachable-issue-121455.stderr
+++ b/tests/ui/privacy/unreachable-issue-121455.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+  --> $DIR/unreachable-issue-121455.rs:1:13
+   |
+LL | fn test(s: &Self::Id) {
+   |             ^^^^ `Self` is only available in impls, traits, and type definitions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
This was caused by 72b172bdf6 in #121206. That commit removed an early return from `analysis` when there are stashed errors. As a result, it's possible to reach privacy analysis when there are stashed errors, which means more code paths can be reached. One such code path was handled in that commit, where a `span_bug` was changed to a `span_delayed_bug`.

This commit handles another such code path uncovered by fuzzing, in much the same way.

Fixes #121455.

r? @oli-obk 