### PR TITLE
Opportunistically resolve regions when processing region outlives obligations

### DIFF
--- a/tests/ui/implied-bounds/impl-implied-bounds-compatibility.rs
+++ b/tests/ui/implied-bounds/impl-implied-bounds-compatibility.rs
@@ -10,7 +10,7 @@ pub trait MessageListenersInterface {
 
 impl<'a> MessageListenersInterface for MessageListeners<'a> {
     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
-        //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter 'b in generic type due to conflicting requirements
+        //~^ ERROR in type `&'a MessageListeners<'_>`, reference has a longer lifetime than the data it references
         self
     }
 }

--- a/tests/ui/implied-bounds/impl-implied-bounds-compatibility.stderr
+++ b/tests/ui/implied-bounds/impl-implied-bounds-compatibility.stderr
@@ -1,27 +1,15 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter 'b in generic type due to conflicting requirements
+error[E0491]: in type `&'a MessageListeners<'_>`, reference has a longer lifetime than the data it references
   --> $DIR/impl-implied-bounds-compatibility.rs:12:5
    |
 LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'c` as defined here...
-  --> $DIR/impl-implied-bounds-compatibility.rs:12:5
-   |
-LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...so that the method type is compatible with trait
-  --> $DIR/impl-implied-bounds-compatibility.rs:12:5
-   |
-LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected `fn(&'c MessageListeners<'_>) -> &'c MessageListeners<'c>`
-              found `fn(&MessageListeners<'_>) -> &'a MessageListeners<'_>`
-note: but, the lifetime must be valid for the lifetime `'a` as defined here...
+note: the pointer is valid for the lifetime `'a` as defined here
   --> $DIR/impl-implied-bounds-compatibility.rs:11:6
    |
 LL | impl<'a> MessageListenersInterface for MessageListeners<'a> {
    |      ^^
-note: ...so that the reference type `&'a MessageListeners<'_>` does not outlive the data it points at
+note: but the referenced data is only valid for the lifetime `'c` as defined here
   --> $DIR/impl-implied-bounds-compatibility.rs:12:5
    |
 LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
@@ -29,4 +17,4 @@ LL |     fn listeners<'b>(&'b self) -> &'a MessageListeners<'b> {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0495`.
+For more information about this error, try `rustc --explain E0491`.


### PR DESCRIPTION
Due to the matching in `TypeOutlives` being structural, we should attempt to opportunistically resolve regions before processing region obligations. Thanks @lcnr for finding this.

r? lcnr