### PR TITLE
Removing absolute path in proc-macro

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -907,7 +907,7 @@ impl Session {
                 | CrateType::Rlib
                 | CrateType::Staticlib
                 | CrateType::Cdylib => continue,
-                CrateType::ProcMacro => return false,
+                CrateType::ProcMacro => return true,
             }
         }
 


### PR DESCRIPTION
With rust 1.75 the absolute build path is embedding into '.rustc' section and which causes reproducibility issues. Detailed issue is here. https://github.com/rust-lang/rust/issues/120825#issuecomment-1964307219

With this change the 'absolute path' changed back to '/rust/$hash' format.