### PR TITLE
Add more BOLT optimizations

### DIFF
--- a/src/tools/opt-dist/src/bolt.rs
+++ b/src/tools/opt-dist/src/bolt.rs
@@ -66,6 +66,8 @@ pub fn bolt_optimize(path: &Utf8Path, profile: &BoltProfile) -> anyhow::Result<(
         // Split function code into hot and code regions
         .arg("-split-functions")
         // Split as many basic blocks as possible
+        .arg("-split-all-cold")
+        // Move jump tables to a separate section
         .arg("-jump-tables=move")
         // Fold functions with identical code
         .arg("-icf=1")
@@ -76,8 +78,6 @@ pub fn bolt_optimize(path: &Utf8Path, profile: &BoltProfile) -> anyhow::Result<(
         // Inline functions smaller than 32 bytes
         .arg("-inline-small-functions")
         .arg("-inline-small-functions-bytes=32")
-        // Perform peephole optimizations
-        .arg("-peepholes=all")
         // The following flag saves about 50 MiB of libLLVM.so size.
         // However, it succeeds very non-deterministically. To avoid frequent artifact size swings,
         // it is kept disabled for now.

--- a/src/tools/opt-dist/src/bolt.rs
+++ b/src/tools/opt-dist/src/bolt.rs
@@ -66,11 +66,18 @@ pub fn bolt_optimize(path: &Utf8Path, profile: &BoltProfile) -> anyhow::Result<(
         // Split function code into hot and code regions
         .arg("-split-functions")
         // Split as many basic blocks as possible
-        .arg("-split-all-cold")
-        // Move jump tables to a separate section
         .arg("-jump-tables=move")
         // Fold functions with identical code
         .arg("-icf=1")
+        // Perform indirect call promotion on calls and jump tables
+        .arg("-indirect-call-promotion=all")
+        // Optimize stack frame accesses
+        .arg("-frame-opt=hot")
+        // Inline functions smaller than 32 bytes
+        .arg("-inline-small-functions")
+        .arg("-inline-small-functions-bytes=32")
+        // Perform peephole optimizations
+        .arg("-peepholes=all")
         // The following flag saves about 50 MiB of libLLVM.so size.
         // However, it succeeds very non-deterministically. To avoid frequent artifact size swings,
         // it is kept disabled for now.


### PR DESCRIPTION
This PR adds some more BOLT flags. I'm not sure why they were not added on the first place. I sadly cannot benchmark the changes on my machines (I'm having some problems). To not expand the build time too much, I only added the most influential on final times (inlining small functions and peepholes being the most influential).

As this is just a experiment, let's not assign anyone yet. Let's hope that this one PR improves runtimes. Improving performance is hard :/
r? ghost