### PR TITLE
Update a test to support Symbol Mangling V0

### DIFF
--- a/tests/codegen/debuginfo-inline-callsite-location.rs
+++ b/tests/codegen/debuginfo-inline-callsite-location.rs
@@ -4,9 +4,9 @@
 // can correctly merge the debug info if it merges the inlined code (e.g., for merging of tail
 // calls to panic.
 
-// CHECK:       tail call void @_ZN4core6option13unwrap_failed17h{{([0-9a-z]{16})}}E
+// CHECK:       tail call void @{{[A-Za-z0-9_]+4core6option13unwrap_failed}}
 // CHECK-SAME:  !dbg ![[#first_dbg:]]
-// CHECK:       tail call void @_ZN4core6option13unwrap_failed17h{{([0-9a-z]{16})}}E
+// CHECK:       tail call void @{{[A-Za-z0-9_]+4core6option13unwrap_failed}}
 // CHECK-SAME:  !dbg ![[#second_dbg:]]
 
 // CHECK-DAG:   ![[#func_dbg:]] = distinct !DISubprogram(name: "unwrap<i32>"


### PR DESCRIPTION
Note that since this is a symbol from `std`, overriding the symbol mangling version via the `compile-flags` directive does not work.