### PR TITLE
Move `emit_stashed_diagnostic` call in rustfmt.

### DIFF
--- a/src/tools/rustfmt/src/parse/session.rs
+++ b/src/tools/rustfmt/src/parse/session.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::sync::{IntoDynSyncSend, Lrc};
 use rustc_errors::emitter::{DynEmitter, Emitter, HumanEmitter};
 use rustc_errors::translation::Translate;
 use rustc_errors::{
-    ColorConfig, DiagCtxt, Diagnostic, DiagnosticBuilder, Level as DiagnosticLevel,
+    ColorConfig, DiagCtxt, Diagnostic, DiagnosticBuilder, ErrorGuaranteed, Level as DiagnosticLevel,
 };
 use rustc_session::parse::ParseSess as RawParseSess;
 use rustc_span::{
@@ -228,6 +228,10 @@ impl ParseSess {
 
     pub(crate) fn ignore_file(&self, path: &FileName) -> bool {
         self.ignore_path_set.as_ref().is_match(path)
+    }
+
+    pub(crate) fn emit_stashed_diagnostics(&mut self) -> Option<ErrorGuaranteed> {
+        self.parse_sess.dcx.emit_stashed_diagnostics()
     }
 
     pub(crate) fn set_silent_emitter(&mut self) {

--- a/src/tools/rustfmt/src/test/parser.rs
+++ b/src/tools/rustfmt/src/test/parser.rs
@@ -62,3 +62,10 @@ fn crate_parsing_stashed_diag() {
     let filename = "tests/parser/stashed-diag.rs";
     assert_parser_error(filename);
 }
+
+#[test]
+fn crate_parsing_stashed_diag2() {
+    // See also https://github.com/rust-lang/rust/issues/121517
+    let filename = "tests/parser/stashed-diag2.rs";
+    assert_parser_error(filename);
+}

--- a/src/tools/rustfmt/tests/parser/stashed-diag2.rs
+++ b/src/tools/rustfmt/tests/parser/stashed-diag2.rs
@@ -1,0 +1,3 @@
+trait Trait<'1> { s> {}
+
+fn main() {}


### PR DESCRIPTION
This call was added to `parse_crate_mod` in #121487, to fix a case where a stashed diagnostic wasn't emitted. But there is another path where a stashed diagnostic might fail to be emitted if there's a parse error, if the `build` call in `parse_crate_inner` fails before `parse_crate_mod` is reached.

So this commit moves the `emit_stashed_diagnostic` call outwards, from `parse_crate_mod` to `format_project`, just after the `Parser::parse_crate` call. This should be far out enough to catch any parsing errors.

Fixes #121517.

r? @oli-obk
cc @ytmimi 