### PR TITLE
 Account for unmet T: !Copy in E0277 message

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -4773,11 +4773,18 @@ pub(super) fn get_explanation_based_on_obligation<'tcx>(
             Some(desc) => format!(" {desc}"),
             None => String::new(),
         };
-        format!(
-            "{pre_message}the trait `{}` is not implemented for{desc} `{}`{post}",
-            trait_predicate.print_modifiers_and_trait_path(),
-            tcx.short_ty_string(trait_ref.skip_binder().self_ty(), &mut None),
-        )
+        if let ty::ImplPolarity::Positive = trait_predicate.polarity() {
+            format!(
+                "{pre_message}the trait `{}` is not implemented for{desc} `{}`{post}",
+                trait_predicate.print_modifiers_and_trait_path(),
+                tcx.short_ty_string(trait_ref.skip_binder().self_ty(), &mut None),
+            )
+        } else {
+            // "the trait bound `T: !Send` is not satisfied" reads better than "`!Send` is
+            // not implemented for `T`".
+            // FIXME: add note explaining explicit negative trait bounds.
+            format!("{pre_message}the trait bound `{trait_predicate}` is not satisfied{post}")
+        }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -4769,21 +4769,15 @@ pub(super) fn get_explanation_based_on_obligation<'tcx>(
         } else {
             String::new()
         };
-        match ty_desc {
-            Some(desc) => format!(
-                "{}the trait `{}` is not implemented for {} `{}`{post}",
-                pre_message,
-                trait_predicate.print_modifiers_and_trait_path(),
-                desc,
-                tcx.short_ty_string(trait_ref.skip_binder().self_ty(), &mut None),
-            ),
-            None => format!(
-                "{}the trait `{}` is not implemented for `{}`{post}",
-                pre_message,
-                trait_predicate.print_modifiers_and_trait_path(),
-                tcx.short_ty_string(trait_ref.skip_binder().self_ty(), &mut None),
-            ),
-        }
+        let desc = match ty_desc {
+            Some(desc) => format!(" {desc}"),
+            None => String::new(),
+        };
+        format!(
+            "{pre_message}the trait `{}` is not implemented for{desc} `{}`{post}",
+            trait_predicate.print_modifiers_and_trait_path(),
+            tcx.short_ty_string(trait_ref.skip_binder().self_ty(), &mut None),
+        )
     }
 }
 

--- a/tests/ui/traits/negative-bounds/simple.stderr
+++ b/tests/ui/traits/negative-bounds/simple.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: !Copy` is not satisfied
   --> $DIR/simple.rs:10:16
    |
 LL |     not_copy::<T>();
-   |                ^ the trait `!Copy` is not implemented for `T`
+   |                ^ the trait bound `T: !Copy` is not satisfied
    |
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `T: !Copy` is not satisfied
   --> $DIR/simple.rs:15:16
    |
 LL |     not_copy::<T>();
-   |                ^ the trait `!Copy` is not implemented for `T`
+   |                ^ the trait bound `T: !Copy` is not satisfied
    |
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `Copyable: !Copy` is not satisfied
   --> $DIR/simple.rs:30:16
    |
 LL |     not_copy::<Copyable>();
-   |                ^^^^^^^^ the trait `!Copy` is not implemented for `Copyable`
+   |                ^^^^^^^^ the trait bound `Copyable: !Copy` is not satisfied
    |
    = help: the trait `Copy` is implemented for `Copyable`
 note: required by a bound in `not_copy`
@@ -44,7 +44,7 @@ error[E0277]: the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
   --> $DIR/simple.rs:37:16
    |
 LL |     not_copy::<NotNecessarilyCopyable>();
-   |                ^^^^^^^^^^^^^^^^^^^^^^ the trait `!Copy` is not implemented for `NotNecessarilyCopyable`
+   |                ^^^^^^^^^^^^^^^^^^^^^^ the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
    |
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16


### PR DESCRIPTION
```
error[E0277]: the trait bound `T: !Copy` is not satisfied
  --> $DIR/simple.rs:10:16
   |
LL |     not_copy::<T>();
   |                ^ the trait bound `T: !Copy` is not satisfied
```
instead of the current

```
error[E0277]: the trait bound `T: !Copy` is not satisfied
  --> $DIR/simple.rs:10:16
   |
LL |     not_copy::<T>();
   |                ^ the trait `!Copy` is not implemented for `T`
```