### PR TITLE
Don't use `unwrap()` in `ArrayIntoIter` lint when typeck fails

### DIFF
--- a/tests/ui/lint/ice-array-into-iter-lint-issue-121532.rs
+++ b/tests/ui/lint/ice-array-into-iter-lint-issue-121532.rs
@@ -1,0 +1,11 @@
+// Regression test for #121532
+// Checks the we don't ICE in ArrayIntoIter
+// lint when typeck has failed
+
+ // Typeck fails for the arg type as
+ // `Self` makes no sense here
+fn func(a: Self::ItemsIterator) { //~ ERROR failed to resolve: `Self` is only available in impls, traits, and type definitions
+    a.into_iter();
+}
+
+fn main() {}

--- a/tests/ui/lint/ice-array-into-iter-lint-issue-121532.stderr
+++ b/tests/ui/lint/ice-array-into-iter-lint-issue-121532.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: `Self` is only available in impls, traits, and type definitions
+  --> $DIR/ice-array-into-iter-lint-issue-121532.rs:7:12
+   |
+LL | fn func(a: Self::ItemsIterator) {
+   |            ^^^^ `Self` is only available in impls, traits, and type definitions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes #121532