### PR TITLE
Deeply normalize obligations in `refining_impl_trait`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -107,6 +107,15 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         self.register_infer_ok_obligations(infer_ok)
     }
 
+    pub fn deeply_normalize<T: TypeFoldable<TyCtxt<'tcx>>>(
+        &self,
+        cause: &ObligationCause<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+        value: T,
+    ) -> Result<T, Vec<FulfillmentError<'tcx>>> {
+        self.infcx.at(cause, param_env).deeply_normalize(value, &mut **self.engine.borrow_mut())
+    }
+
     /// Makes `expected <: actual`.
     pub fn eq_exp<T>(
         &self,

--- a/tests/ui/impl-trait/in-trait/refine-normalize.rs
+++ b/tests/ui/impl-trait/in-trait/refine-normalize.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+//@ edition: 2021
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+
+#![deny(refining_impl_trait)]
+
+pub trait Foo {
+    type Item;
+
+    fn hello() -> impl Iterator<Item = Self::Item>;
+}
+
+impl Foo for () {
+    type Item = ();
+
+    fn hello() -> impl Iterator<Item = ()> { [()].into_iter() }
+}
+
+fn main() {}


### PR DESCRIPTION
We somewhat awkwardly use semantic comparison when checking the `refining_impl_trait` lint. This relies on us being able to normalize bounds eagerly to avoid cases where an unnormalized alias is not considered equal to a normalized alias. Since `normalize` in the new solver is a noop, let's use `deeply_normalize` instead. 

r? lcnr

cc @tmandry, this should fix your bug lol