### PR TITLE
Correctly handle if rustdoc JS script hash changed

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -185,9 +185,12 @@ function preLoadCss(cssUrl) {
 (function() {
     const isHelpPage = window.location.pathname.endsWith("/help.html");
 
-    function loadScript(url) {
+    function loadScript(url, errorCallback) {
         const script = document.createElement("script");
         script.src = url;
+        if (errorCallback !== undefined) {
+            script.onerror = errorCallback;
+        }
         document.head.append(script);
     }
 
@@ -292,11 +295,16 @@ function preLoadCss(cssUrl) {
                 return;
             }
             let searchLoaded = false;
+            // If you're browsing the nightly docs, the page might need to be refreshed for the
+            // search to work because the hash of the JS scripts might have changed.
+            function sendSearchForm() {
+                document.getElementsByClassName("search-form")[0].submit();
+            }
             function loadSearch() {
                 if (!searchLoaded) {
                     searchLoaded = true;
-                    loadScript(getVar("static-root-path") + getVar("search-js"));
-                    loadScript(resourcePath("search-index", ".js"));
+                    loadScript(getVar("static-root-path") + getVar("search-js"), sendSearchForm);
+                    loadScript(resourcePath("search-index", ".js"), sendSearchForm);
                 }
             }
 


### PR DESCRIPTION
It's something that annoyed me for quite some time: I have nightly docs open (for both std and compiler). And often, I don't look at the page for some days. Then when I come back to it, I make a search... except nothing happens. Took me a while to figure out that it was because the hash of one of the JS files we load for the search (either `search.js` or `search-index.js`) was updated in the meantime, preventing the search to be done. To go around it, I added to press `ENTER` to make the form submitted (which would reload the same page but with the correct hashes this time and the search being run).

r? @notriddle 