### PR TITLE
[nightmarish hacks within] Lower UB checks as a new kind of intrinsic, not calls

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -628,6 +628,10 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
                 NonDivergingIntrinsic::CopyNonOverlapping(..) => span_bug!(
                     span,
                     "Unexpected CopyNonOverlapping, should only appear after lower_intrinsics",
+                ),
+                NonDivergingIntrinsic::UbCheck { .. } => span_bug!(
+                    span,
+                    "Unexpected UbCheck, should only appear after lower_intrinsics",
                 )
             }
             // Only relevant for mir typeck

--- a/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
@@ -62,6 +62,18 @@ impl<'cx, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'cx, 'tcx> {
                 self.consume_operand(location, dst);
                 self.consume_operand(location, count);
             }
+            StatementKind::Intrinsic(box NonDivergingIntrinsic::UbCheck {
+                kind: _,
+                func,
+                args,
+                destination,
+                source_info: _,
+                fn_span: _,
+            }) => {
+                self.consume_operand(location, func);
+                self.consume_operand(location, args);
+                self.mutate_place(location, *destination, Shallow(None));
+            }
             // Only relevant for mir typeck
             StatementKind::AscribeUserType(..)
             // Only relevant for liveness and unsafeck

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1367,6 +1367,10 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     stmt.source_info.span,
                     "Unexpected NonDivergingIntrinsic::CopyNonOverlapping, should only appear after lowering_intrinsics",
                 ),
+                NonDivergingIntrinsic::UbCheck { .. } => span_bug!(
+                    stmt.source_info.span,
+                    "Unexpected NonDivergingIntrinsic::UbCheck, should only appear after lowering_intrinsics",
+                ),
             },
             StatementKind::FakeRead(..)
             | StatementKind::StorageLive(..)
@@ -2001,7 +2005,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     ConstraintCategory::SizedBound,
                 );
             }
-            &Rvalue::NullaryOp(NullOp::UbCheck(_), _) => {}
 
             Rvalue::ShallowInitBox(operand, ty) => {
                 self.check_operand(operand, location);

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2001,7 +2001,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     ConstraintCategory::SizedBound,
                 );
             }
-            &Rvalue::NullaryOp(NullOp::DebugAssertions, _) => {}
+            &Rvalue::NullaryOp(NullOp::UbCheck(_), _) => {}
 
             Rvalue::ShallowInitBox(operand, ty) => {
                 self.check_operand(operand, location);

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -767,15 +767,6 @@ fn codegen_stmt<'tcx>(
                         NullOp::OffsetOf(fields) => {
                             layout.offset_of_subfield(fx, fields.iter()).bytes()
                         }
-                        NullOp::UbCheck(_) => {
-                            let val = fx.tcx.sess.opts.debug_assertions;
-                            let val = CValue::by_val(
-                                fx.bcx.ins().iconst(types::I8, i64::try_from(val).unwrap()),
-                                fx.layout_of(fx.tcx.types.bool),
-                            );
-                            lval.write_cvalue(fx, val);
-                            return;
-                        }
                     };
                     let val = CValue::by_val(
                         fx.bcx.ins().iconst(fx.pointer_type, i64::try_from(val).unwrap()),
@@ -844,6 +835,9 @@ fn codegen_stmt<'tcx>(
                     count
                 };
                 fx.bcx.call_memcpy(fx.target_config, dst, src, bytes);
+            }
+            NonDivergingIntrinsic::UbCheck { .. } => {
+                todo!() // FIXME
             }
         },
     }

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -767,7 +767,7 @@ fn codegen_stmt<'tcx>(
                         NullOp::OffsetOf(fields) => {
                             layout.offset_of_subfield(fx, fields.iter()).bytes()
                         }
-                        NullOp::DebugAssertions => {
+                        NullOp::UbCheck(_) => {
                             let val = fx.tcx.sess.opts.debug_assertions;
                             let val = CValue::by_val(
                                 fx.bcx.ins().iconst(types::I8, i64::try_from(val).unwrap()),

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -504,6 +504,7 @@ pub(crate) fn mir_operand_get_const_val<'tcx>(
                         StatementKind::Intrinsic(ref intrinsic) => match **intrinsic {
                             NonDivergingIntrinsic::CopyNonOverlapping(..) => return None,
                             NonDivergingIntrinsic::Assume(..) => {}
+                            NonDivergingIntrinsic::UbCheck { .. } => {}
                         },
                         // conservative handling
                         StatementKind::Assign(_)

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -684,7 +684,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         let val = layout.offset_of_subfield(bx.cx(), fields.iter()).bytes();
                         bx.cx().const_usize(val)
                     }
-                    mir::NullOp::DebugAssertions => {
+                    mir::NullOp::UbCheck(_) => {
+                        // In codegen, we want to check for language UB and library UB
                         let val = bx.tcx().sess.opts.debug_assertions;
                         bx.cx().const_bool(val)
                     }

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -684,11 +684,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         let val = layout.offset_of_subfield(bx.cx(), fields.iter()).bytes();
                         bx.cx().const_usize(val)
                     }
-                    mir::NullOp::UbCheck(_) => {
-                        // In codegen, we want to check for language UB and library UB
-                        let val = bx.tcx().sess.opts.debug_assertions;
-                        bx.cx().const_bool(val)
-                    }
                 };
                 let tcx = self.cx.tcx();
                 OperandRef {

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -317,6 +317,7 @@ impl<'mir, 'tcx: 'mir> CompileTimeEvalContext<'mir, 'tcx> {
                         dest,
                         ret,
                         mir::UnwindAction::Unreachable,
+                        false,
                     )?;
                     Ok(ControlFlow::Break(()))
                 } else {

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -258,10 +258,16 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         let val = layout.offset_of_subfield(self, fields.iter()).bytes();
                         Scalar::from_target_usize(val, self)
                     }
-                    mir::NullOp::DebugAssertions => {
-                        // The checks hidden behind this are always better done by the interpreter
-                        // itself, because it knows the runtime state better.
-                        Scalar::from_bool(false)
+                    mir::NullOp::UbCheck(kind) => {
+                        // We want to enable checks for library UB, because the interpreter doesn't
+                        // know about those on its own.
+                        // But we want to disable checks for language UB, because the interpreter
+                        // has its own better checks for that.
+                        let should_check = match kind {
+                            mir::UbKind::LibraryUb => true,
+                            mir::UbKind::LanguageUb => false,
+                        };
+                        Scalar::from_bool(should_check)
                     }
                 };
                 self.write_scalar(val, &dest)?;

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -558,7 +558,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
             Rvalue::Cast(_, _, _) => {}
 
             Rvalue::NullaryOp(
-                NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) | NullOp::DebugAssertions,
+                NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) | NullOp::UbCheck(_),
                 _,
             ) => {}
             Rvalue::ShallowInitBox(_, _) => {}

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -557,10 +557,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
 
             Rvalue::Cast(_, _, _) => {}
 
-            Rvalue::NullaryOp(
-                NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) | NullOp::UbCheck(_),
-                _,
-            ) => {}
+            Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_), _) => {}
             Rvalue::ShallowInitBox(_, _) => {}
 
             Rvalue::UnaryOp(_, operand) => {

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -1157,7 +1157,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             Rvalue::Repeat(_, _)
             | Rvalue::ThreadLocalRef(_)
             | Rvalue::AddressOf(_, _)
-            | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::DebugAssertions, _)
+            | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::UbCheck(_), _)
             | Rvalue::Discriminant(_) => {}
         }
         self.super_rvalue(rvalue, location);

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -1157,7 +1157,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             Rvalue::Repeat(_, _)
             | Rvalue::ThreadLocalRef(_)
             | Rvalue::AddressOf(_, _)
-            | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::UbCheck(_), _)
+            | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _)
             | Rvalue::Discriminant(_) => {}
         }
         self.super_rvalue(rvalue, location);
@@ -1248,6 +1248,16 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 if op_cnt_ty != self.tcx.types.usize {
                     self.fail(location, format!("bad arg ({op_cnt_ty:?} != usize)"))
                 }
+            }
+            StatementKind::Intrinsic(box NonDivergingIntrinsic::UbCheck {
+                kind: _,
+                func: _,
+                args: _,
+                destination: _,
+                source_info: _,
+                fn_span: _,
+            }) => {
+                // FIXME
             }
             StatementKind::SetDiscriminant { place, .. } => {
                 if self.mir_phase < MirPhase::Runtime(RuntimePhase::Initial) {

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -509,7 +509,9 @@ pub fn check_intrinsic_type(
                 (0, 0, vec![Ty::new_imm_ptr(tcx, Ty::new_unit(tcx))], tcx.types.usize)
             }
 
-            sym::check_language_ub | sym::check_library_ub => (0, 1, Vec::new(), tcx.types.bool),
+            sym::check_language_ub | sym::check_library_ub => {
+                (2, 1, vec![param(0), param(1)], tcx.types.unit)
+            }
 
             sym::simd_eq
             | sym::simd_ne

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -123,7 +123,8 @@ pub fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -
         | sym::variant_count
         | sym::is_val_statically_known
         | sym::ptr_mask
-        | sym::debug_assertions
+        | sym::check_language_ub
+        | sym::check_library_ub
         | sym::fadd_algebraic
         | sym::fsub_algebraic
         | sym::fmul_algebraic
@@ -508,7 +509,7 @@ pub fn check_intrinsic_type(
                 (0, 0, vec![Ty::new_imm_ptr(tcx, Ty::new_unit(tcx))], tcx.types.usize)
             }
 
-            sym::debug_assertions => (0, 1, Vec::new(), tcx.types.bool),
+            sym::check_language_ub | sym::check_library_ub => (0, 1, Vec::new(), tcx.types.bool),
 
             sym::simd_eq
             | sym::simd_ne

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -697,6 +697,9 @@ impl Display for NonDivergingIntrinsic<'_> {
             Self::CopyNonOverlapping(CopyNonOverlapping { src, dst, count }) => {
                 write!(f, "copy_nonoverlapping(dst = {dst:?}, src = {src:?}, count = {count:?})")
             }
+            Self::UbCheck { kind, func, args, .. } => {
+                write!(f, "UbCheck({kind:?}): {func:?}({args:?})")
+            }
         }
     }
 }
@@ -909,7 +912,6 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                     NullOp::SizeOf => write!(fmt, "SizeOf({t})"),
                     NullOp::AlignOf => write!(fmt, "AlignOf({t})"),
                     NullOp::OffsetOf(fields) => write!(fmt, "OffsetOf({t}, {fields:?})"),
-                    NullOp::UbCheck(kind) => write!(fmt, "UbCheck({kind:?})"),
                 }
             }
             ThreadLocalRef(did) => ty::tls::with(|tcx| {

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -909,7 +909,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                     NullOp::SizeOf => write!(fmt, "SizeOf({t})"),
                     NullOp::AlignOf => write!(fmt, "AlignOf({t})"),
                     NullOp::OffsetOf(fields) => write!(fmt, "OffsetOf({t}, {fields:?})"),
-                    NullOp::DebugAssertions => write!(fmt, "cfg!(debug_assertions)"),
+                    NullOp::UbCheck(kind) => write!(fmt, "UbCheck({kind:?})"),
                 }
             }
             ThreadLocalRef(did) => ty::tls::with(|tcx| {

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1361,8 +1361,13 @@ pub enum NullOp<'tcx> {
     AlignOf,
     /// Returns the offset of a field
     OffsetOf(&'tcx List<(VariantIdx, FieldIdx)>),
-    /// cfg!(debug_assertions), but expanded in codegen
-    DebugAssertions,
+    UbCheck(UbKind),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]
+pub enum UbKind {
+    LanguageUb,
+    LibraryUb,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -6,6 +6,7 @@
 use super::{BasicBlock, Const, Local, UserTypeProjection};
 
 use crate::mir::coverage::CoverageKind;
+use crate::mir::SourceInfo;
 use crate::traits::Reveal;
 use crate::ty::adjustment::PointerCoercion;
 use crate::ty::GenericArgsRef;
@@ -444,6 +445,33 @@ pub enum NonDivergingIntrinsic<'tcx> {
     /// **Needs clarification**: Is this typed or not, ie is there a typed load and store involved?
     /// I vaguely remember Ralf saying somewhere that he thought it should not be.
     CopyNonOverlapping(CopyNonOverlapping<'tcx>),
+
+    UbCheck {
+        kind: UbKind,
+        func: Operand<'tcx>,
+        args: Operand<'tcx>,
+        destination: Place<'tcx>,
+        source_info: SourceInfo,
+        fn_span: Span,
+    },
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    TyEncodable,
+    TyDecodable,
+    Hash,
+    HashStable,
+    TypeFoldable,
+    TypeVisitable
+)]
+pub enum UbKind {
+    LanguageUb,
+    LibraryUb,
 }
 
 /// Describes what kind of retag is to be performed.
@@ -1361,13 +1389,6 @@ pub enum NullOp<'tcx> {
     AlignOf,
     /// Returns the offset of a field
     OffsetOf(&'tcx List<(VariantIdx, FieldIdx)>),
-    UbCheck(UbKind),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]
-pub enum UbKind {
-    LanguageUb,
-    LibraryUb,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -194,7 +194,7 @@ impl<'tcx> Rvalue<'tcx> {
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..), _) => {
                 tcx.types.usize
             }
-            Rvalue::NullaryOp(NullOp::DebugAssertions, _) => tcx.types.bool,
+            Rvalue::NullaryOp(NullOp::UbCheck(_), _) => tcx.types.bool,
             Rvalue::Aggregate(ref ak, ref ops) => match **ak {
                 AggregateKind::Array(ty) => Ty::new_array(tcx, ty, ops.len() as u64),
                 AggregateKind::Tuple => {

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -194,7 +194,6 @@ impl<'tcx> Rvalue<'tcx> {
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..), _) => {
                 tcx.types.usize
             }
-            Rvalue::NullaryOp(NullOp::UbCheck(_), _) => tcx.types.bool,
             Rvalue::Aggregate(ref ak, ref ops) => match **ak {
                 AggregateKind::Array(ty) => Ty::new_array(tcx, ty, ops.len() as u64),
                 AggregateKind::Tuple => {

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -444,6 +444,13 @@ macro_rules! make_mir_visitor {
                                 self.visit_operand(dst, location);
                                 self.visit_operand(count, location);
                             }
+                           NonDivergingIntrinsic::UbCheck { kind: _, func, args, destination: _, source_info: _, fn_span: _ } => {
+                                self.visit_operand(func, location);
+                                self.visit_operand(args, location);
+                                // FIXME destination is always a ZST so this probably won't make
+                                // things explode, but we don't have a PlaceContext for this
+                                // situation that won't make ssa.rs ICE.
+                            }
                         }
                     }
                     StatementKind::ConstEvalCounter => {}

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -433,7 +433,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
             | Rvalue::Discriminant(..)
             | Rvalue::Len(..)
             | Rvalue::NullaryOp(
-                NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..) | NullOp::DebugAssertions,
+                NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..) | NullOp::UbCheck(_),
                 _,
             ) => {}
         }

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -432,10 +432,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
             | Rvalue::AddressOf(..)
             | Rvalue::Discriminant(..)
             | Rvalue::Len(..)
-            | Rvalue::NullaryOp(
-                NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..) | NullOp::UbCheck(_),
-                _,
-            ) => {}
+            | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..), _) => {}
         }
     }
 

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -136,6 +136,16 @@ pub trait ValueAnalysis<'tcx> {
             }) => {
                 // This statement represents `*dst = *src`, `count` times.
             }
+            NonDivergingIntrinsic::UbCheck {
+                kind: _,
+                func: _,
+                args: _,
+                destination: _,
+                source_info: _,
+                fn_span: _,
+            } => {
+                // FIXME: Why are the above allowed to ignore everything?
+            }
         }
     }
 

--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -47,7 +47,8 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
             StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Deinit(_)
-            | StatementKind::Nop => {}
+            | StatementKind::Nop
+            | StatementKind::Intrinsic(box NonDivergingIntrinsic::UbCheck { .. }) => {}
             _ => self.cost += INSTR_COST,
         }
     }

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -488,7 +488,7 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
                     NullOp::OffsetOf(fields) => {
                         layout.offset_of_subfield(&self.ecx, fields.iter()).bytes()
                     }
-                    NullOp::DebugAssertions => return None,
+                    NullOp::UbCheck(_) => return None,
                 };
                 let usize_layout = self.ecx.layout_of(self.tcx.types.usize).unwrap();
                 let imm = ImmTy::try_from_uint(val, usize_layout)?;

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -488,7 +488,6 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
                     NullOp::OffsetOf(fields) => {
                         layout.offset_of_subfield(&self.ecx, fields.iter()).bytes()
                     }
-                    NullOp::UbCheck(_) => return None,
                 };
                 let usize_layout = self.ecx.layout_of(self.tcx.types.usize).unwrap();
                 let imm = ImmTy::try_from_uint(val, usize_layout)?;

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -332,6 +332,7 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
             | StatementKind::Intrinsic(box NonDivergingIntrinsic::Assume(..))
             // copy_nonoverlapping takes pointers and mutated the pointed-to value.
             | StatementKind::Intrinsic(box NonDivergingIntrinsic::CopyNonOverlapping(..))
+            | StatementKind::Intrinsic(box NonDivergingIntrinsic::UbCheck { .. })
             | StatementKind::AscribeUserType(..)
             | StatementKind::Coverage(..)
             | StatementKind::FakeRead(..)

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -639,7 +639,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     NullOp::OffsetOf(fields) => {
                         op_layout.offset_of_subfield(self, fields.iter()).bytes()
                     }
-                    NullOp::DebugAssertions => return None,
+                    NullOp::UbCheck(_) => return None,
                 };
                 ImmTy::from_scalar(Scalar::from_target_usize(val, self), layout).into()
             }

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -639,7 +639,6 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     NullOp::OffsetOf(fields) => {
                         op_layout.offset_of_subfield(self, fields.iter()).bytes()
                     }
-                    NullOp::UbCheck(_) => return None,
                 };
                 ImmTy::from_scalar(Scalar::from_target_usize(val, self), layout).into()
             }

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -20,13 +20,30 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                     sym::unreachable => {
                         terminator.kind = TerminatorKind::Unreachable;
                     }
-                    sym::debug_assertions => {
+                    sym::check_language_ub => {
                         let target = target.unwrap();
                         block.statements.push(Statement {
                             source_info: terminator.source_info,
                             kind: StatementKind::Assign(Box::new((
                                 *destination,
-                                Rvalue::NullaryOp(NullOp::DebugAssertions, tcx.types.bool),
+                                Rvalue::NullaryOp(
+                                    NullOp::UbCheck(UbKind::LanguageUb),
+                                    tcx.types.bool,
+                                ),
+                            ))),
+                        });
+                        terminator.kind = TerminatorKind::Goto { target };
+                    }
+                    sym::check_library_ub => {
+                        let target = target.unwrap();
+                        block.statements.push(Statement {
+                            source_info: terminator.source_info,
+                            kind: StatementKind::Assign(Box::new((
+                                *destination,
+                                Rvalue::NullaryOp(
+                                    NullOp::UbCheck(UbKind::LibraryUb),
+                                    tcx.types.bool,
+                                ),
                             ))),
                         });
                         terminator.kind = TerminatorKind::Goto { target };

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -446,7 +446,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                 NullOp::SizeOf => {}
                 NullOp::AlignOf => {}
                 NullOp::OffsetOf(_) => {}
-                NullOp::DebugAssertions => {}
+                NullOp::UbCheck(_) => {}
             },
 
             Rvalue::ShallowInitBox(_, _) => return Err(Unpromotable),

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -446,7 +446,6 @@ impl<'tcx> Validator<'_, 'tcx> {
                 NullOp::SizeOf => {}
                 NullOp::AlignOf => {}
                 NullOp::OffsetOf(_) => {}
-                NullOp::UbCheck(_) => {}
             },
 
             Rvalue::ShallowInitBox(_, _) => return Err(Unpromotable),

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(array_windows)]
 #![feature(is_sorted)]
+#![feature(box_patterns)]
 #![allow(rustc::potential_query_instability)]
 
 #[macro_use]

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -251,13 +251,19 @@ impl<'tcx> Stable<'tcx> for mir::NullOp<'tcx> {
     type T = stable_mir::mir::NullOp;
     fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::NullOp::*;
+        use rustc_middle::mir::UbKind;
         match self {
             SizeOf => stable_mir::mir::NullOp::SizeOf,
             AlignOf => stable_mir::mir::NullOp::AlignOf,
             OffsetOf(indices) => stable_mir::mir::NullOp::OffsetOf(
                 indices.iter().map(|idx| idx.stable(tables)).collect(),
             ),
-            DebugAssertions => stable_mir::mir::NullOp::DebugAssertions,
+            UbCheck(UbKind::LanguageUb) => {
+                stable_mir::mir::NullOp::UbCheck(stable_mir::mir::UbKind::LanguageUb)
+            }
+            UbCheck(UbKind::LibraryUb) => {
+                stable_mir::mir::NullOp::UbCheck(stable_mir::mir::UbKind::LibraryUb)
+            }
         }
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -251,19 +251,12 @@ impl<'tcx> Stable<'tcx> for mir::NullOp<'tcx> {
     type T = stable_mir::mir::NullOp;
     fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         use rustc_middle::mir::NullOp::*;
-        use rustc_middle::mir::UbKind;
         match self {
             SizeOf => stable_mir::mir::NullOp::SizeOf,
             AlignOf => stable_mir::mir::NullOp::AlignOf,
             OffsetOf(indices) => stable_mir::mir::NullOp::OffsetOf(
                 indices.iter().map(|idx| idx.stable(tables)).collect(),
             ),
-            UbCheck(UbKind::LanguageUb) => {
-                stable_mir::mir::NullOp::UbCheck(stable_mir::mir::UbKind::LanguageUb)
-            }
-            UbCheck(UbKind::LibraryUb) => {
-                stable_mir::mir::NullOp::UbCheck(stable_mir::mir::UbKind::LibraryUb)
-            }
         }
     }
 }
@@ -430,6 +423,22 @@ impl<'tcx> Stable<'tcx> for mir::NonDivergingIntrinsic<'tcx> {
                     count: copy_non_overlapping.count.stable(tables),
                 })
             }
+            NonDivergingIntrinsic::UbCheck {
+                kind,
+                func,
+                args,
+                destination,
+                source_info: _,
+                fn_span: _,
+            } => stable_mir::mir::NonDivergingIntrinsic::UbCheck {
+                kind: match kind {
+                    rustc_middle::mir::UbKind::LibraryUb => stable_mir::mir::UbKind::LibraryUb,
+                    rustc_middle::mir::UbKind::LanguageUb => stable_mir::mir::UbKind::LanguageUb,
+                },
+                func: func.stable(tables),
+                args: args.stable(tables),
+                destination: destination.stable(tables),
+            },
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -515,6 +515,8 @@ symbols! {
         cfi,
         cfi_encoding,
         char,
+        check_language_ub,
+        check_library_ub,
         client,
         clippy,
         clobber_abi,

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -639,7 +639,7 @@ impl Rvalue {
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..), _) => {
                 Ok(Ty::usize_ty())
             }
-            Rvalue::NullaryOp(NullOp::DebugAssertions, _) => Ok(Ty::bool_ty()),
+            Rvalue::NullaryOp(NullOp::UbCheck(_), _) => Ok(Ty::bool_ty()),
             Rvalue::Aggregate(ak, ops) => match *ak {
                 AggregateKind::Array(ty) => Ty::try_new_array(ty, ops.len() as u64),
                 AggregateKind::Tuple => Ok(Ty::new_tuple(
@@ -1007,7 +1007,13 @@ pub enum NullOp {
     /// Returns the offset of a field.
     OffsetOf(Vec<(VariantIdx, FieldIdx)>),
     /// cfg!(debug_assertions), but at codegen time
-    DebugAssertions,
+    UbCheck(UbKind),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UbKind {
+    LanguageUb,
+    LibraryUb,
 }
 
 impl Operand {

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -462,6 +462,13 @@ pub struct CopyNonOverlapping {
 pub enum NonDivergingIntrinsic {
     Assume(Operand),
     CopyNonOverlapping(CopyNonOverlapping),
+    UbCheck { kind: UbKind, func: Operand, args: Operand, destination: Place },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UbKind {
+    LanguageUb,
+    LibraryUb,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -639,7 +646,6 @@ impl Rvalue {
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(..), _) => {
                 Ok(Ty::usize_ty())
             }
-            Rvalue::NullaryOp(NullOp::UbCheck(_), _) => Ok(Ty::bool_ty()),
             Rvalue::Aggregate(ak, ops) => match *ak {
                 AggregateKind::Array(ty) => Ty::try_new_array(ty, ops.len() as u64),
                 AggregateKind::Tuple => Ok(Ty::new_tuple(
@@ -1006,14 +1012,6 @@ pub enum NullOp {
     AlignOf,
     /// Returns the offset of a field.
     OffsetOf(Vec<(VariantIdx, FieldIdx)>),
-    /// cfg!(debug_assertions), but at codegen time
-    UbCheck(UbKind),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum UbKind {
-    LanguageUb,
-    LibraryUb,
 }
 
 impl Operand {

--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -228,6 +228,11 @@ pub trait MirVisitor {
                     self.visit_operand(dst, location);
                     self.visit_operand(count, location);
                 }
+                NonDivergingIntrinsic::UbCheck { kind: _, func, args, destination } => {
+                    self.visit_operand(func, location);
+                    self.visit_operand(args, location);
+                    self.visit_place(destination, PlaceContext::MUTATING, location);
+                }
             },
             StatementKind::ConstEvalCounter => {}
             StatementKind::Nop => {}

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -26,6 +26,7 @@ pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {
     // SAFETY: the caller must guarantee that `i` is a valid char value.
     unsafe {
         assert_unsafe_precondition!(
+            check_language_ub,
             "invalid value for `char`",
             (i: u32 = i) => char_try_from_u32(i).is_ok()
         );

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -101,7 +101,11 @@ pub const unsafe fn unreachable_unchecked() -> ! {
     // SAFETY: the safety contract for `intrinsics::unreachable` must
     // be upheld by the caller.
     unsafe {
-        intrinsics::assert_unsafe_precondition!("hint::unreachable_unchecked must never be reached", () => false);
+        intrinsics::assert_unsafe_precondition!(
+            check_language_ub,
+            "hint::unreachable_unchecked must never be reached",
+            () => false
+        );
         intrinsics::unreachable()
     }
 }
@@ -147,6 +151,7 @@ pub const unsafe fn assert_unchecked(cond: bool) {
     // SAFETY: The caller promised `cond` is true.
     unsafe {
         intrinsics::assert_unsafe_precondition!(
+            check_language_ub,
             "hint::assert_unchecked must never be called when the condition is false",
             (cond: bool = cond) => cond,
         );

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -324,8 +324,9 @@ where
                 // SAFETY: The caller guarantees that `n` is non-zero, so this is unreachable.
                 unsafe {
                     intrinsics::assert_unsafe_precondition!(
-                      "NonZero::new_unchecked requires the argument to be non-zero",
-                      () => false,
+                        check_language_ub,
+                        "NonZero::new_unchecked requires the argument to be non-zero",
+                        () => false,
                     );
                     intrinsics::unreachable()
                 }
@@ -363,8 +364,9 @@ where
                 // SAFETY: The caller guarantees that `n` references a value that is non-zero, so this is unreachable.
                 unsafe {
                     intrinsics::assert_unsafe_precondition!(
-                      "NonZero::from_mut_unchecked requires the argument to dereference as non-zero",
-                      () => false,
+                        check_language_ub,
+                        "NonZero::from_mut_unchecked requires the argument to dereference as non-zero",
+                        () => false,
                     );
                     intrinsics::unreachable()
                 }

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -1,4 +1,4 @@
-use crate::intrinsics::{unchecked_add, unchecked_sub};
+use crate::intrinsics::{assert_unsafe_precondition, unchecked_add, unchecked_sub};
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::num::NonZero;
 
@@ -19,9 +19,10 @@ impl IndexRange {
     /// - `start <= end`
     #[inline]
     pub const unsafe fn new_unchecked(start: usize, end: usize) -> Self {
-        crate::panic::debug_assert_nounwind!(
-            start <= end,
-            "IndexRange::new_unchecked requires `start <= end`"
+        assert_unsafe_precondition!(
+            check_library_ub,
+            "IndexRange::new_unchecked requires `start <= end`",
+            (start: usize = start, end: usize = end) => start <= end,
         );
         IndexRange { start, end }
     }

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -139,43 +139,6 @@ pub macro unreachable_2021 {
     ),
 }
 
-/// Like `assert_unsafe_precondition!` the defining features of this macro are that its
-/// checks are enabled when they are monomorphized with debug assertions enabled, and upon failure
-/// a non-unwinding panic is launched so that failures cannot compromise unwind safety.
-///
-/// But there are many differences from `assert_unsafe_precondition!`. This macro does not use
-/// `const_eval_select` internally, and therefore it is sound to call this with an expression
-/// that evaluates to `false`. Also unlike `assert_unsafe_precondition!` the condition being
-/// checked here is not put in an outlined function. If the check compiles to a lot of IR, this
-/// can cause code bloat if the check is monomorphized many times. But it also means that the checks
-/// from this macro can be deduplicated or otherwise optimized out.
-///
-/// In general, this macro should be used to check all public-facing preconditions. But some
-/// preconditions may be called too often or instantiated too often to make the overhead of the
-/// checks tolerable. In such cases, place `#[cfg(debug_assertions)]` on the macro call. That will
-/// disable the check in our precompiled standard library, but if a user wishes, they can still
-/// enable the check by recompiling the standard library with debug assertions enabled.
-#[doc(hidden)]
-#[unstable(feature = "panic_internals", issue = "none")]
-#[allow_internal_unstable(panic_internals, delayed_debug_assertions)]
-#[rustc_macro_transparency = "semitransparent"]
-pub macro debug_assert_nounwind {
-    ($cond:expr $(,)?) => {
-        if $crate::intrinsics::debug_assertions() {
-            if !$cond {
-                $crate::panicking::panic_nounwind($crate::concat!("assertion failed: ", $crate::stringify!($cond)));
-            }
-        }
-    },
-    ($cond:expr, $message:expr) => {
-        if $crate::intrinsics::debug_assertions() {
-            if !$cond {
-                $crate::panicking::panic_nounwind($message);
-            }
-        }
-    },
-}
-
 /// An internal trait used by std to pass data from std to `panic_unwind` and
 /// other panic runtimes. Not intended to be stabilized any time soon, do not
 /// use.

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -1,4 +1,6 @@
 use crate::convert::{TryFrom, TryInto};
+#[cfg(debug_assertions)]
+use crate::intrinsics::assert_unsafe_precondition;
 use crate::num::NonZero;
 use crate::{cmp, fmt, hash, mem, num};
 
@@ -77,9 +79,10 @@ impl Alignment {
     #[inline]
     pub const unsafe fn new_unchecked(align: usize) -> Self {
         #[cfg(debug_assertions)]
-        crate::panic::debug_assert_nounwind!(
-            align.is_power_of_two(),
-            "Alignment::new_unchecked requires a power of two"
+        assert_unsafe_precondition!(
+            check_language_ub,
+            "Alignment::new_unchecked requires a power of two",
+            (align: usize = align) => align.is_power_of_two()
         );
 
         // SAFETY: By precondition, this must be a power of two, and

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -991,24 +991,21 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
         };
     }
 
-    // SAFETY: the caller must guarantee that `x` and `y` are
-    // valid for writes and properly aligned.
-    unsafe {
-        assert_unsafe_precondition!(
-            "ptr::swap_nonoverlapping requires that both pointer arguments are aligned and non-null \
-            and the specified memory ranges do not overlap",
-            (
-                x: *mut () = x as *mut (),
-                y: *mut () = y as *mut (),
-                size: usize = size_of::<T>(),
-                align: usize = align_of::<T>(),
-                count: usize = count,
-            ) =>
-            is_aligned_and_not_null(x, align)
-                && is_aligned_and_not_null(y, align)
-                && is_nonoverlapping(x, y, size, count)
-        );
-    }
+    assert_unsafe_precondition!(
+        check_language_ub,
+        "ptr::swap_nonoverlapping requires that both pointer arguments are aligned and non-null \
+        and the specified memory ranges do not overlap",
+        (
+            x: *mut () = x as *mut (),
+            y: *mut () = y as *mut (),
+            size: usize = size_of::<T>(),
+            align: usize = align_of::<T>(),
+            count: usize = count,
+        ) =>
+        is_aligned_and_not_null(x, align)
+            && is_aligned_and_not_null(y, align)
+            && is_nonoverlapping(x, y, size, count)
+    );
 
     // Split up the slice into small power-of-two-sized chunks that LLVM is able
     // to vectorize (unless it's a special type with more-than-pointer alignment,
@@ -1096,6 +1093,7 @@ pub const unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
     // allocated object.
     unsafe {
         assert_unsafe_precondition!(
+            check_language_ub,
             "ptr::replace requires that the pointer argument is aligned and non-null",
             (
                 addr: *const () = dst as *const (),
@@ -1248,6 +1246,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
     unsafe {
         #[cfg(debug_assertions)] // Too expensive to always enable (for now?)
         assert_unsafe_precondition!(
+            check_language_ub,
             "ptr::read requires that the pointer argument is aligned and non-null",
             (
                 addr: *const () = src as *const (),
@@ -1456,6 +1455,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
     unsafe {
         #[cfg(debug_assertions)] // Too expensive to always enable (for now?)
         assert_unsafe_precondition!(
+            check_language_ub,
             "ptr::write requires that the pointer argument is aligned and non-null",
             (
                 addr: *mut () = dst as *mut (),
@@ -1627,6 +1627,7 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
     // SAFETY: the caller must uphold the safety contract for `volatile_load`.
     unsafe {
         assert_unsafe_precondition!(
+            check_language_ub,
             "ptr::read_volatile requires that the pointer argument is aligned and non-null",
             (
                 addr: *const () = src as *const (),
@@ -1705,6 +1706,7 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
     // SAFETY: the caller must uphold the safety contract for `volatile_store`.
     unsafe {
         assert_unsafe_precondition!(
+            check_language_ub,
             "ptr::write_volatile requires that the pointer argument is aligned and non-null",
             (
                 addr: *mut () = dst as *mut (),

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -218,6 +218,7 @@ impl<T: ?Sized> NonNull<T> {
         // SAFETY: the caller must guarantee that `ptr` is non-null.
         unsafe {
             assert_unsafe_precondition!(
+                check_language_ub,
                 "NonNull::new_unchecked requires that the pointer is non-null",
                 (ptr: *mut () = ptr as *mut ()) => !ptr.is_null()
             );

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -9,11 +9,11 @@
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::fmt;
 use crate::hint;
+use crate::intrinsics::assert_unsafe_precondition;
 use crate::intrinsics::exact_div;
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZero;
 use crate::ops::{Bound, OneSidedRange, Range, RangeBounds};
-use crate::panic::debug_assert_nounwind;
 use crate::ptr;
 use crate::simd::{self, Simd};
 use crate::slice;
@@ -945,9 +945,14 @@ impl<T> [T] {
     #[unstable(feature = "slice_swap_unchecked", issue = "88539")]
     #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
     pub const unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
-        debug_assert_nounwind!(
-            a < self.len() && b < self.len(),
-            "slice::swap_unchecked requires that the indices are within the slice"
+        assert_unsafe_precondition!(
+            check_library_ub,
+            "slice::swap_unchecked requires that the indices are within the slice",
+            (
+                len: usize = self.len(),
+                a: usize = a,
+                b: usize = b,
+            ) => a < len && b < len,
         );
 
         let ptr = self.as_mut_ptr();
@@ -1285,9 +1290,10 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {
-        debug_assert_nounwind!(
-            N != 0 && self.len() % N == 0,
-            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks"
+        assert_unsafe_precondition!(
+            check_language_ub,
+            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks",
+            (n: usize = N, len: usize = self.len()) => n != 0 && len % n == 0,
         );
         // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
         let new_len = unsafe { exact_div(self.len(), N) };
@@ -1439,9 +1445,10 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     pub const unsafe fn as_chunks_unchecked_mut<const N: usize>(&mut self) -> &mut [[T; N]] {
-        debug_assert_nounwind!(
-            N != 0 && self.len() % N == 0,
-            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks"
+        assert_unsafe_precondition!(
+            check_language_ub,
+            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks",
+            (n: usize = N, len: usize = self.len()) => n != 0 && len % n == 0
         );
         // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
         let new_len = unsafe { exact_div(self.len(), N) };
@@ -1971,9 +1978,10 @@ impl<T> [T] {
         let len = self.len();
         let ptr = self.as_ptr();
 
-        debug_assert_nounwind!(
-            mid <= len,
-            "slice::split_at_unchecked requires the index to be within the slice"
+        assert_unsafe_precondition!(
+            check_library_ub,
+            "slice::split_at_unchecked requires the index to be within the slice",
+            (mid: usize = mid, len: usize = len) => mid <= len,
         );
 
         // SAFETY: Caller has to check that `0 <= mid <= self.len()`
@@ -2021,9 +2029,10 @@ impl<T> [T] {
         let len = self.len();
         let ptr = self.as_mut_ptr();
 
-        debug_assert_nounwind!(
-            mid <= len,
-            "slice::split_at_mut_unchecked requires the index to be within the slice"
+        assert_unsafe_precondition!(
+            check_library_ub,
+            "slice::split_at_mut_unchecked requires the index to be within the slice",
+            (mid: usize = mid, len: usize = len) => mid <= len,
         );
 
         // SAFETY: Caller has to check that `0 <= mid <= self.len()`.

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -96,6 +96,7 @@ pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T]
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts`.
     unsafe {
         assert_unsafe_precondition!(
+            check_language_ub,
             "slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
             (
                 data: *mut () = data as *mut (),
@@ -149,6 +150,7 @@ pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a m
     // SAFETY: the caller must uphold the safety contract for `from_raw_parts_mut`.
     unsafe {
         assert_unsafe_precondition!(
+            check_language_ub,
             "slice::from_raw_parts_mut requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
             (
                 data: *mut () = data as *mut (),

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -1,8 +1,8 @@
 //! Trait implementations for `str`.
 
 use crate::cmp::Ordering;
+use crate::intrinsics::assert_unsafe_precondition;
 use crate::ops;
-use crate::panic::debug_assert_nounwind;
 use crate::ptr;
 use crate::slice::SliceIndex;
 
@@ -192,15 +192,20 @@ unsafe impl SliceIndex<str> for ops::Range<usize> {
     unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {
         let slice = slice as *const [u8];
 
-        debug_assert_nounwind!(
+        assert_unsafe_precondition!(
             // We'd like to check that the bounds are on char boundaries,
             // but there's not really a way to do so without reading
             // behind the pointer, which has aliasing implications.
             // It's also not possible to move this check up to
             // `str::get_unchecked` without adding a special function
             // to `SliceIndex` just for this.
-            self.end >= self.start && self.end <= slice.len(),
-            "str::get_unchecked requires that the range is within the string slice"
+            check_library_ub,
+            "str::get_unchecked requires that the range is within the string slice",
+            (
+                start: usize = self.start,
+                end: usize = self.end,
+                len: usize = slice.len()
+            ) => end >= start && end <= len,
         );
 
         // SAFETY: the caller guarantees that `self` is in bounds of `slice`
@@ -213,9 +218,14 @@ unsafe impl SliceIndex<str> for ops::Range<usize> {
     unsafe fn get_unchecked_mut(self, slice: *mut str) -> *mut Self::Output {
         let slice = slice as *mut [u8];
 
-        debug_assert_nounwind!(
-            self.end >= self.start && self.end <= slice.len(),
-            "str::get_unchecked_mut requires that the range is within the string slice"
+        assert_unsafe_precondition!(
+            check_library_ub,
+            "str::get_unchecked_mut requires that the range is within the string slice",
+            (
+                start: usize = self.start,
+                end: usize = self.end,
+                len: usize = slice.len()
+            ) => end >= start && end <= len,
         );
 
         // SAFETY: see comments for `get_unchecked`.

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -174,7 +174,7 @@ fn check_rvalue<'tcx>(
                 ))
             }
         },
-        Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) | NullOp::DebugAssertions, _)
+        Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) | NullOp::UbCheck(_), _)
         | Rvalue::ShallowInitBox(_, _) => Ok(()),
         Rvalue::UnaryOp(_, operand) => {
             let ty = operand.ty(body, tcx);

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -174,7 +174,7 @@ fn check_rvalue<'tcx>(
                 ))
             }
         },
-        Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) | NullOp::UbCheck(_), _)
+        Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_), _)
         | Rvalue::ShallowInitBox(_, _) => Ok(()),
         Rvalue::UnaryOp(_, operand) => {
             let ty = operand.ty(body, tcx);
@@ -221,6 +221,13 @@ fn check_statement<'tcx>(
             check_operand(tcx, src, span, body)?;
             check_operand(tcx, count, span, body)
         },
+        StatementKind::Intrinsic(box NonDivergingIntrinsic::UbCheck { 
+            func, args, ..
+        }) => {
+            check_operand(tcx, func, span, body)?;
+            check_operand(tcx, args, span, body)
+        },
+ 
         // These are all NOPs
         StatementKind::StorageLive(_)
         | StatementKind::StorageDead(_)

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -58,11 +58,10 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb4, otherwise: bb2];
       }
   
       bb1: {
@@ -71,16 +70,21 @@
       }
   
       bb2: {
+          StorageLive(_10);
           _10 = const {0x1 as *mut ()};
           _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {
+          StorageDead(_10);
+          goto -> bb4;
+      }
+  
+      bb4: {
           StorageDead(_8);
           _11 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -58,45 +56,33 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
           StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = const {0x1 as *mut ()};
+          _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+          UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
           StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
+          _10 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
           _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
           _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
           _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -58,11 +58,10 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb4, otherwise: bb3];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb5, otherwise: bb3];
       }
   
       bb1: {
@@ -75,16 +74,21 @@
       }
   
       bb3: {
+          StorageLive(_10);
           _10 = const {0x1 as *mut ()};
           _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
+          StorageDead(_10);
+          goto -> bb5;
+      }
+  
+      bb5: {
           StorageDead(_8);
           _11 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -58,10 +56,28 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
+          StorageLive(_10);
           StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
+          StorageLive(_9);
+          _9 = const {0x1 as *mut ()};
+          _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+          UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
+          StorageDead(_8);
+          _10 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_10);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
       }
   
       bb1: {
@@ -71,36 +87,6 @@
   
       bb2 (cleanup): {
           resume;
-      }
-  
-      bb3: {
-          StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
-          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
-          StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
-          StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
-          StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
-          StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
-          StorageDead(_2);
-          _0 = const ();
-          drop(_1) -> [return: bb1, unwind: bb2];
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -58,11 +58,10 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb4, otherwise: bb2];
       }
   
       bb1: {
@@ -71,16 +70,21 @@
       }
   
       bb2: {
+          StorageLive(_10);
           _10 = const {0x1 as *mut ()};
           _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {
+          StorageDead(_10);
+          goto -> bb4;
+      }
+  
+      bb4: {
           StorageDead(_8);
           _11 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -58,45 +56,33 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
           StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = const {0x1 as *mut ()};
+          _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+          UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
           StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
+          _10 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);
           _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
           _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
           _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -58,11 +58,10 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb4, otherwise: bb3];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb5, otherwise: bb3];
       }
   
       bb1: {
@@ -75,16 +74,21 @@
       }
   
       bb3: {
+          StorageLive(_10);
           _10 = const {0x1 as *mut ()};
           _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
+          StorageDead(_10);
+          goto -> bb5;
+      }
+  
+      bb5: {
           StorageDead(_8);
           _11 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
           StorageDead(_5);

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -58,10 +56,28 @@
           _7 = const 1_usize;
           _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
+          StorageLive(_10);
           StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
+          StorageLive(_9);
+          _9 = const {0x1 as *mut ()};
+          _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+          UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
+          StorageDead(_8);
+          _10 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_10);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
       }
   
       bb1: {
@@ -71,36 +87,6 @@
   
       bb2 (cleanup): {
           resume;
-      }
-  
-      bb3: {
-          StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
-          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
-          StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
-          StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
-          StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
-          StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
-          StorageDead(_2);
-          _0 = const ();
-          drop(_1) -> [return: bb1, unwind: bb2];
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -60,11 +60,10 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb4, otherwise: bb2];
       }
   
       bb1: {
@@ -73,6 +72,7 @@
       }
   
       bb2: {
+          StorageLive(_10);
 -         _10 = _6 as *mut () (PtrToPtr);
 -         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb3, unwind unreachable];
 +         _10 = const {0x1 as *mut ()};
@@ -80,13 +80,17 @@
       }
   
       bb3: {
+          StorageDead(_10);
+          goto -> bb4;
+      }
+  
+      bb4: {
           StorageDead(_8);
 -         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
 -         _5 = NonNull::<[bool; 0]> { pointer: _11 };
 +         _11 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -60,37 +58,22 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
           StorageLive(_10);
--         _10 = _6 as *mut () (PtrToPtr);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb3, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
+          StorageLive(_8);
+          StorageLive(_9);
+-         _9 = _6 as *mut () (PtrToPtr);
+-         _8 = (move _9,);
++         _9 = const {0x1 as *mut ()};
++         _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+-         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(move _8);
++         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
           StorageDead(_8);
--         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
--         _5 = NonNull::<[bool; 0]> { pointer: _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _10 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _10 };
++         _10 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
@@ -100,13 +83,17 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(_3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
 + }
 + 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -60,11 +60,10 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb4, otherwise: bb3];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb5, otherwise: bb3];
       }
   
       bb1: {
@@ -77,6 +76,7 @@
       }
   
       bb3: {
+          StorageLive(_10);
 -         _10 = _6 as *mut () (PtrToPtr);
 -         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb4, unwind unreachable];
 +         _10 = const {0x1 as *mut ()};
@@ -84,13 +84,17 @@
       }
   
       bb4: {
+          StorageDead(_10);
+          goto -> bb5;
+      }
+  
+      bb5: {
           StorageDead(_8);
 -         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
 -         _5 = NonNull::<[bool; 0]> { pointer: _11 };
 +         _11 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -60,41 +58,22 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2 (cleanup): {
-          resume;
-      }
-  
-      bb3: {
           StorageLive(_10);
--         _10 = _6 as *mut () (PtrToPtr);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb4, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
+          StorageLive(_8);
+          StorageLive(_9);
+-         _9 = _6 as *mut () (PtrToPtr);
+-         _8 = (move _9,);
++         _9 = const {0x1 as *mut ()};
++         _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+-         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(move _8);
++         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
           StorageDead(_8);
--         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
--         _5 = NonNull::<[bool; 0]> { pointer: _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _10 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _10 };
++         _10 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
@@ -104,13 +83,21 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(_3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
       }
 + }
 + 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -60,11 +60,10 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb3, otherwise: bb2];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb4, otherwise: bb2];
       }
   
       bb1: {
@@ -73,6 +72,7 @@
       }
   
       bb2: {
+          StorageLive(_10);
 -         _10 = _6 as *mut () (PtrToPtr);
 -         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb3, unwind unreachable];
 +         _10 = const {0x1 as *mut ()};
@@ -80,13 +80,17 @@
       }
   
       bb3: {
+          StorageDead(_10);
+          goto -> bb4;
+      }
+  
+      bb4: {
           StorageDead(_8);
 -         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
 -         _5 = NonNull::<[bool; 0]> { pointer: _11 };
 +         _11 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -60,37 +58,22 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
           StorageLive(_10);
--         _10 = _6 as *mut () (PtrToPtr);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb3, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
+          StorageLive(_8);
+          StorageLive(_9);
+-         _9 = _6 as *mut () (PtrToPtr);
+-         _8 = (move _9,);
++         _9 = const {0x1 as *mut ()};
++         _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+-         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(move _8);
++         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
           StorageDead(_8);
--         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
--         _5 = NonNull::<[bool; 0]> { pointer: _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _10 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _10 };
++         _10 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
@@ -100,13 +83,17 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(_3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
 + }
 + 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -60,11 +60,10 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_10);
           StorageLive(_11);
           StorageLive(_8);
-          _8 = cfg!(debug_assertions);
-          switchInt(move _8) -> [0: bb4, otherwise: bb3];
+          _8 = UbCheck(LanguageUb);
+          switchInt(move _8) -> [0: bb5, otherwise: bb3];
       }
   
       bb1: {
@@ -77,6 +76,7 @@
       }
   
       bb3: {
+          StorageLive(_10);
 -         _10 = _6 as *mut () (PtrToPtr);
 -         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb4, unwind unreachable];
 +         _10 = const {0x1 as *mut ()};
@@ -84,13 +84,17 @@
       }
   
       bb4: {
+          StorageDead(_10);
+          goto -> bb5;
+      }
+  
+      bb5: {
           StorageDead(_8);
 -         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
 -         _5 = NonNull::<[bool; 0]> { pointer: _11 };
 +         _11 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
           StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -23,10 +23,9 @@
                           debug ptr => _6;
                           scope 12 (inlined NonNull::<[bool; 0]>::new_unchecked) {
                               debug ptr => _6;
-                              let mut _8: bool;
-                              let _9: ();
-                              let mut _10: *mut ();
-                              let mut _11: *const [bool; 0];
+                              let mut _8: (*mut (),);
+                              let mut _9: *mut ();
+                              let mut _10: *const [bool; 0];
                               scope 13 {
                               }
                           }
@@ -50,7 +49,6 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
@@ -60,41 +58,22 @@
 +         _7 = const 1_usize;
 +         _6 = const {0x1 as *mut [bool; 0]};
           StorageDead(_7);
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbCheck(LanguageUb);
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2 (cleanup): {
-          resume;
-      }
-  
-      bb3: {
           StorageLive(_10);
--         _10 = _6 as *mut () (PtrToPtr);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb4, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
+          StorageLive(_8);
+          StorageLive(_9);
+-         _9 = _6 as *mut () (PtrToPtr);
+-         _8 = (move _9,);
++         _9 = const {0x1 as *mut ()};
++         _8 = const ({0x1 as *mut ()},);
+          StorageDead(_9);
+-         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(move _8);
++         UbCheck(LanguageUb): NonNull::<T>::new_unchecked::precondition_check(const ({0x1 as *mut ()},));
           StorageDead(_8);
--         _11 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
--         _5 = NonNull::<[bool; 0]> { pointer: _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _10 = _6 as *const [bool; 0] (PointerCoercion(MutToConstPointer));
+-         _5 = NonNull::<[bool; 0]> { pointer: _10 };
++         _10 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
 +         _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
@@ -104,13 +83,21 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(_3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
       }
 + }
 + 

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -37,7 +37,7 @@
 + 
 +     bb2: {
 +         StorageLive(_4);
-+         _4 = cfg!(debug_assertions);
++         _4 = UbCheck(LanguageUb);
 +         assume(_4);
 +         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
 +     }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -8,13 +8,12 @@
 +     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
 +         debug self => _2;
 +         let mut _3: isize;
++         let mut _4: bool;
 +         scope 2 {
 +             debug val => _0;
 +         }
 +         scope 3 {
 +             scope 4 (inlined unreachable_unchecked) {
-+                 let mut _4: bool;
-+                 let _5: ();
 +                 scope 5 {
 +                 }
 +             }
@@ -25,26 +24,16 @@
           StorageLive(_2);
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind unreachable];
+-     }
+- 
+-     bb1: {
 +         StorageLive(_3);
-+         StorageLive(_5);
-+         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
-      }
-  
-      bb1: {
-+         unreachable;
-+     }
-+ 
-+     bb2: {
 +         StorageLive(_4);
-+         _4 = UbCheck(LanguageUb);
-+         assume(_4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
-+     }
-+ 
-+     bb3: {
++         _3 = discriminant(_2);
++         _4 = Eq(_3, const 1_isize);
++         assume(move _4);
 +         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_5);
++         StorageDead(_4);
 +         StorageDead(_3);
           StorageDead(_2);
           return;

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -41,7 +41,7 @@
 -         resume;
 +     bb2: {
 +         StorageLive(_4);
-+         _4 = cfg!(debug_assertions);
++         _4 = UbCheck(LanguageUb);
 +         assume(_4);
 +         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
 +     }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -8,13 +8,12 @@
 +     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
 +         debug self => _2;
 +         let mut _3: isize;
++         let mut _4: bool;
 +         scope 2 {
 +             debug val => _0;
 +         }
 +         scope 3 {
 +             scope 4 (inlined unreachable_unchecked) {
-+                 let mut _4: bool;
-+                 let _5: ();
 +                 scope 5 {
 +                 }
 +             }
@@ -25,33 +24,23 @@
           StorageLive(_2);
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2];
+-     }
+- 
+-     bb1: {
 +         StorageLive(_3);
-+         StorageLive(_5);
++         StorageLive(_4);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
-      }
-  
-      bb1: {
--         StorageDead(_2);
--         return;
-+         unreachable;
-      }
-  
++         _4 = Eq(_3, const 1_isize);
++         assume(move _4);
++         _0 = move ((_2 as Some).0: T);
++         StorageDead(_4);
++         StorageDead(_3);
+          StorageDead(_2);
+          return;
+-     }
+- 
 -     bb2 (cleanup): {
 -         resume;
-+     bb2: {
-+         StorageLive(_4);
-+         _4 = UbCheck(LanguageUb);
-+         assume(_4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
-+     }
-+ 
-+     bb3: {
-+         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_5);
-+         StorageDead(_3);
-+         StorageDead(_2);
-+         return;
       }
   }
   

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
@@ -27,7 +27,7 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
 
     bb1: {
         StorageLive(_3);
-        _3 = cfg!(debug_assertions);
+        _3 = UbCheck(LanguageUb);
         assume(_3);
         _4 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
     }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-abort.mir
@@ -6,13 +6,12 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
         debug self => _1;
         let mut _2: isize;
+        let mut _3: bool;
         scope 2 {
             debug val => _0;
         }
         scope 3 {
             scope 4 (inlined unreachable_unchecked) {
-                let mut _3: bool;
-                let _4: ();
                 scope 5 {
                 }
             }
@@ -21,24 +20,13 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
 
     bb0: {
         StorageLive(_2);
-        _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb3];
-    }
-
-    bb1: {
         StorageLive(_3);
-        _3 = UbCheck(LanguageUb);
-        assume(_3);
-        _4 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
-    }
-
-    bb2: {
+        _2 = discriminant(_1);
+        _3 = Eq(_2, const 1_isize);
+        assume(move _3);
         _0 = ((_1 as Some).0: T);
+        StorageDead(_3);
         StorageDead(_2);
         return;
-    }
-
-    bb3: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
@@ -27,7 +27,7 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
 
     bb1: {
         StorageLive(_3);
-        _3 = cfg!(debug_assertions);
+        _3 = UbCheck(LanguageUb);
         assume(_3);
         _4 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
     }

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.PreCodegen.after.panic-unwind.mir
@@ -6,13 +6,12 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
     scope 1 (inlined #[track_caller] Option::<T>::unwrap_unchecked) {
         debug self => _1;
         let mut _2: isize;
+        let mut _3: bool;
         scope 2 {
             debug val => _0;
         }
         scope 3 {
             scope 4 (inlined unreachable_unchecked) {
-                let mut _3: bool;
-                let _4: ();
                 scope 5 {
                 }
             }
@@ -21,24 +20,13 @@ fn unwrap_unchecked(_1: Option<T>) -> T {
 
     bb0: {
         StorageLive(_2);
-        _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb3];
-    }
-
-    bb1: {
         StorageLive(_3);
-        _3 = UbCheck(LanguageUb);
-        assume(_3);
-        _4 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
-    }
-
-    bb2: {
+        _2 = discriminant(_1);
+        _3 = Eq(_2, const 1_isize);
+        assume(move _3);
         _0 = ((_1 as Some).0: T);
+        StorageDead(_3);
         StorageDead(_2);
         return;
-    }
-
-    bb3: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
@@ -23,7 +23,7 @@ fn ub_if_b(_1: Thing) -> Thing {
 
     bb2: {
         StorageLive(_3);
-        _3 = cfg!(debug_assertions);
+        _3 = UbCheck(LanguageUb);
         assume(_3);
         _4 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
     }

--- a/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/duplicate_switch_targets.ub_if_b.PreCodegen.after.mir
@@ -4,31 +4,17 @@ fn ub_if_b(_1: Thing) -> Thing {
     debug t => _1;
     let mut _0: Thing;
     let mut _2: isize;
+    let mut _3: bool;
     scope 1 (inlined unreachable_unchecked) {
-        let mut _3: bool;
-        let _4: ();
         scope 2 {
         }
     }
 
     bb0: {
         _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb3];
-    }
-
-    bb1: {
+        _3 = Eq(_2, const 0_isize);
+        assume(move _3);
         _0 = move _1;
         return;
-    }
-
-    bb2: {
-        StorageLive(_3);
-        _3 = UbCheck(LanguageUb);
-        assume(_3);
-        _4 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
-    }
-
-    bb3: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
@@ -7,13 +7,94 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     scope 1 (inlined core::slice::<impl [u32]>::get_mut::<usize>) {
         debug self => _1;
         debug index => _2;
+        scope 2 (inlined <usize as SliceIndex<[u32]>>::get_mut) {
+            debug self => _2;
+            debug slice => _1;
+            let mut _3: usize;
+            let mut _4: bool;
+            let mut _5: *mut [u32];
+            let mut _11: *mut u32;
+            let mut _12: &mut u32;
+            scope 3 {
+                scope 4 (inlined <usize as SliceIndex<[u32]>>::get_unchecked_mut) {
+                    debug self => _2;
+                    debug slice => _5;
+                    let mut _8: usize;
+                    let mut _9: (usize, usize);
+                    let mut _10: *mut u32;
+                    scope 5 {
+                        scope 9 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
+                            debug self => _5;
+                        }
+                        scope 10 (inlined std::ptr::mut_ptr::<impl *mut u32>::add) {
+                            debug self => _10;
+                            debug count => _2;
+                            scope 11 {
+                            }
+                        }
+                    }
+                    scope 6 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                        debug self => _5;
+                        let mut _6: *const [u32];
+                        scope 7 (inlined std::ptr::metadata::<[u32]>) {
+                            debug ptr => _6;
+                            let mut _7: std::ptr::metadata::PtrRepr<[u32]>;
+                            scope 8 {
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <usize as SliceIndex<[u32]>>::get_mut(move _2, move _1) -> [return: bb1, unwind unreachable];
+        StorageLive(_11);
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = Len((*_1));
+        _4 = Lt(_2, move _3);
+        switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
+        StorageDead(_3);
+        _0 = const Option::<&mut u32>::None;
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageDead(_3);
+        StorageLive(_12);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_9);
+        StorageLive(_8);
+        StorageLive(_6);
+        _6 = _5 as *const [u32] (PointerCoercion(MutToConstPointer));
+        StorageLive(_7);
+        _7 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _6 };
+        _8 = ((_7.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        StorageDead(_7);
+        StorageDead(_6);
+        _9 = (_2, move _8);
+        StorageDead(_8);
+        UbCheck(LibraryUb): <usize as SliceIndex<[T]>>::get_unchecked_mut::precondition_check(move _9);
+        StorageDead(_9);
+        StorageLive(_10);
+        _10 = _5 as *mut u32 (PtrToPtr);
+        _11 = Offset(_10, _2);
+        StorageDead(_10);
+        StorageDead(_5);
+        _12 = &mut (*_11);
+        _0 = Option::<&mut u32>::Some(move _12);
+        StorageDead(_12);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        StorageDead(_11);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
@@ -7,13 +7,94 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     scope 1 (inlined core::slice::<impl [u32]>::get_mut::<usize>) {
         debug self => _1;
         debug index => _2;
+        scope 2 (inlined <usize as SliceIndex<[u32]>>::get_mut) {
+            debug self => _2;
+            debug slice => _1;
+            let mut _3: usize;
+            let mut _4: bool;
+            let mut _5: *mut [u32];
+            let mut _11: *mut u32;
+            let mut _12: &mut u32;
+            scope 3 {
+                scope 4 (inlined <usize as SliceIndex<[u32]>>::get_unchecked_mut) {
+                    debug self => _2;
+                    debug slice => _5;
+                    let mut _8: usize;
+                    let mut _9: (usize, usize);
+                    let mut _10: *mut u32;
+                    scope 5 {
+                        scope 9 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
+                            debug self => _5;
+                        }
+                        scope 10 (inlined std::ptr::mut_ptr::<impl *mut u32>::add) {
+                            debug self => _10;
+                            debug count => _2;
+                            scope 11 {
+                            }
+                        }
+                    }
+                    scope 6 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                        debug self => _5;
+                        let mut _6: *const [u32];
+                        scope 7 (inlined std::ptr::metadata::<[u32]>) {
+                            debug ptr => _6;
+                            let mut _7: std::ptr::metadata::PtrRepr<[u32]>;
+                            scope 8 {
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     bb0: {
-        _0 = <usize as SliceIndex<[u32]>>::get_mut(move _2, move _1) -> [return: bb1, unwind continue];
+        StorageLive(_11);
+        StorageLive(_4);
+        StorageLive(_3);
+        _3 = Len((*_1));
+        _4 = Lt(_2, move _3);
+        switchInt(move _4) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
+        StorageDead(_3);
+        _0 = const Option::<&mut u32>::None;
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageDead(_3);
+        StorageLive(_12);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_9);
+        StorageLive(_8);
+        StorageLive(_6);
+        _6 = _5 as *const [u32] (PointerCoercion(MutToConstPointer));
+        StorageLive(_7);
+        _7 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _6 };
+        _8 = ((_7.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        StorageDead(_7);
+        StorageDead(_6);
+        _9 = (_2, move _8);
+        StorageDead(_8);
+        UbCheck(LibraryUb): <usize as SliceIndex<[T]>>::get_unchecked_mut::precondition_check(move _9);
+        StorageDead(_9);
+        StorageLive(_10);
+        _10 = _5 as *mut u32 (PtrToPtr);
+        _11 = Offset(_10, _2);
+        StorageDead(_10);
+        StorageDead(_5);
+        _12 = &mut (*_11);
+        _0 = Option::<&mut u32>::Some(move _12);
+        StorageDead(_12);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_4);
+        StorageDead(_11);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -4,24 +4,111 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => _2;
-        let mut _3: *mut [u32];
-        let mut _4: *mut [u32];
+        debug ((index: std::ops::Range<usize>).0: usize) => _3;
+        debug ((index: std::ops::Range<usize>).1: usize) => _4;
+        let mut _5: *mut [u32];
+        let mut _17: *mut [u32];
         scope 2 {
+            scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
+                debug ((self: std::ops::Range<usize>).0: usize) => _3;
+                debug ((self: std::ops::Range<usize>).1: usize) => _4;
+                debug slice => _5;
+                let mut _8: usize;
+                let mut _9: (usize, usize, usize);
+                let mut _11: *mut u32;
+                let mut _12: *mut u32;
+                scope 4 {
+                    let _10: usize;
+                    scope 5 {
+                        debug new_len => _10;
+                        scope 9 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
+                            debug self => _5;
+                        }
+                        scope 10 (inlined std::ptr::mut_ptr::<impl *mut u32>::add) {
+                            debug self => _11;
+                            debug count => _3;
+                            scope 11 {
+                            }
+                        }
+                        scope 12 (inlined slice_from_raw_parts_mut::<u32>) {
+                            debug data => _12;
+                            debug len => _10;
+                            let mut _13: *mut ();
+                            scope 13 (inlined std::ptr::mut_ptr::<impl *mut u32>::cast::<()>) {
+                                debug self => _12;
+                            }
+                            scope 14 (inlined std::ptr::from_raw_parts_mut::<[u32]>) {
+                                debug data_pointer => _13;
+                                debug metadata => _10;
+                                let mut _14: *const ();
+                                let mut _15: std::ptr::metadata::PtrComponents<[u32]>;
+                                let mut _16: std::ptr::metadata::PtrRepr<[u32]>;
+                                scope 15 {
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 6 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                    debug self => _5;
+                    let mut _6: *const [u32];
+                    scope 7 (inlined std::ptr::metadata::<[u32]>) {
+                        debug ptr => _6;
+                        let mut _7: std::ptr::metadata::PtrRepr<[u32]>;
+                        scope 8 {
+                        }
+                    }
+                }
+            }
         }
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = &raw mut (*_1);
-        _4 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut(move _2, move _3) -> [return: bb1, unwind unreachable];
-    }
-
-    bb1: {
-        StorageDead(_3);
-        _0 = &mut (*_4);
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_10);
+        StorageLive(_9);
+        StorageLive(_8);
+        StorageLive(_6);
+        _6 = _5 as *const [u32] (PointerCoercion(MutToConstPointer));
+        StorageLive(_7);
+        _7 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _6 };
+        _8 = ((_7.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        StorageDead(_7);
+        StorageDead(_6);
+        _9 = (_3, _4, move _8);
+        StorageDead(_8);
+        UbCheck(LibraryUb): <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::precondition_check(move _9);
+        StorageDead(_9);
+        _10 = SubUnchecked(_4, _3);
+        StorageLive(_12);
+        StorageLive(_11);
+        _11 = _5 as *mut u32 (PtrToPtr);
+        _12 = Offset(_11, _3);
+        StorageDead(_11);
+        StorageLive(_13);
+        _13 = _12 as *mut () (PtrToPtr);
+        StorageLive(_16);
+        StorageLive(_15);
+        StorageLive(_14);
+        _14 = _12 as *const () (PtrToPtr);
+        _15 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: move _14, metadata: _10 };
+        StorageDead(_14);
+        _16 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _15 };
+        StorageDead(_15);
+        _17 = (_16.1: *mut [u32]);
+        StorageDead(_16);
+        StorageDead(_13);
+        StorageDead(_12);
+        StorageDead(_10);
+        StorageDead(_5);
+        _0 = &mut (*_17);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -4,24 +4,111 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     debug slice => _1;
     debug index => _2;
     let mut _0: &mut [u32];
+    let mut _3: usize;
+    let mut _4: usize;
     scope 1 (inlined core::slice::<impl [u32]>::get_unchecked_mut::<std::ops::Range<usize>>) {
         debug self => _1;
-        debug index => _2;
-        let mut _3: *mut [u32];
-        let mut _4: *mut [u32];
+        debug ((index: std::ops::Range<usize>).0: usize) => _3;
+        debug ((index: std::ops::Range<usize>).1: usize) => _4;
+        let mut _5: *mut [u32];
+        let mut _17: *mut [u32];
         scope 2 {
+            scope 3 (inlined <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut) {
+                debug ((self: std::ops::Range<usize>).0: usize) => _3;
+                debug ((self: std::ops::Range<usize>).1: usize) => _4;
+                debug slice => _5;
+                let mut _8: usize;
+                let mut _9: (usize, usize, usize);
+                let mut _11: *mut u32;
+                let mut _12: *mut u32;
+                scope 4 {
+                    let _10: usize;
+                    scope 5 {
+                        debug new_len => _10;
+                        scope 9 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::as_mut_ptr) {
+                            debug self => _5;
+                        }
+                        scope 10 (inlined std::ptr::mut_ptr::<impl *mut u32>::add) {
+                            debug self => _11;
+                            debug count => _3;
+                            scope 11 {
+                            }
+                        }
+                        scope 12 (inlined slice_from_raw_parts_mut::<u32>) {
+                            debug data => _12;
+                            debug len => _10;
+                            let mut _13: *mut ();
+                            scope 13 (inlined std::ptr::mut_ptr::<impl *mut u32>::cast::<()>) {
+                                debug self => _12;
+                            }
+                            scope 14 (inlined std::ptr::from_raw_parts_mut::<[u32]>) {
+                                debug data_pointer => _13;
+                                debug metadata => _10;
+                                let mut _14: *const ();
+                                let mut _15: std::ptr::metadata::PtrComponents<[u32]>;
+                                let mut _16: std::ptr::metadata::PtrRepr<[u32]>;
+                                scope 15 {
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 6 (inlined std::ptr::mut_ptr::<impl *mut [u32]>::len) {
+                    debug self => _5;
+                    let mut _6: *const [u32];
+                    scope 7 (inlined std::ptr::metadata::<[u32]>) {
+                        debug ptr => _6;
+                        let mut _7: std::ptr::metadata::PtrRepr<[u32]>;
+                        scope 8 {
+                        }
+                    }
+                }
+            }
         }
     }
 
     bb0: {
-        StorageLive(_3);
-        _3 = &raw mut (*_1);
-        _4 = <std::ops::Range<usize> as SliceIndex<[u32]>>::get_unchecked_mut(move _2, move _3) -> [return: bb1, unwind continue];
-    }
-
-    bb1: {
-        StorageDead(_3);
-        _0 = &mut (*_4);
+        _3 = move (_2.0: usize);
+        _4 = move (_2.1: usize);
+        StorageLive(_5);
+        _5 = &raw mut (*_1);
+        StorageLive(_10);
+        StorageLive(_9);
+        StorageLive(_8);
+        StorageLive(_6);
+        _6 = _5 as *const [u32] (PointerCoercion(MutToConstPointer));
+        StorageLive(_7);
+        _7 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: _6 };
+        _8 = ((_7.2: std::ptr::metadata::PtrComponents<[u32]>).1: usize);
+        StorageDead(_7);
+        StorageDead(_6);
+        _9 = (_3, _4, move _8);
+        StorageDead(_8);
+        UbCheck(LibraryUb): <std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked_mut::precondition_check(move _9);
+        StorageDead(_9);
+        _10 = SubUnchecked(_4, _3);
+        StorageLive(_12);
+        StorageLive(_11);
+        _11 = _5 as *mut u32 (PtrToPtr);
+        _12 = Offset(_11, _3);
+        StorageDead(_11);
+        StorageLive(_13);
+        _13 = _12 as *mut () (PtrToPtr);
+        StorageLive(_16);
+        StorageLive(_15);
+        StorageLive(_14);
+        _14 = _12 as *const () (PtrToPtr);
+        _15 = std::ptr::metadata::PtrComponents::<[u32]> { data_pointer: move _14, metadata: _10 };
+        StorageDead(_14);
+        _16 = std::ptr::metadata::PtrRepr::<[u32]> { const_ptr: move _15 };
+        StorageDead(_15);
+        _17 = (_16.1: *mut [u32]);
+        StorageDead(_16);
+        StorageDead(_13);
+        StorageDead(_12);
+        StorageDead(_10);
+        StorageDead(_5);
+        _0 = &mut (*_17);
         return;
     }
 }


### PR DESCRIPTION
I _think_ one reason the UB checks have the compile time overhead that they do is that they impede MIR optimizations by being calls, which are penalized heavily in MIR inlining, and also simply complicate the MIR we generate.

So this is my (ongoing) effort to fix that. Currently the code is strewn with terrible hacks that I'll figure out how to do better later. Right now I just want to establish if this is a path to reducing their compile-time overhead.

r? @ghost