### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -106,13 +106,11 @@ codegen_ssa_invalid_monomorphization_return_type = invalid monomorphization of `
 
 codegen_ssa_invalid_monomorphization_second_argument_length = invalid monomorphization of `{$name}` intrinsic: expected second argument with length {$in_len} (same as input type `{$in_ty}`), found `{$arg_ty}` with length {$out_len}
 
-codegen_ssa_invalid_monomorphization_shuffle_index_not_constant = invalid monomorphization of `{$name}` intrinsic: shuffle index #{$arg_idx} is not a constant
-
-codegen_ssa_invalid_monomorphization_shuffle_index_out_of_bounds = invalid monomorphization of `{$name}` intrinsic: shuffle index #{$arg_idx} is out of bounds (limit {$total_len})
-
 codegen_ssa_invalid_monomorphization_simd_argument = invalid monomorphization of `{$name}` intrinsic: expected SIMD argument type, found non-SIMD `{$ty}`
 
 codegen_ssa_invalid_monomorphization_simd_first = invalid monomorphization of `{$name}` intrinsic: expected SIMD first type, found non-SIMD `{$ty}`
+
+codegen_ssa_invalid_monomorphization_simd_index_out_of_bounds = invalid monomorphization of `{$name}` intrinsic: SIMD index #{$arg_idx} is out of bounds (limit {$total_len})
 
 codegen_ssa_invalid_monomorphization_simd_input = invalid monomorphization of `{$name}` intrinsic: expected SIMD input type, found non-SIMD `{$ty}`
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -797,16 +797,8 @@ pub enum InvalidMonomorphization<'tcx> {
         out_ty: Ty<'tcx>,
     },
 
-    #[diag(codegen_ssa_invalid_monomorphization_shuffle_index_not_constant, code = E0511)]
-    ShuffleIndexNotConstant {
-        #[primary_span]
-        span: Span,
-        name: Symbol,
-        arg_idx: u64,
-    },
-
-    #[diag(codegen_ssa_invalid_monomorphization_shuffle_index_out_of_bounds, code = E0511)]
-    ShuffleIndexOutOfBounds {
+    #[diag(codegen_ssa_invalid_monomorphization_simd_index_out_of_bounds, code = E0511)]
+    SimdIndexOutOfBounds {
         #[primary_span]
         span: Span,
         name: Symbol,

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2434,6 +2434,14 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let suggestion =
                     if has_lifetimes { format!(" + {lt_name}") } else { format!(": {lt_name}") };
                 suggs.push((sp, suggestion))
+            } else if let GenericKind::Alias(ref p) = bound_kind
+                && let ty::Projection = p.kind(self.tcx)
+                && let DefKind::AssocTy = self.tcx.def_kind(p.def_id)
+                && let Some(ty::ImplTraitInTraitData::Trait { .. }) =
+                    self.tcx.opt_rpitit_info(p.def_id)
+            {
+                // The lifetime found in the `impl` is longer than the one on the RPITIT.
+                // Do not suggest `<Type as Trait>::{opaque}: 'static`.
             } else if let Some(generics) = self.tcx.hir().get_generics(suggestion_scope) {
                 let pred = format!("{bound_kind}: {lt_name}");
                 let suggestion = format!("{} {}", generics.add_where_or_trailing_comma(), pred);

--- a/compiler/rustc_target/src/spec/base/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/base/apple/tests.rs
@@ -14,7 +14,7 @@ fn simulator_targets_set_abi() {
         aarch64_apple_watchos_sim::target(),
     ];
 
-    for target in all_sim_targets {
+    for target in &all_sim_targets {
         assert_eq!(target.abi, "sim")
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -320,22 +320,25 @@ fn impl_intersection_has_impossible_obligation<'a, 'cx, 'tcx>(
         let mut errors = fulfill_cx.select_where_possible(infcx);
         errors.pop().map(|err| err.obligation)
     } else {
-        obligations.iter().cloned().find(|obligation| {
-            // We use `evaluate_root_obligation` to correctly track intercrate
-            // ambiguity clauses. We cannot use this in the new solver.
-            let evaluation_result = selcx.evaluate_root_obligation(obligation);
+        obligations
+            .iter()
+            .find(|obligation| {
+                // We use `evaluate_root_obligation` to correctly track intercrate
+                // ambiguity clauses. We cannot use this in the new solver.
+                let evaluation_result = selcx.evaluate_root_obligation(obligation);
 
-            match evaluation_result {
-                Ok(result) => !result.may_apply(),
-                // If overflow occurs, we need to conservatively treat the goal as possibly holding,
-                // since there can be instantiations of this goal that don't overflow and result in
-                // success. This isn't much of a problem in the old solver, since we treat overflow
-                // fatally (this still can be encountered: <https://github.com/rust-lang/rust/issues/105231>),
-                // but in the new solver, this is very important for correctness, since overflow
-                // *must* be treated as ambiguity for completeness.
-                Err(_overflow) => false,
-            }
-        })
+                match evaluation_result {
+                    Ok(result) => !result.may_apply(),
+                    // If overflow occurs, we need to conservatively treat the goal as possibly holding,
+                    // since there can be instantiations of this goal that don't overflow and result in
+                    // success. This isn't much of a problem in the old solver, since we treat overflow
+                    // fatally (this still can be encountered: <https://github.com/rust-lang/rust/issues/105231>),
+                    // but in the new solver, this is very important for correctness, since overflow
+                    // *must* be treated as ambiguity for completeness.
+                    Err(_overflow) => false,
+                }
+            })
+            .cloned()
     }
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -879,11 +879,16 @@ fn primitive_link_fragment(
         match m.primitive_locations.get(&prim) {
             Some(&def_id) if def_id.is_local() => {
                 let len = cx.current.len();
-                let len = if len == 0 { 0 } else { len - 1 };
+                let path = if len == 0 {
+                    let cname_sym = ExternalCrate { crate_num: def_id.krate }.name(cx.tcx());
+                    format!("{cname_sym}/")
+                } else {
+                    "../".repeat(len - 1)
+                };
                 write!(
                     f,
                     "<a class=\"primitive\" href=\"{}primitive.{}.html{fragment}\">",
-                    "../".repeat(len),
+                    path,
                     prim.as_sym()
                 )?;
                 needs_termination = true;

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2503,8 +2503,11 @@ impl<'test> TestCx<'test> {
                 // overridden by `compile-flags`.
                 rustc.arg("-Copt-level=2");
             }
-            RunPassValgrind | Pretty | DebugInfo | Codegen | Rustdoc | RustdocJson | RunMake
-            | CodegenUnits | JsDocTest | Assembly => {
+            Assembly | Codegen => {
+                rustc.arg("-Cdebug-assertions=no");
+            }
+            RunPassValgrind | Pretty | DebugInfo | Rustdoc | RustdocJson | RunMake
+            | CodegenUnits | JsDocTest => {
                 // do not use JSON output
             }
         }

--- a/src/tools/miri/src/shims/intrinsics/simd.rs
+++ b/src/tools/miri/src/shims/intrinsics/simd.rs
@@ -563,9 +563,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                         let right_idx = src_index.checked_sub(left_len).unwrap();
                         this.read_immediate(&this.project_index(&right, right_idx)?)?
                     } else {
-                        span_bug!(
-                            this.cur_span(),
-                            "simd_shuffle index {src_index} is out of bounds for 2 vectors of size {left_len}",
+                        throw_ub_format!(
+                            "`simd_shuffle_generic` index {src_index} is out-of-bounds for 2 vectors with length {dest_len}"
                         );
                     };
                     this.write_immediate(*val, &dest)?;
@@ -604,9 +603,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                         let right_idx = src_index.checked_sub(left_len).unwrap();
                         this.read_immediate(&this.project_index(&right, right_idx)?)?
                     } else {
-                        span_bug!(
-                            this.cur_span(),
-                            "simd_shuffle index {src_index} is out of bounds for 2 vectors of size {left_len}",
+                        throw_ub_format!(
+                            "`simd_shuffle` index {src_index} is out-of-bounds for 2 vectors with length {dest_len}"
                         );
                     };
                     this.write_immediate(*val, &dest)?;

--- a/src/tools/miri/tests/fail/intrinsics/simd-extract.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-extract.rs
@@ -1,0 +1,8 @@
+#![feature(portable_simd, core_intrinsics)]
+use std::simd::*;
+
+fn main() {
+    let v = i32x4::splat(0);
+    let _x: i32 = unsafe { std::intrinsics::simd::simd_extract(v, 4) };
+    //~^ERROR: index 4 is out-of-bounds
+}

--- a/src/tools/miri/tests/fail/intrinsics/simd-extract.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/simd-extract.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: `simd_extract` index 4 is out-of-bounds of vector with length 4
+  --> $DIR/simd-extract.rs:LL:CC
+   |
+LL |     let _x: i32 = unsafe { std::intrinsics::simd::simd_extract(v, 4) };
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `simd_extract` index 4 is out-of-bounds of vector with length 4
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/simd-extract.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/assembly/option-nonzero-eq.rs
+++ b/tests/assembly/option-nonzero-eq.rs
@@ -5,7 +5,6 @@
 //@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
-//@ ignore-debug
 
 use std::cmp::Ordering;
 

--- a/tests/assembly/slice-is_ascii.rs
+++ b/tests/assembly/slice-is_ascii.rs
@@ -5,7 +5,6 @@
 //@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
-//@ ignore-debug
 
 #![feature(str_internals)]
 

--- a/tests/assembly/static-relocation-model.rs
+++ b/tests/assembly/static-relocation-model.rs
@@ -6,7 +6,6 @@
 //@ [A64] needs-llvm-components: aarch64
 //@ [ppc64le] compile-flags: --target powerpc64le-unknown-linux-gnu -Crelocation-model=static
 //@ [ppc64le] needs-llvm-components: powerpc
-//@ ignore-debug: alignment checks insert panics that we don't have a lang item for
 
 #![feature(no_core, lang_items)]
 #![no_core]

--- a/tests/codegen/align-offset.rs
+++ b/tests/codegen/align-offset.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (debug assertions in `slice::from_raw_parts` block optimizations)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/array-map.rs
+++ b/tests/codegen/array-map.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -C opt-level=3 -C target-cpu=x86-64-v3
 //@ only-x86_64
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/ascii-char.rs
+++ b/tests/codegen/ascii-char.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C opt-level=1
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 #![feature(ascii_char)]

--- a/tests/codegen/binary-search-index-no-bound-check.rs
+++ b/tests/codegen/binary-search-index-no-bound-check.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // Make sure no bounds checks are emitted when slicing or indexing

--- a/tests/codegen/infallible-unwrap-in-opt-z.rs
+++ b/tests/codegen/infallible-unwrap-in-opt-z.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C opt-level=z --edition=2021
-//@ ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issue-97217.rs
+++ b/tests/codegen/issue-97217.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -C opt-level=3
-//@ ignore-debug: the debug assertions get in the way
 //@ min-llvm-version: 17.0.2
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-101814.rs
+++ b/tests/codegen/issues/issue-101814.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-106369.rs
+++ b/tests/codegen/issues/issue-106369.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-116878.rs
+++ b/tests/codegen/issues/issue-116878.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 /// Make sure no bounds checks are emitted after a `get_unchecked`.

--- a/tests/codegen/issues/issue-37945.rs
+++ b/tests/codegen/issues/issue-37945.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -Zmerge-functions=disabled
 //@ ignore-32bit LLVM has a bug with them
-//@ ignore-debug
 
 // Check that LLVM understands that `Iter` pointer is not null. Issue #37945.
 

--- a/tests/codegen/issues/issue-45222.rs
+++ b/tests/codegen/issues/issue-45222.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-45466.rs
+++ b/tests/codegen/issues/issue-45466.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type="rlib"]
 

--- a/tests/codegen/issues/issue-45964-bounds-check-slice-pos.rs
+++ b/tests/codegen/issues/issue-45964-bounds-check-slice-pos.rs
@@ -2,7 +2,6 @@
 // prevent optimizing away bounds checks
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type="rlib"]
 

--- a/tests/codegen/issues/issue-69101-bounds-check.rs
+++ b/tests/codegen/issues/issue-69101-bounds-check.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // Make sure no bounds checks are emitted in the loop when upfront slicing

--- a/tests/codegen/issues/issue-73258.rs
+++ b/tests/codegen/issues/issue-73258.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/issues/issue-73396-bounds-check-after-position.rs
+++ b/tests/codegen/issues/issue-73396-bounds-check-after-position.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // Make sure no bounds checks are emitted when slicing or indexing

--- a/tests/codegen/issues/issue-98294-get-mut-copy-from-slice-opt.rs
+++ b/tests/codegen/issues/issue-98294-get-mut-copy-from-slice-opt.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: The debug assertions get in the way
 //@ compile-flags: -O
 
 #![crate_type = "lib"]

--- a/tests/codegen/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen/iter-repeat-n-trivial-drop.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 #![feature(iter_repeat_n)]

--- a/tests/codegen/layout-size-checks.rs
+++ b/tests/codegen/layout-size-checks.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/lib-optimizations/iter-sum.rs
+++ b/tests/codegen/lib-optimizations/iter-sum.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 //@ only-x86_64 (vectorization varies between architectures)
 #![crate_type = "lib"]

--- a/tests/codegen/mem-replace-big-type.rs
+++ b/tests/codegen/mem-replace-big-type.rs
@@ -4,7 +4,7 @@
 // known to be `1` after inlining).
 
 //@ compile-flags: -C no-prepopulate-passes -Zinline-mir=no
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: precondition checks in ptr::read make them a bad candidate for MIR inlining
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/mem-replace-simple-type.rs
+++ b/tests/codegen/mem-replace-simple-type.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -O -C no-prepopulate-passes
 //@ only-x86_64 (to not worry about usize differing)
-//@ ignore-debug (the debug assertions get in the way)
+//@ ignore-debug: precondition checks make mem::replace not a candidate for MIR inlining
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/ptr-arithmetic.rs
+++ b/tests/codegen/ptr-arithmetic.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Z merge-functions=disabled
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/ptr-read-metadata.rs
+++ b/tests/codegen/ptr-read-metadata.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Z merge-functions=disabled
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/simd/simd-wide-sum.rs
+++ b/tests/codegen/simd/simd-wide-sum.rs
@@ -1,7 +1,6 @@
 //@ revisions: llvm mir-opt3
 //@ compile-flags: -C opt-level=3 -Z merge-functions=disabled --edition=2021
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 //@ [mir-opt3]compile-flags: -Zmir-opt-level=3
 //@ [mir-opt3]build-pass
 

--- a/tests/codegen/simd/swap-simd-types.rs
+++ b/tests/codegen/simd/swap-simd-types.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -C target-feature=+avx
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-as_chunks.rs
+++ b/tests/codegen/slice-as_chunks.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 #![feature(slice_as_chunks)]

--- a/tests/codegen/slice-indexing.rs
+++ b/tests/codegen/slice-indexing.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-iter-fold.rs
+++ b/tests/codegen/slice-iter-fold.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-iter-len-eq-zero.rs
+++ b/tests/codegen/slice-iter-len-eq-zero.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions add extra comparisons
 #![crate_type = "lib"]
 
 type Demo = [u8; 3];

--- a/tests/codegen/slice-iter-nonnull.rs
+++ b/tests/codegen/slice-iter-nonnull.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (these add extra checks that make it hard to verify)
 #![crate_type = "lib"]
 #![feature(exact_size_is_empty)]
 

--- a/tests/codegen/slice-ref-equality.rs
+++ b/tests/codegen/slice-ref-equality.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Zmerge-functions=disabled
-//@ ignore-debug (the extra assertions get in the way)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice-reverse.rs
+++ b/tests/codegen/slice-reverse.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions in from_raw_parts get in the way
+//@ ignore-debug: debug assertions prevent generating shufflevector
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/slice_as_from_ptr_range.rs
+++ b/tests/codegen/slice_as_from_ptr_range.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-64bit (because we're using [ui]size)
-//@ ignore-debug (because the assertions get in the way)
 
 #![crate_type = "lib"]
 #![feature(slice_from_ptr_range)]

--- a/tests/codegen/swap-large-types.rs
+++ b/tests/codegen/swap-large-types.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/swap-small-types.rs
+++ b/tests/codegen/swap-small-types.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -Z merge-functions=disabled
 //@ only-x86_64
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/transmute-optimized.rs
+++ b/tests/codegen/transmute-optimized.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O -Z merge-functions=disabled
-//@ ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/unchecked_shifts.rs
+++ b/tests/codegen/unchecked_shifts.rs
@@ -1,5 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug (because unchecked is checked in debug)
 
 #![crate_type = "lib"]
 #![feature(unchecked_shifts)]

--- a/tests/codegen/unwind-landingpad-inline.rs
+++ b/tests/codegen/unwind-landingpad-inline.rs
@@ -1,6 +1,5 @@
 //@ min-llvm-version: 17.0.2
 //@ compile-flags: -Copt-level=3
-//@ ignore-debug: the debug assertions get in the way
 #![crate_type = "lib"]
 
 // This test checks that we can inline drop_in_place in

--- a/tests/codegen/vec-calloc.rs
+++ b/tests/codegen/vec-calloc.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -O -Z merge-functions=disabled
 //@ only-x86_64
-//@ ignore-debug
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-in-place.rs
+++ b/tests/codegen/vec-in-place.rs
@@ -1,4 +1,4 @@
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: FIXME: checks for call detect scoped noalias metadata
 //@ compile-flags: -O -Z merge-functions=disabled
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-iter-collect-len.rs
+++ b/tests/codegen/vec-iter-collect-len.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type="lib"]
 

--- a/tests/codegen/vec-iter.rs
+++ b/tests/codegen/vec-iter.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type = "lib"]
 #![feature(exact_size_is_empty)]

--- a/tests/codegen/vec-optimizes-away.rs
+++ b/tests/codegen/vec-optimizes-away.rs
@@ -1,4 +1,3 @@
-//@ ignore-debug: the debug assertions get in the way
 //@ compile-flags: -O
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-reserve-extend.rs
+++ b/tests/codegen/vec-reserve-extend.rs
@@ -1,6 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug
-// (with debug assertions turned on, `assert_unchecked` generates a real assertion)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vec-shrink-panik.rs
+++ b/tests/codegen/vec-shrink-panik.rs
@@ -4,7 +4,7 @@
 //@ [old]ignore-llvm-version: 17 - 99
 //@ [new]min-llvm-version: 17
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: plain old debug assertions
 //@ needs-unwind
 #![crate_type = "lib"]
 #![feature(shrink_to)]

--- a/tests/codegen/vec_pop_push_noop.rs
+++ b/tests/codegen/vec_pop_push_noop.rs
@@ -1,6 +1,4 @@
 //@ compile-flags: -O
-//@ ignore-debug
-// (with debug assertions turned on, `assert_unchecked` generates a real assertion)
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vecdeque-drain.rs
+++ b/tests/codegen/vecdeque-drain.rs
@@ -1,7 +1,7 @@
 // Check that draining at the front or back doesn't copy memory.
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: FIXME: checks for call detect scoped noalias metadata
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vecdeque-nonempty-get-no-panic.rs
+++ b/tests/codegen/vecdeque-nonempty-get-no-panic.rs
@@ -1,7 +1,6 @@
 // Guards against regression for optimization discussed in issue #80836
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/vecdeque_no_panic.rs
+++ b/tests/codegen/vecdeque_no_panic.rs
@@ -1,7 +1,7 @@
 // This test checks that `VecDeque::front[_mut]()` and `VecDeque::back[_mut]()` can't panic.
 
 //@ compile-flags: -O
-//@ ignore-debug: the debug assertions get in the way
+//@ ignore-debug: plain old debug assertions
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/virtual-function-elimination.rs
+++ b/tests/codegen/virtual-function-elimination.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -Zvirtual-function-elimination -Clto -O -Csymbol-mangling-version=v0
 //@ ignore-32bit
-//@ ignore-debug
 
 // CHECK: @vtable.0 = {{.*}}, !type ![[TYPE0:[0-9]+]], !vcall_visibility ![[VCALL_VIS0:[0-9]+]]
 // CHECK: @vtable.1 = {{.*}}, !type ![[TYPE1:[0-9]+]], !vcall_visibility ![[VCALL_VIS0:[0-9]+]]

--- a/tests/mir-opt/pre-codegen/slice_filter.rs
+++ b/tests/mir-opt/pre-codegen/slice_filter.rs
@@ -1,6 +1,5 @@
 // skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=2
-//@ ignore-debug: standard library debug assertions add a panic that breaks this optimization
 
 #![crate_type = "lib"]
 

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
@@ -1,6 +1,6 @@
 // MIR for `variant_a::{closure#0}` after PreCodegen
 
-fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:8:25: 8:39}, _2: &&(usize, usize, usize, usize)) -> bool {
+fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2: &&(usize, usize, usize, usize)) -> bool {
     let mut _0: bool;
     let mut _3: &(usize, usize, usize, usize);
     let _4: &usize;

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_b-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_b-{closure#0}.PreCodegen.after.mir
@@ -1,6 +1,6 @@
 // MIR for `variant_b::{closure#0}` after PreCodegen
 
-fn variant_b::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:12:25: 12:41}, _2: &&(usize, usize, usize, usize)) -> bool {
+fn variant_b::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:11:25: 11:41}, _2: &&(usize, usize, usize, usize)) -> bool {
     let mut _0: bool;
     let mut _3: &(usize, usize, usize, usize);
     let _4: usize;

--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
@@ -6,8 +6,6 @@ LL |     async fn foo() -> &'static impl T;
    |     |
    |     the associated type `<Self as MyTrait>::{opaque#0}` must be valid for the static lifetime...
    |     ...so that the reference type `&'static impl T` does not outlive the data it points at
-   |
-   = help: consider adding an explicit lifetime bound `<Self as MyTrait>::{opaque#0}: 'static`...
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.rs
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.rs
@@ -1,0 +1,16 @@
+trait Original {
+    fn f() -> impl Fn();
+}
+
+trait Erased {
+    fn f(&self) -> Box<dyn Fn()>;
+}
+
+impl<T: Original> Erased for T {
+    fn f(&self) -> Box<dyn Fn()> {
+        Box::new(<T as Original>::f())
+        //~^ ERROR the associated type `<T as Original>::{opaque#0}` may not live long enough
+    }
+}
+
+fn main () {}

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
@@ -1,0 +1,12 @@
+error[E0310]: the associated type `<T as Original>::{opaque#0}` may not live long enough
+  --> $DIR/missing-static-bound-from-impl.rs:11:9
+   |
+LL |         Box::new(<T as Original>::f())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         the associated type `<T as Original>::{opaque#0}` must be valid for the static lifetime...
+   |         ...so that the type `impl Fn()` will meet its required lifetime bounds
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0310`.

--- a/tests/ui/simd/not-out-of-bounds.stderr
+++ b/tests/ui/simd/not-out-of-bounds.stderr
@@ -1,5 +1,5 @@
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 4)
-  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 4)
+  --> $DIR/not-out-of-bounds.rs:49:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -9,8 +9,8 @@ LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle);
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 8)
-  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 8)
+  --> $DIR/not-out-of-bounds.rs:49:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -20,8 +20,8 @@ LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle);
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 16)
-  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 16)
+  --> $DIR/not-out-of-bounds.rs:49:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -31,8 +31,8 @@ LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle);
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 32)
-  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 32)
+  --> $DIR/not-out-of-bounds.rs:49:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -42,8 +42,8 @@ LL |     test_shuffle_lanes!(16, u8x16, simd_shuffle);
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 64)
-  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 64)
+  --> $DIR/not-out-of-bounds.rs:49:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -53,8 +53,8 @@ LL |     test_shuffle_lanes!(32, u8x32, simd_shuffle);
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 128)
-  --> $DIR/shuffle-not-out-of-bounds.rs:51:21
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 128)
+  --> $DIR/not-out-of-bounds.rs:49:21
    |
 LL |                     $y(vec1, vec2, ARR)
    |                     ^^^^^^^^^^^^^^^^^^^
@@ -64,12 +64,24 @@ LL |     test_shuffle_lanes!(64, u8x64, simd_shuffle);
    |
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: shuffle index #0 is out of bounds (limit 4)
-  --> $DIR/shuffle-not-out-of-bounds.rs:79:23
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 4)
+  --> $DIR/not-out-of-bounds.rs:74:23
    |
 LL |         let _: u8x2 = simd_shuffle(v, v, I);
    |                       ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `u8` (element of input `u8x2`), found `i32`
+  --> $DIR/not-out-of-bounds.rs:80:9
+   |
+LL |         simd_insert(v, 2, 0);
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_extract` intrinsic: SIMD index #1 is out of bounds (limit 2)
+  --> $DIR/not-out-of-bounds.rs:81:24
+   |
+LL |         let _val: u8 = simd_extract(v, 2);
+   |                        ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0511`.


### PR DESCRIPTION
Successful merges:

 - #121435 (Account for RPITIT in E0310 explicit lifetime constraint suggestion)
 - #121490 (Rustdoc: include crate name in links for local primitives)
 - #121520 (delay cloning of iterator items)
 - #121522 (check that simd_insert/extract indices are in-bounds)
 - #121531 (Ignore less tests in debug builds)
 - #121539 (compiler/rustc_target/src/spec/base/apple/tests.rs: Avoid unnecessary large move)
 - #121542 (update stdarch)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121435,121490,121520,121522,121531,121539,121542)
<!-- homu-ignore:end -->