### PR TITLE
[rustdoc] Prevent inclusion of whitespace character after macro_rules ident

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -136,6 +136,7 @@ fn can_merge(class1: Option<Class>, class2: Option<Class>, text: &str) -> bool {
     match (class1, class2) {
         (Some(c1), Some(c2)) => c1.is_equal_to(c2),
         (Some(Class::Ident(_)), None) | (None, Some(Class::Ident(_))) => true,
+        (Some(Class::Macro(_)), _) => false,
         (Some(_), None) | (None, Some(_)) => text.trim().is_empty(),
         (None, None) => true,
     }

--- a/src/librustdoc/html/highlight/fixtures/sample.html
+++ b/src/librustdoc/html/highlight/fixtures/sample.html
@@ -32,7 +32,7 @@
     }
 }
 
-<span class="macro">macro_rules! </span>bar {
+<span class="macro">macro_rules!</span> bar {
     (<span class="macro-nonterminal">$foo</span>:tt) =&gt; {};
 }
 </code></pre>

--- a/tests/rustdoc/source-code-highlight.rs
+++ b/tests/rustdoc/source-code-highlight.rs
@@ -1,0 +1,29 @@
+// We need this option to be enabled for the `foo` macro declaration to ensure
+// that the link on the ident is not including whitespace characters.
+
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+#![crate_name = "foo"]
+
+// @has 'src/foo/source-code-highlight.rs.html'
+
+// @hasraw - '<a href="../../foo/macro.foo.html">foo</a>'
+#[macro_export]
+macro_rules! foo {
+    () => {}
+}
+
+// @hasraw - '<span class="macro">foo!</span>'
+foo! {}
+
+// @hasraw - '<a href="../../foo/fn.f.html">f</a>'
+#[rustfmt::skip]
+pub fn f () {}
+// @hasraw - '<a href="../../foo/struct.Bar.html">Bar</a>'
+// @hasraw - '<a href="../../foo/struct.Bar.html">Bar</a>'
+// @hasraw - '<a href="{{channel}}/std/primitive.u32.html">u32</a>'
+#[rustfmt::skip]
+pub struct Bar ( u32 );
+// @hasraw - '<a href="../../foo/enum.Foo.html">Foo</a>'
+pub enum Foo {
+    A,
+}


### PR DESCRIPTION
Discovered this bug randomly when looking at:

![image](https://github.com/rust-lang/rust/assets/3050060/dca38047-9085-4377-bfac-f98890224be4)

We were too eagerly trying to merge tokens that shouldn't be merged together (for example if you have a code comment followed by a code comment, we merge them in one attribute to reduce the DOM size).

r? @notriddle 