### PR TITLE
never patterns: suggest `!` patterns on non-exhaustive matches

### DIFF
--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -681,15 +681,19 @@ pub enum Constructor<Cx: TypeCx> {
     Or,
     /// Wildcard pattern.
     Wildcard,
+    /// Never pattern. Only used in `WitnessPat`. An actual never pattern should be lowered as
+    /// `Wildcard`.
+    Never,
     /// Fake extra constructor for enums that aren't allowed to be matched exhaustively. Also used
-    /// for those types for which we cannot list constructors explicitly, like `f64` and `str`.
+    /// for those types for which we cannot list constructors explicitly, like `f64` and `str`. Only
+    /// used in `WitnessPat`.
     NonExhaustive,
-    /// Fake extra constructor for variants that should not be mentioned in diagnostics.
-    /// We use this for variants behind an unstable gate as well as
-    /// `#[doc(hidden)]` ones.
+    /// Fake extra constructor for variants that should not be mentioned in diagnostics. We use this
+    /// for variants behind an unstable gate as well as `#[doc(hidden)]` ones. Only used in
+    /// `WitnessPat`.
     Hidden,
     /// Fake extra constructor for constructors that are not seen in the matrix, as explained at the
-    /// top of the file.
+    /// top of the file. Only used for specialization.
     Missing,
     /// Fake extra constructor that indicates and empty field that is private. When we encounter one
     /// we skip the column entirely so we don't observe its emptiness. Only used for specialization.
@@ -711,6 +715,7 @@ impl<Cx: TypeCx> Clone for Constructor<Cx> {
             Constructor::Str(value) => Constructor::Str(value.clone()),
             Constructor::Opaque(inner) => Constructor::Opaque(inner.clone()),
             Constructor::Or => Constructor::Or,
+            Constructor::Never => Constructor::Never,
             Constructor::Wildcard => Constructor::Wildcard,
             Constructor::NonExhaustive => Constructor::NonExhaustive,
             Constructor::Hidden => Constructor::Hidden,

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -189,6 +189,7 @@ impl<Cx: TypeCx> fmt::Debug for DeconstructedPat<Cx> {
                 }
                 Ok(())
             }
+            Never => write!(f, "!"),
             Wildcard | Missing | NonExhaustive | Hidden | PrivateUninhabited => {
                 write!(f, "_ : {:?}", pat.ty())
             }

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -292,18 +292,24 @@ impl<Cx: TypeCx> WitnessPat<Cx> {
     pub(crate) fn new(ctor: Constructor<Cx>, fields: Vec<Self>, ty: Cx::Ty) -> Self {
         Self { ctor, fields, ty }
     }
-    pub(crate) fn wildcard(ty: Cx::Ty) -> Self {
-        Self::new(Wildcard, Vec::new(), ty)
+    /// Create a wildcard pattern for this type. If the type is empty, we create a `!` pattern.
+    pub(crate) fn wildcard(cx: &Cx, ty: Cx::Ty) -> Self {
+        let is_empty = cx.ctors_for_ty(&ty).is_ok_and(|ctors| ctors.all_empty());
+        let ctor = if is_empty { Never } else { Wildcard };
+        Self::new(ctor, Vec::new(), ty)
     }
 
     /// Construct a pattern that matches everything that starts with this constructor.
     /// For example, if `ctor` is a `Constructor::Variant` for `Option::Some`, we get the pattern
     /// `Some(_)`.
     pub(crate) fn wild_from_ctor(cx: &Cx, ctor: Constructor<Cx>, ty: Cx::Ty) -> Self {
+        if matches!(ctor, Wildcard) {
+            return Self::wildcard(cx, ty);
+        }
         let fields = cx
             .ctor_sub_tys(&ctor, &ty)
             .filter(|(_, PrivateUninhabitedField(skip))| !skip)
-            .map(|(ty, _)| Self::wildcard(ty))
+            .map(|(ty, _)| Self::wildcard(cx, ty))
             .collect();
         Self::new(ctor, fields, ty)
     }

--- a/compiler/rustc_pattern_analysis/src/pat.rs
+++ b/compiler/rustc_pattern_analysis/src/pat.rs
@@ -321,6 +321,14 @@ impl<Cx: TypeCx> WitnessPat<Cx> {
         &self.ty
     }
 
+    pub fn is_never_pattern(&self) -> bool {
+        match self.ctor() {
+            Never => true,
+            Or => self.fields.iter().all(|p| p.is_never_pattern()),
+            _ => self.fields.iter().any(|p| p.is_never_pattern()),
+        }
+    }
+
     pub fn iter_fields(&self) -> impl Iterator<Item = &WitnessPat<Cx>> {
         self.fields.iter()
     }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -251,7 +251,7 @@ impl<'p, 'tcx: 'p> RustcMatchCheckCtxt<'p, 'tcx> {
                 _ => bug!("bad slice pattern {:?} {:?}", ctor, ty),
             },
             Bool(..) | IntRange(..) | F32Range(..) | F64Range(..) | Str(..) | Opaque(..)
-            | NonExhaustive | Hidden | Missing | PrivateUninhabited | Wildcard => &[],
+            | Never | NonExhaustive | Hidden | Missing | PrivateUninhabited | Wildcard => &[],
             Or => {
                 bug!("called `Fields::wildcards` on an `Or` ctor")
             }
@@ -279,7 +279,7 @@ impl<'p, 'tcx: 'p> RustcMatchCheckCtxt<'p, 'tcx> {
             Ref => 1,
             Slice(slice) => slice.arity(),
             Bool(..) | IntRange(..) | F32Range(..) | F64Range(..) | Str(..) | Opaque(..)
-            | NonExhaustive | Hidden | Missing | PrivateUninhabited | Wildcard => 0,
+            | Never | NonExhaustive | Hidden | Missing | PrivateUninhabited | Wildcard => 0,
             Or => bug!("The `Or` constructor doesn't have a fixed arity"),
         }
     }
@@ -809,7 +809,8 @@ impl<'p, 'tcx: 'p> RustcMatchCheckCtxt<'p, 'tcx> {
                 }
             }
             &Str(value) => PatKind::Constant { value },
-            Wildcard | NonExhaustive | Hidden | PrivateUninhabited => PatKind::Wild,
+            Never if self.tcx.features().never_patterns => PatKind::Never,
+            Never | Wildcard | NonExhaustive | Hidden | PrivateUninhabited => PatKind::Wild,
             Missing { .. } => bug!(
                 "trying to convert a `Missing` constructor into a `Pat`; this is probably a bug,
                 `Missing` should have been processed in `apply_constructors`"

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -1,23 +1,23 @@
 error: unreachable pattern
-  --> $DIR/empty-types.rs:49:9
+  --> $DIR/empty-types.rs:51:9
    |
 LL |         _ => {}
    |         ^
    |
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:15:9
+  --> $DIR/empty-types.rs:17:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:52:9
+  --> $DIR/empty-types.rs:54:9
    |
 LL |         _x => {}
    |         ^^
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
-  --> $DIR/empty-types.rs:56:11
+  --> $DIR/empty-types.rs:58:11
    |
 LL |     match ref_never {}
    |           ^^^^^^^^^
@@ -32,31 +32,31 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:71:9
+  --> $DIR/empty-types.rs:73:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:78:9
+  --> $DIR/empty-types.rs:80:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:81:9
+  --> $DIR/empty-types.rs:83:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:85:9
+  --> $DIR/empty-types.rs:87:9
    |
 LL |         _ => {}
    |         ^
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
-  --> $DIR/empty-types.rs:89:11
+  --> $DIR/empty-types.rs:91:11
    |
 LL |     match res_u32_never {}
    |           ^^^^^^^^^^^^^ pattern `Ok(_)` not covered
@@ -75,19 +75,19 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:97:9
+  --> $DIR/empty-types.rs:99:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:102:9
+  --> $DIR/empty-types.rs:104:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
-  --> $DIR/empty-types.rs:99:11
+  --> $DIR/empty-types.rs:101:11
    |
 LL |     match res_u32_never {
    |           ^^^^^^^^^^^^^ pattern `Ok(1_u32..=u32::MAX)` not covered
@@ -105,7 +105,7 @@ LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:106:9
+  --> $DIR/empty-types.rs:108:9
    |
 LL |     let Ok(_x) = res_u32_never.as_ref();
    |         ^^^^^^ pattern `Err(_)` not covered
@@ -119,121 +119,121 @@ LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:117:9
+  --> $DIR/empty-types.rs:119:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:121:9
+  --> $DIR/empty-types.rs:123:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:124:9
+  --> $DIR/empty-types.rs:126:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:125:9
+  --> $DIR/empty-types.rs:127:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:128:9
+  --> $DIR/empty-types.rs:130:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:129:9
+  --> $DIR/empty-types.rs:131:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:138:13
+  --> $DIR/empty-types.rs:140:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:141:13
+  --> $DIR/empty-types.rs:143:13
    |
 LL |             _ if false => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:150:13
+  --> $DIR/empty-types.rs:152:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:154:13
+  --> $DIR/empty-types.rs:156:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:206:13
+  --> $DIR/empty-types.rs:208:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:211:13
+  --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:216:13
+  --> $DIR/empty-types.rs:218:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:221:13
+  --> $DIR/empty-types.rs:223:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:227:13
+  --> $DIR/empty-types.rs:229:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:286:9
+  --> $DIR/empty-types.rs:288:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:289:9
+  --> $DIR/empty-types.rs:291:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:292:9
+  --> $DIR/empty-types.rs:294:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:293:9
+  --> $DIR/empty-types.rs:295:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
-  --> $DIR/empty-types.rs:325:11
+  --> $DIR/empty-types.rs:327:11
    |
 LL |     match slice_never {}
    |           ^^^^^^^^^^^
@@ -247,7 +247,7 @@ LL +     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` not covered
-  --> $DIR/empty-types.rs:336:11
+  --> $DIR/empty-types.rs:338:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[]` not covered
@@ -260,7 +260,7 @@ LL +         &[] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` not covered
-  --> $DIR/empty-types.rs:349:11
+  --> $DIR/empty-types.rs:352:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[]` not covered
@@ -274,7 +274,7 @@ LL +         &[] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `[!]` is non-empty
-  --> $DIR/empty-types.rs:355:11
+  --> $DIR/empty-types.rs:359:11
    |
 LL |     match *slice_never {}
    |           ^^^^^^^^^^^^
@@ -288,25 +288,25 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:365:9
+  --> $DIR/empty-types.rs:369:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:368:9
+  --> $DIR/empty-types.rs:372:9
    |
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:371:9
+  --> $DIR/empty-types.rs:375:9
    |
 LL |         [_, ..] => {}
    |         ^^^^^^^
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-types.rs:385:11
+  --> $DIR/empty-types.rs:389:11
    |
 LL |     match array_0_never {}
    |           ^^^^^^^^^^^^^
@@ -320,13 +320,13 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:392:9
+  --> $DIR/empty-types.rs:396:9
    |
 LL |         _ => {}
    |         ^
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-types.rs:394:11
+  --> $DIR/empty-types.rs:398:11
    |
 LL |     match array_0_never {
    |           ^^^^^^^^^^^^^ pattern `[]` not covered
@@ -340,49 +340,49 @@ LL +         [] => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:413:9
+  --> $DIR/empty-types.rs:417:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:418:9
+  --> $DIR/empty-types.rs:422:9
    |
 LL |         Some(_a) => {}
    |         ^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:423:9
+  --> $DIR/empty-types.rs:427:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:428:9
+  --> $DIR/empty-types.rs:432:9
    |
 LL |         _a => {}
    |         ^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:600:9
+  --> $DIR/empty-types.rs:604:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:603:9
+  --> $DIR/empty-types.rs:607:9
    |
 LL |         _x => {}
    |         ^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:606:9
+  --> $DIR/empty-types.rs:610:9
    |
 LL |         _ if false => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:609:9
+  --> $DIR/empty-types.rs:613:9
    |
 LL |         _x if false => {}
    |         ^^

--- a/tests/ui/pattern/usefulness/empty-types.min_exh_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.min_exh_pats.stderr
@@ -1,23 +1,23 @@
 error: unreachable pattern
-  --> $DIR/empty-types.rs:49:9
+  --> $DIR/empty-types.rs:51:9
    |
 LL |         _ => {}
    |         ^
    |
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:15:9
+  --> $DIR/empty-types.rs:17:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:52:9
+  --> $DIR/empty-types.rs:54:9
    |
 LL |         _x => {}
    |         ^^
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
-  --> $DIR/empty-types.rs:56:11
+  --> $DIR/empty-types.rs:58:11
    |
 LL |     match ref_never {}
    |           ^^^^^^^^^
@@ -32,31 +32,31 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:71:9
+  --> $DIR/empty-types.rs:73:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:78:9
+  --> $DIR/empty-types.rs:80:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:81:9
+  --> $DIR/empty-types.rs:83:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:85:9
+  --> $DIR/empty-types.rs:87:9
    |
 LL |         _ => {}
    |         ^
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
-  --> $DIR/empty-types.rs:89:11
+  --> $DIR/empty-types.rs:91:11
    |
 LL |     match res_u32_never {}
    |           ^^^^^^^^^^^^^ pattern `Ok(_)` not covered
@@ -75,19 +75,19 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:97:9
+  --> $DIR/empty-types.rs:99:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:102:9
+  --> $DIR/empty-types.rs:104:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
-  --> $DIR/empty-types.rs:99:11
+  --> $DIR/empty-types.rs:101:11
    |
 LL |     match res_u32_never {
    |           ^^^^^^^^^^^^^ pattern `Ok(1_u32..=u32::MAX)` not covered
@@ -105,7 +105,7 @@ LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:106:9
+  --> $DIR/empty-types.rs:108:9
    |
 LL |     let Ok(_x) = res_u32_never.as_ref();
    |         ^^^^^^ pattern `Err(_)` not covered
@@ -119,7 +119,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:110:9
+  --> $DIR/empty-types.rs:112:9
    |
 LL |     let Ok(_x) = &res_u32_never;
    |         ^^^^^^ pattern `&Err(_)` not covered
@@ -133,67 +133,67 @@ LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:117:9
+  --> $DIR/empty-types.rs:119:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:121:9
+  --> $DIR/empty-types.rs:123:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:124:9
+  --> $DIR/empty-types.rs:126:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:125:9
+  --> $DIR/empty-types.rs:127:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:128:9
+  --> $DIR/empty-types.rs:130:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:129:9
+  --> $DIR/empty-types.rs:131:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:138:13
+  --> $DIR/empty-types.rs:140:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:141:13
+  --> $DIR/empty-types.rs:143:13
    |
 LL |             _ if false => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:150:13
+  --> $DIR/empty-types.rs:152:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:154:13
+  --> $DIR/empty-types.rs:156:13
    |
 LL |             _ => {}
    |             ^
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:163:15
+  --> $DIR/empty-types.rs:165:15
    |
 LL |         match *ref_opt_void {
    |               ^^^^^^^^^^^^^ pattern `Some(_)` not covered
@@ -211,61 +211,61 @@ LL +             Some(_) => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:206:13
+  --> $DIR/empty-types.rs:208:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:211:13
+  --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:216:13
+  --> $DIR/empty-types.rs:218:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:221:13
+  --> $DIR/empty-types.rs:223:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:227:13
+  --> $DIR/empty-types.rs:229:13
    |
 LL |             _ => {}
    |             ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:286:9
+  --> $DIR/empty-types.rs:288:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:289:9
+  --> $DIR/empty-types.rs:291:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:292:9
+  --> $DIR/empty-types.rs:294:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:293:9
+  --> $DIR/empty-types.rs:295:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
-  --> $DIR/empty-types.rs:314:11
+  --> $DIR/empty-types.rs:316:11
    |
 LL |     match *x {}
    |           ^^
@@ -279,7 +279,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `(!, !)` is non-empty
-  --> $DIR/empty-types.rs:316:11
+  --> $DIR/empty-types.rs:318:11
    |
 LL |     match *x {}
    |           ^^
@@ -293,7 +293,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(_)` not covered
-  --> $DIR/empty-types.rs:318:11
+  --> $DIR/empty-types.rs:320:11
    |
 LL |     match *x {}
    |           ^^ patterns `Ok(_)` and `Err(_)` not covered
@@ -315,7 +315,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 3]` is non-empty
-  --> $DIR/empty-types.rs:320:11
+  --> $DIR/empty-types.rs:322:11
    |
 LL |     match *x {}
    |           ^^
@@ -329,7 +329,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
-  --> $DIR/empty-types.rs:325:11
+  --> $DIR/empty-types.rs:327:11
    |
 LL |     match slice_never {}
    |           ^^^^^^^^^^^
@@ -343,7 +343,7 @@ LL +     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
-  --> $DIR/empty-types.rs:327:11
+  --> $DIR/empty-types.rs:329:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[_, ..]` not covered
@@ -356,7 +356,7 @@ LL +         &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[_]` and `&[_, _]` not covered
-  --> $DIR/empty-types.rs:336:11
+  --> $DIR/empty-types.rs:338:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ patterns `&[]`, `&[_]` and `&[_, _]` not covered
@@ -369,7 +369,7 @@ LL +         &[] | &[_] | &[_, _] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` and `&[_, ..]` not covered
-  --> $DIR/empty-types.rs:349:11
+  --> $DIR/empty-types.rs:352:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ patterns `&[]` and `&[_, ..]` not covered
@@ -383,7 +383,7 @@ LL +         &[] | &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `[!]` is non-empty
-  --> $DIR/empty-types.rs:355:11
+  --> $DIR/empty-types.rs:359:11
    |
 LL |     match *slice_never {}
    |           ^^^^^^^^^^^^
@@ -397,25 +397,25 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:365:9
+  --> $DIR/empty-types.rs:369:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:368:9
+  --> $DIR/empty-types.rs:372:9
    |
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:371:9
+  --> $DIR/empty-types.rs:375:9
    |
 LL |         [_, ..] => {}
    |         ^^^^^^^
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-types.rs:385:11
+  --> $DIR/empty-types.rs:389:11
    |
 LL |     match array_0_never {}
    |           ^^^^^^^^^^^^^
@@ -429,13 +429,13 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:392:9
+  --> $DIR/empty-types.rs:396:9
    |
 LL |         _ => {}
    |         ^
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-types.rs:394:11
+  --> $DIR/empty-types.rs:398:11
    |
 LL |     match array_0_never {
    |           ^^^^^^^^^^^^^ pattern `[]` not covered
@@ -449,31 +449,31 @@ LL +         [] => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:413:9
+  --> $DIR/empty-types.rs:417:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:418:9
+  --> $DIR/empty-types.rs:422:9
    |
 LL |         Some(_a) => {}
    |         ^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:423:9
+  --> $DIR/empty-types.rs:427:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:428:9
+  --> $DIR/empty-types.rs:432:9
    |
 LL |         _a => {}
    |         ^^
 
 error[E0004]: non-exhaustive patterns: `&Some(_)` not covered
-  --> $DIR/empty-types.rs:448:11
+  --> $DIR/empty-types.rs:452:11
    |
 LL |     match ref_opt_never {
    |           ^^^^^^^^^^^^^ pattern `&Some(_)` not covered
@@ -491,7 +491,7 @@ LL +         &Some(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:489:11
+  --> $DIR/empty-types.rs:493:11
    |
 LL |     match *ref_opt_never {
    |           ^^^^^^^^^^^^^^ pattern `Some(_)` not covered
@@ -509,7 +509,7 @@ LL +         Some(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Err(_)` not covered
-  --> $DIR/empty-types.rs:537:11
+  --> $DIR/empty-types.rs:541:11
    |
 LL |     match *ref_res_never {
    |           ^^^^^^^^^^^^^^ pattern `Err(_)` not covered
@@ -527,7 +527,7 @@ LL +         Err(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Err(_)` not covered
-  --> $DIR/empty-types.rs:548:11
+  --> $DIR/empty-types.rs:552:11
    |
 LL |     match *ref_res_never {
    |           ^^^^^^^^^^^^^^ pattern `Err(_)` not covered
@@ -545,7 +545,7 @@ LL +         Err(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
-  --> $DIR/empty-types.rs:567:11
+  --> $DIR/empty-types.rs:571:11
    |
 LL |     match *ref_tuple_half_never {}
    |           ^^^^^^^^^^^^^^^^^^^^^
@@ -559,31 +559,31 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:600:9
+  --> $DIR/empty-types.rs:604:9
    |
 LL |         _ => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:603:9
+  --> $DIR/empty-types.rs:607:9
    |
 LL |         _x => {}
    |         ^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:606:9
+  --> $DIR/empty-types.rs:610:9
    |
 LL |         _ if false => {}
    |         ^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:609:9
+  --> $DIR/empty-types.rs:613:9
    |
 LL |         _x if false => {}
    |         ^^
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
-  --> $DIR/empty-types.rs:634:11
+  --> $DIR/empty-types.rs:638:11
    |
 LL |     match ref_never {
    |           ^^^^^^^^^ pattern `&_` not covered
@@ -597,8 +597,26 @@ LL ~         &_a if false => {},
 LL +         &_ => todo!()
    |
 
+error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
+  --> $DIR/empty-types.rs:654:11
+   |
+LL |     match *ref_result_never {
+   |           ^^^^^^^^^^^^^^^^^ pattern `Ok(_)` not covered
+   |
+note: `Result<!, !>` defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+  ::: $SRC_DIR/core/src/result.rs:LL:COL
+   |
+   = note: not covered
+   = note: the matched value is of type `Result<!, !>`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~         Err(_) => {},
+LL +         Ok(_) => todo!()
+   |
+
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:662:11
+  --> $DIR/empty-types.rs:674:11
    |
 LL |     match *x {
    |           ^^ pattern `Some(_)` not covered
@@ -615,7 +633,7 @@ LL ~         None => {},
 LL +         Some(_) => todo!()
    |
 
-error: aborting due to 63 previous errors
+error: aborting due to 64 previous errors
 
 Some errors have detailed explanations: E0004, E0005.
 For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -74,11 +74,11 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
 
-error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(!)` not covered
   --> $DIR/empty-types.rs:91:11
    |
 LL |     match res_u32_never {}
-   |           ^^^^^^^^^^^^^ patterns `Ok(_)` and `Err(_)` not covered
+   |           ^^^^^^^^^^^^^ patterns `Ok(_)` and `Err(!)` not covered
    |
 note: `Result<u32, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -92,15 +92,15 @@ note: `Result<u32, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match res_u32_never {
-LL +         Ok(_) | Err(_) => todo!(),
+LL +         Ok(_) | Err(!) => todo!(),
 LL +     }
    |
 
-error[E0004]: non-exhaustive patterns: `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Err(!)` not covered
   --> $DIR/empty-types.rs:93:11
    |
 LL |     match res_u32_never {
-   |           ^^^^^^^^^^^^^ pattern `Err(_)` not covered
+   |           ^^^^^^^^^^^^^ pattern `Err(!)` not covered
    |
 note: `Result<u32, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -111,7 +111,7 @@ note: `Result<u32, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(_) => {},
-LL +         Err(_) => todo!()
+LL +         Err(!) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -136,7 +136,7 @@ error[E0005]: refutable pattern in local binding
   --> $DIR/empty-types.rs:106:9
    |
 LL |     let Ok(_x) = res_u32_never;
-   |         ^^^^^^ pattern `Err(_)` not covered
+   |         ^^^^^^ pattern `Err(!)` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -164,7 +164,7 @@ error[E0005]: refutable pattern in local binding
   --> $DIR/empty-types.rs:112:9
    |
 LL |     let Ok(_x) = &res_u32_never;
-   |         ^^^^^^ pattern `&Err(_)` not covered
+   |         ^^^^^^ pattern `&Err(!)` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
@@ -174,11 +174,11 @@ help: you might want to use `let else` to handle the variant that isn't matched
 LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++
 
-error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Ok(!)` and `Err(!)` not covered
   --> $DIR/empty-types.rs:116:11
    |
 LL |     match result_never {}
-   |           ^^^^^^^^^^^^ patterns `Ok(_)` and `Err(_)` not covered
+   |           ^^^^^^^^^^^^ patterns `Ok(!)` and `Err(!)` not covered
    |
 note: `Result<!, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -192,15 +192,15 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match result_never {
-LL +         Ok(_) | Err(_) => todo!(),
+LL +         Ok(!) | Err(!) => todo!(),
 LL +     }
    |
 
-error[E0004]: non-exhaustive patterns: `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Err(!)` not covered
   --> $DIR/empty-types.rs:121:11
    |
 LL |     match result_never {
-   |           ^^^^^^^^^^^^ pattern `Err(_)` not covered
+   |           ^^^^^^^^^^^^ pattern `Err(!)` not covered
    |
 note: `Result<!, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -210,7 +210,7 @@ note: `Result<!, !>` defined here
    = note: the matched value is of type `Result<!, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |         Ok(_) => {}, Err(_) => todo!()
+LL |         Ok(_) => {}, Err(!) => todo!()
    |                    +++++++++++++++++++
 
 error: unreachable pattern
@@ -225,11 +225,11 @@ error: unreachable pattern
 LL |             _ if false => {}
    |             ^
 
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:146:15
    |
 LL |         match opt_void {
-   |               ^^^^^^^^ pattern `Some(_)` not covered
+   |               ^^^^^^^^ pattern `Some(!)` not covered
    |
 note: `Option<Void>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -240,14 +240,14 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             None => {},
-LL +             Some(_) => todo!()
+LL +             Some(!) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:165:15
    |
 LL |         match *ref_opt_void {
-   |               ^^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |               ^^^^^^^^^^^^^ pattern `Some(!)` not covered
    |
 note: `Option<Void>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -258,7 +258,7 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             None => {},
-LL +             Some(_) => todo!()
+LL +             Some(!) => todo!()
    |
 
 error: unreachable pattern
@@ -325,11 +325,11 @@ LL +         _ => todo!(),
 LL ~     }
    |
 
-error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Ok(!)` and `Err(!)` not covered
   --> $DIR/empty-types.rs:320:11
    |
 LL |     match *x {}
-   |           ^^ patterns `Ok(_)` and `Err(_)` not covered
+   |           ^^ patterns `Ok(!)` and `Err(!)` not covered
    |
 note: `Result<!, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -343,7 +343,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match *x {
-LL +         Ok(_) | Err(_) => todo!(),
+LL +         Ok(!) | Err(!) => todo!(),
 LL ~     }
    |
 
@@ -375,44 +375,44 @@ LL +         _ => todo!(),
 LL +     }
    |
 
-error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
+error[E0004]: non-exhaustive patterns: `&[!, ..]` not covered
   --> $DIR/empty-types.rs:329:11
    |
 LL |     match slice_never {
-   |           ^^^^^^^^^^^ pattern `&[_, ..]` not covered
+   |           ^^^^^^^^^^^ pattern `&[!, ..]` not covered
    |
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [] => {},
-LL +         &[_, ..] => todo!()
+LL +         &[!, ..] => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `&[]`, `&[_]` and `&[_, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[]`, `&[!]` and `&[!, !]` not covered
   --> $DIR/empty-types.rs:338:11
    |
 LL |     match slice_never {
-   |           ^^^^^^^^^^^ patterns `&[]`, `&[_]` and `&[_, _]` not covered
+   |           ^^^^^^^^^^^ patterns `&[]`, `&[!]` and `&[!, !]` not covered
    |
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         [_, _, _, ..] => {},
-LL +         &[] | &[_] | &[_, _] => todo!()
+LL +         &[] | &[!] | &[!, !] => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `&[]` and `&[_, ..]` not covered
+error[E0004]: non-exhaustive patterns: `&[]` and `&[!, ..]` not covered
   --> $DIR/empty-types.rs:352:11
    |
 LL |     match slice_never {
-   |           ^^^^^^^^^^^ patterns `&[]` and `&[_, ..]` not covered
+   |           ^^^^^^^^^^^ patterns `&[]` and `&[!, ..]` not covered
    |
    = note: the matched value is of type `&[!]`
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         &[..] if false => {},
-LL +         &[] | &[_, ..] => todo!()
+LL +         &[] | &[!, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `[!]` is non-empty
@@ -477,11 +477,11 @@ LL ~         [..] if false => {},
 LL +         [] => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `&Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
   --> $DIR/empty-types.rs:452:11
    |
 LL |     match ref_opt_never {
-   |           ^^^^^^^^^^^^^ pattern `&Some(_)` not covered
+   |           ^^^^^^^^^^^^^ pattern `&Some(!)` not covered
    |
 note: `Option<!>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -492,14 +492,14 @@ note: `Option<!>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &None => {},
-LL +         &Some(_) => todo!()
+LL +         &Some(!) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:493:11
    |
 LL |     match *ref_opt_never {
-   |           ^^^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |           ^^^^^^^^^^^^^^ pattern `Some(!)` not covered
    |
 note: `Option<!>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -510,14 +510,14 @@ note: `Option<!>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(_) => todo!()
+LL +         Some(!) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Err(!)` not covered
   --> $DIR/empty-types.rs:541:11
    |
 LL |     match *ref_res_never {
-   |           ^^^^^^^^^^^^^^ pattern `Err(_)` not covered
+   |           ^^^^^^^^^^^^^^ pattern `Err(!)` not covered
    |
 note: `Result<!, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -528,14 +528,14 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(_) => {},
-LL +         Err(_) => todo!()
+LL +         Err(!) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Err(_)` not covered
+error[E0004]: non-exhaustive patterns: `Err(!)` not covered
   --> $DIR/empty-types.rs:552:11
    |
 LL |     match *ref_res_never {
-   |           ^^^^^^^^^^^^^^ pattern `Err(_)` not covered
+   |           ^^^^^^^^^^^^^^ pattern `Err(!)` not covered
    |
 note: `Result<!, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -546,7 +546,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(_a) => {},
-LL +         Err(_) => todo!()
+LL +         Err(!) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
@@ -587,11 +587,11 @@ error: unreachable pattern
 LL |         _x if false => {}
    |         ^^
 
-error[E0004]: non-exhaustive patterns: `&_` not covered
+error[E0004]: non-exhaustive patterns: `&!` not covered
   --> $DIR/empty-types.rs:638:11
    |
 LL |     match ref_never {
-   |           ^^^^^^^^^ pattern `&_` not covered
+   |           ^^^^^^^^^ pattern `&!` not covered
    |
    = note: the matched value is of type `&!`
    = note: references are always considered inhabited
@@ -599,14 +599,14 @@ LL |     match ref_never {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &_a if false => {},
-LL +         &_ => todo!()
+LL +         &! => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
+error[E0004]: non-exhaustive patterns: `Ok(!)` not covered
   --> $DIR/empty-types.rs:654:11
    |
 LL |     match *ref_result_never {
-   |           ^^^^^^^^^^^^^^^^^ pattern `Ok(_)` not covered
+   |           ^^^^^^^^^^^^^^^^^ pattern `Ok(!)` not covered
    |
 note: `Result<!, !>` defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
@@ -617,14 +617,14 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Err(_) => {},
-LL +         Ok(_) => todo!()
+LL +         Ok(!) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:674:11
    |
 LL |     match *x {
-   |           ^^ pattern `Some(_)` not covered
+   |           ^^ pattern `Some(!)` not covered
    |
 note: `Option<Result<!, !>>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -635,7 +635,7 @@ note: `Option<Result<!, !>>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(_) => todo!()
+LL +         Some(!) => todo!()
    |
 
 error: aborting due to 49 previous errors; 1 warning emitted

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -1,3 +1,12 @@
+warning: the feature `never_patterns` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/empty-types.rs:14:33
+   |
+LL | #![cfg_attr(never_pats, feature(never_patterns))]
+   |                                 ^^^^^^^^^^^^^^
+   |
+   = note: see issue #118155 <https://github.com/rust-lang/rust/issues/118155> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
 error: unreachable pattern
   --> $DIR/empty-types.rs:51:9
    |
@@ -629,7 +638,7 @@ LL ~         None => {},
 LL +         Some(_) => todo!()
    |
 
-error: aborting due to 49 previous errors
+error: aborting due to 49 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0004, E0005.
 For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -111,7 +111,7 @@ note: `Result<u32, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(_) => {},
-LL +         Err(!) => todo!()
+LL +         Err(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -192,7 +192,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match result_never {
-LL +         Ok(!) | Err(!) => todo!(),
+LL +         Ok(!) | Err(!),
 LL +     }
    |
 
@@ -210,8 +210,8 @@ note: `Result<!, !>` defined here
    = note: the matched value is of type `Result<!, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |         Ok(_) => {}, Err(!) => todo!()
-   |                    +++++++++++++++++++
+LL |         Ok(_) => {}, Err(!)
+   |                    ++++++++
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:140:13
@@ -240,7 +240,7 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             None => {},
-LL +             Some(!) => todo!()
+LL +             Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
@@ -258,7 +258,7 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             None => {},
-LL +             Some(!) => todo!()
+LL +             Some(!)
    |
 
 error: unreachable pattern
@@ -343,7 +343,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~     match *x {
-LL +         Ok(!) | Err(!) => todo!(),
+LL +         Ok(!) | Err(!),
 LL ~     }
    |
 
@@ -385,7 +385,7 @@ LL |     match slice_never {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [] => {},
-LL +         &[!, ..] => todo!()
+LL +         &[!, ..]
    |
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[!]` and `&[!, !]` not covered
@@ -492,7 +492,7 @@ note: `Option<!>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &None => {},
-LL +         &Some(!) => todo!()
+LL +         &Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
@@ -510,7 +510,7 @@ note: `Option<!>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(!) => todo!()
+LL +         Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Err(!)` not covered
@@ -528,7 +528,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(_) => {},
-LL +         Err(!) => todo!()
+LL +         Err(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Err(!)` not covered
@@ -546,7 +546,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(_a) => {},
-LL +         Err(!) => todo!()
+LL +         Err(!)
    |
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
@@ -599,7 +599,7 @@ LL |     match ref_never {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &_a if false => {},
-LL +         &! => todo!()
+LL +         &!
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(!)` not covered
@@ -617,7 +617,7 @@ note: `Result<!, !>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Err(_) => {},
-LL +         Ok(!) => todo!()
+LL +         Ok(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
@@ -635,7 +635,7 @@ note: `Option<Result<!, !>>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(!) => todo!()
+LL +         Some(!)
    |
 
 error: aborting due to 49 previous errors; 1 warning emitted

--- a/tests/ui/pattern/usefulness/empty-types.rs
+++ b/tests/ui/pattern/usefulness/empty-types.rs
@@ -338,7 +338,7 @@ fn arrays_and_slices(x: NeverBundle) {
     match slice_never {
         //[normal,min_exh_pats]~^ ERROR `&[]`, `&[_]` and `&[_, _]` not covered
         //[exhaustive_patterns]~^^ ERROR `&[]` not covered
-        //[never_pats]~^^^ ERROR `&[]`, `&[_]` and `&[_, _]` not covered
+        //[never_pats]~^^^ ERROR `&[]`, `&[!]` and `&[!, !]` not covered
         [_, _, _, ..] => {}
     }
     match slice_never {
@@ -352,7 +352,7 @@ fn arrays_and_slices(x: NeverBundle) {
     match slice_never {
         //[normal,min_exh_pats]~^ ERROR `&[]` and `&[_, ..]` not covered
         //[exhaustive_patterns]~^^ ERROR `&[]` not covered
-        //[never_pats]~^^^ ERROR `&[]` and `&[_, ..]` not covered
+        //[never_pats]~^^^ ERROR `&[]` and `&[!, ..]` not covered
         &[..] if false => {}
     }
 
@@ -653,7 +653,7 @@ fn guards_and_validity(x: NeverBundle) {
     }
     match *ref_result_never {
         //[normal,min_exh_pats]~^ ERROR `Ok(_)` not covered
-        //[never_pats]~^^ ERROR `Ok(_)` not covered
+        //[never_pats]~^^ ERROR `Ok(!)` not covered
         // useful, reachable
         Ok(_) if false => {}
         // useful, reachable
@@ -673,7 +673,7 @@ fn diagnostics_subtlety(x: NeverBundle) {
     let x: &Option<Result<!, !>> = &None;
     match *x {
         //[normal,min_exh_pats]~^ ERROR `Some(_)` not covered
-        //[never_pats]~^^ ERROR `Some(_)` not covered
+        //[never_pats]~^^ ERROR `Some(!)` not covered
         None => {}
     }
 }

--- a/tests/ui/pattern/usefulness/empty-types.rs
+++ b/tests/ui/pattern/usefulness/empty-types.rs
@@ -1,4 +1,4 @@
-//@ revisions: normal min_exh_pats exhaustive_patterns
+//@ revisions: normal min_exh_pats exhaustive_patterns never_pats
 // gate-test-min_exhaustive_patterns
 //
 // This tests correct handling of empty types in exhaustiveness checking.
@@ -11,6 +11,8 @@
 #![feature(never_type_fallback)]
 #![cfg_attr(exhaustive_patterns, feature(exhaustive_patterns))]
 #![cfg_attr(min_exh_pats, feature(min_exhaustive_patterns))]
+#![cfg_attr(never_pats, feature(never_patterns))]
+//[never_pats]~^ WARN the feature `never_patterns` is incomplete
 #![allow(dead_code, unreachable_code)]
 #![deny(unreachable_patterns)]
 
@@ -66,14 +68,14 @@ fn basic(x: NeverBundle) {
 
     let tuple_half_never: (u32, !) = x.tuple_half_never;
     match tuple_half_never {}
-    //[normal]~^ ERROR non-empty
+    //[normal,never_pats]~^ ERROR non-empty
     match tuple_half_never {
         (_, _) => {} //[exhaustive_patterns,min_exh_pats]~ ERROR unreachable pattern
     }
 
     let tuple_never: (!, !) = x.tuple_never;
     match tuple_never {}
-    //[normal]~^ ERROR non-empty
+    //[normal,never_pats]~^ ERROR non-empty
     match tuple_never {
         _ => {} //[exhaustive_patterns,min_exh_pats]~ ERROR unreachable pattern
     }
@@ -89,7 +91,7 @@ fn basic(x: NeverBundle) {
     match res_u32_never {}
     //~^ ERROR non-exhaustive
     match res_u32_never {
-        //[normal]~^ ERROR non-exhaustive
+        //[normal,never_pats]~^ ERROR non-exhaustive
         Ok(_) => {}
     }
     match res_u32_never {
@@ -102,22 +104,22 @@ fn basic(x: NeverBundle) {
         Err(_) => {} //[exhaustive_patterns,min_exh_pats]~ ERROR unreachable pattern
     }
     let Ok(_x) = res_u32_never;
-    //[normal]~^ ERROR refutable
+    //[normal,never_pats]~^ ERROR refutable
     let Ok(_x) = res_u32_never.as_ref();
     //~^ ERROR refutable
     // Non-obvious difference: here there's an implicit dereference in the patterns, which makes the
     // inner place !known_valid. `exhaustive_patterns` ignores this.
     let Ok(_x) = &res_u32_never;
-    //[normal,min_exh_pats]~^ ERROR refutable
+    //[normal,min_exh_pats,never_pats]~^ ERROR refutable
 
     let result_never: Result<!, !> = x.result_never;
     match result_never {}
-    //[normal]~^ ERROR non-exhaustive
+    //[normal,never_pats]~^ ERROR non-exhaustive
     match result_never {
         _ => {} //[exhaustive_patterns,min_exh_pats]~ ERROR unreachable pattern
     }
     match result_never {
-        //[normal]~^ ERROR non-exhaustive
+        //[normal,never_pats]~^ ERROR non-exhaustive
         Ok(_) => {} //[exhaustive_patterns,min_exh_pats]~ ERROR unreachable pattern
     }
     match result_never {
@@ -142,7 +144,7 @@ fn void_same_as_never(x: NeverBundle) {
         }
         let opt_void: Option<Void> = None;
         match opt_void {
-            //[normal]~^ ERROR non-exhaustive
+            //[normal,never_pats]~^ ERROR non-exhaustive
             None => {}
         }
         match opt_void {
@@ -161,7 +163,7 @@ fn void_same_as_never(x: NeverBundle) {
         }
         let ref_opt_void: &Option<Void> = &None;
         match *ref_opt_void {
-            //[normal,min_exh_pats]~^ ERROR non-exhaustive
+            //[normal,min_exh_pats,never_pats]~^ ERROR non-exhaustive
             None => {}
         }
         match *ref_opt_void {
@@ -311,13 +313,13 @@ fn invalid_empty_match(bundle: NeverBundle) {
     match *x {}
 
     let x: &(u32, !) = &bundle.tuple_half_never;
-    match *x {} //[normal,min_exh_pats]~ ERROR non-exhaustive
+    match *x {} //[normal,min_exh_pats,never_pats]~ ERROR non-exhaustive
     let x: &(!, !) = &bundle.tuple_never;
-    match *x {} //[normal,min_exh_pats]~ ERROR non-exhaustive
+    match *x {} //[normal,min_exh_pats,never_pats]~ ERROR non-exhaustive
     let x: &Result<!, !> = &bundle.result_never;
-    match *x {} //[normal,min_exh_pats]~ ERROR non-exhaustive
+    match *x {} //[normal,min_exh_pats,never_pats]~ ERROR non-exhaustive
     let x: &[!; 3] = &bundle.array_3_never;
-    match *x {} //[normal,min_exh_pats]~ ERROR non-exhaustive
+    match *x {} //[normal,min_exh_pats,never_pats]~ ERROR non-exhaustive
 }
 
 fn arrays_and_slices(x: NeverBundle) {
@@ -325,7 +327,7 @@ fn arrays_and_slices(x: NeverBundle) {
     match slice_never {}
     //~^ ERROR non-empty
     match slice_never {
-        //[normal,min_exh_pats]~^ ERROR not covered
+        //[normal,min_exh_pats,never_pats]~^ ERROR not covered
         [] => {}
     }
     match slice_never {
@@ -336,6 +338,7 @@ fn arrays_and_slices(x: NeverBundle) {
     match slice_never {
         //[normal,min_exh_pats]~^ ERROR `&[]`, `&[_]` and `&[_, _]` not covered
         //[exhaustive_patterns]~^^ ERROR `&[]` not covered
+        //[never_pats]~^^^ ERROR `&[]`, `&[_]` and `&[_, _]` not covered
         [_, _, _, ..] => {}
     }
     match slice_never {
@@ -349,6 +352,7 @@ fn arrays_and_slices(x: NeverBundle) {
     match slice_never {
         //[normal,min_exh_pats]~^ ERROR `&[]` and `&[_, ..]` not covered
         //[exhaustive_patterns]~^^ ERROR `&[]` not covered
+        //[never_pats]~^^^ ERROR `&[]` and `&[_, ..]` not covered
         &[..] if false => {}
     }
 
@@ -360,7 +364,7 @@ fn arrays_and_slices(x: NeverBundle) {
 
     let array_3_never: [!; 3] = x.array_3_never;
     match array_3_never {}
-    //[normal]~^ ERROR non-empty
+    //[normal,never_pats]~^ ERROR non-empty
     match array_3_never {
         _ => {} //[exhaustive_patterns,min_exh_pats]~ ERROR unreachable pattern
     }
@@ -446,7 +450,7 @@ fn bindings(x: NeverBundle) {
         &_a => {}
     }
     match ref_opt_never {
-        //[normal,min_exh_pats]~^ ERROR non-exhaustive
+        //[normal,min_exh_pats,never_pats]~^ ERROR non-exhaustive
         &None => {}
     }
     match ref_opt_never {
@@ -487,7 +491,7 @@ fn bindings(x: NeverBundle) {
         ref _a => {}
     }
     match *ref_opt_never {
-        //[normal,min_exh_pats]~^ ERROR non-exhaustive
+        //[normal,min_exh_pats,never_pats]~^ ERROR non-exhaustive
         None => {}
     }
     match *ref_opt_never {
@@ -535,7 +539,7 @@ fn bindings(x: NeverBundle) {
 
     let ref_res_never: &Result<!, !> = &x.result_never;
     match *ref_res_never {
-        //[normal,min_exh_pats]~^ ERROR non-exhaustive
+        //[normal,min_exh_pats,never_pats]~^ ERROR non-exhaustive
         // useful, reachable
         Ok(_) => {}
     }
@@ -546,7 +550,7 @@ fn bindings(x: NeverBundle) {
         _ => {}
     }
     match *ref_res_never {
-        //[normal,min_exh_pats]~^ ERROR non-exhaustive
+        //[normal,min_exh_pats,never_pats]~^ ERROR non-exhaustive
         // useful, !reachable
         Ok(_a) => {}
     }
@@ -565,7 +569,7 @@ fn bindings(x: NeverBundle) {
 
     let ref_tuple_half_never: &(u32, !) = &x.tuple_half_never;
     match *ref_tuple_half_never {}
-    //[normal,min_exh_pats]~^ ERROR non-empty
+    //[normal,min_exh_pats,never_pats]~^ ERROR non-empty
     match *ref_tuple_half_never {
         // useful, reachable
         (_, _) => {}
@@ -632,7 +636,7 @@ fn guards_and_validity(x: NeverBundle) {
         _a if false => {}
     }
     match ref_never {
-        //[normal,min_exh_pats]~^ ERROR non-exhaustive
+        //[normal,min_exh_pats,never_pats]~^ ERROR non-exhaustive
         // useful, !reachable
         &_a if false => {}
     }
@@ -645,6 +649,14 @@ fn guards_and_validity(x: NeverBundle) {
         // !useful, !reachable
         Ok(_) => {}
         // useful, !reachable
+        Err(_) => {}
+    }
+    match *ref_result_never {
+        //[normal,min_exh_pats]~^ ERROR `Ok(_)` not covered
+        //[never_pats]~^^ ERROR `Ok(_)` not covered
+        // useful, reachable
+        Ok(_) if false => {}
+        // useful, reachable
         Err(_) => {}
     }
     let ref_tuple_never: &(!, !) = &x.tuple_never;
@@ -661,6 +673,7 @@ fn diagnostics_subtlety(x: NeverBundle) {
     let x: &Option<Result<!, !>> = &None;
     match *x {
         //[normal,min_exh_pats]~^ ERROR `Some(_)` not covered
+        //[never_pats]~^^ ERROR `Some(_)` not covered
         None => {}
     }
 }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.rs
@@ -15,12 +15,12 @@ fn no_arms_or_guards(x: Void) {
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
-    match None::<Void> { //~ ERROR: `Some(_)` not covered
+    match None::<Void> { //~ ERROR: `Some(!)` not covered
         Some(!) if true,
         //~^ ERROR guard on a never pattern
         None => {}
     }
-    match None::<Void> { //~ ERROR: `Some(_)` not covered
+    match None::<Void> { //~ ERROR: `Some(!)` not covered
         Some(!) if true => {}
         //~^ ERROR a never pattern is always unreachable
         None => {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -31,11 +31,11 @@ LL |         Some(never!()) => {}
    |                           this will never be executed
    |                           help: remove this expression
 
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/check.rs:18:11
    |
 LL |     match None::<Void> {
-   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |           ^^^^^^^^^^^^ pattern `Some(!)` not covered
    |
 note: `Option<Void>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -46,14 +46,14 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(_) => todo!()
+LL +         Some(!) => todo!()
    |
 
-error[E0004]: non-exhaustive patterns: `Some(_)` not covered
+error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/check.rs:23:11
    |
 LL |     match None::<Void> {
-   |           ^^^^^^^^^^^^ pattern `Some(_)` not covered
+   |           ^^^^^^^^^^^^ pattern `Some(!)` not covered
    |
 note: `Option<Void>` defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
@@ -64,7 +64,7 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(_) => todo!()
+LL +         Some(!) => todo!()
    |
 
 error: aborting due to 6 previous errors

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -46,7 +46,7 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(!) => todo!()
+LL +         Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
@@ -64,7 +64,7 @@ note: `Option<Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL +         Some(!) => todo!()
+LL +         Some(!)
    |
 
 error: aborting due to 6 previous errors


### PR DESCRIPTION
When a match is non-exhaustive we now suggest never patterns whenever it makes sense.

r? @compiler-errors 