### PR TITLE
Cleanup windows `abort_internal`

### DIFF
--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -75,16 +75,15 @@ pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
                 const FAST_FAIL_FATAL_APP_EXIT: usize = 7;
                 cfg_if::cfg_if! {
                     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-                        core::arch::asm!("int $$0x29", in("ecx") FAST_FAIL_FATAL_APP_EXIT);
+                        core::arch::asm!("int $$0x29", in("ecx") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
                     } else if #[cfg(all(target_arch = "arm", target_feature = "thumb-mode"))] {
-                        core::arch::asm!(".inst 0xDEFB", in("r0") FAST_FAIL_FATAL_APP_EXIT);
+                        core::arch::asm!(".inst 0xDEFB", in("r0") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
                     } else if #[cfg(target_arch = "aarch64")] {
-                        core::arch::asm!("brk 0xF003", in("x0") FAST_FAIL_FATAL_APP_EXIT);
+                        core::arch::asm!("brk 0xF003", in("x0") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
                     } else {
                         core::intrinsics::abort();
                     }
                 }
-                core::intrinsics::unreachable();
             }
         } else if #[cfg(target_os = "teeos")] {
             mod teeos {

--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -2481,6 +2481,7 @@ Windows.Win32.System.SystemInformation.SYSTEM_INFO
 Windows.Win32.System.SystemServices.DLL_PROCESS_DETACH
 Windows.Win32.System.SystemServices.DLL_THREAD_DETACH
 Windows.Win32.System.SystemServices.EXCEPTION_MAXIMUM_PARAMETERS
+Windows.Win32.System.SystemServices.FAST_FAIL_FATAL_APP_EXIT
 Windows.Win32.System.SystemServices.IO_REPARSE_TAG_MOUNT_POINT
 Windows.Win32.System.SystemServices.IO_REPARSE_TAG_SYMLINK
 Windows.Win32.System.Threading.ABOVE_NORMAL_PRIORITY_CLASS

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -3086,6 +3086,7 @@ pub type FACILITY_CODE = u32;
 pub const FACILITY_NT_BIT: FACILITY_CODE = 268435456u32;
 pub const FALSE: BOOL = 0i32;
 pub type FARPROC = ::core::option::Option<unsafe extern "system" fn() -> isize>;
+pub const FAST_FAIL_FATAL_APP_EXIT: u32 = 7u32;
 #[repr(C)]
 pub struct FD_SET {
     pub fd_count: u32,

--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -321,25 +321,26 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
 ///
 /// This is the same implementation as in libpanic_abort's `__rust_start_panic`. See
 /// that function for more information on `__fastfail`
-#[allow(unreachable_code)]
+#[cfg(not(miri))] // inline assembly does not work in Miri
 pub fn abort_internal() -> ! {
-    #[allow(unused)]
-    const FAST_FAIL_FATAL_APP_EXIT: usize = 7;
-    #[cfg(not(miri))] // inline assembly does not work in Miri
     unsafe {
         cfg_if::cfg_if! {
             if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-                core::arch::asm!("int $$0x29", in("ecx") FAST_FAIL_FATAL_APP_EXIT);
-                crate::intrinsics::unreachable();
+                core::arch::asm!("int $$0x29", in("ecx") c::FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
             } else if #[cfg(all(target_arch = "arm", target_feature = "thumb-mode"))] {
-                core::arch::asm!(".inst 0xDEFB", in("r0") FAST_FAIL_FATAL_APP_EXIT);
-                crate::intrinsics::unreachable();
+                core::arch::asm!(".inst 0xDEFB", in("r0") c::FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
             } else if #[cfg(target_arch = "aarch64")] {
-                core::arch::asm!("brk 0xF003", in("x0") FAST_FAIL_FATAL_APP_EXIT);
-                crate::intrinsics::unreachable();
+                core::arch::asm!("brk 0xF003", in("x0") c::FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+            } else {
+                core::intrinsics::abort();
             }
         }
     }
+}
+
+// miri is sensitive to changes here so check that miri is happy if touching this
+#[cfg(miri)]
+pub fn abort_internal() -> ! {
     crate::intrinsics::abort();
 }
 


### PR DESCRIPTION
As the comments on the functions say, we define abort in both in panic_abort and in libstd. This PR makes the two implementation (mostly) the same.

Additionally it:
* uses `options(noreturn)` on the asm instead of using `core::intrinsics::unreachable`.
* removed unnecessary allow lints
* added `FAST_FAIL_FATAL_APP_EXIT` to our generated Windows API bindings instead of defining it manually (std only)
