### PR TITLE
DRAFT: Use a noop `SIGPIPE` handler instead of `SIG_IGN`

### DIFF
--- a/tests/run-make/sigpipe-in-child-processes/Makefile
+++ b/tests/run-make/sigpipe-in-child-processes/Makefile
@@ -1,0 +1,15 @@
+# ignore-cross-compile because we run the compiled code
+# only-unix
+
+# See main.rs for a description of this test.
+
+include ../tools.mk
+
+all:
+	$(RUSTC) assert-sigpipe-disposition.rs -o $(TMPDIR)/assert-sigpipe-disposition;
+	for revision in default sig_dfl sig_ign inherit; do \
+		echo -n "Testing revision $$revision ... "; \
+		$(RUSTC) main.rs --cfg $$revision -o $(TMPDIR)/main.$$revision || exit 1; \
+		$(TMPDIR)/main.$$revision $(TMPDIR)/assert-sigpipe-disposition || exit 1; \
+		echo "ok"; \
+	done

--- a/tests/run-make/sigpipe-in-child-processes/assert-sigpipe-disposition.rs
+++ b/tests/run-make/sigpipe-in-child-processes/assert-sigpipe-disposition.rs
@@ -1,0 +1,25 @@
+#![feature(start, rustc_private)]
+
+extern crate libc;
+
+// Use #[start] so we don't have a runtime that messes with SIGPIPE.
+#[start]
+fn start(argc: isize, argv: *const *const u8) -> isize {
+    assert_eq!(argc, 2, "Must pass SIG_IGN or SIG_DFL as first arg");
+    let expected =
+        match unsafe { std::ffi::CStr::from_ptr(*argv.offset(1) as *const i8) }.to_str().unwrap() {
+            "SIG_IGN" => libc::SIG_IGN,
+            "SIG_DFL" => libc::SIG_DFL,
+            arg => panic!("Must pass SIG_IGN or SIG_DFL as first arg. Got: {}", arg),
+        };
+
+    let actual = unsafe {
+        let mut actual: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut actual);
+        actual.sa_sigaction
+    };
+
+    assert_eq!(actual, expected, "actual and expected SIGPIPE disposition differs");
+
+    return 0;
+}

--- a/tests/run-make/sigpipe-in-child-processes/main.rs
+++ b/tests/run-make/sigpipe-in-child-processes/main.rs
@@ -1,0 +1,33 @@
+// Checks the signal disposition of `SIGPIPE` in child processes. Without any
+// `unix_sigpipe` attribute, `SIG_IGN` is the default. But there is a
+// difference in how `SIGPIPE` is treated in child processes with and without
+// the attribute. Search for `unix_sigpipe_attr_specified()` in the code base to
+// learn more.
+
+// Note that tests for the attribute that does not involve child processes are
+// in tests/ui/attributes/unix_sigpipe.
+
+#![cfg_attr(any(sig_dfl, sig_ign), feature(unix_sigpipe))]
+
+#[cfg_attr(sig_dfl, unix_sigpipe = "sig_dfl")]
+#[cfg_attr(sig_ign, unix_sigpipe = "sig_ign")]
+fn main() {
+    // By default, we get SIG_IGN but the child gets SIG_DFL.
+    #[cfg(default)]
+    let expected = "SIG_DFL";
+
+    // With #[unix_sigpipe = "sig_dfl"] we get SIG_DFL and the child does too.
+    #[cfg(sig_dfl)]
+    let expected = "SIG_DFL";
+
+    // With #[unix_sigpipe = "sig_ign"] we get SIG_IGN and the child does too.
+    #[cfg(sig_ign)]
+    let expected = "SIG_IGN";
+
+    // With #[unix_sigpipe = "inherit"] we get SIG_DFL and the child does too.
+    #[cfg(inherit)]
+    let expected = "SIG_DFL";
+
+    let child_program = std::env::args().nth(1).unwrap();
+    assert!(std::process::Command::new(child_program).arg(expected).status().unwrap().success());
+}

--- a/tests/ui/attributes/unix_sigpipe/auxiliary/sigpipe-utils.rs
+++ b/tests/ui/attributes/unix_sigpipe/auxiliary/sigpipe-utils.rs
@@ -23,7 +23,7 @@ pub fn assert_sigpipe_handler(expected_handler: SignalHandler) {
             SignalHandler::Ignore => libc::SIG_IGN,
             SignalHandler::Default => libc::SIG_DFL,
         };
-        assert_eq!(prev, expected, "expected sigpipe value matches actual value");
+        assert_eq!(prev, expected, "FIXME: How do we know if SIGPIPE is ignored here?");
 
         // Unlikely to matter, but restore the old value anyway
         unsafe {


### PR DESCRIPTION
Here is an implementation of the [proposal](https://github.com/rust-lang/rust/issues/62569#issuecomment-1961586025) to use a noop handler instead of SIG_IGN.

Note that I have based this PR on https://github.com/rust-lang/rust/pull/121573 which is not merged yet.

I have two questions:

1. **How can code (which might be written in C and called from Rust) and our tests know if `SIGPIPE` is ignored?** <br/> The `oldact` return value of `sigaction()` will now point to a hidden function that will be tricky to interpret by others instead of a well-known handler constant.

```
assertion `left == right` failed: FIXME: How do we know if SIGPIPE is ignored here?
  left: 139622762777888
 right: 1
```

2. **Are we sure we want child processes to get `SIG_DFL` if the Rust runtime has set it to `SIG_IGN`?** <br/> Personally I currently think the answer is "yes", but in the current implementation, the answer is explicitly and by design ["no"](https://github.com/rust-lang/rust/pull/101077#issuecomment-1242968622). I have added this as an open unresolved question for `#[unix_sigpipe = "sig_ign"]` to the [tracking issue](https://github.com/rust-lang/rust/issues/97889).