### PR TITLE
Disables frame pointers for sgx target

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1918,7 +1918,7 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Wrustc::internal");
         }
 
-        if self.config.rust_frame_pointers {
+        if self.config.rust_frame_pointers && target != "x86_64-fortanix-unknown-sgx" {
             rustflags.arg("-Cforce-frame-pointers=true");
         }
 


### PR DESCRIPTION
Fixes an sgx-related test failure intorduced by PR https://github.com/rust-lang/rust/pull/121203`. The frame pointer feature from the PR in question adds unexpected assembly instructions for a function `unw_getcontext` which is checked in test `rust/tests/run-make/x86_64-fortanix-unknown-sgx-lvi` .

The test failure looks like this:
```
rust/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/unw_getcontext.checks:2:8: error: CHECK: expected string not found in input
CHECK: lfence
       ^
rust/build/x86_64-unknown-linux-gnu/test/run-make/x86_64-fortanix-unknown-sgx-lvi/x86_64-fortanix-unknown-sgx-lvi/tmp.D32LVJN8Jw:6:33: note: scanning from here
0000000000030781 <unw_getcontext>:
                                ^
rust/build/x86_64-unknown-linux-gnu/test/run-make/x86_64-fortanix-unknown-sgx-lvi/x86_64-fortanix-unknown-sgx-lvi/tmp.D32LVJN8Jw:7:19: note: possible intended match here
 30781: f3 0f 1e fa endbr64
                  ^

Input file: rust/build/x86_64-unknown-linux-gnu/test/run-make/x86_64-fortanix-unknown-sgx-lvi/x86_64-fortanix-unknown-sgx-lvi/tmp.D32LVJN8Jw
Check file: rust/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/unw_getcontext.checks

-dump-input=help explains the following input dump.

Input was:
<<<<<<
           1:  
           2: rust/build/x86_64-unknown-linux-gnu/test/run-make/x86_64-fortanix-unknown-sgx-lvi/x86_64-fortanix-unknown-sgx-lvi/enclave/target/x86_64-fortanix-unknown-sgx/debug/enclave: file format elf64-x86-64 
           3:  
           4: Disassembly of section .text: 
           5:  
           6: 0000000000030781 <unw_getcontext>: 
check:2'0                                     X~~ error: no match found
           7:  30781: f3 0f 1e fa endbr64 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check:2'1                       ?          possible intended match
           8:  30785: 48 89 07 movq %rax, (%rdi) 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           9:  30788: 48 89 5f 08 movq %rbx, 0x8(%rdi) 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          10:  3078c: 48 89 4f 10 movq %rcx, 0x10(%rdi) 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          11:  30790: 48 89 57 18 movq %rdx, 0x18(%rdi) 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          12:  30794: 48 89 7f 20 movq %rdi, 0x20(%rdi) 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


failures:
    [run-make] tests/run-make/x86_64-fortanix-unknown-sgx-lvi
```

Command used to build the compiler and run the tests looks like this
```
export AR_x86_64_fortanix_unknown_sgx=ar
export CC_x86_64_fortanix_unknown_sgx=clang-11
export CFLAGS_x86_64_fortanix_unknown_sgx="-D__ELF__ -isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
export CXX_x86_64_fortanix_unknown_sgx=clang++-11
export CXXFLAGS_x86_64_fortanix_unknown_sgx="-D__ELF__ -isystem/usr/include/x86_64-linux-gnu -mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening"
export CC_x86_64_unknown_linux_gnu=clang-11
export CXX_x86_64_unknown_linux_gnu=clang++-11
git submodule foreach --recursive git reset --hard
git submodule update --init --recursive
git submodule foreach --recursive git fetch --depth=2147483647 origin '+refs/heads/*:refs/remotes/origin/*'
rm -f config.toml
./configure --enable-lld --disable-rpath --set llvm.ninja=false --set rust.verbose-tests=true --set profile=compiler
TF_BUILD=True RUST_TEST_THREADS=1 ./x.py test --stage 1 "library/std" tests/assembly tests/run-make --target=x86_64-fortanix-unknown-sgx --no-doc --exclude src/tools/linkchecker --exclude src/tools/rust-demangler --no-fail-fast
```
Test is fixed by not setting the compiler flag `-Cforce-frame-pointers=true` if the host target is `x86_64-fortanix-unknown-sgx` 
