### PR TITLE
Restore the standard library review rotation to its former glory

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -673,6 +673,12 @@ compiler = [
 libs = [
     "@cuviper",
     "@Mark-Simulacrum",
+    "@m-ou-se",
+    "@Amanieu",
+    "@Nilstrieb",
+    "@workingjubilee",
+    "@joboet",
+    "@jhpratt",
 ]
 bootstrap = [
     "@Mark-Simulacrum",
@@ -810,7 +816,7 @@ project-stable-mir = [
 "/compiler/rustc_type_ir" =                              ["compiler", "types"]
 "/compiler/stable_mir" =                                 ["project-stable-mir"]
 "/library/alloc" =                                       ["libs"]
-"/library/core" =                                        ["libs"]
+"/library/core" =                                        ["libs", "@scottmcm"]
 "/library/panic_abort" =                                 ["libs"]
 "/library/panic_unwind" =                                ["libs"]
 "/library/proc_macro" =                                  ["@petrochenkov"]


### PR DESCRIPTION
This adds 7 reviewers to the standard library review rotation, bringing the total back up to 10 people. Specifically:

* On the main rotation: @cuviper @Mark-Simulacrum @m-ou-se @Amanieu @Nilstrieb @workingjubilee @joboet @jhpratt
* For `core` only: @scottmcm 
* For `std` only: @ChrisDenton 

For everyone pinged here, please confirm that you are happy to be added to the review rotation.