### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -764,10 +764,28 @@ impl<'hir> LoweringContext<'_, 'hir> {
             Some(hir::CoroutineKind::Coroutine(_))
             | Some(hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::Gen, _))
             | None => {
-                return hir::ExprKind::Err(self.dcx().emit_err(AwaitOnlyInAsyncFnAndBlocks {
-                    await_kw_span,
-                    item_span: self.current_item,
-                }));
+                // Lower to a block `{ EXPR; <error> }` so that the awaited expr
+                // is not accidentally orphaned.
+                let stmt_id = self.next_id();
+                let expr_err = self.expr(
+                    expr.span,
+                    hir::ExprKind::Err(self.dcx().emit_err(AwaitOnlyInAsyncFnAndBlocks {
+                        await_kw_span,
+                        item_span: self.current_item,
+                    })),
+                );
+                return hir::ExprKind::Block(
+                    self.block_all(
+                        expr.span,
+                        arena_vec![self; hir::Stmt {
+                            hir_id: stmt_id,
+                            kind: hir::StmtKind::Semi(expr),
+                            span: expr.span,
+                        }],
+                        Some(self.arena.alloc(expr_err)),
+                    ),
+                    None,
+                );
             }
         };
 
@@ -1500,12 +1518,31 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn lower_expr_yield(&mut self, span: Span, opt_expr: Option<&Expr>) -> hir::ExprKind<'hir> {
+        let yielded =
+            opt_expr.as_ref().map(|x| self.lower_expr(x)).unwrap_or_else(|| self.expr_unit(span));
+
         let is_async_gen = match self.coroutine_kind {
             Some(hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::Gen, _)) => false,
             Some(hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::AsyncGen, _)) => true,
             Some(hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::Async, _)) => {
-                return hir::ExprKind::Err(
-                    self.dcx().emit_err(AsyncCoroutinesNotSupported { span }),
+                // Lower to a block `{ EXPR; <error> }` so that the awaited expr
+                // is not accidentally orphaned.
+                let stmt_id = self.next_id();
+                let expr_err = self.expr(
+                    yielded.span,
+                    hir::ExprKind::Err(self.dcx().emit_err(AsyncCoroutinesNotSupported { span })),
+                );
+                return hir::ExprKind::Block(
+                    self.block_all(
+                        yielded.span,
+                        arena_vec![self; hir::Stmt {
+                            hir_id: stmt_id,
+                            kind: hir::StmtKind::Semi(yielded),
+                            span: yielded.span,
+                        }],
+                        Some(self.arena.alloc(expr_err)),
+                    ),
+                    None,
                 );
             }
             Some(hir::CoroutineKind::Coroutine(_)) => {
@@ -1534,9 +1571,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 false
             }
         };
-
-        let yielded =
-            opt_expr.as_ref().map(|x| self.lower_expr(x)).unwrap_or_else(|| self.expr_unit(span));
 
         if is_async_gen {
             // `yield $expr` is transformed into `task_context = yield async_gen_ready($expr)`.

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -297,7 +297,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     FloatTy::F128 => unimplemented!("f16_f128"),
                 }
             }
-            // unsiged int -> float
+            // unsigned int -> float
             Float(fty) => match fty {
                 FloatTy::F16 => unimplemented!("f16_f128"),
                 FloatTy::F32 => Scalar::from_f32(Single::from_u128(v).value),

--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -182,13 +182,14 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     ) -> InterpResult<'tcx, ImmTy<'tcx, M::Provenance>> {
         use rustc_type_ir::TyKind::*;
 
-        let val = match src.layout.ty.kind() {
-            // Floating point
-            Float(FloatTy::F32) => self.cast_from_float(src.to_scalar().to_f32()?, cast_to.ty),
-            Float(FloatTy::F64) => self.cast_from_float(src.to_scalar().to_f64()?, cast_to.ty),
-            _ => {
-                bug!("Can't cast 'Float' type into {}", cast_to.ty);
-            }
+        let Float(fty) = src.layout.ty.kind() else {
+            bug!("FloatToFloat/FloatToInt cast: source type {} is not a float type", src.layout.ty)
+        };
+        let val = match fty {
+            FloatTy::F16 => unimplemented!("f16_f128"),
+            FloatTy::F32 => self.cast_from_float(src.to_scalar().to_f32()?, cast_to.ty),
+            FloatTy::F64 => self.cast_from_float(src.to_scalar().to_f64()?, cast_to.ty),
+            FloatTy::F128 => unimplemented!("f16_f128"),
         };
         Ok(ImmTy::from_scalar(val, cast_to))
     }
@@ -275,6 +276,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         trace!("cast_from_scalar: {}, {} -> {}", v, src_layout.ty, cast_ty);
 
         Ok(match *cast_ty.kind() {
+            // int -> int
             Int(_) | Uint(_) => {
                 let size = match *cast_ty.kind() {
                     Int(t) => Integer::from_int_ty(self, t).size(),
@@ -285,15 +287,26 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Scalar::from_uint(v, size)
             }
 
-            Float(FloatTy::F32) if signed => Scalar::from_f32(Single::from_i128(v as i128).value),
-            Float(FloatTy::F64) if signed => Scalar::from_f64(Double::from_i128(v as i128).value),
-            Float(FloatTy::F32) => Scalar::from_f32(Single::from_u128(v).value),
-            Float(FloatTy::F64) => Scalar::from_f64(Double::from_u128(v).value),
-
-            Char => {
-                // `u8` to `char` cast
-                Scalar::from_u32(u8::try_from(v).unwrap().into())
+            // signed int -> float
+            Float(fty) if signed => {
+                let v = v as i128;
+                match fty {
+                    FloatTy::F16 => unimplemented!("f16_f128"),
+                    FloatTy::F32 => Scalar::from_f32(Single::from_i128(v).value),
+                    FloatTy::F64 => Scalar::from_f64(Double::from_i128(v).value),
+                    FloatTy::F128 => unimplemented!("f16_f128"),
+                }
             }
+            // unsiged int -> float
+            Float(fty) => match fty {
+                FloatTy::F16 => unimplemented!("f16_f128"),
+                FloatTy::F32 => Scalar::from_f32(Single::from_u128(v).value),
+                FloatTy::F64 => Scalar::from_f64(Double::from_u128(v).value),
+                FloatTy::F128 => unimplemented!("f16_f128"),
+            },
+
+            // u8 -> char
+            Char => Scalar::from_u32(u8::try_from(v).unwrap().into()),
 
             // Casts to bool are not permitted by rustc, no need to handle them here.
             _ => span_bug!(self.cur_span(), "invalid int to {} cast", cast_ty),
@@ -339,14 +352,13 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let v = f.to_i128(size.bits_usize()).value;
                 Scalar::from_int(v, size)
             }
-            // float -> f32
-            Float(FloatTy::F32) => {
-                Scalar::from_f32(adjust_nan(self, f, f.convert(&mut false).value))
-            }
-            // float -> f64
-            Float(FloatTy::F64) => {
-                Scalar::from_f64(adjust_nan(self, f, f.convert(&mut false).value))
-            }
+            // float -> float
+            Float(fty) => match fty {
+                FloatTy::F16 => unimplemented!("f16_f128"),
+                FloatTy::F32 => Scalar::from_f32(adjust_nan(self, f, f.convert(&mut false).value)),
+                FloatTy::F64 => Scalar::from_f64(adjust_nan(self, f, f.convert(&mut false).value)),
+                FloatTy::F128 => unimplemented!("f16_f128"),
+            },
             // That's it.
             _ => span_bug!(self.cur_span(), "invalid float to {} cast", dest_ty),
         }

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -166,7 +166,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return false;
         }
 
-        match ty.kind() {
+        match ty.peel_refs().kind() {
             ty::Param(param) => {
                 let generics = self.tcx.generics_of(self.body_id);
                 let generic_param = generics.type_param(&param, self.tcx);
@@ -184,7 +184,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
             }
-            ty::Alias(ty::AliasKind::Opaque, _) => {
+            ty::Slice(..) | ty::Adt(..) | ty::Alias(ty::AliasKind::Opaque, _) => {
                 for unsatisfied in unsatisfied_predicates.iter() {
                     if is_iterator_predicate(unsatisfied.0, self.tcx) {
                         return true;

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -285,9 +285,8 @@ where
                     let lock = query.query_state(qcx).active.get_shard_by_value(&key).lock();
 
                     match lock.get(&key) {
-                        Some(QueryResult::Poisoned) => {
-                            panic!("query '{}' not cached due to poisoning", query.name())
-                        }
+                        // The query we waited on panicked. Continue unwinding here.
+                        Some(QueryResult::Poisoned) => FatalError.raise(),
                         _ => panic!(
                             "query '{}' result must be in the cache or the query must be poisoned after a wait",
                             query.name()

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/type_err_ctxt_ext.rs
@@ -416,9 +416,51 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     ty::PredicateKind::Clause(ty::ClauseKind::Trait(trait_predicate)) => {
                         let trait_predicate = bound_predicate.rebind(trait_predicate);
                         let trait_predicate = self.resolve_vars_if_possible(trait_predicate);
-                        let trait_ref = trait_predicate.to_poly_trait_ref();
 
-                        if let Some(guar) = self.emit_specialized_closure_kind_error(&obligation, trait_ref) {
+                        // Let's use the root obligation as the main message, when we care about the
+                        // most general case ("X doesn't implement Pattern<'_>") over the case that
+                        // happened to fail ("char doesn't implement Fn(&mut char)").
+                        //
+                        // We rely on a few heuristics to identify cases where this root
+                        // obligation is more important than the leaf obligation:
+                        let (main_trait_predicate, o) = if let ty::PredicateKind::Clause(
+                            ty::ClauseKind::Trait(root_pred)
+                        ) = root_obligation.predicate.kind().skip_binder()
+                            // The type of the leaf predicate is (roughly) the same as the type
+                            // from the root predicate, as a proxy for "we care about the root"
+                            // FIXME: this doesn't account for trivial derefs, but works as a first
+                            // approximation.
+                            && (
+                                // `T: Trait` && `&&T: OtherTrait`, we want `OtherTrait`
+                                trait_predicate.self_ty().skip_binder()
+                                    == root_pred.self_ty().peel_refs()
+                                // `&str: Iterator` && `&str: IntoIterator`, we want `IntoIterator`
+                                || trait_predicate.self_ty().skip_binder()
+                                    == root_pred.self_ty()
+                            )
+                            // The leaf trait and the root trait are different, so as to avoid
+                            // talking about `&mut T: Trait` and instead remain talking about
+                            // `T: Trait` instead
+                            && trait_predicate.def_id() != root_pred.def_id()
+                            // The root trait is not `Unsize`, as to avoid talking about it in
+                            // `tests/ui/coercion/coerce-issue-49593-box-never.rs`.
+                            && Some(root_pred.def_id()) != self.tcx.lang_items().unsize_trait()
+                        {
+                            (
+                                self.resolve_vars_if_possible(
+                                    root_obligation.predicate.kind().rebind(root_pred),
+                                ),
+                                root_obligation,
+                            )
+                        } else {
+                            (trait_predicate, &obligation)
+                        };
+                        let trait_ref = main_trait_predicate.to_poly_trait_ref();
+
+                        if let Some(guar) = self.emit_specialized_closure_kind_error(
+                            &obligation,
+                            trait_ref,
+                        ) {
                             return guar;
                         }
 
@@ -459,8 +501,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             notes,
                             parent_label,
                             append_const_msg,
-                        } = self.on_unimplemented_note(trait_ref, &obligation, &mut long_ty_file);
-
+                        } = self.on_unimplemented_note(trait_ref, o, &mut long_ty_file);
                         let have_alt_message = message.is_some() || label.is_some();
                         let is_try_conversion = self.is_try_conversion(span, trait_ref.def_id());
                         let is_unsize =
@@ -483,7 +524,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         };
 
                         let err_msg = self.get_standard_error_message(
-                            &trait_predicate,
+                            &main_trait_predicate,
                             message,
                             predicate_is_const,
                             append_const_msg,

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -944,6 +944,21 @@ impl<T, A: Allocator> Rc<T, A> {
     /// is in fact equivalent to <code>[Rc::try_unwrap]\(this).[ok][Result::ok]()</code>.
     /// (Note that the same kind of equivalence does **not** hold true for
     /// [`Arc`](crate::sync::Arc), due to race conditions that do not apply to `Rc`!)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    ///
+    /// let x = Rc::new(3);
+    /// assert_eq!(Rc::into_inner(x), Some(3));
+    ///
+    /// let x = Rc::new(4);
+    /// let y = Rc::clone(&x);
+    ///
+    /// assert_eq!(Rc::into_inner(y), None);
+    /// assert_eq!(Rc::into_inner(x), Some(4));
+    /// ```
     #[inline]
     #[stable(feature = "rc_into_inner", since = "1.70.0")]
     pub fn into_inner(this: Self) -> Option<T> {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1329,6 +1329,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
     /// let x_ptr = Rc::into_raw(x);
     /// assert_eq!(unsafe { &*x_ptr }, "hello");
     /// ```
+    #[must_use = "losing the pointer will leak memory"]
     #[stable(feature = "rc_raw", since = "1.17.0")]
     #[rustc_never_returns_null_ptr]
     pub fn into_raw(this: Self) -> *const T {
@@ -2966,7 +2967,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     ///
     /// [`from_raw`]: Weak::from_raw
     /// [`as_ptr`]: Weak::as_ptr
-    #[must_use = "`self` will be dropped if the result is not used"]
+    #[must_use = "losing the pointer will leak memory"]
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn into_raw(self) -> *const T {
         let result = self.as_ptr();

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2715,7 +2715,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     ///
     /// [`from_raw`]: Weak::from_raw
     /// [`as_ptr`]: Weak::as_ptr
-    #[must_use = "`self` will be dropped if the result is not used"]
+    #[must_use = "losing the pointer will leak memory"]
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub fn into_raw(self) -> *const T {
         let result = self.as_ptr();

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1493,7 +1493,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Time complexity
     ///
-    /// Takes *O*(`len`) time. All items after the insertion index must be
+    /// Takes *O*([`Vec::len`]) time. All items after the insertion index must be
     /// shifted to the right. In the worst case, all elements are shifted when
     /// the insertion index is 0.
     #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1922,10 +1922,9 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Time complexity
     ///
     /// Takes amortized *O*(1) time. If the vector's length would exceed its
-    /// capacity after the push, the capacity is doubled by allocating
-    /// *O*(*capacity*) space, then *O*(*capacity*) time to copy the vector's
-    /// elements. This expensive operation is offset by the *capacity* *O*(1)
-    /// insertions it allows.
+    /// capacity after the push, *O*(*capacity*) time is taken to copy the
+    /// vector's elements to a larger allocation. This expensive operation is
+    /// offset by the *capacity* *O*(1) insertions it allows.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1490,6 +1490,12 @@ impl<T, A: Allocator> Vec<T, A> {
     /// vec.insert(4, 5);
     /// assert_eq!(vec, [1, 4, 2, 3, 5]);
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(`len`) time. All items after the insertion index must be
+    /// shifted to the right. In the worst case, all elements are shifted when
+    /// the insertion index is 0.
     #[cfg(not(no_global_oom_handling))]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn insert(&mut self, index: usize, element: T) {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1912,6 +1912,13 @@ impl<T, A: Allocator> Vec<T, A> {
     /// vec.push(3);
     /// assert_eq!(vec, [1, 2, 3]);
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes amortized *O*(1) time. If the vector's length would exceed its capacity after
+    /// the push,*O*(*capacity*) space is allocated, doubling the capacity and
+    /// taking *O*(*capacity*) time. This expensive operation is offset by the
+    /// *capacity* *O*(1) insertions it allows.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1922,7 +1922,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Time complexity
     ///
     /// Takes amortized *O*(1) time. If the vector's length would exceed its capacity after
-    /// the push,*O*(*capacity*) space is allocated, doubling the capacity and
+    /// the push, *O*(*capacity*) space is allocated, doubling the capacity and
     /// taking *O*(*capacity*) time. This expensive operation is offset by the
     /// *capacity* *O*(1) insertions it allows.
     #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1921,10 +1921,11 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Time complexity
     ///
-    /// Takes amortized *O*(1) time. If the vector's length would exceed its capacity after
-    /// the push, *O*(*capacity*) space is allocated, doubling the capacity and
-    /// taking *O*(*capacity*) time. This expensive operation is offset by the
-    /// *capacity* *O*(1) insertions it allows.
+    /// Takes amortized *O*(1) time. If the vector's length would exceed its
+    /// capacity after the push, the capacity is doubled by allocating
+    /// *O*(*capacity*) space, then *O*(*capacity*) time to copy the vector's
+    /// elements. This expensive operation is offset by the *capacity* *O*(1)
+    /// insertions it allows.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1999,6 +1999,10 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec.pop(), Some(3));
     /// assert_eq!(vec, [1, 2]);
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(1) time.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn pop(&mut self) -> Option<T> {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1966,6 +1966,10 @@ impl<T, A: Allocator> Vec<T, A> {
     /// }
     /// assert_eq!(from_iter_fallible(0..100), Ok(Vec::from_iter(0..100)));
     /// ```
+    ///
+    /// # Time complexity
+    ///
+    /// Takes *O*(1) time.
     #[inline]
     #[unstable(feature = "vec_push_within_capacity", issue = "100486")]
     pub fn push_within_capacity(&mut self, value: T) -> Result<(), T> {

--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -30,8 +30,7 @@ use crate::task::{Context, Poll};
 #[lang = "future_trait"]
 #[diagnostic::on_unimplemented(
     label = "`{Self}` is not a future",
-    message = "`{Self}` is not a future",
-    note = "{Self} must be a future or must implement `IntoFuture` to be awaited"
+    message = "`{Self}` is not a future"
 )]
 pub trait Future {
     /// The type of value produced on completion.

--- a/library/core/src/future/into_future.rs
+++ b/library/core/src/future/into_future.rs
@@ -100,6 +100,11 @@ use crate::future::Future;
 /// ```
 #[stable(feature = "into_future", since = "1.64.0")]
 #[rustc_diagnostic_item = "IntoFuture"]
+#[diagnostic::on_unimplemented(
+    label = "`{Self}` is not a future",
+    message = "`{Self}` is not a future",
+    note = "{Self} must be a future or must implement `IntoFuture` to be awaited"
+)]
 pub trait IntoFuture {
     /// The output that the future will produce on completion.
     #[stable(feature = "into_future", since = "1.64.0")]

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -236,6 +236,49 @@ pub trait FromIterator<A>: Sized {
 /// ```
 #[rustc_diagnostic_item = "IntoIterator"]
 #[rustc_skip_array_during_method_dispatch]
+#[rustc_on_unimplemented(
+    on(
+        _Self = "core::ops::range::RangeTo<Idx>",
+        label = "if you meant to iterate until a value, add a starting value",
+        note = "`..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a \
+              bounded `Range`: `0..end`"
+    ),
+    on(
+        _Self = "core::ops::range::RangeToInclusive<Idx>",
+        label = "if you meant to iterate until a value (including it), add a starting value",
+        note = "`..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant \
+              to have a bounded `RangeInclusive`: `0..=end`"
+    ),
+    on(
+        _Self = "[]",
+        label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
+    ),
+    on(_Self = "&[]", label = "`{Self}` is not an iterator; try calling `.iter()`"),
+    on(
+        _Self = "alloc::vec::Vec<T, A>",
+        label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
+    ),
+    on(
+        _Self = "&str",
+        label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
+    ),
+    on(
+        _Self = "alloc::string::String",
+        label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
+    ),
+    on(
+        _Self = "{integral}",
+        note = "if you want to iterate between `start` until a value `end`, use the exclusive range \
+              syntax `start..end` or the inclusive range syntax `start..=end`"
+    ),
+    on(
+        _Self = "{float}",
+        note = "if you want to iterate between `start` until a value `end`, use the exclusive range \
+              syntax `start..end` or the inclusive range syntax `start..=end`"
+    ),
+    label = "`{Self}` is not an iterator",
+    message = "`{Self}` is not an iterator"
+)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait IntoIterator {
     /// The type of the elements being iterated over.

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -34,15 +34,6 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
         _Self = "core::ops::range::RangeToInclusive<Idx>",
         note = "you might have meant to use a bounded `RangeInclusive`"
     ),
-    on(
-        _Self = "[]",
-        label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
-    ),
-    on(_Self = "&[]", label = "`{Self}` is not an iterator; try calling `.iter()`"),
-    on(
-        _Self = "alloc::vec::Vec<T, A>",
-        label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
-    ),
     label = "`{Self}` is not an iterator",
     message = "`{Self}` is not an iterator"
 )]

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -28,15 +28,11 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
 #[rustc_on_unimplemented(
     on(
         _Self = "core::ops::range::RangeTo<Idx>",
-        label = "if you meant to iterate until a value, add a starting value",
-        note = "`..end` is a `RangeTo`, which cannot be iterated on; you might have meant to have a \
-              bounded `Range`: `0..end`"
+        note = "you might have meant to use a bounded `Range`"
     ),
     on(
         _Self = "core::ops::range::RangeToInclusive<Idx>",
-        label = "if you meant to iterate until a value (including it), add a starting value",
-        note = "`..=end` is a `RangeToInclusive`, which cannot be iterated on; you might have meant \
-              to have a bounded `RangeInclusive`: `0..=end`"
+        note = "you might have meant to use a bounded `RangeInclusive`"
     ),
     on(
         _Self = "[]",
@@ -46,24 +42,6 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
     on(
         _Self = "alloc::vec::Vec<T, A>",
         label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
-    ),
-    on(
-        _Self = "&str",
-        label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
-    ),
-    on(
-        _Self = "alloc::string::String",
-        label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
-    ),
-    on(
-        _Self = "{integral}",
-        note = "if you want to iterate between `start` until a value `end`, use the exclusive range \
-              syntax `start..end` or the inclusive range syntax `start..=end`"
-    ),
-    on(
-        _Self = "{float}",
-        note = "if you want to iterate between `start` until a value `end`, use the exclusive range \
-              syntax `start..end` or the inclusive range syntax `start..=end`"
     ),
     label = "`{Self}` is not an iterator",
     message = "`{Self}` is not an iterator"

--- a/tests/ui/associated-types/substs-ppaux.normal.stderr
+++ b/tests/ui/associated-types/substs-ppaux.normal.stderr
@@ -70,13 +70,12 @@ help: use parentheses to call this function
 LL |     let x: () = foo::<'static>();
    |                               ++
 
-error[E0277]: the size for values of type `str` cannot be known at compilation time
+error[E0277]: the trait bound `str: Foo<'_, '_, u8>` is not satisfied
   --> $DIR/substs-ppaux.rs:49:6
    |
 LL |     <str as Foo<u8>>::bar;
-   |      ^^^ doesn't have a size known at compile-time
+   |      ^^^ the trait `Sized` is not implemented for `str`, which is required by `str: Foo<'_, '_, u8>`
    |
-   = help: the trait `Sized` is not implemented for `str`, which is required by `str: Foo<'_, '_, u8>`
 note: required for `str` to implement `Foo<'_, '_, u8>`
   --> $DIR/substs-ppaux.rs:11:17
    |

--- a/tests/ui/associated-types/substs-ppaux.rs
+++ b/tests/ui/associated-types/substs-ppaux.rs
@@ -47,6 +47,6 @@ fn foo<'z>() where &'z (): Sized {
     //[normal]~| found fn item `fn() {foo::<'static>}`
 
     <str as Foo<u8>>::bar;
-    //[verbose]~^ ERROR the size for values of type
-    //[normal]~^^ ERROR the size for values of type
+    //[verbose]~^ ERROR the trait bound `str: Foo<'?0, '?1, u8>` is not satisfied
+    //[normal]~^^ ERROR the trait bound `str: Foo<'_, '_, u8>` is not satisfied
 }

--- a/tests/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/tests/ui/associated-types/substs-ppaux.verbose.stderr
@@ -70,13 +70,12 @@ help: use parentheses to call this function
 LL |     let x: () = foo::<'static>();
    |                               ++
 
-error[E0277]: the size for values of type `str` cannot be known at compilation time
+error[E0277]: the trait bound `str: Foo<'?0, '?1, u8>` is not satisfied
   --> $DIR/substs-ppaux.rs:49:6
    |
 LL |     <str as Foo<u8>>::bar;
-   |      ^^^ doesn't have a size known at compile-time
+   |      ^^^ the trait `Sized` is not implemented for `str`, which is required by `str: Foo<'?0, '?1, u8>`
    |
-   = help: the trait `Sized` is not implemented for `str`, which is required by `str: Foo<'?0, '?1, u8>`
 note: required for `str` to implement `Foo<'?0, '?1, u8>`
   --> $DIR/substs-ppaux.rs:11:17
    |

--- a/tests/ui/async-await/async-error-span.stderr
+++ b/tests/ui/async-await/async-error-span.stderr
@@ -5,7 +5,6 @@ LL | fn get_future() -> impl Future<Output = ()> {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not a future
    |
    = help: the trait `Future` is not implemented for `()`
-   = note: () must be a future or must implement `IntoFuture` to be awaited
 
 error[E0282]: type annotations needed
   --> $DIR/async-error-span.rs:13:9

--- a/tests/ui/async-await/async-outside-of-await-issue-121096.rs
+++ b/tests/ui/async-await/async-outside-of-await-issue-121096.rs
@@ -1,0 +1,9 @@
+//@ edition:2021
+
+fn main() {
+    async {
+        use std::ops::Add;
+        let _ = 1.add(3);
+    }.await
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
+}

--- a/tests/ui/async-await/async-outside-of-await-issue-121096.stderr
+++ b/tests/ui/async-await/async-outside-of-await-issue-121096.stderr
@@ -1,0 +1,12 @@
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/async-outside-of-await-issue-121096.rs:7:7
+   |
+LL | fn main() {
+   |    ---- this is not `async`
+...
+LL |     }.await
+   |       ^^^^^ only allowed inside `async` functions and blocks
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0728`.

--- a/tests/ui/async-await/coroutine-not-future.stderr
+++ b/tests/ui/async-await/coroutine-not-future.stderr
@@ -49,7 +49,6 @@ LL |     takes_future(returns_coroutine());
    |     required by a bound introduced by this call
    |
    = help: the trait `Future` is not implemented for `impl Coroutine<Yield = (), Return = ()>`
-   = note: impl Coroutine<Yield = (), Return = ()> must be a future or must implement `IntoFuture` to be awaited
 note: required by a bound in `takes_future`
   --> $DIR/coroutine-not-future.rs:17:26
    |
@@ -69,7 +68,6 @@ LL | |     });
    | |_____^ `{coroutine@$DIR/coroutine-not-future.rs:41:18: 41:23}` is not a future
    |
    = help: the trait `Future` is not implemented for `{coroutine@$DIR/coroutine-not-future.rs:41:18: 41:23}`
-   = note: {coroutine@$DIR/coroutine-not-future.rs:41:18: 41:23} must be a future or must implement `IntoFuture` to be awaited
 note: required by a bound in `takes_future`
   --> $DIR/coroutine-not-future.rs:17:26
    |

--- a/tests/ui/auto-traits/typeck-default-trait-impl-precedence.rs
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-precedence.rs
@@ -17,5 +17,5 @@ impl Signed for i32 { }
 fn main() {
     is_defaulted::<&'static i32>();
     is_defaulted::<&'static u32>();
-    //~^ ERROR `u32: Signed` is not satisfied
+    //~^ ERROR the trait bound `&'static u32: Defaulted` is not satisfied
 }

--- a/tests/ui/auto-traits/typeck-default-trait-impl-precedence.stderr
+++ b/tests/ui/auto-traits/typeck-default-trait-impl-precedence.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `u32: Signed` is not satisfied
+error[E0277]: the trait bound `&'static u32: Defaulted` is not satisfied
   --> $DIR/typeck-default-trait-impl-precedence.rs:19:20
    |
 LL |     is_defaulted::<&'static u32>();
-   |                    ^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`, which is required by `&'static u32: Defaulted`
+   |                    ^^^^^^^^^^^^ the trait `Signed` is not implemented for `&'static u32`, which is required by `&'static u32: Defaulted`
    |
 note: required for `&'static u32` to implement `Defaulted`
   --> $DIR/typeck-default-trait-impl-precedence.rs:10:19

--- a/tests/ui/coroutine/gen_block_is_no_future.stderr
+++ b/tests/ui/coroutine/gen_block_is_no_future.stderr
@@ -5,7 +5,6 @@ LL | fn foo() -> impl std::future::Future {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:21}` is not a future
    |
    = help: the trait `Future` is not implemented for `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:21}`
-   = note: {gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:21} must be a future or must implement `IntoFuture` to be awaited
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -74,7 +74,6 @@ LL | fn use_for() where i32: Iterator {
    |                    ^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 

--- a/tests/ui/for/issue-20605.current.stderr
+++ b/tests/ui/for/issue-20605.current.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for values of type `dyn Iterator<Item = &'a mut u8>` cannot be known at compilation time
+error[E0277]: `dyn Iterator<Item = &'a mut u8>` is not an iterator
   --> $DIR/issue-20605.rs:5:17
    |
 LL |     for item in *things { *item = 0 }

--- a/tests/ui/for/issue-20605.next.stderr
+++ b/tests/ui/for/issue-20605.next.stderr
@@ -1,8 +1,10 @@
-error[E0277]: the trait bound `dyn Iterator<Item = &'a mut u8>: IntoIterator` is not satisfied
+error[E0277]: `dyn Iterator<Item = &'a mut u8>` is not an iterator
   --> $DIR/issue-20605.rs:5:17
    |
 LL |     for item in *things { *item = 0 }
-   |                 ^^^^^^^ the trait `IntoIterator` is not implemented for `dyn Iterator<Item = &'a mut u8>`
+   |                 ^^^^^^^ `dyn Iterator<Item = &'a mut u8>` is not an iterator
+   |
+   = help: the trait `IntoIterator` is not implemented for `dyn Iterator<Item = &'a mut u8>`
 
 error: the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
   --> $DIR/issue-20605.rs:5:17

--- a/tests/ui/for/issue-20605.rs
+++ b/tests/ui/for/issue-20605.rs
@@ -3,8 +3,8 @@
 
 fn changer<'a>(mut things: Box<dyn Iterator<Item=&'a mut u8>>) {
     for item in *things { *item = 0 }
-    //[current]~^ ERROR the size for values of type
-    //[next]~^^ ERROR the trait bound `dyn Iterator<Item = &'a mut u8>: IntoIterator` is not satisfied
+    //[current]~^ ERROR `dyn Iterator<Item = &'a mut u8>` is not an iterator
+    //[next]~^^ ERROR `dyn Iterator<Item = &'a mut u8>` is not an iterator
     //[next]~| ERROR the type `<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
     //[next]~| ERROR the type `&mut <dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter` is not well-formed
     //[next]~| ERROR the type `Option<<<dyn Iterator<Item = &'a mut u8> as IntoIterator>::IntoIter as Iterator>::Item>` is not well-formed

--- a/tests/ui/impl-trait/issues/issue-83919.stderr
+++ b/tests/ui/impl-trait/issues/issue-83919.stderr
@@ -5,7 +5,6 @@ LL |     fn get_fut(&self) -> Self::Fut {
    |                          ^^^^^^^^^ `{integer}` is not a future
    |
    = help: the trait `Future` is not implemented for `{integer}`
-   = note: {integer} must be a future or must implement `IntoFuture` to be awaited
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues-71798.stderr
+++ b/tests/ui/issues-71798.stderr
@@ -14,7 +14,6 @@ LL |     *x
    |     -- return type was inferred to be `u32` here
    |
    = help: the trait `Future` is not implemented for `u32`
-   = note: u32 must be a future or must implement `IntoFuture` to be awaited
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/iterators/bound.stderr
+++ b/tests/ui/iterators/bound.stderr
@@ -5,7 +5,6 @@ LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `u8`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 note: required by a bound in `S`
   --> $DIR/bound.rs:1:13
    |

--- a/tests/ui/iterators/vec-on-unimplemented.fixed
+++ b/tests/ui/iterators/vec-on-unimplemented.fixed
@@ -1,5 +1,5 @@
 //@ run-rustfix
 fn main() {
-    let _ = vec![true, false].map(|v| !v).collect::<Vec<_>>();
+    let _ = vec![true, false].into_iter().map(|v| !v).collect::<Vec<_>>();
     //~^ ERROR no method named `map` found for struct `Vec<bool>` in the current scope
 }

--- a/tests/ui/iterators/vec-on-unimplemented.stderr
+++ b/tests/ui/iterators/vec-on-unimplemented.stderr
@@ -1,14 +1,13 @@
-error[E0599]: `Vec<bool>` is not an iterator
-  --> $DIR/vec-on-unimplemented.rs:2:23
+error[E0599]: no method named `map` found for struct `Vec<bool>` in the current scope
+  --> $DIR/vec-on-unimplemented.rs:3:31
    |
-LL |     vec![true, false].map(|v| !v).collect::<Vec<_>>();
-   |                       ^^^ `Vec<bool>` is not an iterator; try calling `.into_iter()` or `.iter()`
+LL |     let _ = vec![true, false].map(|v| !v).collect::<Vec<_>>();
+   |                               ^^^ `Vec<bool>` is not an iterator
    |
-   = note: the following trait bounds were not satisfied:
-           `Vec<bool>: Iterator`
-           which is required by `&mut Vec<bool>: Iterator`
-           `[bool]: Iterator`
-           which is required by `&mut [bool]: Iterator`
+help: call `.into_iter()` first
+   |
+LL |     let _ = vec![true, false].into_iter().map(|v| !v).collect::<Vec<_>>();
+   |                               ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/kindck/kindck-impl-type-params-2.rs
+++ b/tests/ui/kindck/kindck-impl-type-params-2.rs
@@ -11,5 +11,5 @@ fn take_param<T:Foo>(foo: &T) { }
 fn main() {
     let x: Box<_> = Box::new(3);
     take_param(&x);
-    //~^ ERROR the trait bound `Box<{integer}>: Copy` is not satisfied
+    //~^ ERROR the trait bound `Box<{integer}>: Foo` is not satisfied
 }

--- a/tests/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params-2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `Box<{integer}>: Copy` is not satisfied
+error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-impl-type-params-2.rs:13:16
    |
 LL |     take_param(&x);

--- a/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `Box<{integer}>: Copy` is not satisfied
+error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL |     take_param(&x);

--- a/tests/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `Box<{integer}>: Copy` is not satisfied
+error[E0277]: the trait bound `Box<{integer}>: Foo` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:21:16
    |
 LL |     take_param(&x);

--- a/tests/ui/kindck/kindck-send-object.rs
+++ b/tests/ui/kindck/kindck-send-object.rs
@@ -10,7 +10,7 @@ trait Message : Send { }
 
 fn object_ref_with_static_bound_not_ok() {
     assert_send::<&'static (dyn Dummy + 'static)>();
-    //~^ ERROR `(dyn Dummy + 'static)` cannot be shared between threads safely [E0277]
+    //~^ ERROR `&'static (dyn Dummy + 'static)` cannot be sent between threads safely [E0277]
 }
 
 fn box_object_with_no_bound_not_ok<'a>() {

--- a/tests/ui/kindck/kindck-send-object.stderr
+++ b/tests/ui/kindck/kindck-send-object.stderr
@@ -1,10 +1,10 @@
-error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
+error[E0277]: `&'static (dyn Dummy + 'static)` cannot be sent between threads safely
   --> $DIR/kindck-send-object.rs:12:19
    |
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'static (dyn Dummy + 'static)` cannot be sent between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`, which is required by `&'static (dyn Dummy + 'static): Send`
+   = help: the trait `Sync` is not implemented for `&'static (dyn Dummy + 'static)`, which is required by `&'static (dyn Dummy + 'static): Send`
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object.rs:5:18

--- a/tests/ui/kindck/kindck-send-object1.rs
+++ b/tests/ui/kindck/kindck-send-object1.rs
@@ -8,7 +8,7 @@ trait Dummy { }
 // careful with object types, who knows what they close over...
 fn test51<'a>() {
     assert_send::<&'a dyn Dummy>();
-    //~^ ERROR `(dyn Dummy + 'a)` cannot be shared between threads safely [E0277]
+    //~^ ERROR `&'a (dyn Dummy + 'a)` cannot be sent between threads safely [E0277]
 }
 fn test52<'a>() {
     assert_send::<&'a (dyn Dummy + Sync)>();

--- a/tests/ui/kindck/kindck-send-object1.stderr
+++ b/tests/ui/kindck/kindck-send-object1.stderr
@@ -1,10 +1,10 @@
-error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
+error[E0277]: `&'a (dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:10:19
    |
 LL |     assert_send::<&'a dyn Dummy>();
-   |                   ^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
+   |                   ^^^^^^^^^^^^^ `&'a (dyn Dummy + 'a)` cannot be sent between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`, which is required by `&'a (dyn Dummy + 'a): Send`
+   = help: the trait `Sync` is not implemented for `&'a (dyn Dummy + 'a)`, which is required by `&'a (dyn Dummy + 'a): Send`
    = note: required for `&'a (dyn Dummy + 'a)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object1.rs:5:18

--- a/tests/ui/kindck/kindck-send-object2.rs
+++ b/tests/ui/kindck/kindck-send-object2.rs
@@ -5,7 +5,7 @@ trait Dummy { }
 
 fn test50() {
     assert_send::<&'static dyn Dummy>();
-    //~^ ERROR `(dyn Dummy + 'static)` cannot be shared between threads safely [E0277]
+    //~^ ERROR `&'static (dyn Dummy + 'static)` cannot be sent between threads safely [E0277]
 }
 
 fn test53() {

--- a/tests/ui/kindck/kindck-send-object2.stderr
+++ b/tests/ui/kindck/kindck-send-object2.stderr
@@ -1,10 +1,10 @@
-error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
+error[E0277]: `&'static (dyn Dummy + 'static)` cannot be sent between threads safely
   --> $DIR/kindck-send-object2.rs:7:19
    |
 LL |     assert_send::<&'static dyn Dummy>();
-   |                   ^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
+   |                   ^^^^^^^^^^^^^^^^^^ `&'static (dyn Dummy + 'static)` cannot be sent between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`, which is required by `&'static (dyn Dummy + 'static): Send`
+   = help: the trait `Sync` is not implemented for `&'static (dyn Dummy + 'static)`, which is required by `&'static (dyn Dummy + 'static): Send`
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/kindck-send-object2.rs:3:18

--- a/tests/ui/methods/issues/issue-94581.fixed
+++ b/tests/ui/methods/issues/issue-94581.fixed
@@ -4,5 +4,5 @@ fn get_slice() -> &'static [i32] {
 }
 
 fn main() {
-    let _sqsum: i32 = get_slice().map(|i| i * i).sum(); //~ ERROR [E0599]
+    let _sqsum: i32 = get_slice().into_iter().map(|i| i * i).sum(); //~ ERROR [E0599]
 }

--- a/tests/ui/methods/issues/issue-94581.stderr
+++ b/tests/ui/methods/issues/issue-94581.stderr
@@ -1,14 +1,13 @@
-error[E0599]: `&'static [i32]` is not an iterator
-  --> $DIR/issue-94581.rs:6:29
+error[E0599]: no method named `map` found for reference `&'static [i32]` in the current scope
+  --> $DIR/issue-94581.rs:7:35
    |
-LL |     let sqsum = get_slice().map(|i| i * i).sum();
-   |                             ^^^ `&'static [i32]` is not an iterator; try calling `.iter()`
+LL |     let _sqsum: i32 = get_slice().map(|i| i * i).sum();
+   |                                   ^^^ `&'static [i32]` is not an iterator
    |
-   = note: the following trait bounds were not satisfied:
-           `&'static [i32]: Iterator`
-           which is required by `&mut &'static [i32]: Iterator`
-           `[i32]: Iterator`
-           which is required by `&mut [i32]: Iterator`
+help: call `.into_iter()` first
+   |
+LL |     let _sqsum: i32 = get_slice().into_iter().map(|i| i * i).sum();
+   |                                   ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.rs
@@ -14,7 +14,7 @@ struct PriorityQueueEntry<T> {
 //~^ ERROR can't compare `PriorityQueue<T>` with `PriorityQueue<T>`
 //~| ERROR the trait bound `PriorityQueue<T>: Eq` is not satisfied
 //~| ERROR can't compare `T` with `T`
-//~| ERROR `BinaryHeap<PriorityQueueEntry<T>>` is not an iterator
+//~| ERROR no method named `cmp` found for struct `BinaryHeap<PriorityQueueEntry<T>>`
 //~| ERROR no field `height` on type `&PriorityQueue<T>`
 
 struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -46,15 +46,12 @@ LL | struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
    = help: the trait `PartialOrd<_>` is not implemented for `BinaryHeap<PriorityQueueEntry<T>>`
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: `BinaryHeap<PriorityQueueEntry<T>>` is not an iterator
+error[E0599]: no method named `cmp` found for struct `BinaryHeap<PriorityQueueEntry<T>>` in the current scope
   --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
    |
 LL | #[derive(PartialOrd, AddImpl)]
    |                      ^^^^^^^ `BinaryHeap<PriorityQueueEntry<T>>` is not an iterator
    |
-   = note: the following trait bounds were not satisfied:
-           `BinaryHeap<PriorityQueueEntry<T>>: Iterator`
-           which is required by `&mut BinaryHeap<PriorityQueueEntry<T>>: Iterator`
    = note: this error originates in the derive macro `AddImpl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `height` on type `&PriorityQueue<T>`

--- a/tests/ui/rfcs/rfc-2397-do-not-recommend/feature-gate-do_not_recommend.rs
+++ b/tests/ui/rfcs/rfc-2397-do-not-recommend/feature-gate-do_not_recommend.rs
@@ -17,5 +17,5 @@ fn stuff<T: Bar>(_: T) {}
 
 fn main() {
     stuff(1u8);
-    //~^ the trait bound `u8: Foo` is not satisfied
+    //~^ the trait bound `u8: Bar` is not satisfied
 }

--- a/tests/ui/rfcs/rfc-2397-do-not-recommend/feature-gate-do_not_recommend.stderr
+++ b/tests/ui/rfcs/rfc-2397-do-not-recommend/feature-gate-do_not_recommend.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `u8: Foo` is not satisfied
+error[E0277]: the trait bound `u8: Bar` is not satisfied
   --> $DIR/feature-gate-do_not_recommend.rs:19:11
    |
 LL |     stuff(1u8);

--- a/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -7,7 +7,6 @@ LL |     bar(foo);
    |     required by a bound introduced by this call
    |
    = help: the trait `Future` is not implemented for fn item `fn() -> impl Future<Output = ()> {foo}`
-   = note: fn() -> impl Future<Output = ()> {foo} must be a future or must implement `IntoFuture` to be awaited
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
    |
@@ -27,7 +26,6 @@ LL |     bar(async_closure);
    |     required by a bound introduced by this call
    |
    = help: the trait `Future` is not implemented for `{async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:33}`
-   = note: {async closure@$DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:11:25: 11:33} must be a future or must implement `IntoFuture` to be awaited
 note: required by a bound in `bar`
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:7:16
    |

--- a/tests/ui/suggestions/issue-104961.fixed
+++ b/tests/ui/suggestions/issue-104961.fixed
@@ -2,12 +2,12 @@
 
 fn foo(x: &str) -> bool {
     x.starts_with(&("hi".to_string() + " you"))
-    //~^ ERROR expected a `FnMut(char)` closure, found `String`
+    //~^ ERROR the trait bound `String: Pattern<'_>` is not satisfied [E0277]
 }
 
 fn foo2(x: &str) -> bool {
     x.starts_with(&"hi".to_string())
-    //~^ ERROR expected a `FnMut(char)` closure, found `String`
+    //~^ ERROR the trait bound `String: Pattern<'_>` is not satisfied [E0277]
 }
 
 fn main() {

--- a/tests/ui/suggestions/issue-104961.rs
+++ b/tests/ui/suggestions/issue-104961.rs
@@ -2,12 +2,12 @@
 
 fn foo(x: &str) -> bool {
     x.starts_with("hi".to_string() + " you")
-    //~^ ERROR expected a `FnMut(char)` closure, found `String`
+    //~^ ERROR the trait bound `String: Pattern<'_>` is not satisfied [E0277]
 }
 
 fn foo2(x: &str) -> bool {
     x.starts_with("hi".to_string())
-    //~^ ERROR expected a `FnMut(char)` closure, found `String`
+    //~^ ERROR the trait bound `String: Pattern<'_>` is not satisfied [E0277]
 }
 
 fn main() {

--- a/tests/ui/suggestions/issue-104961.stderr
+++ b/tests/ui/suggestions/issue-104961.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut(char)` closure, found `String`
+error[E0277]: the trait bound `String: Pattern<'_>` is not satisfied
   --> $DIR/issue-104961.rs:4:19
    |
 LL |     x.starts_with("hi".to_string() + " you")
@@ -6,7 +6,6 @@ LL |     x.starts_with("hi".to_string() + " you")
    |       |
    |       required by a bound introduced by this call
    |
-   = note: the trait bound `String: Pattern<'_>` is not satisfied
    = note: required for `String` to implement `Pattern<'_>`
 note: required by a bound in `core::str::<impl str>::starts_with`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
@@ -15,7 +14,7 @@ help: consider borrowing here
 LL |     x.starts_with(&("hi".to_string() + " you"))
    |                   ++                         +
 
-error[E0277]: expected a `FnMut(char)` closure, found `String`
+error[E0277]: the trait bound `String: Pattern<'_>` is not satisfied
   --> $DIR/issue-104961.rs:9:19
    |
 LL |     x.starts_with("hi".to_string())
@@ -23,7 +22,6 @@ LL |     x.starts_with("hi".to_string())
    |       |
    |       required by a bound introduced by this call
    |
-   = note: the trait bound `String: Pattern<'_>` is not satisfied
    = note: required for `String` to implement `Pattern<'_>`
 note: required by a bound in `core::str::<impl str>::starts_with`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL

--- a/tests/ui/suggestions/issue-62843.stderr
+++ b/tests/ui/suggestions/issue-62843.stderr
@@ -1,4 +1,4 @@
-error[E0277]: expected a `FnMut(char)` closure, found `String`
+error[E0277]: the trait bound `String: Pattern<'_>` is not satisfied
   --> $DIR/issue-62843.rs:4:32
    |
 LL |     println!("{:?}", line.find(pattern));
@@ -6,7 +6,6 @@ LL |     println!("{:?}", line.find(pattern));
    |                           |
    |                           required by a bound introduced by this call
    |
-   = note: the trait bound `String: Pattern<'_>` is not satisfied
    = note: required for `String` to implement `Pattern<'_>`
 note: required by a bound in `core::str::<impl str>::find`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL

--- a/tests/ui/suggestions/slice-issue-87994.rs
+++ b/tests/ui/suggestions/slice-issue-87994.rs
@@ -1,16 +1,16 @@
 fn main() {
   let v = vec![1i32, 2, 3];
   for _ in v[1..] {
-    //~^ ERROR [i32]` is not an iterator [E0277]
-    //~^^ ERROR known at compilation time
+    //~^ ERROR `[i32]` is not an iterator [E0277]
+    //~| ERROR `[i32]` is not an iterator [E0277]
   }
   struct K {
     n: i32,
   }
   let mut v2 = vec![K { n: 1 }, K { n: 1 }, K { n: 1 }];
   for i2 in v2[1..] {
-    //~^ ERROR [K]` is not an iterator [E0277]
-    //~^^ ERROR known at compilation time
+    //~^ ERROR `[K]` is not an iterator [E0277]
+    //~| ERROR `[K]` is not an iterator [E0277]
     i2.n = 2;
   }
 }

--- a/tests/ui/suggestions/slice-issue-87994.stderr
+++ b/tests/ui/suggestions/slice-issue-87994.stderr
@@ -13,7 +13,7 @@ LL |   for _ in &v[1..] {
 LL |   for _ in &mut v[1..] {
    |            ++++
 
-error[E0277]: the size for values of type `[i32]` cannot be known at compilation time
+error[E0277]: `[i32]` is not an iterator
   --> $DIR/slice-issue-87994.rs:3:12
    |
 LL |   for _ in v[1..] {
@@ -21,6 +21,7 @@ LL |   for _ in v[1..] {
    |
    = note: the trait bound `[i32]: IntoIterator` is not satisfied
    = note: required for `[i32]` to implement `IntoIterator`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider borrowing here
    |
 LL |   for _ in &v[1..] {
@@ -43,7 +44,7 @@ LL |   for i2 in &v2[1..] {
 LL |   for i2 in &mut v2[1..] {
    |             ++++
 
-error[E0277]: the size for values of type `[K]` cannot be known at compilation time
+error[E0277]: `[K]` is not an iterator
   --> $DIR/slice-issue-87994.rs:11:13
    |
 LL |   for i2 in v2[1..] {
@@ -51,6 +52,7 @@ LL |   for i2 in v2[1..] {
    |
    = note: the trait bound `[K]: IntoIterator` is not satisfied
    = note: required for `[K]` to implement `IntoIterator`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider borrowing here
    |
 LL |   for i2 in &v2[1..] {

--- a/tests/ui/suggestions/suggest-remove-refs-5.stderr
+++ b/tests/ui/suggestions/suggest-remove-refs-5.stderr
@@ -1,10 +1,10 @@
-error[E0277]: `Vec<i32>` is not an iterator
+error[E0277]: `&mut &mut &mut &mut Vec<i32>` is not an iterator
   --> $DIR/suggest-remove-refs-5.rs:4:14
    |
 LL |     for _ in &mut &mut v {}
-   |              ^^^^^^^^^^^ `Vec<i32>` is not an iterator; try calling `.into_iter()` or `.iter()`
+   |              ^^^^^^^^^^^ `&mut &mut &mut &mut Vec<i32>` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `Vec<i32>`, which is required by `&mut &mut &mut &mut Vec<i32>: IntoIterator`
+   = help: the trait `Iterator` is not implemented for `&mut &mut &mut &mut Vec<i32>`, which is required by `&mut &mut &mut &mut Vec<i32>: IntoIterator`
    = note: required for `&mut Vec<i32>` to implement `Iterator`
    = note: 3 redundant requirements hidden
    = note: required for `&mut &mut &mut &mut Vec<i32>` to implement `Iterator`
@@ -15,13 +15,13 @@ LL ~     let v = &mut Vec::<i32>::new();
 LL ~     for _ in v {}
    |
 
-error[E0277]: `[u8; 1]` is not an iterator
+error[E0277]: `&mut &mut &mut [u8; 1]` is not an iterator
   --> $DIR/suggest-remove-refs-5.rs:7:14
    |
 LL |     for _ in &mut v {}
-   |              ^^^^^^ `[u8; 1]` is not an iterator; try calling `.into_iter()` or `.iter()`
+   |              ^^^^^^ `&mut &mut &mut [u8; 1]` is not an iterator
    |
-   = help: the trait `Iterator` is not implemented for `[u8; 1]`, which is required by `&mut &mut &mut [u8; 1]: IntoIterator`
+   = help: the trait `Iterator` is not implemented for `&mut &mut &mut [u8; 1]`, which is required by `&mut &mut &mut [u8; 1]: IntoIterator`
    = note: required for `&mut [u8; 1]` to implement `Iterator`
    = note: 2 redundant requirements hidden
    = note: required for `&mut &mut &mut [u8; 1]` to implement `Iterator`

--- a/tests/ui/traits/alias/cross-crate.rs
+++ b/tests/ui/traits/alias/cross-crate.rs
@@ -12,6 +12,6 @@ fn use_alias<T: SendSync>() {}
 fn main() {
     use_alias::<u32>();
     use_alias::<Rc<u32>>();
-    //~^ ERROR `Rc<u32>` cannot be sent between threads safely [E0277]
-    //~^^ ERROR `Rc<u32>` cannot be shared between threads safely [E0277]
+    //~^ ERROR the trait bound `Rc<u32>: SendSync` is not satisfied [E0277]
+    //~| ERROR the trait bound `Rc<u32>: SendSync` is not satisfied [E0277]
 }

--- a/tests/ui/traits/alias/cross-crate.stderr
+++ b/tests/ui/traits/alias/cross-crate.stderr
@@ -1,10 +1,9 @@
-error[E0277]: `Rc<u32>` cannot be sent between threads safely
+error[E0277]: the trait bound `Rc<u32>: SendSync` is not satisfied
   --> $DIR/cross-crate.rs:14:17
    |
 LL |     use_alias::<Rc<u32>>();
-   |                 ^^^^^^^ `Rc<u32>` cannot be sent between threads safely
+   |                 ^^^^^^^ the trait `Send` is not implemented for `Rc<u32>`, which is required by `Rc<u32>: SendSync`
    |
-   = help: the trait `Send` is not implemented for `Rc<u32>`, which is required by `Rc<u32>: SendSync`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17
@@ -12,13 +11,12 @@ note: required by a bound in `use_alias`
 LL | fn use_alias<T: SendSync>() {}
    |                 ^^^^^^^^ required by this bound in `use_alias`
 
-error[E0277]: `Rc<u32>` cannot be shared between threads safely
+error[E0277]: the trait bound `Rc<u32>: SendSync` is not satisfied
   --> $DIR/cross-crate.rs:14:17
    |
 LL |     use_alias::<Rc<u32>>();
-   |                 ^^^^^^^ `Rc<u32>` cannot be shared between threads safely
+   |                 ^^^^^^^ the trait `Sync` is not implemented for `Rc<u32>`, which is required by `Rc<u32>: SendSync`
    |
-   = help: the trait `Sync` is not implemented for `Rc<u32>`, which is required by `Rc<u32>: SendSync`
    = note: required for `Rc<u32>` to implement `SendSync`
 note: required by a bound in `use_alias`
   --> $DIR/cross-crate.rs:10:17

--- a/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.rs
+++ b/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.rs
@@ -7,5 +7,5 @@ trait IteratorAlias = Iterator;
 fn f(_: impl IteratorAlias) {}
 
 fn main() {
-    f(()) //~ `()` is not an iterator
+    f(()) //~ ERROR the trait bound `(): IteratorAlias` is not satisfied
 }

--- a/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.stderr
+++ b/tests/ui/traits/alias/issue-108072-unmet-trait-alias-bound.stderr
@@ -1,12 +1,11 @@
-error[E0277]: `()` is not an iterator
+error[E0277]: the trait bound `(): IteratorAlias` is not satisfied
   --> $DIR/issue-108072-unmet-trait-alias-bound.rs:10:7
    |
 LL |     f(())
-   |     - ^^ `()` is not an iterator
+   |     - ^^ the trait `Iterator` is not implemented for `()`, which is required by `(): IteratorAlias`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Iterator` is not implemented for `()`, which is required by `(): IteratorAlias`
    = note: required for `()` to implement `IteratorAlias`
 note: required by a bound in `f`
   --> $DIR/issue-108072-unmet-trait-alias-bound.rs:7:14

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -6,7 +6,7 @@ LL | auto trait Magic: Copy {}
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
-error[E0277]: the trait bound `NoClone: Copy` is not satisfied
+error[E0277]: the trait bound `NoClone: Magic` is not satisfied
   --> $DIR/supertrait-auto-trait.rs:16:23
    |
 LL |     let (a, b) = copy(NoClone);

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -93,7 +93,6 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:14:33
@@ -102,7 +101,6 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:3:28
@@ -111,7 +109,6 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                            ^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:11:10
@@ -120,7 +117,6 @@ LL | #[derive(Clone, Copy)]
    |          ^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `i32` is not an iterator
@@ -133,7 +129,6 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 13 previous errors

--- a/tests/ui/traits/suggest-dereferences/root-obligation.fixed
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.fixed
@@ -4,7 +4,7 @@ fn get_vowel_count(string: &str) -> usize {
     string
         .chars()
         .filter(|c| "aeiou".contains(*c))
-        //~^ ERROR expected a `Fn(char)` closure, found `char`
+        //~^ ERROR the trait bound `&char: Pattern<'_>` is not satisfied
         .count()
 }
 

--- a/tests/ui/traits/suggest-dereferences/root-obligation.rs
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.rs
@@ -4,7 +4,7 @@ fn get_vowel_count(string: &str) -> usize {
     string
         .chars()
         .filter(|c| "aeiou".contains(c))
-        //~^ ERROR expected a `Fn(char)` closure, found `char`
+        //~^ ERROR the trait bound `&char: Pattern<'_>` is not satisfied
         .count()
 }
 

--- a/tests/ui/traits/suggest-dereferences/root-obligation.stderr
+++ b/tests/ui/traits/suggest-dereferences/root-obligation.stderr
@@ -1,12 +1,11 @@
-error[E0277]: expected a `Fn(char)` closure, found `char`
+error[E0277]: the trait bound `&char: Pattern<'_>` is not satisfied
   --> $DIR/root-obligation.rs:6:38
    |
 LL |         .filter(|c| "aeiou".contains(c))
-   |                             -------- ^ expected an `Fn(char)` closure, found `char`
+   |                             -------- ^ the trait `Fn<(char,)>` is not implemented for `&char`, which is required by `&char: Pattern<'_>`
    |                             |
    |                             required by a bound introduced by this call
    |
-   = help: the trait `Fn<(char,)>` is not implemented for `char`, which is required by `&char: Pattern<'_>`
    = note: required for `&char` to implement `FnOnce<(char,)>`
    = note: required for `&char` to implement `Pattern<'_>`
 note: required by a bound in `core::str::<impl str>::contains`

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
@@ -1,0 +1,28 @@
+//! This test demonstrates a bug where we accidentally
+//! detected opaque types in struct fields, but only if nested
+//! in projections of another opaque type.
+//@ check-pass
+
+#![feature(impl_trait_in_assoc_type)]
+
+struct Bar;
+
+trait Trait: Sized {
+    type Assoc2;
+    type Assoc;
+    fn foo() -> Self::Assoc;
+}
+
+impl Trait for Bar {
+    type Assoc2 = impl std::fmt::Debug;
+    type Assoc = impl Iterator<Item = Foo>;
+    fn foo() -> Self::Assoc {
+        vec![Foo { field: () }].into_iter()
+    }
+}
+
+struct Foo {
+    field: <Bar as Trait>::Assoc2,
+}
+
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.rs
@@ -1,7 +1,6 @@
 //! This test demonstrates a bug where we accidentally
 //! detected opaque types in struct fields, but only if nested
 //! in projections of another opaque type.
-//@ check-pass
 
 #![feature(impl_trait_in_assoc_type)]
 
@@ -18,6 +17,7 @@ impl Trait for Bar {
     type Assoc = impl Iterator<Item = Foo>;
     fn foo() -> Self::Assoc {
         vec![Foo { field: () }].into_iter()
+        //~^ ERROR item constrains opaque type that is not in its signature
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.stderr
+++ b/tests/ui/type-alias-impl-trait/hidden_behind_struct_field3.stderr
@@ -1,0 +1,15 @@
+error: item constrains opaque type that is not in its signature
+  --> $DIR/hidden_behind_struct_field3.rs:19:27
+   |
+LL |         vec![Foo { field: () }].into_iter()
+   |                           ^^
+   |
+   = note: this item must mention the opaque type in its signature in order to be able to register hidden types
+note: this item must mention the opaque type in its signature in order to be able to register hidden types
+  --> $DIR/hidden_behind_struct_field3.rs:18:8
+   |
+LL |     fn foo() -> Self::Assoc {
+   |        ^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #121213 (Add an example to demonstrate how Rc::into_inner works)
 - #121262 (Add vector time complexity)
 - #121287 (Clarify/add `must_use` message for Rc/Arc/Weak::into_raw.)
 - #121664 (Adjust error `yield`/`await` lowering)
 - #121826 (Use root obligation on E0277 for some cases)
 - #121838 (Use the correct logic for nested impl trait in assoc types)
 - #121913 (Don't panic when waiting on poisoned queries)
 - #121987 (pattern analysis: abort on arity mismatch)
 - #121993 (Avoid using unnecessary queries when printing the query stack in panics)
 - #121997 (interpret/cast: make more matches on FloatTy properly exhaustive)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=121213,121262,121287,121664,121826,121838,121913,121987,121993,121997)
<!-- homu-ignore:end -->