### PR TITLE
Explicitly call `emit_stashed_diagnostics`.

### DIFF
--- a/src/tools/rustfmt/src/parse/parser.rs
+++ b/src/tools/rustfmt/src/parse/parser.rs
@@ -163,13 +163,21 @@ impl<'a> Parser<'a> {
     fn parse_crate_mod(&mut self) -> Result<ast::Crate, ParserError> {
         let mut parser = AssertUnwindSafe(&mut self.parser);
 
-        match catch_unwind(move || parser.parse_crate_mod()) {
-            Ok(Ok(k)) => Ok(k),
-            Ok(Err(db)) => {
+        // rustfmt doesn't use `run_compiler` like other tools, so it must emit
+        // any stashed diagnostics itself, otherwise the `DiagCtxt` will assert
+        // when dropped. The final result here combines the parsing result and
+        // the `emit_stashed_diagnostics` result.
+        let parse_res = catch_unwind(move || parser.parse_crate_mod());
+        let stashed_res = self.parser.dcx().emit_stashed_diagnostics();
+        let err = Err(ParserError::ParsePanicError);
+        match (parse_res, stashed_res) {
+            (Ok(Ok(k)), None) => Ok(k),
+            (Ok(Ok(_)), Some(_guar)) => err,
+            (Ok(Err(db)), _) => {
                 db.emit();
-                Err(ParserError::ParseError)
+                err
             }
-            Err(_) => Err(ParserError::ParsePanicError),
+            (Err(_), _) => err,
         }
     }
 }

--- a/src/tools/rustfmt/src/test/parser.rs
+++ b/src/tools/rustfmt/src/test/parser.rs
@@ -55,3 +55,10 @@ fn crate_parsing_errors_on_unclosed_delims() {
     let filename = "tests/parser/unclosed-delims/issue_4466.rs";
     assert_parser_error(filename);
 }
+
+#[test]
+fn crate_parsing_stashed_diag() {
+    // See also https://github.com/rust-lang/rust/issues/121450
+    let filename = "tests/parser/stashed-diag.rs";
+    assert_parser_error(filename);
+}

--- a/src/tools/rustfmt/tests/parser/stashed-diag.rs
+++ b/src/tools/rustfmt/tests/parser/stashed-diag.rs
@@ -1,0 +1,3 @@
+#![u={static N;}]
+
+fn main() {}


### PR DESCRIPTION
Commit 72b172b in #121206 changed things so that
`emit_stashed_diagnostics` is only called from `run_compiler`. But rustfmt doesn't use `run_compiler`, so it needs to call `emit_stashed_diagnostics` itself to avoid an abort in `DiagCtxtInner::drop` when stashed diagnostics occur.

Fixes #121450.

r? @oli-obk 