### PR TITLE
CFI: Remove unused `typeid_for_fnsig`

### DIFF
--- a/compiler/rustc_symbol_mangling/src/typeid.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid.rs
@@ -4,13 +4,13 @@
 /// For more information about LLVM CFI and cross-language LLVM CFI support for the Rust compiler,
 /// see design document in the tracking issue #89653.
 use bitflags::bitflags;
-use rustc_middle::ty::{FnSig, Instance, Ty, TyCtxt};
+use rustc_middle::ty::{Instance, Ty, TyCtxt};
 use rustc_target::abi::call::FnAbi;
 use std::hash::Hasher;
 use twox_hash::XxHash64;
 
 bitflags! {
-    /// Options for typeid_for_fnabi and typeid_for_fnsig.
+    /// Options for typeid_for_fnabi.
     #[derive(Clone, Copy, Debug)]
     pub struct TypeIdOptions: u32 {
         const GENERALIZE_POINTERS = 1;
@@ -28,15 +28,6 @@ pub fn typeid_for_fnabi<'tcx>(
     options: TypeIdOptions,
 ) -> String {
     typeid_itanium_cxx_abi::typeid_for_fnabi(tcx, fn_abi, options)
-}
-
-/// Returns a type metadata identifier for the specified FnSig.
-pub fn typeid_for_fnsig<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    fn_sig: &FnSig<'tcx>,
-    options: TypeIdOptions,
-) -> String {
-    typeid_itanium_cxx_abi::typeid_for_fnsig(tcx, fn_sig, options)
 }
 
 /// Returns a type metadata identifier for the specified Instance.
@@ -58,19 +49,6 @@ pub fn kcfi_typeid_for_fnabi<'tcx>(
     // xxHash64 of the type metadata identifier. (See llvm/llvm-project@cff5bef.)
     let mut hash: XxHash64 = Default::default();
     hash.write(typeid_itanium_cxx_abi::typeid_for_fnabi(tcx, fn_abi, options).as_bytes());
-    hash.finish() as u32
-}
-
-/// Returns a KCFI type metadata identifier for the specified FnSig.
-pub fn kcfi_typeid_for_fnsig<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    fn_sig: &FnSig<'tcx>,
-    options: TypeIdOptions,
-) -> u32 {
-    // A KCFI type metadata identifier is a 32-bit constant produced by taking the lower half of the
-    // xxHash64 of the type metadata identifier. (See llvm/llvm-project@cff5bef.)
-    let mut hash: XxHash64 = Default::default();
-    hash.write(typeid_itanium_cxx_abi::typeid_for_fnsig(tcx, fn_sig, options).as_bytes());
     hash.finish() as u32
 }
 

--- a/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
+++ b/compiler/rustc_symbol_mangling/src/typeid/typeid_itanium_cxx_abi.rs
@@ -1072,41 +1072,6 @@ pub fn typeid_for_fnabi<'tcx>(
     typeid
 }
 
-/// Returns a type metadata identifier for the specified FnSig using the Itanium C++ ABI with vendor
-/// extended type qualifiers and types for Rust types that are not used at the FFI boundary.
-pub fn typeid_for_fnsig<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    fn_sig: &FnSig<'tcx>,
-    options: TypeIdOptions,
-) -> String {
-    // A name is mangled by prefixing "_Z" to an encoding of its name, and in the case of functions
-    // its type.
-    let mut typeid = String::from("_Z");
-
-    // Clang uses the Itanium C++ ABI's virtual tables and RTTI typeinfo structure name as type
-    // metadata identifiers for function pointers. The typeinfo name encoding is a two-character
-    // code (i.e., 'TS') prefixed to the type encoding for the function.
-    typeid.push_str("TS");
-
-    // A dictionary of substitution candidates used for compression (see
-    // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-compression).
-    let mut dict: FxHashMap<DictKey<'tcx>, usize> = FxHashMap::default();
-
-    // Encode the function signature
-    typeid.push_str(&encode_fnsig(tcx, fn_sig, &mut dict, options));
-
-    // Add encoding suffixes
-    if options.contains(EncodeTyOptions::NORMALIZE_INTEGERS) {
-        typeid.push_str(".normalized");
-    }
-
-    if options.contains(EncodeTyOptions::GENERALIZE_POINTERS) {
-        typeid.push_str(".generalized");
-    }
-
-    typeid
-}
-
 /// Returns a type metadata identifier for the specified Instance using the Itanium C++ ABI with
 /// vendor extended type qualifiers and types for Rust types that are not used at the FFI boundary.
 pub fn typeid_for_instance<'tcx>(


### PR DESCRIPTION
Removes unused `typeid_for_fnsig` for simplifying the compiler CFI API.