### PR TITLE
Add profiling support to AIX

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1631,7 +1631,9 @@ impl<'a> Linker for AixLinker<'a> {
 
     fn optimize(&mut self) {}
 
-    fn pgo_gen(&mut self) {}
+    fn pgo_gen(&mut self) {
+        self.cmd.arg("-bdbg:namedsects:ss");
+    }
 
     fn control_flow_guard(&mut self) {}
 

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -26,6 +26,7 @@ fn main() {
         "InstrProfilingMerge.c",
         "InstrProfilingMergeFile.c",
         "InstrProfilingNameVar.c",
+        "InstrProfilingPlatformAIX.c",
         "InstrProfilingPlatformDarwin.c",
         "InstrProfilingPlatformFuchsia.c",
         "InstrProfilingPlatformLinux.c",


### PR DESCRIPTION
AIX ld needs special option to merge objects with profiling. Also, profiler_builtins should include builtins for AIX from compiler-rt.