### PR TITLE
Avoid panic branch in `EscapeDefault::backslash` and `EscapeDebug::backslash`.

### DIFF
--- a/library/core/src/escape.rs
+++ b/library/core/src/escape.rs
@@ -3,6 +3,7 @@
 use crate::ascii;
 use crate::num::NonZero;
 use crate::ops::Range;
+use crate::ptr;
 
 const HEX_DIGITS: [ascii::Char; 16] = *b"0123456789abcdef".as_ascii().unwrap();
 
@@ -82,7 +83,12 @@ impl<const N: usize> EscapeIterInner<N> {
         const { assert!(M <= N) };
 
         let mut data = [ascii::Char::Null; N];
-        data[..M].copy_from_slice(&array);
+
+        // SAFETY: `M` is smaller than or equal to `N`, and `data` does not overlap `array`.
+        unsafe {
+            ptr::copy_nonoverlapping(array.as_ptr(), data.as_mut_ptr(), M);
+        }
+
         Self::new(data, 0..M as u8)
     }
 


### PR DESCRIPTION
See https://github.com/japaric/ufmt/issues/52 and https://github.com/andrewgazelka/ufmt/blob/e97ce1a86cfcc9fa36ffab6ee62762c00e4b3fc9/src/impls/core.rs#L62.

This avoids the unreachable panicking branch in `char::escape_debug`.

Not sure what the best way to test this is.
