### PR TITLE
rename debug_assert_nounwind → debug_assert_ubcheck

### DIFF
--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -19,7 +19,9 @@ impl IndexRange {
     /// - `start <= end`
     #[inline]
     pub const unsafe fn new_unchecked(start: usize, end: usize) -> Self {
-        crate::panic::debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter
+        // will miss out on this check.
+        crate::panic::debug_assert_ubcheck!(
             start <= end,
             "IndexRange::new_unchecked requires `start <= end`"
         );

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -77,7 +77,7 @@ impl Alignment {
     #[inline]
     pub const unsafe fn new_unchecked(align: usize) -> Self {
         #[cfg(debug_assertions)]
-        crate::panic::debug_assert_nounwind!(
+        crate::panic::debug_assert_ubcheck!(
             align.is_power_of_two(),
             "Alignment::new_unchecked requires a power of two"
         );

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -3,7 +3,7 @@
 use crate::intrinsics::const_eval_select;
 use crate::intrinsics::unchecked_sub;
 use crate::ops;
-use crate::panic::debug_assert_nounwind;
+use crate::panic::debug_assert_ubcheck;
 use crate::ptr;
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -225,7 +225,7 @@ unsafe impl<T> SliceIndex<[T]> for usize {
 
     #[inline]
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const T {
-        debug_assert_nounwind!(
+        debug_assert_ubcheck!(
             self < slice.len(),
             "slice::get_unchecked requires that the index is within the slice"
         );
@@ -243,7 +243,9 @@ unsafe impl<T> SliceIndex<[T]> for usize {
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut T {
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The offset might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             self < slice.len(),
             "slice::get_unchecked_mut requires that the index is within the slice"
         );
@@ -292,7 +294,9 @@ unsafe impl<T> SliceIndex<[T]> for ops::IndexRange {
 
     #[inline]
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const [T] {
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The end might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             self.end() <= slice.len(),
             "slice::get_unchecked requires that the index is within the slice"
         );
@@ -305,7 +309,9 @@ unsafe impl<T> SliceIndex<[T]> for ops::IndexRange {
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut [T] {
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The end might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             self.end() <= slice.len(),
             "slice::get_unchecked_mut requires that the index is within the slice"
         );
@@ -362,7 +368,9 @@ unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
 
     #[inline]
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const [T] {
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The end might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             self.end >= self.start && self.end <= slice.len(),
             "slice::get_unchecked requires that the range is within the slice"
         );
@@ -379,7 +387,9 @@ unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut [T] {
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The end might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             self.end >= self.start && self.end <= slice.len(),
             "slice::get_unchecked_mut requires that the range is within the slice"
         );

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -13,7 +13,7 @@ use crate::intrinsics::exact_div;
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZero;
 use crate::ops::{Bound, OneSidedRange, Range, RangeBounds};
-use crate::panic::debug_assert_nounwind;
+use crate::panic::debug_assert_ubcheck;
 use crate::ptr;
 use crate::simd::{self, Simd};
 use crate::slice;
@@ -945,7 +945,9 @@ impl<T> [T] {
     #[unstable(feature = "slice_swap_unchecked", issue = "88539")]
     #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
     pub const unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The indices might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             a < self.len() && b < self.len(),
             "slice::swap_unchecked requires that the indices are within the slice"
         );
@@ -1285,7 +1287,7 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {
-        debug_assert_nounwind!(
+        debug_assert_ubcheck!(
             N != 0 && self.len() % N == 0,
             "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks"
         );
@@ -1439,7 +1441,7 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     pub const unsafe fn as_chunks_unchecked_mut<const N: usize>(&mut self) -> &mut [[T; N]] {
-        debug_assert_nounwind!(
+        debug_assert_ubcheck!(
             N != 0 && self.len() % N == 0,
             "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks"
         );
@@ -1971,7 +1973,9 @@ impl<T> [T] {
         let len = self.len();
         let ptr = self.as_ptr();
 
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (`mid` might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             mid <= len,
             "slice::split_at_unchecked requires the index to be within the slice"
         );
@@ -2021,7 +2025,9 @@ impl<T> [T] {
         let len = self.len();
         let ptr = self.as_mut_ptr();
 
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (`mid`` might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             mid <= len,
             "slice::split_at_mut_unchecked requires the index to be within the slice"
         );

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -2,7 +2,7 @@
 
 use crate::cmp::Ordering;
 use crate::ops;
-use crate::panic::debug_assert_nounwind;
+use crate::panic::debug_assert_ubcheck;
 use crate::ptr;
 use crate::slice::SliceIndex;
 
@@ -192,7 +192,9 @@ unsafe impl SliceIndex<str> for ops::Range<usize> {
     unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {
         let slice = slice as *const [u8];
 
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The end might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             // We'd like to check that the bounds are on char boundaries,
             // but there's not really a way to do so without reading
             // behind the pointer, which has aliasing implications.
@@ -213,7 +215,9 @@ unsafe impl SliceIndex<str> for ops::Range<usize> {
     unsafe fn get_unchecked_mut(self, slice: *mut str) -> *mut Self::Output {
         let slice = slice as *mut [u8];
 
-        debug_assert_nounwind!(
+        // FIXME: violating this is not immediate language UB, so the interpreter will miss out on
+        // this check. (The end might be OOB of the slice but still inbounds of the allocation.)
+        debug_assert_ubcheck!(
             self.end >= self.start && self.end <= slice.len(),
             "str::get_unchecked_mut requires that the range is within the string slice"
         );


### PR DESCRIPTION
This captures its changed meaning since https://github.com/rust-lang/rust/pull/120863 a bit better.

However, the naming of `debug_assert_ubcheck` vs `assert_unsafe_precondition` is still unclear. Both are guarded by `intrinsics::debug_assertions`, the main difference is whether the check needs to be const-compatible and whether it is being outlined. So maybe `assert_unsafe_precondition` should be renamed to `debug_assert_ubcheck_outline`? Is the outlining even desirable? If we can make `is_aligned_and_not_null` and `is_nonoverlapping` const-compatible (e.g. by using const_eval_select inside them and making them always return ~~`false`~~`true`), then we could use `debug_assert_ubcheck` everywhere.

r? @saethlin 