### PR TITLE
make unused_imports less assertive in test modules

### DIFF
--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -108,7 +108,7 @@ pub(super) fn builtin(
             if let Some(span) = in_test_module {
                 db.span_help(
                     sess.source_map().guess_head_span(span),
-                    "consider adding a `#[cfg(test)]` to the containing module",
+                    "if this is a test module, consider adding a `#[cfg(test)]` to the containing module",
                 );
             }
         }

--- a/tests/ui/imports/unused-imports-in-test-module.stderr
+++ b/tests/ui/imports/unused-imports-in-test-module.stderr
@@ -16,7 +16,7 @@ error: unused import: `super::a`
 LL |     use super::a;
    |         ^^^^^^^^
    |
-help: consider adding a `#[cfg(test)]` to the containing module
+help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
   --> $DIR/unused-imports-in-test-module.rs:8:1
    |
 LL | mod test {
@@ -28,7 +28,7 @@ error: unused import: `super::a`
 LL |     use super::a;
    |         ^^^^^^^^
    |
-help: consider adding a `#[cfg(test)]` to the containing module
+help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
   --> $DIR/unused-imports-in-test-module.rs:18:1
    |
 LL | mod tests {
@@ -40,7 +40,7 @@ error: unused import: `super::a`
 LL |     use super::a;
    |         ^^^^^^^^
    |
-help: consider adding a `#[cfg(test)]` to the containing module
+help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
   --> $DIR/unused-imports-in-test-module.rs:28:1
    |
 LL | mod test_a {
@@ -52,7 +52,7 @@ error: unused import: `super::a`
 LL |     use super::a;
    |         ^^^^^^^^
    |
-help: consider adding a `#[cfg(test)]` to the containing module
+help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
   --> $DIR/unused-imports-in-test-module.rs:38:1
    |
 LL | mod a_test {
@@ -64,7 +64,7 @@ error: unused import: `super::a`
 LL |     use super::a;
    |         ^^^^^^^^
    |
-help: consider adding a `#[cfg(test)]` to the containing module
+help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
   --> $DIR/unused-imports-in-test-module.rs:48:1
    |
 LL | mod tests_a {
@@ -76,7 +76,7 @@ error: unused import: `super::a`
 LL |     use super::a;
    |         ^^^^^^^^
    |
-help: consider adding a `#[cfg(test)]` to the containing module
+help: if this is a test module, consider adding a `#[cfg(test)]` to the containing module
   --> $DIR/unused-imports-in-test-module.rs:58:1
    |
 LL | mod a_tests {


### PR DESCRIPTION
closes #121502 

This is a fairly small change and I used the fix suggested in the example expected error message.
Not sure if I should've rather used the alternatives but this one seems the most descriptive.

Some alternatives:
- if this is meant to be a test module, add `#[cfg(test)]` to the containing module
- try adding #[cfg(test)] to this test module
- consider adding #[allow(unused_imports)] if you want to silent the lint on the unused import
- consider removing the unused import