### PR TITLE
Don't run test_get_os_named_thread on win7

### DIFF
--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -70,7 +70,7 @@ fn test_named_thread_truncation() {
 }
 
 #[cfg(any(
-    target_os = "windows",
+    all(target_os = "windows", not(target_vendor = "win7")),
     target_os = "linux",
     target_os = "macos",
     target_os = "ios",


### PR DESCRIPTION
This test won't work on windows 7, as the Thread::set_name function is not implemented there (win7 does not provide a documented mechanism to set thread names).