### PR TITLE
remove repetitive code

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -603,7 +603,6 @@ impl<'a> TraitDef<'a> {
                     generics: Generics::default(),
                     where_clauses: (
                         ast::TyAliasWhereClause::default(),
-                        ast::TyAliasWhereClause::default(),
                     ),
                     where_predicates_split: 0,
                     bounds: Vec::new(),


### PR DESCRIPTION
It seems that only one definition is needed here, but two definitions are accidentally included