### PR TITLE
Properly deal with GATs when looking for method chains to point at

### DIFF
--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -16,6 +16,7 @@
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
 #![allow(rustc::untranslatable_diagnostic)]
+#![feature(assert_matches)]
 #![feature(associated_type_bounds)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]

--- a/tests/ui/typeck/method-chain-gats.rs
+++ b/tests/ui/typeck/method-chain-gats.rs
@@ -1,0 +1,22 @@
+// Regression test for issue #121898.
+
+trait Base {
+    type Base<B>;
+}
+
+trait Functor<A>: Base {
+    fn fmap<B>(self, f: impl Fn(A) -> B) -> Self::Base<B>
+    where
+        Self::Base<B>: Functor<B>;
+}
+
+fn fmap2<T, A, B, C>(input: T, f1: impl Fn(A) -> B, f2: impl Fn(B) -> C) -> T::Base<C>
+where
+    T: Functor<A>,
+    T::Base<B>: Functor<B, Base<C> = T::Base<C>>,
+{
+    input.fmap(f1).fmap(f2)
+    //~^ ERROR the trait bound `<T as Base>::Base<C>: Functor<C>` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/typeck/method-chain-gats.stderr
+++ b/tests/ui/typeck/method-chain-gats.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `<T as Base>::Base<C>: Functor<C>` is not satisfied
+  --> $DIR/method-chain-gats.rs:18:20
+   |
+LL |     input.fmap(f1).fmap(f2)
+   |                    ^^^^ the trait `Functor<C>` is not implemented for `<T as Base>::Base<C>`
+   |
+note: the method call chain might not have had the expected associated types
+  --> $DIR/method-chain-gats.rs:13:29
+   |
+LL | fn fmap2<T, A, B, C>(input: T, f1: impl Fn(A) -> B, f2: impl Fn(B) -> C) -> T::Base<C>
+   |                             ^ `Base::Base` is `<T as Base>::Base<_>` here
+note: required by a bound in `Functor::fmap`
+  --> $DIR/method-chain-gats.rs:10:24
+   |
+LL |     fn fmap<B>(self, f: impl Fn(A) -> B) -> Self::Base<B>
+   |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self::Base<B>: Functor<B>;
+   |                        ^^^^^^^^^^ required by this bound in `Functor::fmap`
+help: consider further restricting the associated type
+   |
+LL |     T::Base<B>: Functor<B, Base<C> = T::Base<C>>, <T as Base>::Base<C>: Functor<C>
+   |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #121898.

~~While it prevents an ICE and the structured suggestion is correct, the method chain diagnostic notes are weird / useless / incorrect judging by a quick look. I guess I should improve that in this PR.~~ Sufficiently taken care of.

r? estebank or compiler-errors (#105332, #105674).