### PR TITLE
Consider middle segments of paths in `unused_qualifications`

### DIFF
--- a/tests/ui/lint/lint-qualification.fixed
+++ b/tests/ui/lint/lint-qualification.fixed
@@ -1,6 +1,6 @@
 //@ run-rustfix
 #![deny(unused_qualifications)]
-#![allow(deprecated)]
+#![allow(deprecated, dead_code)]
 
 mod foo {
     pub fn bar() {}
@@ -9,13 +9,37 @@ mod foo {
 fn main() {
     use foo::bar;
     bar(); //~ ERROR: unnecessary qualification
+    bar(); //~ ERROR: unnecessary qualification
     bar();
 
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
-    macro_rules! m { () => {
+    let _ = String::new(); //~ ERROR: unnecessary qualification
+    let _ = std::env::current_dir(); //~ ERROR: unnecessary qualification
+
+    let _: Vec<String> = Vec::<String>::new();
+    //~^ ERROR: unnecessary qualification
+    //~| ERROR: unnecessary qualification
+
+    use std::fmt;
+    let _: fmt::Result = Ok(()); //~ ERROR: unnecessary qualification
+
+    macro_rules! m { ($a:ident, $b:ident) => {
         $crate::foo::bar(); // issue #37357
         ::foo::bar(); // issue #38682
+        foo::bar();
+        foo::$b(); // issue #96698
+        $a::bar();
     } }
-    m!();
+    m!(foo, bar);
+}
+
+mod conflicting_names {
+    mod std {}
+    mod cell {}
+
+    fn f() {
+        let _ = ::std::env::current_dir();
+        let _ = core::cell::Cell::new(1);
+    }
 }

--- a/tests/ui/lint/lint-qualification.rs
+++ b/tests/ui/lint/lint-qualification.rs
@@ -1,6 +1,6 @@
 //@ run-rustfix
 #![deny(unused_qualifications)]
-#![allow(deprecated)]
+#![allow(deprecated, dead_code)]
 
 mod foo {
     pub fn bar() {}
@@ -9,13 +9,37 @@ mod foo {
 fn main() {
     use foo::bar;
     foo::bar(); //~ ERROR: unnecessary qualification
+    crate::foo::bar(); //~ ERROR: unnecessary qualification
     bar();
 
     let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
-    macro_rules! m { () => {
+    let _ = std::string::String::new(); //~ ERROR: unnecessary qualification
+    let _ = ::std::env::current_dir(); //~ ERROR: unnecessary qualification
+
+    let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
+    //~^ ERROR: unnecessary qualification
+    //~| ERROR: unnecessary qualification
+
+    use std::fmt;
+    let _: std::fmt::Result = Ok(()); //~ ERROR: unnecessary qualification
+
+    macro_rules! m { ($a:ident, $b:ident) => {
         $crate::foo::bar(); // issue #37357
         ::foo::bar(); // issue #38682
+        foo::bar();
+        foo::$b(); // issue #96698
+        $a::bar();
     } }
-    m!();
+    m!(foo, bar);
+}
+
+mod conflicting_names {
+    mod std {}
+    mod cell {}
+
+    fn f() {
+        let _ = ::std::env::current_dir();
+        let _ = core::cell::Cell::new(1);
+    }
 }

--- a/tests/ui/lint/lint-qualification.stderr
+++ b/tests/ui/lint/lint-qualification.stderr
@@ -15,5 +15,77 @@ LL -     foo::bar();
 LL +     bar();
    |
 
-error: aborting due to 1 previous error
+error: unnecessary qualification
+  --> $DIR/lint-qualification.rs:12:5
+   |
+LL |     crate::foo::bar();
+   |     ^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL -     crate::foo::bar();
+LL +     bar();
+   |
+
+error: unnecessary qualification
+  --> $DIR/lint-qualification.rs:17:13
+   |
+LL |     let _ = std::string::String::new();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL -     let _ = std::string::String::new();
+LL +     let _ = String::new();
+   |
+
+error: unnecessary qualification
+  --> $DIR/lint-qualification.rs:18:13
+   |
+LL |     let _ = ::std::env::current_dir();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL -     let _ = ::std::env::current_dir();
+LL +     let _ = std::env::current_dir();
+   |
+
+error: unnecessary qualification
+  --> $DIR/lint-qualification.rs:20:12
+   |
+LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
+   |            ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL -     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
+LL +     let _: Vec<String> = std::vec::Vec::<String>::new();
+   |
+
+error: unnecessary qualification
+  --> $DIR/lint-qualification.rs:20:36
+   |
+LL |     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL -     let _: std::vec::Vec<String> = std::vec::Vec::<String>::new();
+LL +     let _: std::vec::Vec<String> = Vec::<String>::new();
+   |
+
+error: unnecessary qualification
+  --> $DIR/lint-qualification.rs:25:12
+   |
+LL |     let _: std::fmt::Result = Ok(());
+   |            ^^^^^^^^^^^^^^^^
+   |
+help: remove the unnecessary path segments
+   |
+LL -     let _: std::fmt::Result = Ok(());
+LL +     let _: fmt::Result = Ok(());
+   |
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Currently `unused_qualifications` looks at the last segment of a path to see if it can be trimmed, this PR extends the check to the middle segments also

```rust
// currently linted
use std::env::args();
std::env::args(); // Removes `std::env::`
```
```rust
// newly linted
use std::env;
std::env::args(); // Removes `std::`
```

Paths with generics in them are now linted as long as the part being trimmed is before any generic args, e.g. it will now suggest trimming `std::vec::` from `std::vec::Vec<usize>`

Paths with any segments that are from an expansion are no longer linted

Fixes #100979
Fixes #96698