### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -137,27 +137,6 @@ pub(crate) struct BenchSig {
 }
 
 #[derive(Diagnostic)]
-#[diag(builtin_macros_test_arg_non_lifetime)]
-pub(crate) struct TestArgNonLifetime {
-    #[primary_span]
-    pub(crate) span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(builtin_macros_should_panic)]
-pub(crate) struct ShouldPanic {
-    #[primary_span]
-    pub(crate) span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(builtin_macros_test_args)]
-pub(crate) struct TestArgs {
-    #[primary_span]
-    pub(crate) span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(builtin_macros_alloc_must_statics)]
 pub(crate) struct AllocMustStatics {
     #[primary_span]

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -536,16 +536,19 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     gated!(
         rustc_allow_const_fn_unstable, Normal,
-        template!(Word, List: "feat1, feat2, ..."), DuplicatesOk,
+        template!(Word, List: "feat1, feat2, ..."), DuplicatesOk, @only_local: true,
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
     gated!(
         allow_internal_unsafe, Normal, template!(Word), WarnFollowing,
-        "allow_internal_unsafe side-steps the unsafe_code lint",
+        @only_local: true, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
-    rustc_attr!(rustc_allowed_through_unstable_modules, Normal, template!(Word), WarnFollowing,
-    "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
-    through unstable paths"),
+    rustc_attr!(
+        rustc_allowed_through_unstable_modules, Normal, template!(Word),
+        WarnFollowing, @only_local: true,
+        "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
+        through unstable paths"
+    ),
 
     // ==========================================================================
     // Internal attributes: Type system related:
@@ -553,7 +556,8 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     gated!(fundamental, Normal, template!(Word), WarnFollowing, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, template!(Word), WarnFollowing, dropck_eyepatch,
+        may_dangle, Normal, template!(Word), WarnFollowing,
+        @only_local: true, dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
 
@@ -561,31 +565,51 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Runtime related:
     // ==========================================================================
 
-    rustc_attr!(rustc_allocator, Normal, template!(Word), WarnFollowing, IMPL_DETAIL),
-    rustc_attr!(rustc_nounwind, Normal, template!(Word), WarnFollowing, IMPL_DETAIL),
-    rustc_attr!(rustc_reallocator, Normal, template!(Word), WarnFollowing, IMPL_DETAIL),
-    rustc_attr!(rustc_deallocator, Normal, template!(Word), WarnFollowing, IMPL_DETAIL),
-    rustc_attr!(rustc_allocator_zeroed, Normal, template!(Word), WarnFollowing, IMPL_DETAIL),
-    gated!(
-        default_lib_allocator, Normal, template!(Word), WarnFollowing, allocator_internals,
-        experimental!(default_lib_allocator),
+    rustc_attr!(
+        rustc_allocator, Normal, template!(Word), WarnFollowing,
+        @only_local: true, IMPL_DETAIL
+    ),
+    rustc_attr!(
+        rustc_nounwind, Normal, template!(Word), WarnFollowing,
+        @only_local: true, IMPL_DETAIL
+    ),
+    rustc_attr!(
+        rustc_reallocator, Normal, template!(Word), WarnFollowing,
+        @only_local: true, IMPL_DETAIL
+    ),
+    rustc_attr!(
+        rustc_deallocator, Normal, template!(Word), WarnFollowing,
+        @only_local: true, IMPL_DETAIL
+    ),
+    rustc_attr!(
+        rustc_allocator_zeroed, Normal, template!(Word), WarnFollowing,
+        @only_local: true, IMPL_DETAIL
     ),
     gated!(
-        needs_allocator, Normal, template!(Word), WarnFollowing, allocator_internals,
-        experimental!(needs_allocator),
+        default_lib_allocator, Normal, template!(Word), WarnFollowing,
+        @only_local: true, allocator_internals, experimental!(default_lib_allocator),
     ),
-    gated!(panic_runtime, Normal, template!(Word), WarnFollowing, experimental!(panic_runtime)),
+    gated!(
+        needs_allocator, Normal, template!(Word), WarnFollowing,
+        @only_local: true, allocator_internals, experimental!(needs_allocator),
+    ),
+    gated!(
+        panic_runtime, Normal, template!(Word), WarnFollowing,
+        @only_local: true, experimental!(panic_runtime)
+    ),
     gated!(
         needs_panic_runtime, Normal, template!(Word), WarnFollowing,
-        experimental!(needs_panic_runtime)
+        @only_local: true, experimental!(needs_panic_runtime)
     ),
     gated!(
         compiler_builtins, Normal, template!(Word), WarnFollowing,
+        @only_local: true,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
         profiler_runtime, Normal, template!(Word), WarnFollowing,
+        @only_local: true,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
     ),
@@ -611,7 +635,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         template!(Word, List: "name, /*opt*/ attributes(name1, name2, ...)"), ErrorFollowing,
         IMPL_DETAIL,
     ),
-    rustc_attr!(rustc_proc_macro_decls, Normal, template!(Word), WarnFollowing, INTERNAL_UNSTABLE),
+    rustc_attr!(
+        rustc_proc_macro_decls, Normal, template!(Word), WarnFollowing,
+        @only_local: true, INTERNAL_UNSTABLE
+    ),
     rustc_attr!(
         rustc_macro_transparency, Normal,
         template!(NameValueStr: "transparent|semitransparent|opaque"), ErrorFollowing,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1005,13 +1005,6 @@ pub(crate) struct StaticSpecialize {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_missing_tilde_const)]
-pub(crate) struct MissingTildeConst {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 pub(crate) enum DropImplPolarity {
     #[diag(hir_analysis_drop_impl_negative)]
     Negative {

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -558,14 +558,6 @@ pub(crate) struct CatchAfterTry {
 }
 
 #[derive(Diagnostic)]
-#[diag(parse_gen_fn)]
-#[help]
-pub(crate) struct GenFn {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(parse_comma_after_base_struct)]
 #[note]
 pub(crate) struct CommaAfterBaseStruct {

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -187,7 +187,7 @@ passes_doc_attr_not_crate_level =
     `#![doc({$attr_name} = "...")]` isn't allowed as a crate-level attribute
 
 passes_doc_cfg_hide_takes_list =
-    `#[doc(cfg_hide(...)]` takes a list of attributes
+    `#[doc(cfg_hide(...))]` takes a list of attributes
 
 passes_doc_expect_str =
     doc {$attr_name} attribute expects a string: #[doc({$attr_name} = "a")]

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -8,32 +8,6 @@ use rustc_span::{
 use crate::{late::PatternSource, Res};
 
 #[derive(Diagnostic)]
-#[diag(resolve_parent_module_reset_for_binding, code = E0637)]
-pub(crate) struct ParentModuleResetForBinding;
-
-#[derive(Diagnostic)]
-#[diag(resolve_ampersand_used_without_explicit_lifetime_name, code = E0637)]
-#[note]
-pub(crate) struct AmpersandUsedWithoutExplicitLifetimeName(#[primary_span] pub(crate) Span);
-
-#[derive(Diagnostic)]
-#[diag(resolve_underscore_lifetime_name_cannot_be_used_here, code = E0637)]
-#[note]
-pub(crate) struct UnderscoreLifetimeNameCannotBeUsedHere(#[primary_span] pub(crate) Span);
-
-#[derive(Diagnostic)]
-#[diag(resolve_crate_may_not_be_imported)]
-pub(crate) struct CrateMayNotBeImported(#[primary_span] pub(crate) Span);
-
-#[derive(Diagnostic)]
-#[diag(resolve_crate_root_imports_must_be_named_explicitly)]
-pub(crate) struct CrateRootNamesMustBeNamedExplicitly(#[primary_span] pub(crate) Span);
-
-#[derive(Diagnostic)]
-#[diag(resolve_crate_root_imports_must_be_named_explicitly)]
-pub(crate) struct ResolutionError(#[primary_span] pub(crate) Span);
-
-#[derive(Diagnostic)]
 #[diag(resolve_generic_params_from_outer_item, code = E0401)]
 pub(crate) struct GenericParamsFromOuterItem {
     #[primary_span]
@@ -465,19 +439,6 @@ pub(crate) struct UnreachableLabelSubLabel {
 pub(crate) struct UnreachableLabelSubLabelUnreachable {
     #[primary_span]
     pub(crate) ident_span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(resolve_trait_impl_mismatch)]
-pub(crate) struct TraitImplMismatch {
-    #[primary_span]
-    #[label]
-    pub(crate) span: Span,
-    pub(crate) name: Symbol,
-    pub(crate) kind: String,
-    #[label(resolve_label_trait_item)]
-    pub(crate) trait_item_span: Span,
-    pub(crate) trait_path: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -107,6 +107,15 @@ impl<'a, 'tcx> ObligationCtxt<'a, 'tcx> {
         self.register_infer_ok_obligations(infer_ok)
     }
 
+    pub fn deeply_normalize<T: TypeFoldable<TyCtxt<'tcx>>>(
+        &self,
+        cause: &ObligationCause<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+        value: T,
+    ) -> Result<T, Vec<FulfillmentError<'tcx>>> {
+        self.infcx.at(cause, param_env).deeply_normalize(value, &mut **self.engine.borrow_mut())
+    }
+
     /// Makes `expected <: actual`.
     pub fn eq_exp<T>(
         &self,

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -152,6 +152,7 @@
 #![feature(set_ptr_value)]
 #![feature(sized_type_properties)]
 #![feature(slice_from_ptr_range)]
+#![feature(slice_index_methods)]
 #![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]
 #![feature(slice_range)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -54,7 +54,7 @@ use core::ops::Add;
 use core::ops::AddAssign;
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Bound::{Excluded, Included, Unbounded};
-use core::ops::{self, Index, IndexMut, Range, RangeBounds};
+use core::ops::{self, Range, RangeBounds};
 use core::ptr;
 use core::slice;
 use core::str::pattern::Pattern;
@@ -2433,100 +2433,26 @@ impl AddAssign<&str> for String {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl ops::Index<ops::Range<usize>> for String {
-    type Output = str;
+impl<I> ops::Index<I> for String
+where
+    I: slice::SliceIndex<str>,
+{
+    type Output = I::Output;
 
     #[inline]
-    fn index(&self, index: ops::Range<usize>) -> &str {
-        &self[..][index]
+    fn index(&self, index: I) -> &I::Output {
+        index.index(self.as_str())
     }
 }
+
 #[stable(feature = "rust1", since = "1.0.0")]
-impl ops::Index<ops::RangeTo<usize>> for String {
-    type Output = str;
-
+impl<I> ops::IndexMut<I> for String
+where
+    I: slice::SliceIndex<str>,
+{
     #[inline]
-    fn index(&self, index: ops::RangeTo<usize>) -> &str {
-        &self[..][index]
-    }
-}
-#[stable(feature = "rust1", since = "1.0.0")]
-impl ops::Index<ops::RangeFrom<usize>> for String {
-    type Output = str;
-
-    #[inline]
-    fn index(&self, index: ops::RangeFrom<usize>) -> &str {
-        &self[..][index]
-    }
-}
-#[stable(feature = "rust1", since = "1.0.0")]
-impl ops::Index<ops::RangeFull> for String {
-    type Output = str;
-
-    #[inline]
-    fn index(&self, _index: ops::RangeFull) -> &str {
-        unsafe { str::from_utf8_unchecked(&self.vec) }
-    }
-}
-#[stable(feature = "inclusive_range", since = "1.26.0")]
-impl ops::Index<ops::RangeInclusive<usize>> for String {
-    type Output = str;
-
-    #[inline]
-    fn index(&self, index: ops::RangeInclusive<usize>) -> &str {
-        Index::index(&**self, index)
-    }
-}
-#[stable(feature = "inclusive_range", since = "1.26.0")]
-impl ops::Index<ops::RangeToInclusive<usize>> for String {
-    type Output = str;
-
-    #[inline]
-    fn index(&self, index: ops::RangeToInclusive<usize>) -> &str {
-        Index::index(&**self, index)
-    }
-}
-
-#[stable(feature = "derefmut_for_string", since = "1.3.0")]
-impl ops::IndexMut<ops::Range<usize>> for String {
-    #[inline]
-    fn index_mut(&mut self, index: ops::Range<usize>) -> &mut str {
-        &mut self[..][index]
-    }
-}
-#[stable(feature = "derefmut_for_string", since = "1.3.0")]
-impl ops::IndexMut<ops::RangeTo<usize>> for String {
-    #[inline]
-    fn index_mut(&mut self, index: ops::RangeTo<usize>) -> &mut str {
-        &mut self[..][index]
-    }
-}
-#[stable(feature = "derefmut_for_string", since = "1.3.0")]
-impl ops::IndexMut<ops::RangeFrom<usize>> for String {
-    #[inline]
-    fn index_mut(&mut self, index: ops::RangeFrom<usize>) -> &mut str {
-        &mut self[..][index]
-    }
-}
-#[stable(feature = "derefmut_for_string", since = "1.3.0")]
-impl ops::IndexMut<ops::RangeFull> for String {
-    #[inline]
-    fn index_mut(&mut self, _index: ops::RangeFull) -> &mut str {
-        unsafe { str::from_utf8_unchecked_mut(&mut *self.vec) }
-    }
-}
-#[stable(feature = "inclusive_range", since = "1.26.0")]
-impl ops::IndexMut<ops::RangeInclusive<usize>> for String {
-    #[inline]
-    fn index_mut(&mut self, index: ops::RangeInclusive<usize>) -> &mut str {
-        IndexMut::index_mut(&mut **self, index)
-    }
-}
-#[stable(feature = "inclusive_range", since = "1.26.0")]
-impl ops::IndexMut<ops::RangeToInclusive<usize>> for String {
-    #[inline]
-    fn index_mut(&mut self, index: ops::RangeToInclusive<usize>) -> &mut str {
-        IndexMut::index_mut(&mut **self, index)
+    fn index_mut(&mut self, index: I) -> &mut I::Output {
+        index.index_mut(self.as_mut_str())
     }
 }
 

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -258,6 +258,9 @@ fn _var(key: &OsStr) -> Result<String, VarError> {
 ///     None => println!("{key} is not defined in the environment.")
 /// }
 /// ```
+///
+/// If expecting a delimited variable (such as `PATH`), [`split_paths`]
+/// can be used to separate items.
 #[must_use]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn var_os<K: AsRef<OsStr>>(key: K) -> Option<OsString> {
@@ -441,6 +444,16 @@ pub struct SplitPaths<'a> {
 /// Returns an iterator over the paths contained in `unparsed`. The iterator
 /// element type is [`PathBuf`].
 ///
+/// On most Unix platforms, the separator is `:` and on Windows it is `;`. This
+/// also performs unquoting on Windows.
+///
+/// [`join_paths`] can be used to recombine elements.
+///
+/// # Panics
+///
+/// This will panic on systems where theere is no delimited `PATH` variable,
+/// such as UEFI.
+///
 /// # Examples
 ///
 /// ```
@@ -456,6 +469,7 @@ pub struct SplitPaths<'a> {
 ///     None => println!("{key} is not defined in the environment.")
 /// }
 /// ```
+#[doc(alias = "PATH")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn split_paths<T: AsRef<OsStr> + ?Sized>(unparsed: &T) -> SplitPaths<'_> {
     SplitPaths { inner: os_imp::split_paths(unparsed.as_ref()) }
@@ -496,7 +510,8 @@ pub struct JoinPathsError {
 ///
 /// Returns an [`Err`] (containing an error message) if one of the input
 /// [`Path`]s contains an invalid character for constructing the `PATH`
-/// variable (a double quote on Windows or a colon on Unix).
+/// variable (a double quote on Windows or a colon on Unix), or if the system
+/// does not have a `PATH`-like variable (e.g. UEFI or WASI).
 ///
 /// # Examples
 ///
@@ -550,6 +565,7 @@ pub struct JoinPathsError {
 /// ```
 ///
 /// [`env::split_paths()`]: split_paths
+#[doc(alias = "PATH")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn join_paths<I, T>(paths: I) -> Result<OsString, JoinPathsError>
 where

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -451,7 +451,7 @@ pub struct SplitPaths<'a> {
 ///
 /// # Panics
 ///
-/// This will panic on systems where theere is no delimited `PATH` variable,
+/// This will panic on systems where there is no delimited `PATH` variable,
 /// such as UEFI.
 ///
 /// # Examples

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -6,7 +6,7 @@ use crate::any::Any;
 use crate::collections;
 use crate::panicking;
 use crate::sync::atomic::{AtomicU8, Ordering};
-use crate::sync::{Mutex, RwLock};
+use crate::sync::{Condvar, Mutex, RwLock};
 use crate::thread::Result;
 
 #[doc(hidden)]
@@ -67,11 +67,15 @@ pub fn panic_any<M: 'static + Any + Send>(msg: M) -> ! {
 impl<T: ?Sized> UnwindSafe for Mutex<T> {}
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: ?Sized> UnwindSafe for RwLock<T> {}
+#[stable(feature = "catch_unwind", since = "1.9.0")]
+impl UnwindSafe for Condvar {}
 
 #[stable(feature = "unwind_safe_lock_refs", since = "1.12.0")]
 impl<T: ?Sized> RefUnwindSafe for Mutex<T> {}
 #[stable(feature = "unwind_safe_lock_refs", since = "1.12.0")]
 impl<T: ?Sized> RefUnwindSafe for RwLock<T> {}
+#[stable(feature = "unwind_safe_lock_refs", since = "1.12.0")]
+impl RefUnwindSafe for Condvar {}
 
 // https://github.com/rust-lang/rust/issues/62301
 #[stable(feature = "hashbrown", since = "1.36.0")]

--- a/library/std/src/sync/mpmc/list.rs
+++ b/library/std/src/sync/mpmc/list.rs
@@ -547,6 +547,9 @@ impl<T> Channel<T> {
         }
 
         let mut head = self.head.index.load(Ordering::Acquire);
+        // the channel may be uninitialized, so we have to swap to avoid overwriting any sender's attempts
+        // to initalize the first block before noticing that the receivers disconnected. late allocations
+        // will be deallocated by the sender in Drop
         let mut block = self.head.block.swap(ptr::null_mut(), Ordering::AcqRel);
 
         // If we're going to be dropping messages we need to synchronize with initialization

--- a/library/std/src/sync/mpmc/list.rs
+++ b/library/std/src/sync/mpmc/list.rs
@@ -547,9 +547,9 @@ impl<T> Channel<T> {
         }
 
         let mut head = self.head.index.load(Ordering::Acquire);
-        // the channel may be uninitialized, so we have to swap to avoid overwriting any sender's attempts
-        // to initalize the first block before noticing that the receivers disconnected. late allocations
-        // will be deallocated by the sender in Drop
+        // The channel may be uninitialized, so we have to swap to avoid overwriting any sender's attempts
+        // to initalize the first block before noticing that the receivers disconnected. Late allocations
+        // will be deallocated by the sender in Drop.
         let mut block = self.head.block.swap(ptr::null_mut(), Ordering::AcqRel);
 
         // If we're going to be dropping messages we need to synchronize with initialization

--- a/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
+++ b/tests/rustdoc-ui/lints/doc_cfg_hide.stderr
@@ -18,7 +18,7 @@ help: to apply to the crate, use an inner attribute
 LL | #![doc(cfg_hide(doc))]
    |  +
 
-error: `#[doc(cfg_hide(...)]` takes a list of attributes
+error: `#[doc(cfg_hide(...))]` takes a list of attributes
   --> $DIR/doc_cfg_hide.rs:4:8
    |
 LL | #![doc(cfg_hide = "test")]
@@ -27,7 +27,7 @@ LL | #![doc(cfg_hide = "test")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: `#[doc(cfg_hide(...)]` takes a list of attributes
+error: `#[doc(cfg_hide(...))]` takes a list of attributes
   --> $DIR/doc_cfg_hide.rs:6:8
    |
 LL | #![doc(cfg_hide)]

--- a/tests/ui/impl-trait/in-trait/refine-normalize.rs
+++ b/tests/ui/impl-trait/in-trait/refine-normalize.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+//@ edition: 2021
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+
+#![deny(refining_impl_trait)]
+
+pub trait Foo {
+    type Item;
+
+    fn hello() -> impl Iterator<Item = Self::Item>;
+}
+
+impl Foo for () {
+    type Item = ();
+
+    fn hello() -> impl Iterator<Item = ()> { [()].into_iter() }
+}
+
+fn main() {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -673,6 +673,12 @@ compiler = [
 libs = [
     "@cuviper",
     "@Mark-Simulacrum",
+    "@m-ou-se",
+    "@Amanieu",
+    "@Nilstrieb",
+    "@workingjubilee",
+    "@joboet",
+    "@jhpratt",
 ]
 bootstrap = [
     "@Mark-Simulacrum",
@@ -810,7 +816,7 @@ project-stable-mir = [
 "/compiler/rustc_type_ir" =                              ["compiler", "types"]
 "/compiler/stable_mir" =                                 ["project-stable-mir"]
 "/library/alloc" =                                       ["libs"]
-"/library/core" =                                        ["libs"]
+"/library/core" =                                        ["libs", "@scottmcm"]
 "/library/panic_abort" =                                 ["libs"]
 "/library/panic_unwind" =                                ["libs"]
 "/library/proc_macro" =                                  ["@petrochenkov"]


### PR DESCRIPTION
Successful merges:

 - #119748 (Increase visibility of `join_path` and `split_paths`)
 - #120291 (Have `String` use `SliceIndex` impls from `str`)
 - #121723 (Two diagnostic things)
 - #121740 (Changing some attributes to only_local.)
 - #121745 (Deeply normalize obligations in `refining_impl_trait`)
 - #121748 (Restore the standard library review rotation to its former glory)
 - #121768 (Implement unwind safety for Condvar on all platforms )
 - #121777 (Fix typo in `rustc_passes/messages.ftl`)
 - #121778 (Document potential memory leak in unbounded channel)
 - #121779 (Remove unused diagnostic struct)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=119748,120291,121723,121740,121745,121748,121768,121777,121778,121779)
<!-- homu-ignore:end -->