### PR TITLE
Give deadlock handler access to `GlobalCtxt`

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -43,6 +43,9 @@ pub struct Compiler {
     pub compiler_for_deadlock_handler: Arc<AtomicPtr<()>>,
 }
 
+impl !Sync for Compiler {}
+impl !rustc_data_structures::sync::DynSync for Compiler {}
+
 /// Converts strings provided as `--cfg [cfgspec]` into a `Cfg`.
 pub(crate) fn parse_cfg(dcx: &DiagCtxt, cfgs: Vec<String>) -> Cfg {
     cfgs.into_iter()

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(let_chains)]
 #![feature(thread_spawn_unchecked)]
 #![feature(try_blocks)]
+#![feature(negative_impls)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
Doesn't work yet, because we try to share a `Compiler` across thread boundaries, which mostly doesn't work because some things like `FreezeLock` are not `Sync`, but only `DynSync`.

intended as a replacement for  #115220

cc @Zoxc do you think this is doable once we nuke the non-parallel-compiler cfgs and do some cleanups by using the thread safe sync primitives everywhere?