### PR TITLE
Experiment: Don't initialize `ThreadInfo` in main if there's no `Guard`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
           - name: x86_64-gnu-tools
             os: ubuntu-20.04-16core-64gb
             env: {}
+          - name: test-various
+            os: ubuntu-20.04-8core-32gb
+            env: {}
     defaults:
       run:
         shell: "${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash' }}"

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -97,12 +97,14 @@ unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
         sys::init(argc, argv, sigpipe);
 
         let main_guard = sys::thread::guard::init();
-        // Next, set up the current Thread with the guard information we just
-        // created. Note that this isn't necessary in general for new threads,
-        // but we just do this to name the main thread and to give it correct
-        // info about the stack bounds.
-        let thread = Thread::new(Some(rtunwrap!(Ok, CString::new("main"))));
-        thread_info::set(main_guard, thread);
+        if main_guard.is_some() {
+            // Next, set up the current Thread with the guard information we just
+            // created. Note that this isn't necessary in general for new threads,
+            // but we just do this to name the main thread and to give it correct
+            // info about the stack bounds.
+            let thread = Thread::new(Some(rtunwrap!(Ok, CString::new("main"))));
+            thread_info::set(main_guard, thread);
+        }
     }
 }
 

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -365,6 +365,9 @@ jobs:
           - name: x86_64-gnu-tools
             <<: *job-linux-16c
 
+          - name: test-various
+            <<: *job-linux-8c
+
   auto:
     <<: *base-ci-job
     name: auto - ${{ matrix.name }}


### PR DESCRIPTION
I'd like to make this change on Windows but I want to see if it can be done on other platforms that also don't use a `Guard`.

r? ghost