### PR TITLE
Now that inlining, mir validation and const eval all use reveal-all, we won't be constraining hidden types here anymore

### DIFF
--- a/compiler/rustc_const_eval/src/util/compare_types.rs
+++ b/compiler/rustc_const_eval/src/util/compare_types.rs
@@ -4,7 +4,7 @@
 //! other areas of the compiler as well.
 
 use rustc_infer::infer::TyCtxtInferExt;
-use rustc_middle::traits::{DefiningAnchor, ObligationCause};
+use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::{ParamEnv, Ty, TyCtxt, Variance};
 use rustc_trait_selection::traits::ObligationCtxt;
 
@@ -33,9 +33,6 @@ pub fn is_equal_up_to_subtyping<'tcx>(
 /// When validating assignments, the variance should be `Covariant`. When checking
 /// during `MirPhase` >= `MirPhase::Runtime(RuntimePhase::Initial)` variance should be `Invariant`
 /// because we want to check for type equality.
-///
-/// This mostly ignores opaque types as it can be used in constraining contexts
-/// while still computing the final underlying type.
 pub fn relate_types<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
@@ -47,8 +44,7 @@ pub fn relate_types<'tcx>(
         return true;
     }
 
-    let mut builder =
-        tcx.infer_ctxt().ignoring_regions().with_opaque_type_inference(DefiningAnchor::Bubble);
+    let mut builder = tcx.infer_ctxt().ignoring_regions();
     let infcx = builder.build();
     let ocx = ObligationCtxt::new(&infcx);
     let cause = ObligationCause::dummy();
@@ -58,20 +54,5 @@ pub fn relate_types<'tcx>(
         Ok(()) => {}
         Err(_) => return false,
     };
-    let errors = ocx.select_all_or_error();
-    // With `Reveal::All`, opaque types get normalized away, with `Reveal::UserFacing`
-    // we would get unification errors because we're unable to look into opaque types,
-    // even if they're constrained in our current function.
-    for (key, ty) in infcx.take_opaque_types() {
-        let hidden_ty = tcx.type_of(key.def_id).instantiate(tcx, key.args);
-        if hidden_ty != ty.hidden_type.ty {
-            span_bug!(
-                ty.hidden_type.span,
-                "{}, {}",
-                tcx.type_of(key.def_id).instantiate(tcx, key.args),
-                ty.hidden_type.ty
-            );
-        }
-    }
-    errors.is_empty()
+    ocx.select_all_or_error().is_empty()
 }

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.default.stderr
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.default.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/hidden-type-is-opaque-2.rs:8:17
+  --> $DIR/hidden-type-is-opaque-2.rs:10:17
    |
 LL |     Thunk::new(|mut cont| {
    |                 ^^^^^^^^
@@ -13,7 +13,7 @@ LL |     Thunk::new(|mut cont: /* Type */| {
    |                         ++++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/hidden-type-is-opaque-2.rs:18:17
+  --> $DIR/hidden-type-is-opaque-2.rs:20:17
    |
 LL |     Thunk::new(|mut cont| {
    |                 ^^^^^^^^

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.next.stderr
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.next.stderr
@@ -1,0 +1,31 @@
+error[E0282]: type annotations needed
+  --> $DIR/hidden-type-is-opaque-2.rs:10:17
+   |
+LL |     Thunk::new(|mut cont| {
+   |                 ^^^^^^^^
+LL |
+LL |         cont.reify_as();
+   |         ---- type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     Thunk::new(|mut cont: /* Type */| {
+   |                         ++++++++++++
+
+error[E0282]: type annotations needed
+  --> $DIR/hidden-type-is-opaque-2.rs:20:17
+   |
+LL |     Thunk::new(|mut cont| {
+   |                 ^^^^^^^^
+LL |
+LL |         cont.reify_as();
+   |         ---- type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     Thunk::new(|mut cont: /* Type */| {
+   |                         ++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/impl-trait/hidden-type-is-opaque-2.rs
+++ b/tests/ui/impl-trait/hidden-type-is-opaque-2.rs
@@ -1,6 +1,8 @@
 // This doesn't work, because we don't flow information from opaque types
 // into function arguments via the function's generic parameters
 // FIXME(oli-obk): make `expected_inputs_for_expected_output` support this
+//@ revisions: default next
+//@[next] compile-flags: -Znext-solver
 
 #![feature(type_alias_impl_trait)]
 


### PR DESCRIPTION
r? @compiler-errors 

one bubble down, two more to go

the test is unrelated, just something I noticed would be good to test in both the old solver and the new.