### PR TITLE
Add FileCheck annotations to MIR-opt unnamed-fields tests

### DIFF
--- a/tests/mir-opt/unnamed-fields/field_access.rs
+++ b/tests/mir-opt/unnamed-fields/field_access.rs
@@ -1,4 +1,4 @@
-//@ unit-test: UnnamedFields
+// Tests the correct handling of unnamed fields within structs and unions marked with #[repr(C)].
 
 // EMIT_MIR field_access.foo.SimplifyCfg-initial.after.mir
 // EMIT_MIR field_access.bar.SimplifyCfg-initial.after.mir

--- a/tests/mir-opt/unnamed-fields/field_access.rs
+++ b/tests/mir-opt/unnamed-fields/field_access.rs
@@ -1,4 +1,5 @@
-// skip-filecheck
+//@ unit-test: UnnamedFields
+
 // EMIT_MIR field_access.foo.SimplifyCfg-initial.after.mir
 // EMIT_MIR field_access.bar.SimplifyCfg-initial.after.mir
 
@@ -36,18 +37,36 @@ union Bar {
 
 fn access<T>(_: T) {}
 
+// CHECK-LABEL: fn foo(
 fn foo(foo: Foo) {
+    // CHECK _3 = (_1.0: u8);
+    // CHECK _2 = access::<u8>(move _3) -> [return: bb1, unwind: bb5];
     access(foo.a);
+    // CHECK _5 = ((_1.1: Foo::{anon_adt#0}).0: i8);
+    // CHECK _4 = access::<i8>(move _5) -> [return: bb2, unwind: bb5];
     access(foo.b);
+    // CHECK _7 = ((_1.1: Foo::{anon_adt#0}).1: bool);
+    // CHECK _6 = access::<bool>(move _7) -> [return: bb3, unwind: bb5];
     access(foo.c);
+    // CHECK _9 = (((_1.2: Foo::{anon_adt#1}).0: Foo::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
+    // CHECK _8 = access::<[u8; 1]>(move _9) -> [return: bb4, unwind: bb5];
     access(foo.d);
 }
 
+// CHECK-LABEL: fn bar(
 fn bar(bar: Bar) {
     unsafe {
+        // CHECK _3 = (_1.0: u8);
+        // CHECK _2 = access::<u8>(move _3) -> [return: bb1, unwind: bb5];
         access(bar.a);
+        // CHECK _5 = ((_1.1: Bar::{anon_adt#0}).0: i8);
+        // CHECK _4 = access::<i8>(move _5) -> [return: bb2, unwind: bb5];
         access(bar.b);
+        // CHECK _7 = ((_1.1: Bar::{anon_adt#0}).1: bool);
+        // CHECK _6 = access::<bool>(move _7) -> [return: bb3, unwind: bb5];
         access(bar.c);
+        // CHECK _9 = (((_1.2: Bar::{anon_adt#1}).0: Bar::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
+        // CHECK _8 = access::<[u8; 1]>(move _9) -> [return: bb4, unwind: bb5];
         access(bar.d);
     }
 }

--- a/tests/mir-opt/unnamed-fields/field_access.rs
+++ b/tests/mir-opt/unnamed-fields/field_access.rs
@@ -39,34 +39,34 @@ fn access<T>(_: T) {}
 
 // CHECK-LABEL: fn foo(
 fn foo(foo: Foo) {
-    // CHECK _3 = (_1.0: u8);
-    // CHECK _2 = access::<u8>(move _3) -> [return: bb1, unwind: bb5];
+    // CHECK [[a:_.*]] = (_1.0: u8);
+    // CHECK _.* = access::<u8>(move [[a]]) -> [return: bb1, unwind: bb5];
     access(foo.a);
-    // CHECK _5 = ((_1.1: Foo::{anon_adt#0}).0: i8);
-    // CHECK _4 = access::<i8>(move _5) -> [return: bb2, unwind: bb5];
+    // CHECK [[b:_.*]] = ((_1.1: Foo::{anon_adt#0}).0: i8);
+    // CHECK _.* = access::<i8>(move [[b]]) -> [return: bb2, unwind: bb5];
     access(foo.b);
-    // CHECK _7 = ((_1.1: Foo::{anon_adt#0}).1: bool);
-    // CHECK _6 = access::<bool>(move _7) -> [return: bb3, unwind: bb5];
+    // CHECK [[c:_.*]] = ((_1.1: Foo::{anon_adt#0}).1: bool);
+    // CHECK _.* = access::<bool>(move [[c]]) -> [return: bb3, unwind: bb5];
     access(foo.c);
-    // CHECK _9 = (((_1.2: Foo::{anon_adt#1}).0: Foo::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
-    // CHECK _8 = access::<[u8; 1]>(move _9) -> [return: bb4, unwind: bb5];
+    // CHECK [[d:_.*]] = (((_1.2: Foo::{anon_adt#1}).0: Foo::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
+    // CHECK _.* = access::<[u8; 1]>(move [[d]]) -> [return: bb4, unwind: bb5];
     access(foo.d);
 }
 
 // CHECK-LABEL: fn bar(
 fn bar(bar: Bar) {
     unsafe {
-        // CHECK _3 = (_1.0: u8);
-        // CHECK _2 = access::<u8>(move _3) -> [return: bb1, unwind: bb5];
+        // CHECK [[a:_.*]] = (_1.0: u8);
+        // CHECK _.* = access::<u8>(move [[a]]) -> [return: bb1, unwind: bb5];
         access(bar.a);
-        // CHECK _5 = ((_1.1: Bar::{anon_adt#0}).0: i8);
-        // CHECK _4 = access::<i8>(move _5) -> [return: bb2, unwind: bb5];
+        // CHECK [[b:_.*]] = ((_1.1: Bar::{anon_adt#0}).0: i8);
+        // CHECK _.* = access::<i8>(move [[b]]) -> [return: bb2, unwind: bb5];
         access(bar.b);
-        // CHECK _7 = ((_1.1: Bar::{anon_adt#0}).1: bool);
-        // CHECK _6 = access::<bool>(move _7) -> [return: bb3, unwind: bb5];
+        // CHECK [[c:_.*]] = ((_1.1: Bar::{anon_adt#0}).1: bool);
+        // CHECK _.* = access::<bool>(move [[c]]) -> [return: bb3, unwind: bb5];
         access(bar.c);
-        // CHECK _9 = (((_1.2: Bar::{anon_adt#1}).0: Bar::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
-        // CHECK _8 = access::<[u8; 1]>(move _9) -> [return: bb4, unwind: bb5];
+        // CHECK [[d:_.*]] = (((_1.2: Bar::{anon_adt#1}).0: Bar::{anon_adt#1}::{anon_adt#0}).0: [u8; 1]);
+        // CHECK _.* = access::<[u8; 1]>(move [[d]]) -> [return: bb4, unwind: bb5];
         access(bar.d);
     }
 }


### PR DESCRIPTION
Part of #116971
Adds filecheck annotations to unnamed-fields mir-opt tests in `tests/mir-opt/unnamed-fields`

