### PR TITLE
Remove doc aliases to PATH

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -469,7 +469,6 @@ pub struct SplitPaths<'a> {
 ///     None => println!("{key} is not defined in the environment.")
 /// }
 /// ```
-#[doc(alias = "PATH")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn split_paths<T: AsRef<OsStr> + ?Sized>(unparsed: &T) -> SplitPaths<'_> {
     SplitPaths { inner: os_imp::split_paths(unparsed.as_ref()) }
@@ -565,7 +564,6 @@ pub struct JoinPathsError {
 /// ```
 ///
 /// [`env::split_paths()`]: split_paths
-#[doc(alias = "PATH")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn join_paths<I, T>(paths: I) -> Result<OsString, JoinPathsError>
 where


### PR DESCRIPTION
Remove aliases for `split_paths` and `join_paths` as should have been done in <https://github.com/rust-lang/rust/pull/119748> (Bors merged the wrong commit).