### PR TITLE
link libunwind dynamically and allow controlling it via `crt-static` on gnullvm targets

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -42,6 +42,8 @@ pub(crate) fn opts() -> TargetOptions {
         eh_frame_header: false,
         no_default_libraries: false,
         has_thread_local: true,
+        crt_static_allows_dylibs: true,
+        crt_static_respected: true,
         // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
         // output DWO, despite using DWARF, doesn't use ELF..
         debuginfo_kind: DebuginfoKind::Pdb,

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -180,3 +180,8 @@ cfg_if::cfg_if! {
 #[cfg(target_os = "hurd")]
 #[link(name = "gcc_s")]
 extern "C" {}
+
+#[cfg(all(target_os = "windows", target_env = "gnu", target_abi = "llvm"))]
+#[link(name = "unwind", kind = "static", modifiers = "-bundle", cfg(target_feature = "crt-static"))]
+#[link(name = "unwind", cfg(not(target_feature = "crt-static")))]
+extern "C" {}

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -102,12 +102,9 @@ pub type _Unwind_Exception_Cleanup_Fn =
 // rustc_codegen_ssa::src::back::symbol_export, rustc_middle::middle::exported_symbols
 // and RFC 2841
 #[cfg_attr(
-    any(
-        all(
-            feature = "llvm-libunwind",
-            any(target_os = "fuchsia", target_os = "linux", target_os = "xous")
-        ),
-        all(target_os = "windows", target_env = "gnu", target_abi = "llvm")
+    all(
+        feature = "llvm-libunwind",
+        any(target_os = "fuchsia", target_os = "linux", target_os = "xous")
     ),
     link(name = "unwind", kind = "static", modifiers = "-bundle")
 )]


### PR DESCRIPTION
Alternative to https://github.com/rust-lang/rust/pull/121794

```
$ cargo b -r
    Finished `release` profile [optimized] target(s) in 0.38s

$ ntldd target/release/hello.exe | rg unwind
        libunwind.dll => H:\msys64\clang64\bin\libunwind.dll (0x0000020c35df0000)

$ RUSTFLAGS="-C target-feature=+crt-static" cargo b -r
    Finished `release` profile [optimized] target(s) in 0.23s

$ ntldd target/release/hello.exe | rg unwind
```