### PR TITLE
compiler/rustc_target/src/spec/base/apple/tests.rs: Avoid unnecessary large move

### DIFF
--- a/compiler/rustc_target/src/spec/base/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/base/apple/tests.rs
@@ -14,7 +14,7 @@ fn simulator_targets_set_abi() {
         aarch64_apple_watchos_sim::target(),
     ];
 
-    for target in all_sim_targets {
+    for target in &all_sim_targets {
         assert_eq!(target.abi, "sim")
     }
 }


### PR DESCRIPTION
Fixes:

    $ MAGIC_EXTRA_RUSTFLAGS=-Zmove-size-limit=4096 ./x test compiler/rustc_target
    error: moving 6216 bytes
      --> compiler/rustc_target/src/spec/base/apple/tests.rs:17:19
       |
    17 |     for target in all_sim_targets {
       |                   ^^^^^^^^^^^^^^^ value moved from here
       |
       = note: The current maximum size is 4096, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
       = note: `-D large-assignments` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(large_assignments)]`

Part of https://github.com/rust-lang/rust/issues/83518

The goal is to enable the lint by default at one point. There are many cases where it needs to be allowed. But here we don't need to allow it. We can simply fix it.

I don't want to enable the lint in the file, because I don't want the "default size threshold for when a value is OK to move" to be duplicated in many places. We'll want the threshold in one central place once we enable it by default.