### PR TITLE
Fix tuple element tys returned from `sized_conditions()`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2116,9 +2116,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
 
             ty::Str | ty::Slice(_) | ty::Dynamic(..) | ty::Foreign(..) => None,
 
-            ty::Tuple(tys) => Where(
-                obligation.predicate.rebind(tys.last().map_or_else(Vec::new, |&last| vec![last])),
-            ),
+            ty::Tuple(tys) => Where(obligation.predicate.rebind(tys.to_vec())),
 
             ty::Adt(def, args) => {
                 let sized_crit = def.sized_constraint(self.tcx());

--- a/tests/ui/dst/dst-bad-deep-2.rs
+++ b/tests/ui/dst/dst-bad-deep-2.rs
@@ -9,5 +9,5 @@ pub fn main() {
     let f: ([isize; 3],) = ([5, 6, 7],);
     let g: &([isize],) = &f;
     let h: &(([isize],),) = &(*g,);
-    //~^ ERROR the size for values of type
+    //~^ ERROR the size for values of type `[isize]` cannot be known at compilation time
 }

--- a/tests/ui/layout/issue-84108.rs
+++ b/tests/ui/layout/issue-84108.rs
@@ -11,4 +11,5 @@ const BAR: (&Path, [u8], usize) = ("hello", [], 42);
 
 static BAZ: ([u8], usize) = ([], 0);
 //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+//~| ERROR the size for values of type `[u8]` cannot be known at compilation time
 //~| ERROR mismatched types

--- a/tests/ui/layout/issue-84108.stderr
+++ b/tests/ui/layout/issue-84108.stderr
@@ -29,6 +29,16 @@ LL | static BAZ: ([u8], usize) = ([], 0);
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: only the last element of a tuple may have a dynamically sized type
 
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/issue-84108.rs:12:29
+   |
+LL | static BAZ: ([u8], usize) = ([], 0);
+   |                             ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `([u8], usize)`, the trait `Sized` is not implemented for `[u8]`, which is required by `([u8], usize): Sized`
+   = note: required because it appears within the type `([u8], usize)`
+   = note: constant expressions must have a statically known size
+
 error[E0308]: mismatched types
   --> $DIR/issue-84108.rs:12:30
    |
@@ -38,7 +48,7 @@ LL | static BAZ: ([u8], usize) = ([], 0);
    = note: expected slice `[u8]`
               found array `[_; 0]`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0412.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
@@ -1,0 +1,16 @@
+// Regression test for #121443
+// Checks that no ICE occurs upon encountering
+// a tuple with unsized element that is not
+// the last element
+
+type Fn = dyn FnOnce() -> u8;
+
+const TEST: Fn = some_fn;
+//~^ ERROR cannot find value `some_fn` in this scope
+//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+const TEST2: (Fn, u8) = (TEST, 0);
+//~^ ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
@@ -1,0 +1,46 @@
+error[E0425]: cannot find value `some_fn` in this scope
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:8:18
+   |
+LL | const TEST: Fn = some_fn;
+   |                  ^^^^^^^ not found in this scope
+
+error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:8:13
+   |
+LL | const TEST: Fn = some_fn;
+   |             ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+
+error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:8:18
+   |
+LL | const TEST: Fn = some_fn;
+   |                  ^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = note: constant expressions must have a statically known size
+
+error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:12:14
+   |
+LL | const TEST2: (Fn, u8) = (TEST, 0);
+   |              ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = note: only the last element of a tuple may have a dynamically sized type
+
+error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:12:25
+   |
+LL | const TEST2: (Fn, u8) = (TEST, 0);
+   |                         ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `((dyn FnOnce() -> u8 + 'static), u8)`, the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`, which is required by `((dyn FnOnce() -> u8 + 'static), u8): Sized`
+   = note: required because it appears within the type `((dyn FnOnce() -> u8 + 'static), u8)`
+   = note: constant expressions must have a statically known size
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0425.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/unsized-bound.stderr
+++ b/tests/ui/trait-bounds/unsized-bound.stderr
@@ -1,3 +1,27 @@
+error[E0277]: the size for values of type `A` cannot be known at compilation time
+  --> $DIR/unsized-bound.rs:2:30
+   |
+LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
+   |      -                       ^^^^^^ doesn't have a size known at compile-time
+   |      |
+   |      this type parameter needs to be `Sized`
+   |
+   = note: required because it appears within the type `(A, B)`
+note: required by an implicit `Sized` bound in `Trait`
+  --> $DIR/unsized-bound.rs:1:13
+   |
+LL | trait Trait<A> {}
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
+LL + impl<A, B> Trait<(A, B)> for (A, B) where B: ?Sized, {}
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Trait<A: ?Sized> {}
+   |              ++++++++
+
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:2:30
    |
@@ -23,19 +47,48 @@ LL | trait Trait<A: ?Sized> {}
    |              ++++++++
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:2:30
+  --> $DIR/unsized-bound.rs:5:52
    |
-LL | impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
-   |      -                       ^^^^^^ doesn't have a size known at compile-time
-   |      |
-   |      this type parameter needs to be `Sized`
+LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
+   |      - this type parameter needs to be `Sized`     ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = note: only the last element of a tuple may have a dynamically sized type
+   = note: required because it appears within the type `(A, B, C)`
+note: required by an implicit `Sized` bound in `Trait`
+  --> $DIR/unsized-bound.rs:1:13
+   |
+LL | trait Trait<A> {}
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
-LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
-LL + impl<A, B> Trait<(A, B)> for (A, B) where B: ?Sized, {}
+LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
+LL + impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C)  {}
    |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Trait<A: ?Sized> {}
+   |              ++++++++
+
+error[E0277]: the size for values of type `B` cannot be known at compilation time
+  --> $DIR/unsized-bound.rs:5:52
+   |
+LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
+   |         - this type parameter needs to be `Sized`  ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: required because it appears within the type `(A, B, C)`
+note: required by an implicit `Sized` bound in `Trait`
+  --> $DIR/unsized-bound.rs:1:13
+   |
+LL | trait Trait<A> {}
+   |             ^ required by the implicit `Sized` requirement on this type parameter in `Trait`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
+LL + impl<A, B, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | trait Trait<A: ?Sized> {}
+   |              ++++++++
 
 error[E0277]: the size for values of type `C` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:5:52
@@ -62,30 +115,28 @@ LL | trait Trait<A: ?Sized> {}
    |              ++++++++
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:5:52
+  --> $DIR/unsized-bound.rs:10:47
    |
-LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |      - this type parameter needs to be `Sized`     ^^^^^^^^^ doesn't have a size known at compile-time
+LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
+   |      -                                        ^^^^^^ doesn't have a size known at compile-time
+   |      |
+   |      this type parameter needs to be `Sized`
    |
-   = note: only the last element of a tuple may have a dynamically sized type
+   = note: required because it appears within the type `(A, B)`
+note: required by an implicit `Sized` bound in `Trait2`
+  --> $DIR/unsized-bound.rs:9:14
+   |
+LL | trait Trait2<A> {}
+   |              ^ required by the implicit `Sized` requirement on this type parameter in `Trait2`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
-LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-LL + impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C)  {}
+LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
+LL + impl<A, B: ?Sized> Trait2<(A, B)> for (A, B) {}
    |
-
-error[E0277]: the size for values of type `B` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:5:52
+help: consider relaxing the implicit `Sized` restriction
    |
-LL | impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |         - this type parameter needs to be `Sized`  ^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = note: only the last element of a tuple may have a dynamically sized type
-help: consider removing the `?Sized` bound to make the type parameter `Sized`
-   |
-LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-LL + impl<A, B, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   |
+LL | trait Trait2<A: ?Sized> {}
+   |               ++++++++
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:10:47
@@ -110,21 +161,6 @@ help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait2<A: ?Sized> {}
    |               ++++++++
-
-error[E0277]: the size for values of type `A` cannot be known at compilation time
-  --> $DIR/unsized-bound.rs:10:47
-   |
-LL | impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
-   |      -                                        ^^^^^^ doesn't have a size known at compile-time
-   |      |
-   |      this type parameter needs to be `Sized`
-   |
-   = note: only the last element of a tuple may have a dynamically sized type
-help: consider removing the `?Sized` bound to make the type parameter `Sized`
-   |
-LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
-LL + impl<A, B: ?Sized> Trait2<(A, B)> for (A, B) {}
-   |
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:14:23

--- a/tests/ui/unsized/unsized3.rs
+++ b/tests/ui/unsized/unsized3.rs
@@ -39,6 +39,7 @@ fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
 fn f9<X: ?Sized>(x1: Box<S<X>>) {
     f5(&(*x1, 34));
     //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
 }
 
 fn f10<X: ?Sized>(x1: Box<S<X>>) {

--- a/tests/ui/unsized/unsized3.stderr
+++ b/tests/ui/unsized/unsized3.stderr
@@ -75,19 +75,20 @@ LL | fn f5<Y: ?Sized>(x: &Y) {}
    |        ++++++++
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:40:5
+  --> $DIR/unsized3.rs:40:9
    |
 LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
    |       - this type parameter needs to be `Sized`
 LL |     f5(&(*x1, 34));
-   |     ^^ doesn't have a size known at compile-time
+   |         ^^^^^^^^^ doesn't have a size known at compile-time
    |
 note: required because it appears within the type `S<X>`
   --> $DIR/unsized3.rs:28:8
    |
 LL | struct S<X: ?Sized> {
    |        ^
-   = note: only the last element of a tuple may have a dynamically sized type
+   = note: required because it appears within the type `(S<X>, {integer})`
+   = note: tuples must have a statically known size to be initialized
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f9<X: ?Sized>(x1: Box<S<X>>) {
@@ -95,7 +96,38 @@ LL + fn f9<X>(x1: Box<S<X>>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:45:9
+  --> $DIR/unsized3.rs:40:8
+   |
+LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
+   |       - this type parameter needs to be `Sized`
+LL |     f5(&(*x1, 34));
+   |     -- ^^^^^^^^^^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required because it appears within the type `S<X>`
+  --> $DIR/unsized3.rs:28:8
+   |
+LL | struct S<X: ?Sized> {
+   |        ^
+   = note: required because it appears within the type `(S<X>, {integer})`
+note: required by an implicit `Sized` bound in `f5`
+  --> $DIR/unsized3.rs:24:7
+   |
+LL | fn f5<Y>(x: &Y) {}
+   |       ^ required by the implicit `Sized` requirement on this type parameter in `f5`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn f9<X: ?Sized>(x1: Box<S<X>>) {
+LL + fn f9<X>(x1: Box<S<X>>) {
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | fn f5<Y: ?Sized>(x: &Y) {}
+   |        ++++++++
+
+error[E0277]: the size for values of type `X` cannot be known at compilation time
+  --> $DIR/unsized3.rs:46:9
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
    |        - this type parameter needs to be `Sized`
@@ -116,7 +148,7 @@ LL + fn f10<X>(x1: Box<S<X>>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:45:8
+  --> $DIR/unsized3.rs:46:8
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
    |        - this type parameter needs to be `Sized`
@@ -146,6 +178,6 @@ help: consider relaxing the implicit `Sized` restriction
 LL | fn f5<Y: ?Sized>(x: &Y) {}
    |        ++++++++
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/unsized/unsized6.rs
+++ b/tests/ui/unsized/unsized6.rs
@@ -25,6 +25,7 @@ fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     //~^ ERROR the size for values of type
     let (y, z) = (*x3, 4);
     //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
 }
 fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     let y: X = *x1;
@@ -33,6 +34,7 @@ fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
     //~^ ERROR the size for values of type
     let (y, z) = (*x3, 4);
     //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
 }
 
 fn g1<X: ?Sized>(x: X) {}

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -125,6 +125,23 @@ LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
+  --> $DIR/unsized6.rs:26:18
+   |
+LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
+   |       - this type parameter needs to be `Sized`
+...
+LL |     let (y, z) = (*x3, 4);
+   |                  ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: required because it appears within the type `(X, {integer})`
+   = note: tuples must have a statically known size to be initialized
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
+LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
+   |
+
+error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:26:10
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
@@ -142,7 +159,7 @@ LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:30:9
+  --> $DIR/unsized6.rs:31:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
@@ -162,7 +179,7 @@ LL |     let y: &X = *x1;
    |            +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:32:9
+  --> $DIR/unsized6.rs:33:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
@@ -179,7 +196,24 @@ LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:34:10
+  --> $DIR/unsized6.rs:35:18
+   |
+LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
+   |       - this type parameter needs to be `Sized`
+...
+LL |     let (y, z) = (*x3, 4);
+   |                  ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: required because it appears within the type `(X, {integer})`
+   = note: tuples must have a statically known size to be initialized
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
+LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
+   |
+
+error[E0277]: the size for values of type `X` cannot be known at compilation time
+  --> $DIR/unsized6.rs:35:10
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |       - this type parameter needs to be `Sized`
@@ -196,7 +230,7 @@ LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:38:18
+  --> $DIR/unsized6.rs:40:18
    |
 LL | fn g1<X: ?Sized>(x: X) {}
    |       -          ^ doesn't have a size known at compile-time
@@ -215,7 +249,7 @@ LL | fn g1<X: ?Sized>(x: &X) {}
    |                     +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:40:22
+  --> $DIR/unsized6.rs:42:22
    |
 LL | fn g2<X: ?Sized + T>(x: X) {}
    |       -              ^ doesn't have a size known at compile-time
@@ -233,6 +267,6 @@ help: function arguments must have a statically known size, borrowed types alway
 LL | fn g2<X: ?Sized + T>(x: &X) {}
    |                         +
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Instead of returning the type of the last element we flip it around and return types of all elements _except_ the last one. This matches the the constraint on tuple types which says that only the last element can be unsized.

**Edit**
Returning all elements except the last was a mistake. We now return all the elements.

Fixes #121443