### PR TITLE
Windows: Don't initialize `thread_info` in main

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -97,12 +97,15 @@ unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
         sys::init(argc, argv, sigpipe);
 
         let main_guard = sys::thread::guard::init();
-        // Next, set up the current Thread with the guard information we just
-        // created. Note that this isn't necessary in general for new threads,
-        // but we just do this to name the main thread and to give it correct
-        // info about the stack bounds.
-        let thread = Thread::new(Some(rtunwrap!(Ok, CString::new("main"))));
-        thread_info::set(main_guard, thread);
+        // Setting thread_info from main is unnecessary on some platforms (i.e. Windows)
+        if !sys::thread::LAZY_INIT_MAIN_THREAD_INFO || main_guard.is_some() {
+            // Next, set up the current Thread with the guard information we just
+            // created. Note that this isn't necessary in general for new threads,
+            // but we just do this to name the main thread and to give it correct
+            // info about the stack bounds.
+            let thread = Thread::new(Some(rtunwrap!(Ok, CString::new("main"))));
+            thread_info::set(main_guard, thread);
+        }
     }
 }
 

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -19,6 +19,7 @@ unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 1 << 20;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     pub unsafe fn new_with_coreid(

--- a/library/std/src/sys/pal/itron/thread.rs
+++ b/library/std/src/sys/pal/itron/thread.rs
@@ -86,6 +86,7 @@ const LIFECYCLE_EXITED_OR_FINISHED_OR_JOIN_FINALIZE: usize = usize::MAX;
 
 // 64KiB for 32-bit ISAs, 128KiB for 64-bit ISAs.
 pub const DEFAULT_MIN_STACK_SIZE: usize = 0x4000 * crate::mem::size_of::<usize>();
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     /// # Safety

--- a/library/std/src/sys/pal/sgx/thread.rs
+++ b/library/std/src/sys/pal/sgx/thread.rs
@@ -10,6 +10,7 @@ use super::abi::usercalls;
 pub struct Thread(task_queue::JoinHandle);
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 pub use self::task_queue::JoinNotifier;
 

--- a/library/std/src/sys/pal/teeos/thread.rs
+++ b/library/std/src/sys/pal/teeos/thread.rs
@@ -10,6 +10,7 @@ use crate::sys::os;
 use crate::time::Duration;
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 8 * 1024;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 pub struct Thread {
     id: libc::pthread_t,

--- a/library/std/src/sys/pal/uefi/thread.rs
+++ b/library/std/src/sys/pal/uefi/thread.rs
@@ -8,6 +8,7 @@ use crate::time::Duration;
 pub struct Thread(!);
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -19,6 +19,7 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
 pub const DEFAULT_MIN_STACK_SIZE: usize = 256 * 1024;
 #[cfg(target_os = "espidf")]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 0; // 0 indicates that the stack size configured in the ESP-IDF menuconfig system should be used
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 #[cfg(target_os = "fuchsia")]
 mod zircon {

--- a/library/std/src/sys/pal/unsupported/thread.rs
+++ b/library/std/src/sys/pal/unsupported/thread.rs
@@ -7,6 +7,7 @@ use crate::time::Duration;
 pub struct Thread(!);
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements

--- a/library/std/src/sys/pal/wasi/thread.rs
+++ b/library/std/src/sys/pal/wasi/thread.rs
@@ -67,6 +67,7 @@ cfg_if::cfg_if! {
 }
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements

--- a/library/std/src/sys/pal/wasm/atomics/thread.rs
+++ b/library/std/src/sys/pal/wasm/atomics/thread.rs
@@ -7,6 +7,7 @@ use crate::time::Duration;
 pub struct Thread(!);
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -16,6 +16,7 @@ use super::time::WaitableTimer;
 use super::to_u16s;
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = true;
 
 pub struct Thread {
     handle: Handle,

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -16,7 +16,9 @@ use super::time::WaitableTimer;
 use super::to_u16s;
 
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
-pub const LAZY_INIT_MAIN_THREAD_INFO: bool = true;
+// Miri doesn't currently implement the GetThreadDescription function,
+// which is necessary for its test suite unless main's thread_info is initialized.
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = if cfg!(miri) { false } else { true };
 
 pub struct Thread {
     handle: Handle,

--- a/library/std/src/sys/pal/xous/thread.rs
+++ b/library/std/src/sys/pal/xous/thread.rs
@@ -16,6 +16,7 @@ pub struct Thread {
 pub const DEFAULT_MIN_STACK_SIZE: usize = 131072;
 const MIN_STACK_SIZE: usize = 4096;
 pub const GUARD_PAGE_SIZE: usize = 4096;
+pub const LAZY_INIT_MAIN_THREAD_INFO: bool = false;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements


### PR DESCRIPTION
I've been trying to reduce the "runtime" a bit on Windows and it occurred to me that `thread_info` can be lazily initialized on first use rather than in main. This allows it to be optimized out if it's not used. I tried generalizing this to any platform that doesn't set a guard but unfortunately it failed in tests so I made this a Windows specific change for now. Out of an abundance of caution though I do still makes sure the `Guard` is `None`.