### PR TITLE
[DONT MERGE] fix(libstd): switch to `-Zpublic-dependency` cargo flag

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["public-dependency"]
-
 [package]
 name = "std"
 version = "0.0.0"

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -71,7 +71,8 @@ macro_rules! clean_crate_tree {
                 // Since https://github.com/rust-lang/rust/pull/111076 enables
                 // unstable cargo feature (`public-dependency`), we need to ensure
                 // that unstable features are enabled before reading libstd Cargo.toml.
-                cargo.env("RUSTC_BOOTSTRAP", "1");
+                cargo.env("RUSTC_BOOTSTRAP", "1")
+                    .arg("-Zpublic-dependency");
 
                 for krate in &*self.crates {
                     cargo.arg("-p");

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1014,6 +1014,7 @@ impl Step for PlainSourceTarball {
                 // Will read the libstd Cargo.toml
                 // which uses the unstable `public-dependency` feature.
                 .env("RUSTC_BOOTSTRAP", "1")
+                .arg("-Zpublic-dependency")
                 .current_dir(plain_dst_src);
 
             let config = if !builder.config.dry_run() {

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2899,6 +2899,7 @@ impl Step for Distcheck {
                 // Will read the libstd Cargo.toml
                 // which uses the unstable `public-dependency` feature.
                 .env("RUSTC_BOOTSTRAP", "1")
+                .arg("-Zpublic-dependency")
                 .arg("generate-lockfile")
                 .arg("--manifest-path")
                 .arg(&toml)

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1799,6 +1799,9 @@ impl<'a> Builder<'a> {
 
         // Enable usage of unstable features
         cargo.env("RUSTC_BOOTSTRAP", "1");
+        // In addition, we enable Cargo's `-Zpublic-dependency` so that every
+        // build runs `exported-private-dependencies` and suppress unstable warnings.
+        cargo.arg("-Zpublic-dependency");
 
         if self.config.dump_bootstrap_shims {
             prepare_behaviour_dump_dir(self.build);

--- a/src/bootstrap/src/core/metadata.rs
+++ b/src/bootstrap/src/core/metadata.rs
@@ -76,6 +76,7 @@ fn workspace_members(build: &Build) -> impl Iterator<Item = Package> {
             // Will read the libstd Cargo.toml
             // which uses the unstable `public-dependency` feature.
             .env("RUSTC_BOOTSTRAP", "1")
+            .arg("-Zpublic-dependency")
             .arg("metadata")
             .arg("--format-version")
             .arg("1")


### PR DESCRIPTION
rust-lang/cargo#13340 switches the feature gate for public-dependency from `cargo-features` in Cargo.toml to CLI flag `-Zpublic-dependency`.

`cargo-features` will continue working for 1 to 2 release cycles as a transition period, to make sure that it doesn't break self-rebuilds.