### PR TITLE
library/ptr: mention that ptr::without_provenance is equivalent to deriving from the null ptr

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -574,6 +574,8 @@ pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
 
 /// Creates a pointer with the given address and no provenance.
 ///
+/// This is equivalent to `ptr::null().with_addr(addr)`.
+///
 /// Without provenance, this pointer is not associated with any actual allocation. Such a
 /// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
 /// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
@@ -615,6 +617,8 @@ pub const fn dangling<T>() -> *const T {
 }
 
 /// Creates a pointer with the given address and no provenance.
+///
+/// This is equivalent to `ptr::null_mut().with_addr(addr)`.
 ///
 /// Without provenance, this pointer is not associated with any actual allocation. Such a
 /// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but


### PR DESCRIPTION
This might help clarify why you can't do memory accesses with it.