### PR TITLE
Handle stashing of delayed bugs

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -780,11 +780,11 @@ impl DiagCtxt {
         let err = self.inner.borrow_mut().stashed_diagnostics.swap_remove(&key);
         err.map(|(err, guar)| {
             // The use of `::<ErrorGuaranteed>` is safe because level is `Level::Error`.
-            assert_eq!(err.level, Level::Error);
+            assert_eq!(err.level, Error);
             assert!(guar.is_some());
             let mut err = Diag::<ErrorGuaranteed>::new_diagnostic(self, err);
             modify_err(&mut err);
-            assert_eq!(err.level, Level::Error);
+            assert_eq!(err.level, Error);
             err.emit()
         })
     }
@@ -803,7 +803,7 @@ impl DiagCtxt {
         let old_err = self.inner.borrow_mut().stashed_diagnostics.swap_remove(&key);
         match old_err {
             Some((old_err, guar)) => {
-                assert_eq!(old_err.level, Level::Error);
+                assert_eq!(old_err.level, Error);
                 assert!(guar.is_some());
                 // Because `old_err` has already been counted, it can only be
                 // safely cancelled because the `new_err` supplants it.
@@ -1367,7 +1367,7 @@ impl DiagCtxtInner {
         }
 
         if diagnostic.has_future_breakage() {
-            // Future breakages aren't emitted if they're Level::Allow,
+            // Future breakages aren't emitted if they're `Level::Allow`,
             // but they still need to be constructed and stashed below,
             // so they'll trigger the must_produce_diag check.
             self.suppressed_expected_diag = true;
@@ -1453,7 +1453,7 @@ impl DiagCtxtInner {
                 diagnostic.children.extract_if(already_emitted_sub).for_each(|_| {});
                 if already_emitted {
                     let msg = "duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`";
-                    diagnostic.sub(Level::Note, msg, MultiSpan::new());
+                    diagnostic.sub(Note, msg, MultiSpan::new());
                 }
 
                 if is_error {
@@ -1623,7 +1623,7 @@ impl DiagCtxtInner {
                 bug.arg("level", bug.level);
                 let msg = crate::fluent_generated::errors_invalid_flushed_delayed_diagnostic_level;
                 let msg = self.eagerly_translate_for_subdiag(&bug, msg); // after the `arg` call
-                bug.sub(Level::Note, msg, bug.span.primary_span().unwrap().into());
+                bug.sub(Note, msg, bug.span.primary_span().unwrap().into());
             }
             bug.level = Bug;
 
@@ -1671,7 +1671,7 @@ impl DelayedDiagInner {
         diag.arg("emitted_at", diag.emitted_at.clone());
         diag.arg("note", self.note);
         let msg = dcx.eagerly_translate_for_subdiag(&diag, msg); // after the `arg` calls
-        diag.sub(Level::Note, msg, diag.span.primary_span().unwrap_or(DUMMY_SP).into());
+        diag.sub(Note, msg, diag.span.primary_span().unwrap_or(DUMMY_SP).into());
         diag
     }
 }

--- a/compiler/rustc_hir_analysis/src/astconv/lint.rs
+++ b/compiler/rustc_hir_analysis/src/astconv/lint.rs
@@ -1,5 +1,5 @@
 use rustc_ast::TraitObjectSyntax;
-use rustc_errors::{codes::*, Diag, EmissionGuarantee, Level, StashKey};
+use rustc_errors::{codes::*, Diag, EmissionGuarantee, StashKey};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_lint_defs::{builtin::BARE_TRAIT_OBJECTS, Applicability};
@@ -237,15 +237,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
                 // check if the impl trait that we are considering is a impl of a local trait
                 self.maybe_lint_blanket_trait_impl(self_ty, &mut diag);
-                match diag.level() {
-                    Level::Error => {
-                        diag.stash(self_ty.span, StashKey::TraitMissingMethod);
-                    }
-                    Level::DelayedBug => {
-                        diag.emit();
-                    }
-                    _ => unreachable!(),
-                }
+                diag.stash(self_ty.span, StashKey::TraitMissingMethod);
             } else {
                 let msg = "trait objects without an explicit `dyn` are deprecated";
                 tcx.node_span_lint(BARE_TRAIT_OBJECTS, self_ty.hir_id, self_ty.span, msg, |lint| {

--- a/tests/ui/typeck/invalid-stashed-level-issue-121812.rs
+++ b/tests/ui/typeck/invalid-stashed-level-issue-121812.rs
@@ -1,0 +1,8 @@
+union U {
+    a: u16,
+    b: [u8; 3],
+}
+
+fn main() {
+    _ = U { b: [()] }; //~ ERROR mismatched types
+}

--- a/tests/ui/typeck/invalid-stashed-level-issue-121812.stderr
+++ b/tests/ui/typeck/invalid-stashed-level-issue-121812.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/invalid-stashed-level-issue-121812.rs:7:17
+   |
+LL |     _ = U { b: [()] };
+   |                 ^^ expected `u8`, found `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
By just emitting them immediately, because it does happen in practice, when errors are downgraded to delayed bugs.
    
We already had one case in `lint.rs` where we handled this at the callsite. This commit changes things so it's handled within `stash_diagnostic` instead, because #121812 identified a second case, and it's possible there are more.
    
Fixes #121812.

r? @oli-obk
