### PR TITLE
bootstrap/format: send larger batches to rustfmt

### DIFF
--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -279,8 +279,8 @@ pub fn format(build: &Builder<'_>, check: bool, paths: &[PathBuf]) {
     let thread = std::thread::spawn(move || {
         let mut children = VecDeque::new();
         while let Ok(path) = rx.recv() {
-            // try getting a few more paths from the channel to amortize the overhead of spawning processes
-            let paths: Vec<_> = rx.try_iter().take(7).chain(std::iter::once(path)).collect();
+            // try getting more paths from the channel to amortize the overhead of spawning processes
+            let paths: Vec<_> = rx.try_iter().take(63).chain(std::iter::once(path)).collect();
 
             let child = rustfmt(&src, &rustfmt_path, paths.as_slice(), check);
             children.push_back(child);


### PR DESCRIPTION
This helps on systems with low core counts. To benchmark this I made a lot of files be modified:
```
for FILE in $(find compiler/ -name "*.rs"); do echo "// end of the file" >>$FILE; done
```
Then I ran
```
hyperfine "./x.py fmt -j1" -w 1 -r 4
```
Before this patch:
```
Benchmark 1: ./x.py fmt -j1
  Time (mean ± σ):      3.426 s ±  0.032 s    [User: 4.681 s, System: 1.376 s]
  Range (min … max):    3.389 s …  3.462 s    4 runs
```
With this patch:
```
Benchmark 1: ./x.py fmt -j1
  Time (mean ± σ):      2.530 s ±  0.054 s    [User: 4.042 s, System: 0.467 s]
  Range (min … max):    2.452 s …  2.576 s    4 runs
```