### PR TITLE
Add `p=1` to weekly `cargo update`

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -20,6 +20,8 @@ env:
   PR_MESSAGE: |
     Automation to keep dependencies in `Cargo.lock` current.
 
+    @bors p=1
+
     The following is the output from `cargo update`:
   COMMIT_MESSAGE: "cargo update \n\n"
 


### PR DESCRIPTION
Since bumping dependencies tends to be very conflictly.

Blocked on https://github.com/rust-lang/homu/pull/211 (if that takes a while this could just be a followup comment instead).