### PR TITLE
Fixing shellcheck comments on lvi test script

### DIFF
--- a/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh
+++ b/tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh
@@ -1,20 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 set -exuo pipefail
 
 function build {
     CRATE=enclave
 
-    mkdir -p $WORK_DIR
-    pushd $WORK_DIR
-        rm -rf $CRATE
-        cp -a $TEST_DIR/enclave .
+    mkdir -p "${WORK_DIR}"
+    pushd "${WORK_DIR}"
+        rm -rf "${CRATE}"
+        cp -a "${TEST_DIR}"/enclave .
         pushd $CRATE
-            echo ${WORK_DIR}
+            echo "${WORK_DIR}"
             # HACK(eddyb) sets `RUSTC_BOOTSTRAP=1` so Cargo can accept nightly features.
             # These come from the top-level Rust workspace, that this crate is not a
             # member of, but Cargo tries to load the workspace `Cargo.toml` anyway.
             env RUSTC_BOOTSTRAP=1
-                cargo -v run --target $TARGET
+                cargo -v run --target "${TARGET}"
         popd
     popd
 }
@@ -22,17 +22,18 @@ function build {
 function check {
     local func_re="$1"
     local checks="${TEST_DIR}/$2"
-    local asm=$(mktemp)
+    local asm=""
     local objdump="${LLVM_BIN_DIR}/llvm-objdump"
     local filecheck="${LLVM_BIN_DIR}/FileCheck"
     local enclave=${WORK_DIR}/enclave/target/x86_64-fortanix-unknown-sgx/debug/enclave
 
-    func="$(${objdump} --syms --demangle ${enclave} | \
+    asm=$(mktemp)
+    func="$(${objdump} --syms --demangle "${enclave}" | \
             grep --only-matching -E "[[:blank:]]+${func_re}\$" | \
             sed -e 's/^[[:space:]]*//' )"
     ${objdump} --disassemble-symbols="${func}" --demangle \
-      ${enclave} > ${asm}
-    ${filecheck} --input-file ${asm} ${checks}
+      "${enclave}" > "${asm}"
+    ${filecheck} --input-file "${asm}" "${checks}"
 
     if [ "${func_re}" != "rust_plus_one_global_asm" &&
          "${func_re}" != "cmake_plus_one_c_global_asm" ]; then
@@ -40,7 +41,7 @@ function check {
         # of `shlq $0x0, (%rsp); lfence; retq` are used instead.
         # https://www.intel.com/content/www/us/en/developer/articles/technical/
         #     software-security-guidance/technical-documentation/load-value-injection.html
-        ${filecheck} --implicit-check-not ret --input-file ${asm} ${checks}
+        ${filecheck} --implicit-check-not ret --input-file "${asm}" "${checks}"
     fi
 }
 


### PR DESCRIPTION
Running `shellcheck` on `tests/run-make/x86_64-fortanix-unknown-sgx-lvi/script.sh` gives plenty of warnings. This PR fixes those issues. For completeness: #121683 fixes another warning as well