### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -929,6 +929,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         omit_gdb_pretty_printer_section, Normal, template!(Word), WarnFollowing,
         "the `#[omit_gdb_pretty_printer_section]` attribute is just used for the Rust test suite",
     ),
+    rustc_attr!(
+        TEST, pattern_complexity, CrateLevel, template!(NameValueStr: "N"),
+        ErrorFollowing, @only_local: true,
+    ),
 ];
 
 pub fn deprecated_attributes() -> Vec<&'static BuiltinAttribute> {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -213,6 +213,8 @@ declare_features! (
     (internal, negative_bounds, "1.71.0", None),
     /// Allows using `#[omit_gdb_pretty_printer_section]`.
     (internal, omit_gdb_pretty_printer_section, "1.5.0", None),
+    /// Set the maximum pattern complexity allowed (not limited by default).
+    (internal, pattern_complexity, "CURRENT_RUSTC_VERSION", None),
     /// Allows using `#[prelude_import]` on glob `use` items.
     (internal, prelude_import, "1.2.0", None),
     /// Used to identify crates that contain the profiler runtime.

--- a/compiler/rustc_middle/src/middle/limits.rs
+++ b/compiler/rustc_middle/src/middle/limits.rs
@@ -40,6 +40,13 @@ pub fn get_recursion_limit(krate_attrs: &[Attribute], sess: &Session) -> Limit {
 }
 
 fn get_limit(krate_attrs: &[Attribute], sess: &Session, name: Symbol, default: usize) -> Limit {
+    match get_limit_size(krate_attrs, sess, name) {
+        Some(size) => Limit::new(size),
+        None => Limit::new(default),
+    }
+}
+
+pub fn get_limit_size(krate_attrs: &[Attribute], sess: &Session, name: Symbol) -> Option<usize> {
     for attr in krate_attrs {
         if !attr.has_name(name) {
             continue;
@@ -47,7 +54,7 @@ fn get_limit(krate_attrs: &[Attribute], sess: &Session, name: Symbol, default: u
 
         if let Some(s) = attr.value_str() {
             match s.as_str().parse() {
-                Ok(n) => return Limit::new(n),
+                Ok(n) => return Some(n),
                 Err(e) => {
                     let value_span = attr
                         .meta()
@@ -69,5 +76,5 @@ fn get_limit(krate_attrs: &[Attribute], sess: &Session, name: Symbol, default: u
             }
         }
     }
-    return Limit::new(default);
+    None
 }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -895,6 +895,11 @@ impl<'p, 'tcx: 'p> TypeCx for RustcMatchCheckCtxt<'p, 'tcx> {
             errors::OverlappingRangeEndpoints { overlap: overlaps, range: pat_span },
         );
     }
+
+    fn complexity_exceeded(&self) -> Result<(), Self::Error> {
+        let span = self.whole_match_span.unwrap_or(self.scrut_span);
+        Err(self.tcx.dcx().span_err(span, "reached pattern complexity limit"))
+    }
 }
 
 /// Recursively expand this pattern into its subpatterns. Only useful for or-patterns.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1273,6 +1273,7 @@ symbols! {
         pat,
         pat_param,
         path,
+        pattern_complexity,
         pattern_parentheses,
         phantom_data,
         pic,

--- a/library/std/src/sys/pal/wasm/atomics/thread.rs
+++ b/library/std/src/sys/pal/wasm/atomics/thread.rs
@@ -1,4 +1,5 @@
 use crate::ffi::CStr;
+use crate::ffi::CString;
 use crate::io;
 use crate::num::NonZero;
 use crate::sys::unsupported;
@@ -17,6 +18,9 @@ impl Thread {
     pub fn yield_now() {}
 
     pub fn set_name(_name: &CStr) {}
+    pub fn get_name() -> Option<CString> {
+        None
+    }
 
     pub fn sleep(dur: Duration) {
         use crate::arch::wasm32;

--- a/tests/ui/feature-gates/feature-gate-pattern-complexity.rs
+++ b/tests/ui/feature-gates/feature-gate-pattern-complexity.rs
@@ -1,0 +1,6 @@
+// check that `pattern_complexity` is feature-gated
+
+#![pattern_complexity = "42"]
+//~^ ERROR: the `#[pattern_complexity]` attribute is just used for rustc unit tests
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pattern-complexity.stderr
+++ b/tests/ui/feature-gates/feature-gate-pattern-complexity.stderr
@@ -1,0 +1,12 @@
+error[E0658]: the `#[pattern_complexity]` attribute is just used for rustc unit tests and will never be stable
+  --> $DIR/feature-gate-pattern-complexity.rs:3:1
+   |
+LL | #![pattern_complexity = "42"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/pattern/complexity_limit.rs
+++ b/tests/ui/pattern/complexity_limit.rs
@@ -1,7 +1,7 @@
 #![feature(rustc_attrs)]
-#![pattern_complexity = "61"]
+#![pattern_complexity = "10000"]
 
-//@ check-pass
+#[derive(Default)]
 struct BaseCommand {
     field01: bool,
     field02: bool,
@@ -36,7 +36,7 @@ struct BaseCommand {
 }
 
 fn request_key(command: BaseCommand) {
-    match command {
+    match command { //~ ERROR: reached pattern complexity limit
         BaseCommand { field01: true, .. } => {}
         BaseCommand { field02: true, .. } => {}
         BaseCommand { field03: true, .. } => {}
@@ -68,8 +68,39 @@ fn request_key(command: BaseCommand) {
         BaseCommand { field29: true, .. } => {}
         BaseCommand { field30: true, .. } => {}
 
-        _ => {}
+        BaseCommand { field01: false, .. } => {}
+        BaseCommand { field02: false, .. } => {}
+        BaseCommand { field03: false, .. } => {}
+        BaseCommand { field04: false, .. } => {}
+        BaseCommand { field05: false, .. } => {}
+        BaseCommand { field06: false, .. } => {}
+        BaseCommand { field07: false, .. } => {}
+        BaseCommand { field08: false, .. } => {}
+        BaseCommand { field09: false, .. } => {}
+        BaseCommand { field10: false, .. } => {}
+        BaseCommand { field11: false, .. } => {}
+        BaseCommand { field12: false, .. } => {}
+        BaseCommand { field13: false, .. } => {}
+        BaseCommand { field14: false, .. } => {}
+        BaseCommand { field15: false, .. } => {}
+        BaseCommand { field16: false, .. } => {}
+        BaseCommand { field17: false, .. } => {}
+        BaseCommand { field18: false, .. } => {}
+        BaseCommand { field19: false, .. } => {}
+        BaseCommand { field20: false, .. } => {}
+        BaseCommand { field21: false, .. } => {}
+        BaseCommand { field22: false, .. } => {}
+        BaseCommand { field23: false, .. } => {}
+        BaseCommand { field24: false, .. } => {}
+        BaseCommand { field25: false, .. } => {}
+        BaseCommand { field26: false, .. } => {}
+        BaseCommand { field27: false, .. } => {}
+        BaseCommand { field28: false, .. } => {}
+        BaseCommand { field29: false, .. } => {}
+        BaseCommand { field30: false, .. } => {}
     }
 }
 
-fn main() {}
+fn main() {
+    request_key(BaseCommand::default());
+}

--- a/tests/ui/pattern/complexity_limit.stderr
+++ b/tests/ui/pattern/complexity_limit.stderr
@@ -1,0 +1,14 @@
+error: reached pattern complexity limit
+  --> $DIR/complexity_limit.rs:39:5
+   |
+LL | /     match command {
+LL | |         BaseCommand { field01: true, .. } => {}
+LL | |         BaseCommand { field02: true, .. } => {}
+LL | |         BaseCommand { field03: true, .. } => {}
+...  |
+LL | |         BaseCommand { field30: false, .. } => {}
+LL | |     }
+   | |_____^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #121917 (Add new `pattern_complexity` attribute to add possibility to limit and check recursion in pattern matching)
 - #121933 (Add missing get_name for wasm::thread.)
 - #121934 (rustc_log: expose tracing-tree "wraparound" in an env var)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121917,121933,121934)
<!-- homu-ignore:end -->