### PR TITLE
Correctly generate item info of trait items

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1680,7 +1680,7 @@ fn render_impl(
                 write!(
                     &mut doc_buffer,
                     "{}",
-                    document_short(item, cx, link, parent, rendering_params.show_def_docs,)
+                    document_short(item, cx, link, parent, rendering_params.show_def_docs)
                 );
             }
         }
@@ -2043,15 +2043,13 @@ pub(crate) fn render_impl_summary(
     w.write_str("</h3>");
 
     let is_trait = inner_impl.trait_.is_some();
-    if is_trait {
-        if let Some(portability) = portability(&i.impl_item, Some(parent)) {
-            write!(
-                w,
-                "<span class=\"item-info\">\
-                     <div class=\"stab portability\">{portability}</div>\
-                 </span>",
-            );
-        }
+    if is_trait && let Some(portability) = portability(&i.impl_item, Some(parent)) {
+        write!(
+            w,
+            "<span class=\"item-info\">\
+                 <div class=\"stab portability\">{portability}</div>\
+             </span>",
+        );
     }
 
     w.write_str("</section>");

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -33,6 +33,7 @@ use crate::html::format::{
 };
 use crate::html::layout::Page;
 use crate::html::markdown::{HeadingOffset, MarkdownSummaryLine};
+use crate::html::render::{document_full, document_item_info};
 use crate::html::url_parts_builder::UrlPartsBuilder;
 use crate::html::{highlight, static_files};
 
@@ -818,8 +819,10 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
         info!("Documenting {name} on {ty_name:?}", ty_name = t.name);
         let item_type = m.type_();
         let id = cx.derive_id(format!("{item_type}.{name}"));
+
         let mut content = Buffer::empty_from(w);
-        write!(&mut content, "{}", document(cx, m, Some(t), HeadingOffset::H5));
+        write!(content, "{}", document_full(m, cx, HeadingOffset::H5));
+
         let toggled = !content.is_empty();
         if toggled {
             let method_toggle_class = if item_type.is_method() { " method-toggle" } else { "" };
@@ -836,8 +839,8 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
             cx,
             RenderMode::Normal,
         );
-        w.write_str("</h4>");
-        w.write_str("</section>");
+        w.write_str("</h4></section>");
+        document_item_info(cx, m, Some(t)).render_into(w).unwrap();
         if toggled {
             write!(w, "</summary>");
             w.push_buffer(content);

--- a/tests/rustdoc/trait-item-info.rs
+++ b/tests/rustdoc/trait-item-info.rs
@@ -1,0 +1,24 @@
+// This is a regression test for <https://github.com/rust-lang/rust/issues/121772>.
+// The goal is to ensure that the item information is always part of the `<summary>`
+// if there is one.
+
+#![crate_name = "foo"]
+#![feature(staged_api)]
+
+#![unstable(feature = "test", issue = "none")]
+
+// @has 'foo/trait.Foo.html'
+
+#[stable(feature = "rust2", since = "2.2.2")]
+pub trait Foo {
+    // @has - '//div[@class="methods"]/span[@class="item-info"]' 'bla'
+    // Should not be in a `<details>` because there is no doc.
+    #[unstable(feature = "bla", reason = "bla", issue = "111")]
+    fn bla() {}
+
+    // @has - '//details[@class="toggle method-toggle"]/summary/span[@class="item-info"]' 'bar'
+    // Should have a `<summary>` in the `<details>` containing the unstable info.
+    /// doc
+    #[unstable(feature = "bar", reason = "bla", issue = "222")]
+    fn bar() {}
+}


### PR DESCRIPTION
Fixes #121772.

The `document_info` function was wrongly used when documenting a trait item.

r? @notriddle 