### PR TITLE
Make `DefiningAnchor::Bind` only store the opaque types that may be constrained, instead of the current infcx root item.

### DIFF
--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -106,7 +106,7 @@ pub fn get_body_with_borrowck_facts(
     options: ConsumerOptions,
 ) -> BodyWithBorrowckFacts<'_> {
     let (input_body, promoted) = tcx.mir_promoted(def);
-    let infcx = tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(def)).build();
+    let infcx = tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::bind(tcx, def)).build();
     let input_body: &Body<'_> = &input_body.borrow();
     let promoted: &IndexSlice<_, _> = &promoted.borrow();
     *super::do_mir_borrowck(&infcx, input_body, promoted, Some(options)).1.unwrap()

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -126,10 +126,7 @@ fn mir_borrowck(tcx: TyCtxt<'_>, def: LocalDefId) -> &BorrowCheckResult<'_> {
         return tcx.arena.alloc(result);
     }
 
-    let hir_owner = tcx.local_def_id_to_hir_id(def).owner;
-
-    let infcx =
-        tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::Bind(hir_owner.def_id)).build();
+    let infcx = tcx.infer_ctxt().with_opaque_type_inference(DefiningAnchor::bind(tcx, def)).build();
     let promoted: &IndexSlice<_, _> = &promoted.borrow();
     let opt_closure_req = do_mir_borrowck(&infcx, input_body, promoted, None).0;
     debug!("mir_borrowck done");

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -311,7 +311,7 @@ fn check_opaque_type_well_formed<'tcx>(
         parent_def_id = tcx.local_parent(parent_def_id);
     }
 
-    // FIXME(-Znext-solver): We probably should use `DefiningAnchor::Error`
+    // FIXME(-Znext-solver): We probably should use `DefiningAnchor::Bind(&[])`
     // and prepopulate this `InferCtxt` with known opaque values, rather than
     // using the `Bind` anchor here. For now it's fine.
     let infcx = tcx

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -317,7 +317,7 @@ fn check_opaque_type_well_formed<'tcx>(
     let infcx = tcx
         .infer_ctxt()
         .with_next_trait_solver(next_trait_solver)
-        .with_opaque_type_inference(DefiningAnchor::Bind(parent_def_id))
+        .with_opaque_type_inference(DefiningAnchor::bind(tcx, parent_def_id))
         .build();
     let ocx = ObligationCtxt::new(&infcx);
     let identity_args = GenericArgs::identity_for_item(tcx, def_id);

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -347,7 +347,7 @@ fn check_opaque_meets_bounds<'tcx>(
 
     let infcx = tcx
         .infer_ctxt()
-        .with_opaque_type_inference(DefiningAnchor::Bind(defining_use_anchor))
+        .with_opaque_type_inference(DefiningAnchor::bind(tcx, defining_use_anchor))
         .build();
     let ocx = ObligationCtxt::new(&infcx);
 
@@ -1558,7 +1558,7 @@ pub(super) fn check_coroutine_obligations(
         .ignoring_regions()
         // Bind opaque types to type checking root, as they should have been checked by borrowck,
         // but may show up in some cases, like when (root) obligations are stalled in the new solver.
-        .with_opaque_type_inference(DefiningAnchor::Bind(typeck.hir_owner.def_id))
+        .with_opaque_type_inference(DefiningAnchor::bind(tcx, typeck.hir_owner.def_id))
         .build();
 
     let mut fulfillment_cx = <dyn TraitEngine<'_>>::new(&infcx);

--- a/compiler/rustc_hir_typeck/src/inherited.rs
+++ b/compiler/rustc_hir_typeck/src/inherited.rs
@@ -79,7 +79,7 @@ impl<'tcx> Inherited<'tcx> {
         let infcx = tcx
             .infer_ctxt()
             .ignoring_regions()
-            .with_opaque_type_inference(DefiningAnchor::Bind(def_id))
+            .with_opaque_type_inference(DefiningAnchor::bind(tcx, def_id))
             .build();
         let typeck_results = RefCell::new(ty::TypeckResults::new(hir_owner));
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -242,7 +242,8 @@ pub struct InferCtxt<'tcx> {
     /// short lived InferCtxt within queries. The opaque type obligations are forwarded
     /// to the outside until the end up in an `InferCtxt` for typeck or borrowck.
     ///
-    /// Its default value is `DefiningAnchor::Error`, this way it is easier to catch errors that
+    /// Its default value is `DefiningAnchor::Bind(&[])`, which means no opaque types may be defined.
+    /// This way it is easier to catch errors that
     /// might come up during inference or typeck.
     pub defining_use_anchor: DefiningAnchor<'tcx>,
 
@@ -620,7 +621,7 @@ impl<'tcx> TyCtxt<'tcx> {
     fn infer_ctxt(self) -> InferCtxtBuilder<'tcx> {
         InferCtxtBuilder {
             tcx: self,
-            defining_use_anchor: DefiningAnchor::Error,
+            defining_use_anchor: DefiningAnchor::Bind(ty::List::empty()),
             considering_regions: true,
             skip_leak_check: false,
             intercrate: false,
@@ -1208,13 +1209,11 @@ impl<'tcx> InferCtxt<'tcx> {
 
     #[instrument(level = "debug", skip(self), ret)]
     pub fn take_opaque_types(&self) -> opaque_types::OpaqueTypeMap<'tcx> {
-        debug_assert_ne!(self.defining_use_anchor, DefiningAnchor::Error);
         std::mem::take(&mut self.inner.borrow_mut().opaque_type_storage.opaque_types)
     }
 
     #[instrument(level = "debug", skip(self), ret)]
     pub fn clone_opaque_types(&self) -> opaque_types::OpaqueTypeMap<'tcx> {
-        debug_assert_ne!(self.defining_use_anchor, DefiningAnchor::Error);
         self.inner.borrow().opaque_type_storage.opaque_types.clone()
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -244,7 +244,7 @@ pub struct InferCtxt<'tcx> {
     ///
     /// Its default value is `DefiningAnchor::Error`, this way it is easier to catch errors that
     /// might come up during inference or typeck.
-    pub defining_use_anchor: DefiningAnchor,
+    pub defining_use_anchor: DefiningAnchor<'tcx>,
 
     /// Whether this inference context should care about region obligations in
     /// the root universe. Most notably, this is used during hir typeck as region
@@ -605,7 +605,7 @@ impl fmt::Display for FixupError {
 /// Used to configure inference contexts before their creation.
 pub struct InferCtxtBuilder<'tcx> {
     tcx: TyCtxt<'tcx>,
-    defining_use_anchor: DefiningAnchor,
+    defining_use_anchor: DefiningAnchor<'tcx>,
     considering_regions: bool,
     skip_leak_check: bool,
     /// Whether we are in coherence mode.
@@ -636,7 +636,7 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
     /// It is only meant to be called in two places, for typeck
     /// (via `Inherited::build`) and for the inference context used
     /// in mir borrowck.
-    pub fn with_opaque_type_inference(mut self, defining_use_anchor: DefiningAnchor) -> Self {
+    pub fn with_opaque_type_inference(mut self, defining_use_anchor: DefiningAnchor<'tcx>) -> Self {
         self.defining_use_anchor = defining_use_anchor;
         self
     }

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -150,9 +150,6 @@ impl<'tcx> InferCtxt<'tcx> {
                         }
                     }
                     DefiningAnchor::Bubble => {}
-                    DefiningAnchor::Error => {
-                        return None;
-                    }
                 }
                 if let ty::Alias(ty::Opaque, ty::AliasTy { def_id: b_def_id, .. }) = *b.kind() {
                     // We could accept this, but there are various ways to handle this situation, and we don't
@@ -379,7 +376,7 @@ impl<'tcx> InferCtxt<'tcx> {
     #[instrument(skip(self), level = "trace", ret)]
     pub fn opaque_type_origin(&self, def_id: LocalDefId) -> Option<OpaqueTyOrigin> {
         let defined_opaque_types = match self.defining_use_anchor {
-            DefiningAnchor::Bubble | DefiningAnchor::Error => return None,
+            DefiningAnchor::Bubble => return None,
             DefiningAnchor::Bind(bind) => bind,
         };
 

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -378,28 +378,14 @@ impl<'tcx> InferCtxt<'tcx> {
     /// in its defining scope.
     #[instrument(skip(self), level = "trace", ret)]
     pub fn opaque_type_origin(&self, def_id: LocalDefId) -> Option<OpaqueTyOrigin> {
-        let opaque_hir_id = self.tcx.local_def_id_to_hir_id(def_id);
-        let parent_def_id = match self.defining_use_anchor {
+        let defined_opaque_types = match self.defining_use_anchor {
             DefiningAnchor::Bubble | DefiningAnchor::Error => return None,
             DefiningAnchor::Bind(bind) => bind,
         };
 
         let origin = self.tcx.opaque_type_origin(def_id);
-        let in_definition_scope = match origin {
-            // Async `impl Trait`
-            hir::OpaqueTyOrigin::AsyncFn(parent) => parent == parent_def_id,
-            // Anonymous `impl Trait`
-            hir::OpaqueTyOrigin::FnReturn(parent) => parent == parent_def_id,
-            // Named `type Foo = impl Bar;`
-            hir::OpaqueTyOrigin::TyAlias { in_assoc_ty, .. } => {
-                if in_assoc_ty {
-                    self.tcx.opaque_types_defined_by(parent_def_id).contains(&def_id)
-                } else {
-                    may_define_opaque_type(self.tcx, parent_def_id, opaque_hir_id)
-                }
-            }
-        };
-        in_definition_scope.then_some(origin)
+
+        defined_opaque_types.contains(&def_id).then_some(origin)
     }
 }
 
@@ -655,44 +641,4 @@ impl<'tcx> InferCtxt<'tcx> {
             ));
         }
     }
-}
-
-/// Returns `true` if `opaque_hir_id` is a sibling or a child of a sibling of `def_id`.
-///
-/// Example:
-/// ```ignore UNSOLVED (is this a bug?)
-/// # #![feature(type_alias_impl_trait)]
-/// pub mod foo {
-///     pub mod bar {
-///         pub trait Bar { /* ... */ }
-///         pub type Baz = impl Bar;
-///
-///         # impl Bar for () {}
-///         fn f1() -> Baz { /* ... */ }
-///     }
-///     fn f2() -> bar::Baz { /* ... */ }
-/// }
-/// ```
-///
-/// Here, `def_id` is the `LocalDefId` of the defining use of the opaque type (e.g., `f1` or `f2`),
-/// and `opaque_hir_id` is the `HirId` of the definition of the opaque type `Baz`.
-/// For the above example, this function returns `true` for `f1` and `false` for `f2`.
-fn may_define_opaque_type(tcx: TyCtxt<'_>, def_id: LocalDefId, opaque_hir_id: hir::HirId) -> bool {
-    let mut hir_id = tcx.local_def_id_to_hir_id(def_id);
-
-    // Named opaque types can be defined by any siblings or children of siblings.
-    let scope = tcx.hir().get_defining_scope(opaque_hir_id);
-    // We walk up the node tree until we hit the root or the scope of the opaque type.
-    while hir_id != scope && hir_id != hir::CRATE_HIR_ID {
-        hir_id = tcx.hir().get_parent_item(hir_id).into();
-    }
-    // Syntactically, we are allowed to define the concrete type if:
-    let res = hir_id == scope;
-    trace!(
-        "may_define_opaque_type(def={:?}, opaque_node={:?}) = {}",
-        tcx.hir_node(hir_id),
-        tcx.hir_node(opaque_hir_id),
-        res
-    );
-    res
 }

--- a/compiler/rustc_middle/src/mir/type_foldable.rs
+++ b/compiler/rustc_middle/src/mir/type_foldable.rs
@@ -1,6 +1,7 @@
 //! `TypeFoldable` implementations for MIR types
 
 use rustc_ast::InlineAsmTemplatePiece;
+use rustc_hir::def_id::LocalDefId;
 
 use super::*;
 
@@ -36,6 +37,15 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for &'tcx [InlineAsmTemplatePiece] {
 }
 
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for &'tcx [Span] {
+    fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
+        self,
+        _folder: &mut F,
+    ) -> Result<Self, F::Error> {
+        Ok(self)
+    }
+}
+
+impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for &'tcx ty::List<LocalDefId> {
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         _folder: &mut F,

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -12,8 +12,8 @@ pub mod util;
 use crate::infer::canonical::Canonical;
 use crate::mir::ConstraintCategory;
 use crate::ty::abstract_const::NotConstEvaluatable;
-use crate::ty::GenericArgsRef;
 use crate::ty::{self, AdtKind, Ty};
+use crate::ty::{GenericArgsRef, TyCtxt};
 
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, Diag, EmissionGuarantee};
@@ -1001,10 +1001,10 @@ pub enum CodegenObligationError {
 /// opaques are replaced with inference vars eagerly in the old solver (e.g.
 /// in projection, and in the signature during function type-checking).
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
-pub enum DefiningAnchor {
-    /// Define opaques which are in-scope of the `LocalDefId`. Also, eagerly
-    /// replace opaque types in `replace_opaque_types_with_inference_vars`.
-    Bind(LocalDefId),
+pub enum DefiningAnchor<'tcx> {
+    /// Define opaques which are in-scope of the current item being analyzed.
+    /// Also, eagerly replace these opaque types in `replace_opaque_types_with_inference_vars`.
+    Bind(&'tcx ty::List<LocalDefId>),
     /// In contexts where we don't currently know what opaques are allowed to be
     /// defined, such as (old solver) canonical queries, we will simply allow
     /// opaques to be defined, but "bubble" them up in the canonical response or
@@ -1017,4 +1017,10 @@ pub enum DefiningAnchor {
     /// errors when handling opaque types, and also should be used when we would
     /// otherwise reveal opaques (such as [`Reveal::All`] reveal mode).
     Error,
+}
+
+impl<'tcx> DefiningAnchor<'tcx> {
+    pub fn bind(tcx: TyCtxt<'tcx>, item: LocalDefId) -> Self {
+        Self::Bind(tcx.opaque_types_defined_by(item))
+    }
 }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -1004,6 +1004,10 @@ pub enum CodegenObligationError {
 pub enum DefiningAnchor<'tcx> {
     /// Define opaques which are in-scope of the current item being analyzed.
     /// Also, eagerly replace these opaque types in `replace_opaque_types_with_inference_vars`.
+    ///
+    /// If the list is empty, do not allow any opaques to be defined. This is used to catch type mismatch
+    /// errors when handling opaque types, and also should be used when we would
+    /// otherwise reveal opaques (such as [`Reveal::All`] reveal mode).
     Bind(&'tcx ty::List<LocalDefId>),
     /// In contexts where we don't currently know what opaques are allowed to be
     /// defined, such as (old solver) canonical queries, we will simply allow
@@ -1013,10 +1017,6 @@ pub enum DefiningAnchor<'tcx> {
     /// We do not eagerly replace opaque types in `replace_opaque_types_with_inference_vars`,
     /// which may affect what predicates pass and fail in the old trait solver.
     Bubble,
-    /// Do not allow any opaques to be defined. This is used to catch type mismatch
-    /// errors when handling opaque types, and also should be used when we would
-    /// otherwise reveal opaques (such as [`Reveal::All`] reveal mode).
-    Error,
 }
 
 impl<'tcx> DefiningAnchor<'tcx> {

--- a/compiler/rustc_middle/src/traits/solve.rs
+++ b/compiler/rustc_middle/src/traits/solve.rs
@@ -114,7 +114,7 @@ impl MaybeCause {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, HashStable, TypeFoldable, TypeVisitable)]
 pub struct QueryInput<'tcx, T> {
     pub goal: Goal<'tcx, T>,
-    pub anchor: DefiningAnchor,
+    pub anchor: DefiningAnchor<'tcx>,
     pub predefined_opaques_in_body: PredefinedOpaques<'tcx>,
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -17,6 +17,7 @@ use crate::traits;
 use crate::ty::GenericArgsRef;
 use crate::ty::{self, AdtDef, Ty};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def_id::LocalDefId;
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_span::Span;
@@ -428,6 +429,15 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D> for ty::List<Fi
         decoder
             .interner()
             .mk_fields_from_iter((0..len).map::<FieldIdx, _>(|_| Decodable::decode(decoder)))
+    }
+}
+
+impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> RefDecodable<'tcx, D> for ty::List<LocalDefId> {
+    fn decode(decoder: &mut D) -> &'tcx Self {
+        let len = decoder.read_usize();
+        decoder.interner().mk_local_def_ids_from_iter(
+            (0..len).map::<LocalDefId, _>(|_| Decodable::decode(decoder)),
+        )
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2014,6 +2014,14 @@ impl<'tcx> TyCtxt<'tcx> {
         self.intern_local_def_ids(clauses)
     }
 
+    pub fn mk_local_def_ids_from_iter<I, T>(self, iter: I) -> T::Output
+    where
+        I: Iterator<Item = T>,
+        T: CollectAndApply<LocalDefId, &'tcx List<LocalDefId>>,
+    {
+        T::collect_and_apply(iter, |xs| self.mk_local_def_ids(xs))
+    }
+
     pub fn mk_const_list_from_iter<I, T>(self, iter: I) -> T::Output
     where
         I: Iterator<Item = T>,

--- a/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_trait_selection/src/solve/eval_ctxt/mod.rs
@@ -16,7 +16,7 @@ use rustc_middle::traits::solve::{
     CanonicalInput, CanonicalResponse, Certainty, IsNormalizesToHack, PredefinedOpaques,
     PredefinedOpaquesData, QueryResult,
 };
-use rustc_middle::traits::{specialization_graph, DefiningAnchor};
+use rustc_middle::traits::specialization_graph;
 use rustc_middle::ty::{
     self, InferCtxtLike, OpaqueTypeKey, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable,
     TypeVisitable, TypeVisitableExt, TypeVisitor,
@@ -258,10 +258,7 @@ impl<'a, 'tcx> EvalCtxt<'a, 'tcx> {
         // instead of taking them. This would cause an ICE here, since we have
         // assertions against dropping an `InferCtxt` without taking opaques.
         // FIXME: Once we remove support for the old impl we can remove this.
-        if input.anchor != DefiningAnchor::Error {
-            // This seems ok, but fragile.
-            let _ = infcx.take_opaque_types();
-        }
+        let _ = infcx.take_opaque_types();
 
         result
     }

--- a/tests/ui/generic-associated-types/issue-88595.rs
+++ b/tests/ui/generic-associated-types/issue-88595.rs
@@ -19,4 +19,5 @@ impl<'a> A<'a> for C {
     type B<'b> = impl Clone;
 
     fn a(&'a self) -> Self::B<'a> {} //~ ERROR: non-defining opaque type use in defining scope
+    //~^ ERROR: non-defining opaque type use in defining scope
 }

--- a/tests/ui/generic-associated-types/issue-88595.stderr
+++ b/tests/ui/generic-associated-types/issue-88595.stderr
@@ -10,5 +10,19 @@ note: for this opaque type
 LL |     type B<'b> = impl Clone;
    |                  ^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: non-defining opaque type use in defining scope
+  --> $DIR/issue-88595.rs:21:35
+   |
+LL |     fn a(&'a self) -> Self::B<'a> {}
+   |                                   ^^
+   |
+note: lifetime used multiple times
+  --> $DIR/issue-88595.rs:18:6
+   |
+LL | impl<'a> A<'a> for C {
+   |      ^^
+LL |     type B<'b> = impl Clone;
+   |            ^^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/auto-trait-leak.stderr
+++ b/tests/ui/impl-trait/auto-trait-leak.stderr
@@ -6,16 +6,12 @@ LL |     send(cycle1().clone());
    |     |
    |     required by a bound introduced by this call
    |
+   = note: fetching the hidden types of an opaque inside of the defining scope is not supported. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
 note: opaque type is declared here
   --> $DIR/auto-trait-leak.rs:11:16
    |
 LL | fn cycle1() -> impl Clone {
    |                ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leak.rs:17:4
-   |
-LL | fn cycle2() -> impl Clone {
-   |    ^^^^^^
 note: required by a bound in `send`
   --> $DIR/auto-trait-leak.rs:4:12
    |

--- a/tests/ui/impl-trait/issues/issue-78722-2.rs
+++ b/tests/ui/impl-trait/issues/issue-78722-2.rs
@@ -12,9 +12,9 @@ struct Bug {
             //~^ ERROR future that resolves to `u8`, but it resolves to `()`
             async {}
         }
+        // FIXME(type_alias_impl_trait): inform the user about why `F` is not available here.
         let f: F = async { 1 };
-        //~^ ERROR item constrains opaque type that is not in its signature
-        //~| ERROR `async` blocks are not allowed in constants
+        //~^ ERROR mismatched types
         1
     }],
 }

--- a/tests/ui/impl-trait/issues/issue-78722-2.stderr
+++ b/tests/ui/impl-trait/issues/issue-78722-2.stderr
@@ -4,30 +4,21 @@ error[E0271]: expected `{async block@$DIR/issue-78722-2.rs:13:13: 13:21}` to be 
 LL |         fn concrete_use() -> F {
    |                              ^ expected `()`, found `u8`
 
-error: item constrains opaque type that is not in its signature
-  --> $DIR/issue-78722-2.rs:15:20
+error[E0308]: mismatched types
+  --> $DIR/issue-78722-2.rs:16:20
    |
+LL | type F = impl core::future::Future<Output = u8>;
+   |          -------------------------------------- the expected future
+...
 LL |         let f: F = async { 1 };
-   |                    ^^^^^^^^^^^
+   |                -   ^^^^^^^^^^^ expected future, found `async` block
+   |                |
+   |                expected due to this
    |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/issue-78722-2.rs:15:20
-   |
-LL |         let f: F = async { 1 };
-   |                    ^^^^^^^^^^^
+   = note: expected opaque type `F`
+            found `async` block `{async block@$DIR/issue-78722-2.rs:16:20: 16:31}`
 
-error[E0658]: `async` blocks are not allowed in constants
-  --> $DIR/issue-78722-2.rs:15:20
-   |
-LL |         let f: F = async { 1 };
-   |                    ^^^^^^^^^^^
-   |
-   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
-   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0271, E0658.
+Some errors have detailed explanations: E0271, E0308.
 For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/lint/issue-99387.rs
+++ b/tests/ui/lint/issue-99387.rs
@@ -19,8 +19,8 @@ impl<'a> Tr for &'a () {
 }
 
 pub fn ohno<'a>() -> <&'a () as Tr>::Item {
-    //~^ ERROR item constrains opaque type that is not in its signature
     None.into_iter()
+    //~^ ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/lint/issue-99387.stderr
+++ b/tests/ui/lint/issue-99387.stderr
@@ -1,11 +1,17 @@
-error: item constrains opaque type that is not in its signature
-  --> $DIR/issue-99387.rs:21:22
+error[E0308]: mismatched types
+  --> $DIR/issue-99387.rs:22:5
    |
+LL | pub type Successors<'a> = impl Iterator<Item = &'a ()>;
+   |                           ---------------------------- the expected opaque type
+...
 LL | pub fn ohno<'a>() -> <&'a () as Tr>::Item {
-   |                      ^^^^^^^^^^^^^^^^^^^^
+   |                      -------------------- expected `Successors<'a>` because of return type
+LL |     None.into_iter()
+   |     ^^^^^^^^^^^^^^^^ expected opaque type, found `IntoIter<_>`
    |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
+   = note: expected opaque type `Successors<'a>`
+                   found struct `std::option::IntoIter<_>`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/issue-99387.rs:21:8
    |
 LL | pub fn ohno<'a>() -> <&'a () as Tr>::Item {
@@ -13,3 +19,4 @@ LL | pub fn ohno<'a>() -> <&'a () as Tr>::Item {
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage3.stderr
@@ -6,16 +6,12 @@ LL |         is_send(foo());
    |         |
    |         required by a bound introduced by this call
    |
+   = note: fetching the hidden types of an opaque inside of the defining scope is not supported. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
 note: opaque type is declared here
   --> $DIR/auto-trait-leakage3.rs:7:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
    |                    ^^^^^^^^^^^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/auto-trait-leakage3.rs:12:12
-   |
-LL |     pub fn bar() {
-   |            ^^^
 note: required by a bound in `is_send`
   --> $DIR/auto-trait-leakage3.rs:17:19
    |

--- a/tests/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
@@ -35,18 +35,6 @@ LL | type TwoLifetimes<'a, 'b> = impl Debug;
    |                             ^^^^^^^^^^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_duplicate_param_use.rs:29:5
-   |
-LL |     t
-   |     ^
-   |
-note: lifetime used multiple times
-  --> $DIR/generic_duplicate_param_use.rs:17:19
-   |
-LL | type TwoLifetimes<'a, 'b> = impl Debug;
-   |                   ^^  ^^
-
-error: non-defining opaque type use in defining scope
   --> $DIR/generic_duplicate_param_use.rs:33:50
    |
 LL | fn one_const<const N: usize>(t: *mut [u8; N]) -> TwoConsts<N, N> {
@@ -57,6 +45,18 @@ note: for this opaque type
    |
 LL | type TwoConsts<const X: usize, const Y: usize> = impl Debug;
    |                                                  ^^^^^^^^^^
+
+error: non-defining opaque type use in defining scope
+  --> $DIR/generic_duplicate_param_use.rs:29:5
+   |
+LL |     t
+   |     ^
+   |
+note: lifetime used multiple times
+  --> $DIR/generic_duplicate_param_use.rs:17:19
+   |
+LL | type TwoLifetimes<'a, 'b> = impl Debug;
+   |                   ^^  ^^
 
 error: non-defining opaque type use in defining scope
   --> $DIR/generic_duplicate_param_use.rs:35:5

--- a/tests/ui/type-alias-impl-trait/generic_nondefining_use.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_nondefining_use.stderr
@@ -31,15 +31,6 @@ note: for this opaque type
 LL | type OneLifetime<'a> = impl Debug;
    |                        ^^^^^^^^^^
 
-error[E0792]: expected generic lifetime parameter, found `'static`
-  --> $DIR/generic_nondefining_use.rs:23:5
-   |
-LL | type OneLifetime<'a> = impl Debug;
-   |                  -- cannot use static lifetime; use a bound lifetime instead or remove the lifetime parameter from the opaque type
-...
-LL |     6u32
-   |     ^^^^
-
 error[E0792]: non-defining opaque type use in defining scope
   --> $DIR/generic_nondefining_use.rs:27:24
    |
@@ -51,6 +42,15 @@ note: for this opaque type
    |
 LL | type OneConst<const X: usize> = impl Debug;
    |                                 ^^^^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'static`
+  --> $DIR/generic_nondefining_use.rs:23:5
+   |
+LL | type OneLifetime<'a> = impl Debug;
+   |                  -- cannot use static lifetime; use a bound lifetime instead or remove the lifetime parameter from the opaque type
+...
+LL |     6u32
+   |     ^^^^
 
 error[E0792]: expected generic constant parameter, found `123`
   --> $DIR/generic_nondefining_use.rs:29:5

--- a/tests/ui/type-alias-impl-trait/hidden_type_mismatch.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_type_mismatch.rs
@@ -9,7 +9,6 @@
 mod sus {
     use super::*;
     pub type Sep = impl Sized + std::fmt::Display;
-    //~^ ERROR: concrete type differs from previous defining opaque type use
     pub fn mk_sep() -> Sep {
         String::from("hello")
     }
@@ -42,6 +41,7 @@ mod sus {
         (): Proj<Assoc = i32>,
     {
         Bar { inner: 1i32, _marker: () }
+        //~^ ERROR type mismatch
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/hidden_type_mismatch.stderr
+++ b/tests/ui/type-alias-impl-trait/hidden_type_mismatch.stderr
@@ -1,14 +1,27 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/hidden_type_mismatch.rs:11:20
+error[E0271]: type mismatch resolving `<() as Proj>::Assoc == i32`
+  --> $DIR/hidden_type_mismatch.rs:43:9
    |
 LL |     pub type Sep = impl Sized + std::fmt::Display;
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, got `String`
+   |                    ------------------------------ the expected opaque type
+...
+LL |         Bar { inner: 1i32, _marker: () }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<() as Proj>::Assoc == i32`
    |
-note: previous use here
-  --> $DIR/hidden_type_mismatch.rs:37:21
+note: expected this to be `Sep`
+  --> $DIR/hidden_type_mismatch.rs:20:22
    |
-LL |     pub type Tait = impl Copy + From<Bar<()>> + Into<Bar<()>>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         type Assoc = sus::Sep;
+   |                      ^^^^^^^^
+   = note: expected opaque type `Sep`
+                     found type `i32`
+note: required for `Bar<()>` to implement `Copy`
+  --> $DIR/hidden_type_mismatch.rs:32:39
+   |
+LL |     impl<T: Proj<Assoc = i32> + Copy> Copy for Bar<T> {}
+   |                  -----------          ^^^^     ^^^^^^
+   |                  |
+   |                  unsatisfied trait bound introduced here
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/type-alias-impl-trait/higher_kinded_params2.rs
+++ b/tests/ui/type-alias-impl-trait/higher_kinded_params2.rs
@@ -24,7 +24,7 @@ type Successors<'a> = impl std::fmt::Debug + 'a;
 impl Terminator {
     fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> Successors<'_> {
         f = g;
-        //~^ ERROR item constrains opaque type that is not in its signature
+        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/higher_kinded_params2.stderr
+++ b/tests/ui/type-alias-impl-trait/higher_kinded_params2.stderr
@@ -1,11 +1,15 @@
-error: item constrains opaque type that is not in its signature
+error[E0308]: mismatched types
   --> $DIR/higher_kinded_params2.rs:26:13
    |
+LL | type Tait = impl std::fmt::Debug;
+   |             -------------------- the expected opaque type
+...
 LL |         f = g;
-   |             ^
+   |             ^ expected fn pointer, found fn item
    |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
+   = note: expected fn pointer `for<'x> fn(&'x ()) -> Tait`
+                 found fn item `for<'a> fn(&'a ()) -> String {g}`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/higher_kinded_params2.rs:25:8
    |
 LL |     fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> Successors<'_> {
@@ -13,3 +17,4 @@ LL |     fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> S
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/higher_kinded_params3.rs
+++ b/tests/ui/type-alias-impl-trait/higher_kinded_params3.rs
@@ -25,7 +25,6 @@ impl Terminator {
     fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> Successors<'_> {
         f = g;
         //~^ ERROR mismatched types
-        //~| ERROR item constrains opaque type that is not in its signature
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/higher_kinded_params3.stderr
+++ b/tests/ui/type-alias-impl-trait/higher_kinded_params3.stderr
@@ -1,28 +1,20 @@
-error: item constrains opaque type that is not in its signature
-  --> $DIR/higher_kinded_params3.rs:26:13
-   |
-LL |         f = g;
-   |             ^
-   |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/higher_kinded_params3.rs:25:8
-   |
-LL |     fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> Successors<'_> {
-   |        ^^^^^^^^^^
-
 error[E0308]: mismatched types
-  --> $DIR/higher_kinded_params3.rs:26:9
+  --> $DIR/higher_kinded_params3.rs:26:13
    |
 LL | type Tait<'a> = impl std::fmt::Debug + 'a;
    |                 ------------------------- the expected opaque type
 ...
 LL |         f = g;
-   |         ^^^^^ one type is more general than the other
+   |             ^ expected fn pointer, found fn item
    |
    = note: expected fn pointer `for<'x> fn(&'x ()) -> Tait<'x>`
-              found fn pointer `for<'a> fn(&'a ()) -> &'a ()`
+                 found fn item `for<'a> fn(&'a ()) -> &'a () {g}`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/higher_kinded_params3.rs:25:8
+   |
+LL |     fn successors(&self, mut f: for<'x> fn(&'x ()) -> <&'x A as B>::C) -> Successors<'_> {
+   |        ^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/implied_bounds_from_types.rs
+++ b/tests/ui/type-alias-impl-trait/implied_bounds_from_types.rs
@@ -12,6 +12,7 @@ impl<'a> Convert<'a> for () {
     type Witness = WithLifetime<&'a ()>;
 
     fn convert<'b, T: ?Sized>(_proof: &'b WithLifetime<&'a ()>, x: &'a T) -> &'b T {
+        //~^ ERROR non-defining opaque type use
         // compiler used to think it gets to assume 'a: 'b here because
         // of the `&'b WithLifetime<&'a ()>` argument
         x

--- a/tests/ui/type-alias-impl-trait/implied_bounds_from_types.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_bounds_from_types.stderr
@@ -1,5 +1,17 @@
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/implied_bounds_from_types.rs:14:39
+   |
+LL |     fn convert<'b, T: ?Sized>(_proof: &'b WithLifetime<&'a ()>, x: &'a T) -> &'b T {
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^ argument `&'a ()` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/implied_bounds_from_types.rs:3:24
+   |
+LL | type WithLifetime<T> = impl Equals<SelfType = ()>;
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: lifetime may not live long enough
-  --> $DIR/implied_bounds_from_types.rs:17:9
+  --> $DIR/implied_bounds_from_types.rs:18:9
    |
 LL | impl<'a> Convert<'a> for () {
    |      -- lifetime `'a` defined here
@@ -12,5 +24,6 @@ LL |         x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/inference-cycle.stderr
+++ b/tests/ui/type-alias-impl-trait/inference-cycle.stderr
@@ -6,16 +6,12 @@ LL |         is_send(foo());
    |         |
    |         required by a bound introduced by this call
    |
+   = note: fetching the hidden types of an opaque inside of the defining scope is not supported. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
 note: opaque type is declared here
   --> $DIR/inference-cycle.rs:5:20
    |
 LL |     pub type Foo = impl std::fmt::Debug;
    |                    ^^^^^^^^^^^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/inference-cycle.rs:11:12
-   |
-LL |     pub fn bar() {
-   |            ^^^
 note: required by a bound in `is_send`
   --> $DIR/inference-cycle.rs:21:19
    |

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.rs
@@ -4,6 +4,7 @@
 type Bug<T, U> = impl Fn(T) -> U + Copy; //~ ERROR cycle detected
 
 const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
+//~^ ERROR: non-defining opaque type use
 
 fn make_bug<T, U: From<T>>() -> Bug<T, U> {
     |x| x.into() //~ ERROR the trait bound `U: From<T>` is not satisfied

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
@@ -1,3 +1,15 @@
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/issue-53092-2.rs:6:18
+   |
+LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
+   |                  ^^^^^^^^^^^ argument `u8` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/issue-53092-2.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0391]: cycle detected when computing type of `Bug::{opaque#0}`
   --> $DIR/issue-53092-2.rs:4:18
    |
@@ -25,13 +37,13 @@ LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0277]: the trait bound `U: From<T>` is not satisfied
-  --> $DIR/issue-53092-2.rs:9:5
+  --> $DIR/issue-53092-2.rs:10:5
    |
 LL |     |x| x.into()
    |     ^^^^^^^^^^^^ the trait `From<T>` is not implemented for `U`
    |
 note: required by a bound in `make_bug`
-  --> $DIR/issue-53092-2.rs:8:19
+  --> $DIR/issue-53092-2.rs:9:19
    |
 LL | fn make_bug<T, U: From<T>>() -> Bug<T, U> {
    |                   ^^^^^^^ required by this bound in `make_bug`
@@ -40,7 +52,7 @@ help: consider restricting type parameter `U`
 LL | type Bug<T, U: std::convert::From<T>> = impl Fn(T) -> U + Copy;
    |              +++++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0277, E0391.
+Some errors have detailed explanations: E0277, E0391, E0792.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/issue-53092.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53092.rs
@@ -9,6 +9,7 @@ union Moo {
 }
 
 const CONST_BUG: Bug<u8, ()> = unsafe { Moo { y: () }.x };
+//~^ ERROR non-defining opaque type use
 
 fn make_bug<T, U: From<T>>() -> Bug<T, U> {
     |x| x.into() //~ ERROR the trait bound `U: From<T>` is not satisfied

--- a/tests/ui/type-alias-impl-trait/issue-53092.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092.stderr
@@ -1,11 +1,23 @@
+error[E0792]: non-defining opaque type use in defining scope
+  --> $DIR/issue-53092.rs:11:18
+   |
+LL | const CONST_BUG: Bug<u8, ()> = unsafe { Moo { y: () }.x };
+   |                  ^^^^^^^^^^^ argument `u8` is not a generic parameter
+   |
+note: for this opaque type
+  --> $DIR/issue-53092.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0277]: the trait bound `U: From<T>` is not satisfied
-  --> $DIR/issue-53092.rs:14:5
+  --> $DIR/issue-53092.rs:15:5
    |
 LL |     |x| x.into()
    |     ^^^^^^^^^^^^ the trait `From<T>` is not implemented for `U`
    |
 note: required by a bound in `make_bug`
-  --> $DIR/issue-53092.rs:13:19
+  --> $DIR/issue-53092.rs:14:19
    |
 LL | fn make_bug<T, U: From<T>>() -> Bug<T, U> {
    |                   ^^^^^^^ required by this bound in `make_bug`
@@ -14,6 +26,7 @@ help: consider restricting type parameter `U`
 LL | type Bug<T, U: std::convert::From<T>> = impl Fn(T) -> U + Copy;
    |              +++++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0277, E0792.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/type-alias-impl-trait/issue-70121.rs
+++ b/tests/ui/type-alias-impl-trait/issue-70121.rs
@@ -15,8 +15,8 @@ impl<'a> Tr for &'a () {
 }
 
 pub fn kazusa<'a>() -> <&'a () as Tr>::Item {
-    //~^ ERROR item constrains opaque type that is not in its signature
     None.into_iter()
+    //~^ ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/issue-70121.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-70121.stderr
@@ -1,11 +1,17 @@
-error: item constrains opaque type that is not in its signature
-  --> $DIR/issue-70121.rs:17:24
+error[E0308]: mismatched types
+  --> $DIR/issue-70121.rs:18:5
    |
+LL | pub type Successors<'a> = impl Iterator<Item = &'a ()>;
+   |                           ---------------------------- the expected opaque type
+...
 LL | pub fn kazusa<'a>() -> <&'a () as Tr>::Item {
-   |                        ^^^^^^^^^^^^^^^^^^^^
+   |                        -------------------- expected `Successors<'a>` because of return type
+LL |     None.into_iter()
+   |     ^^^^^^^^^^^^^^^^ expected opaque type, found `IntoIter<_>`
    |
-   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
-note: this item must mention the opaque type in its signature in order to be able to register hidden types
+   = note: expected opaque type `Successors<'a>`
+                   found struct `std::option::IntoIter<_>`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/issue-70121.rs:17:8
    |
 LL | pub fn kazusa<'a>() -> <&'a () as Tr>::Item {
@@ -13,3 +19,4 @@ LL | pub fn kazusa<'a>() -> <&'a () as Tr>::Item {
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/type-alias-impl-trait/issue-77179.rs
+++ b/tests/ui/type-alias-impl-trait/issue-77179.rs
@@ -7,7 +7,7 @@ type Pointer<T> = impl std::ops::Deref<Target = T>;
 fn test() -> Pointer<_> {
     //~^ ERROR: the placeholder `_` is not allowed within types
     Box::new(1)
-    //~^ ERROR: expected generic type parameter, found `i32`
+    //~^ ERROR: mismatched types
 }
 
 fn main() {

--- a/tests/ui/type-alias-impl-trait/issue-77179.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-77179.stderr
@@ -1,11 +1,28 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-77179.rs:9:5
+   |
+LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
+   |                   -------------------------------- the expected opaque type
+LL |
+LL | fn test() -> Pointer<_> {
+   |              ---------- expected `Pointer<_>` because of return type
+LL |
+LL |     Box::new(1)
+   |     ^^^^^^^^^^^ expected opaque type, found `Box<{integer}>`
+   |
+   = note: expected opaque type `Pointer<_>`
+                   found struct `Box<{integer}>`
+note: this item must have the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/issue-77179.rs:7:4
+   |
+LL | fn test() -> Pointer<_> {
+   |    ^^^^
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/issue-77179.rs:7:22
    |
 LL | fn test() -> Pointer<_> {
-   |              --------^-
-   |              |       |
-   |              |       not allowed in type signatures
-   |              help: replace with the correct return type: `Pointer<i32>`
+   |                      ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/issue-77179.rs:18:25
@@ -16,16 +33,7 @@ LL |     fn bar() -> Pointer<_>;
    |                         not allowed in type signatures
    |                         help: use type parameters instead: `T`
 
-error[E0792]: expected generic type parameter, found `i32`
-  --> $DIR/issue-77179.rs:9:5
-   |
-LL | type Pointer<T> = impl std::ops::Deref<Target = T>;
-   |              - this generic parameter must be used with a generic type parameter
-...
-LL |     Box::new(1)
-   |     ^^^^^^^^^^^
-
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0121, E0792.
+Some errors have detailed explanations: E0121, E0308.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/type-alias-impl-trait/multi-error.rs
+++ b/tests/ui/type-alias-impl-trait/multi-error.rs
@@ -17,6 +17,7 @@ impl Foo for () {
     fn foo() -> (Self::Bar<u32>, Self::Baz) {
         //~^ ERROR non-defining opaque type use
         ((), ())
+        //~^ ERROR expected generic type parameter
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/multi-error.stderr
+++ b/tests/ui/type-alias-impl-trait/multi-error.stderr
@@ -10,6 +10,15 @@ note: for this opaque type
 LL |     type Bar<T> = impl Sized;
    |                   ^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0792]: expected generic type parameter, found `u32`
+  --> $DIR/multi-error.rs:19:9
+   |
+LL |     type Bar<T> = impl Sized;
+   |              - this generic parameter must be used with a generic type parameter
+...
+LL |         ((), ())
+   |         ^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/non-defining-method.rs
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.rs
@@ -15,6 +15,7 @@ impl Foo for () {
     type Bar<T> = impl Sized;
     fn foo() -> Self::Bar<u32> {}
     //~^ ERROR non-defining opaque type use
+    //~| ERROR expected generic type parameter, found `u32`
     fn bar<T>() -> Self::Bar<T> {}
 }
 

--- a/tests/ui/type-alias-impl-trait/non-defining-method.stderr
+++ b/tests/ui/type-alias-impl-trait/non-defining-method.stderr
@@ -10,6 +10,14 @@ note: for this opaque type
 LL |     type Bar<T> = impl Sized;
    |                   ^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0792]: expected generic type parameter, found `u32`
+  --> $DIR/non-defining-method.rs:16:32
+   |
+LL |     type Bar<T> = impl Sized;
+   |              - this generic parameter must be used with a generic type parameter
+LL |     fn foo() -> Self::Bar<u32> {}
+   |                                ^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/reveal_local.stderr
+++ b/tests/ui/type-alias-impl-trait/reveal_local.stderr
@@ -4,16 +4,12 @@ error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque
 LL |     is_send::<Foo>();
    |               ^^^
    |
+   = note: fetching the hidden types of an opaque inside of the defining scope is not supported. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
 note: opaque type is declared here
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/reveal_local.rs:9:4
-   |
-LL | fn not_good() {
-   |    ^^^^^^^^
 note: required by a bound in `is_send`
   --> $DIR/reveal_local.rs:7:15
    |
@@ -26,16 +22,12 @@ error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque
 LL |     is_send::<Foo>();
    |               ^^^
    |
+   = note: fetching the hidden types of an opaque inside of the defining scope is not supported. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
 note: opaque type is declared here
   --> $DIR/reveal_local.rs:5:12
    |
 LL | type Foo = impl Debug;
    |            ^^^^^^^^^^
-note: this item depends on auto traits of the hidden type, but may also be registering the hidden type. This is not supported right now. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
-  --> $DIR/reveal_local.rs:16:4
-   |
-LL | fn not_gooder() -> Foo {
-   |    ^^^^^^^^^^
 note: required by a bound in `is_send`
   --> $DIR/reveal_local.rs:7:15
    |


### PR DESCRIPTION
This makes `Bind` almost always be empty, so we can start forwarding it to queries, allowing us to remove `Bubble` entirely (not done in this PR)

The only behaviour change is in diagnostics.

r? @lcnr @compiler-errors 
