### PR TITLE
Process alias-relate obligations in CoerceUnsized loop

### DIFF
--- a/tests/ui/traits/next-solver/constrain-alias-goals-in-unsize.rs
+++ b/tests/ui/traits/next-solver/constrain-alias-goals-in-unsize.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+use std::mem::ManuallyDrop;
+
+trait Foo {}
+
+struct Guard<T> {
+    value: ManuallyDrop<T>,
+}
+
+impl<T: Foo> Guard<T> {
+    fn uwu(&self) {
+        let x: &dyn Foo = &*self.value;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
After #119106, we now emit `AliasRelate` goals when relating `?0` and `Alias<T, ..>` in the new solver. In the ad-hoc `CoerceUnsized` selection loop, we now may have `AliasRelate` goals which must be processed to constrain type variables which are mentioned in other goals.

---

For example, in the included test, we try to coerce `&<ManuallyDrop<T> as Deref>::Target` to `&dyn Foo`. This requires proving:
* 1 `&<ManuallyDrop<T> as Deref>::Target: CoerceUnsized<&dyn Foo>`
    * 2 `<ManuallyDrop<T> as Deref>::Target alias-relate ?0`
    * 3 `?0: Unsize<dyn Foo>`
        * 4 `?0: Foo`
        * 5 `?0: Sized`

If we don't process goal (2.) before processing goal (3.), then we hit ambiguity since `?0` is never constrained, and therefore we bail out, refusing to coerce the types. After processing (2.), we know `?0 := T`, and the rest of the goals can be processed normally.