### PR TITLE
Ignore less tests in debug builds

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2503,8 +2503,11 @@ impl<'test> TestCx<'test> {
                 // overridden by `compile-flags`.
                 rustc.arg("-Copt-level=2");
             }
-            RunPassValgrind | Pretty | DebugInfo | Codegen | Rustdoc | RustdocJson | RunMake
-            | CodegenUnits | JsDocTest | Assembly => {
+            Assembly | Codegen => {
+                rustc.arg("-Cdebug-assertions=no");
+            }
+            RunPassValgrind | Pretty | DebugInfo | Rustdoc | RustdocJson | RunMake
+            | CodegenUnits | JsDocTest => {
                 // do not use JSON output
             }
         }

--- a/tests/assembly/option-nonzero-eq.rs
+++ b/tests/assembly/option-nonzero-eq.rs
@@ -5,7 +5,6 @@
 //@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
-//@ ignore-debug
 
 use std::cmp::Ordering;
 

--- a/tests/assembly/slice-is_ascii.rs
+++ b/tests/assembly/slice-is_ascii.rs
@@ -5,7 +5,6 @@
 //@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
-//@ ignore-debug
 
 #![feature(str_internals)]
 

--- a/tests/assembly/static-relocation-model.rs
+++ b/tests/assembly/static-relocation-model.rs
@@ -6,7 +6,6 @@
 //@ [A64] needs-llvm-components: aarch64
 //@ [ppc64le] compile-flags: --target powerpc64le-unknown-linux-gnu -Crelocation-model=static
 //@ [ppc64le] needs-llvm-components: powerpc
-//@ ignore-debug: alignment checks insert panics that we don't have a lang item for
 
 #![feature(no_core, lang_items)]
 #![no_core]

--- a/tests/codegen/align-offset.rs
+++ b/tests/codegen/align-offset.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (debug assertions in `slice::from_raw_parts` block optimizations)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -C opt-level=3 -C target-cpu=x86-64-v3
 //@ only-x86_64
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/ascii-char.rs
+++ b/tests/codegen/ascii-char.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C opt-level=1
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 #![feature(ascii_char)]

--- a/tests/codegen/binary-search-index-no-bound-check.rs
+++ b/tests/codegen/binary-search-index-no-bound-check.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // Make sure no bounds checks are emitted when slicing or indexing

--- a/tests/codegen/infallible-unwrap-in-opt-z.rs
+++ b/tests/codegen/infallible-unwrap-in-opt-z.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C opt-level=z --edition=2021
-//@ ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issue-97217.rs
+++ b/tests/codegen/issue-97217.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C opt-level=3
-//@ ignore-debug: the debug assertions get in the way
 //@ min-llvm-version: 17.0.2
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-101814.rs
+++ b/tests/codegen/issues/issue-101814.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-106369.rs
+++ b/tests/codegen/issues/issue-106369.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-116878.rs
+++ b/tests/codegen/issues/issue-116878.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 /// Make sure no bounds checks are emitted after a `get_unchecked`.

--- a/tests/codegen/issues/issue-37945.rs
+++ b/tests/codegen/issues/issue-37945.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -Zmerge-functions=disabled
 //@ ignore-32bit LLVM has a bug with them
-//@ ignore-debug
 
 // Check that LLVM understands that `Iter` pointer is not null. Issue #37945.
 

--- a/tests/codegen/issues/issue-45222.rs
+++ b/tests/codegen/issues/issue-45222.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-45466.rs
+++ b/tests/codegen/issues/issue-45466.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type="rlib"]
 

--- a/tests/codegen/issues/issue-45964-bounds-check-slice-pos.rs
+++ b/tests/codegen/issues/issue-45964-bounds-check-slice-pos.rs
@@ -2,7 +2,6 @@
 // prevent optimizing away bounds checks
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type="rlib"]
 

--- a/tests/codegen/issues/issue-69101-bounds-check.rs
+++ b/tests/codegen/issues/issue-69101-bounds-check.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // Make sure no bounds checks are emitted in the loop when upfront slicing

--- a/tests/codegen/issues/issue-73258.rs
+++ b/tests/codegen/issues/issue-73258.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-73396-bounds-check-after-position.rs
+++ b/tests/codegen/issues/issue-73396-bounds-check-after-position.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // Make sure no bounds checks are emitted when slicing or indexing

--- a/tests/codegen/issues/issue-98294-get-mut-copy-from-slice-opt.rs
+++ b/tests/codegen/issues/issue-98294-get-mut-copy-from-slice-opt.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: The debug assertions get in the way
 //@ compile-flags: -O
 
 #![crate_type = "lib"]

--- a/tests/codegen/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen/iter-repeat-n-trivial-drop.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 #![feature(iter_repeat_n)]

--- a/tests/codegen/layout-size-checks.rs
+++ b/tests/codegen/layout-size-checks.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/lib-optimizations/iter-sum.rs
+++ b/tests/codegen/lib-optimizations/iter-sum.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 //@ only-x86_64 (vectorization varies between architectures)
 #![crate_type = "lib"]

--- a/tests/codegen/mem-replace-big-type.rs
+++ b/tests/codegen/mem-replace-big-type.rs
@@ -4,7 +4,7 @@
 // known to be `1` after inlining).
 
 //@ compile-flags: -C no-prepopulate-passes -Zinline-mir=no
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: precondition checks in ptr::read make them a bad candidate for MIR inlining
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/mem-replace-simple-type.rs
+++ b/tests/codegen/mem-replace-simple-type.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -O -C no-prepopulate-passes
 //@ only-x86_64 (to not worry about usize differing)
-//@ ignore-debug (the debug assertions get in the way)
+//@ ignore-debug: precondition checks make mem::replace not a candidate for MIR inlining
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/ptr-arithmetic.rs
+++ b/tests/codegen/ptr-arithmetic.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Z merge-functions=disabled
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/ptr-read-metadata.rs
+++ b/tests/codegen/ptr-read-metadata.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Z merge-functions=disabled
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/simd/simd-wide-sum.rs
+++ b/tests/codegen/simd/simd-wide-sum.rs
@@ -1,7 +1,6 @@
 //@ revisions: llvm mir-opt3
 //@ compile-flags: -C opt-level=3 -Z merge-functions=disabled --edition=2021
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 //@ [mir-opt3]compile-flags: -Zmir-opt-level=3
 //@ [mir-opt3]build-pass
 

--- a/tests/codegen/simd/swap-simd-types.rs
+++ b/tests/codegen/simd/swap-simd-types.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -C target-feature=+avx
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-as_chunks.rs
+++ b/tests/codegen/slice-as_chunks.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 #![feature(slice_as_chunks)]

--- a/tests/codegen/slice-indexing.rs
+++ b/tests/codegen/slice-indexing.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-iter-fold.rs
+++ b/tests/codegen/slice-iter-fold.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-iter-len-eq-zero.rs
+++ b/tests/codegen/slice-iter-len-eq-zero.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions add extra comparisons
 #![crate_type = "lib"]
 
 type Demo = [u8; 3];

--- a/tests/codegen/slice-iter-nonnull.rs
+++ b/tests/codegen/slice-iter-nonnull.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (these add extra checks that make it hard to verify)
 #![crate_type = "lib"]
 #![feature(exact_size_is_empty)]
 

--- a/tests/codegen/slice-ref-equality.rs
+++ b/tests/codegen/slice-ref-equality.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Zmerge-functions=disabled
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-reverse.rs
+++ b/tests/codegen/slice-reverse.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions in from_raw_parts get in the way
+//@ ignore-debug: debug assertions prevent generating shufflevector
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice_as_from_ptr_range.rs
+++ b/tests/codegen/slice_as_from_ptr_range.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-64bit (because we're using [ui]size)
-//@ ignore-debug (because the assertions get in the way)
 
 #![crate_type = "lib"]
 #![feature(slice_from_ptr_range)]

--- a/tests/codegen/swap-large-types.rs
+++ b/tests/codegen/swap-large-types.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/swap-small-types.rs
+++ b/tests/codegen/swap-small-types.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -Z merge-functions=disabled
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/transmute-optimized.rs
+++ b/tests/codegen/transmute-optimized.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Z merge-functions=disabled
-//@ ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/unchecked_shifts.rs
+++ b/tests/codegen/unchecked_shifts.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (because unchecked is checked in debug)
 
 #![crate_type = "lib"]
 #![feature(unchecked_shifts)]

--- a/tests/codegen/unwind-landingpad-inline.rs
+++ b/tests/codegen/unwind-landingpad-inline.rs
@@ -1,6 +1,5 @@
 //@ min-llvm-version: 17.0.2
 //@ compile-flags: -Copt-level=3
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // This test checks that we can inline drop_in_place in

--- a/tests/codegen/vec-calloc.rs
+++ b/tests/codegen/vec-calloc.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -Z merge-functions=disabled
 //@ only-x86_64
-//@ ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-in-place.rs
+++ b/tests/codegen/vec-in-place.rs
@@ -1,4 +1,4 @@
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: FIXME: checks for call detect scoped noalias metadata
 //@ compile-flags: -O -Z merge-functions=disabled
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-iter-collect-len.rs
+++ b/tests/codegen/vec-iter-collect-len.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type="lib"]
 

--- a/tests/codegen/vec-iter.rs
+++ b/tests/codegen/vec-iter.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type = "lib"]
 #![feature(exact_size_is_empty)]

--- a/tests/codegen/vec-optimizes-away.rs
+++ b/tests/codegen/vec-optimizes-away.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-reserve-extend.rs
+++ b/tests/codegen/vec-reserve-extend.rs
@@ -1,6 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug
-// (with debug assertions turned on, `assert_unchecked` generates a real assertion)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-shrink-panik.rs
+++ b/tests/codegen/vec-shrink-panik.rs
@@ -4,7 +4,7 @@
 //@ [old]ignore-llvm-version: 17 - 99
 //@ [new]min-llvm-version: 17
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: plain old debug assertions
 //@ needs-unwind
 #![crate_type = "lib"]
 #![feature(shrink_to)]

--- a/tests/codegen/vec_pop_push_noop.rs
+++ b/tests/codegen/vec_pop_push_noop.rs
@@ -1,6 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug
-// (with debug assertions turned on, `assert_unchecked` generates a real assertion)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vecdeque-drain.rs
+++ b/tests/codegen/vecdeque-drain.rs
@@ -1,7 +1,7 @@
 // Check that draining at the front or back doesn't copy memory.
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: FIXME: checks for call detect scoped noalias metadata
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vecdeque-nonempty-get-no-panic.rs
+++ b/tests/codegen/vecdeque-nonempty-get-no-panic.rs
@@ -1,7 +1,6 @@
 // Guards against regression for optimization discussed in issue #80836
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vecdeque_no_panic.rs
+++ b/tests/codegen/vecdeque_no_panic.rs
@@ -1,7 +1,7 @@
 // This test checks that `VecDeque::front[_mut]()` and `VecDeque::back[_mut]()` can't panic.
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: plain old debug assertions
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/virtual-function-elimination.rs
+++ b/tests/codegen/virtual-function-elimination.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -Zvirtual-function-elimination -Clto -O -Csymbol-mangling-version=v0
 //@ ignore-32bit
-//@ ignore-debug
 
 // CHECK: @vtable.0 = {{.*}}, !type ![[TYPE0:[0-9]+]], !vcall_visibility ![[VCALL_VIS0:[0-9]+]]
 // CHECK: @vtable.1 = {{.*}}, !type ![[TYPE1:[0-9]+]], !vcall_visibility ![[VCALL_VIS0:[0-9]+]]

--- a/tests/mir-opt/pre-codegen/slice_filter.rs
+++ b/tests/mir-opt/pre-codegen/slice_filter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
-//@ ignore-debug: standard library debug assertions add a panic that breaks this optimization
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
@@ -1,6 +1,6 @@
 // MIR for `variant_a::{closure#0}` after PreCodegen
 
-fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:8:25: 8:39}, _2: &&(usize, usize, usize, usize)) -> bool {
+fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2: &&(usize, usize, usize, usize)) -> bool {
     let mut _0: bool;
     let mut _3: &(usize, usize, usize, usize);
     let _4: &usize;

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_b-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_b-{closure#0}.PreCodegen.after.mir
@@ -1,6 +1,6 @@
 // MIR for `variant_b::{closure#0}` after PreCodegen
 
-fn variant_b::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:12:25: 12:41}, _2: &&(usize, usize, usize, usize)) -> bool {
+fn variant_b::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:11:25: 11:41}, _2: &&(usize, usize, usize, usize)) -> bool {
     let mut _0: bool;
     let mut _3: &(usize, usize, usize, usize);
     let _4: usize;


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/120594 and https://github.com/rust-lang/rust/pull/120863, nearly all UB-detecting debug assertions get compiled out of code that is monomorphized by a crate built with debug assertions disabled.

Which means that if we default all our codegen tests to `-Cdebug-assertions=no`, most of them work just fine against a sysroot built with debug assertions.

I also tried to explain a bit better why some tests need to be skipped, for those that still need to be skipped.