### PR TITLE
Lower struct patterns and struct expressions with unnamed fields

### DIFF
--- a/compiler/rustc_hir_typeck/messages.ftl
+++ b/compiler/rustc_hir_typeck/messages.ftl
@@ -138,6 +138,11 @@ hir_typeck_trivial_cast = trivial {$numeric ->
     }: `{$expr_ty}` as `{$cast_ty}`
     .help = cast can be replaced by coercion; this might require a temporary variable
 
+hir_typeck_union_pat_absent = there are no fields from this union
+    .label = union defined here
+
+hir_typeck_union_pat_conflict = there are multiple fields from this union
+
 hir_typeck_union_pat_dotdot = `..` cannot be used in union patterns
 
 hir_typeck_union_pat_multiple_fields = union patterns should have exactly one field

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -412,11 +412,29 @@ pub struct ConstSelectMustBeFn<'a> {
     pub ty: Ty<'a>,
 }
 
+#[derive(Subdiagnostic)]
+#[note(hir_typeck_union_pat_absent)]
+pub struct UnionPatAbsent {
+    #[primary_span]
+    pub span: MultiSpan,
+}
+
+#[derive(Subdiagnostic)]
+#[note(hir_typeck_union_pat_conflict)]
+pub struct UnionPatConflict {
+    #[primary_span]
+    pub span: MultiSpan,
+}
+
 #[derive(Diagnostic)]
 #[diag(hir_typeck_union_pat_multiple_fields)]
 pub struct UnionPatMultipleFields {
     #[primary_span]
     pub span: Span,
+    #[subdiagnostic]
+    pub conflict_set: Vec<UnionPatConflict>,
+    #[subdiagnostic]
+    pub absent_set: Vec<UnionPatAbsent>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(try_blocks)]
 #![feature(never_type)]
 #![feature(box_patterns)]
+#![feature(array_windows)]
 #![cfg_attr(bootstrap, feature(min_specialization))]
 #![feature(control_flow_enum)]
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2243,10 +2243,6 @@ rustc_queries! {
         desc { "whether the item should be made inlinable across crates" }
         separate_provide_extern
     }
-
-    query find_field((def_id, ident): (DefId, rustc_span::symbol::Ident)) -> Option<rustc_target::abi::FieldIdx> {
-        desc { |tcx| "find the index of maybe nested field `{ident}` in `{}`", tcx.def_path_str(def_id) }
-    }
 }
 
 rustc_query_append! { define_callbacks! }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1409,6 +1409,17 @@ impl<'tcx> FieldDef {
     pub fn is_unnamed(&self) -> bool {
         self.name == rustc_span::symbol::kw::Underscore
     }
+
+    /// Returns the definition of an anonymous ADT of this unnamed field.
+    pub fn nested_adt_def(&self, tcx: TyCtxt<'tcx>) -> ty::AdtDef<'tcx> {
+        assert!(self.is_unnamed(), "Expect an unnamed field to evaluate the nested ADT");
+        match tcx.type_of(self.did).instantiate_identity().kind() {
+            ty::Adt(adt_def, ..) => *adt_def,
+            ty_kind => {
+                span_bug!(tcx.def_span(self.did), "Expect anonymous ADT but found: {ty_kind:?}")
+            }
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/tests/mir-opt/unnamed-fields/field_access.bar.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/unnamed-fields/field_access.bar.SimplifyCfg-initial.after.mir
@@ -44,7 +44,7 @@ fn bar(_1: Bar) -> () {
         StorageDead(_6);
         StorageLive(_8);
         StorageLive(_9);
-        _9 = (((_1.2: Bar::{anon_adt#1}).0: Bar::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
+        _9 = (((_1.2: Bar::{anon_adt#1}).0: Nested).0: [u8; 1]);
         _8 = access::<[u8; 1]>(move _9) -> [return: bb4, unwind: bb5];
     }
 

--- a/tests/mir-opt/unnamed-fields/field_access.foo.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/unnamed-fields/field_access.foo.SimplifyCfg-initial.after.mir
@@ -42,7 +42,7 @@ fn foo(_1: Foo) -> () {
         StorageDead(_6);
         StorageLive(_8);
         StorageLive(_9);
-        _9 = (((_1.2: Foo::{anon_adt#1}).0: Foo::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
+        _9 = (((_1.2: Foo::{anon_adt#1}).0: Nested).0: [u8; 1]);
         _8 = access::<[u8; 1]>(move _9) -> [return: bb4, unwind: bb5];
     }
 

--- a/tests/mir-opt/unnamed-fields/field_access.rs
+++ b/tests/mir-opt/unnamed-fields/field_access.rs
@@ -6,6 +6,12 @@
 #![feature(unnamed_fields)]
 
 #[repr(C)]
+#[derive(Clone, Copy)]
+struct Nested {
+    d: [u8; 1],
+}
+
+#[repr(C)]
 struct Foo {
     a: u8,
     _: struct {
@@ -13,9 +19,7 @@ struct Foo {
         c: bool,
     },
     _: struct {
-        _: struct {
-            d: [u8; 1],
-        }
+        _: Nested,
     }
 }
 
@@ -27,9 +31,7 @@ union Bar {
         c: bool,
     },
     _: union {
-        _: union {
-            d: [u8; 1],
-        }
+        _: Nested,
     }
 }
 

--- a/tests/ui/union/union-fields-2.stderr
+++ b/tests/ui/union/union-fields-2.stderr
@@ -41,18 +41,38 @@ error: union patterns should have exactly one field
    |
 LL |     let U {} = u;
    |         ^^^^
+   |
+note: there are no fields from this union
 
 error: union patterns should have exactly one field
   --> $DIR/union-fields-2.rs:17:9
    |
 LL |     let U { a, b } = u;
    |         ^^^^^^^^^^
+   |
+note: there are multiple fields from this union
+  --> $DIR/union-fields-2.rs:17:13
+   |
+LL | union U {
+   | ------- union defined here
+...
+LL |     let U { a, b } = u;
+   |             ^  ^
 
 error: union patterns should have exactly one field
   --> $DIR/union-fields-2.rs:18:9
    |
 LL |     let U { a, b, c } = u;
    |         ^^^^^^^^^^^^^
+   |
+note: there are multiple fields from this union
+  --> $DIR/union-fields-2.rs:18:13
+   |
+LL | union U {
+   | ------- union defined here
+...
+LL |     let U { a, b, c } = u;
+   |             ^  ^
 
 error[E0026]: union `U` does not have a field named `c`
   --> $DIR/union-fields-2.rs:18:19
@@ -65,6 +85,8 @@ error: union patterns should have exactly one field
    |
 LL |     let U { .. } = u;
    |         ^^^^^^^^
+   |
+note: there are no fields from this union
 
 error: `..` cannot be used in union patterns
   --> $DIR/union-fields-2.rs:20:9

--- a/tests/ui/union/unnamed-fields/pat_field_check.rs
+++ b/tests/ui/union/unnamed-fields/pat_field_check.rs
@@ -1,0 +1,78 @@
+#![allow(incomplete_features)]
+#![feature(unnamed_fields)]
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Foo {
+    x: (),
+    y: (),
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+union Bar {
+    w: (),
+    z: (),
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct U {
+    a: (),
+    _: struct {
+        b: (),
+        c: (),
+        _: union {
+            d: (),
+            e: (),
+        },
+        _: union {},
+    },
+    _: union {
+        f: (),
+        g: (),
+        _: struct {
+            i: (),
+            j: (),
+        },
+        _: struct {},
+    },
+    _: Foo,
+    _: Bar,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+union V {
+    a: (),
+    _: struct {
+        b: (),
+        c: (),
+        _: union {
+            d: (),
+            e: (),
+        },
+        _: union {},
+    },
+    _: union {
+        f: (),
+        g: (),
+        _: struct {
+            i: (),
+            j: (),
+        },
+        _: struct {},
+    },
+    _: Foo,
+    _: Bar,
+}
+
+fn case_u(u: U) {
+    let U { a, b, c, d, e, f, g, i, j, x, y, w, z } = u; //~ ERROR union patterns should have exactly one field
+}
+
+fn case_v(v: V) {
+    let V { a, b, c, d, e, f, g, i, j, x, y, w, z } = v; //~ ERROR union patterns should have exactly one field
+}
+
+fn main() {}

--- a/tests/ui/union/unnamed-fields/pat_field_check.stderr
+++ b/tests/ui/union/unnamed-fields/pat_field_check.stderr
@@ -1,0 +1,71 @@
+error: union patterns should have exactly one field
+  --> $DIR/pat_field_check.rs:71:9
+   |
+LL |     let U { a, b, c, d, e, f, g, i, j, x, y, w, z } = u;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: there are multiple fields from this union
+  --> $DIR/pat_field_check.rs:71:22
+   |
+LL |           _: union {
+   |  ____________-
+LL | |             d: (),
+LL | |             e: (),
+LL | |         },
+   | |_________- union defined here
+...
+LL |       let U { a, b, c, d, e, f, g, i, j, x, y, w, z } = u;
+   |                        ^  ^
+note: there are multiple fields from this union
+  --> $DIR/pat_field_check.rs:71:28
+   |
+LL |       _: union {
+   |  ________-
+LL | |         f: (),
+LL | |         g: (),
+LL | |         _: struct {
+...  |
+LL | |         _: struct {},
+LL | |     },
+   | |_____- union defined here
+...
+LL |       let U { a, b, c, d, e, f, g, i, j, x, y, w, z } = u;
+   |                              ^  ^  ^  ^
+note: there are multiple fields from this union
+  --> $DIR/pat_field_check.rs:71:46
+   |
+LL | union Bar {
+   | --------- union defined here
+...
+LL |     let U { a, b, c, d, e, f, g, i, j, x, y, w, z } = u;
+   |                                              ^  ^
+
+error: union patterns should have exactly one field
+  --> $DIR/pat_field_check.rs:75:9
+   |
+LL |     let V { a, b, c, d, e, f, g, i, j, x, y, w, z } = v;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: there are multiple fields from this union
+  --> $DIR/pat_field_check.rs:75:22
+   |
+LL |           _: union {
+   |  ____________-
+LL | |             d: (),
+LL | |             e: (),
+LL | |         },
+   | |_________- union defined here
+...
+LL |       let V { a, b, c, d, e, f, g, i, j, x, y, w, z } = v;
+   |                        ^  ^
+note: there are multiple fields from this union
+  --> $DIR/pat_field_check.rs:75:13
+   |
+LL | union V {
+   | ------- union defined here
+...
+LL |     let V { a, b, c, d, e, f, g, i, j, x, y, w, z } = v;
+   |             ^  ^  ^  ^  ^  ^  ^  ^  ^  ^  ^  ^  ^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
This implements #49804.

Goals:
- [ ] pattern matching with unnamed fields
    - [x] check field conflict/absent errors
    - [ ] lower to THIR
- [ ] struct expressions with unnamed fields
    - [ ] check field conflict/absent errors
    - [ ] lower to THIR
 
Non-Goals (will be in the next PRs)
- capturing generic params for the anonymous ADTs from the parent ADT
- rustdoc support of unnamed fields and anonymous ADTs

r? @davidtwco