### PR TITLE
Use the correct logic for nested impl trait in assoc types

### DIFF
--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
@@ -1,0 +1,28 @@
+//! This test demonstrates a bug where we accidentally
+//! detected opaque types in struct fields, but only if nested
+//! in projections of another opaque type.
+//@ check-pass
+
+#![feature(impl_trait_in_assoc_type)]
+
+struct Bar;
+
+trait Trait: Sized {
+    type Assoc2;
+    type Assoc;
+    fn foo() -> Self::Assoc;
+}
+
+impl Trait for Bar {
+    type Assoc2 = impl std::fmt::Debug;
+    type Assoc = impl Iterator<Item = Foo>;
+    fn foo() -> Self::Assoc {
+        vec![Foo { field: () }].into_iter()
+    }
+}
+
+struct Foo {
+    field: <Bar as Trait>::Assoc2,
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
@@ -1,7 +1,6 @@
 //! This test demonstrates a bug where we accidentally
 //! detected opaque types in struct fields, but only if nested
 //! in projections of another opaque type.
-//@ check-pass
 
 #![feature(impl_trait_in_assoc_type)]
 
@@ -18,6 +17,7 @@ impl Trait for Bar {
     type Assoc = impl Iterator<Item = Foo>;
     fn foo() -> Self::Assoc {
         vec![Foo { field: () }].into_iter()
+        //~^ ERROR item constrains opaque type that is not in its signature
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.stderr
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.stderr
@@ -1,0 +1,15 @@
+error: item constrains opaque type that is not in its signature
+  --> $DIR/hidden_behind_struct_field3.rs:19:27
+   |
+LL |         vec![Foo { field: () }].into_iter()
+   |                           ^^
+   |
+   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
+note: this item must mention the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/hidden_behind_struct_field3.rs:18:8
+   |
+LL |     fn foo() -> Self::Assoc {
+   |        ^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Previously we accidentally continued with the TAIT visitor, which allowed more than we wanted to.

r? @compiler-errors 