### PR TITLE
Adjust printing for RPITITs

### DIFF
--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -420,7 +420,9 @@ impl DefPathData {
     pub fn name(&self) -> DefPathDataName {
         use self::DefPathData::*;
         match *self {
-            TypeNs(name) if name == kw::Empty => DefPathDataName::Anon { namespace: sym::opaque },
+            TypeNs(name) if name == kw::Empty => {
+                DefPathDataName::Anon { namespace: sym::synthetic }
+            }
             TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) => {
                 DefPathDataName::Named(name)
             }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1690,6 +1690,7 @@ symbols! {
         suggestion,
         sym,
         sync,
+        synthetic,
         t32,
         target,
         target_abi,

--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.rs
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.rs
@@ -5,7 +5,7 @@ trait T {}
 
 trait MyTrait {
     async fn foo() -> &'static impl T;
-    //~^ ERROR the associated type `<Self as MyTrait>::{opaque#0}` may not live long enough
+    //~^ ERROR the associated type `impl T` may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
@@ -1,10 +1,10 @@
-error[E0310]: the associated type `<Self as MyTrait>::{synthetic#0}` may not live long enough
+error[E0310]: the associated type `impl T` may not live long enough
   --> $DIR/async-and-ret-ref.rs:7:5
    |
 LL |     async fn foo() -> &'static impl T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
-   |     the associated type `<Self as MyTrait>::{synthetic#0}` must be valid for the static lifetime...
+   |     the associated type `impl T` must be valid for the static lifetime...
    |     ...so that the reference type `&'static impl T` does not outlive the data it points at
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
+++ b/tests/ui/impl-trait/in-trait/async-and-ret-ref.stderr
@@ -1,10 +1,10 @@
-error[E0310]: the associated type `<Self as MyTrait>::{opaque#0}` may not live long enough
+error[E0310]: the associated type `<Self as MyTrait>::{synthetic#0}` may not live long enough
   --> $DIR/async-and-ret-ref.rs:7:5
    |
 LL |     async fn foo() -> &'static impl T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |
-   |     the associated type `<Self as MyTrait>::{opaque#0}` must be valid for the static lifetime...
+   |     the associated type `<Self as MyTrait>::{synthetic#0}` must be valid for the static lifetime...
    |     ...so that the reference type `&'static impl T` does not outlive the data it points at
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/in-trait/doesnt-satisfy.stderr
+++ b/tests/ui/impl-trait/in-trait/doesnt-satisfy.stderr
@@ -6,11 +6,11 @@ LL |     fn bar() -> () {}
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-note: required by a bound in `Foo::{opaque#0}`
+note: required by a bound in `Foo::{synthetic#0}`
   --> $DIR/doesnt-satisfy.rs:2:22
    |
 LL |     fn bar() -> impl std::fmt::Display;
-   |                      ^^^^^^^^^^^^^^^^^ required by this bound in `Foo::{opaque#0}`
+   |                      ^^^^^^^^^^^^^^^^^ required by this bound in `Foo::{synthetic#0}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.rs
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.rs
@@ -9,7 +9,7 @@ trait Erased {
 impl<T: Original> Erased for T {
     fn f(&self) -> Box<dyn Fn()> {
         Box::new(<T as Original>::f())
-        //~^ ERROR the associated type `<T as Original>::{opaque#0}` may not live long enough
+        //~^ ERROR the associated type `impl Fn()` may not live long enough
     }
 }
 

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
@@ -1,10 +1,10 @@
-error[E0310]: the associated type `<T as Original>::{synthetic#0}` may not live long enough
+error[E0310]: the associated type `impl Fn()` may not live long enough
   --> $DIR/missing-static-bound-from-impl.rs:11:9
    |
 LL |         Box::new(<T as Original>::f())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         the associated type `<T as Original>::{synthetic#0}` must be valid for the static lifetime...
+   |         the associated type `impl Fn()` must be valid for the static lifetime...
    |         ...so that the type `impl Fn()` will meet its required lifetime bounds
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
+++ b/tests/ui/impl-trait/in-trait/missing-static-bound-from-impl.stderr
@@ -1,10 +1,10 @@
-error[E0310]: the associated type `<T as Original>::{opaque#0}` may not live long enough
+error[E0310]: the associated type `<T as Original>::{synthetic#0}` may not live long enough
   --> $DIR/missing-static-bound-from-impl.rs:11:9
    |
 LL |         Box::new(<T as Original>::f())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         the associated type `<T as Original>::{opaque#0}` must be valid for the static lifetime...
+   |         the associated type `<T as Original>::{synthetic#0}` must be valid for the static lifetime...
    |         ...so that the type `impl Fn()` will meet its required lifetime bounds
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -5,11 +5,11 @@ LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
    |                                  ^^^^^^^^^^^^ the trait `Foo<char>` is not implemented for `impl Foo<u8>`
    |
    = help: the trait `Foo<char>` is implemented for `Bar`
-note: required by a bound in `Foo::{opaque#0}`
+note: required by a bound in `Foo::{synthetic#0}`
   --> $DIR/return-dont-satisfy-bounds.rs:2:30
    |
 LL |     fn foo<F2>(self) -> impl Foo<T>;
-   |                              ^^^^^^ required by this bound in `Foo::{opaque#0}`
+   |                              ^^^^^^ required by this bound in `Foo::{synthetic#0}`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/return-dont-satisfy-bounds.rs:8:16

--- a/tests/ui/rfcs/rfc-1937-termination-trait/issue-103052-2.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/issue-103052-2.stderr
@@ -4,11 +4,11 @@ error[E0277]: the trait bound `Something: Termination` is not satisfied
 LL |         fn main() -> Something {
    |                      ^^^^^^^^^ the trait `Termination` is not implemented for `Something`
    |
-note: required by a bound in `Main::{opaque#0}`
+note: required by a bound in `Main::{synthetic#0}`
   --> $DIR/issue-103052-2.rs:5:27
    |
 LL |         fn main() -> impl std::process::Termination;
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Main::{opaque#0}`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Main::{synthetic#0}`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
1. Call RPITITs `{synthetic#N}` instead of `{opaque#N}`.
2. Fall back to printing the RPITIT like an opaque even when printed as an `AliasTy`, just like we do for `ty::Alias`.

You could argue that (2.) is misleading, but I believe it's more consistent than naming `{synthetic#N}`, which I assume approximately nobody knows where that def path name comes from.

r? lcnr