### PR TITLE
remove platform-intrinsics ABI; make SIMD intrinsics be regular intrinsics

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/float-minmax-pass.rs
+++ b/compiler/rustc_codegen_cranelift/example/float-minmax-pass.rs
@@ -4,17 +4,14 @@
 
 // Test that the simd_f{min,max} intrinsics produce the correct results.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "intrinsic" {
-    fn simd_fmin<T>(x: T, y: T) -> T;
-    fn simd_fmax<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::*;
 
 fn main() {
     let x = f32x4(1.0, 2.0, 3.0, 4.0);

--- a/compiler/rustc_codegen_cranelift/example/float-minmax-pass.rs
+++ b/compiler/rustc_codegen_cranelift/example/float-minmax-pass.rs
@@ -4,14 +4,14 @@
 
 // Test that the simd_f{min,max} intrinsics produce the correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "intrinsic" {
     fn simd_fmin<T>(x: T, y: T) -> T;
     fn simd_fmax<T>(x: T, y: T) -> T;
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0511.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0511.md
@@ -3,9 +3,9 @@ Invalid monomorphization of an intrinsic function was used.
 Erroneous code example:
 
 ```compile_fail,E0511
-#![feature(platform_intrinsics)]
+#![feature(intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(a: T, b: T) -> T;
 }
 
@@ -19,13 +19,13 @@ The generic type has to be a SIMD type. Example:
 
 ```
 #![feature(repr_simd)]
-#![feature(platform_intrinsics)]
+#![feature(intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct i32x2(i32, i32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(a: T, b: T) -> T;
 }
 

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -156,6 +156,9 @@ declare_features! (
      Some("removed in favor of `#![feature(marker_trait_attr)]`")),
     (removed, panic_implementation, "1.28.0", Some(44489),
      Some("subsumed by `#[panic_handler]`")),
+    /// Allows `extern "platform-intrinsic" { ... }`.
+    (removed, platform_intrinsics, "1.4.0", Some(27731),
+     Some("SIMD intrinsics use the regular intrinsics ABI now")),
     /// Allows using `#![plugin(myplugin)]`.
     (removed, plugin, "1.75.0", Some(29597),
      Some("plugins are no longer supported")),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -259,8 +259,6 @@ declare_features! (
     (internal, needs_panic_runtime, "1.10.0", Some(32837)),
     /// Allows using the `#![panic_runtime]` attribute.
     (internal, panic_runtime, "1.10.0", Some(32837)),
-    /// Allows `extern "platform-intrinsic" { ... }`.
-    (internal, platform_intrinsics, "1.4.0", Some(27731)),
     /// Allows using `#[rustc_allow_const_fn_unstable]`.
     /// This is an attribute on `const fn` for the same
     /// purpose as `#[allow_internal_unstable]`.

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -612,17 +612,6 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     }
                 }
 
-                Abi::PlatformIntrinsic => {
-                    for item in items {
-                        intrinsic::check_platform_intrinsic_type(
-                            tcx,
-                            item.id.owner_id.def_id,
-                            item.span,
-                            item.ident.name,
-                        );
-                    }
-                }
-
                 _ => {
                     for item in items {
                         let def_id = item.id.owner_id.def_id;

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -510,6 +510,77 @@ pub fn check_intrinsic_type(
 
             sym::debug_assertions => (0, 1, Vec::new(), tcx.types.bool),
 
+            sym::simd_eq
+            | sym::simd_ne
+            | sym::simd_lt
+            | sym::simd_le
+            | sym::simd_gt
+            | sym::simd_ge => (2, 0, vec![param(0), param(0)], param(1)),
+            sym::simd_add
+            | sym::simd_sub
+            | sym::simd_mul
+            | sym::simd_rem
+            | sym::simd_div
+            | sym::simd_shl
+            | sym::simd_shr
+            | sym::simd_and
+            | sym::simd_or
+            | sym::simd_xor
+            | sym::simd_fmin
+            | sym::simd_fmax
+            | sym::simd_fpow
+            | sym::simd_saturating_add
+            | sym::simd_saturating_sub => (1, 0, vec![param(0), param(0)], param(0)),
+            sym::simd_arith_offset => (2, 0, vec![param(0), param(1)], param(0)),
+            sym::simd_neg
+            | sym::simd_bswap
+            | sym::simd_bitreverse
+            | sym::simd_ctlz
+            | sym::simd_cttz
+            | sym::simd_fsqrt
+            | sym::simd_fsin
+            | sym::simd_fcos
+            | sym::simd_fexp
+            | sym::simd_fexp2
+            | sym::simd_flog2
+            | sym::simd_flog10
+            | sym::simd_flog
+            | sym::simd_fabs
+            | sym::simd_ceil
+            | sym::simd_floor
+            | sym::simd_round
+            | sym::simd_trunc => (1, 0, vec![param(0)], param(0)),
+            sym::simd_fpowi => (1, 0, vec![param(0), tcx.types.i32], param(0)),
+            sym::simd_fma => (1, 0, vec![param(0), param(0), param(0)], param(0)),
+            sym::simd_gather => (3, 0, vec![param(0), param(1), param(2)], param(0)),
+            sym::simd_masked_load => (3, 0, vec![param(0), param(1), param(2)], param(2)),
+            sym::simd_masked_store => (3, 0, vec![param(0), param(1), param(2)], Ty::new_unit(tcx)),
+            sym::simd_scatter => (3, 0, vec![param(0), param(1), param(2)], Ty::new_unit(tcx)),
+            sym::simd_insert => (2, 0, vec![param(0), tcx.types.u32, param(1)], param(0)),
+            sym::simd_extract => (2, 0, vec![param(0), tcx.types.u32], param(1)),
+            sym::simd_cast
+            | sym::simd_as
+            | sym::simd_cast_ptr
+            | sym::simd_expose_addr
+            | sym::simd_from_exposed_addr => (2, 0, vec![param(0)], param(1)),
+            sym::simd_bitmask => (2, 0, vec![param(0)], param(1)),
+            sym::simd_select | sym::simd_select_bitmask => {
+                (2, 0, vec![param(0), param(1), param(1)], param(1))
+            }
+            sym::simd_reduce_all | sym::simd_reduce_any => (1, 0, vec![param(0)], tcx.types.bool),
+            sym::simd_reduce_add_ordered | sym::simd_reduce_mul_ordered => {
+                (2, 0, vec![param(0), param(1)], param(1))
+            }
+            sym::simd_reduce_add_unordered
+            | sym::simd_reduce_mul_unordered
+            | sym::simd_reduce_and
+            | sym::simd_reduce_or
+            | sym::simd_reduce_xor
+            | sym::simd_reduce_min
+            | sym::simd_reduce_max => (2, 0, vec![param(0)], param(1)),
+            sym::simd_shuffle => (3, 0, vec![param(0), param(0), param(1)], param(2)),
+            sym::simd_shuffle_generic => (2, 1, vec![param(0), param(0)], param(1)),
+
             other => {
                 tcx.dcx().emit_err(UnrecognizedIntrinsicFunction { span, name: other });
                 return;
@@ -520,103 +591,4 @@ pub fn check_intrinsic_type(
     let sig = tcx.mk_fn_sig(inputs, output, false, unsafety, abi);
     let sig = ty::Binder::bind_with_vars(sig, bound_vars);
     equate_intrinsic_type(tcx, span, intrinsic_id, n_tps, n_lts, n_cts, sig)
-}
-
-/// Type-check `extern "platform-intrinsic" { ... }` functions.
-pub fn check_platform_intrinsic_type(
-    tcx: TyCtxt<'_>,
-    intrinsic_id: LocalDefId,
-    span: Span,
-    name: Symbol,
-) {
-    let generics = tcx.generics_of(intrinsic_id);
-    let param = |n| {
-        if let Some(&ty::GenericParamDef {
-            name, kind: ty::GenericParamDefKind::Type { .. }, ..
-        }) = generics.opt_param_at(n as usize, tcx)
-        {
-            Ty::new_param(tcx, n, name)
-        } else {
-            Ty::new_error_with_message(tcx, span, "expected param")
-        }
-    };
-
-    let (n_tps, n_cts, inputs, output) = match name {
-        sym::simd_eq | sym::simd_ne | sym::simd_lt | sym::simd_le | sym::simd_gt | sym::simd_ge => {
-            (2, 0, vec![param(0), param(0)], param(1))
-        }
-        sym::simd_add
-        | sym::simd_sub
-        | sym::simd_mul
-        | sym::simd_rem
-        | sym::simd_div
-        | sym::simd_shl
-        | sym::simd_shr
-        | sym::simd_and
-        | sym::simd_or
-        | sym::simd_xor
-        | sym::simd_fmin
-        | sym::simd_fmax
-        | sym::simd_fpow
-        | sym::simd_saturating_add
-        | sym::simd_saturating_sub => (1, 0, vec![param(0), param(0)], param(0)),
-        sym::simd_arith_offset => (2, 0, vec![param(0), param(1)], param(0)),
-        sym::simd_neg
-        | sym::simd_bswap
-        | sym::simd_bitreverse
-        | sym::simd_ctlz
-        | sym::simd_cttz
-        | sym::simd_fsqrt
-        | sym::simd_fsin
-        | sym::simd_fcos
-        | sym::simd_fexp
-        | sym::simd_fexp2
-        | sym::simd_flog2
-        | sym::simd_flog10
-        | sym::simd_flog
-        | sym::simd_fabs
-        | sym::simd_ceil
-        | sym::simd_floor
-        | sym::simd_round
-        | sym::simd_trunc => (1, 0, vec![param(0)], param(0)),
-        sym::simd_fpowi => (1, 0, vec![param(0), tcx.types.i32], param(0)),
-        sym::simd_fma => (1, 0, vec![param(0), param(0), param(0)], param(0)),
-        sym::simd_gather => (3, 0, vec![param(0), param(1), param(2)], param(0)),
-        sym::simd_masked_load => (3, 0, vec![param(0), param(1), param(2)], param(2)),
-        sym::simd_masked_store => (3, 0, vec![param(0), param(1), param(2)], Ty::new_unit(tcx)),
-        sym::simd_scatter => (3, 0, vec![param(0), param(1), param(2)], Ty::new_unit(tcx)),
-        sym::simd_insert => (2, 0, vec![param(0), tcx.types.u32, param(1)], param(0)),
-        sym::simd_extract => (2, 0, vec![param(0), tcx.types.u32], param(1)),
-        sym::simd_cast
-        | sym::simd_as
-        | sym::simd_cast_ptr
-        | sym::simd_expose_addr
-        | sym::simd_from_exposed_addr => (2, 0, vec![param(0)], param(1)),
-        sym::simd_bitmask => (2, 0, vec![param(0)], param(1)),
-        sym::simd_select | sym::simd_select_bitmask => {
-            (2, 0, vec![param(0), param(1), param(1)], param(1))
-        }
-        sym::simd_reduce_all | sym::simd_reduce_any => (1, 0, vec![param(0)], tcx.types.bool),
-        sym::simd_reduce_add_ordered | sym::simd_reduce_mul_ordered => {
-            (2, 0, vec![param(0), param(1)], param(1))
-        }
-        sym::simd_reduce_add_unordered
-        | sym::simd_reduce_mul_unordered
-        | sym::simd_reduce_and
-        | sym::simd_reduce_or
-        | sym::simd_reduce_xor
-        | sym::simd_reduce_min
-        | sym::simd_reduce_max => (2, 0, vec![param(0)], param(1)),
-        sym::simd_shuffle => (3, 0, vec![param(0), param(0), param(1)], param(2)),
-        sym::simd_shuffle_generic => (2, 1, vec![param(0), param(0)], param(1)),
-        _ => {
-            let msg = format!("unrecognized platform-specific intrinsic function: `{name}`");
-            tcx.dcx().span_err(span, msg);
-            return;
-        }
-    };
-
-    let sig = tcx.mk_fn_sig(inputs, output, false, hir::Unsafety::Unsafe, Abi::PlatformIntrinsic);
-    let sig = ty::Binder::dummy(sig);
-    equate_intrinsic_type(tcx, span, intrinsic_id, n_tps, 0, n_cts, sig)
 }

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -142,7 +142,7 @@ fn get_owner_return_paths(
 /// as they must always be defined by the compiler.
 // FIXME: Move this to a more appropriate place.
 pub fn forbid_intrinsic_abi(tcx: TyCtxt<'_>, sp: Span, abi: Abi) {
-    if let Abi::RustIntrinsic | Abi::PlatformIntrinsic = abi {
+    if let Abi::RustIntrinsic = abi {
         tcx.dcx().span_err(sp, "intrinsic must be in `extern \"rust-intrinsic\" { ... }` block");
     }
 }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1677,10 +1677,7 @@ fn compute_sig_of_foreign_fn_decl<'tcx>(
 
     // Feature gate SIMD types in FFI, since I am not sure that the
     // ABIs are handled at all correctly. -huonw
-    if abi != abi::Abi::RustIntrinsic
-        && abi != abi::Abi::PlatformIntrinsic
-        && !tcx.features().simd_ffi
-    {
+    if abi != abi::Abi::RustIntrinsic && !tcx.features().simd_ffi {
         let check = |ast_ty: &hir::Ty<'_>, ty: Ty<'_>| {
             if ty.is_simd() {
                 let snip = tcx

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1173,11 +1173,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         if let (Some(a_sig), Some(b_sig)) = (a_sig, b_sig) {
             // Intrinsics are not coercible to function pointers.
-            if a_sig.abi() == Abi::RustIntrinsic
-                || a_sig.abi() == Abi::PlatformIntrinsic
-                || b_sig.abi() == Abi::RustIntrinsic
-                || b_sig.abi() == Abi::PlatformIntrinsic
-            {
+            if a_sig.abi() == Abi::RustIntrinsic || b_sig.abi() == Abi::RustIntrinsic {
                 return Err(TypeError::IntrinsicCast);
             }
             // The signature must match.

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1587,10 +1587,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     }
 
     fn is_internal_abi(&self, abi: SpecAbi) -> bool {
-        matches!(
-            abi,
-            SpecAbi::Rust | SpecAbi::RustCall | SpecAbi::RustIntrinsic | SpecAbi::PlatformIntrinsic
-        )
+        matches!(abi, SpecAbi::Rust | SpecAbi::RustCall | SpecAbi::RustIntrinsic)
     }
 
     /// Find any fn-ptr types with external ABIs in `ty`.

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -99,7 +99,7 @@ impl<'tcx> Collector<'tcx> {
 
         let sess = self.tcx.sess;
 
-        if matches!(abi, Abi::Rust | Abi::RustIntrinsic | Abi::PlatformIntrinsic) {
+        if matches!(abi, Abi::Rust | Abi::RustIntrinsic) {
             return;
         }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1244,7 +1244,6 @@ pub fn fn_can_unwind(tcx: TyCtxt<'_>, fn_def_id: Option<DefId>, abi: SpecAbi) ->
         | RiscvInterruptS
         | CCmseNonSecureCall
         | Wasm
-        | PlatformIntrinsic
         | Unadjusted => false,
         Rust | RustCall | RustCold | RustIntrinsic => {
             tcx.sess.panic_strategy() == PanicStrategy::Unwind

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1643,7 +1643,7 @@ pub fn is_doc_notable_trait(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 
 /// Determines whether an item is an intrinsic by Abi. or by whether it has a `rustc_intrinsic` attribute
 pub fn intrinsic(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<Symbol> {
-    if matches!(tcx.fn_sig(def_id).skip_binder().abi(), Abi::RustIntrinsic | Abi::PlatformIntrinsic)
+    if matches!(tcx.fn_sig(def_id).skip_binder().abi(), Abi::RustIntrinsic)
         || tcx.has_attr(def_id, sym::rustc_intrinsic)
     {
         Some(tcx.item_name(def_id.into()))

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -34,7 +34,6 @@ fn abi_can_unwind(abi: Abi) -> bool {
         | CCmseNonSecureCall
         | Wasm
         | RustIntrinsic
-        | PlatformIntrinsic
         | Unadjusted => false,
         Rust | RustCall | RustCold => true,
     }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1389,7 +1389,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         if target == Target::ForeignMod
             && let hir::Node::Item(item) = self.tcx.hir_node(hir_id)
             && let Item { kind: ItemKind::ForeignMod { abi, .. }, .. } = item
-            && !matches!(abi, Abi::Rust | Abi::RustIntrinsic | Abi::PlatformIntrinsic)
+            && !matches!(abi, Abi::Rust | Abi::RustIntrinsic)
         {
             return;
         }
@@ -2071,7 +2071,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     ) -> bool {
         if let Target::ForeignFn = target
             && let hir::Node::Item(Item {
-                kind: ItemKind::ForeignMod { abi: Abi::RustIntrinsic | Abi::PlatformIntrinsic, .. },
+                kind: ItemKind::ForeignMod { abi: Abi::RustIntrinsic, .. },
                 ..
             }) = self.tcx.parent_hir_node(hir_id)
         {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -173,10 +173,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         // If the current node is a function, has const stability attributes and if it doesn not have an intrinsic ABI,
         // check if the function/method is const or the parent impl block is const
         if let (Some(const_span), Some(fn_sig)) = (const_span, fn_sig) {
-            if fn_sig.header.abi != Abi::RustIntrinsic
-                && fn_sig.header.abi != Abi::PlatformIntrinsic
-                && !fn_sig.header.is_const()
-            {
+            if fn_sig.header.abi != Abi::RustIntrinsic && !fn_sig.header.is_const() {
                 if !self.in_trait_impl
                     || (self.in_trait_impl && !self.tcx.is_const_fn_raw(def_id.to_def_id()))
                 {

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -457,7 +457,6 @@ impl RustcInternal for Abi {
             Abi::System { unwind } => rustc_target::spec::abi::Abi::System { unwind },
             Abi::RustIntrinsic => rustc_target::spec::abi::Abi::RustIntrinsic,
             Abi::RustCall => rustc_target::spec::abi::Abi::RustCall,
-            Abi::PlatformIntrinsic => rustc_target::spec::abi::Abi::PlatformIntrinsic,
             Abi::Unadjusted => rustc_target::spec::abi::Abi::Unadjusted,
             Abi::RustCold => rustc_target::spec::abi::Abi::RustCold,
             Abi::RiscvInterruptM => rustc_target::spec::abi::Abi::RiscvInterruptM,

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -833,7 +833,6 @@ impl<'tcx> Stable<'tcx> for rustc_target::spec::abi::Abi {
             abi::Abi::System { unwind } => Abi::System { unwind },
             abi::Abi::RustIntrinsic => Abi::RustIntrinsic,
             abi::Abi::RustCall => Abi::RustCall,
-            abi::Abi::PlatformIntrinsic => Abi::PlatformIntrinsic,
             abi::Abi::Unadjusted => Abi::Unadjusted,
             abi::Abi::RustCold => Abi::RustCold,
             abi::Abi::RiscvInterruptM => Abi::RiscvInterruptM,

--- a/compiler/rustc_target/src/spec/abi/mod.rs
+++ b/compiler/rustc_target/src/spec/abi/mod.rs
@@ -54,7 +54,6 @@ pub enum Abi {
     },
     RustIntrinsic,
     RustCall,
-    PlatformIntrinsic,
     Unadjusted,
     /// For things unlikely to be called, where reducing register pressure in
     /// `extern "Rust"` callers is worth paying extra cost in the callee.
@@ -129,7 +128,6 @@ const AbiDatas: &[AbiData] = &[
     AbiData { abi: Abi::System { unwind: true }, name: "system-unwind" },
     AbiData { abi: Abi::RustIntrinsic, name: "rust-intrinsic" },
     AbiData { abi: Abi::RustCall, name: "rust-call" },
-    AbiData { abi: Abi::PlatformIntrinsic, name: "platform-intrinsic" },
     AbiData { abi: Abi::Unadjusted, name: "unadjusted" },
     AbiData { abi: Abi::RustCold, name: "rust-cold" },
     AbiData { abi: Abi::RiscvInterruptM, name: "riscv-interrupt-m" },
@@ -198,10 +196,6 @@ pub fn is_stable(name: &str) -> Result<(), AbiDisabled> {
         "rust-intrinsic" => Err(AbiDisabled::Unstable {
             feature: sym::intrinsics,
             explain: "intrinsics are subject to change",
-        }),
-        "platform-intrinsic" => Err(AbiDisabled::Unstable {
-            feature: sym::platform_intrinsics,
-            explain: "platform intrinsics are experimental and possibly buggy",
         }),
         "vectorcall" => Err(AbiDisabled::Unstable {
             feature: sym::abi_vectorcall,
@@ -299,11 +293,10 @@ impl Abi {
             System { unwind: true } => 28,
             RustIntrinsic => 29,
             RustCall => 30,
-            PlatformIntrinsic => 31,
-            Unadjusted => 32,
-            RustCold => 33,
-            RiscvInterruptM => 34,
-            RiscvInterruptS => 35,
+            Unadjusted => 31,
+            RustCold => 32,
+            RiscvInterruptM => 33,
+            RiscvInterruptS => 34,
         };
         debug_assert!(
             AbiDatas

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2448,7 +2448,6 @@ impl Target {
             | System { .. }
             | RustIntrinsic
             | RustCall
-            | PlatformIntrinsic
             | Unadjusted
             | Cdecl { .. }
             | RustCold => true,

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -906,7 +906,6 @@ pub enum Abi {
     System { unwind: bool },
     RustIntrinsic,
     RustCall,
-    PlatformIntrinsic,
     Unadjusted,
     RustCold,
     RiscvInterruptM,

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -2,7 +2,11 @@
 //!
 //! In this module, a "vector" is any `repr(simd)` type.
 
-extern "platform-intrinsic" {
+// Temporary macro while we switch the ABI from "platform-intrinsics" to "intrinsics".
+#[rustfmt::skip]
+macro_rules! declare_intrinsics {
+($abi:tt) => {
+extern $abi {
     /// Insert an element into a vector, returning the updated vector.
     ///
     /// `T` must be a vector with element type `U`.
@@ -10,6 +14,7 @@ extern "platform-intrinsic" {
     /// # Safety
     ///
     /// `idx` must be in-bounds of the vector.
+    #[rustc_nounwind]
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
 
     /// Extract an element from a vector.
@@ -19,21 +24,25 @@ extern "platform-intrinsic" {
     /// # Safety
     ///
     /// `idx` must be in-bounds of the vector.
+    #[rustc_nounwind]
     pub fn simd_extract<T, U>(x: T, idx: u32) -> U;
 
     /// Add two simd vectors elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
+    #[rustc_nounwind]
     pub fn simd_add<T>(x: T, y: T) -> T;
 
     /// Subtract `rhs` from `lhs` elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
+    #[rustc_nounwind]
     pub fn simd_sub<T>(lhs: T, rhs: T) -> T;
 
     /// Multiply two simd vectors elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
+    #[rustc_nounwind]
     pub fn simd_mul<T>(x: T, y: T) -> T;
 
     /// Divide `lhs` by `rhs` elementwise.
@@ -43,6 +52,7 @@ extern "platform-intrinsic" {
     /// # Safety
     /// For integers, `rhs` must not contain any zero elements.
     /// Additionally for signed integers, `<int>::MIN / -1` is undefined behavior.
+    #[rustc_nounwind]
     pub fn simd_div<T>(lhs: T, rhs: T) -> T;
 
     /// Remainder of two vectors elementwise
@@ -52,6 +62,7 @@ extern "platform-intrinsic" {
     /// # Safety
     /// For integers, `rhs` must not contain any zero elements.
     /// Additionally for signed integers, `<int>::MIN / -1` is undefined behavior.
+    #[rustc_nounwind]
     pub fn simd_rem<T>(lhs: T, rhs: T) -> T;
 
     /// Elementwise vector left shift, with UB on overflow.
@@ -63,6 +74,7 @@ extern "platform-intrinsic" {
     /// # Safety
     ///
     /// Each element of `rhs` must be less than `<int>::BITS`.
+    #[rustc_nounwind]
     pub fn simd_shl<T>(lhs: T, rhs: T) -> T;
 
     /// Elementwise vector right shift, with UB on overflow.
@@ -74,21 +86,25 @@ extern "platform-intrinsic" {
     /// # Safety
     ///
     /// Each element of `rhs` must be less than `<int>::BITS`.
+    #[rustc_nounwind]
     pub fn simd_shr<T>(lhs: T, rhs: T) -> T;
 
     /// Elementwise vector "and".
     ///
     /// `T` must be a vector of integer primitive types.
+    #[rustc_nounwind]
     pub fn simd_and<T>(x: T, y: T) -> T;
 
     /// Elementwise vector "or".
     ///
     /// `T` must be a vector of integer primitive types.
+    #[rustc_nounwind]
     pub fn simd_or<T>(x: T, y: T) -> T;
 
     /// Elementwise vector "exclusive or".
     ///
     /// `T` must be a vector of integer primitive types.
+    #[rustc_nounwind]
     pub fn simd_xor<T>(x: T, y: T) -> T;
 
     /// Numerically cast a vector, elementwise.
@@ -109,6 +125,7 @@ extern "platform-intrinsic" {
     /// * Not be `NaN`
     /// * Not be infinite
     /// * Be representable in the return type, after truncating off its fractional part
+    #[rustc_nounwind]
     pub fn simd_cast<T, U>(x: T) -> U;
 
     /// Numerically cast a vector, elementwise.
@@ -122,6 +139,7 @@ extern "platform-intrinsic" {
     /// When casting floats to integers, the result is truncated.
     /// When casting integers to floats, the result is rounded.
     /// Otherwise, truncates or extends the value, maintaining the sign for signed integers.
+    #[rustc_nounwind]
     pub fn simd_as<T, U>(x: T) -> U;
 
     /// Elementwise negation of a vector.
@@ -129,11 +147,13 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
     /// Rust panics for `-<int>::Min` due to overflow, but it is not UB with this intrinsic.
+    #[rustc_nounwind]
     pub fn simd_neg<T>(x: T) -> T;
 
     /// Elementwise absolute value of a vector.
     ///
     /// `T` must be a vector of floating-point primitive types.
+    #[rustc_nounwind]
     pub fn simd_fabs<T>(x: T) -> T;
 
     /// Elementwise minimum of a vector.
@@ -141,6 +161,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of floating-point primitive types.
     ///
     /// Follows IEEE-754 `minNum` semantics.
+    #[rustc_nounwind]
     pub fn simd_fmin<T>(x: T, y: T) -> T;
 
     /// Elementwise maximum of a vector.
@@ -148,6 +169,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of floating-point primitive types.
     ///
     /// Follows IEEE-754 `maxNum` semantics.
+    #[rustc_nounwind]
     pub fn simd_fmax<T>(x: T, y: T) -> T;
 
     /// Tests elementwise equality of two vectors.
@@ -157,6 +179,7 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of integers with the same number of elements and element size as `T`.
     ///
     /// Returns `0` for false and `!0` for true.
+    #[rustc_nounwind]
     pub fn simd_eq<T, U>(x: T, y: T) -> U;
 
     /// Tests elementwise inequality equality of two vectors.
@@ -166,6 +189,7 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of integers with the same number of elements and element size as `T`.
     ///
     /// Returns `0` for false and `!0` for true.
+    #[rustc_nounwind]
     pub fn simd_ne<T, U>(x: T, y: T) -> U;
 
     /// Tests if `x` is less than `y`, elementwise.
@@ -175,6 +199,7 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of integers with the same number of elements and element size as `T`.
     ///
     /// Returns `0` for false and `!0` for true.
+    #[rustc_nounwind]
     pub fn simd_lt<T, U>(x: T, y: T) -> U;
 
     /// Tests if `x` is less than or equal to `y`, elementwise.
@@ -184,6 +209,7 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of integers with the same number of elements and element size as `T`.
     ///
     /// Returns `0` for false and `!0` for true.
+    #[rustc_nounwind]
     pub fn simd_le<T, U>(x: T, y: T) -> U;
 
     /// Tests if `x` is greater than `y`, elementwise.
@@ -193,6 +219,7 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of integers with the same number of elements and element size as `T`.
     ///
     /// Returns `0` for false and `!0` for true.
+    #[rustc_nounwind]
     pub fn simd_gt<T, U>(x: T, y: T) -> U;
 
     /// Tests if `x` is greater than or equal to `y`, elementwise.
@@ -202,6 +229,7 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of integers with the same number of elements and element size as `T`.
     ///
     /// Returns `0` for false and `!0` for true.
+    #[rustc_nounwind]
     pub fn simd_ge<T, U>(x: T, y: T) -> U;
 
     /// Shuffle two vectors by const indices.
@@ -216,6 +244,7 @@ extern "platform-intrinsic" {
     /// Returns a new vector such that element `i` is selected from `xy[idx[i]]`, where `xy`
     /// is the concatenation of `x` and `y`. It is a compile-time error if `idx[i]` is out-of-bounds
     /// of `xy`.
+    #[rustc_nounwind]
     pub fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 
     /// Shuffle two vectors by const indices.
@@ -227,6 +256,7 @@ extern "platform-intrinsic" {
     /// Returns a new vector such that element `i` is selected from `xy[IDX[i]]`, where `xy`
     /// is the concatenation of `x` and `y`. It is a compile-time error if `IDX[i]` is out-of-bounds
     /// of `xy`.
+    #[rustc_nounwind]
     pub fn simd_shuffle_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
 
     /// Read a vector of pointers.
@@ -249,6 +279,7 @@ extern "platform-intrinsic" {
     /// type).
     ///
     /// `mask` must only contain `0` or `!0` values.
+    #[rustc_nounwind]
     pub fn simd_gather<T, U, V>(val: T, ptr: U, mask: V) -> T;
 
     /// Write to a vector of pointers.
@@ -271,6 +302,7 @@ extern "platform-intrinsic" {
     /// type).
     ///
     /// `mask` must only contain `0` or `!0` values.
+    #[rustc_nounwind]
     pub fn simd_scatter<T, U, V>(val: T, ptr: U, mask: V);
 
     /// Read a vector of pointers.
@@ -292,6 +324,7 @@ extern "platform-intrinsic" {
     /// type).
     ///
     /// `mask` must only contain `0` or `!0` values.
+    #[rustc_nounwind]
     pub fn simd_masked_load<V, U, T>(mask: V, ptr: U, val: T) -> T;
 
     /// Write to a vector of pointers.
@@ -312,11 +345,13 @@ extern "platform-intrinsic" {
     /// type).
     ///
     /// `mask` must only contain `0` or `!0` values.
+    #[rustc_nounwind]
     pub fn simd_masked_store<V, U, T>(mask: V, ptr: U, val: T);
 
     /// Add two simd vectors elementwise, with saturation.
     ///
     /// `T` must be a vector of integer primitive types.
+    #[rustc_nounwind]
     pub fn simd_saturating_add<T>(x: T, y: T) -> T;
 
     /// Subtract two simd vectors elementwise, with saturation.
@@ -324,6 +359,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer primitive types.
     ///
     /// Subtract `rhs` from `lhs`.
+    #[rustc_nounwind]
     pub fn simd_saturating_sub<T>(lhs: T, rhs: T) -> T;
 
     /// Add elements within a vector from left to right.
@@ -333,6 +369,7 @@ extern "platform-intrinsic" {
     /// `U` must be the element type of `T`.
     ///
     /// Starting with the value `y`, add the elements of `x` and accumulate.
+    #[rustc_nounwind]
     pub fn simd_reduce_add_ordered<T, U>(x: T, y: U) -> U;
 
     /// Add elements within a vector in arbitrary order. May also be re-associated with
@@ -341,6 +378,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
     /// `U` must be the element type of `T`.
+    #[rustc_nounwind]
     pub fn simd_reduce_add_unordered<T, U>(x: T) -> U;
 
     /// Multiply elements within a vector from left to right.
@@ -350,6 +388,7 @@ extern "platform-intrinsic" {
     /// `U` must be the element type of `T`.
     ///
     /// Starting with the value `y`, multiply the elements of `x` and accumulate.
+    #[rustc_nounwind]
     pub fn simd_reduce_mul_ordered<T, U>(x: T, y: U) -> U;
 
     /// Add elements within a vector in arbitrary order. May also be re-associated with
@@ -358,6 +397,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
     /// `U` must be the element type of `T`.
+    #[rustc_nounwind]
     pub fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
 
     /// Check if all mask values are true.
@@ -366,6 +406,7 @@ extern "platform-intrinsic" {
     ///
     /// # Safety
     /// `x` must contain only `0` or `!0`.
+    #[rustc_nounwind]
     pub fn simd_reduce_all<T>(x: T) -> bool;
 
     /// Check if all mask values are true.
@@ -374,6 +415,7 @@ extern "platform-intrinsic" {
     ///
     /// # Safety
     /// `x` must contain only `0` or `!0`.
+    #[rustc_nounwind]
     pub fn simd_reduce_any<T>(x: T) -> bool;
 
     /// Return the maximum element of a vector.
@@ -383,6 +425,7 @@ extern "platform-intrinsic" {
     /// `U` must be the element type of `T`.
     ///
     /// For floating-point values, uses IEEE-754 `maxNum`.
+    #[rustc_nounwind]
     pub fn simd_reduce_max<T, U>(x: T) -> U;
 
     /// Return the minimum element of a vector.
@@ -392,6 +435,7 @@ extern "platform-intrinsic" {
     /// `U` must be the element type of `T`.
     ///
     /// For floating-point values, uses IEEE-754 `minNum`.
+    #[rustc_nounwind]
     pub fn simd_reduce_min<T, U>(x: T) -> U;
 
     /// Logical "and" all elements together.
@@ -399,6 +443,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
     /// `U` must be the element type of `T`.
+    #[rustc_nounwind]
     pub fn simd_reduce_and<T, U>(x: T) -> U;
 
     /// Logical "or" all elements together.
@@ -406,6 +451,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
     /// `U` must be the element type of `T`.
+    #[rustc_nounwind]
     pub fn simd_reduce_or<T, U>(x: T) -> U;
 
     /// Logical "exclusive or" all elements together.
@@ -413,6 +459,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
     /// `U` must be the element type of `T`.
+    #[rustc_nounwind]
     pub fn simd_reduce_xor<T, U>(x: T) -> U;
 
     /// Truncate an integer vector to a bitmask.
@@ -441,6 +488,7 @@ extern "platform-intrinsic" {
     ///
     /// # Safety
     /// `x` must contain only `0` and `!0`.
+    #[rustc_nounwind]
     pub fn simd_bitmask<T, U>(x: T) -> U;
 
     /// Select elements from a mask.
@@ -455,6 +503,7 @@ extern "platform-intrinsic" {
     ///
     /// # Safety
     /// `mask` must only contain `0` and `!0`.
+    #[rustc_nounwind]
     pub fn simd_select<M, T>(mask: M, if_true: T, if_false: T) -> T;
 
     /// Select elements from a bitmask.
@@ -471,6 +520,7 @@ extern "platform-intrinsic" {
     ///
     /// # Safety
     /// Padding bits must be all zero.
+    #[rustc_nounwind]
     pub fn simd_select_bitmask<M, T>(m: M, yes: T, no: T) -> T;
 
     /// Elementwise calculates the offset from a pointer vector, potentially wrapping.
@@ -480,11 +530,13 @@ extern "platform-intrinsic" {
     /// `U` must be a vector of `isize` or `usize` with the same number of elements as `T`.
     ///
     /// Operates as if by `<ptr>::wrapping_offset`.
+    #[rustc_nounwind]
     pub fn simd_arith_offset<T, U>(ptr: T, offset: U) -> T;
 
     /// Cast a vector of pointers.
     ///
     /// `T` and `U` must be vectors of pointers with the same number of elements.
+    #[rustc_nounwind]
     pub fn simd_cast_ptr<T, U>(ptr: T) -> U;
 
     /// Expose a vector of pointers as a vector of addresses.
@@ -492,6 +544,7 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of pointers.
     ///
     /// `U` must be a vector of `usize` with the same length as `T`.
+    #[rustc_nounwind]
     pub fn simd_expose_addr<T, U>(ptr: T) -> U;
 
     /// Create a vector of pointers from a vector of addresses.
@@ -499,92 +552,117 @@ extern "platform-intrinsic" {
     /// `T` must be a vector of `usize`.
     ///
     /// `U` must be a vector of pointers, with the same length as `T`.
+    #[rustc_nounwind]
     pub fn simd_from_exposed_addr<T, U>(addr: T) -> U;
 
     /// Swap bytes of each element.
     ///
     /// `T` must be a vector of integers.
+    #[rustc_nounwind]
     pub fn simd_bswap<T>(x: T) -> T;
 
     /// Reverse bits of each element.
     ///
     /// `T` must be a vector of integers.
+    #[rustc_nounwind]
     pub fn simd_bitreverse<T>(x: T) -> T;
 
     /// Count the leading zeros of each element.
     ///
     /// `T` must be a vector of integers.
+    #[rustc_nounwind]
     pub fn simd_ctlz<T>(x: T) -> T;
 
     /// Count the trailing zeros of each element.
     ///
     /// `T` must be a vector of integers.
+    #[rustc_nounwind]
     pub fn simd_cttz<T>(x: T) -> T;
 
     /// Round up each element to the next highest integer-valued float.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_ceil<T>(x: T) -> T;
 
     /// Round down each element to the next lowest integer-valued float.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_floor<T>(x: T) -> T;
 
     /// Round each element to the closest integer-valued float.
     /// Ties are resolved by rounding away from 0.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_round<T>(x: T) -> T;
 
     /// Return the integer part of each element as an integer-valued float.
     /// In other words, non-integer values are truncated towards zero.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_trunc<T>(x: T) -> T;
 
     /// Takes the square root of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_fsqrt<T>(x: T) -> T;
 
     /// Computes `(x*y) + z` for each element, but without any intermediate rounding.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_fma<T>(x: T, y: T, z: T) -> T;
 
     // Computes the sine of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_fsin<T>(a: T) -> T;
 
     // Computes the cosine of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_fcos<T>(a: T) -> T;
 
     // Computes the exponential function of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_fexp<T>(a: T) -> T;
 
     // Computes 2 raised to the power of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_fexp2<T>(a: T) -> T;
 
     // Computes the base 10 logarithm of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_flog10<T>(a: T) -> T;
 
     // Computes the base 2 logarithm of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_flog2<T>(a: T) -> T;
 
     // Computes the natural logarithm of each element.
     ///
     /// `T` must be a vector of floats.
+    #[rustc_nounwind]
     pub fn simd_flog<T>(a: T) -> T;
 }
+}
+}
+
+#[cfg(bootstrap)]
+declare_intrinsics!("platform-intrinsic");
+#[cfg(not(bootstrap))]
+declare_intrinsics!("rust-intrinsic");

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -202,6 +202,7 @@
 //
 // Language features:
 // tidy-alphabetical-start
+#![cfg_attr(bootstrap, feature(platform_intrinsics))]
 #![feature(abi_unadjusted)]
 #![feature(adt_const_params)]
 #![feature(allow_internal_unsafe)]
@@ -246,7 +247,6 @@
 #![feature(never_type)]
 #![feature(no_core)]
 #![feature(no_sanitize)]
-#![feature(platform_intrinsics)]
 #![feature(prelude_import)]
 #![feature(repr_simd)]
 #![feature(rustc_allow_const_fn_unstable)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -270,6 +270,7 @@
 //
 // Language features:
 // tidy-alphabetical-start
+#![cfg_attr(bootstrap, feature(platform_intrinsics))]
 #![feature(alloc_error_handler)]
 #![feature(allocator_internals)]
 #![feature(allow_internal_unsafe)]
@@ -301,7 +302,6 @@
 #![feature(negative_impls)]
 #![feature(never_type)]
 #![feature(no_sanitize)]
-#![feature(platform_intrinsics)]
 #![feature(prelude_import)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-div-by-zero.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-div-by-zero.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    pub(crate) fn simd_div<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::simd_div;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-div-overflow.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-div-overflow.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    pub(crate) fn simd_div<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::simd_div;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-reduce-invalid-bool.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-reduce-invalid-bool.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    pub(crate) fn simd_reduce_any<T>(x: T) -> bool;
-}
+use std::intrinsics::simd::simd_reduce_any;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-rem-by-zero.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-rem-by-zero.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    pub(crate) fn simd_rem<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::simd_rem;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-select-bitmask-invalid.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-select-bitmask-invalid.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    fn simd_select_bitmask<M, T>(m: M, yes: T, no: T) -> T;
-}
+use std::intrinsics::simd::simd_select_bitmask;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-select-invalid-bool.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-select-invalid-bool.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    fn simd_select<M, T>(m: M, yes: T, no: T) -> T;
-}
+use std::intrinsics::simd::simd_select;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-shl-too-far.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-shl-too-far.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    pub(crate) fn simd_shl<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::simd_shl;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/fail/intrinsics/simd-shr-too-far.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-shr-too-far.rs
@@ -1,8 +1,6 @@
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
-    pub(crate) fn simd_shr<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::simd_shr;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]

--- a/src/tools/miri/tests/pass/float_nan.rs
+++ b/src/tools/miri/tests/pass/float_nan.rs
@@ -1,4 +1,4 @@
-#![feature(float_gamma, portable_simd, core_intrinsics, platform_intrinsics)]
+#![feature(float_gamma, portable_simd, core_intrinsics)]
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -524,12 +524,6 @@ fn test_casts() {
 fn test_simd() {
     use std::intrinsics::simd::*;
     use std::simd::*;
-
-    extern "platform-intrinsic" {
-        fn simd_fsqrt<T>(x: T) -> T;
-        fn simd_ceil<T>(x: T) -> T;
-        fn simd_fma<T>(x: T, y: T, z: T) -> T;
-    }
 
     let nan = F32::nan(Neg, Quiet, 0).as_f32();
     check_all_outcomes(

--- a/src/tools/miri/tests/pass/portable-simd-ptrs.rs
+++ b/src/tools/miri/tests/pass/portable-simd-ptrs.rs
@@ -1,6 +1,6 @@
 // Separate test without strict provenance
 //@compile-flags: -Zmiri-permissive-provenance
-#![feature(portable_simd, platform_intrinsics)]
+#![feature(portable_simd)]
 use std::ptr;
 use std::simd::prelude::*;
 

--- a/src/tools/miri/tests/pass/portable-simd.rs
+++ b/src/tools/miri/tests/pass/portable-simd.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-strict-provenance
-#![feature(portable_simd, platform_intrinsics, adt_const_params, inline_const, core_intrinsics)]
+#![feature(portable_simd, adt_const_params, inline_const, core_intrinsics)]
 #![allow(incomplete_features, internal_features)]
 use std::intrinsics::simd as intrinsics;
 use std::ptr;
@@ -216,10 +216,7 @@ fn simd_ops_i32() {
 }
 
 fn simd_mask() {
-    extern "platform-intrinsic" {
-        pub(crate) fn simd_bitmask<T, U>(x: T) -> U;
-        pub(crate) fn simd_select_bitmask<M, T>(m: M, yes: T, no: T) -> T;
-    }
+    use std::intrinsics::simd::*;
 
     let intmask = Mask::from_int(i32x4::from_array([0, -1, 0, 0]));
     assert_eq!(intmask, Mask::from_array([false, true, false, false]));
@@ -497,9 +494,6 @@ fn simd_round() {
 
 fn simd_intrinsics() {
     use intrinsics::*;
-    extern "platform-intrinsic" {
-        fn simd_shuffle_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
-    }
 
     unsafe {
         // Make sure simd_eq returns all-1 for `true`

--- a/src/tools/miri/tests/pass/simd-intrinsic-generic-elements.rs
+++ b/src/tools/miri/tests/pass/simd-intrinsic-generic-elements.rs
@@ -1,4 +1,4 @@
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/tests/codegen/issues/issue-84268.rs
+++ b/tests/codegen/issues/issue-84268.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -O --crate-type=rlib
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fabs<T>(x: T) -> T;
     fn simd_eq<T, U>(x: T, y: T) -> U;
 }

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fabs<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_ceil<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fcos<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fexp<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fexp2<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_floor<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fma<T>(x: T, b: T, c: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fsqrt<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_flog<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_flog10<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_flog2<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
@@ -2,14 +2,14 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fmin<T>(x: T, y: T) -> T;
     fn simd_fmax<T>(x: T, y: T) -> T;
 }

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-pow.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-pow.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fpow<T>(x: T, b: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-powi.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-powi.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fpowi<T>(x: T, b: i32) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -25,7 +25,7 @@ pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32,
                   pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fsin<T>(x: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
@@ -3,7 +3,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 #![deny(unused)]
 
@@ -111,7 +111,7 @@
 #[repr(simd)] #[derive(Copy, Clone)] pub struct u128x2(u128, u128);
 #[repr(simd)] #[derive(Copy, Clone)] pub struct u128x4(u128, u128, u128, u128);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_saturating_add<T>(x: T, y: T) -> T;
     fn simd_saturating_sub<T>(x: T, y: T) -> T;
 }

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
@@ -3,7 +3,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -22,7 +22,7 @@ pub struct i8x16(
 );
 
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_bitmask<T, U>(x: T) -> U;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-gather.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-gather.rs
@@ -4,7 +4,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -15,7 +15,7 @@ pub struct Vec2<T>(pub T, pub T);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_gather<T, P, M>(value: T, pointers: P, mask: M) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -13,7 +13,7 @@ pub struct Vec2<T>(pub T, pub T);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -13,7 +13,7 @@ pub struct Vec2<T>(pub T, pub T);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-scatter.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-scatter.rs
@@ -4,7 +4,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -15,7 +15,7 @@ pub struct Vec2<T>(pub T, pub T);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_scatter<T, P, M>(value: T, pointers: P, mask: M);
 }
 

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-select.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-select.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #[allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -17,7 +17,7 @@ pub struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct b8x4(pub i8, pub i8, pub i8, pub i8);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_select<T, U>(x: T, a: U, b: U) -> U;
     fn simd_select_bitmask<T, U>(x: T, a: U, b: U) -> U;
 }

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -3,7 +3,7 @@
 
 #![crate_type = "lib"]
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![feature(inline_const)]
 
 #[repr(simd)]

--- a/tests/codegen/simd/simd_arith_offset.rs
+++ b/tests/codegen/simd/simd_arith_offset.rs
@@ -3,9 +3,9 @@
 //
 
 #![crate_type = "lib"]
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     pub(crate) fn simd_arith_offset<T, U>(ptrs: T, offsets: U) -> T;
 }
 

--- a/tests/incremental/issue-61530.rs
+++ b/tests/incremental/issue-61530.rs
@@ -1,11 +1,11 @@
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 //@ revisions:rpass1 rpass2
 
 #[repr(simd)]
 struct I32x2(i32, i32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 

--- a/tests/ui/consts/const-eval/simd/insert_extract.rs
+++ b/tests/ui/consts/const-eval/simd/insert_extract.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![feature(repr_simd)]
-#![feature(platform_intrinsics)]
+#![feature(intrinsics)]
 #![feature(staged_api)]
 #![stable(feature = "foo", since = "1.3.37")]
 #![allow(non_camel_case_types)]
@@ -11,7 +11,7 @@
 #[repr(simd)] struct i8x1_arr([i8; 1]);
 #[repr(simd)] struct f32x4([f32; 4]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     #[rustc_const_stable(feature = "foo", since = "1.3.37")]
     fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
     #[rustc_const_stable(feature = "foo", since = "1.3.37")]

--- a/tests/ui/error-codes/E0511.rs
+++ b/tests/ui/error-codes/E0511.rs
@@ -1,8 +1,8 @@
 //@ build-fail
 
-#![feature(platform_intrinsics)]
+#![feature(intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(a: T, b: T) -> T;
 }
 

--- a/tests/ui/feature-gates/feature-gate-abi.rs
+++ b/tests/ui/feature-gates/feature-gate-abi.rs
@@ -1,5 +1,4 @@
 // gate-test-intrinsics
-// gate-test-platform_intrinsics
 //@ compile-flags: --crate-type=rlib
 
 #![feature(no_core, lang_items)]
@@ -15,7 +14,7 @@ trait Tuple { }
 extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
                                    //~^ ERROR intrinsic must be in
                                    //~| ERROR unrecognized intrinsic function: `f1`
-extern "platform-intrinsic" fn f2() {} //~ ERROR platform intrinsics are experimental
+extern "rust-intrinsic" fn f2() {} //~ ERROR intrinsics are subject to change
                                        //~^ ERROR intrinsic must be in
                                        //~| ERROR unrecognized intrinsic function: `f2`
 extern "rust-call" fn f4(_: ()) {} //~ ERROR rust-call ABI is subject to change
@@ -24,7 +23,7 @@ extern "rust-call" fn f4(_: ()) {} //~ ERROR rust-call ABI is subject to change
 trait Tr {
     extern "rust-intrinsic" fn m1(); //~ ERROR intrinsics are subject to change
                                      //~^ ERROR intrinsic must be in
-    extern "platform-intrinsic" fn m2(); //~ ERROR platform intrinsics are experimental
+    extern "rust-intrinsic" fn m2(); //~ ERROR intrinsics are subject to change
                                          //~^ ERROR intrinsic must be in
     extern "rust-call" fn m4(_: ()); //~ ERROR rust-call ABI is subject to change
 
@@ -37,7 +36,7 @@ struct S;
 impl Tr for S {
     extern "rust-intrinsic" fn m1() {} //~ ERROR intrinsics are subject to change
                                        //~^ ERROR intrinsic must be in
-    extern "platform-intrinsic" fn m2() {} //~ ERROR platform intrinsics are experimental
+    extern "rust-intrinsic" fn m2() {} //~ ERROR intrinsics are subject to change
                                            //~^ ERROR intrinsic must be in
     extern "rust-call" fn m4(_: ()) {} //~ ERROR rust-call ABI is subject to change
 }
@@ -46,17 +45,17 @@ impl Tr for S {
 impl S {
     extern "rust-intrinsic" fn im1() {} //~ ERROR intrinsics are subject to change
                                         //~^ ERROR intrinsic must be in
-    extern "platform-intrinsic" fn im2() {} //~ ERROR platform intrinsics are experimental
+    extern "rust-intrinsic" fn im2() {} //~ ERROR intrinsics are subject to change
                                             //~^ ERROR intrinsic must be in
     extern "rust-call" fn im4(_: ()) {} //~ ERROR rust-call ABI is subject to change
 }
 
 // Function pointer types
 type A1 = extern "rust-intrinsic" fn(); //~ ERROR intrinsics are subject to change
-type A2 = extern "platform-intrinsic" fn(); //~ ERROR platform intrinsics are experimental
+type A2 = extern "rust-intrinsic" fn(); //~ ERROR intrinsics are subject to change
 type A4 = extern "rust-call" fn(_: ()); //~ ERROR rust-call ABI is subject to change
 
 // Foreign modules
 extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
-extern "platform-intrinsic" {} //~ ERROR platform intrinsics are experimental
+extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
 extern "rust-call" {} //~ ERROR rust-call ABI is subject to change

--- a/tests/ui/feature-gates/feature-gate-abi.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi.stderr
@@ -1,5 +1,5 @@
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:15:8
+  --> $DIR/feature-gate-abi.rs:14:8
    |
 LL | extern "rust-intrinsic" fn f1() {}
    |        ^^^^^^^^^^^^^^^^
@@ -7,18 +7,17 @@ LL | extern "rust-intrinsic" fn f1() {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:18:8
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:17:8
    |
-LL | extern "platform-intrinsic" fn f2() {}
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | extern "rust-intrinsic" fn f2() {}
+   |        ^^^^^^^^^^^^^^^^
    |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:21:8
+  --> $DIR/feature-gate-abi.rs:20:8
    |
 LL | extern "rust-call" fn f4(_: ()) {}
    |        ^^^^^^^^^^^
@@ -28,7 +27,7 @@ LL | extern "rust-call" fn f4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:25:12
+  --> $DIR/feature-gate-abi.rs:24:12
    |
 LL |     extern "rust-intrinsic" fn m1();
    |            ^^^^^^^^^^^^^^^^
@@ -36,18 +35,17 @@ LL |     extern "rust-intrinsic" fn m1();
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:27:12
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:26:12
    |
-LL |     extern "platform-intrinsic" fn m2();
-   |            ^^^^^^^^^^^^^^^^^^^^
+LL |     extern "rust-intrinsic" fn m2();
+   |            ^^^^^^^^^^^^^^^^
    |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:29:12
+  --> $DIR/feature-gate-abi.rs:28:12
    |
 LL |     extern "rust-call" fn m4(_: ());
    |            ^^^^^^^^^^^
@@ -57,7 +55,7 @@ LL |     extern "rust-call" fn m4(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:31:12
+  --> $DIR/feature-gate-abi.rs:30:12
    |
 LL |     extern "rust-call" fn dm4(_: ()) {}
    |            ^^^^^^^^^^^
@@ -67,7 +65,7 @@ LL |     extern "rust-call" fn dm4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:38:12
+  --> $DIR/feature-gate-abi.rs:37:12
    |
 LL |     extern "rust-intrinsic" fn m1() {}
    |            ^^^^^^^^^^^^^^^^
@@ -75,18 +73,17 @@ LL |     extern "rust-intrinsic" fn m1() {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:40:12
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:39:12
    |
-LL |     extern "platform-intrinsic" fn m2() {}
-   |            ^^^^^^^^^^^^^^^^^^^^
+LL |     extern "rust-intrinsic" fn m2() {}
+   |            ^^^^^^^^^^^^^^^^
    |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:42:12
+  --> $DIR/feature-gate-abi.rs:41:12
    |
 LL |     extern "rust-call" fn m4(_: ()) {}
    |            ^^^^^^^^^^^
@@ -96,7 +93,7 @@ LL |     extern "rust-call" fn m4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:47:12
+  --> $DIR/feature-gate-abi.rs:46:12
    |
 LL |     extern "rust-intrinsic" fn im1() {}
    |            ^^^^^^^^^^^^^^^^
@@ -104,18 +101,17 @@ LL |     extern "rust-intrinsic" fn im1() {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:49:12
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:48:12
    |
-LL |     extern "platform-intrinsic" fn im2() {}
-   |            ^^^^^^^^^^^^^^^^^^^^
+LL |     extern "rust-intrinsic" fn im2() {}
+   |            ^^^^^^^^^^^^^^^^
    |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:51:12
+  --> $DIR/feature-gate-abi.rs:50:12
    |
 LL |     extern "rust-call" fn im4(_: ()) {}
    |            ^^^^^^^^^^^
@@ -125,7 +121,7 @@ LL |     extern "rust-call" fn im4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:55:18
+  --> $DIR/feature-gate-abi.rs:54:18
    |
 LL | type A1 = extern "rust-intrinsic" fn();
    |                  ^^^^^^^^^^^^^^^^
@@ -133,24 +129,32 @@ LL | type A1 = extern "rust-intrinsic" fn();
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:56:18
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:55:18
    |
-LL | type A2 = extern "platform-intrinsic" fn();
-   |                  ^^^^^^^^^^^^^^^^^^^^
+LL | type A2 = extern "rust-intrinsic" fn();
+   |                  ^^^^^^^^^^^^^^^^
    |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:57:18
+  --> $DIR/feature-gate-abi.rs:56:18
    |
 LL | type A4 = extern "rust-call" fn(_: ());
    |                  ^^^^^^^^^^^
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:59:8
+   |
+LL | extern "rust-intrinsic" {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: intrinsics are subject to change
@@ -162,18 +166,8 @@ LL | extern "rust-intrinsic" {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:61:8
-   |
-LL | extern "platform-intrinsic" {}
-   |        ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
-   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:62:8
+  --> $DIR/feature-gate-abi.rs:61:8
    |
 LL | extern "rust-call" {}
    |        ^^^^^^^^^^^
@@ -183,7 +177,7 @@ LL | extern "rust-call" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0093]: unrecognized intrinsic function: `f1`
-  --> $DIR/feature-gate-abi.rs:15:28
+  --> $DIR/feature-gate-abi.rs:14:28
    |
 LL | extern "rust-intrinsic" fn f1() {}
    |                            ^^ unrecognized intrinsic
@@ -191,60 +185,60 @@ LL | extern "rust-intrinsic" fn f1() {}
    = help: if you're adding an intrinsic, be sure to update `check_intrinsic_type`
 
 error[E0093]: unrecognized intrinsic function: `f2`
-  --> $DIR/feature-gate-abi.rs:18:32
+  --> $DIR/feature-gate-abi.rs:17:28
    |
-LL | extern "platform-intrinsic" fn f2() {}
-   |                                ^^ unrecognized intrinsic
+LL | extern "rust-intrinsic" fn f2() {}
+   |                            ^^ unrecognized intrinsic
    |
    = help: if you're adding an intrinsic, be sure to update `check_intrinsic_type`
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:25:32
+  --> $DIR/feature-gate-abi.rs:24:32
    |
 LL |     extern "rust-intrinsic" fn m1();
    |                                ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:27:36
+  --> $DIR/feature-gate-abi.rs:26:32
    |
-LL |     extern "platform-intrinsic" fn m2();
-   |                                    ^^
+LL |     extern "rust-intrinsic" fn m2();
+   |                                ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:15:33
+  --> $DIR/feature-gate-abi.rs:14:33
    |
 LL | extern "rust-intrinsic" fn f1() {}
    |                                 ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:18:37
+  --> $DIR/feature-gate-abi.rs:17:33
    |
-LL | extern "platform-intrinsic" fn f2() {}
-   |                                     ^^
+LL | extern "rust-intrinsic" fn f2() {}
+   |                                 ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:38:37
+  --> $DIR/feature-gate-abi.rs:37:37
    |
 LL |     extern "rust-intrinsic" fn m1() {}
    |                                     ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:40:41
+  --> $DIR/feature-gate-abi.rs:39:37
    |
-LL |     extern "platform-intrinsic" fn m2() {}
-   |                                         ^^
+LL |     extern "rust-intrinsic" fn m2() {}
+   |                                     ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:47:38
+  --> $DIR/feature-gate-abi.rs:46:38
    |
 LL |     extern "rust-intrinsic" fn im1() {}
    |                                      ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:49:42
+  --> $DIR/feature-gate-abi.rs:48:38
    |
-LL |     extern "platform-intrinsic" fn im2() {}
-   |                                          ^^
+LL |     extern "rust-intrinsic" fn im2() {}
+   |                                      ^^
 
 error: aborting due to 29 previous errors
 

--- a/tests/ui/inline-const/instance-doesnt-depend-on-type.rs
+++ b/tests/ui/inline-const/instance-doesnt-depend-on-type.rs
@@ -6,5 +6,5 @@
 fn main() {
     const { core::mem::transmute::<u8, u8> };
     // Don't resolve the instance of this inline constant to be an intrinsic,
-    // even if the type of the constant is `extern "intrinsic" fn(u8) -> u8`.
+    // even if the type of the constant is `extern "rust-intrinsic" fn(u8) -> u8`.
 }

--- a/tests/ui/intrinsics/bad-intrinsic-monomorphization.rs
+++ b/tests/ui/intrinsics/bad-intrinsic-monomorphization.rs
@@ -1,13 +1,13 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics, core_intrinsics)]
+#![feature(repr_simd, intrinsics, core_intrinsics)]
 #![allow(warnings)]
 #![crate_type = "rlib"]
 
 // Bad monomorphizations could previously cause LLVM asserts even though the
 // error was caught in the compiler.
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
 }
 

--- a/tests/ui/simd/array-trait.rs
+++ b/tests/ui/simd/array-trait.rs
@@ -4,7 +4,7 @@
 
 //@ pretty-expanded FIXME #23616
 
-#![feature(repr_simd, platform_intrinsics, generic_const_exprs)]
+#![feature(repr_simd, intrinsics, generic_const_exprs)]
 #![allow(non_camel_case_types, incomplete_features)]
 
 pub trait Simd {
@@ -25,7 +25,7 @@ pub struct T<S: Simd>([S::Lane; S::SIZE]);
 //~| ERROR SIMD vector element type should be a primitive scalar
 //~| ERROR unconstrained generic constant
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 }

--- a/tests/ui/simd/array-type.rs
+++ b/tests/ui/simd/array-type.rs
@@ -3,7 +3,7 @@
 
 //@ pretty-expanded FIXME #23616
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -13,7 +13,7 @@ struct S([i32; 4]);
 #[derive(Copy, Clone)]
 struct T<const N: usize>([i32; N]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 }

--- a/tests/ui/simd/generics.rs
+++ b/tests/ui/simd/generics.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 use std::ops;
 
@@ -21,7 +21,7 @@ struct B<T>([T; 4]);
 struct C<T, const N: usize>([T; N]);
 
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
 }
 

--- a/tests/ui/simd/intrinsic/float-math-pass.rs
+++ b/tests/ui/simd/intrinsic/float-math-pass.rs
@@ -8,14 +8,14 @@
 
 // Test that the simd floating-point math intrinsics produce correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_fsqrt<T>(x: T) -> T;
     fn simd_fabs<T>(x: T) -> T;
     fn simd_fsin<T>(x: T) -> T;

--- a/tests/ui/simd/intrinsic/float-minmax-pass.rs
+++ b/tests/ui/simd/intrinsic/float-minmax-pass.rs
@@ -3,17 +3,14 @@
 
 // Test that the simd_f{min,max} intrinsics produce the correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
-    fn simd_fmin<T>(x: T, y: T) -> T;
-    fn simd_fmax<T>(x: T, y: T) -> T;
-}
+use std::intrinsics::simd::*;
 
 fn main() {
     let x = f32x4(1.0, 2.0, 3.0, 4.0);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-2.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-2.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -14,7 +14,7 @@ pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
 #[derive(Copy, Clone)]
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
     fn simd_sub<T>(x: T, y: T) -> T;
     fn simd_mul<T>(x: T, y: T) -> T;

--- a/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
 //@ ignore-emscripten FIXME(#45351) hits an LLVM assert
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -31,7 +31,7 @@ macro_rules! all_eq_ {
     }};
 }
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
     fn simd_sub<T>(x: T, y: T) -> T;
     fn simd_mul<T>(x: T, y: T) -> T;

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 //@ ignore-emscripten
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -14,7 +14,7 @@ pub struct x4<T>(pub T, pub T, pub T, pub T);
 #[derive(Copy, Clone)]
 pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_saturating_add<T>(x: T, y: T) -> T;
     fn simd_saturating_sub<T>(x: T, y: T) -> T;
 }

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
@@ -2,7 +2,7 @@
 //@ ignore-emscripten
 
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -12,7 +12,7 @@ struct u32x4(pub u32, pub u32, pub u32, pub u32);
 #[derive(Copy, Clone)]
 struct I32<const N: usize>([i32; N]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_saturating_add<T>(x: T, y: T) -> T;
     fn simd_saturating_sub<T>(x: T, y: T) -> T;
 }

--- a/tests/ui/simd/intrinsic/generic-as.rs
+++ b/tests/ui/simd/intrinsic/generic-as.rs
@@ -1,8 +1,8 @@
 //@ run-pass
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_as<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/generic-bitmask-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-bitmask-pass.rs
@@ -6,7 +6,7 @@
 
 // Test that the simd_bitmask intrinsic produces correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #[allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -21,7 +21,7 @@ struct u8x4(pub u8, pub u8, pub u8, pub u8);
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct Tx4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_bitmask<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/generic-bitmask.rs
+++ b/tests/ui/simd/intrinsic/generic-bitmask.rs
@@ -3,7 +3,7 @@
 // Test that the simd_bitmask intrinsic produces ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -30,7 +30,7 @@ struct u8x32([u8; 32]);
 #[derive(Copy, Clone)]
 struct u8x64([u8; 64]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_bitmask<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/generic-bswap-byte.rs
+++ b/tests/ui/simd/intrinsic/generic-bswap-byte.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -10,7 +10,7 @@ struct i8x4([i8; 4]);
 #[derive(Copy, Clone)]
 struct u8x4([u8; 4]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_bswap<T>(x: T) -> T;
 }
 

--- a/tests/ui/simd/intrinsic/generic-cast-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-cast-pass.rs
@@ -1,9 +1,9 @@
 //@ run-pass
 //@ ignore-emscripten FIXME(#45351) hits an LLVM assert
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_cast<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/generic-cast-pointer-width.rs
+++ b/tests/ui/simd/intrinsic/generic-cast-pointer-width.rs
@@ -1,7 +1,7 @@
 //@ run-pass
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_cast<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/generic-cast.rs
+++ b/tests/ui/simd/intrinsic/generic-cast.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -23,7 +23,7 @@ struct f32x8(f32, f32, f32, f32,
              f32, f32, f32, f32);
 
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_cast<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/generic-comparison-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison-pass.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ ignore-emscripten FIXME(#45351) hits an LLVM assert
 
-#![feature(repr_simd, platform_intrinsics, concat_idents)]
+#![feature(repr_simd, intrinsics, concat_idents)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -14,7 +14,7 @@ struct u32x4(pub u32, pub u32, pub u32, pub u32);
 #[derive(Copy, Clone)]
 struct f32x4(pub f32, pub f32, pub f32, pub f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_eq<T, U>(x: T, y: T) -> U;
     fn simd_ne<T, U>(x: T, y: T) -> U;
     fn simd_lt<T, U>(x: T, y: T) -> U;

--- a/tests/ui/simd/intrinsic/generic-comparison.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -12,7 +12,7 @@ struct i32x4(i32, i32, i32, i32);
 struct i16x8(i16, i16, i16, i16,
              i16, i16, i16, i16);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_eq<T, U>(x: T, y: T) -> U;
     fn simd_ne<T, U>(x: T, y: T) -> U;
     fn simd_lt<T, U>(x: T, y: T) -> U;

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ ignore-emscripten FIXME(#45351) hits an LLVM assert
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![feature(inline_const)]
 
 #[repr(simd)]
@@ -18,7 +18,7 @@ struct i32x4(i32, i32, i32, i32);
 struct i32x8(i32, i32, i32, i32,
              i32, i32, i32, i32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 

--- a/tests/ui/simd/intrinsic/generic-elements.rs
+++ b/tests/ui/simd/intrinsic/generic-elements.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics, rustc_attrs, adt_const_params)]
+#![feature(repr_simd, intrinsics, rustc_attrs, adt_const_params)]
 #![allow(incomplete_features)]
 
 #[repr(simd)]
@@ -31,7 +31,7 @@ struct f32x4(f32, f32, f32, f32);
 struct f32x8(f32, f32, f32, f32,
              f32, f32, f32, f32);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
     fn simd_extract<T, E>(x: T, idx: u32) -> E;
 

--- a/tests/ui/simd/intrinsic/generic-gather-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-gather-pass.rs
@@ -3,14 +3,14 @@
 
 // Test that the simd_{gather,scatter} intrinsics produce the correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct x4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
     fn simd_scatter<T, U, V>(x: T, y: U, z: V) -> ();
 }

--- a/tests/ui/simd/intrinsic/generic-reduction-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction-pass.rs
@@ -5,7 +5,7 @@
 
 // Test that the simd_reduce_{op} intrinsics produce the correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #[allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -24,7 +24,7 @@ struct f32x4(pub f32, pub f32, pub f32, pub f32);
 #[derive(Copy, Clone)]
 struct b8x4(pub i8, pub i8, pub i8, pub i8);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_reduce_add_unordered<T, U>(x: T) -> U;
     fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
     fn simd_reduce_add_ordered<T, U>(x: T, acc: U) -> U;

--- a/tests/ui/simd/intrinsic/generic-reduction.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction.rs
@@ -4,7 +4,7 @@
 // Test that the simd_reduce_{op} intrinsics produce ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -16,7 +16,7 @@ pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
 pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
 
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_reduce_add_ordered<T, U>(x: T, y: U) -> U;
     fn simd_reduce_mul_ordered<T, U>(x: T, y: U) -> U;
     fn simd_reduce_and<T, U>(x: T) -> U;

--- a/tests/ui/simd/intrinsic/generic-select-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-select-pass.rs
@@ -6,7 +6,7 @@
 
 // Test that the simd_select intrinsics produces correct results.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #[allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -29,7 +29,7 @@ struct f32x4(pub f32, pub f32, pub f32, pub f32);
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct b8x4(pub i8, pub i8, pub i8, pub i8);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_select<T, U>(x: T, a: U, b: U) -> U;
     fn simd_select_bitmask<T, U>(x: T, a: U, b: U) -> U;
 }

--- a/tests/ui/simd/intrinsic/generic-select.rs
+++ b/tests/ui/simd/intrinsic/generic-select.rs
@@ -3,7 +3,7 @@
 // Test that the simd_select intrinsic produces ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -22,7 +22,7 @@ struct b8x4(pub i8, pub i8, pub i8, pub i8);
 #[derive(Copy, Clone, PartialEq)]
 struct b8x8(pub i8, pub i8, pub i8, pub i8, pub i8, pub i8, pub i8, pub i8);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_select<T, U>(x: T, a: U, b: U) -> U;
     fn simd_select_bitmask<T, U>(x: T, a: U, b: U) -> U;
 }

--- a/tests/ui/simd/intrinsic/generic-shuffle.rs
+++ b/tests/ui/simd/intrinsic/generic-shuffle.rs
@@ -3,13 +3,13 @@
 // Test that the simd_shuffle intrinsic produces ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct Simd<T, const N: usize>([T; N]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
@@ -3,9 +3,9 @@
 //
 //@ run-pass
 //@ compile-flags: -Zmir-opt-level=4
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/inlining-issue67557.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557.rs
@@ -3,9 +3,9 @@
 //
 //@ run-pass
 //@ compile-flags: -Zmir-opt-level=4
-#![feature(platform_intrinsics, repr_simd)]
+#![feature(intrinsics, repr_simd)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 

--- a/tests/ui/simd/intrinsic/issue-85855.rs
+++ b/tests/ui/simd/intrinsic/issue-85855.rs
@@ -2,10 +2,10 @@
 // with the wrong number of generic lifetime/type/const parameters, and
 // that no ICE occurs in these cases.
 
-#![feature(platform_intrinsics)]
+#![feature(intrinsics)]
 #![crate_type="lib"]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_saturating_add<'a, T: 'a>(x: T, y: T);
     //~^ ERROR: intrinsic has wrong number of lifetime parameters
 

--- a/tests/ui/simd/intrinsic/ptr-cast.rs
+++ b/tests/ui/simd/intrinsic/ptr-cast.rs
@@ -1,8 +1,8 @@
 //@ run-pass
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_cast_ptr<T, U>(x: T) -> U;
     fn simd_expose_addr<T, U>(x: T) -> U;
     fn simd_from_exposed_addr<T, U>(x: T) -> U;

--- a/tests/ui/simd/issue-105439.rs
+++ b/tests/ui/simd/issue-105439.rs
@@ -2,14 +2,14 @@
 //@ compile-flags: -O -Zverify-llvm-ir
 
 #![feature(repr_simd)]
-#![feature(platform_intrinsics)]
+#![feature(intrinsics)]
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy)]
 #[repr(simd)]
 struct i32x4([i32; 4]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     pub(crate) fn simd_add<T>(x: T, y: T) -> T;
 }
 

--- a/tests/ui/simd/issue-39720.rs
+++ b/tests/ui/simd/issue-39720.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ ignore-emscripten FIXME(#45351)
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug)]
@@ -11,7 +11,7 @@ pub struct Char3(pub i8, pub i8, pub i8);
 #[derive(Copy, Clone, Debug)]
 pub struct Short3(pub i16, pub i16, pub i16);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_cast<T, U>(x: T) -> U;
 }
 

--- a/tests/ui/simd/issue-85915-simd-ptrs.rs
+++ b/tests/ui/simd/issue-85915-simd-ptrs.rs
@@ -3,7 +3,7 @@
 
 // Short form of the generic gather/scatter tests,
 // verifying simd([*const T; N]) and simd([*mut T; N]) pass typeck and work.
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
@@ -22,7 +22,7 @@ struct f32x4([f32; 4]);
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct i32x4([i32; 4]);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
     fn simd_scatter<T, U, V>(x: T, y: U, z: V) -> ();
 }

--- a/tests/ui/simd/issue-89193.rs
+++ b/tests/ui/simd/issue-89193.rs
@@ -3,14 +3,14 @@
 // Test that simd gather instructions on slice of usize don't cause crash
 // See issue #89183 - https://github.com/rust-lang/rust/issues/89193
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct x4<T>(pub T, pub T, pub T, pub T);
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
 }
 

--- a/tests/ui/simd/masked-load-store-build-fail.rs
+++ b/tests/ui/simd/masked-load-store-build-fail.rs
@@ -1,7 +1,7 @@
 //@ build-fail
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
     fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
 }

--- a/tests/ui/simd/masked-load-store-check-fail.rs
+++ b/tests/ui/simd/masked-load-store-check-fail.rs
@@ -1,7 +1,7 @@
 //@ check-fail
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
     fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
 }

--- a/tests/ui/simd/masked-load-store.rs
+++ b/tests/ui/simd/masked-load-store.rs
@@ -1,7 +1,7 @@
 //@ run-pass
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
     fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
 }

--- a/tests/ui/simd/monomorphize-shuffle-index.rs
+++ b/tests/ui/simd/monomorphize-shuffle-index.rs
@@ -1,10 +1,10 @@
 //@[old]run-pass
 //@[generic_with_fn]run-pass
 //@ revisions: old generic generic_with_fn
-#![feature(repr_simd, platform_intrinsics, adt_const_params, generic_const_exprs)]
+#![feature(repr_simd, intrinsics, adt_const_params, generic_const_exprs)]
 #![allow(incomplete_features)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     #[cfg(old)]
     fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
     #[cfg(any(generic, generic_with_fn))]

--- a/tests/ui/simd/repr_packed.rs
+++ b/tests/ui/simd/repr_packed.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd, packed)]
@@ -25,7 +25,7 @@ fn check_ty<T>() {
     check_size_align::<T, 15>();
 }
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_add<T>(a: T, b: T) -> T;
 }
 

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -2,11 +2,11 @@
 //@ revisions: opt noopt
 //@[noopt] compile-flags: -Copt-level=0
 //@[opt] compile-flags: -O
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 #![allow(incomplete_features)]
 #![feature(adt_const_params)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
 }
 

--- a/tests/ui/simd/simd-bitmask.rs
+++ b/tests/ui/simd/simd-bitmask.rs
@@ -1,8 +1,8 @@
 //@run-pass
 //@ignore-endian-big behavior of simd_select_bitmask is endian-specific
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
-extern "platform-intrinsic" {
+extern "rust-intrinsic" {
     fn simd_bitmask<T, U>(v: T) -> U;
     fn simd_select_bitmask<T, U>(m: T, a: U, b: U) -> U;
 }

--- a/tests/ui/simd/type-generic-monomorphisation-empty.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-empty.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 //@ error-pattern:monomorphising SIMD type `Simd<0>` of zero length
 

--- a/tests/ui/simd/type-generic-monomorphisation-oversized.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-oversized.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 //@ error-pattern:monomorphising SIMD type `Simd<65536>` of length greater than 32768
 

--- a/tests/ui/simd/type-generic-monomorphisation-power-of-two.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-power-of-two.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 #[repr(simd)]
 struct Simd<const N: usize>([f32; N]);

--- a/tests/ui/simd/type-generic-monomorphisation.rs
+++ b/tests/ui/simd/type-generic-monomorphisation.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, intrinsics)]
 
 
 //@ error-pattern:monomorphising SIMD type `Simd2<X>` with a non-primitive-scalar (integer/float/pointer) element type `X`


### PR DESCRIPTION
@Amanieu @workingjubilee I don't think there is any reason these need to be "special"? The [original RFC](https://rust-lang.github.io/rfcs/1199-simd-infrastructure.html) indicated eventually making them stable, but I think that is no longer the plan, so seems to me like we can clean this up a bit.

Blocked on https://github.com/rust-lang/stdarch/pull/1538, https://github.com/rust-lang/rust/pull/121542.