### PR TITLE
Use `LitKind::Err` for malformed floats

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -501,9 +501,11 @@ impl<'sess, 'src> StringReader<'sess, 'src> {
                 (kind, self.symbol_from_to(start, end))
             }
             rustc_lexer::LiteralKind::Float { base, empty_exponent } => {
+                let mut kind = token::Float;
                 if empty_exponent {
                     let span = self.mk_sp(start, self.pos);
-                    self.dcx().emit_err(errors::EmptyExponentFloat { span });
+                    let guar = self.dcx().emit_err(errors::EmptyExponentFloat { span });
+                    kind = token::Err(guar);
                 }
                 let base = match base {
                     Base::Hexadecimal => Some("hexadecimal"),
@@ -515,7 +517,7 @@ impl<'sess, 'src> StringReader<'sess, 'src> {
                     let span = self.mk_sp(start, end);
                     self.dcx().emit_err(errors::FloatLiteralUnsupportedBase { span, base });
                 }
-                (token::Float, self.symbol_from_to(start, end))
+                (kind, self.symbol_from_to(start, end))
             }
         }
     }

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -515,7 +515,9 @@ impl<'sess, 'src> StringReader<'sess, 'src> {
                 };
                 if let Some(base) = base {
                     let span = self.mk_sp(start, end);
-                    self.dcx().emit_err(errors::FloatLiteralUnsupportedBase { span, base });
+                    let guar =
+                        self.dcx().emit_err(errors::FloatLiteralUnsupportedBase { span, base });
+                    kind = token::Err(guar)
                 }
                 (kind, self.symbol_from_to(start, end))
             }

--- a/src/tools/clippy/tests/ui/crashes/ice-10912.rs
+++ b/src/tools/clippy/tests/ui/crashes/ice-10912.rs
@@ -2,7 +2,5 @@
 //@no-rustfix
 fn f2() -> impl Sized { && 3.14159265358979323846E }
 //~^ ERROR: expected at least one digit in exponent
-//~| ERROR: long literal lacking separators
-//~| NOTE: `-D clippy::unreadable-literal` implied by `-D warnings`
 
 fn main() {}

--- a/src/tools/clippy/tests/ui/crashes/ice-10912.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-10912.stderr
@@ -4,14 +4,5 @@ error: expected at least one digit in exponent
 LL | fn f2() -> impl Sized { && 3.14159265358979323846E }
    |                            ^^^^^^^^^^^^^^^^^^^^^^^
 
-error: long literal lacking separators
-  --> tests/ui/crashes/ice-10912.rs:3:28
-   |
-LL | fn f2() -> impl Sized { && 3.14159265358979323846E }
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^ help: consider: `3.141_592_653_589_793_238_46`
-   |
-   = note: `-D clippy::unreadable-literal` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::unreadable_literal)]`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.rs
+++ b/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.rs
@@ -1,6 +1,5 @@
 const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
 //~^ ERROR expected at least one digit in exponent
 //~| ERROR unknown start of token: \u{2212}
-//~| ERROR cannot subtract `{integer}` from `{float}`
 
 fn main() {}

--- a/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -15,24 +15,5 @@ help: Unicode character '−' (Minus Sign) looks like '-' (Minus/Hyphen), but it
 LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e-11; // m³⋅kg⁻¹⋅s⁻²
    |                                                     ~
 
-error[E0277]: cannot subtract `{integer}` from `{float}`
-  --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:1:53
-   |
-LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
-   |                                                     ^ no implementation for `{float} - {integer}`
-   |
-   = help: the trait `Sub<{integer}>` is not implemented for `{float}`
-   = help: the following other types implement trait `Sub<Rhs>`:
-             <isize as Sub>
-             <isize as Sub<&isize>>
-             <i8 as Sub>
-             <i8 as Sub<&i8>>
-             <i16 as Sub>
-             <i16 as Sub<&i16>>
-             <i32 as Sub>
-             <i32 as Sub<&i32>>
-           and 48 others
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/parser/float-field.rs
+++ b/tests/ui/parser/float-field.rs
@@ -3,60 +3,89 @@ struct S(u8, (u8, u8));
 fn main() {
     let s = S(0, (0, 0));
 
-    s.1e1; //~ ERROR no field `1e1` on type `S`
-    s.1.; //~ ERROR unexpected token: `;`
-    s.1.1;
-    s.1.1e1; //~ ERROR no field `1e1` on type `(u8, u8)`
+    { s.1e1; } //~ ERROR no field `1e1` on type `S`
+
+    { s.1.; } //~ ERROR unexpected token: `;`
+
+    { s.1.1; }
+
+    { s.1.1e1; } //~ ERROR no field `1e1` on type `(u8, u8)`
+
     { s.1e+; } //~ ERROR unexpected token: `1e+`
                //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+`
                //~| ERROR expected at least one digit in exponent
+
     { s.1e-; } //~ ERROR unexpected token: `1e-`
                //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-`
                //~| ERROR expected at least one digit in exponent
+
     { s.1e+1; } //~ ERROR unexpected token: `1e+1`
                 //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+1`
+
     { s.1e-1; } //~ ERROR unexpected token: `1e-1`
                 //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-1`
+
     { s.1.1e+1; } //~ ERROR unexpected token: `1.1e+1`
                   //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e+1`
+
     { s.1.1e-1; } //~ ERROR unexpected token: `1.1e-1`
                   //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e-1`
-    s.0x1e1;  //~ ERROR no field `0x1e1` on type `S`
-    s.0x1.; //~ ERROR no field `0x1` on type `S`
-            //~| ERROR hexadecimal float literal is not supported
-            //~| ERROR unexpected token: `;`
-    s.0x1.1; //~ ERROR no field `0x1` on type `S`
-             //~| ERROR hexadecimal float literal is not supported
-    s.0x1.1e1; //~ ERROR no field `0x1` on type `S`
-               //~| ERROR hexadecimal float literal is not supported
+
+    { s.0x1e1; } //~ ERROR no field `0x1e1` on type `S`
+
+    { s.0x1.; } //~ ERROR no field `0x1` on type `S`
+                //~| ERROR hexadecimal float literal is not supported
+                //~| ERROR unexpected token: `;`
+
+    { s.0x1.1; } //~ ERROR no field `0x1` on type `S`
+                 //~| ERROR hexadecimal float literal is not supported
+
+    { s.0x1.1e1; } //~ ERROR no field `0x1` on type `S`
+                   //~| ERROR hexadecimal float literal is not supported
+
     { s.0x1e+; } //~ ERROR expected expression, found `;`
+
     { s.0x1e-; } //~ ERROR expected expression, found `;`
-    s.0x1e+1; //~ ERROR no field `0x1e` on type `S`
-    s.0x1e-1; //~ ERROR no field `0x1e` on type `S`
+
+    { s.0x1e+1; } //~ ERROR no field `0x1e` on type `S`
+
+    { s.0x1e-1; } //~ ERROR no field `0x1e` on type `S`
+
     { s.0x1.1e+1; } //~ ERROR unexpected token: `0x1.1e+1`
                     //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e+1`
                     //~| ERROR hexadecimal float literal is not supported
+
     { s.0x1.1e-1; } //~ ERROR unexpected token: `0x1.1e-1`
                     //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e-1`
                     //~| ERROR hexadecimal float literal is not supported
-    s.1e1f32; //~ ERROR no field `1e1` on type `S`
-              //~| ERROR suffixes on a tuple index are invalid
-    s.1.f32; //~ ERROR no field `f32` on type `(u8, u8)`
-    s.1.1f32; //~ ERROR suffixes on a tuple index are invalid
-    s.1.1e1f32; //~ ERROR no field `1e1` on type `(u8, u8)`
-                //~| ERROR suffixes on a tuple index are invalid
+
+    { s.1e1f32; } //~ ERROR no field `1e1` on type `S`
+                  //~| ERROR suffixes on a tuple index are invalid
+
+    { s.1.f32; } //~ ERROR no field `f32` on type `(u8, u8)`
+
+    { s.1.1f32; } //~ ERROR suffixes on a tuple index are invalid
+
+    { s.1.1e1f32; } //~ ERROR no field `1e1` on type `(u8, u8)`
+                    //~| ERROR suffixes on a tuple index are invalid
+
     { s.1e+f32; } //~ ERROR unexpected token: `1e+f32`
                   //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+f32`
                   //~| ERROR expected at least one digit in exponent
+
     { s.1e-f32; } //~ ERROR unexpected token: `1e-f32`
                   //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-f32`
                   //~| ERROR expected at least one digit in exponent
+
     { s.1e+1f32; } //~ ERROR unexpected token: `1e+1f32`
                    //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+1f32`
+
     { s.1e-1f32; } //~ ERROR unexpected token: `1e-1f32`
                    //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-1f32`
+
     { s.1.1e+1f32; } //~ ERROR unexpected token: `1.1e+1f32`
                     //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e+1f32`
+
     { s.1.1e-1f32; } //~ ERROR unexpected token: `1.1e-1f32`
                     //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e-1f32`
 }

--- a/tests/ui/parser/float-field.rs
+++ b/tests/ui/parser/float-field.rs
@@ -33,15 +33,17 @@ fn main() {
 
     { s.0x1e1; } //~ ERROR no field `0x1e1` on type `S`
 
-    { s.0x1.; } //~ ERROR no field `0x1` on type `S`
-                //~| ERROR hexadecimal float literal is not supported
-                //~| ERROR unexpected token: `;`
+    { s.0x1.; } //~ ERROR hexadecimal float literal is not supported
+                //~| ERROR unexpected token: `0x1.`
+                //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.`
 
-    { s.0x1.1; } //~ ERROR no field `0x1` on type `S`
-                 //~| ERROR hexadecimal float literal is not supported
+    { s.0x1.1; } //~ ERROR hexadecimal float literal is not supported
+                 //~| ERROR unexpected token: `0x1.1`
+                 //~| expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1`
 
-    { s.0x1.1e1; } //~ ERROR no field `0x1` on type `S`
-                   //~| ERROR hexadecimal float literal is not supported
+    { s.0x1.1e1; } //~ ERROR hexadecimal float literal is not supported
+                   //~| ERROR unexpected token: `0x1.1e1`
+                   //~| expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e1`
 
     { s.0x1e+; } //~ ERROR expected expression, found `;`
 

--- a/tests/ui/parser/float-field.stderr
+++ b/tests/ui/parser/float-field.stderr
@@ -1,348 +1,348 @@
 error: expected at least one digit in exponent
-  --> $DIR/float-field.rs:10:9
+  --> $DIR/float-field.rs:14:9
    |
 LL |     { s.1e+; }
    |         ^^^
 
 error: expected at least one digit in exponent
-  --> $DIR/float-field.rs:13:9
+  --> $DIR/float-field.rs:18:9
    |
 LL |     { s.1e-; }
    |         ^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:25:7
-   |
-LL |     s.0x1.;
-   |       ^^^^
-
-error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:28:7
-   |
-LL |     s.0x1.1;
-   |       ^^^^^
-
-error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:30:7
-   |
-LL |     s.0x1.1e1;
-   |       ^^^^^^^
-
-error: hexadecimal float literal is not supported
   --> $DIR/float-field.rs:36:9
+   |
+LL |     { s.0x1.; }
+   |         ^^^^
+
+error: hexadecimal float literal is not supported
+  --> $DIR/float-field.rs:40:9
+   |
+LL |     { s.0x1.1; }
+   |         ^^^^^
+
+error: hexadecimal float literal is not supported
+  --> $DIR/float-field.rs:43:9
+   |
+LL |     { s.0x1.1e1; }
+   |         ^^^^^^^
+
+error: hexadecimal float literal is not supported
+  --> $DIR/float-field.rs:54:9
    |
 LL |     { s.0x1.1e+1; }
    |         ^^^^^^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:39:9
+  --> $DIR/float-field.rs:58:9
    |
 LL |     { s.0x1.1e-1; }
    |         ^^^^^^^^
 
 error: expected at least one digit in exponent
-  --> $DIR/float-field.rs:48:9
+  --> $DIR/float-field.rs:72:9
    |
 LL |     { s.1e+f32; }
    |         ^^^^^^
 
 error: expected at least one digit in exponent
-  --> $DIR/float-field.rs:51:9
+  --> $DIR/float-field.rs:76:9
    |
 LL |     { s.1e-f32; }
    |         ^^^^^^
 
 error: unexpected token: `;`
-  --> $DIR/float-field.rs:7:9
+  --> $DIR/float-field.rs:8:11
    |
-LL |     s.1.;
-   |         ^
+LL |     { s.1.; }
+   |           ^
 
 error: unexpected token: `1e+`
-  --> $DIR/float-field.rs:10:9
+  --> $DIR/float-field.rs:14:9
    |
 LL |     { s.1e+; }
    |         ^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+`
-  --> $DIR/float-field.rs:10:9
+  --> $DIR/float-field.rs:14:9
    |
 LL |     { s.1e+; }
    |         ^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e-`
-  --> $DIR/float-field.rs:13:9
+  --> $DIR/float-field.rs:18:9
    |
 LL |     { s.1e-; }
    |         ^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-`
-  --> $DIR/float-field.rs:13:9
+  --> $DIR/float-field.rs:18:9
    |
 LL |     { s.1e-; }
    |         ^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e+1`
-  --> $DIR/float-field.rs:16:9
+  --> $DIR/float-field.rs:22:9
    |
 LL |     { s.1e+1; }
    |         ^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+1`
-  --> $DIR/float-field.rs:16:9
+  --> $DIR/float-field.rs:22:9
    |
 LL |     { s.1e+1; }
    |         ^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e-1`
-  --> $DIR/float-field.rs:18:9
+  --> $DIR/float-field.rs:25:9
    |
 LL |     { s.1e-1; }
    |         ^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-1`
-  --> $DIR/float-field.rs:18:9
+  --> $DIR/float-field.rs:25:9
    |
 LL |     { s.1e-1; }
    |         ^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1.1e+1`
-  --> $DIR/float-field.rs:20:9
+  --> $DIR/float-field.rs:28:9
    |
 LL |     { s.1.1e+1; }
    |         ^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e+1`
-  --> $DIR/float-field.rs:20:9
+  --> $DIR/float-field.rs:28:9
    |
 LL |     { s.1.1e+1; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1.1e-1`
-  --> $DIR/float-field.rs:22:9
+  --> $DIR/float-field.rs:31:9
    |
 LL |     { s.1.1e-1; }
    |         ^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e-1`
-  --> $DIR/float-field.rs:22:9
+  --> $DIR/float-field.rs:31:9
    |
 LL |     { s.1.1e-1; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `;`
-  --> $DIR/float-field.rs:25:11
+  --> $DIR/float-field.rs:36:13
    |
-LL |     s.0x1.;
-   |           ^
+LL |     { s.0x1.; }
+   |             ^
 
 error: expected expression, found `;`
-  --> $DIR/float-field.rs:32:14
+  --> $DIR/float-field.rs:46:14
    |
 LL |     { s.0x1e+; }
    |              ^ expected expression
 
 error: expected expression, found `;`
-  --> $DIR/float-field.rs:33:14
+  --> $DIR/float-field.rs:48:14
    |
 LL |     { s.0x1e-; }
    |              ^ expected expression
 
 error: unexpected token: `0x1.1e+1`
-  --> $DIR/float-field.rs:36:9
+  --> $DIR/float-field.rs:54:9
    |
 LL |     { s.0x1.1e+1; }
    |         ^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e+1`
-  --> $DIR/float-field.rs:36:9
+  --> $DIR/float-field.rs:54:9
    |
 LL |     { s.0x1.1e+1; }
    |         ^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `0x1.1e-1`
-  --> $DIR/float-field.rs:39:9
+  --> $DIR/float-field.rs:58:9
    |
 LL |     { s.0x1.1e-1; }
    |         ^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e-1`
-  --> $DIR/float-field.rs:39:9
+  --> $DIR/float-field.rs:58:9
    |
 LL |     { s.0x1.1e-1; }
    |         ^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/float-field.rs:42:7
+  --> $DIR/float-field.rs:62:9
    |
-LL |     s.1e1f32;
-   |       ^^^^^^ invalid suffix `f32`
+LL |     { s.1e1f32; }
+   |         ^^^^^^ invalid suffix `f32`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/float-field.rs:45:7
+  --> $DIR/float-field.rs:67:9
    |
-LL |     s.1.1f32;
-   |       ^^^^^^ invalid suffix `f32`
+LL |     { s.1.1f32; }
+   |         ^^^^^^ invalid suffix `f32`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/float-field.rs:46:7
+  --> $DIR/float-field.rs:69:9
    |
-LL |     s.1.1e1f32;
-   |       ^^^^^^^^ invalid suffix `f32`
+LL |     { s.1.1e1f32; }
+   |         ^^^^^^^^ invalid suffix `f32`
 
 error: unexpected token: `1e+f32`
-  --> $DIR/float-field.rs:48:9
+  --> $DIR/float-field.rs:72:9
    |
 LL |     { s.1e+f32; }
    |         ^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+f32`
-  --> $DIR/float-field.rs:48:9
+  --> $DIR/float-field.rs:72:9
    |
 LL |     { s.1e+f32; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e-f32`
-  --> $DIR/float-field.rs:51:9
+  --> $DIR/float-field.rs:76:9
    |
 LL |     { s.1e-f32; }
    |         ^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-f32`
-  --> $DIR/float-field.rs:51:9
+  --> $DIR/float-field.rs:76:9
    |
 LL |     { s.1e-f32; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e+1f32`
-  --> $DIR/float-field.rs:54:9
+  --> $DIR/float-field.rs:80:9
    |
 LL |     { s.1e+1f32; }
    |         ^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+1f32`
-  --> $DIR/float-field.rs:54:9
+  --> $DIR/float-field.rs:80:9
    |
 LL |     { s.1e+1f32; }
    |         ^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e-1f32`
-  --> $DIR/float-field.rs:56:9
+  --> $DIR/float-field.rs:83:9
    |
 LL |     { s.1e-1f32; }
    |         ^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-1f32`
-  --> $DIR/float-field.rs:56:9
+  --> $DIR/float-field.rs:83:9
    |
 LL |     { s.1e-1f32; }
    |         ^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1.1e+1f32`
-  --> $DIR/float-field.rs:58:9
+  --> $DIR/float-field.rs:86:9
    |
 LL |     { s.1.1e+1f32; }
    |         ^^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e+1f32`
-  --> $DIR/float-field.rs:58:9
+  --> $DIR/float-field.rs:86:9
    |
 LL |     { s.1.1e+1f32; }
    |         ^^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1.1e-1f32`
-  --> $DIR/float-field.rs:60:9
+  --> $DIR/float-field.rs:89:9
    |
 LL |     { s.1.1e-1f32; }
    |         ^^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e-1f32`
-  --> $DIR/float-field.rs:60:9
+  --> $DIR/float-field.rs:89:9
    |
 LL |     { s.1.1e-1f32; }
    |         ^^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error[E0609]: no field `1e1` on type `S`
-  --> $DIR/float-field.rs:6:7
+  --> $DIR/float-field.rs:6:9
    |
-LL |     s.1e1;
-   |       ^^^ unknown field
+LL |     { s.1e1; }
+   |         ^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e1` on type `(u8, u8)`
-  --> $DIR/float-field.rs:9:9
+  --> $DIR/float-field.rs:12:11
    |
-LL |     s.1.1e1;
-   |         ^^^ unknown field
+LL |     { s.1.1e1; }
+   |           ^^^ unknown field
 
 error[E0609]: no field `0x1e1` on type `S`
-  --> $DIR/float-field.rs:24:7
+  --> $DIR/float-field.rs:34:9
    |
-LL |     s.0x1e1;
-   |       ^^^^^ unknown field
-   |
-   = note: available fields are: `0`, `1`
-
-error[E0609]: no field `0x1` on type `S`
-  --> $DIR/float-field.rs:25:7
-   |
-LL |     s.0x1.;
-   |       ^^^ unknown field
+LL |     { s.0x1e1; }
+   |         ^^^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0x1` on type `S`
-  --> $DIR/float-field.rs:28:7
+  --> $DIR/float-field.rs:36:9
    |
-LL |     s.0x1.1;
-   |       ^^^ unknown field
+LL |     { s.0x1.; }
+   |         ^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0x1` on type `S`
-  --> $DIR/float-field.rs:30:7
+  --> $DIR/float-field.rs:40:9
    |
-LL |     s.0x1.1e1;
-   |       ^^^ unknown field
+LL |     { s.0x1.1; }
+   |         ^^^ unknown field
+   |
+   = note: available fields are: `0`, `1`
+
+error[E0609]: no field `0x1` on type `S`
+  --> $DIR/float-field.rs:43:9
+   |
+LL |     { s.0x1.1e1; }
+   |         ^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0x1e` on type `S`
-  --> $DIR/float-field.rs:34:7
+  --> $DIR/float-field.rs:50:9
    |
-LL |     s.0x1e+1;
-   |       ^^^^ unknown field
+LL |     { s.0x1e+1; }
+   |         ^^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0x1e` on type `S`
-  --> $DIR/float-field.rs:35:7
+  --> $DIR/float-field.rs:52:9
    |
-LL |     s.0x1e-1;
-   |       ^^^^ unknown field
+LL |     { s.0x1e-1; }
+   |         ^^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e1` on type `S`
-  --> $DIR/float-field.rs:42:7
+  --> $DIR/float-field.rs:62:9
    |
-LL |     s.1e1f32;
-   |       ^^^^^^ unknown field
+LL |     { s.1e1f32; }
+   |         ^^^^^^ unknown field
    |
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `f32` on type `(u8, u8)`
-  --> $DIR/float-field.rs:44:9
+  --> $DIR/float-field.rs:65:11
    |
-LL |     s.1.f32;
-   |         ^^^ unknown field
+LL |     { s.1.f32; }
+   |           ^^^ unknown field
 
 error[E0609]: no field `1e1` on type `(u8, u8)`
-  --> $DIR/float-field.rs:46:7
+  --> $DIR/float-field.rs:69:9
    |
-LL |     s.1.1e1f32;
-   |       ^^^^^^^^ unknown field
+LL |     { s.1.1e1f32; }
+   |         ^^^^^^^^ unknown field
 
 error: aborting due to 55 previous errors
 

--- a/tests/ui/parser/float-field.stderr
+++ b/tests/ui/parser/float-field.stderr
@@ -23,31 +23,31 @@ LL |     { s.0x1.1; }
    |         ^^^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:43:9
+  --> $DIR/float-field.rs:44:9
    |
 LL |     { s.0x1.1e1; }
    |         ^^^^^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:54:9
+  --> $DIR/float-field.rs:56:9
    |
 LL |     { s.0x1.1e+1; }
    |         ^^^^^^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/float-field.rs:58:9
+  --> $DIR/float-field.rs:60:9
    |
 LL |     { s.0x1.1e-1; }
    |         ^^^^^^^^
 
 error: expected at least one digit in exponent
-  --> $DIR/float-field.rs:72:9
+  --> $DIR/float-field.rs:74:9
    |
 LL |     { s.1e+f32; }
    |         ^^^^^^
 
 error: expected at least one digit in exponent
-  --> $DIR/float-field.rs:76:9
+  --> $DIR/float-field.rs:78:9
    |
 LL |     { s.1e-f32; }
    |         ^^^^^^
@@ -130,134 +130,164 @@ error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e-1`
 LL |     { s.1.1e-1; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
-error: unexpected token: `;`
-  --> $DIR/float-field.rs:36:13
+error: unexpected token: `0x1.`
+  --> $DIR/float-field.rs:36:9
    |
 LL |     { s.0x1.; }
-   |             ^
+   |         ^^^^
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.`
+  --> $DIR/float-field.rs:36:9
+   |
+LL |     { s.0x1.; }
+   |         ^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+
+error: unexpected token: `0x1.1`
+  --> $DIR/float-field.rs:40:9
+   |
+LL |     { s.0x1.1; }
+   |         ^^^^^
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1`
+  --> $DIR/float-field.rs:40:9
+   |
+LL |     { s.0x1.1; }
+   |         ^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+
+error: unexpected token: `0x1.1e1`
+  --> $DIR/float-field.rs:44:9
+   |
+LL |     { s.0x1.1e1; }
+   |         ^^^^^^^
+
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e1`
+  --> $DIR/float-field.rs:44:9
+   |
+LL |     { s.0x1.1e1; }
+   |         ^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: expected expression, found `;`
-  --> $DIR/float-field.rs:46:14
+  --> $DIR/float-field.rs:48:14
    |
 LL |     { s.0x1e+; }
    |              ^ expected expression
 
 error: expected expression, found `;`
-  --> $DIR/float-field.rs:48:14
+  --> $DIR/float-field.rs:50:14
    |
 LL |     { s.0x1e-; }
    |              ^ expected expression
 
 error: unexpected token: `0x1.1e+1`
-  --> $DIR/float-field.rs:54:9
+  --> $DIR/float-field.rs:56:9
    |
 LL |     { s.0x1.1e+1; }
    |         ^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e+1`
-  --> $DIR/float-field.rs:54:9
+  --> $DIR/float-field.rs:56:9
    |
 LL |     { s.0x1.1e+1; }
    |         ^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `0x1.1e-1`
-  --> $DIR/float-field.rs:58:9
+  --> $DIR/float-field.rs:60:9
    |
 LL |     { s.0x1.1e-1; }
    |         ^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e-1`
-  --> $DIR/float-field.rs:58:9
+  --> $DIR/float-field.rs:60:9
    |
 LL |     { s.0x1.1e-1; }
    |         ^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/float-field.rs:62:9
+  --> $DIR/float-field.rs:64:9
    |
 LL |     { s.1e1f32; }
    |         ^^^^^^ invalid suffix `f32`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/float-field.rs:67:9
+  --> $DIR/float-field.rs:69:9
    |
 LL |     { s.1.1f32; }
    |         ^^^^^^ invalid suffix `f32`
 
 error: suffixes on a tuple index are invalid
-  --> $DIR/float-field.rs:69:9
+  --> $DIR/float-field.rs:71:9
    |
 LL |     { s.1.1e1f32; }
    |         ^^^^^^^^ invalid suffix `f32`
 
 error: unexpected token: `1e+f32`
-  --> $DIR/float-field.rs:72:9
+  --> $DIR/float-field.rs:74:9
    |
 LL |     { s.1e+f32; }
    |         ^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+f32`
-  --> $DIR/float-field.rs:72:9
+  --> $DIR/float-field.rs:74:9
    |
 LL |     { s.1e+f32; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e-f32`
-  --> $DIR/float-field.rs:76:9
+  --> $DIR/float-field.rs:78:9
    |
 LL |     { s.1e-f32; }
    |         ^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-f32`
-  --> $DIR/float-field.rs:76:9
+  --> $DIR/float-field.rs:78:9
    |
 LL |     { s.1e-f32; }
    |         ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e+1f32`
-  --> $DIR/float-field.rs:80:9
+  --> $DIR/float-field.rs:82:9
    |
 LL |     { s.1e+1f32; }
    |         ^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e+1f32`
-  --> $DIR/float-field.rs:80:9
+  --> $DIR/float-field.rs:82:9
    |
 LL |     { s.1e+1f32; }
    |         ^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1e-1f32`
-  --> $DIR/float-field.rs:83:9
+  --> $DIR/float-field.rs:85:9
    |
 LL |     { s.1e-1f32; }
    |         ^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1e-1f32`
-  --> $DIR/float-field.rs:83:9
+  --> $DIR/float-field.rs:85:9
    |
 LL |     { s.1e-1f32; }
    |         ^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1.1e+1f32`
-  --> $DIR/float-field.rs:86:9
+  --> $DIR/float-field.rs:88:9
    |
 LL |     { s.1.1e+1f32; }
    |         ^^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e+1f32`
-  --> $DIR/float-field.rs:86:9
+  --> $DIR/float-field.rs:88:9
    |
 LL |     { s.1.1e+1f32; }
    |         ^^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
 
 error: unexpected token: `1.1e-1f32`
-  --> $DIR/float-field.rs:89:9
+  --> $DIR/float-field.rs:91:9
    |
 LL |     { s.1.1e-1f32; }
    |         ^^^^^^^^^
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1e-1f32`
-  --> $DIR/float-field.rs:89:9
+  --> $DIR/float-field.rs:91:9
    |
 LL |     { s.1.1e-1f32; }
    |         ^^^^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
@@ -284,32 +314,8 @@ LL |     { s.0x1e1; }
    |
    = note: available fields are: `0`, `1`
 
-error[E0609]: no field `0x1` on type `S`
-  --> $DIR/float-field.rs:36:9
-   |
-LL |     { s.0x1.; }
-   |         ^^^ unknown field
-   |
-   = note: available fields are: `0`, `1`
-
-error[E0609]: no field `0x1` on type `S`
-  --> $DIR/float-field.rs:40:9
-   |
-LL |     { s.0x1.1; }
-   |         ^^^ unknown field
-   |
-   = note: available fields are: `0`, `1`
-
-error[E0609]: no field `0x1` on type `S`
-  --> $DIR/float-field.rs:43:9
-   |
-LL |     { s.0x1.1e1; }
-   |         ^^^ unknown field
-   |
-   = note: available fields are: `0`, `1`
-
 error[E0609]: no field `0x1e` on type `S`
-  --> $DIR/float-field.rs:50:9
+  --> $DIR/float-field.rs:52:9
    |
 LL |     { s.0x1e+1; }
    |         ^^^^ unknown field
@@ -317,7 +323,7 @@ LL |     { s.0x1e+1; }
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `0x1e` on type `S`
-  --> $DIR/float-field.rs:52:9
+  --> $DIR/float-field.rs:54:9
    |
 LL |     { s.0x1e-1; }
    |         ^^^^ unknown field
@@ -325,7 +331,7 @@ LL |     { s.0x1e-1; }
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `1e1` on type `S`
-  --> $DIR/float-field.rs:62:9
+  --> $DIR/float-field.rs:64:9
    |
 LL |     { s.1e1f32; }
    |         ^^^^^^ unknown field
@@ -333,17 +339,17 @@ LL |     { s.1e1f32; }
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `f32` on type `(u8, u8)`
-  --> $DIR/float-field.rs:65:11
+  --> $DIR/float-field.rs:67:11
    |
 LL |     { s.1.f32; }
    |           ^^^ unknown field
 
 error[E0609]: no field `1e1` on type `(u8, u8)`
-  --> $DIR/float-field.rs:69:9
+  --> $DIR/float-field.rs:71:9
    |
 LL |     { s.1.1e1f32; }
    |         ^^^^^^^^ unknown field
 
-error: aborting due to 55 previous errors
+error: aborting due to 57 previous errors
 
 For more information about this error, try `rustc --explain E0609`.


### PR DESCRIPTION
#121120 changed `StringReader::cook_lexer_literal` to return `LitKind::Err` for malformed integer literals. This commit does the same for float literals, for consistency.

r? @fmease