### PR TITLE
match lowering: improve or-pattern simplification

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1441,20 +1441,20 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             return;
         }
 
-        let match_pairs = mem::take(&mut first_candidate.match_pairs);
-        let (first_match_pair, remaining_match_pairs) = match_pairs.split_first().unwrap();
-        let TestCase::Or { ref pats } = &first_match_pair.test_case else { unreachable!() };
+        let first_match_pair = first_candidate.match_pairs.remove(0);
+        let or_span = first_match_pair.pattern.span;
+        let TestCase::Or { pats } = first_match_pair.test_case else { unreachable!() };
 
         let remainder_start = self.cfg.start_new_block();
-        let or_span = first_match_pair.pattern.span;
         // Test the alternatives of this or-pattern.
         self.test_or_pattern(first_candidate, start_block, remainder_start, pats, or_span);
 
-        if !remaining_match_pairs.is_empty() {
+        if !first_candidate.match_pairs.is_empty() {
             // If more match pairs remain, test them after each subcandidate.
             // We could add them to the or-candidates before the call to `test_or_pattern` but this
             // would make it impossible to detect simplifiable or-patterns. That would guarantee
             // exponentially large CFGs for cases like `(1 | 2, 3 | 4, ...)`.
+            let remaining_match_pairs = mem::take(&mut first_candidate.match_pairs);
             first_candidate.visit_leaves(|leaf_candidate| {
                 assert!(leaf_candidate.match_pairs.is_empty());
                 leaf_candidate.match_pairs.extend(remaining_match_pairs.iter().cloned());
@@ -1492,13 +1492,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         candidate: &mut Candidate<'pat, 'tcx>,
         start_block: BasicBlock,
         otherwise_block: BasicBlock,
-        pats: &[FlatPat<'pat, 'tcx>],
+        pats: Box<[FlatPat<'pat, 'tcx>]>,
         or_span: Span,
     ) {
         debug!("candidate={:#?}\npats={:#?}", candidate, pats);
         let mut or_candidates: Vec<_> = pats
-            .iter()
-            .cloned()
+            .into_vec()
+            .into_iter()
             .map(|flat_pat| Candidate::from_flat_pat(flat_pat, candidate.has_guard))
             .collect();
         let mut or_candidate_refs: Vec<_> = or_candidates.iter_mut().collect();

--- a/tests/ui/or-patterns/bindings-runpass-2.rs
+++ b/tests/ui/or-patterns/bindings-runpass-2.rs
@@ -26,5 +26,6 @@ fn main() {
     assert_eq!(or_at(Err(7)), 207);
     assert_eq!(or_at(Err(8)), 8);
     assert_eq!(or_at(Err(20)), 220);
+    assert_eq!(or_at(Err(34)), 134);
     assert_eq!(or_at(Err(50)), 500);
 }

--- a/tests/ui/or-patterns/inner-or-pat.or3.stderr
+++ b/tests/ui/or-patterns/inner-or-pat.or3.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/inner-or-pat.rs:38:54
+  --> $DIR/inner-or-pat.rs:36:54
    |
 LL |     match x {
    |           - this expression has type `&str`

--- a/tests/ui/or-patterns/inner-or-pat.or4.stderr
+++ b/tests/ui/or-patterns/inner-or-pat.or4.stderr
@@ -1,5 +1,5 @@
 error[E0408]: variable `x` is not bound in all patterns
-  --> $DIR/inner-or-pat.rs:53:37
+  --> $DIR/inner-or-pat.rs:51:37
    |
 LL |         (x @ "red" | (x @ "blue" |  "red")) => {
    |                       -             ^^^^^ pattern doesn't bind `x`

--- a/tests/ui/or-patterns/inner-or-pat.rs
+++ b/tests/ui/or-patterns/inner-or-pat.rs
@@ -1,7 +1,5 @@
-//@ revisions: or1 or2 or3 or4 or5
+//@ revisions: or1 or3 or4
 //@ [or1] run-pass
-//@ [or2] run-pass
-//@ [or5] run-pass
 
 #![allow(unreachable_patterns)]
 #![allow(unused_variables)]

--- a/tests/ui/or-patterns/issue-70413-no-unreachable-pat-and-guard.rs
+++ b/tests/ui/or-patterns/issue-70413-no-unreachable-pat-and-guard.rs
@@ -1,21 +1,20 @@
-//@ check-pass
+//@ run-pass
 
 #![deny(unreachable_patterns)]
 
 fn main() {
-    match (3,42) {
-        (a,_) | (_,a) if a > 10 => {println!("{}", a)}
-        _ => ()
+    match (3, 42) {
+        (a, _) | (_, a) if a > 10 => {}
+        _ => unreachable!(),
     }
 
-    match Some((3,42)) {
-        Some((a, _)) | Some((_, a)) if a > 10 => {println!("{}", a)}
-        _ => ()
-
+    match Some((3, 42)) {
+        Some((a, _)) | Some((_, a)) if a > 10 => {}
+        _ => unreachable!(),
     }
 
-    match Some((3,42)) {
-        Some((a, _) | (_, a)) if a > 10 => {println!("{}", a)}
-        _ => ()
+    match Some((3, 42)) {
+        Some((a, _) | (_, a)) if a > 10 => {}
+        _ => unreachable!(),
     }
 }

--- a/tests/ui/or-patterns/search-via-bindings.rs
+++ b/tests/ui/or-patterns/search-via-bindings.rs
@@ -42,6 +42,23 @@ fn search_old_style(target: (bool, bool, bool)) -> u32 {
     }
 }
 
+// Check that a dummy or-pattern also leads to running the guard multiple times.
+fn search_with_dummy(target: (bool, bool)) -> u32 {
+    let x = ((false, true), (false, true), ());
+    let mut guard_count = 0;
+    match x {
+        ((a, _) | (_, a), (b, _) | (_, b), _ | _)
+            if {
+                guard_count += 1;
+                (a, b) == target
+            } =>
+        {
+            guard_count
+        }
+        _ => unreachable!(),
+    }
+}
+
 fn main() {
     assert_eq!(search((false, false, false)), 1);
     assert_eq!(search((false, false, true)), 2);
@@ -60,4 +77,9 @@ fn main() {
     assert_eq!(search_old_style((true, false, true)), 6);
     assert_eq!(search_old_style((true, true, false)), 7);
     assert_eq!(search_old_style((true, true, true)), 8);
+
+    assert_eq!(search_with_dummy((false, false)), 1);
+    assert_eq!(search_with_dummy((false, true)), 3);
+    assert_eq!(search_with_dummy((true, false)), 5);
+    assert_eq!(search_with_dummy((true, true)), 7);
 }


### PR DESCRIPTION
Thanks to the recent refactoring work, we can now tell ahead of time whether the branches of an or-pattern must be kept separate or not. This PR uses this to simplify the or-pattern handling code a little bit. I also removed the `FIXME`s because I believe we are already merging as much as possible.

r? @matthewjasper 