### PR TITLE
Fix link generation for foreign macro in jump to definition feature

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -575,7 +575,7 @@ fn generate_macro_def_id_path(
         ExternalLocation::Local => {
             // `root_path` always end with a `/`.
             format!(
-                "{root_path}{crate_name}/{path}",
+                "{root_path}{path}",
                 root_path = root_path.unwrap_or(""),
                 path = path.iter().map(|p| p.as_str()).join("/")
             )

--- a/tests/rustdoc/auxiliary/jump-to-def-macro.rs
+++ b/tests/rustdoc/auxiliary/jump-to-def-macro.rs
@@ -1,0 +1,6 @@
+#[macro_export]
+macro_rules! symbols {
+    ($name:ident = $value:expr) => {
+        pub const $name: isize = $value;
+    }
+}

--- a/tests/rustdoc/jump-to-def-macro.rs
+++ b/tests/rustdoc/jump-to-def-macro.rs
@@ -1,0 +1,15 @@
+//@ aux-build:jump-to-def-macro.rs
+//@ build-aux-docs
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+
+#![crate_name = "foo"]
+
+// @has 'src/foo/jump-to-def-macro.rs.html'
+
+#[macro_use]
+extern crate jump_to_def_macro;
+
+// @has - '//a[@href="../../jump_to_def_macro/macro.symbols.html"]' 'symbols!'
+symbols! {
+    A = 12
+}


### PR DESCRIPTION
The crate name is already added to the link so it shouldn't be added a second time for local foreign macros.

Part of https://github.com/rust-lang/rust/issues/89095.

r? @notriddle 