### PR TITLE
Fix typo in `rustc_passes/messages.ftl`

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -187,7 +187,7 @@ passes_doc_attr_not_crate_level =
     `#![doc({$attr_name} = "...")]` isn't allowed as a crate-level attribute
 
 passes_doc_cfg_hide_takes_list =
-    `#[doc(cfg_hide(...)]` takes a list of attributes
+    `#[doc(cfg_hide(...))]` takes a list of attributes
 
 passes_doc_expect_str =
     doc {$attr_name} attribute expects a string: #[doc({$attr_name} = "a")]

--- a/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
@@ -18,7 +18,7 @@ help: to apply to the crate, use an inner attribute
 LL | #![doc(cfg_hide(doc))]
    |  +
 
-error: `#[doc(cfg_hide(...)]` takes a list of attributes
+error: `#[doc(cfg_hide(...))]` takes a list of attributes
   --> $DIR/doc_cfg_hide.rs:4:8
    |
 LL | #![doc(cfg_hide = "test")]
@@ -27,7 +27,7 @@ LL | #![doc(cfg_hide = "test")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: `#[doc(cfg_hide(...)]` takes a list of attributes
+error: `#[doc(cfg_hide(...))]` takes a list of attributes
   --> $DIR/doc_cfg_hide.rs:6:8
    |
 LL | #![doc(cfg_hide)]


### PR DESCRIPTION
Line 190 contains unpaired parentheses:

```
passes_doc_cfg_hide_takes_list =
    `#[doc(cfg_hide(...)]` takes a list of attributes
```

The `#[doc(cfg_hide(...)]` contains unpaired parentheses. This PR changes it to `#[doc(cfg_hide(...))]`, which made the parentheses paired.