### PR TITLE
windows-gnullvm: Avoid linking to libunwind statically

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -6,10 +6,7 @@ pub fn opts() -> TargetOptions {
     // as a path since it's not added to linker search path by the default.
     // There were attempts to make it behave like libgcc (so one can just use -l<name>)
     // but LLVM maintainers rejected it: https://reviews.llvm.org/D51440
-    let pre_link_args = TargetOptions::link_args(
-        LinkerFlavor::Gnu(Cc::Yes, Lld::No),
-        &["-nolibc", "--unwindlib=none"],
-    );
+    let pre_link_args = TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-nolibc"]);
     // Order of `late_link_args*` does not matter with LLD.
     let late_link_args = TargetOptions::link_args(
         LinkerFlavor::Gnu(Cc::Yes, Lld::No),

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(link_cfg)]
 #![feature(staged_api)]
 #![feature(c_unwind)]
-#![cfg_attr(bootstrap, feature(cfg_target_abi))]
 #![feature(strict_provenance)]
 #![cfg_attr(not(target_env = "msvc"), feature(libc))]
 #![allow(internal_features)]

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -102,12 +102,9 @@ pub type _Unwind_Exception_Cleanup_Fn =
 // rustc_codegen_ssa::src::back::symbol_export, rustc_middle::middle::exported_symbols
 // and RFC 2841
 #[cfg_attr(
-    any(
-        all(
-            feature = "llvm-libunwind",
-            any(target_os = "fuchsia", target_os = "linux", target_os = "xous")
-        ),
-        all(target_os = "windows", target_env = "gnu", target_abi = "llvm")
+    all(
+        feature = "llvm-libunwind",
+        any(target_os = "fuchsia", target_os = "linux", target_os = "xous")
     ),
     link(name = "unwind", kind = "static", modifiers = "-bundle")
 )]


### PR DESCRIPTION
Avoid linking against the static variant of libunwind, which is not always available. Instead, prefer to use the unwind library from the toolchain, which the linker will automatically include, depending on what's available.