### PR TITLE
 Support for Raw Pointers in `windows_process_extensions_raw_attribute` Implementation

### DIFF
--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -482,8 +482,11 @@ fn test_proc_thread_attributes() {
     let mut child_cmd = Command::new("cmd");
 
     unsafe {
-        child_cmd
-            .raw_attribute(PROC_THREAD_ATTRIBUTE_PARENT_PROCESS, parent.0.as_raw_handle() as isize);
+        child_cmd.raw_attribute(
+            PROC_THREAD_ATTRIBUTE_PARENT_PROCESS,
+            parent.0.as_raw_handle(),
+            mem::size_of::<HANDLE>(),
+        );
     }
 
     let child = ProcessDropGuard(child_cmd.spawn().unwrap());


### PR DESCRIPTION
As extensively discussed in issue #114854, the current implementation of the unstable `windows_process_extensions_raw_attribute` features lacks support for passing a raw pointer.

This PR addresses this issue by allowing the passing of raw pointer types to the `std::os::windows::CommandExt::raw_attribute` method, which is directly handed to the [`UpdateProcThreadAttribute`](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Threading/fn.UpdateProcThreadAttribute.html) Win32 API call.

This change does introduce some concerns with the necessity to pass a raw pointer, but considering this should be treated as a raw interface to set `ProcThreadAttributes`, there is no real alternative besides drastically increasing the complexity of the interface.