### PR TITLE
Fix race between block initialization and receiver disconnection

### DIFF
--- a/library/std/src/sync/mpmc/list.rs
+++ b/library/std/src/sync/mpmc/list.rs
@@ -547,7 +547,7 @@ impl<T> Channel<T> {
         }
 
         let mut head = self.head.index.load(Ordering::Acquire);
-        let mut block = self.head.block.load(Ordering::Acquire);
+        let mut block = self.head.block.swap(ptr::null_mut(), Ordering::AcqRel);
 
         // If we're going to be dropping messages we need to synchronize with initialization
         if head >> SHIFT != tail >> SHIFT {
@@ -588,8 +588,8 @@ impl<T> Channel<T> {
                 drop(Box::from_raw(block));
             }
         }
+
         head &= !MARK_BIT;
-        self.head.block.store(ptr::null_mut(), Ordering::Release);
         self.head.index.store(head, Ordering::Release);
     }
 


### PR DESCRIPTION
Port of https://github.com/crossbeam-rs/crossbeam/pull/1084. Closes https://github.com/rust-lang/rust/issues/121582.