### PR TITLE
delay expand macro bang when there has indeterminate path

### DIFF
--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -9,7 +9,7 @@ use rustc_ast::tokenstream::{DelimSpan, TokenStream};
 use rustc_ast::{DelimArgs, Expr, ExprKind, MacCall, Path, PathSegment, UnOp};
 use rustc_ast_pretty::pprust;
 use rustc_errors::PResult;
-use rustc_expand::base::{DummyResult, ExtCtxt, MacEager, MacResult};
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
 use rustc_parse::parser::Parser;
 use rustc_span::symbol::{sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
@@ -19,12 +19,12 @@ pub fn expand_assert<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     span: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'cx> {
+) -> MacroExpanderResult<'cx> {
     let Assert { cond_expr, custom_message } = match parse_assert(cx, span, tts) {
         Ok(assert) => assert,
         Err(err) => {
             let guar = err.emit();
-            return DummyResult::any(span, guar);
+            return ExpandResult::Ready(DummyResult::any(span, guar));
         }
     };
 
@@ -92,7 +92,7 @@ pub fn expand_assert<'cx>(
         expr_if_not(cx, call_site_span, cond_expr, then, None)
     };
 
-    MacEager::expr(expr)
+    ExpandResult::Ready(MacEager::expr(expr))
 }
 
 struct Assert {

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -8,17 +8,17 @@ use rustc_ast::token;
 use rustc_ast::tokenstream::TokenStream;
 use rustc_attr as attr;
 use rustc_errors::PResult;
-use rustc_expand::base::{DummyResult, ExtCtxt, MacEager, MacResult};
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
 use rustc_span::Span;
 
 pub fn expand_cfg(
     cx: &mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'static> {
+) -> MacroExpanderResult<'static> {
     let sp = cx.with_def_site_ctxt(sp);
 
-    match parse_cfg(cx, sp, tts) {
+    ExpandResult::Ready(match parse_cfg(cx, sp, tts) {
         Ok(cfg) => {
             let matches_cfg = attr::cfg_matches(
                 &cfg,
@@ -32,7 +32,7 @@ pub fn expand_cfg(
             let guar = err.emit();
             DummyResult::any(sp, guar)
         }
-    }
+    })
 }
 
 fn parse_cfg<'a>(cx: &mut ExtCtxt<'a>, span: Span, tts: TokenStream) -> PResult<'a, ast::MetaItem> {

--- a/compiler/rustc_builtin_macros/src/compile_error.rs
+++ b/compiler/rustc_builtin_macros/src/compile_error.rs
@@ -1,22 +1,26 @@
 // The compiler code necessary to support the compile_error! extension.
 
 use rustc_ast::tokenstream::TokenStream;
-use rustc_expand::base::{get_single_str_from_tts, DummyResult, ExtCtxt, MacResult};
+use rustc_expand::base::get_single_str_from_tts;
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
 use rustc_span::Span;
 
 pub fn expand_compile_error<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'cx> {
-    let var = match get_single_str_from_tts(cx, sp, tts, "compile_error!") {
+) -> MacroExpanderResult<'cx> {
+    let ExpandResult::Ready(mac) = get_single_str_from_tts(cx, sp, tts, "compile_error!") else {
+        return ExpandResult::Retry(());
+    };
+    let var = match mac {
         Ok(var) => var,
-        Err(guar) => return DummyResult::any(sp, guar),
+        Err(guar) => return ExpandResult::Ready(DummyResult::any(sp, guar)),
     };
 
     #[expect(rustc::diagnostic_outside_of_impl, reason = "diagnostic message is specified by user")]
     #[expect(rustc::untranslatable_diagnostic, reason = "diagnostic message is specified by user")]
     let guar = cx.dcx().span_err(sp, var.to_string());
 
-    DummyResult::any(sp, guar)
+    ExpandResult::Ready(DummyResult::any(sp, guar))
 }

--- a/compiler/rustc_builtin_macros/src/concat_bytes.rs
+++ b/compiler/rustc_builtin_macros/src/concat_bytes.rs
@@ -1,5 +1,6 @@
 use rustc_ast::{ptr::P, token, tokenstream::TokenStream, ExprKind, LitIntType, LitKind, UintTy};
-use rustc_expand::base::{get_exprs_from_tts, DummyResult, ExtCtxt, MacEager, MacResult};
+use rustc_expand::base::get_exprs_from_tts;
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
 use rustc_session::errors::report_lit_error;
 use rustc_span::{ErrorGuaranteed, Span};
 
@@ -111,10 +112,13 @@ pub fn expand_concat_bytes(
     cx: &mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'static> {
-    let es = match get_exprs_from_tts(cx, tts) {
+) -> MacroExpanderResult<'static> {
+    let ExpandResult::Ready(mac) = get_exprs_from_tts(cx, tts) else {
+        return ExpandResult::Retry(());
+    };
+    let es = match mac {
         Ok(es) => es,
-        Err(guar) => return DummyResult::any(sp, guar),
+        Err(guar) => return ExpandResult::Ready(DummyResult::any(sp, guar)),
     };
     let mut accumulator = Vec::new();
     let mut missing_literals = vec![];
@@ -170,12 +174,13 @@ pub fn expand_concat_bytes(
             }
         }
     }
-    if !missing_literals.is_empty() {
+    ExpandResult::Ready(if !missing_literals.is_empty() {
         let guar = cx.dcx().emit_err(errors::ConcatBytesMissingLiteral { spans: missing_literals });
-        return MacEager::expr(DummyResult::raw_expr(sp, Some(guar)));
+        MacEager::expr(DummyResult::raw_expr(sp, Some(guar)))
     } else if let Some(guar) = guar {
-        return MacEager::expr(DummyResult::raw_expr(sp, Some(guar)));
-    }
-    let sp = cx.with_def_site_ctxt(sp);
-    MacEager::expr(cx.expr_byte_str(sp, accumulator))
+        MacEager::expr(DummyResult::raw_expr(sp, Some(guar)))
+    } else {
+        let sp = cx.with_def_site_ctxt(sp);
+        MacEager::expr(cx.expr_byte_str(sp, accumulator))
+    })
 }

--- a/compiler/rustc_builtin_macros/src/concat_idents.rs
+++ b/compiler/rustc_builtin_macros/src/concat_idents.rs
@@ -2,7 +2,7 @@ use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Token};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_ast::{AttrVec, Expr, ExprKind, Path, Ty, TyKind, DUMMY_NODE_ID};
-use rustc_expand::base::{DummyResult, ExtCtxt, MacResult};
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacResult, MacroExpanderResult};
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::Span;
 
@@ -12,10 +12,10 @@ pub fn expand_concat_idents<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'cx> {
+) -> MacroExpanderResult<'cx> {
     if tts.is_empty() {
         let guar = cx.dcx().emit_err(errors::ConcatIdentsMissingArgs { span: sp });
-        return DummyResult::any(sp, guar);
+        return ExpandResult::Ready(DummyResult::any(sp, guar));
     }
 
     let mut res_str = String::new();
@@ -25,7 +25,7 @@ pub fn expand_concat_idents<'cx>(
                 TokenTree::Token(Token { kind: token::Comma, .. }, _) => {}
                 _ => {
                     let guar = cx.dcx().emit_err(errors::ConcatIdentsMissingComma { span: sp });
-                    return DummyResult::any(sp, guar);
+                    return ExpandResult::Ready(DummyResult::any(sp, guar));
                 }
             }
         } else {
@@ -37,7 +37,7 @@ pub fn expand_concat_idents<'cx>(
             }
 
             let guar = cx.dcx().emit_err(errors::ConcatIdentsIdentArgs { span: sp });
-            return DummyResult::any(sp, guar);
+            return ExpandResult::Ready(DummyResult::any(sp, guar));
         }
     }
 
@@ -68,5 +68,5 @@ pub fn expand_concat_idents<'cx>(
         }
     }
 
-    Box::new(ConcatIdentsResult { ident })
+    ExpandResult::Ready(Box::new(ConcatIdentsResult { ident }))
 }

--- a/compiler/rustc_builtin_macros/src/edition_panic.rs
+++ b/compiler/rustc_builtin_macros/src/edition_panic.rs
@@ -20,7 +20,7 @@ pub fn expand_panic<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'cx> {
+) -> MacroExpanderResult<'cx> {
     let mac = if use_panic_2021(sp) { sym::panic_2021 } else { sym::panic_2015 };
     expand(mac, cx, sp, tts)
 }
@@ -33,7 +33,7 @@ pub fn expand_unreachable<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'cx> {
+) -> MacroExpanderResult<'cx> {
     let mac = if use_panic_2021(sp) { sym::unreachable_2021 } else { sym::unreachable_2015 };
     expand(mac, cx, sp, tts)
 }
@@ -43,10 +43,10 @@ fn expand<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
-) -> Box<dyn MacResult + 'cx> {
+) -> MacroExpanderResult<'cx> {
     let sp = cx.with_call_site_ctxt(sp);
 
-    MacEager::expr(
+    ExpandResult::Ready(MacEager::expr(
         cx.expr(
             sp,
             ExprKind::MacCall(P(MacCall {
@@ -66,7 +66,7 @@ fn expand<'cx>(
                 }),
             })),
         ),
-    )
+    ))
 }
 
 pub fn use_panic_2021(mut span: Span) -> bool {

--- a/compiler/rustc_builtin_macros/src/log_syntax.rs
+++ b/compiler/rustc_builtin_macros/src/log_syntax.rs
@@ -1,14 +1,14 @@
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast_pretty::pprust;
-use rustc_expand::base;
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
 
 pub fn expand_log_syntax<'cx>(
-    _cx: &'cx mut base::ExtCtxt<'_>,
+    _cx: &'cx mut ExtCtxt<'_>,
     sp: rustc_span::Span,
     tts: TokenStream,
-) -> Box<dyn base::MacResult + 'cx> {
+) -> MacroExpanderResult<'cx> {
     println!("{}", pprust::tts_to_string(&tts));
 
     // any so that `log_syntax` can be invoked as an expression and item.
-    base::DummyResult::any_valid(sp)
+    ExpandResult::Ready(DummyResult::any_valid(sp))
 }

--- a/compiler/rustc_builtin_macros/src/trace_macros.rs
+++ b/compiler/rustc_builtin_macros/src/trace_macros.rs
@@ -1,6 +1,6 @@
 use crate::errors;
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
-use rustc_expand::base::{self, ExtCtxt};
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
 use rustc_span::symbol::kw;
 use rustc_span::Span;
 
@@ -8,7 +8,7 @@ pub fn expand_trace_macros(
     cx: &mut ExtCtxt<'_>,
     sp: Span,
     tt: TokenStream,
-) -> Box<dyn base::MacResult + 'static> {
+) -> MacroExpanderResult<'static> {
     let mut cursor = tt.trees();
     let mut err = false;
     let value = match &cursor.next() {
@@ -26,5 +26,5 @@ pub fn expand_trace_macros(
         cx.set_trace_macros(value);
     }
 
-    base::DummyResult::any_valid(sp)
+    ExpandResult::Ready(DummyResult::any_valid(sp))
 }

--- a/compiler/rustc_builtin_macros/src/type_ascribe.rs
+++ b/compiler/rustc_builtin_macros/src/type_ascribe.rs
@@ -2,25 +2,25 @@ use rustc_ast::ptr::P;
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{token, Expr, ExprKind, Ty};
 use rustc_errors::PResult;
-use rustc_expand::base::{self, DummyResult, ExtCtxt, MacEager};
+use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacEager, MacroExpanderResult};
 use rustc_span::Span;
 
 pub fn expand_type_ascribe(
     cx: &mut ExtCtxt<'_>,
     span: Span,
     tts: TokenStream,
-) -> Box<dyn base::MacResult + 'static> {
+) -> MacroExpanderResult<'static> {
     let (expr, ty) = match parse_ascribe(cx, tts) {
         Ok(parsed) => parsed,
         Err(err) => {
             let guar = err.emit();
-            return DummyResult::any(span, guar);
+            return ExpandResult::Ready(DummyResult::any(span, guar));
         }
     };
 
     let asc_expr = cx.expr(span, ExprKind::Type(expr, ty));
 
-    return MacEager::expr(asc_expr);
+    ExpandResult::Ready(MacEager::expr(asc_expr))
 }
 
 fn parse_ascribe<'a>(cx: &mut ExtCtxt<'a>, stream: TokenStream) -> PResult<'a, (P<Expr>, P<Ty>)> {

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -1,5 +1,5 @@
-use crate::base::{DummyResult, ExtCtxt, MacResult, TTMacroExpander};
-use crate::base::{SyntaxExtension, SyntaxExtensionKind};
+use crate::base::{DummyResult, SyntaxExtension, SyntaxExtensionKind};
+use crate::base::{ExpandResult, ExtCtxt, MacResult, MacroExpanderResult, TTMacroExpander};
 use crate::expand::{ensure_complete_parse, parse_ast_fragment, AstFragment, AstFragmentKind};
 use crate::mbe;
 use crate::mbe::diagnostics::{annotate_doc_comment, parse_failure_msg};
@@ -111,8 +111,8 @@ impl TTMacroExpander for MacroRulesMacroExpander {
         cx: &'cx mut ExtCtxt<'_>,
         sp: Span,
         input: TokenStream,
-    ) -> Box<dyn MacResult + 'cx> {
-        expand_macro(
+    ) -> MacroExpanderResult<'cx> {
+        ExpandResult::Ready(expand_macro(
             cx,
             sp,
             self.span,
@@ -122,7 +122,7 @@ impl TTMacroExpander for MacroRulesMacroExpander {
             input,
             &self.lhses,
             &self.rhses,
-        )
+        ))
     }
 }
 
@@ -134,8 +134,8 @@ impl TTMacroExpander for DummyExpander {
         _: &'cx mut ExtCtxt<'_>,
         span: Span,
         _: TokenStream,
-    ) -> Box<dyn MacResult + 'cx> {
-        DummyResult::any(span, self.0)
+    ) -> ExpandResult<Box<dyn MacResult + 'cx>, ()> {
+        ExpandResult::Ready(DummyResult::any(span, self.0))
     }
 }
 

--- a/tests/ui/macros/expand-full-asm.rs
+++ b/tests/ui/macros/expand-full-asm.rs
@@ -1,0 +1,27 @@
+//@only-aarch64
+//@check-pass
+//@edition: 2018
+
+// https://github.com/rust-lang/rust/issues/98291
+
+use std::arch::{asm, global_asm};
+
+macro_rules! wrap {
+    () => {
+        macro_rules! _a {
+            () => {
+                "nop"
+            };
+        }
+    };
+}
+
+wrap!();
+
+use _a as a;
+
+fn main() {
+    unsafe { asm!(a!()); }
+}
+
+global_asm!(a!());

--- a/tests/ui/macros/expand-full-in-format-str.rs
+++ b/tests/ui/macros/expand-full-in-format-str.rs
@@ -1,0 +1,33 @@
+//@check-pass
+//@edition: 2018
+
+// https://github.com/rust-lang/rust/issues/98291
+
+macro_rules! wrap {
+    () => {
+        macro_rules! _a {
+            () => {
+                "auxiliary/macro-include-items-expr.rs"
+            };
+        }
+        macro_rules! _env_name {
+            () => {
+                "PATH"
+            }
+        }
+    };
+}
+
+wrap!();
+
+use _a as a;
+use _env_name as env_name;
+
+fn main() {
+    format_args!(a!());
+    include!(a!());
+    include_str!(a!());
+    include_bytes!(a!());
+    env!(env_name!());
+    option_env!(env_name!());
+}

--- a/tests/ui/macros/expand-full-no-resolution.rs
+++ b/tests/ui/macros/expand-full-no-resolution.rs
@@ -1,0 +1,20 @@
+//@edition: 2018
+
+// https://github.com/rust-lang/rust/issues/98291
+
+macro_rules! wrap {
+    () => {
+        macro_rules! _a {
+            () => {
+                ""
+            };
+        }
+    };
+}
+
+wrap!();
+
+fn main() {
+    format_args!(a!()); //~ ERROR: cannot find macro `a` in this scope
+    env!(a!()); //~ ERROR: cannot find macro `a` in this scope
+}

--- a/tests/ui/macros/expand-full-no-resolution.stderr
+++ b/tests/ui/macros/expand-full-no-resolution.stderr
@@ -1,0 +1,30 @@
+error: cannot find macro `a` in this scope
+  --> $DIR/expand-full-no-resolution.rs:18:18
+   |
+LL |         macro_rules! _a {
+   |         --------------- similarly named macro `_a` defined here
+...
+LL |     format_args!(a!());
+   |                  ^
+   |
+help: a macro with a similar name exists, consider renaming `_a` into `a`
+   |
+LL |         macro_rules! a {
+   |                      ~
+
+error: cannot find macro `a` in this scope
+  --> $DIR/expand-full-no-resolution.rs:19:10
+   |
+LL |         macro_rules! _a {
+   |         --------------- similarly named macro `_a` defined here
+...
+LL |     env!(a!());
+   |          ^
+   |
+help: a macro with a similar name exists, consider renaming `_a` into `a`
+   |
+LL |         macro_rules! a {
+   |                      ~
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Related #98291

I will attempt to clarify the root problem through several examples:

Firstly, 

```rs
// rustc code.rs --edition=2018

macro_rules! wrap {
    () => {
        macro_rules! _a {
            () => {
                "Hello world"
            };
        }
    };
}

wrap!();

use _a as a;

fn main() {
    format_args!(_a!());
}
```

The above case will compile successfully because `_a` is defined after the `wrap` expaned, ensuring `_a` can be resolved without any issues.

And,

```rs
// rustc code.rs --edition=2018

macro_rules! wrap {
    () => {
        macro_rules! _a {
            () => {
                "Hello world"
            };
        }
    };
}

wrap!();

use _a as a;

fn main() {
    format_args!("{}", a!());
}
```

The above example will also compile successfully because the `parse_args` in `expand_format_args_impl` will return a value `MacroInput { fmtstr: Expr::Lit::Str, args: [Expr::MacroCall]}`. Since the graph for `args` will be build lately, `a` will eventually be resolved.

However, in the case of:

```rs
// rustc code.rs --edition=2018

macro_rules! wrap {
    () => {
        macro_rules! _a {
            () => {
                "Hello world"
            };
        }
    };
}

wrap!();

use _a as a;

fn main() {
    format_args!(a!());
}
```

The result of `parse_args` is `MacroInput {fmtstr: Expr::Lit::Macro, args: [] }`, we attempt to expand `fmtstr` **eagerly** within `expr_to_spanned_string`. Although we have recorded `(root, _a)` into resolutions, `use _a as a` is an indeterminate import, which will not try to resolve under the conditions of `expander.monotonic = false`.

Therefore, I've altered the strategy for resolving indeterminate imports, ensuring it will also resolve during eager expansion. This could be a significant change to the resolution infra. However, I think it's acceptable if the goal of avoiding resolution under eager expansion is to save time.

r? @petrochenkov 

