### PR TITLE
Rustdoc: include crate name in links for local primitives

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -879,11 +879,16 @@ fn primitive_link_fragment(
         match m.primitive_locations.get(&prim) {
             Some(&def_id) if def_id.is_local() => {
                 let len = cx.current.len();
-                let len = if len == 0 { 0 } else { len - 1 };
+                let path = if len == 0 {
+                    let cname_sym = ExternalCrate { crate_num: def_id.krate }.name(cx.tcx());
+                    format!("{cname_sym}/")
+                } else {
+                    "../".repeat(len - 1)
+                };
                 write!(
                     f,
                     "<a class=\"primitive\" href=\"{}primitive.{}.html{fragment}\">",
-                    "../".repeat(len),
+                    path,
                     prim.as_sym()
                 )?;
                 needs_termination = true;


### PR DESCRIPTION
Fixes #121106. 

This change makes links to primitives easier to use when the path of the page where they will be embedded is not known beforehand such as when we generate impls dynamically from the `register_type_impls` method in `main.js`, which is exactly what is happening in #121106. 

An example to show the effect of this change: earlier, if the current page in `cx.current` inside `primitive_link_fragment()` was `std::simd::prelude::Simd` the generated path would be `../../primitive.<prim>.html`. Now it would be `../../../std/primitive.<prim>.html` instead.

A side effect of the change is that local primitive links _everywhere_ will now contain the crate name, even outside of the dynamic situation mentioned above. I'm not sure if there are any major downsides of that other than making the links a bit longer. Ideally I wanted to restrict this behaviour change to only the dynamic cases. We could have achieved that by passing an additional bool arg to `primitive_link_fragment()`, but it felt awkward to do so. Any alternative suggestions are welcome.

