### PR TITLE
Improve renaming suggestion when item starts with underscore

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1571,9 +1571,10 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         {
             // When the suggested binding change would be from `x` to `_x`, suggest changing the
             // original binding definition instead. (#60164)
-            (span, snippet, ", consider changing it")
+            let post = format!(", consider renaming `{}` into `{snippet}`", suggestion.candidate);
+            (span, snippet, post)
         } else {
-            (span, suggestion.candidate.to_string(), "")
+            (span, suggestion.candidate.to_string(), String::new())
         };
         let msg = match suggestion.target {
             SuggestionTarget::SimilarlyNamed => format!(

--- a/tests/ui/suggestions/silenced-binding-typo.stderr
+++ b/tests/ui/suggestions/silenced-binding-typo.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `x` in this scope
 LL |     let _y = x;
    |              ^
    |
-help: a local variable with a similar name exists, consider changing it
+help: a local variable with a similar name exists, consider renaming `_x` into `x`
    |
 LL |     let x = 42;
    |         ~


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/121776.

It goes from:

```terminal
error[E0433]: failed to resolve: use of undeclared type `Foo`
 --> src/foo.rs:6:13
  |
6 |     let _ = Foo::Bar;
  |             ^^^ use of undeclared type `Foo`
  |
help: an enum with a similar name exists, consider changing it
  |
1 | enum Foo {
  |      ~~~
```

to:

```terminal
error[E0433]: failed to resolve: use of undeclared type `Foo`
 --> foo.rs:6:13
  |
6 |     let _ = Foo::Bar;
  |             ^^^ use of undeclared type `Foo`
  |
help: an enum with a similar name exists, consider renaming `_Foo` into `Foo`
  |
1 | enum Foo {
  |      ~~~

error: aborting due to 1 previous error
```