### PR TITLE
Merge `collect_mod_item_types` query into `check_well_formed`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -58,11 +58,11 @@ fn collect_mod_item_types(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
     let items = tcx.hir_module_items(module_def_id);
     let hir = tcx.hir();
     let _ = items.par_items(|item| Ok(CollectItemTypesVisitor { tcx }.visit_item(hir.item(item))));
-    let _ = items.par_trait_items(|item| {
-        Ok(CollectItemTypesVisitor { tcx }.visit_trait_item(hir.trait_item(item)))
-    });
     let _ = items.par_impl_items(|item| {
         Ok(CollectItemTypesVisitor { tcx }.visit_impl_item(hir.impl_item(item)))
+    });
+    let _ = items.par_trait_items(|item| {
+        Ok(CollectItemTypesVisitor { tcx }.visit_trait_item(hir.trait_item(item)))
     });
     let _ = items.par_foreign_items(|item| {
         Ok(CollectItemTypesVisitor { tcx }.visit_foreign_item(hir.foreign_item(item)))

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -20,7 +20,7 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{Applicability, Diag, ErrorGuaranteed, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::{DefId, LocalDefId, LocalModDefId};
+use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{GenericParamKind, Node};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
@@ -52,22 +52,6 @@ mod resolve_bound_vars;
 mod type_of;
 
 ///////////////////////////////////////////////////////////////////////////
-// Main entry point
-
-fn collect_mod_item_types(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    let items = tcx.hir_module_items(module_def_id);
-    let hir = tcx.hir();
-    let _ = items.par_items(|item| Ok(CollectItemTypesVisitor { tcx }.visit_item(hir.item(item))));
-    let _ = items.par_impl_items(|item| {
-        Ok(CollectItemTypesVisitor { tcx }.visit_impl_item(hir.impl_item(item)))
-    });
-    let _ = items.par_trait_items(|item| {
-        Ok(CollectItemTypesVisitor { tcx }.visit_trait_item(hir.trait_item(item)))
-    });
-    let _ = items.par_foreign_items(|item| {
-        Ok(CollectItemTypesVisitor { tcx }.visit_foreign_item(hir.foreign_item(item)))
-    });
-}
 
 pub fn provide(providers: &mut Providers) {
     resolve_bound_vars::provide(providers);
@@ -93,7 +77,6 @@ pub fn provide(providers: &mut Providers) {
         impl_trait_header,
         coroutine_kind,
         coroutine_for_closure,
-        collect_mod_item_types,
         is_type_alias_impl_trait,
         find_field,
         ..*providers
@@ -166,8 +149,8 @@ impl<'v> Visitor<'v> for HirPlaceholderCollector {
     }
 }
 
-struct CollectItemTypesVisitor<'tcx> {
-    tcx: TyCtxt<'tcx>,
+pub struct CollectItemTypesVisitor<'tcx> {
+    pub tcx: TyCtxt<'tcx>,
 }
 
 /// If there are any placeholder types (`_`), emit an error explaining that this is not allowed

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -159,12 +159,6 @@ pub fn provide(providers: &mut Providers) {
 pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorGuaranteed> {
     let _prof_timer = tcx.sess.timer("type_check_crate");
 
-    // this ensures that later parts of type checking can assume that items
-    // have valid types and not error
-    tcx.sess.time("type_collecting", || {
-        tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
-    });
-
     if tcx.features().rustc_attrs {
         tcx.sess.time("outlives_testing", || outlives::test::test_inferred_outlives(tcx))?;
     }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -763,6 +763,7 @@ rustc_queries! {
         desc { |tcx| "computing the variances of `{}`", tcx.def_path_str(def_id) }
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
+        cycle_delay_bug
     }
 
     /// Maps from thee `DefId` of a type to its (inferred) outlives.
@@ -958,10 +959,6 @@ rustc_queries! {
     query check_mod_type_wf(key: LocalModDefId) -> Result<(), ErrorGuaranteed> {
         desc { |tcx| "checking that types are well-formed in {}", describe_as_module(key, tcx) }
         ensure_forwards_result_if_red
-    }
-
-    query collect_mod_item_types(key: LocalModDefId) {
-        desc { |tcx| "collecting item types in {}", describe_as_module(key, tcx) }
     }
 
     /// Caches `CoerceUnsized` kinds for impls on custom types.

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -314,12 +314,6 @@ pub(crate) fn run_global_ctxt(
     // typeck function bodies or run the default rustc lints.
     // (see `override_queries` in the `config`)
 
-    // HACK(jynelson) this calls an _extremely_ limited subset of `typeck`
-    // and might break if queries change their assumptions in the future.
-    tcx.sess.time("type_collecting", || {
-        tcx.hir().for_each_module(|module| tcx.ensure().collect_mod_item_types(module))
-    });
-
     // NOTE: These are copy/pasted from typeck/lib.rs and should be kept in sync with those changes.
     let _ = tcx.sess.time("wf_checking", || {
         tcx.hir().try_par_for_each_module(|module| tcx.ensure().check_mod_type_wf(module))

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -324,11 +324,6 @@ pub(crate) fn run_global_ctxt(
     let _ = tcx.sess.time("wf_checking", || {
         tcx.hir().try_par_for_each_module(|module| tcx.ensure().check_mod_type_wf(module))
     });
-    tcx.sess.time("item_types_checking", || {
-        tcx.hir().for_each_module(|module| {
-            let _ = tcx.ensure().check_mod_type_wf(module);
-        });
-    });
 
     if let Some(guar) = tcx.dcx().has_errors() {
         return Err(guar);

--- a/tests/rustdoc-ui/issue-110629-private-type-cycle-dyn.stderr
+++ b/tests/rustdoc-ui/issue-110629-private-type-cycle-dyn.stderr
@@ -8,17 +8,11 @@ LL | type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
    = note: type aliases cannot be recursive
    = help: consider using a struct, enum, or union instead to break the cycle
    = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `Bar` is well-formed
   --> $DIR/issue-110629-private-type-cycle-dyn.rs:1:1
    |
-LL | / type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
-LL | |
-LL | |
-LL | | fn bar<'a, 'b>(i: &'a i32) -> Bar<'a, 'b> {
-...  |
-LL | |     assert!(bar(&meh) == bar(&muh));
-LL | | }
-   | |_^
+LL | type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
+   | ^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/rustdoc-ui/issues/issue-105742.stderr
+++ b/tests/rustdoc-ui/issues/issue-105742.stderr
@@ -465,38 +465,6 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/issue-105742.rs:61:38
-   |
-LL |     fn len(&self) -> <Self as SVec>::Item;
-   |                                      ^^^^ expected 1 lifetime argument
-   |
-note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/issue-105742.rs:59:10
-   |
-LL |     type Item<'a, T>;
-   |          ^^^^ --
-help: add missing lifetime argument
-   |
-LL |     fn len(&self) -> <Self as SVec>::Item<'_>;
-   |                                          ++++
-
-error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/issue-105742.rs:61:38
-   |
-LL |     fn len(&self) -> <Self as SVec>::Item;
-   |                                      ^^^^ expected 1 generic argument
-   |
-note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/issue-105742.rs:59:10
-   |
-LL |     type Item<'a, T>;
-   |          ^^^^     -
-help: add missing generic argument
-   |
-LL |     fn len(&self) -> <Self as SVec>::Item<T>;
-   |                                          +++
-
-error[E0107]: missing generics for associated type `SVec::Item`
   --> $DIR/issue-105742.rs:15:21
    |
 LL |     <Self as SVec>::Item,
@@ -631,6 +599,38 @@ help: add missing generic argument
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
+
+error[E0107]: missing generics for associated type `SVec::Item`
+  --> $DIR/issue-105742.rs:61:38
+   |
+LL |     fn len(&self) -> <Self as SVec>::Item;
+   |                                      ^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-105742.rs:59:10
+   |
+LL |     type Item<'a, T>;
+   |          ^^^^ --
+help: add missing lifetime argument
+   |
+LL |     fn len(&self) -> <Self as SVec>::Item<'_>;
+   |                                          ++++
+
+error[E0107]: missing generics for associated type `SVec::Item`
+  --> $DIR/issue-105742.rs:61:38
+   |
+LL |     fn len(&self) -> <Self as SVec>::Item;
+   |                                      ^^^^ expected 1 generic argument
+   |
+note: associated type defined here, with 1 generic parameter: `T`
+  --> $DIR/issue-105742.rs:59:10
+   |
+LL |     type Item<'a, T>;
+   |          ^^^^     -
+help: add missing generic argument
+   |
+LL |     fn len(&self) -> <Self as SVec>::Item<T>;
+   |                                          +++
 
 error: aborting due to 37 previous errors
 

--- a/tests/ui/associated-inherent-types/bugs/cycle-iat-inside-of-adt.stderr
+++ b/tests/ui/associated-inherent-types/bugs/cycle-iat-inside-of-adt.stderr
@@ -26,17 +26,11 @@ note: ...which requires computing normalized predicates of `Foo`...
 LL | struct Foo {
    | ^^^^^^^^^^
    = note: ...which again requires computing predicates of `Foo`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/cycle-iat-inside-of-adt.rs:3:1
+note: cycle used when checking that `Foo` is well-formed
+  --> $DIR/cycle-iat-inside-of-adt.rs:7:1
    |
-LL | / #![feature(inherent_associated_types)]
-LL | | #![allow(incomplete_features)]
-LL | | // FIXME(inherent_associated_types): This should pass.
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | struct Foo {
+   | ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/associated-inherent-types/bugs/cycle-iat-inside-of-where-predicate.stderr
+++ b/tests/ui/associated-inherent-types/bugs/cycle-iat-inside-of-where-predicate.stderr
@@ -20,19 +20,23 @@ note: ...which requires computing normalized predicates of `user`...
 LL | fn user<T>() where S<T>::P: std::fmt::Debug {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires computing predicates of `user`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/cycle-iat-inside-of-where-predicate.rs:3:1
+note: cycle used when checking that `user` is well-formed
+  --> $DIR/cycle-iat-inside-of-where-predicate.rs:8:1
    |
-LL | / #![feature(inherent_associated_types)]
-LL | | #![allow(incomplete_features)]
-LL | |
-LL | | // FIXME(inherent_associated_types): This shouldn't lead to a cycle error.
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | fn user<T>() where S<T>::P: std::fmt::Debug {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error
+error[E0392]: type parameter `T` is never used
+  --> $DIR/cycle-iat-inside-of-where-predicate.rs:10:10
+   |
+LL | struct S<T>;
+   |          ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
-For more information about this error, try `rustc --explain E0391`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0391, E0392.
+For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
+++ b/tests/ui/associated-inherent-types/issue-109071.no_gate.stderr
@@ -20,16 +20,6 @@ help: add missing generic argument
 LL | impl<T> Windows<T> {
    |                +++
 
-error[E0658]: inherent associated types are unstable
-  --> $DIR/issue-109071.rs:8:5
-   |
-LL |     type Item = &[T];
-   |     ^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
-   = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0223]: ambiguous associated type
   --> $DIR/issue-109071.rs:15:22
    |
@@ -42,6 +32,16 @@ LL |     fn T() -> Option<<Windows<T> as IntoAsyncIterator>::Item> {}
    |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 LL |     fn T() -> Option<<Windows<T> as IntoIterator>::Item> {}
    |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error[E0658]: inherent associated types are unstable
+  --> $DIR/issue-109071.rs:8:5
+   |
+LL |     type Item = &[T];
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-type-bounds/duplicate.stderr
+++ b/tests/ui/associated-type-bounds/duplicate.stderr
@@ -198,6 +198,17 @@ LL | fn FRPIT1() -> impl Iterator<Item: Copy, Item: Send> {
    |                              |
    |                              `Item` bound here first
 
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:136:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:139:42
    |
@@ -206,6 +217,17 @@ LL | fn FRPIT2() -> impl Iterator<Item: Copy, Item: Copy> {
    |                              |
    |                              `Item` bound here first
 
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:141:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
+
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:144:45
    |
@@ -213,6 +235,17 @@ LL | fn FRPIT3() -> impl Iterator<Item: 'static, Item: 'static> {
    |                              -------------  ^^^^^^^^^^^^^ re-bound here
    |                              |
    |                              `Item` bound here first
+
+error[E0282]: type annotations needed
+  --> $DIR/duplicate.rs:146:5
+   |
+LL |     iter::empty()
+   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
+   |
+help: consider specifying the generic argument
+   |
+LL |     iter::empty::<T>()
+   |                +++++
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:149:40
@@ -377,6 +410,16 @@ LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:197:34
+   |
+LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:201:34
    |
 LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
@@ -395,12 +438,32 @@ LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:201:34
+   |
+LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
+   |                      ----------  ^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:205:37
    |
 LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:205:37
+   |
+LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
+   |                      -------------  ^^^^^^^^^^^^^ re-bound here
+   |                      |
+   |                      `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:205:37
@@ -455,6 +518,16 @@ LL |     Self: Iterator<Item: Copy, Item: Send>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:229:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Send>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:237:32
    |
 LL |     Self: Iterator<Item: Copy, Item: Copy>,
@@ -473,12 +546,32 @@ LL |     Self: Iterator<Item: Copy, Item: Copy>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:237:32
+   |
+LL |     Self: Iterator<Item: Copy, Item: Copy>,
+   |                    ----------  ^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:245:35
    |
 LL |     Self: Iterator<Item: 'static, Item: 'static>,
    |                    -------------  ^^^^^^^^^^^^^ re-bound here
    |                    |
    |                    `Item` bound here first
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/duplicate.rs:245:35
+   |
+LL |     Self: Iterator<Item: 'static, Item: 'static>,
+   |                    -------------  ^^^^^^^^^^^^^ re-bound here
+   |                    |
+   |                    `Item` bound here first
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/duplicate.rs:245:35
@@ -513,99 +606,6 @@ LL |     type A: Iterator<Item: 'static, Item: 'static>;
    |                      -------------  ^^^^^^^^^^^^^ re-bound here
    |                      |
    |                      `Item` bound here first
-
-error[E0282]: type annotations needed
-  --> $DIR/duplicate.rs:136:5
-   |
-LL |     iter::empty()
-   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
-   |
-help: consider specifying the generic argument
-   |
-LL |     iter::empty::<T>()
-   |                +++++
-
-error[E0282]: type annotations needed
-  --> $DIR/duplicate.rs:141:5
-   |
-LL |     iter::empty()
-   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
-   |
-help: consider specifying the generic argument
-   |
-LL |     iter::empty::<T>()
-   |                +++++
-
-error[E0282]: type annotations needed
-  --> $DIR/duplicate.rs:146:5
-   |
-LL |     iter::empty()
-   |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
-   |
-help: consider specifying the generic argument
-   |
-LL |     iter::empty::<T>()
-   |                +++++
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:197:34
-   |
-LL | trait TRS1: Iterator<Item: Copy, Item: Send> {}
-   |                      ----------  ^^^^^^^^^^ re-bound here
-   |                      |
-   |                      `Item` bound here first
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:201:34
-   |
-LL | trait TRS2: Iterator<Item: Copy, Item: Copy> {}
-   |                      ----------  ^^^^^^^^^^ re-bound here
-   |                      |
-   |                      `Item` bound here first
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:205:37
-   |
-LL | trait TRS3: Iterator<Item: 'static, Item: 'static> {}
-   |                      -------------  ^^^^^^^^^^^^^ re-bound here
-   |                      |
-   |                      `Item` bound here first
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:229:32
-   |
-LL |     Self: Iterator<Item: Copy, Item: Send>,
-   |                    ----------  ^^^^^^^^^^ re-bound here
-   |                    |
-   |                    `Item` bound here first
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:237:32
-   |
-LL |     Self: Iterator<Item: Copy, Item: Copy>,
-   |                    ----------  ^^^^^^^^^^ re-bound here
-   |                    |
-   |                    `Item` bound here first
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/duplicate.rs:245:35
-   |
-LL |     Self: Iterator<Item: 'static, Item: 'static>,
-   |                    -------------  ^^^^^^^^^^^^^ re-bound here
-   |                    |
-   |                    `Item` bound here first
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 72 previous errors
 

--- a/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.stderr
+++ b/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.stderr
@@ -62,27 +62,6 @@ LL | fn c<C>(_: <C as Vehicle>::Color) where C : Vehicle, C : Box {
    |            ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
-  --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:30:20
-   |
-LL |     type Color;
-   |     ---------- ambiguous `Color` from `Vehicle`
-...
-LL |     type Color;
-   |     ---------- ambiguous `Color` from `Box`
-...
-LL |     fn d(&self, _: X::Color) where X : Box { }
-   |                    ^^^^^^^^ ambiguous associated type `Color`
-   |
-help: use fully-qualified syntax to disambiguate
-   |
-LL |     fn d(&self, _: <X as Box>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~
-help: use fully-qualified syntax to disambiguate
-   |
-LL |     fn d(&self, _: <X as Vehicle>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~~~~~
-
-error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:35:20
    |
 LL |     type Color;
@@ -122,6 +101,27 @@ LL |     fn f(&self, _: <X as Box>::Color) where X : Box { }
 help: use fully-qualified syntax to disambiguate
    |
 LL |     fn f(&self, _: <X as Vehicle>::Color) where X : Box { }
+   |                    ~~~~~~~~~~~~~~~~
+
+error[E0221]: ambiguous associated type `Color` in bounds of `X`
+  --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:30:20
+   |
+LL |     type Color;
+   |     ---------- ambiguous `Color` from `Vehicle`
+...
+LL |     type Color;
+   |     ---------- ambiguous `Color` from `Box`
+...
+LL |     fn d(&self, _: X::Color) where X : Box { }
+   |                    ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     fn d(&self, _: <X as Box>::Color) where X : Box { }
+   |                    ~~~~~~~~~~~~
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     fn d(&self, _: <X as Vehicle>::Color) where X : Box { }
    |                    ~~~~~~~~~~~~~~~~
 
 error: aborting due to 6 previous errors

--- a/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.stderr
+++ b/tests/ui/associated-types/associated-type-projection-ambig-between-bound-and-where-clause.stderr
@@ -62,6 +62,27 @@ LL | fn c<C>(_: <C as Vehicle>::Color) where C : Vehicle, C : Box {
    |            ~~~~~~~~~~~~~~~~
 
 error[E0221]: ambiguous associated type `Color` in bounds of `X`
+  --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:30:20
+   |
+LL |     type Color;
+   |     ---------- ambiguous `Color` from `Vehicle`
+...
+LL |     type Color;
+   |     ---------- ambiguous `Color` from `Box`
+...
+LL |     fn d(&self, _: X::Color) where X : Box { }
+   |                    ^^^^^^^^ ambiguous associated type `Color`
+   |
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     fn d(&self, _: <X as Box>::Color) where X : Box { }
+   |                    ~~~~~~~~~~~~
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     fn d(&self, _: <X as Vehicle>::Color) where X : Box { }
+   |                    ~~~~~~~~~~~~~~~~
+
+error[E0221]: ambiguous associated type `Color` in bounds of `X`
   --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:35:20
    |
 LL |     type Color;
@@ -101,27 +122,6 @@ LL |     fn f(&self, _: <X as Box>::Color) where X : Box { }
 help: use fully-qualified syntax to disambiguate
    |
 LL |     fn f(&self, _: <X as Vehicle>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~~~~~
-
-error[E0221]: ambiguous associated type `Color` in bounds of `X`
-  --> $DIR/associated-type-projection-ambig-between-bound-and-where-clause.rs:30:20
-   |
-LL |     type Color;
-   |     ---------- ambiguous `Color` from `Vehicle`
-...
-LL |     type Color;
-   |     ---------- ambiguous `Color` from `Box`
-...
-LL |     fn d(&self, _: X::Color) where X : Box { }
-   |                    ^^^^^^^^ ambiguous associated type `Color`
-   |
-help: use fully-qualified syntax to disambiguate
-   |
-LL |     fn d(&self, _: <X as Box>::Color) where X : Box { }
-   |                    ~~~~~~~~~~~~
-help: use fully-qualified syntax to disambiguate
-   |
-LL |     fn d(&self, _: <X as Vehicle>::Color) where X : Box { }
    |                    ~~~~~~~~~~~~~~~~
 
 error: aborting due to 6 previous errors

--- a/tests/ui/associated-types/associated-types-in-ambiguous-context.stderr
+++ b/tests/ui/associated-types/associated-types-in-ambiguous-context.stderr
@@ -10,6 +10,23 @@ LL | fn get<T:Get,U:Get>(x: T, y: U) -> <Example as Get>::Value {}
    |                                    ~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0223]: ambiguous associated type
+  --> $DIR/associated-types-in-ambiguous-context.rs:13:23
+   |
+LL |     fn grab(&self) -> Grab::Value;
+   |                       ^^^^^^^^^^^ help: use fully-qualified syntax: `<Self as Grab>::Value`
+
+error[E0223]: ambiguous associated type
+  --> $DIR/associated-types-in-ambiguous-context.rs:16:22
+   |
+LL |     fn get(&self) -> Get::Value;
+   |                      ^^^^^^^^^^
+   |
+help: if there were a type named `Example` that implemented `Get`, you could use the fully-qualified path
+   |
+LL |     fn get(&self) -> <Example as Get>::Value;
+   |                      ~~~~~~~~~~~~~~~~~~~~~~~
+
+error[E0223]: ambiguous associated type
   --> $DIR/associated-types-in-ambiguous-context.rs:22:17
    |
 LL | trait Foo where Foo::Assoc: Bar {
@@ -32,23 +49,6 @@ LL | type X = <IoSliceMut<'_> as Deref>::Target;
 LL | type X = <OsString as Deref>::Target;
    |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      and N other candidates
-
-error[E0223]: ambiguous associated type
-  --> $DIR/associated-types-in-ambiguous-context.rs:13:23
-   |
-LL |     fn grab(&self) -> Grab::Value;
-   |                       ^^^^^^^^^^^ help: use fully-qualified syntax: `<Self as Grab>::Value`
-
-error[E0223]: ambiguous associated type
-  --> $DIR/associated-types-in-ambiguous-context.rs:16:22
-   |
-LL |     fn get(&self) -> Get::Value;
-   |                      ^^^^^^^^^^
-   |
-help: if there were a type named `Example` that implemented `Get`, you could use the fully-qualified path
-   |
-LL |     fn get(&self) -> <Example as Get>::Value;
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/associated-types/associated-types-project-from-hrtb-in-trait-method.stderr
+++ b/tests/ui/associated-types/associated-types-project-from-hrtb-in-trait-method.stderr
@@ -1,15 +1,4 @@
 error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
-  --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:32:24
-   |
-LL |     fn mango(&self) -> X::Assoc {
-   |                        ^^^^^^^^
-   |
-help: use a fully qualified path with inferred lifetimes
-   |
-LL |     fn mango(&self) -> <X as Banana<'_>>::Assoc {
-   |                        ~~~~~~~~~~~~~~~~~~~
-
-error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
   --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:13:32
    |
 LL |     fn some_method(&self, arg: I::A);
@@ -19,6 +8,17 @@ help: use a fully qualified path with inferred lifetimes
    |
 LL |     fn some_method(&self, arg: <I as Foo<&isize>>::A);
    |                                ~~~~~~~~~~~~~~~~~~~~
+
+error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
+  --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:32:24
+   |
+LL |     fn mango(&self) -> X::Assoc {
+   |                        ^^^^^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     fn mango(&self) -> <X as Banana<'_>>::Assoc {
+   |                        ~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-types/associated-types-project-from-hrtb-in-trait-method.stderr
+++ b/tests/ui/associated-types/associated-types-project-from-hrtb-in-trait-method.stderr
@@ -1,15 +1,4 @@
 error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
-  --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:13:32
-   |
-LL |     fn some_method(&self, arg: I::A);
-   |                                ^^^^
-   |
-help: use a fully qualified path with inferred lifetimes
-   |
-LL |     fn some_method(&self, arg: <I as Foo<&isize>>::A);
-   |                                ~~~~~~~~~~~~~~~~~~~~
-
-error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
   --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:32:24
    |
 LL |     fn mango(&self) -> X::Assoc {
@@ -19,6 +8,17 @@ help: use a fully qualified path with inferred lifetimes
    |
 LL |     fn mango(&self) -> <X as Banana<'_>>::Assoc {
    |                        ~~~~~~~~~~~~~~~~~~~
+
+error[E0212]: cannot use the associated type of a trait with uninferred generic parameters
+  --> $DIR/associated-types-project-from-hrtb-in-trait-method.rs:13:32
+   |
+LL |     fn some_method(&self, arg: I::A);
+   |                                ^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     fn some_method(&self, arg: <I as Foo<&isize>>::A);
+   |                                ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -74,26 +74,6 @@ LL | static TY_STATIC_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
    |                         not allowed in type signatures
    |                         help: replace with the correct type: `Bar<i32, 3>`
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/in-signature.rs:35:21
-   |
-LL |     const ARR: [u8; _];
-   |                     ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/in-signature.rs:39:25
-   |
-LL |     const ARR: Bar<i32, _>;
-   |                         ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/in-signature.rs:43:20
-   |
-LL |     const ARR: Bar<_, _>;
-   |                    ^  ^ not allowed in type signatures
-   |                    |
-   |                    not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
   --> $DIR/in-signature.rs:51:23
    |
@@ -113,6 +93,26 @@ LL |     type Assoc = Bar<_, _>;
    |                      ^  ^ not allowed in type signatures
    |                      |
    |                      not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/in-signature.rs:35:21
+   |
+LL |     const ARR: [u8; _];
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/in-signature.rs:39:25
+   |
+LL |     const ARR: Bar<i32, _>;
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/in-signature.rs:43:20
+   |
+LL |     const ARR: Bar<_, _>;
+   |                    ^  ^ not allowed in type signatures
+   |                    |
+   |                    not allowed in type signatures
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -48,17 +48,11 @@ note: ...which requires computing type of `S::S`...
 LL | struct S<const S: (), const S: S = { S }>;
    |                                ^
    = note: ...which again requires computing type of `S`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-103790.rs:1:1
+note: cycle used when checking that `S` is well-formed
+  --> $DIR/issue-103790.rs:4:1
    |
-LL | / #![feature(generic_const_exprs)]
-LL | | #![allow(incomplete_features)]
-LL | |
-LL | | struct S<const S: (), const S: S = { S }>;
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | struct S<const S: (), const S: S = { S }>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: `()` is forbidden as the type of a const generic parameter

--- a/tests/ui/consts/issue-36163.stderr
+++ b/tests/ui/consts/issue-36163.stderr
@@ -20,17 +20,11 @@ note: ...which requires const-evaluating + checking `A`...
 LL | const A: isize = Foo::B as isize;
    |                  ^^^^^^^^^^^^^^^
    = note: ...which again requires simplifying constant for the type system `Foo::B::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-36163.rs:1:1
+note: cycle used when checking that `Foo` is well-formed
+  --> $DIR/issue-36163.rs:3:1
    |
-LL | / const A: isize = Foo::B as isize;
-LL | |
-LL | | enum Foo {
-LL | |     B = A,
-LL | | }
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | enum Foo {
+   | ^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/cycle-trait/cycle-trait-default-type-trait.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-default-type-trait.stderr
@@ -5,15 +5,11 @@ LL | trait Foo<X = Box<dyn Foo>> {
    |                       ^^^
    |
    = note: ...which immediately requires computing type of `Foo::X` again
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `Foo` is well-formed
   --> $DIR/cycle-trait-default-type-trait.rs:4:1
    |
-LL | / trait Foo<X = Box<dyn Foo>> {
-LL | |
-LL | | }
-LL | |
-LL | | fn main() { }
-   | |_____________^
+LL | trait Foo<X = Box<dyn Foo>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
@@ -5,7 +5,7 @@ LL | trait Chromosome: Chromosome {
    |                   ^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super predicates of `Chromosome` again
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `Chromosome` is well-formed
   --> $DIR/cycle-trait-supertrait-direct.rs:3:1
    |
 LL | / trait Chromosome: Chromosome {

--- a/tests/ui/cycle-trait/issue-12511.stderr
+++ b/tests/ui/cycle-trait/issue-12511.stderr
@@ -10,7 +10,7 @@ note: ...which requires computing the super predicates of `T2`...
 LL | trait T2 : T1 {
    |            ^^
    = note: ...which again requires computing the super predicates of `T1`, completing the cycle
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `T1` is well-formed
   --> $DIR/issue-12511.rs:1:1
    |
 LL | / trait T1 : T2 {

--- a/tests/ui/delegation/not-supported.stderr
+++ b/tests/ui/delegation/not-supported.stderr
@@ -8,24 +8,6 @@ LL | #![feature(fn_delegation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: delegation with early bound generics is not supported yet
-  --> $DIR/not-supported.rs:16:29
-   |
-LL |         fn bar(&self, x: T) -> T { x }
-   |         ------------------------ callee defined here
-...
-LL |         reuse GenericTrait::bar;
-   |                             ^^^
-
-error: delegation with early bound generics is not supported yet
-  --> $DIR/not-supported.rs:18:29
-   |
-LL |         fn bar1() {}
-   |         --------- callee defined here
-...
-LL |         reuse GenericTrait::bar1;
-   |                             ^^^^
-
-error: delegation with early bound generics is not supported yet
   --> $DIR/not-supported.rs:29:39
    |
 LL |         fn bar(&self, x: T) -> T { x }
@@ -96,6 +78,24 @@ LL |         fn foo(&self, x: i32) -> i32 { x }
 ...
 LL |         reuse Trait::foo { &self.0 }
    |                      ^^^
+
+error: delegation with early bound generics is not supported yet
+  --> $DIR/not-supported.rs:16:29
+   |
+LL |         fn bar(&self, x: T) -> T { x }
+   |         ------------------------ callee defined here
+...
+LL |         reuse GenericTrait::bar;
+   |                             ^^^
+
+error: delegation with early bound generics is not supported yet
+  --> $DIR/not-supported.rs:18:29
+   |
+LL |         fn bar1() {}
+   |         --------- callee defined here
+...
+LL |         reuse GenericTrait::bar1;
+   |                             ^^^^
 
 error: delegation with early bound generics is not supported yet
   --> $DIR/not-supported.rs:74:21

--- a/tests/ui/delegation/not-supported.stderr
+++ b/tests/ui/delegation/not-supported.stderr
@@ -8,6 +8,24 @@ LL | #![feature(fn_delegation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: delegation with early bound generics is not supported yet
+  --> $DIR/not-supported.rs:16:29
+   |
+LL |         fn bar(&self, x: T) -> T { x }
+   |         ------------------------ callee defined here
+...
+LL |         reuse GenericTrait::bar;
+   |                             ^^^
+
+error: delegation with early bound generics is not supported yet
+  --> $DIR/not-supported.rs:18:29
+   |
+LL |         fn bar1() {}
+   |         --------- callee defined here
+...
+LL |         reuse GenericTrait::bar1;
+   |                             ^^^^
+
+error: delegation with early bound generics is not supported yet
   --> $DIR/not-supported.rs:29:39
    |
 LL |         fn bar(&self, x: T) -> T { x }
@@ -52,14 +70,14 @@ LL |         fn foo(&self, x: i32) -> i32 { x }
 LL |         reuse Trait::foo;
    |                      ^^^
 
-error: delegation with early bound generics is not supported yet
+error[E0049]: method `foo2` has 0 type parameters but its trait declaration has 1 type parameter
   --> $DIR/not-supported.rs:49:22
    |
 LL |         fn foo2<T>(&self, x: T) -> T { x }
-   |         ---------------------------- callee defined here
+   |                 - expected 1 type parameter
 ...
 LL |         reuse Trait::foo2 { &self.0 }
-   |                      ^^^^
+   |                      ^^^^ found 0 type parameters
 
 error: delegation with early bound generics is not supported yet
   --> $DIR/not-supported.rs:52:29
@@ -69,6 +87,15 @@ LL |         fn foo3<'a: 'a>(_: &'a u32) {}
 ...
 LL |         reuse <F as Trait>::foo3;
    |                             ^^^^
+
+error[E0195]: lifetime parameters or bounds on method `foo3` do not match the trait declaration
+  --> $DIR/not-supported.rs:52:29
+   |
+LL |         fn foo3<'a: 'a>(_: &'a u32) {}
+   |                -------- lifetimes in impl do not match this method in trait
+...
+LL |         reuse <F as Trait>::foo3;
+   |                             ^^^^ lifetimes do not match method in trait
 
 error: delegation with early bound generics is not supported yet
   --> $DIR/not-supported.rs:59:22
@@ -80,22 +107,13 @@ LL |         reuse Trait::foo { &self.0 }
    |                      ^^^
 
 error: delegation with early bound generics is not supported yet
-  --> $DIR/not-supported.rs:16:29
+  --> $DIR/not-supported.rs:49:22
    |
-LL |         fn bar(&self, x: T) -> T { x }
-   |         ------------------------ callee defined here
+LL |         fn foo2<T>(&self, x: T) -> T { x }
+   |         ---------------------------- callee defined here
 ...
-LL |         reuse GenericTrait::bar;
-   |                             ^^^
-
-error: delegation with early bound generics is not supported yet
-  --> $DIR/not-supported.rs:18:29
-   |
-LL |         fn bar1() {}
-   |         --------- callee defined here
-...
-LL |         reuse GenericTrait::bar1;
-   |                             ^^^^
+LL |         reuse Trait::foo2 { &self.0 }
+   |                      ^^^^
 
 error: delegation with early bound generics is not supported yet
   --> $DIR/not-supported.rs:74:21
@@ -159,24 +177,6 @@ LL |         pub reuse to_reuse2::foo;
 ...
 LL |     reuse to_reuse1::foo;
    |                      ^^^
-
-error[E0049]: method `foo2` has 0 type parameters but its trait declaration has 1 type parameter
-  --> $DIR/not-supported.rs:49:22
-   |
-LL |         fn foo2<T>(&self, x: T) -> T { x }
-   |                 - expected 1 type parameter
-...
-LL |         reuse Trait::foo2 { &self.0 }
-   |                      ^^^^ found 0 type parameters
-
-error[E0195]: lifetime parameters or bounds on method `foo3` do not match the trait declaration
-  --> $DIR/not-supported.rs:52:29
-   |
-LL |         fn foo3<'a: 'a>(_: &'a u32) {}
-   |                -------- lifetimes in impl do not match this method in trait
-...
-LL |         reuse <F as Trait>::foo3;
-   |                             ^^^^ lifetimes do not match method in trait
 
 error: aborting due to 19 previous errors; 1 warning emitted
 

--- a/tests/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.stderr
@@ -272,6 +272,17 @@ help: use type parameters instead
 LL | struct L<F, T>(F) where F: Fn() -> T;
    |           +++                      ~
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/bad-assoc-ty.rs:82:38
+   |
+LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
+   |                                      ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn foo<F, T>(_: F) where F: Fn() -> T {}
+   |             +++                         ~
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/bad-assoc-ty.rs:62:30
    |
@@ -305,28 +316,6 @@ help: use type parameters instead
 LL | union O<F, T> where F: Fn() -> T {
    |          +++                   ~
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
-  --> $DIR/bad-assoc-ty.rs:77:29
-   |
-LL | trait P<F> where F: Fn() -> _ {
-   |                             ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL | trait P<F, T> where F: Fn() -> T {
-   |          +++                   ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/bad-assoc-ty.rs:82:38
-   |
-LL |     fn foo<F>(_: F) where F: Fn() -> _ {}
-   |                                      ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn foo<F, T>(_: F) where F: Fn() -> T {}
-   |             +++                         ~
-
 error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
   --> $DIR/bad-assoc-ty.rs:73:5
    |
@@ -338,6 +327,17 @@ help: wrap the field type in `ManuallyDrop<...>`
    |
 LL |     foo: std::mem::ManuallyDrop<F>,
    |          +++++++++++++++++++++++ +
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for traits
+  --> $DIR/bad-assoc-ty.rs:77:29
+   |
+LL | trait P<F> where F: Fn() -> _ {
+   |                             ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | trait P<F, T> where F: Fn() -> T {
+   |          +++                   ~
 
 error: aborting due to 29 previous errors; 1 warning emitted
 

--- a/tests/ui/error-codes/E0719.stderr
+++ b/tests/ui/error-codes/E0719.stderr
@@ -17,14 +17,6 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
-  --> $DIR/E0719.rs:8:42
-   |
-LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
-   |                               ---------  ^^^^^^^^^^^ re-bound here
-   |                               |
-   |                               `Item` bound here first
-
-error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/E0719.rs:1:33
    |
 LL | trait Foo: Iterator<Item = i32, Item = i32> {}
@@ -33,6 +25,14 @@ LL | trait Foo: Iterator<Item = i32, Item = i32> {}
    |                     `Item` bound here first
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
+  --> $DIR/E0719.rs:8:42
+   |
+LL | fn test() -> Box<dyn Iterator<Item = (), Item = Unit>> {
+   |                               ---------  ^^^^^^^^^^^ re-bound here
+   |                               |
+   |                               `Item` bound here first
 
 error[E0719]: the value of the associated type `Item` in trait `Iterator` is already specified
   --> $DIR/E0719.rs:14:38

--- a/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
+++ b/tests/ui/feature-gates/feature-gate-impl_trait_in_assoc_type.stderr
@@ -18,6 +18,14 @@ LL |     type Bop = impl std::fmt::Debug;
    = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: unconstrained opaque type
+  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16
+   |
+LL |     type Bar = impl std::fmt::Debug;
+   |                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `Bar` must be used in combination with a concrete type within the same impl
+
 error[E0658]: inherent associated types are unstable
   --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:5
    |
@@ -27,14 +35,6 @@ LL |     type Bop = impl std::fmt::Debug;
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: unconstrained opaque type
-  --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:6:16
-   |
-LL |     type Bar = impl std::fmt::Debug;
-   |                ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `Bar` must be used in combination with a concrete type within the same impl
 
 error: unconstrained opaque type
   --> $DIR/feature-gate-impl_trait_in_assoc_type.rs:14:16

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -56,26 +56,6 @@ LL | impl Fn<()> for Foo {
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
-   |
-LL | impl FnOnce() for Foo1 {
-   |      ^^^^^^^^ manual implementations of `FnOnce` are experimental
-   |
-   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-
-error[E0229]: associated type bindings are not allowed here
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
-   |
-LL | impl FnOnce() for Foo1 {
-   |      ^^^^^^^^ associated type not allowed here
-   |
-help: parenthesized trait syntax expands to `FnOnce<(), Output=()>`
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
-   |
-LL | impl FnOnce() for Foo1 {
-   |      ^^^^^^^^
-
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:26:6
    |
@@ -91,24 +71,6 @@ error[E0183]: manual implementations of `FnMut` are experimental
    |
 LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^ manual implementations of `FnMut` are experimental
-   |
-   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-
-error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
-   |
-LL | impl FnOnce<()> for Baz {
-   |      ^^^^^^^^^^
-   |
-   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
-   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
-   |
-LL | impl FnOnce<()> for Baz {
-   |      ^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
@@ -134,6 +96,44 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |
    = note: expected signature `extern "rust-call" fn(&Foo, ()) -> _`
               found signature `extern "rust-call" fn(Foo, ())`
+
+error[E0183]: manual implementations of `FnOnce` are experimental
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
+   |
+LL | impl FnOnce() for Foo1 {
+   |      ^^^^^^^^ manual implementations of `FnOnce` are experimental
+   |
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
+   |
+LL | impl FnOnce() for Foo1 {
+   |      ^^^^^^^^ associated type not allowed here
+   |
+help: parenthesized trait syntax expands to `FnOnce<(), Output=()>`
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6
+   |
+LL | impl FnOnce() for Foo1 {
+   |      ^^^^^^^^
+
+error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
+   |
+LL | impl FnOnce<()> for Baz {
+   |      ^^^^^^^^^^
+   |
+   = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0183]: manual implementations of `FnOnce` are experimental
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:6
+   |
+LL | impl FnOnce<()> for Baz {
+   |      ^^^^^^^^^^ manual implementations of `FnOnce` are experimental
+   |
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0046]: not all trait items implemented, missing: `Output`
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:1

--- a/tests/ui/generic-associated-types/elided-in-expr-position.stderr
+++ b/tests/ui/generic-associated-types/elided-in-expr-position.stderr
@@ -1,20 +1,4 @@
 error[E0107]: missing generics for associated type `Trait::Assoc`
-  --> $DIR/elided-in-expr-position.rs:31:26
-   |
-LL |     fn g(&self) -> Self::Assoc {
-   |                          ^^^^^ expected 1 lifetime argument
-   |
-note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/elided-in-expr-position.rs:4:10
-   |
-LL |     type Assoc<'a> where Self: 'a;
-   |          ^^^^^ --
-help: add missing lifetime argument
-   |
-LL |     fn g(&self) -> Self::Assoc<'_> {
-   |                               ++++
-
-error[E0107]: missing generics for associated type `Trait::Assoc`
   --> $DIR/elided-in-expr-position.rs:9:26
    |
 LL |     fn g(&self) -> Self::Assoc;
@@ -28,6 +12,22 @@ LL |     type Assoc<'a> where Self: 'a;
 help: add missing lifetime argument
    |
 LL |     fn g(&self) -> Self::Assoc<'_>;
+   |                               ++++
+
+error[E0107]: missing generics for associated type `Trait::Assoc`
+  --> $DIR/elided-in-expr-position.rs:31:26
+   |
+LL |     fn g(&self) -> Self::Assoc {
+   |                          ^^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/elided-in-expr-position.rs:4:10
+   |
+LL |     type Assoc<'a> where Self: 'a;
+   |          ^^^^^ --
+help: add missing lifetime argument
+   |
+LL |     fn g(&self) -> Self::Assoc<'_> {
    |                               ++++
 
 error: aborting due to 2 previous errors

--- a/tests/ui/generic-associated-types/elided-in-expr-position.stderr
+++ b/tests/ui/generic-associated-types/elided-in-expr-position.stderr
@@ -1,20 +1,4 @@
 error[E0107]: missing generics for associated type `Trait::Assoc`
-  --> $DIR/elided-in-expr-position.rs:9:26
-   |
-LL |     fn g(&self) -> Self::Assoc;
-   |                          ^^^^^ expected 1 lifetime argument
-   |
-note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/elided-in-expr-position.rs:4:10
-   |
-LL |     type Assoc<'a> where Self: 'a;
-   |          ^^^^^ --
-help: add missing lifetime argument
-   |
-LL |     fn g(&self) -> Self::Assoc<'_>;
-   |                               ++++
-
-error[E0107]: missing generics for associated type `Trait::Assoc`
   --> $DIR/elided-in-expr-position.rs:31:26
    |
 LL |     fn g(&self) -> Self::Assoc {
@@ -28,6 +12,22 @@ LL |     type Assoc<'a> where Self: 'a;
 help: add missing lifetime argument
    |
 LL |     fn g(&self) -> Self::Assoc<'_> {
+   |                               ++++
+
+error[E0107]: missing generics for associated type `Trait::Assoc`
+  --> $DIR/elided-in-expr-position.rs:9:26
+   |
+LL |     fn g(&self) -> Self::Assoc;
+   |                          ^^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/elided-in-expr-position.rs:4:10
+   |
+LL |     type Assoc<'a> where Self: 'a;
+   |          ^^^^^ --
+help: add missing lifetime argument
+   |
+LL |     fn g(&self) -> Self::Assoc<'_>;
    |                               ++++
 
 error: aborting due to 2 previous errors

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -1,3 +1,23 @@
+error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/gat-trait-path-missing-lifetime.rs:8:10
+   |
+LL |   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
+   |          -- expected 0 type parameters
+...
+LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
+   |          ^^  ^^
+   |          |
+   |          found 1 type parameter
+
+error[E0046]: not all trait items implemented, missing: `Y`
+  --> $DIR/gat-trait-path-missing-lifetime.rs:7:1
+   |
+LL |   type Y<'a>;
+   |   ---------- `Y` from trait
+...
+LL | impl<T> X for T {
+   | ^^^^^^^^^^^^^^^ missing `Y` in implementation
+
 error[E0107]: missing generics for associated type `X::Y`
   --> $DIR/gat-trait-path-missing-lifetime.rs:8:20
    |
@@ -30,26 +50,6 @@ help: add missing lifetime argument
    |
 LL |   fn foo<'a, T1: X<Y<'a> = T1>>(t : T1) -> T1::Y<'a> {
    |                     ++++
-
-error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
-  --> $DIR/gat-trait-path-missing-lifetime.rs:8:10
-   |
-LL |   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }
-   |          -- expected 0 type parameters
-...
-LL |   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
-   |          ^^  ^^
-   |          |
-   |          found 1 type parameter
-
-error[E0046]: not all trait items implemented, missing: `Y`
-  --> $DIR/gat-trait-path-missing-lifetime.rs:7:1
-   |
-LL |   type Y<'a>;
-   |   ---------- `Y` from trait
-...
-LL | impl<T> X for T {
-   | ^^^^^^^^^^^^^^^ missing `Y` in implementation
 
 error: lifetime may not live long enough
   --> $DIR/gat-trait-path-missing-lifetime.rs:8:3

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -54,22 +54,6 @@ LL |   type Y<'a>;
    |        ^
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
-   |
-LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
-   |                           ^ expected 1 lifetime argument
-   |
-note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
-   |
-LL |   type Y<'a>;
-   |        ^ --
-help: add missing lifetime argument
-   |
-LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
-   |                             ++
-
-error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
@@ -153,6 +137,22 @@ LL | trait X {
 LL |   type Y<'a>;
    |        ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait
+
+error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/gat-trait-path-parenthesised-args.rs:18:27
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
+   |                           ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
+   |
+LL |   type Y<'a>;
+   |        ^ --
+help: add missing lifetime argument
+   |
+LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
+   |                             ++
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:18:27

--- a/tests/ui/generic-associated-types/issue-80433.stderr
+++ b/tests/ui/generic-associated-types/issue-80433.stderr
@@ -1,3 +1,14 @@
+error: missing required bound on `Output`
+  --> $DIR/issue-80433.rs:7:5
+   |
+LL |     type Output<'a>;
+   |     ^^^^^^^^^^^^^^^-
+   |                    |
+   |                    help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
 error[E0107]: missing generics for associated type `TestMut::Output`
   --> $DIR/issue-80433.rs:21:47
    |
@@ -13,17 +24,6 @@ help: add missing lifetime argument
    |
 LL | fn test_simpler<'a>(dst: &'a mut impl TestMut<Output<'a> = &'a mut f32>)
    |                                                     ++++
-
-error: missing required bound on `Output`
-  --> $DIR/issue-80433.rs:7:5
-   |
-LL |     type Output<'a>;
-   |     ^^^^^^^^^^^^^^^-
-   |                    |
-   |                    help: add the required where clause: `where Self: 'a`
-   |
-   = note: this bound is currently required to ensure that impls have maximum flexibility
-   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error[E0499]: cannot borrow `*dst` as mutable more than once at a time
   --> $DIR/issue-80433.rs:25:10

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -14,42 +14,6 @@ help: add missing lifetime arguments
 LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
    |                                 ++++++++
 
-error[E0107]: struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/missing_lifetime_args.rs:17:26
-   |
-LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
-   |                          ^^^ --  -- supplied 2 lifetime arguments
-   |                          |
-   |                          expected 3 lifetime arguments
-   |
-note: struct defined here, with 3 lifetime parameters: `'a`, `'b`, `'c`
-  --> $DIR/missing_lifetime_args.rs:5:8
-   |
-LL | struct Foo<'a, 'b, 'c> {
-   |        ^^^ --  --  --
-help: add missing lifetime argument
-   |
-LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b, 'a>) {}
-   |                                    ++++
-
-error[E0107]: struct takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing_lifetime_args.rs:20:16
-   |
-LL | fn f<'a>(_arg: Foo<'a>) {}
-   |                ^^^ -- supplied 1 lifetime argument
-   |                |
-   |                expected 3 lifetime arguments
-   |
-note: struct defined here, with 3 lifetime parameters: `'a`, `'b`, `'c`
-  --> $DIR/missing_lifetime_args.rs:5:8
-   |
-LL | struct Foo<'a, 'b, 'c> {
-   |        ^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL | fn f<'a>(_arg: Foo<'a, 'a, 'a>) {}
-   |                      ++++++++
-
 error[E0107]: missing generics for associated type `X::Y`
   --> $DIR/missing_lifetime_args.rs:11:32
    |
@@ -98,6 +62,42 @@ LL | trait X {
 LL |     type Y<'a, 'b>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait
+
+error[E0107]: struct takes 3 lifetime arguments but 2 lifetime arguments were supplied
+  --> $DIR/missing_lifetime_args.rs:17:26
+   |
+LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
+   |                          ^^^ --  -- supplied 2 lifetime arguments
+   |                          |
+   |                          expected 3 lifetime arguments
+   |
+note: struct defined here, with 3 lifetime parameters: `'a`, `'b`, `'c`
+  --> $DIR/missing_lifetime_args.rs:5:8
+   |
+LL | struct Foo<'a, 'b, 'c> {
+   |        ^^^ --  --  --
+help: add missing lifetime argument
+   |
+LL | fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b, 'a>) {}
+   |                                    ++++
+
+error[E0107]: struct takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing_lifetime_args.rs:20:16
+   |
+LL | fn f<'a>(_arg: Foo<'a>) {}
+   |                ^^^ -- supplied 1 lifetime argument
+   |                |
+   |                expected 3 lifetime arguments
+   |
+note: struct defined here, with 3 lifetime parameters: `'a`, `'b`, `'c`
+  --> $DIR/missing_lifetime_args.rs:5:8
+   |
+LL | struct Foo<'a, 'b, 'c> {
+   |        ^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL | fn f<'a>(_arg: Foo<'a, 'a, 'a>) {}
+   |                      ++++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/generic-associated-types/unknown-lifetime-ice-119827.rs
+++ b/tests/ui/generic-associated-types/unknown-lifetime-ice-119827.rs
@@ -1,16 +1,10 @@
 trait Foo {
+    //~^ ERROR cycle detected
     type Context<'c>
     where
         Self: 'c;
 }
 
 impl Foo for Box<dyn Foo> {}
-//~^ ERROR `Foo` cannot be made into an object
-//~| ERROR `Foo` cannot be made into an object
-//~| ERROR cycle detected
-//~| ERROR cycle detected
-//~| ERROR cycle detected
-//~| ERROR the trait bound `Box<(dyn Foo + 'static)>: Foo` is not satisfied
-//~| ERROR not all trait items implemented
 
 fn main() {}

--- a/tests/ui/generic-associated-types/unknown-lifetime-ice-119827.stderr
+++ b/tests/ui/generic-associated-types/unknown-lifetime-ice-119827.stderr
@@ -1,119 +1,22 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:7:1: 7:26>`
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:1
-   |
-LL | impl Foo for Box<dyn Foo> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: ...which requires finding trait impls of `Foo`...
+error[E0391]: cycle detected when finding trait impls of `Foo`
   --> $DIR/unknown-lifetime-ice-119827.rs:1:1
    |
 LL | trait Foo {
    | ^^^^^^^^^
-   = note: ...which again requires computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:7:1: 7:26>`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/unknown-lifetime-ice-119827.rs:1:1
    |
-LL | / trait Foo {
-LL | |     type Context<'c>
-LL | |     where
-LL | |         Self: 'c;
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
-
-error[E0391]: cycle detected when computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:7:1: 7:26>`
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:1
+note: ...which requires computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:8:1: 8:26>`...
+  --> $DIR/unknown-lifetime-ice-119827.rs:8:1
    |
 LL | impl Foo for Box<dyn Foo> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:7:1: 7:26>` again
-note: cycle used when collecting item types in top-level module
+   = note: ...which again requires finding trait impls of `Foo`, completing the cycle
+note: cycle used when checking that `Foo` is well-formed
   --> $DIR/unknown-lifetime-ice-119827.rs:1:1
    |
-LL | / trait Foo {
-LL | |     type Context<'c>
-LL | |     where
-LL | |         Self: 'c;
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | trait Foo {
+   | ^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:7:1: 7:26>`
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:1
-   |
-LL | impl Foo for Box<dyn Foo> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ...which immediately requires computing type of `<impl at $DIR/unknown-lifetime-ice-119827.rs:7:1: 7:26>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/unknown-lifetime-ice-119827.rs:1:1
-   |
-LL | / trait Foo {
-LL | |     type Context<'c>
-LL | |     where
-LL | |         Self: 'c;
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+error: aborting due to 1 previous error
 
-error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:22
-   |
-LL | impl Foo for Box<dyn Foo> {}
-   |                      ^^^ `Foo` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/unknown-lifetime-ice-119827.rs:2:10
-   |
-LL | trait Foo {
-   |       --- this trait cannot be made into an object...
-LL |     type Context<'c>
-   |          ^^^^^^^ ...because it contains the generic associated type `Context`
-   = help: consider moving `Context` to another trait
-   = help: only type `{type error}` implements the trait, consider using it directly instead
-
-error[E0277]: the trait bound `Box<(dyn Foo + 'static)>: Foo` is not satisfied
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:14
-   |
-LL | impl Foo for Box<dyn Foo> {}
-   |              ^^^^^^^^^^^^ the trait `Foo` is not implemented for `Box<(dyn Foo + 'static)>`
-   |
-   = help: the trait `Foo` is implemented for `Box<(dyn Foo + 'static)>`
-
-error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:14
-   |
-LL | impl Foo for Box<dyn Foo> {}
-   |              ^^^^^^^^^^^^ `Foo` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/unknown-lifetime-ice-119827.rs:2:10
-   |
-LL | trait Foo {
-   |       --- this trait cannot be made into an object...
-LL |     type Context<'c>
-   |          ^^^^^^^ ...because it contains the generic associated type `Context`
-   = help: consider moving `Context` to another trait
-   = help: only type `std::boxed::Box<(dyn Foo + 'static)>` implements the trait, consider using it directly instead
-
-error[E0046]: not all trait items implemented, missing: `Context`
-  --> $DIR/unknown-lifetime-ice-119827.rs:7:1
-   |
-LL |     type Context<'c>
-   |     ---------------- `Context` from trait
-...
-LL | impl Foo for Box<dyn Foo> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Context` in implementation
-
-error: aborting due to 7 previous errors
-
-Some errors have detailed explanations: E0038, E0046, E0277, E0391.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -22,6 +22,15 @@ note: lifetime declared here
 LL | fn a() -> impl Fn(&u8) -> (impl Debug + '_) {
    |                   ^
 
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:6:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
   --> $DIR/impl-fn-hrtb-bounds.rs:10:52
    |
@@ -34,6 +43,15 @@ note: lifetime declared here
 LL | fn b() -> impl for<'a> Fn(&'a u8) -> (impl Debug + 'a) {
    |                    ^^
 
+error: lifetime may not live long enough
+  --> $DIR/impl-fn-hrtb-bounds.rs:12:9
+   |
+LL |     |x| x
+   |      -- ^ returning this value requires that `'1` must outlive `'2`
+   |      ||
+   |      |return type of closure is impl Debug + '2
+   |      has type `&'1 u8`
+
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
   --> $DIR/impl-fn-hrtb-bounds.rs:16:52
    |
@@ -45,24 +63,6 @@ note: lifetime declared here
    |
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                    ^^
-
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-hrtb-bounds.rs:6:9
-   |
-LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is impl Debug + '2
-   |      has type `&'1 u8`
-
-error: lifetime may not live long enough
-  --> $DIR/impl-fn-hrtb-bounds.rs:12:9
-   |
-LL |     |x| x
-   |      -- ^ returning this value requires that `'1` must outlive `'2`
-   |      ||
-   |      |return type of closure is impl Debug + '2
-   |      has type `&'1 u8`
 
 error: lifetime may not live long enough
   --> $DIR/impl-fn-hrtb-bounds.rs:18:9

--- a/tests/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-88236-2.stderr
@@ -22,18 +22,6 @@ note: lifetime declared here
 LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                               ^^
 
-error: higher kinded lifetime bounds on nested opaque types are not supported yet
-  --> $DIR/issue-88236-2.rs:25:78
-   |
-LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
-   |                                                                              ^^
-   |
-note: lifetime declared here
-  --> $DIR/issue-88236-2.rs:25:45
-   |
-LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
-   |                                             ^^
-
 error: implementation of `Hrtb` is not general enough
   --> $DIR/issue-88236-2.rs:20:5
    |
@@ -51,6 +39,18 @@ LL |     &()
    |
    = note: `Hrtb<'a>` would have to be implemented for the type `&()`
    = note: ...but `Hrtb<'0>` is actually implemented for the type `&'0 ()`, for some specific lifetime `'0`
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-88236-2.rs:25:78
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                                                                              ^^
+   |
+note: lifetime declared here
+  --> $DIR/issue-88236-2.rs:25:45
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                                             ^^
 
 error: lifetime may not live long enough
   --> $DIR/issue-88236-2.rs:27:5

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -65,6 +65,15 @@ note: lifetime declared here
 LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
    |                                         ^^
 
+error: implementation of `Bar` is not general enough
+  --> $DIR/nested-rpit-hrtb.rs:32:78
+   |
+LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
+   |                                                                              ^^ implementation of `Bar` is not general enough
+   |
+   = note: `()` must implement `Bar<'a>`
+   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
+
 error: higher kinded lifetime bounds on nested opaque types are not supported yet
   --> $DIR/nested-rpit-hrtb.rs:36:73
    |
@@ -76,15 +85,6 @@ note: lifetime declared here
    |
 LL | fn one_hrtb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl Qux<'a>> {}
    |                                            ^^
-
-error: implementation of `Bar` is not general enough
-  --> $DIR/nested-rpit-hrtb.rs:32:78
-   |
-LL | fn one_hrtb_outlives_uses() -> impl for<'a> Bar<'a, Assoc = impl Sized + 'a> {}
-   |                                                                              ^^ implementation of `Bar` is not general enough
-   |
-   = note: `()` must implement `Bar<'a>`
-   = note: ...but it actually implements `Bar<'0>`, for some specific lifetime `'0`
 
 error[E0277]: the trait bound `for<'a> &'a (): Qux<'_>` is not satisfied
   --> $DIR/nested-rpit-hrtb.rs:36:64

--- a/tests/ui/impl-trait/where-allowed.stderr
+++ b/tests/ui/impl-trait/where-allowed.stderr
@@ -342,25 +342,6 @@ LL |     let _in_return_in_local_variable = || -> impl Fn() { || {} };
    |
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
-error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:239:7
-   |
-LL | impl <T = impl Debug> T {}
-   |       ^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-   = note: `#[deny(invalid_type_param_default)]` on by default
-
-error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/where-allowed.rs:246:36
-   |
-LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
-   |                                    ^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
-
 error[E0283]: type annotations needed
   --> $DIR/where-allowed.rs:46:57
    |
@@ -380,6 +361,16 @@ LL | fn in_impl_Fn_return_in_return() -> &'static impl Fn() -> impl Debug { pani
              where A: Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
+
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/where-allowed.rs:239:7
+   |
+LL | impl <T = impl Debug> T {}
+   |       ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
+   = note: `#[deny(invalid_type_param_default)]` on by default
 
 error[E0118]: no nominal type found for inherent implementation
   --> $DIR/where-allowed.rs:239:1
@@ -427,6 +418,15 @@ LL |     type Out = impl Debug;
    |                ^^^^^^^^^^
    |
    = note: `Out` must be used in combination with a concrete type within the same impl
+
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/where-allowed.rs:246:36
+   |
+LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
+   |                                    ^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
 error: aborting due to 50 previous errors
 

--- a/tests/ui/infinite/infinite-trait-alias-recursion.stderr
+++ b/tests/ui/infinite/infinite-trait-alias-recursion.stderr
@@ -16,7 +16,7 @@ LL | trait T3 = T1 + T3;
    |            ^^
    = note: ...which again requires computing the super predicates of `T1`, completing the cycle
    = note: trait aliases cannot be recursive
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `T1` is well-formed
   --> $DIR/infinite-trait-alias-recursion.rs:3:1
    |
 LL | trait T1 = T2;

--- a/tests/ui/infinite/infinite-type-alias-mutual-recursion.gated.stderr
+++ b/tests/ui/infinite/infinite-type-alias-mutual-recursion.gated.stderr
@@ -18,17 +18,11 @@ LL | type X3 = X1;
    = note: type aliases cannot be recursive
    = help: consider using a struct, enum, or union instead to break the cycle
    = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
-note: cycle used when collecting item types in top-level module
-  --> $DIR/infinite-type-alias-mutual-recursion.rs:3:1
+note: cycle used when checking that `X1` is well-formed
+  --> $DIR/infinite-type-alias-mutual-recursion.rs:6:1
    |
-LL | / #![cfg_attr(feature, feature(lazy_type_alias))]
-LL | | #![allow(incomplete_features)]
-LL | |
-LL | | type X1 = X2;
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | type X1 = X2;
+   | ^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/infinite/infinite-vec-type-recursion.gated.stderr
+++ b/tests/ui/infinite/infinite-vec-type-recursion.gated.stderr
@@ -8,17 +8,11 @@ LL | type X = Vec<X>;
    = note: type aliases cannot be recursive
    = help: consider using a struct, enum, or union instead to break the cycle
    = help: see <https://doc.rust-lang.org/reference/types.html#recursive-types> for more information
-note: cycle used when collecting item types in top-level module
-  --> $DIR/infinite-vec-type-recursion.rs:3:1
+note: cycle used when checking that `X` is well-formed
+  --> $DIR/infinite-vec-type-recursion.rs:6:1
    |
-LL | / #![cfg_attr(feature, feature(lazy_type_alias))]
-LL | | #![allow(incomplete_features)]
-LL | |
-LL | | type X = Vec<X>;
-...  |
-LL | | #[rustfmt::skip]
-LL | | fn main() { let b: X = Vec::new(); }
-   | |____________________________________^
+LL | type X = Vec<X>;
+   | ^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-23302-enum-infinite-recursion/issue-23302-1.stderr
+++ b/tests/ui/issues/issue-23302-enum-infinite-recursion/issue-23302-1.stderr
@@ -10,15 +10,11 @@ note: ...which requires const-evaluating + checking `X::A::{constant#0}`...
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
    = note: ...which again requires simplifying constant for the type system `X::A::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `X` is well-formed
   --> $DIR/issue-23302-1.rs:3:1
    |
-LL | / enum X {
-LL | |     A = X::A as isize,
-LL | | }
-LL | |
-LL | | fn main() { }
-   | |_____________^
+LL | enum X {
+   | ^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-23302-enum-infinite-recursion/issue-23302-2.stderr
+++ b/tests/ui/issues/issue-23302-enum-infinite-recursion/issue-23302-2.stderr
@@ -10,16 +10,11 @@ note: ...which requires const-evaluating + checking `Y::A::{constant#0}`...
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
    = note: ...which again requires simplifying constant for the type system `Y::A::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `Y` is well-formed
   --> $DIR/issue-23302-2.rs:3:1
    |
-LL | / enum Y {
-LL | |     A = Y::B as isize,
-LL | |     B,
-LL | | }
-LL | |
-LL | | fn main() { }
-   | |_____________^
+LL | enum Y {
+   | ^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -10,17 +10,11 @@ note: ...which requires expanding type alias `DefaultFoo`...
 LL | type DefaultFoo = Foo;
    |                   ^^^
    = note: ...which again requires computing type of `Foo::T`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-34373.rs:1:1
+note: cycle used when checking that `Foo` is well-formed
+  --> $DIR/issue-34373.rs:7:1
    |
-LL | / #![allow(warnings)]
-LL | |
-LL | | trait Trait<T> {
-LL | |     fn foo(_: T) {}
-...  |
-LL | | fn main() {
-LL | | }
-   | |_^
+LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0038]: the trait `Trait` cannot be made into an object

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -32,12 +32,6 @@ help: parenthesized trait syntax expands to `Fn<(&isize,), Output=()>`
 LL | impl Fn(&isize) for Error {
    |      ^^^^^^^^^^
 
-error[E0220]: associated type `B` not found for `Self`
-  --> $DIR/issue-95023.rs:8:44
-   |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
-   |                                            ^ help: `Self` has the following associated type: `Output`
-
 error[E0277]: expected a `FnMut(&isize)` closure, found `Error`
   --> $DIR/issue-95023.rs:3:21
    |
@@ -55,6 +49,12 @@ LL | impl Fn(&isize) for Error {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ missing `call` in implementation
    |
    = help: implement the missing item: `fn call(&self, _: (&isize,)) -> <Self as FnOnce<(&isize,)>>::Output { todo!() }`
+
+error[E0220]: associated type `B` not found for `Self`
+  --> $DIR/issue-95023.rs:8:44
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+   |                                            ^ help: `Self` has the following associated type: `Output`
 
 error[E0220]: associated type `B` not found for `Self`
   --> $DIR/issue-95023.rs:8:44

--- a/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-alias.stderr
@@ -25,22 +25,6 @@ help: consider using one of the available lifetimes here
 LL | type C<'a, 'b> = <A<'a> as Trait<'lifetime>>::Bar;
    |                                 +++++++++++
 
-error[E0107]: missing generics for associated type `Trait::Bar`
-  --> $DIR/missing-lifetime-in-alias.rs:27:36
-   |
-LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
-   |                                    ^^^ expected 1 lifetime argument
-   |
-note: associated type defined here, with 1 lifetime parameter: `'b`
-  --> $DIR/missing-lifetime-in-alias.rs:4:10
-   |
-LL |     type Bar<'b>
-   |          ^^^ --
-help: add missing lifetime argument
-   |
-LL | type C<'a, 'b> = <A<'a> as Trait>::Bar<'a>;
-   |                                       ++++
-
 error[E0477]: the type `Impl<'a>` does not fulfill the required lifetime
   --> $DIR/missing-lifetime-in-alias.rs:16:20
    |
@@ -59,6 +43,22 @@ help: copy the `where` clause predicates from the trait
    |
 LL |     type Bar<'b> = &'b () where Self: 'b;
    |                           ++++++++++++++
+
+error[E0107]: missing generics for associated type `Trait::Bar`
+  --> $DIR/missing-lifetime-in-alias.rs:27:36
+   |
+LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
+   |                                    ^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'b`
+  --> $DIR/missing-lifetime-in-alias.rs:4:10
+   |
+LL |     type Bar<'b>
+   |          ^^^ --
+help: add missing lifetime argument
+   |
+LL | type C<'a, 'b> = <A<'a> as Trait>::Bar<'a>;
+   |                                       ++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -1,21 +1,3 @@
-error[E0038]: the trait `Baz` cannot be made into an object
-  --> $DIR/object-safety-supertrait-mentions-Self.rs:16:31
-   |
-LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
-   |                               ^^^^^^^ `Baz` cannot be made into an object
-   |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
-   |
-LL | trait Baz : Bar<Self> {
-   |       ---   ^^^^^^^^^ ...because it uses `Self` as a type parameter
-   |       |
-   |       this trait cannot be made into an object...
-help: consider using an opaque type instead
-   |
-LL | fn make_baz<T:Baz>(t: &T) -> &impl Baz {
-   |                               ~~~~
-
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
    |
@@ -35,6 +17,24 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Bar<T: ?Sized> {
    |            ++++++++
+
+error[E0038]: the trait `Baz` cannot be made into an object
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:16:31
+   |
+LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
+   |                               ^^^^^^^ `Baz` cannot be made into an object
+   |
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
+   |
+LL | trait Baz : Bar<Self> {
+   |       ---   ^^^^^^^^^ ...because it uses `Self` as a type parameter
+   |       |
+   |       this trait cannot be made into an object...
+help: consider using an opaque type instead
+   |
+LL | fn make_baz<T:Baz>(t: &T) -> &impl Baz {
+   |                               ~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/resolve-self-in-impl.stderr
+++ b/tests/ui/resolve/resolve-self-in-impl.stderr
@@ -14,6 +14,20 @@ LL | impl Tr for S<Self> {}
    |
    = note: replace `Self` with a different type
 
+error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>`
+  --> $DIR/resolve-self-in-impl.rs:19:1
+   |
+LL | impl Tr<Self::A> for S {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>` again
+note: cycle used when building specialization graph of trait `Tr`
+  --> $DIR/resolve-self-in-impl.rs:4:1
+   |
+LL | trait Tr<T = u8> {
+   | ^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
 error: `Self` is not valid in the self type of an impl block
   --> $DIR/resolve-self-in-impl.rs:16:6
    |
@@ -37,26 +51,6 @@ LL | impl (Self, Self) {}
    |       ^^^^  ^^^^
    |
    = note: replace `Self` with a different type
-
-error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>`
-  --> $DIR/resolve-self-in-impl.rs:19:1
-   |
-LL | impl Tr<Self::A> for S {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:19:1: 19:23>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
@@ -1,5 +1,5 @@
 error: `#[target_feature(..)]` cannot be applied to safe trait method
-  --> $DIR/trait-impl.rs:22:5
+  --> $DIR/trait-impl.rs:13:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be applied to safe trait method
@@ -8,7 +8,7 @@ LL |     fn foo(&self) {}
    |     ------------- not an `unsafe` function
 
 error: `#[target_feature(..)]` cannot be applied to safe trait method
-  --> $DIR/trait-impl.rs:13:5
+  --> $DIR/trait-impl.rs:22:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be applied to safe trait method

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const_derives/derive-const-use.stderr
@@ -13,6 +13,15 @@ LL | impl const Default for A {
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
 
+error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/derive-const-use.rs:7:6
+   |
+LL | impl const Default for A {
+   |      ^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
 error: const `impl` for trait `Default` which is not marked with `#[const_trait]`
   --> $DIR/derive-const-use.rs:15:16
    |
@@ -22,15 +31,6 @@ LL | #[derive_const(Default, PartialEq)]
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/derive-const-use.rs:7:6
-   |
-LL | impl const Default for A {
-   |      ^^^^^ unconstrained const parameter
-   |
-   = note: expressions using a const parameter must map each value to a distinct output value
-   = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `host` is not constrained by the impl trait, self type, or predicates
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -25,18 +25,18 @@ LL | trait Bar: ~const Foo {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:18:24
-   |
-LL | const fn foo<T: ~const Bar>(x: &T) {
-   |                        ^^^
-
-error: `~const` can only be applied to `#[const_trait]` traits
   --> $DIR/super-traits-fail-3.rs:12:19
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:18:24
+   |
+LL | const fn foo<T: ~const Bar>(x: &T) {
+   |                        ^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/tilde-const-invalid-places.stderr
@@ -262,16 +262,6 @@ LL |     const CONSTANT<T: ~const Trait>: () = ();
    = help: add `#![feature(generic_const_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: inherent associated types are unstable
-  --> $DIR/tilde-const-invalid-places.rs:44:5
-   |
-LL |     type Type<T: ~const Trait> = ();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
-   = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0392]: type parameter `T` is never used
   --> $DIR/tilde-const-invalid-places.rs:11:19
    |
@@ -303,6 +293,16 @@ note: required by a bound in `NonConstTrait::Type`
    |
 LL |     type Type<T: ~const Trait>: ~const Trait;
    |                                 ^^^^^^^^^^^^ required by this bound in `NonConstTrait::Type`
+
+error[E0658]: inherent associated types are unstable
+  --> $DIR/tilde-const-invalid-places.rs:44:5
+   |
+LL |     type Type<T: ~const Trait> = ();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 30 previous errors
 

--- a/tests/ui/span/issue-35987.rs
+++ b/tests/ui/span/issue-35987.rs
@@ -7,6 +7,7 @@ impl<T: Clone, Add> Add for Foo<T> {
     type Output = usize;
 
     fn add(self, rhs: Self) -> Self::Output {
+        //~^ ERROR ambiguous associated type
         unimplemented!();
     }
 }

--- a/tests/ui/span/issue-35987.stderr
+++ b/tests/ui/span/issue-35987.stderr
@@ -9,6 +9,20 @@ LL | impl<T: Clone, Add> Add for Foo<T> {
    |                |
    |                found this type parameter
 
-error: aborting due to 1 previous error
+error[E0223]: ambiguous associated type
+  --> $DIR/issue-35987.rs:9:32
+   |
+LL |     fn add(self, rhs: Self) -> Self::Output {
+   |                                ^^^^^^^^^^^^
+   |
+help: use fully-qualified syntax
+   |
+LL |     fn add(self, rhs: Self) -> <Foo<T> as BitOr>::Output {
+   |                                ~~~~~~~~~~~~~~~~~~~~~~~~~
+LL |     fn add(self, rhs: Self) -> <Foo<T> as IntoFuture>::Output {
+   |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For more information about this error, try `rustc --explain E0404`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0223, E0404.
+For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -150,6 +150,14 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next() }
    |         ++++                              ++
 
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
+   |     -----------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
+
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
   --> $DIR/impl-trait-missing-lifetime-gated.rs:25:35
    |
@@ -175,6 +183,14 @@ help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.next() }
    |         ++++                              ~~
+
+error: lifetime may not live long enough
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
+   |
+LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
+   |     |
+   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
   --> $DIR/impl-trait-missing-lifetime-gated.rs:46:18
@@ -227,22 +243,6 @@ help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
    |         ++++                 +++
-
-error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
-   |
-LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-   |     -----------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
-   |     |
-   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
-
-error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
-   |
-LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-   |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
-   |     |
-   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/suggestions/suggest-blanket-impl-local-trait.stderr
+++ b/tests/ui/suggestions/suggest-blanket-impl-local-trait.stderr
@@ -1,41 +1,4 @@
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/suggest-blanket-impl-local-trait.rs:13:24
-   |
-LL | impl LocalTraitTwo for LocalTraitOne {}
-   |                        ^^^^^^^^^^^^^
-   |
-help: add `dyn` keyword before this trait
-   |
-LL | impl LocalTraitTwo for dyn LocalTraitOne {}
-   |                        +++
-help: alternatively use a blanket implementation to implement `LocalTraitTwo` for all types that also implement `LocalTraitOne`
-   |
-LL | impl<T: LocalTraitOne> LocalTraitTwo for T {}
-   |     ++++++++++++++++++                   ~
-
-error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/suggest-blanket-impl-local-trait.rs:18:23
-   |
-LL | impl fmt::Display for LocalTraitOne {
-   |                       ^^^^^^^^^^^^^
-   |
-help: add `dyn` keyword before this trait
-   |
-LL | impl fmt::Display for dyn LocalTraitOne {
-   |                       +++
-
-error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/suggest-blanket-impl-local-trait.rs:26:23
-   |
-LL | impl fmt::Display for LocalTraitTwo + Send {
-   |                       ^^^^^^^^^^^^^^^^^^^^
-   |
-help: add `dyn` keyword before this trait
-   |
-LL | impl fmt::Display for dyn LocalTraitTwo + Send {
-   |                       +++
-
-error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/suggest-blanket-impl-local-trait.rs:34:24
    |
 LL | impl LocalTraitOne for fmt::Display {}
@@ -66,6 +29,21 @@ LL | impl<T: fmt::Display + Send> LocalTraitOne for T {}
    |     ++++++++++++++++++++++++                   ~
 
 error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/suggest-blanket-impl-local-trait.rs:13:24
+   |
+LL | impl LocalTraitTwo for LocalTraitOne {}
+   |                        ^^^^^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | impl LocalTraitTwo for dyn LocalTraitOne {}
+   |                        +++
+help: alternatively use a blanket implementation to implement `LocalTraitTwo` for all types that also implement `LocalTraitOne`
+   |
+LL | impl<T: LocalTraitOne> LocalTraitTwo for T {}
+   |     ++++++++++++++++++                   ~
+
+error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/suggest-blanket-impl-local-trait.rs:46:29
    |
 LL | impl<E> GenericTrait<E> for LocalTraitOne {}
@@ -79,6 +57,28 @@ help: alternatively use a blanket implementation to implement `GenericTrait<E>` 
    |
 LL | impl<E, T: LocalTraitOne> GenericTrait<E> for T {}
    |       ++++++++++++++++++                      ~
+
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/suggest-blanket-impl-local-trait.rs:18:23
+   |
+LL | impl fmt::Display for LocalTraitOne {
+   |                       ^^^^^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | impl fmt::Display for dyn LocalTraitOne {
+   |                       +++
+
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/suggest-blanket-impl-local-trait.rs:26:23
+   |
+LL | impl fmt::Display for LocalTraitTwo + Send {
+   |                       ^^^^^^^^^^^^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | impl fmt::Display for dyn LocalTraitTwo + Send {
+   |                       +++
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/suggest-blanket-impl-local-trait.rs:53:35

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.rs
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.rs
@@ -15,8 +15,10 @@ impl<'a, T> Struct<T> for Trait<'a, T> {}
 
 impl<'a, T> Enum<T> for Trait<'a, T> {}
 //~^ ERROR expected trait, found enum `Enum`
+//~| ERROR trait objects must include the `dyn` keyword
 
 impl<'a, T> Union<T> for Trait<'a, T> {}
 //~^ ERROR expected trait, found union `Union`
+//~| ERROR trait objects must include the `dyn` keyword
 
 fn main() {}

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.rs
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.rs
@@ -3,9 +3,12 @@
 pub trait Trait<'a, T> {}
 
 pub struct Struct<T>;
+//~^ ERROR `T` is never used
 pub enum Enum<T> {}
+//~^ ERROR `T` is never used
 
 pub union Union<T> {
+    //~^ ERROR `T` is never used
     f1: usize,
 }
 

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
@@ -1,5 +1,5 @@
 error[E0404]: expected trait, found struct `Struct`
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:12:13
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:15:13
    |
 LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |             ^^^^^^^^^ not a trait
@@ -10,7 +10,7 @@ LL | impl<'a, T> Trait<'a, T> for Struct<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~~~
 
 error[E0404]: expected trait, found enum `Enum`
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:16:13
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:19:13
    |
 LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |             ^^^^^^^ not a trait
@@ -21,7 +21,7 @@ LL | impl<'a, T> Trait<'a, T> for Enum<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~
 
 error[E0404]: expected trait, found union `Union`
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:20:13
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:23:13
    |
 LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |             ^^^^^^^^ not a trait
@@ -31,8 +31,35 @@ help: `impl` items mention the trait being implemented first and the type it is 
 LL | impl<'a, T> Trait<'a, T> for Union<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~~
 
+error[E0392]: type parameter `T` is never used
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:5:19
+   |
+LL | pub struct Struct<T>;
+   |                   ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:7:15
+   |
+LL | pub enum Enum<T> {}
+   |               ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:10:17
+   |
+LL | pub union Union<T> {
+   |                 ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:12:27
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:15:27
    |
 LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |                           ^^^^^^^^^^^^
@@ -43,7 +70,7 @@ LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
    |                           +++
 
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:16:25
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:19:25
    |
 LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |                         ^^^^^^^^^^^^
@@ -54,7 +81,7 @@ LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
    |                         +++
 
 error[E0782]: trait objects must include the `dyn` keyword
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:20:26
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:23:26
    |
 LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |                          ^^^^^^^^^^^^
@@ -64,7 +91,7 @@ help: add `dyn` keyword before this trait
 LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}
    |                          +++
 
-error: aborting due to 6 previous errors
+error: aborting due to 9 previous errors
 
-Some errors have detailed explanations: E0404, E0782.
-For more information about an error, try `rustc --explain E0404`.
+Some errors have detailed explanations: E0392, E0404, E0782.
+For more information about an error, try `rustc --explain E0392`.

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
@@ -21,7 +21,7 @@ LL | impl<'a, T> Trait<'a, T> for Enum<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~
 
 error[E0404]: expected trait, found union `Union`
-  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:19:13
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:20:13
    |
 LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |             ^^^^^^^^ not a trait
@@ -42,7 +42,29 @@ help: add `dyn` keyword before this trait
 LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
    |                           +++
 
-error: aborting due to 4 previous errors
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:16:25
+   |
+LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
+   |                         ^^^^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
+   |                         +++
+
+error[E0782]: trait objects must include the `dyn` keyword
+  --> $DIR/suggest-swapping-self-ty-and-trait-edition-2021.rs:20:26
+   |
+LL | impl<'a, T> Union<T> for Trait<'a, T> {}
+   |                          ^^^^^^^^^^^^
+   |
+help: add `dyn` keyword before this trait
+   |
+LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}
+   |                          +++
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0404, E0782.
 For more information about an error, try `rustc --explain E0404`.

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.rs
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.rs
@@ -14,8 +14,12 @@ impl<'a, T> Struct<T> for Trait<'a, T> {}
 
 impl<'a, T> Enum<T> for Trait<'a, T> {}
 //~^ ERROR expected trait, found enum `Enum`
+//~| WARNING trait objects without an explicit `dyn` are deprecated
+//~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
 
 impl<'a, T> Union<T> for Trait<'a, T> {}
 //~^ ERROR expected trait, found union `Union`
+//~| WARNING trait objects without an explicit `dyn` are deprecated
+//~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
 
 fn main() {}

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.rs
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.rs
@@ -1,9 +1,12 @@
 pub trait Trait<'a, T> {}
 
 pub struct Struct<T>;
+//~^ ERROR `T` is never used
 pub enum Enum<T> {}
+//~^ ERROR `T` is never used
 
 pub union Union<T> {
+    //~^ ERROR `T` is never used
     f1: usize,
 }
 

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -1,5 +1,5 @@
 error[E0404]: expected trait, found struct `Struct`
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:10:13
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:13:13
    |
 LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |             ^^^^^^^^^ not a trait
@@ -10,7 +10,7 @@ LL | impl<'a, T> Trait<'a, T> for Struct<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~~~
 
 error[E0404]: expected trait, found enum `Enum`
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:15:13
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:18:13
    |
 LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |             ^^^^^^^ not a trait
@@ -21,7 +21,7 @@ LL | impl<'a, T> Trait<'a, T> for Enum<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~
 
 error[E0404]: expected trait, found union `Union`
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:20:13
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:23:13
    |
 LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |             ^^^^^^^^ not a trait
@@ -31,8 +31,35 @@ help: `impl` items mention the trait being implemented first and the type it is 
 LL | impl<'a, T> Trait<'a, T> for Union<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~~
 
+error[E0392]: type parameter `T` is never used
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:3:19
+   |
+LL | pub struct Struct<T>;
+   |                   ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:5:15
+   |
+LL | pub enum Enum<T> {}
+   |               ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:8:17
+   |
+LL | pub union Union<T> {
+   |                 ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:10:27
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:13:27
    |
 LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    |                           ^^^^^^^^^^^^
@@ -46,7 +73,7 @@ LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
    |                           +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:15:25
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:18:25
    |
 LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |                         ^^^^^^^^^^^^
@@ -59,7 +86,7 @@ LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
    |                         +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:20:26
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:23:26
    |
 LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |                          ^^^^^^^^^^^^
@@ -71,6 +98,7 @@ help: if this is an object-safe trait, use `dyn`
 LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}
    |                          +++
 
-error: aborting due to 3 previous errors; 3 warnings emitted
+error: aborting due to 6 previous errors; 3 warnings emitted
 
-For more information about this error, try `rustc --explain E0404`.
+Some errors have detailed explanations: E0392, E0404.
+For more information about an error, try `rustc --explain E0392`.

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -21,7 +21,7 @@ LL | impl<'a, T> Trait<'a, T> for Enum<T> {}
    |             ~~~~~~~~~~~~     ~~~~~~~
 
 error[E0404]: expected trait, found union `Union`
-  --> $DIR/suggest-swapping-self-ty-and-trait.rs:18:13
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:20:13
    |
 LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |             ^^^^^^^^ not a trait
@@ -45,6 +45,32 @@ help: if this is an object-safe trait, use `dyn`
 LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
    |                           +++
 
-error: aborting due to 3 previous errors; 1 warning emitted
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:15:25
+   |
+LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
+   |                         ^^^^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
+   |                         +++
+
+warning: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/suggest-swapping-self-ty-and-trait.rs:20:26
+   |
+LL | impl<'a, T> Union<T> for Trait<'a, T> {}
+   |                          ^^^^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
+help: if this is an object-safe trait, use `dyn`
+   |
+LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}
+   |                          +++
+
+error: aborting due to 3 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0404`.

--- a/tests/ui/tag-type-args.stderr
+++ b/tests/ui/tag-type-args.stderr
@@ -1,3 +1,12 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/tag-type-args.rs:1:11
+   |
+LL | enum Quux<T> { Bar }
+   |           ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
 error[E0107]: missing generics for enum `Quux`
   --> $DIR/tag-type-args.rs:4:11
    |
@@ -13,15 +22,6 @@ help: add missing generic argument
    |
 LL | fn foo(c: Quux<T>) { assert!((false)); }
    |               +++
-
-error[E0392]: type parameter `T` is never used
-  --> $DIR/tag-type-args.rs:1:11
-   |
-LL | enum Quux<T> { Bar }
-   |           ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -183,6 +183,15 @@ error: cannot use `#[inline(always)]` with `#[target_feature]`
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
+error[E0046]: not all trait items implemented, missing: `foo`
+  --> $DIR/invalid-attribute.rs:88:1
+   |
+LL | impl Quux for u8 {}
+   | ^^^^^^^^^^^^^^^^ missing `foo` in implementation
+...
+LL |     fn foo();
+   |     --------- `foo` from trait
+
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
   --> $DIR/invalid-attribute.rs:103:5
    |
@@ -195,15 +204,6 @@ LL |     fn foo() {}
    = note: see issue #69098 <https://github.com/rust-lang/rust/issues/69098> for more information
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0046]: not all trait items implemented, missing: `foo`
-  --> $DIR/invalid-attribute.rs:88:1
-   |
-LL | impl Quux for u8 {}
-   | ^^^^^^^^^^^^^^^^ missing `foo` in implementation
-...
-LL |     fn foo();
-   |     --------- `foo` from trait
 
 error: aborting due to 23 previous errors
 

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -1,3 +1,9 @@
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
+   |
+LL | impl<T, S> Trait<T> for i32 {
+   |         ^ unconstrained type parameter
+
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:12
    |
@@ -9,6 +15,12 @@ note: trait defined here, with 1 generic parameter: `T`
    |
 LL | pub trait Trait<T> {
    |           ^^^^^ -
+
+error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:9
+   |
+LL | impl<T, S> Trait<T, S> for () {}
+   |         ^ unconstrained type parameter
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:12
@@ -41,6 +53,12 @@ help: replace the generic bound with the associated type
    |
 LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), Assoc = i32> {
    |                                                        +++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:41
+   |
+LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
+   |                                         ^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:27:18
@@ -103,24 +121,6 @@ note: struct defined here, with 1 generic parameter: `T`
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
-
-error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:9:9
-   |
-LL | impl<T, S> Trait<T> for i32 {
-   |         ^ unconstrained type parameter
-
-error[E0207]: the type parameter `S` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:15:9
-   |
-LL | impl<T, S> Trait<T, S> for () {}
-   |         ^ unconstrained type parameter
-
-error[E0282]: type annotations needed
-  --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:20:41
-   |
-LL | fn func<T: Trait<u32, String>>(t: T) -> impl Trait<(), i32> {
-   |                                         ^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -1,3 +1,23 @@
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/issue-28576.rs:5:16
+   |
+LL | pub trait Bar: Foo<Assoc=()> {
+   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by an implicit `Sized` bound in `Foo`
+  --> $DIR/issue-28576.rs:1:15
+   |
+LL | pub trait Foo<RHS=Self> {
+   |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
+help: consider further restricting `Self`
+   |
+LL | pub trait Bar: Foo<Assoc=()> + Sized {
+   |                              +++++++
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | pub trait Foo<RHS: ?Sized=Self> {
+   |                  ++++++++
+
 error[E0038]: the trait `Bar` cannot be made into an object
   --> $DIR/issue-28576.rs:9:12
    |
@@ -18,26 +38,6 @@ help: consider using an opaque type instead
    |
 LL |            impl Bar
    |            ~~~~
-
-error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-28576.rs:5:16
-   |
-LL | pub trait Bar: Foo<Assoc=()> {
-   |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-note: required by an implicit `Sized` bound in `Foo`
-  --> $DIR/issue-28576.rs:1:15
-   |
-LL | pub trait Foo<RHS=Self> {
-   |               ^^^^^^^^ required by the implicit `Sized` requirement on this type parameter in `Foo`
-help: consider further restricting `Self`
-   |
-LL | pub trait Bar: Foo<Assoc=()> + Sized {
-   |                              +++++++
-help: consider relaxing the implicit `Sized` restriction
-   |
-LL | pub trait Foo<RHS: ?Sized=Self> {
-   |                  ++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/issue-28576.rs:5:16

--- a/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.rs
+++ b/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.rs
@@ -1,5 +1,6 @@
 trait A: B + A {}
 //~^ ERROR cycle detected when computing the super predicates of `A` [E0391]
+//~| ERROR cycle detected when computing the implied predicates of `A` [E0391]
 
 trait B {}
 

--- a/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
+++ b/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
@@ -5,13 +5,27 @@ LL | trait A: B + A {}
    |              ^
    |
    = note: ...which immediately requires computing the super predicates of `A` again
-note: cycle used when collecting item types in top-level module
+note: cycle used when checking that `A` is well-formed
   --> $DIR/cyclic-trait-resolution.rs:1:1
    |
 LL | trait A: B + A {}
    | ^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error
+error[E0391]: cycle detected when computing the implied predicates of `A`
+  --> $DIR/cyclic-trait-resolution.rs:1:14
+   |
+LL | trait A: B + A {}
+   |              ^
+   |
+   = note: ...which immediately requires computing the implied predicates of `A` again
+note: cycle used when checking that `<impl at $DIR/cyclic-trait-resolution.rs:7:1: 7:14>` is well-formed
+  --> $DIR/cyclic-trait-resolution.rs:7:1
+   |
+LL | impl A for () {}
+   | ^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/type-alias-enum-variants/self-in-enum-definition.stderr
+++ b/tests/ui/type-alias-enum-variants/self-in-enum-definition.stderr
@@ -46,17 +46,11 @@ LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires computing layout of `Alpha`...
    = note: ...which again requires simplifying constant for the type system `Alpha::V3::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/self-in-enum-definition.rs:1:1
+note: cycle used when checking that `Alpha` is well-formed
+  --> $DIR/self-in-enum-definition.rs:2:1
    |
-LL | / #[repr(u8)]
-LL | | enum Alpha {
-LL | |     V1 = 41,
-LL | |     V2 = Self::V1 as u8 + 1,    // OK; See #50072.
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+LL | enum Alpha {
+   | ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 1 previous error

--- a/tests/ui/typeck/type-placeholder-fn-in-const.stderr
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.stderr
@@ -4,16 +4,16 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
-   |
-LL |     const TEST: fn() -> _ = 42;
-   |                         ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/type-placeholder-fn-in-const.rs:4:25
    |
 LL |     const TEST: fn() -> _;
+   |                         ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/type-placeholder-fn-in-const.rs:10:25
+   |
+LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants

--- a/tests/ui/typeck/type-placeholder-fn-in-const.stderr
+++ b/tests/ui/typeck/type-placeholder-fn-in-const.stderr
@@ -1,25 +1,25 @@
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/type-placeholder-fn-in-const.rs:4:25
+  --> $DIR/type-placeholder-fn-in-const.rs:10:25
    |
-LL |     const TEST: fn() -> _;
+LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/type-placeholder-fn-in-const.rs:4:25
+  --> $DIR/type-placeholder-fn-in-const.rs:10:25
    |
-LL |     const TEST: fn() -> _;
+LL |     const TEST: fn() -> _ = 42;
    |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
+  --> $DIR/type-placeholder-fn-in-const.rs:4:25
    |
-LL |     const TEST: fn() -> _ = 42;
+LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/type-placeholder-fn-in-const.rs:10:25
+  --> $DIR/type-placeholder-fn-in-const.rs:4:25
    |
-LL |     const TEST: fn() -> _ = 42;
+LL |     const TEST: fn() -> _;
    |                         ^ not allowed in type signatures
 
 error: aborting due to 4 previous errors

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -25,6 +25,16 @@ LL | trait Trait: Copy<dyn Send> {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
+   |
+LL | trait Trait: Copy<dyn Send> {}
+   |              ^^^^---------- help: remove these generics
+   |              |
+   |              expected 0 generic arguments
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:9:21
    |
 LL | struct MyStruct1<T: Copy<T>>(T);
@@ -55,16 +65,6 @@ LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^     - help: remove this generic argument
    |               |
    |               expected 0 generic arguments
-
-error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
-   |
-LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^---------- help: remove these generics
-   |              |
-   |              expected 0 generic arguments
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -169,6 +169,28 @@ LL | unsafe fn test12(x: *const usize) -> *const *const _ {
    |                                      |             not allowed in type signatures
    |                                      help: replace with the correct return type: `*const *const usize`
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:59:24
+   |
+LL |     fn clone(&self) -> _ { Test9 }
+   |                        ^ not allowed in type signatures
+   |
+help: try replacing `_` with the type in the corresponding trait method signature
+   |
+LL |     fn clone(&self) -> Test9 { Test9 }
+   |                        ~~~~~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:62:37
+   |
+LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
+   |                                     ^ not allowed in type signatures
+   |
+help: try replacing `_` with the type in the corresponding trait method signature
+   |
+LL |     fn clone_from(&mut self, other: &Test9) { *self = Test9; }
+   |                                     ~~~~~~
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/typeck_type_placeholder_item.rs:67:8
    |
@@ -294,6 +316,28 @@ help: use type parameters instead
 LL |     fn fn_test8<T>(_f: fn() -> T) { }
    |                +++             ~
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:115:28
+   |
+LL |         fn clone(&self) -> _ { FnTest9 }
+   |                            ^ not allowed in type signatures
+   |
+help: try replacing `_` with the type in the corresponding trait method signature
+   |
+LL |         fn clone(&self) -> FnTest9 { FnTest9 }
+   |                            ~~~~~~~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:118:41
+   |
+LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
+   |                                         ^ not allowed in type signatures
+   |
+help: try replacing `_` with the type in the corresponding trait method signature
+   |
+LL |         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
+   |                                         ~~~~~~~~
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
   --> $DIR/typeck_type_placeholder_item.rs:123:12
    |
@@ -345,220 +389,6 @@ LL |     fn fn_test13(x: _) -> (i32, _) { (x, x) }
    |                           |     |
    |                           |     not allowed in type signatures
    |                           help: replace with the correct return type: `(i32, i32)`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:154:21
-   |
-LL | struct BadStruct<_>(_);
-   |                     ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL | struct BadStruct<T>(T);
-   |                  ~  ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
-  --> $DIR/typeck_type_placeholder_item.rs:159:15
-   |
-LL | impl BadTrait<_> for BadStruct<_> {}
-   |               ^                ^ not allowed in type signatures
-   |               |
-   |               not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL | impl<T> BadTrait<T> for BadStruct<T> {}
-   |     +++          ~                ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
-  --> $DIR/typeck_type_placeholder_item.rs:162:34
-   |
-LL | fn impl_trait() -> impl BadTrait<_> {
-   |                                  ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:167:25
-   |
-LL | struct BadStruct1<_, _>(_);
-   |                         ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL | struct BadStruct1<T, _>(T);
-   |                   ~     ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
-  --> $DIR/typeck_type_placeholder_item.rs:172:25
-   |
-LL | struct BadStruct2<_, T>(_, T);
-   |                         ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL | struct BadStruct2<U, T>(U, T);
-   |                   ~     ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
-  --> $DIR/typeck_type_placeholder_item.rs:176:14
-   |
-LL | type X = Box<_>;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
-  --> $DIR/typeck_type_placeholder_item.rs:182:21
-   |
-LL | type Y = impl Trait<_>;
-   |                     ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:217:31
-   |
-LL | fn value() -> Option<&'static _> {
-   |               ----------------^-
-   |               |               |
-   |               |               not allowed in type signatures
-   |               help: replace with the correct return type: `Option<&'static u8>`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:222:10
-   |
-LL | const _: Option<_> = map(value);
-   |          ^^^^^^^^^
-   |          |
-   |          not allowed in type signatures
-   |          help: replace with the correct type: `Option<u8>`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:225:31
-   |
-LL | fn evens_squared(n: usize) -> _ {
-   |                               ^
-   |                               |
-   |                               not allowed in type signatures
-   |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:230:10
-   |
-LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
-   |          ^ not allowed in type signatures
-   |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:230:14
-   |
-LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:41:24
-   |
-LL |     fn test9(&self) -> _ { () }
-   |                        ^
-   |                        |
-   |                        not allowed in type signatures
-   |                        help: replace with the correct return type: `()`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:44:27
-   |
-LL |     fn test10(&self, _x : _) { }
-   |                           ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn test10<T>(&self, _x : T) { }
-   |              +++             ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:59:24
-   |
-LL |     fn clone(&self) -> _ { Test9 }
-   |                        ^ not allowed in type signatures
-   |
-help: try replacing `_` with the type in the corresponding trait method signature
-   |
-LL |     fn clone(&self) -> Test9 { Test9 }
-   |                        ~~~~~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:62:37
-   |
-LL |     fn clone_from(&mut self, other: _) { *self = Test9; }
-   |                                     ^ not allowed in type signatures
-   |
-help: try replacing `_` with the type in the corresponding trait method signature
-   |
-LL |     fn clone_from(&mut self, other: &Test9) { *self = Test9; }
-   |                                     ~~~~~~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:107:31
-   |
-LL |         fn fn_test9(&self) -> _ { () }
-   |                               ^
-   |                               |
-   |                               not allowed in type signatures
-   |                               help: replace with the correct return type: `()`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:110:34
-   |
-LL |         fn fn_test10(&self, _x : _) { }
-   |                                  ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |         fn fn_test10<T>(&self, _x : T) { }
-   |                     +++             ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:115:28
-   |
-LL |         fn clone(&self) -> _ { FnTest9 }
-   |                            ^ not allowed in type signatures
-   |
-help: try replacing `_` with the type in the corresponding trait method signature
-   |
-LL |         fn clone(&self) -> FnTest9 { FnTest9 }
-   |                            ~~~~~~~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:118:41
-   |
-LL |         fn clone_from(&mut self, other: _) { *self = FnTest9; }
-   |                                         ^ not allowed in type signatures
-   |
-help: try replacing `_` with the type in the corresponding trait method signature
-   |
-LL |         fn clone_from(&mut self, other: &FnTest9) { *self = FnTest9; }
-   |                                         ~~~~~~~~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:202:14
-   |
-LL |     type A = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:204:14
-   |
-LL |     type B = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:206:14
-   |
-LL |     const C: _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:209:14
-   |
-LL |     const D: _ = 42;
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:140:31
@@ -630,6 +460,194 @@ help: use type parameters instead
 LL |     fn assoc_fn_test3<T>() -> T;
    |                      +++      ~
 
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:154:21
+   |
+LL | struct BadStruct<_>(_);
+   |                     ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | struct BadStruct<T>(T);
+   |                  ~  ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/typeck_type_placeholder_item.rs:159:15
+   |
+LL | impl BadTrait<_> for BadStruct<_> {}
+   |               ^                ^ not allowed in type signatures
+   |               |
+   |               not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | impl<T> BadTrait<T> for BadStruct<T> {}
+   |     +++          ~                ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:162:34
+   |
+LL | fn impl_trait() -> impl BadTrait<_> {
+   |                                  ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:167:25
+   |
+LL | struct BadStruct1<_, _>(_);
+   |                         ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | struct BadStruct1<T, _>(T);
+   |                   ~     ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for structs
+  --> $DIR/typeck_type_placeholder_item.rs:172:25
+   |
+LL | struct BadStruct2<_, T>(_, T);
+   |                         ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | struct BadStruct2<U, T>(U, T);
+   |                   ~     ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for type aliases
+  --> $DIR/typeck_type_placeholder_item.rs:176:14
+   |
+LL | type X = Box<_>;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for opaque types
+  --> $DIR/typeck_type_placeholder_item.rs:182:21
+   |
+LL | type Y = impl Trait<_>;
+   |                     ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:44:27
+   |
+LL |     fn test10(&self, _x : _) { }
+   |                           ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn test10<T>(&self, _x : T) { }
+   |              +++             ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:110:34
+   |
+LL |         fn fn_test10(&self, _x : _) { }
+   |                                  ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |         fn fn_test10<T>(&self, _x : T) { }
+   |                     +++             ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:217:31
+   |
+LL | fn value() -> Option<&'static _> {
+   |               ----------------^-
+   |               |               |
+   |               |               not allowed in type signatures
+   |               help: replace with the correct return type: `Option<&'static u8>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:222:10
+   |
+LL | const _: Option<_> = map(value);
+   |          ^^^^^^^^^
+   |          |
+   |          not allowed in type signatures
+   |          help: replace with the correct type: `Option<u8>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:206:14
+   |
+LL |     const C: _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:209:14
+   |
+LL |     const D: _ = 42;
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace with the correct type: `i32`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:194:14
+   |
+LL |     const D: _ = 42;
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace with the correct type: `i32`
+
+error[E0046]: not all trait items implemented, missing: `F`
+  --> $DIR/typeck_type_placeholder_item.rs:200:1
+   |
+LL |     type F: std::ops::Fn(_);
+   |     ----------------------- `F` from trait
+...
+LL | impl Qux for Struct {
+   | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:225:31
+   |
+LL | fn evens_squared(n: usize) -> _ {
+   |                               ^
+   |                               |
+   |                               not allowed in type signatures
+   |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/typeck_type_placeholder_item.rs:230:10
+   |
+LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+   |          ^ not allowed in type signatures
+   |
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:230:14
+   |
+LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:41:24
+   |
+LL |     fn test9(&self) -> _ { () }
+   |                        ^
+   |                        |
+   |                        not allowed in type signatures
+   |                        help: replace with the correct return type: `()`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/typeck_type_placeholder_item.rs:107:31
+   |
+LL |         fn fn_test9(&self) -> _ { () }
+   |                               ^
+   |                               |
+   |                               not allowed in type signatures
+   |                               help: replace with the correct return type: `()`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:202:14
+   |
+LL |     type A = _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:204:14
+   |
+LL |     type B = _;
+   |              ^ not allowed in type signatures
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
   --> $DIR/typeck_type_placeholder_item.rs:190:14
    |
@@ -642,29 +660,11 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     const C: _;
    |              ^ not allowed in type signatures
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:194:14
-   |
-LL |     const D: _ = 42;
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct type: `i32`
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
   --> $DIR/typeck_type_placeholder_item.rs:197:26
    |
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
-
-error[E0046]: not all trait items implemented, missing: `F`
-  --> $DIR/typeck_type_placeholder_item.rs:200:1
-   |
-LL |     type F: std::ops::Fn(_);
-   |     ----------------------- `F` from trait
-...
-LL | impl Qux for Struct {
-   | ^^^^^^^^^^^^^^^^^^^ missing `F` in implementation
 
 error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}>` in constants
   --> $DIR/typeck_type_placeholder_item.rs:230:22

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -449,103 +449,6 @@ note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_pl
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:140:31
-   |
-LL |     fn method_test1(&self, x: _);
-   |                               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn method_test1<T>(&self, x: T);
-   |                    +++           ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:142:31
-   |
-LL |     fn method_test2(&self, x: _) -> _;
-   |                               ^     ^ not allowed in type signatures
-   |                               |
-   |                               not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn method_test2<T>(&self, x: T) -> T;
-   |                    +++           ~     ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:144:31
-   |
-LL |     fn method_test3(&self) -> _;
-   |                               ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn method_test3<T>(&self) -> T;
-   |                    +++           ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:146:26
-   |
-LL |     fn assoc_fn_test1(x: _);
-   |                          ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn assoc_fn_test1<T>(x: T);
-   |                      +++    ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:148:26
-   |
-LL |     fn assoc_fn_test2(x: _) -> _;
-   |                          ^     ^ not allowed in type signatures
-   |                          |
-   |                          not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn assoc_fn_test2<T>(x: T) -> T;
-   |                      +++    ~     ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/typeck_type_placeholder_item.rs:150:28
-   |
-LL |     fn assoc_fn_test3() -> _;
-   |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     fn assoc_fn_test3<T>() -> T;
-   |                      +++      ~
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:190:14
-   |
-LL |     type B = _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:192:14
-   |
-LL |     const C: _;
-   |              ^ not allowed in type signatures
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item.rs:194:14
-   |
-LL |     const D: _ = 42;
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct type: `i32`
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
-  --> $DIR/typeck_type_placeholder_item.rs:197:26
-   |
-LL |     type F: std::ops::Fn(_);
-   |                          ^ not allowed in type signatures
-
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:41:24
    |
@@ -656,6 +559,103 @@ LL |     const D: _ = 42;
    |              |
    |              not allowed in type signatures
    |              help: replace with the correct type: `i32`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:140:31
+   |
+LL |     fn method_test1(&self, x: _);
+   |                               ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn method_test1<T>(&self, x: T);
+   |                    +++           ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:142:31
+   |
+LL |     fn method_test2(&self, x: _) -> _;
+   |                               ^     ^ not allowed in type signatures
+   |                               |
+   |                               not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn method_test2<T>(&self, x: T) -> T;
+   |                    +++           ~     ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:144:31
+   |
+LL |     fn method_test3(&self) -> _;
+   |                               ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn method_test3<T>(&self) -> T;
+   |                    +++           ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:146:26
+   |
+LL |     fn assoc_fn_test1(x: _);
+   |                          ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn assoc_fn_test1<T>(x: T);
+   |                      +++    ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:148:26
+   |
+LL |     fn assoc_fn_test2(x: _) -> _;
+   |                          ^     ^ not allowed in type signatures
+   |                          |
+   |                          not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn assoc_fn_test2<T>(x: T) -> T;
+   |                      +++    ~     ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/typeck_type_placeholder_item.rs:150:28
+   |
+LL |     fn assoc_fn_test3() -> _;
+   |                            ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     fn assoc_fn_test3<T>() -> T;
+   |                      +++      ~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:190:14
+   |
+LL |     type B = _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:192:14
+   |
+LL |     const C: _;
+   |              ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
+  --> $DIR/typeck_type_placeholder_item.rs:194:14
+   |
+LL |     const D: _ = 42;
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace with the correct type: `i32`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
+  --> $DIR/typeck_type_placeholder_item.rs:197:26
+   |
+LL |     type F: std::ops::Fn(_);
+   |                          ^ not allowed in type signatures
 
 error[E0046]: not all trait items implemented, missing: `F`
   --> $DIR/typeck_type_placeholder_item.rs:200:1

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -38,18 +38,18 @@ LL | const TEST4: fn() -> _ = 42;
    |                      ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:18:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:25:18
    |
-LL |     const TEST5: _ = 42;
+LL |     const TEST6: _ = 13;
    |                  ^
    |                  |
    |                  not allowed in type signatures
    |                  help: replace with the correct type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
-  --> $DIR/typeck_type_placeholder_item_help.rs:25:18
+  --> $DIR/typeck_type_placeholder_item_help.rs:18:18
    |
-LL |     const TEST6: _ = 13;
+LL |     const TEST5: _ = 42;
    |                  ^
    |                  |
    |                  not allowed in type signatures


### PR DESCRIPTION
follow-up to https://github.com/rust-lang/rust/pull/121154

this removes more potential parallel-compiler bottlenecks and moves diagnostics for the same items next to each other, instead of grouping diagnostics by analysis kind