### PR TITLE
[EXPERIMENTAL] Lower constant pattern subslices into valtrees

### DIFF
--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -115,6 +115,7 @@ macro_rules! arena_types {
             [] features: rustc_feature::Features,
             [decode] specialization_graph: rustc_middle::traits::specialization_graph::Graph,
             [] crate_inherent_impls: rustc_middle::ty::CrateInherentImpls,
+            [] pats: rustc_middle::thir::Pat<'tcx>,
         ]);
     )
 }


### PR DESCRIPTION
🚧 This PR is *experimental* because this is the first time I touch MIR stuff :3

This PR attempts to revive <https://github.com/rust-lang/rust/pull/112370> and work towards fixing <https://github.com/rust-lang/rust/issues/110870>.

### Checklist

- [ ] Resolve unable to compare `[T; N] == [T; N]` via `~const PartialEq`.
- [ ] Add before/after MIR tests to confirm this PR does indeed affect MIR build simplification in a desirable way.