### PR TITLE
Don't grab variances in `TypeRelating` relation if we're invariant

### DIFF
--- a/tests/ui/associated-inherent-types/variance-computation-requires-equality.rs
+++ b/tests/ui/associated-inherent-types/variance-computation-requires-equality.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+
+#![feature(inherent_associated_types)]
+//~^ WARN the feature `inherent_associated_types` is incomplete
+
+struct D<T> {
+  a: T
+}
+
+impl<T: Default> D<T> {
+    type Item = T;
+
+    fn next() -> Self::Item {
+        Self::Item::default()
+    }
+}
+
+
+fn main() {
+}

--- a/tests/ui/associated-inherent-types/variance-computation-requires-equality.stderr
+++ b/tests/ui/associated-inherent-types/variance-computation-requires-equality.stderr
@@ -1,0 +1,11 @@
+warning: the feature `inherent_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/variance-computation-requires-equality.rs:3:12
+   |
+LL | #![feature(inherent_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Since `Invariant.xform(var) = Invariant` always, so just copy what the generalizer relation does.

Fixes #110106