### PR TITLE
Run linking and incremental saving / finalizing in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3545,6 +3545,7 @@ dependencies = [
  "portable-atomic",
  "rustc-hash 2.1.1",
  "rustc-rayon",
+ "rustc-rayon-core",
  "rustc-stable-hash",
  "rustc_arena",
  "rustc_graphviz",

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -36,7 +36,7 @@ pub trait BackendTypes {
     type DIVariable: Copy;
 }
 
-pub trait CodegenBackend {
+pub trait CodegenBackend: DynSync + DynSend {
     /// Locale resources for diagnostic messages - a string the content of the Fluent resource.
     /// Called before `init` so that all other functions are able to emit translatable diagnostics.
     fn locale_resource(&self) -> &'static str;
@@ -73,16 +73,16 @@ pub trait CodegenBackend {
         tcx: TyCtxt<'tcx>,
         metadata: EncodedMetadata,
         need_metadata_module: bool,
-    ) -> Box<dyn Any>;
+    ) -> Box<dyn Any + DynSend>;
 
-    /// This is called on the returned `Box<dyn Any>` from [`codegen_crate`](Self::codegen_crate)
+    /// This is called on the returned `Box<dyn Any + DynSend>` from [`codegen_crate`](Self::codegen_crate)
     ///
     /// # Panics
     ///
-    /// Panics when the passed `Box<dyn Any>` was not returned by [`codegen_crate`](Self::codegen_crate).
+    /// Panics when the passed `Box<dyn Any + DynSend>` was not returned by [`codegen_crate`](Self::codegen_crate).
     fn join_codegen(
         &self,
-        ongoing_codegen: Box<dyn Any>,
+        ongoing_codegen: Box<dyn Any + DynSend>,
         sess: &Session,
         outputs: &OutputFilenames,
     ) -> (CodegenResults, FxIndexMap<WorkProductId, WorkProduct>);

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -15,6 +15,7 @@ jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "12.0.1"
 rustc-hash = "2.0.0"
 rustc-rayon = { version = "0.5.1", features = ["indexmap"] }
+rustc-rayon-core = { version = "0.5.0" }
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }
 rustc_graphviz = { path = "../rustc_graphviz" }

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -50,6 +50,10 @@ pub use self::worker_local::{Registry, WorkerLocal};
 pub use crate::marker::*;
 
 mod freeze;
+
+mod task;
+pub use task::{Task, task};
+
 mod lock;
 mod parallel;
 mod vec;

--- a/compiler/rustc_data_structures/src/sync/task.rs
+++ b/compiler/rustc_data_structures/src/sync/task.rs
@@ -1,0 +1,101 @@
+use std::any::Any;
+use std::mem;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Arc;
+
+use parking_lot::{Condvar, Mutex};
+
+use crate::jobserver;
+use crate::sync::{DynSend, FromDyn, IntoDynSyncSend, mode};
+
+enum TaskState<T: DynSend + 'static> {
+    Unexecuted(Box<dyn FnOnce() -> T + DynSend>),
+    Running,
+    Joined,
+    Result(Result<T, IntoDynSyncSend<Box<dyn Any + Send + 'static>>>),
+}
+
+struct TaskData<T: DynSend + 'static> {
+    state: Mutex<TaskState<T>>,
+    waiter: Condvar,
+}
+
+#[must_use]
+pub struct Task<T: DynSend + 'static> {
+    data: Arc<TaskData<T>>,
+}
+
+/// This attempts to run a closure in a background thread. It returns a `Task` type which
+/// you must call `join` on to ensure that the closure runs.
+pub fn task<T: DynSend>(f: impl FnOnce() -> T + DynSend + 'static) -> Task<T> {
+    let task = Task {
+        data: Arc::new(TaskData {
+            state: Mutex::new(TaskState::Unexecuted(Box::new(f))),
+            waiter: Condvar::new(),
+        }),
+    };
+
+    if mode::is_dyn_thread_safe() {
+        let data = FromDyn::from(Arc::clone(&task.data));
+
+        // Try to execute the task on a separate thread.
+        rayon::spawn(move || {
+            let data = data.into_inner();
+            let mut state = data.state.lock();
+            if matches!(*state, TaskState::Unexecuted(..)) {
+                if let TaskState::Unexecuted(f) = mem::replace(&mut *state, TaskState::Running) {
+                    drop(state);
+                    let result = panic::catch_unwind(AssertUnwindSafe(f));
+
+                    let unblock = {
+                        let mut state = data.state.lock();
+                        let unblock = matches!(*state, TaskState::Joined);
+                        *state = TaskState::Result(result.map_err(|e| IntoDynSyncSend(e)));
+                        unblock
+                    };
+
+                    if unblock {
+                        rayon_core::mark_unblocked(&rayon_core::Registry::current());
+                    }
+
+                    data.waiter.notify_one();
+                }
+            }
+        });
+    }
+
+    task
+}
+
+#[inline]
+fn unwind<T>(result: Result<T, IntoDynSyncSend<Box<dyn Any + Send + 'static>>>) -> T {
+    match result {
+        Ok(r) => r,
+        Err(err) => panic::resume_unwind(err.0),
+    }
+}
+
+impl<T: DynSend> Task<T> {
+    pub fn join(self) -> T {
+        let mut state_guard = self.data.state.lock();
+
+        match mem::replace(&mut *state_guard, TaskState::Joined) {
+            TaskState::Unexecuted(f) => f(),
+            TaskState::Result(result) => unwind(result),
+            TaskState::Running => {
+                rayon_core::mark_blocked();
+                jobserver::release_thread();
+
+                self.data.waiter.wait(&mut state_guard);
+
+                jobserver::acquire_thread();
+
+                match mem::replace(&mut *state_guard, TaskState::Joined) {
+                    TaskState::Result(result) => unwind(result),
+                    _ => panic!(),
+                }
+            }
+            TaskState::Joined => panic!(),
+        }
+    }
+}

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -380,13 +380,14 @@ pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks + Send)) 
                 }
             }
 
-            Some(Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend))
+            Some(Linker::codegen_and_build_linker(tcx, compiler))
         });
 
         // Linking is done outside the `compiler.enter()` so that the
         // `GlobalCtxt` within `Queries` can be freed as early as possible.
         if let Some(linker) = linker {
-            linker.link(sess, codegen_backend);
+            let _timer = sess.timer("waiting for linking");
+            linker.join();
         }
     })
 }

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -37,8 +37,8 @@ pub type Result<T> = result::Result<T, ErrorGuaranteed>;
 /// Can be used to run `rustc_interface` queries.
 /// Created by passing [`Config`] to [`run_compiler`].
 pub struct Compiler {
-    pub sess: Session,
-    pub codegen_backend: Box<dyn CodegenBackend>,
+    pub sess: Arc<Session>,
+    pub codegen_backend: Arc<dyn CodegenBackend>,
     pub(crate) override_queries: Option<fn(&Session, &mut Providers)>,
     pub(crate) current_gcx: CurrentGcx,
 }
@@ -494,8 +494,8 @@ pub fn run_compiler<R: Send>(config: Config, f: impl FnOnce(&Compiler) -> R + Se
             util::check_abi_required_features(&sess);
 
             let compiler = Compiler {
-                sess,
-                codegen_backend,
+                sess: Arc::new(sess),
+                codegen_backend: Arc::from(codegen_backend),
                 override_queries: config.override_queries,
                 current_gcx,
             };

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(try_blocks)]
+#![recursion_limit = "256"]
 // tidy-alphabetical-end
 
 mod callbacks;

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -9,7 +9,7 @@ use rustc_ast as ast;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_data_structures::parallel;
 use rustc_data_structures::steal::Steal;
-use rustc_data_structures::sync::{AppendOnlyIndexVec, FreezeLock, WorkerLocal};
+use rustc_data_structures::sync::{AppendOnlyIndexVec, DynSend, FreezeLock, WorkerLocal};
 use rustc_expand::base::{ExtCtxt, LintStoreExpand};
 use rustc_feature::Features;
 use rustc_fs_util::try_canonicalize;
@@ -1072,7 +1072,7 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) {
 pub(crate) fn start_codegen<'tcx>(
     codegen_backend: &dyn CodegenBackend,
     tcx: TyCtxt<'tcx>,
-) -> Box<dyn Any> {
+) -> Box<dyn Any + DynSend> {
     // Hook for tests.
     if let Some((def_id, _)) = tcx.entry_fn(())
         && tcx.has_attr(def_id, sym::rustc_delayed_bug_from_inside_query)

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -1,9 +1,12 @@
 use std::any::Any;
 use std::sync::Arc;
+use std::sync::mpsc::Receiver;
 
 use rustc_codegen_ssa::CodegenResults;
 use rustc_codegen_ssa::traits::CodegenBackend;
+use rustc_data_structures::jobserver;
 use rustc_data_structures::svh::Svh;
+use rustc_data_structures::sync::{DynSend, Task, join, task};
 use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::dep_graph::DepGraph;
 use rustc_middle::ty::TyCtxt;
@@ -11,24 +14,24 @@ use rustc_session::Session;
 use rustc_session::config::{self, OutputFilenames, OutputType};
 
 use crate::errors::FailedWritingFile;
+use crate::interface::Compiler;
 use crate::passes;
 
 pub struct Linker {
+    dep_graph_serialized_rx: Receiver<()>,
     dep_graph: DepGraph,
     output_filenames: Arc<OutputFilenames>,
     // Only present when incr. comp. is enabled.
     crate_hash: Option<Svh>,
-    ongoing_codegen: Box<dyn Any>,
+    ongoing_codegen: Box<dyn Any + DynSend>,
 }
 
 impl Linker {
-    pub fn codegen_and_build_linker(
-        tcx: TyCtxt<'_>,
-        codegen_backend: &dyn CodegenBackend,
-    ) -> Linker {
-        let ongoing_codegen = passes::start_codegen(codegen_backend, tcx);
+    pub fn codegen_and_build_linker(tcx: TyCtxt<'_>, compiler: &Compiler) -> Task<()> {
+        let ongoing_codegen = passes::start_codegen(&*compiler.codegen_backend, tcx);
 
-        Linker {
+        let linker = Linker {
+            dep_graph_serialized_rx: tcx.dep_graph_serialized_rx.lock().take().unwrap(),
             dep_graph: tcx.dep_graph.clone(),
             output_filenames: Arc::clone(tcx.output_filenames(())),
             crate_hash: if tcx.needs_crate_hash() {
@@ -37,10 +40,15 @@ impl Linker {
                 None
             },
             ongoing_codegen,
-        }
+        };
+
+        let sess = Arc::clone(&compiler.sess);
+        let codegen_backend = Arc::clone(&compiler.codegen_backend);
+
+        task(move || linker.link(&sess, &*codegen_backend))
     }
 
-    pub fn link(self, sess: &Session, codegen_backend: &dyn CodegenBackend) {
+    fn link(self, sess: &Session, codegen_backend: &dyn CodegenBackend) {
         let (codegen_results, work_products) = sess.time("finish_ongoing_codegen", || {
             codegen_backend.join_codegen(self.ongoing_codegen, sess, &self.output_filenames)
         });
@@ -53,37 +61,53 @@ impl Linker {
             rustc_incremental::save_work_product_index(sess, &self.dep_graph, work_products)
         });
 
-        let prof = sess.prof.clone();
-        prof.generic_activity("drop_dep_graph").run(move || drop(self.dep_graph));
+        let dep_graph_serialized_rx = self.dep_graph_serialized_rx;
 
-        // Now that we won't touch anything in the incremental compilation directory
-        // any more, we can finalize it (which involves renaming it)
-        rustc_incremental::finalize_session_directory(sess, self.crate_hash);
+        join(
+            || {
+                if !sess
+                    .opts
+                    .output_types
+                    .keys()
+                    .any(|&i| i == OutputType::Exe || i == OutputType::Metadata)
+                {
+                    return;
+                }
 
-        if !sess
-            .opts
-            .output_types
-            .keys()
-            .any(|&i| i == OutputType::Exe || i == OutputType::Metadata)
-        {
-            return;
-        }
+                if sess.opts.unstable_opts.no_link {
+                    let rlink_file = self.output_filenames.with_extension(config::RLINK_EXT);
+                    CodegenResults::serialize_rlink(
+                        sess,
+                        &rlink_file,
+                        &codegen_results,
+                        &*self.output_filenames,
+                    )
+                    .unwrap_or_else(|error| {
+                        sess.dcx().emit_fatal(FailedWritingFile { path: &rlink_file, error })
+                    });
+                    return;
+                }
 
-        if sess.opts.unstable_opts.no_link {
-            let rlink_file = self.output_filenames.with_extension(config::RLINK_EXT);
-            CodegenResults::serialize_rlink(
-                sess,
-                &rlink_file,
-                &codegen_results,
-                &*self.output_filenames,
-            )
-            .unwrap_or_else(|error| {
-                sess.dcx().emit_fatal(FailedWritingFile { path: &rlink_file, error })
-            });
-            return;
-        }
+                let _timer = sess.prof.verbose_generic_activity("link_crate");
+                codegen_backend.link(sess, codegen_results, &self.output_filenames)
+            },
+            || {
+                let dep_graph_serialized_rx = dep_graph_serialized_rx;
 
-        let _timer = sess.prof.verbose_generic_activity("link_crate");
-        codegen_backend.link(sess, codegen_results, &self.output_filenames)
+                // Wait for the dep graph to be serialized before finalizing the session directory.
+                if !dep_graph_serialized_rx.try_recv().is_ok() {
+                    jobserver::release_thread();
+                    dep_graph_serialized_rx.recv().unwrap();
+                    jobserver::acquire_thread();
+                }
+
+                sess.prof.generic_activity("drop_dep_graph").run(move || drop(self.dep_graph));
+
+                // Now that we won't touch anything in the incremental compilation directory
+                // any more, we can finalize it (which involves renaming it)
+                rustc_incremental::finalize_session_directory(sess, self.crate_hash);
+            },
+        )
+        .0
     }
 }

--- a/tests/ui-fulldeps/run-compiler-twice.rs
+++ b/tests/ui-fulldeps/run-compiler-twice.rs
@@ -80,8 +80,8 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf, linker: Option<&Path
         let krate = rustc_interface::passes::parse(&compiler.sess);
         let linker = rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
             let _ = tcx.analysis(());
-            Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend)
+            Linker::codegen_and_build_linker(tcx, compiler)
         });
-        linker.link(&compiler.sess, &*compiler.codegen_backend);
+        linker.join();
     });
 }


### PR DESCRIPTION
This makes saving the dep graph and finalizing the incremental session directory run in parallel with linking.

It adds a `task` function which allows a closure to run on the Rayon thread pool and be waited on later. This is used in `codegen_and_build_linker` to start the linker in separate task.

This is blocked on https://github.com/rust-lang/rustc-rayon/pull/12 as otherwise this runs into deadlocks.