### PR TITLE
rename 'try' intrinsic to 'catch_unwind'

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -23,7 +23,7 @@ use rustc_middle::ty::layout::{HasParamEnv, ValidityRequirement};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::GenericArgsRef;
 use rustc_span::source_map::Spanned;
-use rustc_span::symbol::{kw, sym, Symbol};
+use rustc_span::symbol::{sym, Symbol};
 
 pub(crate) use self::llvm::codegen_llvm_intrinsic_call;
 use crate::prelude::*;
@@ -1132,7 +1132,7 @@ fn codegen_regular_intrinsic_call<'tcx>(
             ret.write_cvalue(fx, val);
         }
 
-        kw::Try => {
+        sym::catch_unwind => {
             intrinsic_args!(fx, args => (f, data, catch_fn); intrinsic);
             let f = f.load_scalar(fx);
             let data = data.load_scalar(fx);

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -21,7 +21,7 @@ use rustc_middle::ty::{self, Instance, Ty};
 use rustc_middle::ty::layout::LayoutOf;
 #[cfg(feature="master")]
 use rustc_middle::ty::layout::{FnAbiOf, HasTyCtxt};
-use rustc_span::{Span, Symbol, symbol::kw, sym};
+use rustc_span::{Span, Symbol, sym};
 use rustc_target::abi::HasDataLayout;
 use rustc_target::abi::call::{ArgAbi, FnAbi, PassMode};
 use rustc_target::spec::PanicStrategy;
@@ -129,7 +129,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                     let res = self.context.new_call(None, builtin, &[a]);
                     self.icmp(IntPredicate::IntEQ, res, self.const_i32(0))
                 }
-                kw::Try => {
+                sym::catch_unwind => {
                     try_intrinsic(
                         self,
                         args[0].immediate(),

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -17,7 +17,7 @@ use rustc_hir as hir;
 use rustc_middle::ty::layout::{FnAbiOf, HasTyCtxt, LayoutOf};
 use rustc_middle::ty::{self, GenericArgsRef, Ty};
 use rustc_middle::{bug, span_bug};
-use rustc_span::{sym, symbol::kw, Span, Symbol};
+use rustc_span::{sym, Span, Symbol};
 use rustc_target::abi::{self, Align, HasDataLayout, Primitive};
 use rustc_target::spec::{HasTargetSpec, PanicStrategy};
 
@@ -133,8 +133,8 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
             }
             sym::unlikely => self
                 .call_intrinsic("llvm.expect.i1", &[args[0].immediate(), self.const_bool(false)]),
-            kw::Try => {
-                try_intrinsic(
+            sym::catch_unwind => {
+                catch_unwind_intrinsic(
                     self,
                     args[0].immediate(),
                     args[1].immediate(),
@@ -457,7 +457,7 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
     }
 }
 
-fn try_intrinsic<'ll>(
+fn catch_unwind_intrinsic<'ll>(
     bx: &mut Builder<'_, 'll, '_>,
     try_func: &'ll Value,
     data: &'ll Value,

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -12,7 +12,7 @@ use rustc_hir as hir;
 use rustc_middle::traits::{ObligationCause, ObligationCauseCode};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::def_id::LocalDefId;
-use rustc_span::symbol::{kw, sym};
+use rustc_span::symbol::sym;
 use rustc_span::{Span, Symbol};
 use rustc_target::spec::abi::Abi;
 
@@ -445,7 +445,7 @@ pub fn check_intrinsic_type(
                 )
             }
 
-            kw::Try => {
+            sym::catch_unwind => {
                 let mut_u8 = Ty::new_mut_ptr(tcx, tcx.types.u8);
                 let try_fn_ty = ty::Binder::dummy(tcx.mk_fn_sig(
                     [mut_u8],

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -487,6 +487,7 @@ symbols! {
         call_once,
         caller_location,
         capture_disjoint_fields,
+        catch_unwind,
         cause,
         cdylib,
         ceilf32,

--- a/library/panic_unwind/src/miri.rs
+++ b/library/panic_unwind/src/miri.rs
@@ -8,14 +8,14 @@ type Payload = Box<Box<dyn Any + Send>>;
 
 extern "Rust" {
     /// Miri-provided extern function to begin unwinding.
-    fn miri_start_panic(payload: *mut u8) -> !;
+    fn miri_start_unwind(payload: *mut u8) -> !;
 }
 
 pub unsafe fn panic(payload: Box<dyn Any + Send>) -> u32 {
-    // The payload we pass to `miri_start_panic` will be exactly the argument we get
+    // The payload we pass to `miri_start_unwind` will be exactly the argument we get
     // in `cleanup` below. So we just box it up once, to get something pointer-sized.
     let payload_box: Payload = Box::new(payload);
-    miri_start_panic(Box::into_raw(payload_box) as *mut u8)
+    miri_start_unwind(Box::into_raw(payload_box) as *mut u8)
 }
 
 pub unsafe fn cleanup(payload_box: *mut u8) -> Box<dyn Any + Send> {

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -508,12 +508,12 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     // Access to the union's fields: this is `std` and we know that the `r#try`
     // intrinsic fills in the `r` or `p` union field based on its return value.
     //
-    // The call to `intrinsics::r#try` is made safe by:
+    // The call to `intrinsics::catch_unwind` is made safe by:
     // - `do_call`, the first argument, can be called with the initial `data_ptr`.
     // - `do_catch`, the second argument, can be called with the `data_ptr` as well.
     // See their safety preconditions for more information
     unsafe {
-        return if intrinsics::r#try(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
+        return if intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
             Ok(ManuallyDrop::into_inner(data.r))
         } else {
             Err(ManuallyDrop::into_inner(data.p))
@@ -540,7 +540,7 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     // Its must contains a valid `f` (type: F) value that can be use to fill
     // `data.r`.
     //
-    // This function cannot be marked as `unsafe` because `intrinsics::r#try`
+    // This function cannot be marked as `unsafe` because `intrinsics::catch_unwind`
     // expects normal function pointers.
     #[inline]
     fn do_call<F: FnOnce() -> R, R>(data: *mut u8) {
@@ -562,7 +562,7 @@ pub unsafe fn r#try<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>>
     // Since this uses `cleanup` it also hinges on a correct implementation of
     // `__rustc_panic_cleanup`.
     //
-    // This function cannot be marked as `unsafe` because `intrinsics::r#try`
+    // This function cannot be marked as `unsafe` because `intrinsics::catch_unwind`
     // expects normal function pointers.
     #[inline]
     #[rustc_nounwind] // `intrinsic::r#try` requires catch fn to be nounwind

--- a/src/tools/miri/src/concurrency/thread.rs
+++ b/src/tools/miri/src/concurrency/thread.rs
@@ -143,7 +143,7 @@ pub struct Thread<'mir, 'tcx> {
     join_status: ThreadJoinStatus,
 
     /// Stack of active panic payloads for the current thread. Used for storing
-    /// the argument of the call to `miri_start_panic` (the panic payload) when unwinding.
+    /// the argument of the call to `miri_start_unwind` (the panic payload) when unwinding.
     /// This is pointer-sized, and matches the `Payload` type in `src/libpanic_unwind/miri.rs`.
     ///
     /// In real unwinding, the payload gets passed as an argument to the landing pad,

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -68,9 +68,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         let ret = match ret {
             None =>
                 match link_name.as_str() {
-                    "miri_start_panic" => {
-                        // `check_shim` happens inside `handle_miri_start_panic`.
-                        this.handle_miri_start_panic(abi, link_name, args, unwind)?;
+                    "miri_start_unwind" => {
+                        // `check_shim` happens inside `handle_miri_start_unwind`.
+                        this.handle_miri_start_unwind(abi, link_name, args, unwind)?;
                         return Ok(None);
                     }
                     // This matches calls to the foreign item `panic_impl`.

--- a/src/tools/miri/src/shims/intrinsics/mod.rs
+++ b/src/tools/miri/src/shims/intrinsics/mod.rs
@@ -54,7 +54,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
 
         // Some intrinsics are special and need the "ret".
         match intrinsic_name {
-            "try" => return this.handle_try(args, dest, ret),
+            "catch_unwind" => return this.handle_catch_unwind(args, dest, ret),
             _ => {}
         }
 

--- a/src/tools/miri/src/shims/panic.rs
+++ b/src/tools/miri/src/shims/panic.rs
@@ -3,9 +3,9 @@
 //! The core pieces of the runtime are:
 //! - An implementation of `__rust_maybe_catch_panic` that pushes the invoked stack frame with
 //!   some extra metadata derived from the panic-catching arguments of `__rust_maybe_catch_panic`.
-//! - A hack in `libpanic_unwind` that calls the `miri_start_panic` intrinsic instead of the
+//! - A hack in `libpanic_unwind` that calls the `miri_start_unwind` intrinsic instead of the
 //!   target-native panic runtime. (This lives in the rustc repo.)
-//! - An implementation of `miri_start_panic` that stores its argument (the panic payload), and then
+//! - An implementation of `miri_start_unwind` that stores its argument (the panic payload), and then
 //!   immediately returns, but on the *unwind* edge (not the normal return edge), thus initiating unwinding.
 //! - A hook executed each time a frame is popped, such that if the frame pushed by `__rust_maybe_catch_panic`
 //!   gets popped *during unwinding*, we take the panic payload and store it according to the extra
@@ -44,9 +44,9 @@ impl VisitProvenance for CatchUnwindData<'_> {
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriInterpCx<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
-    /// Handles the special `miri_start_panic` intrinsic, which is called
+    /// Handles the special `miri_start_unwind` intrinsic, which is called
     /// by libpanic_unwind to delegate the actual unwinding process to Miri.
-    fn handle_miri_start_panic(
+    fn handle_miri_start_unwind(
         &mut self,
         abi: Abi,
         link_name: Symbol,
@@ -55,7 +55,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        trace!("miri_start_panic: {:?}", this.frame().instance);
+        trace!("miri_start_unwind: {:?}", this.frame().instance);
 
         // Get the raw pointer stored in arg[0] (the panic payload).
         let [payload] = this.check_shim(abi, Abi::Rust, link_name, args)?;
@@ -85,7 +85,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         // what that is), and returns 1.
         // The `payload` is passed (by libstd) to `__rust_panic_cleanup`, which is then expected to
         // return a `Box<dyn Any + Send + 'static>`.
-        // In Miri, `miri_start_panic` is passed exactly that type, so we make the `payload` simply
+        // In Miri, `miri_start_unwind` is passed exactly that type, so we make the `payload` simply
         // a pointer to `Box<dyn Any + Send + 'static>`.
 
         // Get all the arguments.
@@ -141,7 +141,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             // We set the return value of `try` to 1, since there was a panic.
             this.write_scalar(Scalar::from_i32(1), &catch_unwind.dest)?;
 
-            // The Thread's `panic_payload` holds what was passed to `miri_start_panic`.
+            // The Thread's `panic_payload` holds what was passed to `miri_start_unwind`.
             // This is exactly the second argument we need to pass to `catch_fn`.
             let payload = this.active_thread_mut().panic_payloads.pop().unwrap();
 

--- a/src/tools/miri/src/shims/panic.rs
+++ b/src/tools/miri/src/shims/panic.rs
@@ -69,7 +69,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     }
 
     /// Handles the `try` intrinsic, the underlying implementation of `std::panicking::try`.
-    fn handle_try(
+    fn handle_catch_unwind(
         &mut self,
         args: &[OpTy<'tcx, Provenance>],
         dest: &PlaceTy<'tcx, Provenance>,

--- a/src/tools/miri/tests/fail/function_calls/check_callback_abi.rs
+++ b/src/tools/miri/tests/fail/function_calls/check_callback_abi.rs
@@ -8,7 +8,7 @@ fn main() {
     unsafe {
         // Make sure we check the ABI when Miri itself invokes a function
         // as part of a shim implementation.
-        std::intrinsics::r#try(
+        std::intrinsics::catch_unwind(
             //~^ ERROR: calling a function with ABI C using caller ABI Rust
             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
             std::ptr::null_mut(),

--- a/src/tools/miri/tests/fail/function_calls/check_callback_abi.stderr
+++ b/src/tools/miri/tests/fail/function_calls/check_callback_abi.stderr
@@ -1,7 +1,7 @@
 error: Undefined Behavior: calling a function with ABI C using caller ABI Rust
   --> $DIR/check_callback_abi.rs:LL:CC
    |
-LL | /         std::intrinsics::r#try(
+LL | /         std::intrinsics::catch_unwind(
 LL | |
 LL | |             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
 LL | |             std::ptr::null_mut(),

--- a/src/tools/miri/tests/fail/panic/bad_miri_start_unwind.rs
+++ b/src/tools/miri/tests/fail/panic/bad_miri_start_unwind.rs
@@ -3,10 +3,10 @@
 #![feature(c_unwind)]
 
 extern "C" {
-    fn miri_start_panic(payload: *mut u8) -> !;
+    fn miri_start_unwind(payload: *mut u8) -> !;
 }
 
 fn main() {
-    unsafe { miri_start_panic(&mut 0) }
+    unsafe { miri_start_unwind(&mut 0) }
     //~^ ERROR: unwinding past a stack frame that does not allow unwinding
 }

--- a/src/tools/miri/tests/fail/panic/bad_miri_start_unwind.stderr
+++ b/src/tools/miri/tests/fail/panic/bad_miri_start_unwind.stderr
@@ -1,15 +1,15 @@
 WARNING: the flag `-Zmiri-disable-abi-check` is deprecated and planned to be removed.
 If you have a use-case for it, please file an issue.
 error: Undefined Behavior: unwinding past a stack frame that does not allow unwinding
-  --> $DIR/bad_miri_start_panic.rs:LL:CC
+  --> $DIR/bad_miri_start_unwind.rs:LL:CC
    |
-LL |     unsafe { miri_start_panic(&mut 0) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ unwinding past a stack frame that does not allow unwinding
+LL |     unsafe { miri_start_unwind(&mut 0) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ unwinding past a stack frame that does not allow unwinding
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
-   = note: inside `main` at $DIR/bad_miri_start_panic.rs:LL:CC
+   = note: inside `main` at $DIR/bad_miri_start_unwind.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/panic/unwind_panic_abort.rs
+++ b/src/tools/miri/tests/fail/panic/unwind_panic_abort.rs
@@ -3,11 +3,11 @@
 //! Unwinding despite `-C panic=abort` is an error.
 
 extern "Rust" {
-    fn miri_start_panic(payload: *mut u8) -> !;
+    fn miri_start_unwind(payload: *mut u8) -> !;
 }
 
 fn main() {
     unsafe {
-        miri_start_panic(&mut 0); //~ ERROR: unwinding past a stack frame that does not allow unwinding
+        miri_start_unwind(&mut 0); //~ ERROR: unwinding past a stack frame that does not allow unwinding
     }
 }

--- a/src/tools/miri/tests/fail/panic/unwind_panic_abort.stderr
+++ b/src/tools/miri/tests/fail/panic/unwind_panic_abort.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: unwinding past a stack frame that does not allow unwinding
   --> $DIR/unwind_panic_abort.rs:LL:CC
    |
-LL |         miri_start_panic(&mut 0);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ unwinding past a stack frame that does not allow unwinding
+LL |         miri_start_unwind(&mut 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ unwinding past a stack frame that does not allow unwinding
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/pass/function_calls/disable_abi_check.rs
+++ b/src/tools/miri/tests/pass/function_calls/disable_abi_check.rs
@@ -15,7 +15,7 @@ fn main() {
     unsafe {
         let _ = malloc(0);
         std::mem::transmute::<fn(), extern "C" fn()>(foo)();
-        std::intrinsics::r#try(
+        std::intrinsics::catch_unwind(
             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
             std::ptr::null_mut(),
             |_, _| unreachable!(),

--- a/src/tools/miri/tests/utils/miri_extern.rs
+++ b/src/tools/miri/tests/utils/miri_extern.rs
@@ -56,7 +56,7 @@ extern "Rust" {
     ///
     /// This is internal and unstable and should not be used; we give it here
     /// just to be complete.
-    pub fn miri_start_panic(payload: *mut u8) -> !;
+    pub fn miri_start_unwind(payload: *mut u8) -> !;
 
     /// Miri-provided extern function to get the internal unique identifier for the allocation that a pointer
     /// points to. If this pointer is invalid (not pointing to an allocation), interpretation will abort.

--- a/tests/assembly/wasm_exceptions.rs
+++ b/tests/assembly/wasm_exceptions.rs
@@ -41,7 +41,7 @@ pub fn test_cleanup() {
 #[no_mangle]
 pub fn test_rtry() {
     unsafe {
-        core::intrinsics::r#try(|_| {
+        core::intrinsics::catch_unwind(|_| {
             may_panic();
         }, core::ptr::null_mut(), |data, exception| {
             log_number(data as usize);

--- a/tests/codegen/wasm_exceptions.rs
+++ b/tests/codegen/wasm_exceptions.rs
@@ -35,7 +35,7 @@ pub fn test_cleanup() {
 #[no_mangle]
 pub fn test_rtry() {
     unsafe {
-        core::intrinsics::r#try(|_| {
+        core::intrinsics::catch_unwind(|_| {
             may_panic();
         }, core::ptr::null_mut(), |data, exception| {
             log_number(data as usize);

--- a/tests/run-make/wasm-exceptions-nostd/src/lib.rs
+++ b/tests/run-make/wasm-exceptions-nostd/src/lib.rs
@@ -39,7 +39,7 @@ pub extern "C" fn start() -> usize {
     let data = 0x1234usize as *mut u8; // Something to recognize
 
     unsafe {
-        core::intrinsics::r#try(|data: *mut u8| {
+        core::intrinsics::catch_unwind(|data: *mut u8| {
             let _log_on_drop = LogOnDrop;
 
             logging::log_str(&alloc::format!("`r#try` called with ptr {:?}", data));

--- a/tests/ui/interior-mutability/interior-mutability.stderr
+++ b/tests/ui/interior-mutability/interior-mutability.stderr
@@ -15,7 +15,7 @@ note: required because it's used within this closure
    |
 LL |     catch_unwind(|| { x.set(23); });
    |                  ^^
-note: required by a bound in `catch_unwind`
+note: required by a bound in `std::panic::catch_unwind`
   --> $SRC_DIR/std/src/panic.rs:LL:COL
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
The intrinsic has nothing to do with `try` blocks, and corresponds to the stable `catch_unwind` function, so this makes a lot more sense IMO.

Also rename Miri's special function while we are at it, to reflect the level of abstraction it works on: it's an unwinding mechanism, on which Rust implements panics.