### PR TITLE
coverage: Use variable name `this` in `CoverageGraph::from_mir`

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -52,19 +52,18 @@ impl CoverageGraph {
             }
         }
 
-        let mut basic_coverage_blocks =
-            Self { bcbs, bb_to_bcb, successors, predecessors, dominators: None };
-        let dominators = dominators::dominators(&basic_coverage_blocks);
-        basic_coverage_blocks.dominators = Some(dominators);
+        let mut this = Self { bcbs, bb_to_bcb, successors, predecessors, dominators: None };
+
+        this.dominators = Some(dominators::dominators(&this));
 
         // The coverage graph's entry-point node (bcb0) always starts with bb0,
         // which never has predecessors. Any other blocks merged into bcb0 can't
         // have multiple (coverage-relevant) predecessors, so bcb0 always has
         // zero in-edges.
-        assert!(basic_coverage_blocks[START_BCB].leader_bb() == mir::START_BLOCK);
-        assert!(basic_coverage_blocks.predecessors[START_BCB].is_empty());
+        assert!(this[START_BCB].leader_bb() == mir::START_BLOCK);
+        assert!(this.predecessors[START_BCB].is_empty());
 
-        basic_coverage_blocks
+        this
     }
 
     fn compute_basic_coverage_blocks(


### PR DESCRIPTION
A tiny little improvement, extracted from #120013.

This makes it easier to see that we're manipulating the instance that is being constructed, and is a lot less verbose than `basic_coverage_blocks`.